### PR TITLE
fix(sentry): skip backend sentry init in development (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/common/sentry/instrument.ts
+++ b/ayunis-core-backend/src/common/sentry/instrument.ts
@@ -20,13 +20,16 @@ function readPackageVersion(): string | undefined {
   }
 }
 
-if (sentryDsn) {
+// Never report from local development, even when a SENTRY_DSN is present in
+// the local .env — dev noise (e.g. crons failing against stopped local
+// services) pollutes the shared project and buries production signals.
+if (sentryDsn && environment !== 'development') {
   Sentry.init({
     dsn: sentryDsn,
     environment,
     release,
     enableLogs: true,
-    // Performance Monitoring - sample 100% in dev, 10% in prod
+    // Performance Monitoring - sample 100% on staging, 10% in prod
     tracesSampleRate: environment === 'production' ? 0.1 : 1.0,
     beforeSend(event, hint) {
       const error = hint.originalException;
@@ -47,6 +50,8 @@ if (sentryDsn) {
   });
 
   console.warn(`✅ Sentry initialized for environment: ${environment}`);
+} else if (sentryDsn) {
+  console.warn('⚠️  Sentry disabled in development - SENTRY_DSN ignored');
 } else {
   console.warn('⚠️  SENTRY_DSN not configured - error tracking disabled');
 }


### PR DESCRIPTION
- A local dev machine flooded the shared Sentry project with 2200+
  AggregateError events (cron hitting a stopped local service), burying
  production signals during the AYC-423 latency investigation
- Gate Sentry.init on environment !== development, matching the frontend
  which already gates on import.meta.env.PROD
- Local structured logs already skip the Sentry transport in development

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change for local dev; staging and production Sentry behavior is unchanged when `NODE_ENV` is not development.
> 
> **Overview**
> **Backend Sentry no longer initializes when `NODE_ENV` is development**, even if `SENTRY_DSN` is set in a local `.env`. That stops local cron failures and similar noise from flooding the shared Sentry project.
> 
> When a DSN is present in development, startup now logs that Sentry is disabled and the DSN is ignored. The performance-sampling comment is updated to say **staging** gets 100% traces (not “dev”), matching non-production behavior after this gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e04bfc268c1b126acd4bfe8223bfabe07c650532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->