### PR TITLE
fix(deploy): pin runtime to node:24.16.0-alpine to bisect connection stalls (AYC-423)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 # Multi-stage build for production deployment (pnpm workspaces)
 
 # ---- Stage 1: Build — install workspace, build FE + BE, create prod bundle ----
-FROM node:26-alpine AS build
+# Pinned back to node 24 to bisect the production outbound-connection stalls
+# that started with the node 26 bump (AYC-423). Revert to 26 once exonerated
+# or once the stall mechanism is identified and mitigated.
+FROM node:24.16.0-alpine AS build
 
 # pnpm via corepack (version pinned by root package.json "packageManager").
-# node:26-alpine no longer bundles corepack, so install it explicitly before
-# enabling. `corepack enable` still honors the root "packageManager" pin.
+# Installed explicitly (node:26-alpine dropped the bundled corepack; harmless
+# on node:24, and keeps this line stable across the 24↔26 A/B).
 RUN npm install -g corepack@latest && corepack enable
 # Native build deps for bcrypt (node-pre-gyp builds from source on musl/alpine)
 RUN apk add --no-cache python3 make g++ gcc
@@ -54,7 +57,7 @@ RUN pnpm --filter core-backend run build
 RUN pnpm --filter=core-backend --prod --legacy deploy /prod/backend
 
 # ---- Stage 2: Production runtime ----
-FROM node:26-alpine AS production
+FROM node:24.16.0-alpine AS production
 
 # Chromium for Puppeteer PDF export
 RUN apk add --no-cache chromium


### PR DESCRIPTION
## What & why

Closes nothing on its own — this is the A/B experiment for [AYC-423](https://linear.app/ayunis/issue/AYC-423/confirm-node26-alpine-runtime-bump-as-root-cause-of-outbound): pin the production runtime back to the exact last-known-good Node version to confirm (or exonerate) the node 24→26 bump as the root cause of the outbound-connection stalls behind the "models are slow" reports.

**Evidence so far** (details in the Linear ticket):
- Sentry `runtime` tag: prod ran `node v24.16.0` until 2026-06-24 16:57 UTC, then `v26.3.1`/`v26.4.0` — hours before send-message p95 jumped 73s → 300–530s on 06-25, and both 26.x versions show the degradation
- Single outbound calls stall for minutes (Mistral embeddings POSTs of 316s/447s, Bedrock stream per-call p50 4s→74s) with no 429s; short requests and the internally-routed Azure endpoint are unaffected
- Mistral status page shows zero incidents in the window; two independent providers degrading the same day rules out provider-side causes

## Changes

- `FROM node:26-alpine` → `FROM node:24.16.0-alpine` (build + production stages) — exact pin, not the floating `24-alpine` tag, so the A/B reproduces the known-good runtime precisely
- Kept the explicit corepack install (verified working on `24.16.0-alpine`; keeps the line stable across the 24↔26 A/B)

## Deploy & measurement plan

1. Verify staging build/boot
2. Deploy to production **mid-week** (weekend traffic is too thin to measure)
3. Watch 24–48h in Sentry:
   - Bedrock per-call p50/p95 (`span.op:http.client span.description:*bedrock-runtime*`) — baseline 4–7s p50, currently 14–74s
   - Mistral embeddings p95 (`POST https://api.mistral.ai/v1/embeddings`) — baseline ~1.3s, currently 4–44s
   - Long-duration `permission_denied` / `internal_error` Bedrock spans (connection deaths) — should disappear
4. Latencies snap back → runtime confirmed; stay pinned, land AYC-422/AYC-424, then isolate the node 26 mechanism before re-upgrading. No change → runtime exonerated; revert this, shift to host-egress investigation, unblock AYC-422 immediately

⚠️ Hold AYC-422 (client timeouts) until the measurement window closes — timeouts would truncate exactly the stalls being measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DKpEpBvP59oT3HQMTMmVyD
