### PR TITLE
fix(inference): translate tool wire names for ollama (AYC-412)

### DIFF
--- a/packages/provider-ollama/src/convert-chunk.spec.ts
+++ b/packages/provider-ollama/src/convert-chunk.spec.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { ChatResponse, Message } from 'ollama';
 
-import { convertChunk } from './convert-chunk';
+import { ToolNameCodec } from '@ayunis/inference';
+
+import { convertChunk as convert } from './convert-chunk';
+
+// Passthrough map — name translation is covered by its own tests below.
+const convertChunk = (c: ChatResponse) => convert(c, new ToolNameCodec([]));
 
 const chunk = (
   message: Partial<Message>,
@@ -80,5 +85,27 @@ describe('convertChunk', () => {
 
   it('returns null for an empty, non-final chunk', () => {
     expect(convertChunk(chunk({}))).toBeNull();
+  });
+});
+
+describe('convertChunk wire-name decoding', () => {
+  it('maps a wire tool name back to the original and records the wire name', () => {
+    const codec = new ToolNameCodec([
+      { name: 'notion.search', description: 'd', parameters: {} },
+    ]);
+    const result = convert(
+      chunk({
+        tool_calls: [
+          { function: { name: 'notion_search', arguments: { q: 'x' } } },
+        ],
+      }),
+      codec,
+    );
+    const delta = result?.toolCallDeltas?.[0];
+    expect(delta).toMatchObject({
+      name: 'notion.search',
+      argumentsDelta: '{"q":"x"}',
+      providerMetadata: { wireName: 'notion_search' },
+    });
   });
 });

--- a/packages/provider-ollama/src/convert-chunk.ts
+++ b/packages/provider-ollama/src/convert-chunk.ts
@@ -6,6 +6,7 @@ import type {
   FinishReason,
   ProviderChunk,
   ToolCallDelta,
+  ToolNameCodec,
 } from '@ayunis/inference';
 
 /**
@@ -15,7 +16,10 @@ import type {
  * are split host-side). Usage and finish reason arrive on the final (`done`)
  * chunk.
  */
-export const convertChunk = (chunk: ChatResponse): ProviderChunk | null => {
+export const convertChunk = (
+  chunk: ChatResponse,
+  codec: ToolNameCodec,
+): ProviderChunk | null => {
   const message = chunk.message;
   const result: ProviderChunk = {};
   let carriesSomething = false;
@@ -28,7 +32,7 @@ export const convertChunk = (chunk: ChatResponse): ProviderChunk | null => {
     result.textDelta = message.content;
     carriesSomething = true;
   }
-  const toolCallDeltas = extractToolCallDeltas(message.tool_calls);
+  const toolCallDeltas = extractToolCallDeltas(message.tool_calls, codec);
   if (toolCallDeltas.length > 0) {
     result.toolCallDeltas = toolCallDeltas;
     carriesSomething = true;
@@ -47,13 +51,20 @@ export const convertChunk = (chunk: ChatResponse): ProviderChunk | null => {
 
 const extractToolCallDeltas = (
   toolCalls: OllamaToolCall[] | undefined,
+  codec: ToolNameCodec,
 ): ToolCallDelta[] =>
-  toolCalls?.map((toolCall, index) => ({
-    index,
-    id: randomUUID(),
-    name: toolCall.function.name,
-    argumentsDelta: JSON.stringify(toolCall.function.arguments),
-  })) ?? [];
+  toolCalls?.map((toolCall, index) => {
+    const wireName = toolCall.function.name;
+    const name = codec.decode(wireName);
+    return {
+      index,
+      id: randomUUID(),
+      name,
+      argumentsDelta: JSON.stringify(toolCall.function.arguments),
+      // Record what the model actually saw when names were translated.
+      ...(name !== wireName ? { providerMetadata: { wireName } } : {}),
+    };
+  }) ?? [];
 
 // Ollama reports `done_reason` as a free-form string; `done` already signals
 // completion, so an unrecognized reason falls back to a plain stop.

--- a/packages/provider-ollama/src/convert-request.spec.ts
+++ b/packages/provider-ollama/src/convert-request.spec.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Message, ToolSchema } from '@ayunis/inference';
+import { ToolNameCodec } from '@ayunis/inference';
 
-import { convertMessages, convertTool } from './convert-request';
+import {
+  convertMessages as convertMessagesFn,
+  convertTool as convertToolFn,
+} from './convert-request';
+
+// Passthrough map — name translation is covered by its own tests below.
+const passthrough = new ToolNameCodec([]);
+const convertMessages = (instructions: string, messages: Message[]) =>
+  convertMessagesFn(instructions, messages, passthrough);
+const convertTool = (tool: ToolSchema) => convertToolFn(tool, passthrough);
 
 describe('convertTool', () => {
   it('maps a tool schema to an Ollama function tool with strict mode', () => {
@@ -101,5 +111,35 @@ describe('convertMessages', () => {
   it('drops user turns with neither text nor images', () => {
     const result = convertMessages('', [{ role: 'user', content: [] }]);
     expect(result).toHaveLength(0);
+  });
+});
+
+describe('wire-name encoding', () => {
+  const codec = new ToolNameCodec([
+    { name: 'notion.search', description: 'd', parameters: {} },
+  ]);
+
+  it('declares tools under their wire names', () => {
+    expect(
+      convertToolFn(
+        { name: 'notion.search', description: 'd', parameters: {} },
+        codec,
+      ).function.name,
+    ).toBe('notion_search');
+  });
+
+  it('translates tool_call names in assistant history', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'c1', name: 'notion.search', input: {} },
+        ],
+      },
+    ];
+    const [assistant] = convertMessagesFn('', messages, codec);
+    expect(assistant.tool_calls).toEqual([
+      { function: { name: 'notion_search', arguments: {} } },
+    ]);
   });
 });

--- a/packages/provider-ollama/src/convert-request.ts
+++ b/packages/provider-ollama/src/convert-request.ts
@@ -4,7 +4,12 @@ import type {
   ToolCall as OllamaToolCall,
 } from 'ollama';
 
-import type { Message, MessageContent, ToolSchema } from '@ayunis/inference';
+import type {
+  Message,
+  MessageContent,
+  ToolSchema,
+  ToolNameCodec,
+} from '@ayunis/inference';
 
 /**
  * Ollama tool functions accept a `strict` flag the SDK's `Tool` type does not
@@ -12,9 +17,12 @@ import type { Message, MessageContent, ToolSchema } from '@ayunis/inference';
  */
 type OllamaToolFunction = OllamaTool['function'] & { strict?: boolean };
 
-export const convertTool = (tool: ToolSchema): OllamaTool => {
+export const convertTool = (
+  tool: ToolSchema,
+  codec: ToolNameCodec,
+): OllamaTool => {
   const fn: OllamaToolFunction = {
-    name: tool.name,
+    name: codec.encode(tool.name),
     description: tool.description,
     parameters: tool.parameters,
     strict: true,
@@ -32,6 +40,7 @@ export const convertTool = (tool: ToolSchema): OllamaTool => {
 export const convertMessages = (
   instructions: string,
   messages: readonly Message[],
+  codec: ToolNameCodec,
 ): OllamaMessage[] => {
   const converted: OllamaMessage[] = [];
   if (instructions) {
@@ -39,7 +48,7 @@ export const convertMessages = (
   }
   for (const message of messages) {
     if (message.role === 'assistant') {
-      converted.push(convertAssistant(message.content));
+      converted.push(convertAssistant(message.content, codec));
     } else if (message.role === 'tool_result') {
       converted.push(...convertToolResults(message.content));
     } else if (message.role === 'system') {
@@ -82,6 +91,7 @@ const convertUser = (
 
 const convertAssistant = (
   content: readonly MessageContent[],
+  codec: ToolNameCodec,
 ): OllamaMessage & { role: 'assistant' } => {
   let text: string | undefined;
   let thinking: string | undefined;
@@ -92,7 +102,9 @@ const convertAssistant = (
     } else if (c.type === 'thinking') {
       thinking = c.thinking;
     } else if (c.type === 'tool_use') {
-      toolCalls.push({ function: { name: c.name, arguments: c.input } });
+      toolCalls.push({
+        function: { name: codec.encode(c.name), arguments: c.input },
+      });
     }
   }
   return {

--- a/packages/provider-ollama/src/ollama-provider.ts
+++ b/packages/provider-ollama/src/ollama-provider.ts
@@ -6,6 +6,7 @@ import type {
   ProviderChunk,
   ProviderRequest,
 } from '@ayunis/inference';
+import { ToolNameCodec } from '@ayunis/inference';
 
 import { convertChunk } from './convert-chunk';
 import { convertMessages, convertTool } from './convert-request';
@@ -50,7 +51,8 @@ async function* streamChat(
   options: OllamaProviderOptions,
   request: ProviderRequest,
 ): AsyncIterable<ProviderChunk> {
-  const params = buildParams(options, request);
+  const codec = new ToolNameCodec(request.tools);
+  const params = buildParams(options, request, codec);
   const iterator = await retry(
     () => client.chat(params),
     options.maxRetries ?? 0,
@@ -65,7 +67,7 @@ async function* streamChat(
     }
   }
   for await (const chunk of iterator) {
-    const converted = convertChunk(chunk);
+    const converted = convertChunk(chunk, codec);
     if (converted) {
       yield converted;
     }
@@ -78,11 +80,12 @@ async function* streamChat(
 const buildParams = (
   options: OllamaProviderOptions,
   request: ProviderRequest,
+  codec: ToolNameCodec,
 ): ChatRequest & { stream: true } => {
-  const tools = request.tools.map(convertTool);
+  const tools = request.tools.map((tool) => convertTool(tool, codec));
   return {
     model: options.model,
-    messages: convertMessages(request.instructions, request.messages),
+    messages: convertMessages(request.instructions, request.messages, codec),
     tools: tools.length > 0 ? tools : undefined,
     stream: true,
     options: { num_ctx: options.numCtx ?? DEFAULT_NUM_CTX },


### PR DESCRIPTION
Wires the `ToolNameCodec` (#993) through the Ollama provider for consistency: declarations, history, and inbound chunks. Ollama itself performs no name/schema validation, so no schema normalization is needed — this keeps the codec contract (canonical names in, canonical names out) uniform across all five providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Ollama request/chunk conversion with dedicated tests; no auth or schema changes, though wrong mapping would affect tool-call routing.
> 
> **Overview**
> The Ollama provider now uses **`ToolNameCodec`** end-to-end so canonical tool names (e.g. `notion.search`) stay in the runtime while Ollama sees wire-safe names (e.g. `notion_search`).
> 
> **Outbound:** `convertTool`, assistant-history `tool_use`, and chat params built in `ollama-provider` **encode** names via a codec built from `request.tools`.
> 
> **Inbound:** streaming `convertChunk` **decodes** wire names back to canonical names on tool-call deltas; when translation happened, **`providerMetadata.wireName`** records what the model emitted.
> 
> Existing unit tests use a passthrough codec; new specs cover encode on declarations/history and decode on chunks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe5c8cc4025ebe7322521a80b656b9ffbb6a3037. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->