### PR TITLE
fix(models): bound all llm, embeddings and file-api clients with explicit timeouts (AYC-422)

### DIFF
--- a/ayunis-core-backend/src/common/util/mistral-transient-error.spec.ts
+++ b/ayunis-core-backend/src/common/util/mistral-transient-error.spec.ts
@@ -1,0 +1,51 @@
+import {
+  ConnectionError,
+  MistralError,
+  RequestTimeoutError,
+} from '@mistralai/mistralai/models/errors';
+import { isTransientMistralError } from './mistral-transient-error';
+
+function createMistralError(statusCode: number): MistralError {
+  const response = {
+    status: statusCode,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    url: 'https://api.mistral.ai/v1/embeddings',
+  } as unknown as Response;
+  return new MistralError(`API error: ${statusCode}`, {
+    response,
+    request: {} as Request,
+    body: '',
+  });
+}
+
+describe('isTransientMistralError', () => {
+  it('treats a client-side request timeout as transient', () => {
+    expect(
+      isTransientMistralError(new RequestTimeoutError('request timed out')),
+    ).toBe(true);
+  });
+
+  it('treats a connection failure as transient', () => {
+    expect(
+      isTransientMistralError(new ConnectionError('connect ECONNREFUSED')),
+    ).toBe(true);
+  });
+
+  it('treats rate limiting (429) as transient', () => {
+    expect(isTransientMistralError(createMistralError(429))).toBe(true);
+  });
+
+  it('treats server errors (5xx) as transient', () => {
+    expect(isTransientMistralError(createMistralError(500))).toBe(true);
+    expect(isTransientMistralError(createMistralError(503))).toBe(true);
+  });
+
+  it('does not retry client errors (4xx other than 429)', () => {
+    expect(isTransientMistralError(createMistralError(400))).toBe(false);
+    expect(isTransientMistralError(createMistralError(422))).toBe(false);
+  });
+
+  it('does not retry unknown errors', () => {
+    expect(isTransientMistralError(new Error('unrelated failure'))).toBe(false);
+  });
+});

--- a/ayunis-core-backend/src/common/util/mistral-transient-error.ts
+++ b/ayunis-core-backend/src/common/util/mistral-transient-error.ts
@@ -1,0 +1,25 @@
+import {
+  ConnectionError,
+  MistralError,
+  RequestTimeoutError,
+} from '@mistralai/mistralai/models/errors';
+
+/**
+ * Transient Mistral SDK failures worth a bounded retry: rate limits (429),
+ * server errors (5xx), and client-side timeouts / connection failures.
+ * Per-attempt `timeoutMs` on the client turns stalled connections into
+ * `RequestTimeoutError`s, so retrying them is bounded — without it they
+ * hang forever and never reach a retry predicate (AYC-422).
+ */
+export function isTransientMistralError(error: Error): boolean {
+  if (
+    error instanceof RequestTimeoutError ||
+    error instanceof ConnectionError
+  ) {
+    return true;
+  }
+  return (
+    error instanceof MistralError &&
+    (error.statusCode >= 500 || error.statusCode === 429)
+  );
+}

--- a/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/mistral-embeddings.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/mistral-embeddings.handler.spec.ts
@@ -1,0 +1,86 @@
+import { Test } from '@nestjs/testing';
+import type { TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { Mistral } from '@mistralai/mistralai';
+import { RequestTimeoutError } from '@mistralai/mistralai/models/errors';
+import { MistralEmbeddingsHandler } from './mistral-embeddings.handler';
+import { EmbeddingModel } from '../../domain/embedding-model.entity';
+import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { EmbeddingDimensions } from 'src/domain/models/domain/value-objects/embedding-dimensions.enum';
+
+jest.mock('@mistralai/mistralai', () => ({
+  Mistral: jest.fn().mockImplementation(() => ({
+    embeddings: { create: jest.fn() },
+  })),
+}));
+
+const retryCalls: Array<{
+  fn: () => Promise<unknown>;
+  retryIfError?: (error: Error) => boolean;
+}> = [];
+jest.mock('src/common/util/retryWithBackoff', () => ({
+  __esModule: true,
+  default: (options: {
+    fn: () => Promise<unknown>;
+    retryIfError?: (error: Error) => boolean;
+  }) => {
+    retryCalls.push(options);
+    return options.fn();
+  },
+}));
+
+describe('MistralEmbeddingsHandler', () => {
+  let handler: MistralEmbeddingsHandler;
+
+  const model = new EmbeddingModel({
+    name: 'mistral-embed',
+    provider: ModelProvider.MISTRAL,
+    displayName: 'Mistral Embed',
+    dimensions: EmbeddingDimensions.DIMENSION_1024,
+    isArchived: false,
+  });
+
+  beforeEach(async () => {
+    retryCalls.length = 0;
+    (Mistral as unknown as jest.Mock).mockClear();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MistralEmbeddingsHandler,
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue('mistral-api-key') },
+        },
+      ],
+    }).compile();
+
+    handler = module.get(MistralEmbeddingsHandler);
+  });
+
+  it('bounds each embeddings attempt with a 30s timeout', () => {
+    expect(Mistral).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 30_000 }),
+    );
+  });
+
+  it('retries client-side timeouts instead of failing the run', async () => {
+    const client = (Mistral as unknown as jest.Mock).mock.results[0].value as {
+      embeddings: { create: jest.Mock };
+    };
+    client.embeddings.create.mockResolvedValue({
+      data: [{ embedding: [0.1, 0.2], index: 0 }],
+    });
+
+    await handler.embed(
+      ['Wie beantrage ich einen Anwohnerparkausweis?'],
+      model,
+    );
+
+    expect(retryCalls).toHaveLength(1);
+    const { retryIfError } = retryCalls[0];
+    expect(retryIfError?.(new RequestTimeoutError('request timed out'))).toBe(
+      true,
+    );
+    expect(retryIfError?.(new Error('schema validation failed'))).toBe(false);
+  });
+});

--- a/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/mistral-embeddings.handler.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/mistral-embeddings.handler.ts
@@ -2,12 +2,18 @@ import { Injectable, Logger } from '@nestjs/common';
 import { EmbeddingsHandler } from '../../application/ports/embeddings.handler';
 import { Embedding } from '../../domain/embedding.entity';
 import { Mistral } from '@mistralai/mistralai';
-import { SDKError } from '@mistralai/mistralai/models/errors';
 import { ConfigService } from '@nestjs/config';
 import { EmbeddingModel } from '../../domain/embedding-model.entity';
 import { EmbeddingsProvider } from '../../domain/embeddings-provider.enum';
 import { NoEmbeddingsReturnedError } from '../../application/embeddings.errors';
 import retryWithBackoff from 'src/common/util/retryWithBackoff';
+import { isTransientMistralError } from 'src/common/util/mistral-transient-error';
+
+// Embeddings are small, fast requests (healthy p95 ~1.3s). The tight
+// per-attempt timeout turns a stalled connection into a quick retry instead
+// of an indefinite hang that also wedges a slot in the global embeddings
+// queue (AYC-422).
+const EMBEDDINGS_TIMEOUT_MS = 30_000;
 
 @Injectable()
 export class MistralEmbeddingsHandler extends EmbeddingsHandler {
@@ -18,6 +24,7 @@ export class MistralEmbeddingsHandler extends EmbeddingsHandler {
     super();
     this.mistral = new Mistral({
       apiKey: this.configService.get('embeddings.mistral.apiKey'),
+      timeoutMs: EMBEDDINGS_TIMEOUT_MS,
     });
   }
 
@@ -39,14 +46,12 @@ export class MistralEmbeddingsHandler extends EmbeddingsHandler {
       maxRetries: 3,
       delay: 2000,
       retryIfError: (error: Error) => {
-        const isTransient =
-          error instanceof SDKError &&
-          (error.statusCode >= 500 || error.statusCode === 429);
+        const isTransient = isTransientMistralError(error);
         if (isTransient) {
           this.logger.warn(
             'Retrying Mistral embeddings after transient error',
             {
-              statusCode: error.statusCode,
+              name: error.name,
               message: error.message,
             },
           );

--- a/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/openai-embeddings.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/openai-embeddings.handler.spec.ts
@@ -1,0 +1,54 @@
+import { Test } from '@nestjs/testing';
+import type { TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { OpenAI } from 'openai';
+import { OpenAIEmbeddingsHandler } from './openai-embeddings.handler';
+import { EmbeddingModel } from '../../domain/embedding-model.entity';
+import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
+import { EmbeddingDimensions } from 'src/domain/models/domain/value-objects/embedding-dimensions.enum';
+
+jest.mock('openai', () => ({
+  OpenAI: jest.fn().mockImplementation(() => ({
+    embeddings: {
+      create: jest
+        .fn()
+        .mockResolvedValue({ data: [{ embedding: [0.1], index: 0 }] }),
+    },
+  })),
+}));
+
+describe('OpenAIEmbeddingsHandler', () => {
+  let handler: OpenAIEmbeddingsHandler;
+
+  beforeEach(async () => {
+    (OpenAI as unknown as jest.Mock).mockClear();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OpenAIEmbeddingsHandler,
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue('openai-api-key') },
+        },
+      ],
+    }).compile();
+
+    handler = module.get(OpenAIEmbeddingsHandler);
+  });
+
+  it('bounds each embeddings attempt with a 30s timeout', async () => {
+    const model = new EmbeddingModel({
+      name: 'text-embedding-3-small',
+      provider: ModelProvider.OPENAI,
+      displayName: 'Text Embedding 3 Small',
+      dimensions: EmbeddingDimensions.DIMENSION_1536,
+      isArchived: false,
+    });
+
+    await handler.embed(['Öffnungszeiten des Bürgeramts'], model);
+
+    expect(OpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 30_000 }),
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/openai-embeddings.handler.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/openai-embeddings.handler.ts
@@ -5,6 +5,11 @@ import { ConfigService } from '@nestjs/config';
 import { Embedding } from '../../domain/embedding.entity';
 import { EmbeddingModel } from '../../domain/embedding-model.entity';
 
+// Embeddings are small, fast requests. The tight per-attempt timeout turns a
+// stalled connection into a quick SDK-level retry instead of hanging the run
+// until the SDK's 10-minute default (AYC-422).
+const EMBEDDINGS_TIMEOUT_MS = 30_000;
+
 @Injectable()
 export class OpenAIEmbeddingsHandler extends EmbeddingsHandler {
   private openai: OpenAI | null = null;
@@ -19,7 +24,7 @@ export class OpenAIEmbeddingsHandler extends EmbeddingsHandler {
       if (!apiKey) {
         throw new Error('OpenAI embeddings API key not configured');
       }
-      this.openai = new OpenAI({ apiKey });
+      this.openai = new OpenAI({ apiKey, timeout: EMBEDDINGS_TIMEOUT_MS });
     }
     return this.openai;
   }
@@ -37,7 +42,6 @@ export class OpenAIEmbeddingsHandler extends EmbeddingsHandler {
   }
 
   isAvailable(): boolean {
-    // TODO
     return !!this.configService.get('embeddings.openai.apiKey');
   }
 }

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.spec.ts
@@ -80,6 +80,17 @@ describe('MistralFileRetrieverHandler', () => {
     mockClient = (handler as unknown as { client: typeof mockClient }).client;
   });
 
+  describe('client construction', () => {
+    it('bounds each file-API attempt with a 120s timeout instead of 5 minutes', () => {
+      const { Mistral } = jest.requireMock<{ Mistral: jest.Mock }>(
+        '@mistralai/mistralai',
+      );
+      expect(Mistral).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutMs: 120_000 }),
+      );
+    });
+  });
+
   describe('transient upstream error handling', () => {
     beforeEach(() => {
       // Setup upload and signedUrl to succeed — error on OCR process

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.ts
@@ -14,6 +14,7 @@ import { MistralError } from '@mistralai/mistralai/models/errors';
 import { Mistral } from '@mistralai/mistralai';
 import { OCRResponse } from '@mistralai/mistralai/models/components';
 import retryWithBackoff from 'src/common/util/retryWithBackoff';
+import { isTransientMistralError } from 'src/common/util/mistral-transient-error';
 import { File } from '../../domain/file.entity';
 import { ConfigService } from '@nestjs/config';
 
@@ -22,8 +23,12 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
   private readonly logger = new Logger(MistralFileRetrieverHandler.name);
   private readonly client: Mistral;
   private readonly MODEL_NAME = 'mistral-ocr-latest';
-  // 5 minutes timeout for large document OCR processing
-  private readonly TIMEOUT_MS = 5 * 60 * 1000;
+  // Per-attempt timeout for the Mistral file APIs (upload, signed URL, OCR,
+  // delete). Healthy OCR p95 is ~27s; the slowest successful calls observed
+  // in production were ~115s, so 120s leaves headroom for large documents
+  // while a stalled connection fails fast and retries instead of eating a
+  // 5-minute slice per attempt (AYC-422).
+  private readonly TIMEOUT_MS = 120 * 1000;
 
   constructor(private readonly configService: ConfigService) {
     super();
@@ -43,82 +48,10 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
       const blobPart: BlobPart = file.fileData as unknown as BlobPart;
       const fileBlob = new Blob([blobPart], { type: file.fileType });
 
-      const uploaded_pdf = await retryWithBackoff({
-        fn: () =>
-          this.client.files.upload({
-            file: fileBlob,
-            purpose: 'ocr',
-          }),
-        maxRetries: 3,
-        delay: 1000,
-      }).catch((error) => {
-        this.logger.debug('File upload to Mistral failed', {
-          error: error as Error,
-        });
-        this.logger.error('File upload to Mistral failed');
-        throw error;
-      });
+      const uploadedFileId = await this.uploadFile(fileBlob);
+      const ocrResponse = await this.runOcr(uploadedFileId);
+      await this.deleteFileBestEffort(uploadedFileId);
 
-      const signedUrl = await retryWithBackoff({
-        fn: () =>
-          this.client.files.getSignedUrl({
-            fileId: uploaded_pdf.id,
-          }),
-        maxRetries: 3,
-        delay: 1000,
-      }).catch(async (error) => {
-        this.logger.error(
-          `Mistral OCR signed URL retrieval failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
-          error instanceof Error ? error.stack : 'Unknown error',
-        );
-        await this.client.files
-          .delete({ fileId: uploaded_pdf.id })
-          .catch(() => undefined);
-        throw error;
-      });
-
-      this.logger.debug('signed URL', { signedUrl });
-      const ocrResponse = await retryWithBackoff({
-        fn: () =>
-          this.client.ocr.process({
-            model: this.MODEL_NAME,
-            document: {
-              type: 'document_url',
-              documentUrl: signedUrl.url,
-            },
-            includeImageBase64: true,
-          }),
-        maxRetries: 3,
-        delay: 1000,
-      }).catch(async (error) => {
-        this.logger.error(
-          `Mistral OCR processing failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
-          error instanceof Error ? error.stack : 'Unknown error',
-        );
-        await this.client.files
-          .delete({ fileId: uploaded_pdf.id })
-          .catch(() => undefined);
-        throw error;
-      });
-
-      // Best-effort cleanup — don't fail the operation if the file
-      // was already auto-deleted by Mistral (404) or is temporarily
-      // unreachable (5xx). The OCR result is already obtained.
-      await retryWithBackoff({
-        fn: () =>
-          this.client.files.delete({
-            fileId: uploaded_pdf.id,
-          }),
-        maxRetries: 3,
-        delay: 1000,
-      }).catch((error) => {
-        this.logger.warn('Failed to delete file from Mistral (best-effort)', {
-          fileId: uploaded_pdf.id,
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
-      });
-
-      // Parse the response
       return this.parseResponse(ocrResponse);
     } catch (error) {
       this.logger.error(
@@ -139,6 +72,83 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
 
       throw new FileRetrieverUnexpectedError(error as Error, metadata);
     }
+  }
+
+  private async uploadFile(fileBlob: Blob): Promise<string> {
+    const uploaded = await retryWithBackoff({
+      fn: () =>
+        this.client.files.upload({
+          file: fileBlob,
+          purpose: 'ocr',
+        }),
+      maxRetries: 3,
+      delay: 1000,
+      retryIfError: isTransientMistralError,
+    }).catch((error) => {
+      this.logger.debug('File upload to Mistral failed', {
+        error: error as Error,
+      });
+      this.logger.error('File upload to Mistral failed');
+      throw error;
+    });
+    return uploaded.id;
+  }
+
+  /** Fetches the signed URL and runs OCR; deletes the uploaded file on failure. */
+  private async runOcr(fileId: string): Promise<OCRResponse> {
+    const signedUrl = await retryWithBackoff({
+      fn: () => this.client.files.getSignedUrl({ fileId }),
+      maxRetries: 3,
+      delay: 1000,
+      retryIfError: isTransientMistralError,
+    }).catch(async (error) => {
+      this.logger.error(
+        `Mistral OCR signed URL retrieval failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        error instanceof Error ? error.stack : 'Unknown error',
+      );
+      await this.client.files.delete({ fileId }).catch(() => undefined);
+      throw error;
+    });
+
+    this.logger.debug('signed URL', { signedUrl });
+    return retryWithBackoff({
+      fn: () =>
+        this.client.ocr.process({
+          model: this.MODEL_NAME,
+          document: {
+            type: 'document_url',
+            documentUrl: signedUrl.url,
+          },
+          includeImageBase64: true,
+        }),
+      maxRetries: 3,
+      delay: 1000,
+      retryIfError: isTransientMistralError,
+    }).catch(async (error) => {
+      this.logger.error(
+        `Mistral OCR processing failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        error instanceof Error ? error.stack : 'Unknown error',
+      );
+      await this.client.files.delete({ fileId }).catch(() => undefined);
+      throw error;
+    });
+  }
+
+  // Best-effort cleanup — don't fail the operation if the file was already
+  // auto-deleted by Mistral (404) or is temporarily unreachable (5xx). The
+  // OCR result is already obtained.
+  private async deleteFileBestEffort(fileId: string): Promise<void> {
+    await retryWithBackoff({
+      fn: () => this.client.files.delete({ fileId }),
+      maxRetries: 3,
+      delay: 1000,
+      retryIfError: isTransientMistralError,
+    }).catch((error) => {
+      this.logger.warn('Failed to delete file from Mistral (best-effort)', {
+        fileId,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    });
   }
 
   private parseResponse(response: OCRResponse): FileRetrieverResult {

--- a/packages/provider-anthropic/src/anthropic-provider.ts
+++ b/packages/provider-anthropic/src/anthropic-provider.ts
@@ -22,6 +22,13 @@ import {
 // warrants it. Hosts needing longer outputs can pass `maxTokens` explicitly.
 export const DEFAULT_MAX_TOKENS = 16_384;
 
+// Bounds each connection attempt — the SDK aborts if the response hasn't
+// started, and clears the timer once streaming begins, so long healthy
+// streams are unaffected. Well below the SDK's 10-minute default so a
+// stalled connection surfaces as a retryable error instead of hanging the
+// caller. Hosts can override via `timeoutMs`.
+export const DEFAULT_TIMEOUT_MS = 120_000;
+
 /**
  * Any client that speaks the Anthropic Messages streaming API — the Anthropic
  * SDK and the Bedrock SDK both satisfy this, so they share the stream core.
@@ -38,6 +45,8 @@ export interface AnthropicProviderOptions {
   baseUrl?: string;
   /** SDK-level retry count for transient failures. Default: 2. */
   maxRetries?: number;
+  /** Per-attempt timeout in ms until the response starts. Default: 120s. */
+  timeoutMs?: number;
 }
 
 /**
@@ -48,6 +57,7 @@ export interface AnthropicProviderOptions {
 export const anthropic = (options: AnthropicProviderOptions): ModelProvider => {
   const client = new Anthropic({
     apiKey: options.apiKey,
+    timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     ...(options.baseUrl ? { baseURL: options.baseUrl } : {}),
     ...(options.maxRetries !== undefined
       ? { maxRetries: options.maxRetries }

--- a/packages/provider-anthropic/src/bedrock-provider.ts
+++ b/packages/provider-anthropic/src/bedrock-provider.ts
@@ -5,6 +5,7 @@ import type { ModelProvider } from '@ayunis/inference';
 import {
   createMessagesProvider,
   DEFAULT_MAX_TOKENS,
+  DEFAULT_TIMEOUT_MS,
 } from './anthropic-provider';
 
 const DEFAULT_AWS_REGION = 'eu-central-1';
@@ -21,6 +22,8 @@ export interface BedrockProviderOptions {
   maxTokens?: number;
   /** SDK-level retry count for transient failures. Default: 2. */
   maxRetries?: number;
+  /** Per-attempt timeout in ms until the response starts. Default: 120s. */
+  timeoutMs?: number;
 }
 
 /**
@@ -54,15 +57,19 @@ const createBedrockClient = (
   options: BedrockProviderOptions,
 ): AnthropicBedrock => {
   const awsRegion = resolveAwsRegion(options.awsRegion);
-  const maxRetries =
-    options.maxRetries !== undefined ? { maxRetries: options.maxRetries } : {};
+  const sharedOptions = {
+    awsRegion,
+    timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    ...(options.maxRetries !== undefined
+      ? { maxRetries: options.maxRetries }
+      : {}),
+  };
   if (options.awsAccessKey && options.awsSecretKey) {
     return new AnthropicBedrock({
-      awsRegion,
+      ...sharedOptions,
       awsAccessKey: options.awsAccessKey,
       awsSecretKey: options.awsSecretKey,
-      ...maxRetries,
     });
   }
-  return new AnthropicBedrock({ awsRegion, ...maxRetries });
+  return new AnthropicBedrock(sharedOptions);
 };

--- a/packages/provider-anthropic/src/client-construction.spec.ts
+++ b/packages/provider-anthropic/src/client-construction.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+import { anthropic, DEFAULT_TIMEOUT_MS } from './anthropic-provider';
+import { bedrock } from './bedrock-provider';
+
+const anthropicCtor = vi.hoisted(() => vi.fn());
+const bedrockCtor = vi.hoisted(() => vi.fn());
+
+vi.mock('@anthropic-ai/sdk', () => ({ default: anthropicCtor }));
+vi.mock('@anthropic-ai/bedrock-sdk', () => ({ default: bedrockCtor }));
+
+beforeEach(() => {
+  anthropicCtor.mockClear();
+  bedrockCtor.mockClear();
+});
+
+describe('anthropic client construction', () => {
+  it('bounds each request attempt with the default timeout', () => {
+    anthropic({ apiKey: 'sk-ant-test', model: 'claude-sonnet-4-5' });
+
+    expect(anthropicCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: DEFAULT_TIMEOUT_MS }),
+    );
+  });
+
+  it('lets the host override the timeout', () => {
+    anthropic({
+      apiKey: 'sk-ant-test',
+      model: 'claude-sonnet-4-5',
+      timeoutMs: 45_000,
+    });
+
+    expect(anthropicCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 45_000 }),
+    );
+  });
+});
+
+describe('bedrock client construction', () => {
+  it('bounds each request attempt with the default timeout (credential chain)', () => {
+    bedrock({ model: 'eu.anthropic.claude-sonnet-4-6' });
+
+    expect(bedrockCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: DEFAULT_TIMEOUT_MS }),
+    );
+  });
+
+  it('bounds each request attempt with the default timeout (static keys)', () => {
+    bedrock({
+      model: 'eu.anthropic.claude-sonnet-4-6',
+      awsAccessKey: 'AKIA-test',
+      awsSecretKey: 'secret-test',
+    });
+
+    expect(bedrockCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: DEFAULT_TIMEOUT_MS }),
+    );
+  });
+
+  it('lets the host override the timeout', () => {
+    bedrock({ model: 'eu.anthropic.claude-sonnet-4-6', timeoutMs: 45_000 });
+
+    expect(bedrockCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 45_000 }),
+    );
+  });
+});

--- a/packages/provider-mistral/src/client-construction.spec.ts
+++ b/packages/provider-mistral/src/client-construction.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+import { DEFAULT_TIMEOUT_MS, mistral } from './mistral-provider';
+
+const mistralCtor = vi.hoisted(() => vi.fn());
+
+vi.mock('@mistralai/mistralai', () => ({ Mistral: mistralCtor }));
+
+beforeEach(() => {
+  mistralCtor.mockClear();
+});
+
+describe('mistral client construction', () => {
+  it('bounds the whole request with the default timeout', () => {
+    mistral({ apiKey: 'mistral-key', model: 'mistral-large-latest' });
+
+    expect(mistralCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: DEFAULT_TIMEOUT_MS }),
+    );
+  });
+
+  it('lets the host override the timeout', () => {
+    mistral({
+      apiKey: 'mistral-key',
+      model: 'mistral-large-latest',
+      timeoutMs: 60_000,
+    });
+
+    expect(mistralCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 60_000 }),
+    );
+  });
+});

--- a/packages/provider-mistral/src/mistral-provider.ts
+++ b/packages/provider-mistral/src/mistral-provider.ts
@@ -15,6 +15,15 @@ import {
   convertToolChoice,
 } from './convert-request';
 
+// Hard ceiling on the WHOLE request, stream consumption included: the Mistral
+// SDK arms AbortSignal.timeout(timeoutMs) as the fetch signal, which stays
+// active while the body streams. Generous on purpose — long healthy chat
+// streams must fit — while still bounding a stalled connection, which
+// previously hung forever (the SDK has no default timeout). Note: the SDK
+// skips this when a per-request signal is supplied, so a host-provided
+// AbortSignal takes over the deadline entirely.
+export const DEFAULT_TIMEOUT_MS = 300_000;
+
 export interface MistralProviderOptions {
   apiKey: string;
   /** Mistral model id, e.g. 'mistral-large-latest'. */
@@ -22,6 +31,8 @@ export interface MistralProviderOptions {
   baseUrl?: string;
   /** SDK-level retry budget for transient failures. Default: SDK default. */
   maxRetries?: number;
+  /** Whole-request timeout in ms, stream included. Default: 300s. */
+  timeoutMs?: number;
 }
 
 /**
@@ -33,6 +44,7 @@ export interface MistralProviderOptions {
 export const mistral = (options: MistralProviderOptions): ModelProvider => {
   const client = new Mistral({
     apiKey: options.apiKey,
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     ...(options.baseUrl ? { serverURL: options.baseUrl } : {}),
     ...(options.maxRetries !== undefined
       ? { retryConfig: toRetryConfig(options.maxRetries) }

--- a/packages/provider-openai/src/client-construction.spec.ts
+++ b/packages/provider-openai/src/client-construction.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+import { azure, DEFAULT_TIMEOUT_MS, openai } from './openai-provider';
+
+const openaiCtor = vi.hoisted(() => vi.fn());
+const azureCtor = vi.hoisted(() => vi.fn());
+
+vi.mock('openai', () => ({ default: openaiCtor, AzureOpenAI: azureCtor }));
+
+beforeEach(() => {
+  openaiCtor.mockClear();
+  azureCtor.mockClear();
+});
+
+describe('openai client construction', () => {
+  it('bounds each request attempt with the default timeout', () => {
+    openai({ apiKey: 'sk-test', model: 'gpt-5.4' });
+
+    expect(openaiCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: DEFAULT_TIMEOUT_MS }),
+    );
+  });
+
+  it('lets the host override the timeout', () => {
+    openai({ apiKey: 'sk-test', model: 'gpt-5.4', timeoutMs: 45_000 });
+
+    expect(openaiCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 45_000 }),
+    );
+  });
+});
+
+describe('azure client construction', () => {
+  it('bounds each request attempt with the default timeout', () => {
+    azure({
+      apiKey: 'azure-key',
+      endpoint: 'https://my-resource.openai.azure.com',
+      apiVersion: '2024-10-21',
+      model: 'gpt-5.4',
+    });
+
+    expect(azureCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: DEFAULT_TIMEOUT_MS }),
+    );
+  });
+
+  it('lets the host override the timeout', () => {
+    azure({
+      apiKey: 'azure-key',
+      endpoint: 'https://my-resource.openai.azure.com',
+      apiVersion: '2024-10-21',
+      model: 'gpt-5.4',
+      timeoutMs: 45_000,
+    });
+
+    expect(azureCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 45_000 }),
+    );
+  });
+});

--- a/packages/provider-openai/src/openai-provider.ts
+++ b/packages/provider-openai/src/openai-provider.ts
@@ -14,6 +14,13 @@ import {
   convertToolChoice,
 } from './convert-request';
 
+// Bounds each connection attempt — the SDK aborts if the response hasn't
+// started, and clears the timer once streaming begins, so long healthy
+// streams are unaffected. Well below the SDK's 10-minute default so a
+// stalled connection surfaces as a retryable error instead of hanging the
+// caller. Hosts can override via `timeoutMs`.
+export const DEFAULT_TIMEOUT_MS = 120_000;
+
 export interface OpenAIProviderOptions {
   apiKey: string;
   /** OpenAI model id, e.g. 'gpt-4.1'. */
@@ -21,6 +28,8 @@ export interface OpenAIProviderOptions {
   baseUrl?: string;
   /** SDK-level retry count for transient failures. Default: 2. */
   maxRetries?: number;
+  /** Per-attempt timeout in ms until the response starts. Default: 120s. */
+  timeoutMs?: number;
 }
 
 export interface AzureProviderOptions {
@@ -33,6 +42,8 @@ export interface AzureProviderOptions {
   model: string;
   /** SDK-level retry count for transient failures. Default: 2. */
   maxRetries?: number;
+  /** Per-attempt timeout in ms until the response starts. Default: 120s. */
+  timeoutMs?: number;
 }
 
 /**
@@ -43,6 +54,7 @@ export interface AzureProviderOptions {
 export const openai = (options: OpenAIProviderOptions): ModelProvider => {
   const client = new OpenAI({
     apiKey: options.apiKey,
+    timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     ...(options.baseUrl ? { baseURL: options.baseUrl } : {}),
     ...(options.maxRetries !== undefined
       ? { maxRetries: options.maxRetries }
@@ -61,6 +73,7 @@ export const azure = (options: AzureProviderOptions): ModelProvider => {
     apiKey: options.apiKey,
     endpoint: options.endpoint,
     apiVersion: options.apiVersion,
+    timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     ...(options.maxRetries !== undefined
       ? { maxRetries: options.maxRetries }
       : {}),


### PR DESCRIPTION
- Chat providers (anthropic, bedrock, openai, azure): per-attempt timeout
  of 120s until response start, replacing the 10-minute SDK default; the
  timer clears once streaming begins so long healthy streams are unaffected
- Mistral chat provider: 300s whole-request ceiling (the Mistral SDK arms
  the timeout signal for the entire request including stream consumption,
  and previously had NO timeout at all)
- Mistral embeddings: 30s per attempt (healthy p95 ~1.3s; observed hangs of
  316-447s blocked runs and wedged slots in the global embeddings queue)
- OpenAI embeddings: 30s per attempt
- Mistral OCR file retriever: 120s per attempt instead of 5 minutes
  (healthy OCR p95 ~27s, slowest observed success ~115s), stop retrying
  non-transient 4xx errors, and split processFile into helpers to satisfy
  the max-lines gate
- New shared isTransientMistralError predicate: retries rate limits,
  5xx, client-side timeouts and connection failures; timeouts are now
  retryable because each attempt is bounded
- All timeouts overridable via provider options (timeoutMs)

Production evidence and analysis: AYC-422/AYC-423. Root-cause A/B for the
underlying stalls runs separately (node 24 runtime pin, PR #1001).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core inference, embeddings queue, and OCR paths with tighter timeouts that could cause more retries or failures on slow but valid requests; behavior is mitigated by overrides and production-tuned limits.
> 
> **Overview**
> Addresses **AYC-422** by replacing long or missing SDK timeouts with explicit per-client limits so stalled upstream calls fail fast, release queue slots, and can retry instead of hanging runs.
> 
> **Chat inference packages** now pass default timeouts into SDK clients: **120s** until the response starts for Anthropic, Bedrock, OpenAI, and Azure (overridable via `timeoutMs`); **300s** whole-request for Mistral chat (stream included). **Embeddings** use **30s** per attempt on Mistral and OpenAI handlers.
> 
> **Mistral OCR file retrieval** drops the **5-minute** client timeout to **120s**, refactors `processFile` into upload/OCR/delete helpers, and wires **`retryIfError: isTransientMistralError`** on all file API retries.
> 
> A new shared **`isTransientMistralError`** helper centralizes retry eligibility (429, 5xx, timeouts, connection errors); Mistral embeddings switch from `SDKError` checks to this predicate. Tests cover the predicate, handler timeouts, and provider client construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99865d60912ee373d857cfe542e6dc91e4a7b085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->