### PR TITLE
feat(ui): port new-chat settle and loading orb animations from redesign (AYC-94)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/ui/AssistantRunBlock.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/AssistantRunBlock.tsx
@@ -1,9 +1,6 @@
 import { useRef } from 'react';
-import { Avatar, AvatarFallback } from '@/shared/ui/shadcn/avatar';
-import { useTheme } from '@/features/theme';
 import { cn } from '@/shared/lib/shadcn/utils';
-import brandIconLight from '@/shared/assets/brand/brand-icon-round-light.svg';
-import brandIconDark from '@/shared/assets/brand/brand-icon-round-dark.svg';
+import { AyunisProgressOrb } from '@/widgets/ayunis-progress-orb';
 import { AgentRunTimeline } from '@/pages/chat/ui/agent-run-timeline';
 import type { AgentRunUnit } from '@/pages/chat/ui/agent-run-timeline';
 import CopyAssistantTextButton from './CopyAssistantTextButton';
@@ -21,7 +18,6 @@ export default function AssistantRunBlock({
   threadId,
   onOpenArtifact,
 }: Readonly<AssistantRunBlockProps>) {
-  const { theme } = useTheme();
   const contentRef = useRef<HTMLDivElement>(null);
   const hasFinalText = unit.finalText.length > 0;
 
@@ -30,15 +26,7 @@ export default function AssistantRunBlock({
       className={cn('flex flex-col items-start gap-2', !hideAvatar && 'mt-4')}
     >
       {!hideAvatar && (
-        <Avatar className="h-8 w-8">
-          <AvatarFallback>
-            <img
-              src={theme === 'dark' ? brandIconDark : brandIconLight}
-              alt="Ayunis Logo"
-              className="h-8 w-8 object-contain"
-            />
-          </AvatarFallback>
-        </Avatar>
+        <AyunisProgressOrb isActive={unit.isStreaming} aria-label="Ayunis" />
       )}
       <div className="max-w-2xl min-w-0 space-y-1 w-full">
         <div

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -1,10 +1,8 @@
 import { useState, useRef, useCallback, useMemo, lazy, Suspense } from 'react';
 import ChatInterfaceLayout from '@/layouts/chat-interface-layout/ui/ChatInterfaceLayout';
-import ChatMessage from '@/pages/chat/ui/ChatMessage';
-import AssistantRunBlock from '@/pages/chat/ui/AssistantRunBlock';
-import LoadingAssistantBlock from '@/pages/chat/ui/LoadingAssistantBlock';
+import { ChatThreadContent } from '@/pages/chat/ui/ChatThreadContent';
 import { groupMessagesIntoRuns } from '@/pages/chat/ui/agent-run-timeline';
-import ChatInput from '@/widgets/chat-input';
+import ChatInput, { getChatInputSubmissionState } from '@/widgets/chat-input';
 import { useMessageSend } from '../api/useMessageSend';
 import ChatHeader from './ChatHeader';
 import LongChatWarning from './LongChatWarning';
@@ -373,44 +371,26 @@ export default function ChatPage({
       groupMessagesIntoRuns(sortedMessages, {
         isStreaming,
         toolResultsByToolId,
+        hasPendingUserTurn: pendingSubmission !== null,
       }),
-    [sortedMessages, isStreaming, toolResultsByToolId],
+    [sortedMessages, isStreaming, toolResultsByToolId, pendingSubmission],
   );
 
   const lastUnitKind =
     renderUnits.length > 0
       ? renderUnits[renderUnits.length - 1].kind
       : undefined;
-  const showPendingUserBubble = pendingSubmission !== null;
   const showLoadingPlaceholder =
     pendingSubmission !== null || (isStreaming && lastUnitKind === 'user');
 
   const chatContent = (
-    <div className="p-4 pb-8">
-      {renderUnits.map((unit, i) => {
-        if (unit.kind === 'user') {
-          return <ChatMessage key={unit.key} message={unit.message} />;
-        }
-        const previousUnit = i > 0 ? renderUnits[i - 1] : undefined;
-        const hideAvatar = previousUnit?.kind === 'agent-run';
-        return (
-          <AssistantRunBlock
-            key={unit.key}
-            unit={unit}
-            hideAvatar={hideAvatar}
-            threadId={thread.id}
-            onOpenArtifact={handleOpenArtifact}
-          />
-        );
-      })}
-      {showPendingUserBubble && (
-        <ChatMessage
-          key="pending-user"
-          message={makePendingUserMessage(pendingSubmission)}
-        />
-      )}
-      {showLoadingPlaceholder && <LoadingAssistantBlock />}
-    </div>
+    <ChatThreadContent
+      renderUnits={renderUnits}
+      threadId={thread.id}
+      pendingSubmission={pendingSubmission}
+      showLoadingPlaceholder={showLoadingPlaceholder}
+      onOpenArtifact={handleOpenArtifact}
+    />
   );
 
   // Controls are always disabled — thread already has messages
@@ -430,7 +410,10 @@ export default function ChatPage({
         knowledgeBases={thread.knowledgeBases}
         mcpIntegrations={thread.mcpIntegrations}
         isAnonymous={thread.isAnonymous}
-        submissionState={isStreaming ? 'streaming' : 'idle'}
+        submissionState={getChatInputSubmissionState(
+          isStreaming,
+          pendingSubmission,
+        )}
         isSendDisabled={isSendDisabled}
         onModelChange={() => {}}
         onFileUpload={handleFileUpload}
@@ -488,13 +471,4 @@ export default function ChatPage({
       />
     </AppLayout>
   );
-}
-
-function makePendingUserMessage(text: string): Message {
-  return {
-    id: 'pending-user-message',
-    role: 'user',
-    content: [{ type: 'text', text }],
-    createdAt: new Date().toISOString(),
-  } as unknown as Message;
 }

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatThreadContent.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatThreadContent.tsx
@@ -1,0 +1,60 @@
+import ChatMessage from '@/pages/chat/ui/ChatMessage';
+import AssistantRunBlock from '@/pages/chat/ui/AssistantRunBlock';
+import LoadingAssistantBlock from '@/pages/chat/ui/LoadingAssistantBlock';
+import type { RenderUnit } from '@/pages/chat/ui/agent-run-timeline';
+import type { Message } from '@/pages/chat/model/openapi';
+
+interface ChatThreadContentProps {
+  readonly renderUnits: readonly RenderUnit[];
+  readonly threadId: string;
+  readonly pendingSubmission: string | null;
+  readonly showLoadingPlaceholder: boolean;
+  readonly onOpenArtifact: (artifactId: string) => void;
+}
+
+export function ChatThreadContent({
+  renderUnits,
+  threadId,
+  pendingSubmission,
+  showLoadingPlaceholder,
+  onOpenArtifact,
+}: ChatThreadContentProps) {
+  const showPendingUserBubble = pendingSubmission !== null;
+
+  return (
+    <div className="p-4 pb-8">
+      {renderUnits.map((unit, i) => {
+        if (unit.kind === 'user') {
+          return <ChatMessage key={unit.key} message={unit.message} />;
+        }
+        const previousUnit = i > 0 ? renderUnits[i - 1] : undefined;
+        const hideAvatar = previousUnit?.kind === 'agent-run';
+        return (
+          <AssistantRunBlock
+            key={unit.key}
+            unit={unit}
+            hideAvatar={hideAvatar}
+            threadId={threadId}
+            onOpenArtifact={onOpenArtifact}
+          />
+        );
+      })}
+      {showPendingUserBubble && (
+        <ChatMessage
+          key="pending-user"
+          message={makePendingUserMessage(pendingSubmission)}
+        />
+      )}
+      {showLoadingPlaceholder && <LoadingAssistantBlock />}
+    </div>
+  );
+}
+
+function makePendingUserMessage(text: string): Message {
+  return {
+    id: 'pending-user-message',
+    role: 'user',
+    content: [{ type: 'text', text }],
+    createdAt: new Date().toISOString(),
+  } as unknown as Message;
+}

--- a/ayunis-core-frontend/src/pages/chat/ui/LoadingAssistantBlock.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/LoadingAssistantBlock.tsx
@@ -1,22 +1,9 @@
-import { Avatar, AvatarFallback } from '@/shared/ui/shadcn/avatar';
-import { useTheme } from '@/features/theme';
-import brandIconLight from '@/shared/assets/brand/brand-icon-round-light.svg';
-import brandIconDark from '@/shared/assets/brand/brand-icon-round-dark.svg';
+import { AyunisProgressOrb } from '@/widgets/ayunis-progress-orb';
 
 export default function LoadingAssistantBlock() {
-  const { theme } = useTheme();
-
   return (
     <div className="flex flex-col items-start gap-2 mt-4">
-      <Avatar className="h-8 w-8 animate-pulse">
-        <AvatarFallback>
-          <img
-            src={theme === 'dark' ? brandIconDark : brandIconLight}
-            alt="Ayunis Logo"
-            className="h-8 w-8 object-contain"
-          />
-        </AvatarFallback>
-      </Avatar>
+      <AyunisProgressOrb isActive aria-label="Ayunis arbeitet" />
     </div>
   );
 }

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/group-messages-into-runs.test.ts
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/group-messages-into-runs.test.ts
@@ -211,6 +211,21 @@ describe('groupMessagesIntoRuns', () => {
     ]);
   });
 
+  it('does not mark a prior agent-run as streaming while a new user turn is pending', () => {
+    const messages = [
+      userMessage('first'),
+      assistantMessage([{ type: 'text', text: 'reply' }]),
+    ];
+    const units = groupMessagesIntoRuns(messages, {
+      isStreaming: true,
+      toolResultsByToolId: {},
+      hasPendingUserTurn: true,
+    });
+    const run = units[1];
+    if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+    expect(run.isStreaming).toBe(false);
+  });
+
   it('marks only the last agent-run as streaming when isStreaming is true', () => {
     const messages = [
       userMessage('first'),

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/group-messages-into-runs.ts
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/group-messages-into-runs.ts
@@ -11,11 +11,17 @@ import { isRichTool } from './tool-classification';
 interface GroupingOptions {
   isStreaming: boolean;
   toolResultsByToolId: Readonly<Record<string, string>>;
+  /** New user turn is pending outside `messages` (optimistic bubble only). */
+  hasPendingUserTurn?: boolean;
 }
 
 export function groupMessagesIntoRuns(
   messages: readonly Message[],
-  { isStreaming, toolResultsByToolId }: GroupingOptions,
+  {
+    isStreaming,
+    toolResultsByToolId,
+    hasPendingUserTurn = false,
+  }: GroupingOptions,
 ): RenderUnit[] {
   const units: RenderUnit[] = [];
   let currentRun: AgentRunUnit | null = null;
@@ -66,7 +72,7 @@ export function groupMessagesIntoRuns(
 
   closeRun();
 
-  if (isStreaming && units.length > 0) {
+  if (isStreaming && !hasPendingUserTurn && units.length > 0) {
     const lastUnit = units[units.length - 1];
     if (lastUnit.kind === 'agent-run') {
       lastUnit.isStreaming = true;

--- a/ayunis-core-frontend/src/pages/new-chat/api/useInitiateChat.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/api/useInitiateChat.tsx
@@ -25,6 +25,14 @@ import type { SourceResponseDtoType } from '@/shared/api';
 const PROCESSING_POLL_INTERVAL_MS = 500;
 const PROCESSING_TIMEOUT_MS = 180_000;
 const UPLOAD_TIMEOUT_MS = 60_000;
+/** Compose slide duration (matches --new-chat-settle-duration in CSS) */
+const NEW_CHAT_SETTLE_MS = 1450;
+/** Disclaimer soft fade after slide (matches --new-chat-disclaimer-fade-duration) */
+const NEW_CHAT_DISCLAIMER_FADE_MS = 900;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 interface PendingSource {
   id: string;
@@ -86,11 +94,34 @@ export const useInitiateChat = (options?: { onSuccess?: () => void }) => {
   const queryClient = useQueryClient();
   const createThreadMutation = useThreadsControllerCreate();
   const [isAttachingResources, setIsAttachingResources] = useState(false);
+  const [isSettlingLayout, setIsSettlingLayout] = useState(false);
+  const settleStartedAtRef = useRef<number | null>(null);
 
   // Cancellation flag is a ref because we want `cancel()` to flip it
   // synchronously and have any in-flight pipeline observe it on the next
   // checkpoint, without dragging it through the dependency graph.
   const cancelledRef = useRef(false);
+
+  function beginSettleAnimation(): void {
+    settleStartedAtRef.current = Date.now();
+    setIsSettlingLayout(true);
+  }
+
+  function endSettleAnimation(): void {
+    settleStartedAtRef.current = null;
+    setIsSettlingLayout(false);
+  }
+
+  async function waitForSettleAnimation(): Promise<void> {
+    const startedAt = settleStartedAtRef.current;
+    if (startedAt === null) return;
+    const elapsed = Date.now() - startedAt;
+    const totalMs = NEW_CHAT_SETTLE_MS + NEW_CHAT_DISCLAIMER_FADE_MS + 80;
+    const remaining = totalMs - elapsed;
+    if (remaining > 0) {
+      await sleep(remaining);
+    }
+  }
 
   async function uploadOneSource(
     threadId: string,
@@ -186,6 +217,7 @@ export const useInitiateChat = (options?: { onSuccess?: () => void }) => {
     onSourceStatus,
   }: InitiateChatParams): Promise<void> {
     cancelledRef.current = false;
+    beginSettleAnimation();
     const isCancelled = () => cancelledRef.current;
 
     let thread;
@@ -200,16 +232,20 @@ export const useInitiateChat = (options?: { onSuccess?: () => void }) => {
     } catch (error) {
       console.error('Failed to create thread:', error);
       showError(t('chat.errorSendMessage'));
+      endSettleAnimation();
       return;
     }
-    if (isCancelled()) return;
+    if (isCancelled()) {
+      endSettleAnimation();
+      return;
+    }
 
     if (
       sources.length === 0 &&
       knowledgeBases.length === 0 &&
       mcpIntegrations.length === 0
     ) {
-      finalizeAndNavigate(thread.id, message);
+      await finalizeAndNavigate(thread.id, message);
       return;
     }
 
@@ -217,14 +253,21 @@ export const useInitiateChat = (options?: { onSuccess?: () => void }) => {
     try {
       if (sources.length > 0) {
         const ok = await uploadAllSources(thread.id, sources, onSourceStatus);
-        if (!ok || isCancelled()) return;
+        if (!ok || isCancelled()) {
+          endSettleAnimation();
+          return;
+        }
 
         try {
           await waitForSourcesProcessed(thread.id, isCancelled);
         } catch (error) {
-          if (error instanceof CancelledError) return;
+          if (error instanceof CancelledError) {
+            endSettleAnimation();
+            return;
+          }
           console.error('Source processing failed or timed out:', error);
           showError(tCommon('sources.fileSourceTimeoutError'));
+          endSettleAnimation();
           return;
         }
       }
@@ -234,22 +277,45 @@ export const useInitiateChat = (options?: { onSuccess?: () => void }) => {
         knowledgeBases,
         isCancelled,
       );
-      if (!kbOk || isCancelled()) return;
+      if (!kbOk || isCancelled()) {
+        endSettleAnimation();
+        return;
+      }
 
       const integrationsOk = await attachIntegrations(
         thread.id,
         mcpIntegrations,
         isCancelled,
       );
-      if (!integrationsOk || isCancelled()) return;
+      if (!integrationsOk || isCancelled()) {
+        endSettleAnimation();
+        return;
+      }
 
-      finalizeAndNavigate(thread.id, message);
+      await finalizeAndNavigate(thread.id, message);
     } finally {
       setIsAttachingResources(false);
     }
   }
 
-  function finalizeAndNavigate(threadId: string, message: string) {
+  async function finalizeAndNavigate(
+    threadId: string,
+    message: string,
+  ): Promise<void> {
+    if (cancelledRef.current) {
+      endSettleAnimation();
+      return;
+    }
+
+    await waitForSettleAnimation();
+
+    // Cancel may fire while the settle animation is running.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- ref toggled from cancel()
+    if (cancelledRef.current) {
+      endSettleAnimation();
+      return;
+    }
+
     void queryClient.invalidateQueries({
       queryKey: getThreadsControllerFindAllQueryKey(),
     });
@@ -258,18 +324,25 @@ export const useInitiateChat = (options?: { onSuccess?: () => void }) => {
     });
     setPendingMessage(message);
     options?.onSuccess?.();
+
+    // Keep settling state until unmount — avoids snapping back to --idle transform.
+    // No view transition: positions are aligned manually; morph caused the end snap.
     void navigate({ to: '/chats/$threadId', params: { threadId } });
   }
 
   function cancel() {
     cancelledRef.current = true;
     setIsAttachingResources(false);
+    endSettleAnimation();
   }
 
   return {
     initiateChat,
     cancel,
-    isCreating: createThreadMutation.isPending || isAttachingResources,
+    isCreating:
+      isSettlingLayout ||
+      createThreadMutation.isPending ||
+      isAttachingResources,
     error: createThreadMutation.error,
   };
 };

--- a/ayunis-core-frontend/src/pages/new-chat/model/useComposeLift.ts
+++ b/ayunis-core-frontend/src/pages/new-chat/model/useComposeLift.ts
@@ -1,0 +1,62 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+
+/**
+ * Measures how far the bottom-anchored compose block must be lifted so it
+ * appears vertically centered in the stage while idle. Re-measures on resize
+ * of either element; frozen while settling so the slide-down transition runs
+ * from the last idle position.
+ */
+export function useComposeLift(enabled: boolean, isSettling: boolean) {
+  const stageRef = useRef<HTMLDivElement>(null);
+  const composeRef = useRef<HTMLDivElement>(null);
+  const [liftPx, setLiftPx] = useState(0);
+
+  const measureLift = useCallback(() => {
+    if (isSettling) return;
+
+    const stage = stageRef.current;
+    const block = composeRef.current;
+    if (!stage || !block) return;
+
+    const lift = -((stage.clientHeight - block.offsetHeight) / 2);
+    const nextLift = Math.round(lift);
+
+    setLiftPx((prev) => {
+      if (prev === nextLift) return prev;
+      // Ignore sub-pixel layout churn (textarea autosize, fonts) while idle
+      if (prev !== 0 && Math.abs(prev - nextLift) <= 2) return prev;
+      return nextLift;
+    });
+  }, [isSettling]);
+
+  useLayoutEffect(() => {
+    if (!enabled || isSettling) return;
+    measureLift();
+  }, [enabled, measureLift, isSettling]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const stage = stageRef.current;
+    const block = composeRef.current;
+    if (!stage || !block) return;
+
+    const observer = new ResizeObserver(() => {
+      measureLift();
+    });
+    observer.observe(stage);
+    observer.observe(block);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [enabled, measureLift]);
+
+  return { stageRef, composeRef, liftPx };
+}

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatBackdrop.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatBackdrop.tsx
@@ -1,9 +1,61 @@
+import { cn } from '@/shared/lib/shadcn/utils';
+import { useCallback, useEffect, useRef } from 'react';
 import './new-chat-backdrop.css';
 
-export default function NewChatBackdrop() {
+export type NewChatBackdropPhase = 'idle' | 'exiting';
+
+/** Matches --new-chat-backdrop-exit-duration in new-chat-backdrop.css */
+const EXIT_MS = 1300;
+
+interface NewChatBackdropProps {
+  phase?: NewChatBackdropPhase;
+  /** Fired once when the exit fade has finished (transitionend or fallback). */
+  onExitComplete?: () => void;
+}
+
+export default function NewChatBackdrop({
+  phase = 'idle',
+  onExitComplete,
+}: Readonly<NewChatBackdropProps>) {
+  const canvasRef = useRef<HTMLDivElement>(null);
+  const exitDoneRef = useRef(false);
+  const isExiting = phase === 'exiting';
+
+  const finishExit = useCallback(() => {
+    if (exitDoneRef.current) return;
+    exitDoneRef.current = true;
+    onExitComplete?.();
+  }, [onExitComplete]);
+
+  useEffect(() => {
+    if (!isExiting) return;
+
+    const node = canvasRef.current;
+
+    function handleTransitionEnd(event: TransitionEvent) {
+      if (event.target !== node) return;
+      if (event.propertyName !== 'opacity') return;
+      finishExit();
+    }
+
+    node?.addEventListener('transitionend', handleTransitionEnd);
+    const timeoutId = window.setTimeout(finishExit, EXIT_MS + 80);
+
+    return () => {
+      node?.removeEventListener('transitionend', handleTransitionEnd);
+      window.clearTimeout(timeoutId);
+    };
+  }, [isExiting, finishExit]);
+
   return (
-    <div className="new-chat-backdrop" aria-hidden>
-      <div className="new-chat-backdrop__canvas">
+    <div
+      className={cn(
+        'new-chat-backdrop',
+        isExiting && 'new-chat-backdrop--exiting',
+      )}
+      aria-hidden
+    >
+      <div ref={canvasRef} className="new-chat-backdrop__canvas">
         <div className="new-chat-backdrop__blobs">
           <div className="new-chat-backdrop__blob is-1" />
           <div className="new-chat-backdrop__blob is-2" />

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -1,11 +1,12 @@
 import { Lock } from 'lucide-react';
-import NewChatPageLayout from './NewChatPageLayout';
+import NewChatPageLayout, { type NewChatMistPhase } from './NewChatPageLayout';
 import ChatInput, { type ChatInputRef } from '@/widgets/chat-input';
+import { cn } from '@/shared/lib/shadcn/utils';
 import {
   useInitiateChat,
   type SourceUploadStatus,
 } from '../api/useInitiateChat';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
 import { HelpLink } from '@/shared/ui/help-link/HelpLink';
@@ -110,6 +111,11 @@ export default function NewChatPage({
   >([]);
   const [selectedSkillId, setSelectedSkillId] = useState<string>();
   const [selectedSkillName, setSelectedSkillName] = useState<string>();
+  const [mistPhase, setMistPhase] = useState<NewChatMistPhase>('idle');
+
+  const handleMistExitComplete = useCallback(() => {
+    setMistPhase('hidden');
+  }, []);
   const selectedModel = models.find((m) => m.id === modelId);
 
   const isAnonymousEnforced = selectedModel?.anonymousOnly ?? false;
@@ -166,6 +172,8 @@ export default function NewChatPage({
       return;
     }
 
+    setMistPhase((current) => (current === 'idle' ? 'exiting' : current));
+
     setPendingImages(imageFiles && imageFiles.length > 0 ? imageFiles : []);
     setPendingSkillId(skillId);
 
@@ -213,66 +221,103 @@ export default function NewChatPage({
 
   return (
     <NewChatPageLayout
+      isSettling={isCreating}
+      mistPhase={mistPhase}
+      onMistExitComplete={handleMistExitComplete}
       header={
         <ContentAreaHeader
           breadcrumbs={[{ label: t('newChat.newChat') }]}
           action={<HelpLink path="" />}
         />
       }
-    >
-      <div className="text-center">
-        <h1 className="text-2xl font-bold">{greeting}</h1>
-      </div>
-      <div className="w-full flex flex-col gap-4 mt-2">
-        <ChatInput
-          ref={chatInputRef}
-          modelId={modelId}
-          sources={sources}
-          knowledgeBases={selectedKnowledgeBases}
-          mcpIntegrations={selectedIntegrations}
-          submissionState={isCreating ? 'submitting' : 'idle'}
-          onModelChange={handleModelChange}
-          onSend={handleSend}
-          onCancel={handleCancel}
-          onFileUpload={handleFileUpload}
-          onRemoveSource={handleRemoveSource}
-          onDownloadSource={() => null}
-          onAddKnowledgeBase={(kb) => {
-            setSelectedKnowledgeBases((prev) => [...prev, kb]);
-          }}
-          onRemoveKnowledgeBase={(kbId) => {
-            setSelectedKnowledgeBases((prev) =>
-              prev.filter((kb) => kb.id !== kbId),
-            );
-          }}
-          onAddIntegration={(integration) => {
-            setSelectedIntegrations((prev) => [...prev, integration]);
-          }}
-          onRemoveIntegration={(integrationId) => {
-            setSelectedIntegrations((prev) =>
-              prev.filter((integration) => integration.id !== integrationId),
-            );
-          }}
-          isEmbeddingModelEnabled={isEmbeddingModelEnabled}
-          isAnonymous={isAnonymous}
-          onAnonymousChange={setIsAnonymous}
-          isAnonymousEnforced={isAnonymousEnforced}
-          isVisionEnabled={isVisionEnabled}
-          selectedSkillId={selectedSkillId}
-          selectedSkillName={selectedSkillName}
-          onSkillRemove={handleSkillRemove}
-        />
-        <OnboardingTourTarget name={TOUR_TARGET.pinnedSkills} settleMs={900}>
-          <PinnedSkills
-            onSkillSelect={handleSkillSelect}
-            selectedSkillId={selectedSkillId}
-          />
-        </OnboardingTourTarget>
-        <div className="flex justify-center items-center gap-1.5 text-xs text-muted-foreground">
-          <Lock className="h-3 w-3" />
-          <span>{t('newChat.privacyHint')}</span>
-        </div>
-      </div>
-    </NewChatPageLayout>
+      compose={
+        <>
+          <h1
+            className={cn(
+              'new-chat-greeting text-center text-2xl font-bold',
+              isCreating && 'new-chat-greeting--exit',
+            )}
+            aria-hidden={isCreating}
+          >
+            {greeting}
+          </h1>
+
+          <div className="new-chat-input-stack relative w-full">
+            <p
+              className={cn(
+                'new-chat-disclaimer absolute bottom-full left-0 right-0 mb-2 text-center text-xs text-muted-foreground',
+                isCreating && 'new-chat-disclaimer--visible',
+              )}
+              aria-hidden={!isCreating}
+            >
+              {t('chat.inputDisclaimer')}
+            </p>
+
+            <ChatInput
+              ref={chatInputRef}
+              modelId={modelId}
+              sources={sources}
+              knowledgeBases={selectedKnowledgeBases}
+              mcpIntegrations={selectedIntegrations}
+              submissionState={isCreating ? 'submitting' : 'idle'}
+              onModelChange={handleModelChange}
+              onSend={handleSend}
+              onCancel={handleCancel}
+              onFileUpload={handleFileUpload}
+              onRemoveSource={handleRemoveSource}
+              onDownloadSource={() => null}
+              onAddKnowledgeBase={(kb) => {
+                setSelectedKnowledgeBases((prev) => [...prev, kb]);
+              }}
+              onRemoveKnowledgeBase={(kbId) => {
+                setSelectedKnowledgeBases((prev) =>
+                  prev.filter((kb) => kb.id !== kbId),
+                );
+              }}
+              onAddIntegration={(integration) => {
+                setSelectedIntegrations((prev) => [...prev, integration]);
+              }}
+              onRemoveIntegration={(integrationId) => {
+                setSelectedIntegrations((prev) =>
+                  prev.filter(
+                    (integration) => integration.id !== integrationId,
+                  ),
+                );
+              }}
+              isEmbeddingModelEnabled={isEmbeddingModelEnabled}
+              isAnonymous={isAnonymous}
+              onAnonymousChange={setIsAnonymous}
+              isAnonymousEnforced={isAnonymousEnforced}
+              isVisionEnabled={isVisionEnabled}
+              selectedSkillId={selectedSkillId}
+              selectedSkillName={selectedSkillName}
+              onSkillRemove={handleSkillRemove}
+            />
+          </div>
+
+          <div
+            className={cn(
+              'new-chat-dock-extras mt-4 flex flex-col gap-4 overflow-hidden',
+              isCreating && 'new-chat-dock-extras--collapsed',
+            )}
+            aria-hidden={isCreating}
+          >
+            <OnboardingTourTarget
+              name={TOUR_TARGET.pinnedSkills}
+              settleMs={900}
+            >
+              <PinnedSkills
+                onSkillSelect={handleSkillSelect}
+                selectedSkillId={selectedSkillId}
+              />
+            </OnboardingTourTarget>
+            <div className="flex justify-center items-center gap-1.5 text-xs text-muted-foreground">
+              <Lock className="h-3 w-3 shrink-0" />
+              <span>{t('newChat.privacyHint')}</span>
+            </div>
+          </div>
+        </>
+      }
+    />
   );
 }

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPageLayout.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPageLayout.tsx
@@ -1,27 +1,81 @@
 import AppLayout from '@/layouts/app-layout';
-import NewChatBackdrop from './NewChatBackdrop';
+import { cn } from '@/shared/lib/shadcn/utils';
+import NewChatBackdrop, { type NewChatBackdropPhase } from './NewChatBackdrop';
+import { useComposeLift } from '../model/useComposeLift';
+
+export type NewChatMistPhase = NewChatBackdropPhase | 'hidden';
 
 interface NewChatPageLayoutProps {
   header: React.ReactNode;
-  children: React.ReactNode;
+  /** Centered content (personalization, errors) */
+  children?: React.ReactNode;
+  /** Greeting + input stack; lifted when idle, slides to chat dock when settling */
+  compose?: React.ReactNode;
+  isSettling?: boolean;
+  mistPhase?: NewChatMistPhase;
+  onMistExitComplete?: () => void;
 }
 
 export default function NewChatPageLayout({
   header,
   children,
+  compose,
+  isSettling = false,
+  mistPhase = 'idle',
+  onMistExitComplete,
 }: Readonly<NewChatPageLayoutProps>) {
+  const useComposeLayout = compose !== undefined;
+  const { stageRef, composeRef, liftPx } = useComposeLift(
+    useComposeLayout,
+    isSettling,
+  );
+
   return (
     <AppLayout>
       <div className="absolute inset-0 overflow-hidden">
-        <NewChatBackdrop />
-        <div className="content-area-page-header">{header}</div>
-        <div className="absolute inset-0 z-[1] flex items-center justify-center px-4">
-          {/* Entrance animation: 200ms delay + 700ms = 900ms. Tour targets inside
-              (e.g. sendMessage, pinnedSkills) mirror this via settleMs so the
-              spotlight measures them only after they settle. */}
-          <div className="w-full max-w-[800px] flex flex-col gap-4 animate-in fade-in-0 slide-in-from-bottom-2 duration-700 fill-mode-both [animation-delay:200ms]">
-            {children}
-          </div>
+        {mistPhase !== 'hidden' && (
+          <NewChatBackdrop
+            phase={mistPhase}
+            onExitComplete={onMistExitComplete}
+          />
+        )}
+        <div className="absolute inset-0 z-[1] flex min-h-0 flex-col">
+          <div className="content-area-page-header">{header}</div>
+
+          {useComposeLayout ? (
+            <div
+              ref={stageRef}
+              className="flex min-h-0 flex-1 flex-col justify-end px-4 pb-4"
+            >
+              <div
+                ref={composeRef}
+                className={cn(
+                  'new-chat-compose mx-auto w-full max-w-[800px]',
+                  isSettling
+                    ? 'new-chat-compose--settling'
+                    : 'new-chat-compose--idle',
+                )}
+                style={
+                  isSettling
+                    ? undefined
+                    : ({
+                        '--new-chat-lift': `${liftPx}px`,
+                      } as React.CSSProperties)
+                }
+              >
+                {/* Entrance animation: 200ms delay + 700ms = 900ms. Tour targets
+                    inside mirror this via settleMs. Lives on an inner wrapper so
+                    its keyframe transform doesn't override the lift transform. */}
+                <div className="new-chat-compose__content flex w-full flex-col gap-4 animate-in fade-in-0 slide-in-from-bottom-2 duration-700 fill-mode-both [animation-delay:200ms]">
+                  {compose}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="flex min-h-0 flex-1 flex-col items-center justify-center overflow-y-auto px-4 pb-4">
+              <div className="w-full max-w-[800px]">{children}</div>
+            </div>
+          )}
         </div>
       </div>
     </AppLayout>

--- a/ayunis-core-frontend/src/pages/new-chat/ui/new-chat-backdrop.css
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/new-chat-backdrop.css
@@ -1,5 +1,7 @@
 .new-chat-backdrop {
   --new-chat-backdrop-scale: 0.58;
+  --new-chat-backdrop-exit-duration: 1.3s;
+  --new-chat-backdrop-exit-ease: cubic-bezier(0.22, 1, 0.36, 1);
 
   --backdrop-blob-color: var(--brand);
 
@@ -37,6 +39,12 @@
   inset: 0;
   overflow: hidden;
   pointer-events: none;
+  opacity: 1;
+  transition:
+    opacity var(--new-chat-backdrop-exit-duration)
+      var(--new-chat-backdrop-exit-ease),
+    transform var(--new-chat-backdrop-exit-duration)
+      var(--new-chat-backdrop-exit-ease);
   animation: newChatBackdropAppear 1.8s cubic-bezier(0.22, 1, 0.36, 1) 0.4s both;
   background: linear-gradient(
     180deg,
@@ -50,6 +58,18 @@
       68%,
     color-mix(in oklab, var(--brand) 13%, var(--background)) 100%
   );
+}
+
+/* animation: none lets the exit transition win over the appear animation
+   even when the user sends before the entrance has finished */
+.new-chat-backdrop--exiting .new-chat-backdrop__canvas {
+  animation: none;
+  opacity: 0;
+  transform: translate3d(0, 18%, 0);
+}
+
+.new-chat-backdrop--exiting .new-chat-backdrop__blob {
+  animation-play-state: paused !important;
 }
 
 @keyframes newChatBackdropAppear {
@@ -175,6 +195,12 @@
 @media (prefers-reduced-motion: reduce) {
   .new-chat-backdrop__canvas {
     animation: none;
+    transition: none;
+  }
+
+  .new-chat-backdrop--exiting .new-chat-backdrop__canvas {
+    opacity: 0;
+    transform: none;
   }
 
   .new-chat-backdrop__blob {

--- a/ayunis-core-frontend/src/widgets/ayunis-progress-orb/index.ts
+++ b/ayunis-core-frontend/src/widgets/ayunis-progress-orb/index.ts
@@ -1,0 +1,1 @@
+export { AyunisProgressOrb } from './ui/AyunisProgressOrb';

--- a/ayunis-core-frontend/src/widgets/ayunis-progress-orb/ui/AyunisProgressOrb.tsx
+++ b/ayunis-core-frontend/src/widgets/ayunis-progress-orb/ui/AyunisProgressOrb.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState, type AnimationEvent } from 'react';
+import { cn } from '@/shared/lib/shadcn/utils';
+import './ayunis-progress-orb.css';
+
+type OrbPhase = 'hidden' | 'working' | 'completing';
+
+interface AyunisProgressOrbProps {
+  /** True while Ayunis is working on the current task. */
+  isActive: boolean;
+  size?: 'sm' | 'md';
+  className?: string;
+  'aria-label'?: string;
+}
+
+const DISSOLVE_FALLBACK_MS = 900;
+
+function initialPhase(isActive: boolean): OrbPhase {
+  return isActive ? 'working' : 'hidden';
+}
+
+export function AyunisProgressOrb({
+  isActive,
+  size = 'sm',
+  className,
+  'aria-label': ariaLabel = 'Ayunis',
+}: Readonly<AyunisProgressOrbProps>) {
+  const [phase, setPhase] = useState<OrbPhase>(() => initialPhase(isActive));
+  const [prevIsActive, setPrevIsActive] = useState(isActive);
+
+  if (isActive !== prevIsActive) {
+    setPrevIsActive(isActive);
+    if (isActive) {
+      setPhase('working');
+    } else {
+      setPhase((current) => (current === 'working' ? 'completing' : current));
+    }
+  }
+
+  useEffect(() => {
+    if (phase !== 'completing') return;
+
+    const timeoutId = window.setTimeout(() => {
+      setPhase('hidden');
+    }, DISSOLVE_FALLBACK_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [phase]);
+
+  const handleShellAnimationEnd = (event: AnimationEvent<HTMLDivElement>) => {
+    if (phase !== 'completing') return;
+    if (event.currentTarget !== event.target) return;
+    if (
+      event.animationName !== 'ayunis-orb-dissolve' &&
+      event.animationName !== 'ayunis-orb-dissolve-reduced'
+    ) {
+      return;
+    }
+    setPhase('hidden');
+  };
+
+  if (phase === 'hidden') {
+    return null;
+  }
+
+  const isWorking = phase === 'working';
+
+  return (
+    <div
+      className={cn(
+        'ayunis-progress-orb-shell',
+        size === 'md' && 'ayunis-progress-orb-shell--md',
+        isWorking && 'ayunis-progress-orb-shell--active',
+        phase === 'completing' && 'ayunis-progress-orb-shell--completing',
+        className,
+      )}
+      role="img"
+      aria-label={ariaLabel}
+      onAnimationEnd={handleShellAnimationEnd}
+    >
+      <div
+        className={cn(
+          'ayunis-progress-orb__motion',
+          isWorking && 'ayunis-progress-orb__motion--working',
+        )}
+        aria-hidden
+      >
+        <div className="ayunis-progress-orb">
+          <div className="ayunis-progress-orb__core" aria-hidden>
+            <span className="ayunis-progress-orb__blob ayunis-progress-orb__blob--1" />
+            <span className="ayunis-progress-orb__blob ayunis-progress-orb__blob--2" />
+            <span className="ayunis-progress-orb__blob ayunis-progress-orb__blob--3" />
+          </div>
+          <div className="ayunis-progress-orb__glass" aria-hidden />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/widgets/ayunis-progress-orb/ui/ayunis-progress-orb.css
+++ b/ayunis-core-frontend/src/widgets/ayunis-progress-orb/ui/ayunis-progress-orb.css
@@ -1,0 +1,405 @@
+/* Flat glass disc — theme tokens on shell; no drop shadow */
+
+.ayunis-progress-orb-shell {
+  --ayunis-orb-highlight: #e8e4f2;
+  --ayunis-orb-mid: #a799cf;
+  --ayunis-orb-shadow: #9f93d0;
+  --ayunis-orb-brand: #584b9a;
+  --ayunis-orb-brand-deep: #4a4088;
+  --ayunis-orb-base-top: rgba(248, 246, 252, 0.92);
+  --ayunis-orb-base-bottom: rgba(183, 171, 216, 0.88);
+  --ayunis-orb-base-mid: #d8d2eb;
+  --ayunis-orb-core-top: rgba(255, 255, 255, 0.2);
+  --ayunis-orb-core-mid: rgba(232, 228, 242, 0.35);
+  --ayunis-orb-core-bottom: rgba(167, 153, 207, 0.28);
+  --ayunis-orb-blob-brand-fade: rgba(88, 75, 154, 0.7);
+  --ayunis-orb-blob-deep-fade: rgba(74, 64, 136, 0.65);
+  --ayunis-orb-blob-light: rgba(216, 210, 235, 0.95);
+  --ayunis-orb-blob-light-fade: rgba(167, 153, 207, 0.45);
+  --ayunis-orb-blob-blend: multiply;
+  --ayunis-orb-blob-3-blend: soft-light;
+  --ayunis-orb-blob-opacity: 0.88;
+  --ayunis-orb-blob-3-opacity: 0.82;
+  --ayunis-orb-inset-top: rgba(255, 255, 255, 0.5);
+  --ayunis-orb-glass-top: rgba(255, 255, 255, 0.52);
+  --ayunis-orb-glass-mid: rgba(255, 255, 255, 0.14);
+  --ayunis-orb-glass-tint: rgba(232, 228, 242, 0.06);
+  --ayunis-orb-glass-bottom: rgba(255, 255, 255, 0.08);
+  --ayunis-orb-edge-border: rgba(255, 255, 255, 0.58);
+  --ayunis-orb-edge-recess: rgba(88, 75, 154, 0.16);
+  --ayunis-orb-glass-specular-strong: rgba(255, 255, 255, 0.62);
+  --ayunis-orb-glass-specular-soft: rgba(255, 255, 255, 0.22);
+  --ayunis-orb-backdrop-saturate: 1.12;
+  --orb-shell-size: 2rem;
+  --orb-size: 1.5rem;
+
+  position: relative;
+  display: grid;
+  flex-shrink: 0;
+  place-items: center;
+  width: var(--orb-shell-size);
+  height: var(--orb-shell-size);
+}
+
+:is(.dark, .theme-core.dark) .ayunis-progress-orb-shell {
+  --ayunis-orb-highlight: #3a364f;
+  --ayunis-orb-mid: #524d6c;
+  --ayunis-orb-shadow: #6a6488;
+  --ayunis-orb-brand: #a49fce;
+  --ayunis-orb-brand-deep: #8178c3;
+  --ayunis-orb-base-top: rgba(36, 33, 50, 0.96);
+  --ayunis-orb-base-bottom: rgba(58, 54, 78, 0.94);
+  --ayunis-orb-base-mid: #46415f;
+  --ayunis-orb-core-top: rgba(196, 191, 232, 0.14);
+  --ayunis-orb-core-mid: rgba(124, 117, 160, 0.28);
+  --ayunis-orb-core-bottom: rgba(74, 68, 102, 0.42);
+  --ayunis-orb-blob-brand-fade: rgba(164, 159, 206, 0.55);
+  --ayunis-orb-blob-deep-fade: rgba(129, 120, 195, 0.5);
+  --ayunis-orb-blob-light: rgba(196, 191, 232, 0.75);
+  --ayunis-orb-blob-light-fade: rgba(129, 120, 195, 0.35);
+  --ayunis-orb-blob-blend: screen;
+  --ayunis-orb-blob-3-blend: screen;
+  --ayunis-orb-blob-opacity: 0.92;
+  --ayunis-orb-blob-3-opacity: 0.78;
+  --ayunis-orb-inset-top: rgba(196, 191, 232, 0.22);
+  --ayunis-orb-glass-top: rgba(210, 205, 235, 0.22);
+  --ayunis-orb-glass-mid: rgba(164, 159, 206, 0.1);
+  --ayunis-orb-glass-tint: rgba(90, 84, 120, 0.12);
+  --ayunis-orb-glass-bottom: rgba(120, 114, 150, 0.1);
+  --ayunis-orb-edge-border: rgba(196, 191, 232, 0.28);
+  --ayunis-orb-edge-recess: rgba(12, 10, 22, 0.42);
+  --ayunis-orb-glass-specular-strong: rgba(220, 216, 242, 0.34);
+  --ayunis-orb-glass-specular-soft: rgba(164, 159, 206, 0.14);
+  --ayunis-orb-backdrop-saturate: 1.25;
+}
+
+.ayunis-progress-orb-shell--md {
+  --orb-shell-size: 9.25rem;
+  --orb-size: 6.5rem;
+}
+
+.ayunis-progress-orb__motion {
+  display: grid;
+  place-items: center;
+  width: var(--orb-size);
+  height: var(--orb-size);
+}
+
+.ayunis-progress-orb {
+  position: relative;
+  width: var(--orb-size);
+  height: var(--orb-size);
+  border-radius: 999px;
+  overflow: hidden;
+  isolation: isolate;
+  background: linear-gradient(
+    180deg,
+    var(--ayunis-orb-base-top) 0%,
+    var(--ayunis-orb-highlight) 38%,
+    var(--ayunis-orb-base-mid) 72%,
+    var(--ayunis-orb-base-bottom) 100%
+  );
+  box-shadow:
+    inset 0 1px 0 var(--ayunis-orb-inset-top),
+    inset 0 0 0 1px var(--ayunis-orb-edge-border),
+    inset 0 3px 10px var(--ayunis-orb-edge-recess);
+  transform: scale(1);
+}
+
+.ayunis-progress-orb-shell--active .ayunis-progress-orb {
+  animation: ayunis-orb-disc-wobble 4.2s cubic-bezier(0.45, 0.05, 0.55, 0.95)
+    infinite;
+  will-change: transform;
+}
+
+.ayunis-progress-orb-shell--completing .ayunis-progress-orb__motion {
+  animation: none;
+}
+
+.ayunis-progress-orb-shell--completing .ayunis-progress-orb {
+  transform: scale(1);
+  animation: ayunis-orb-disc-settle-round 0.22s ease-out forwards;
+}
+
+.ayunis-progress-orb-shell--completing {
+  animation: ayunis-orb-dissolve 0.58s ease-out 0.18s forwards;
+}
+
+.ayunis-progress-orb__core {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  overflow: hidden;
+  background: linear-gradient(
+    180deg,
+    var(--ayunis-orb-core-top) 0%,
+    var(--ayunis-orb-core-mid) 45%,
+    var(--ayunis-orb-core-bottom) 100%
+  );
+}
+
+.ayunis-progress-orb-shell--active .ayunis-progress-orb__core {
+  animation: ayunis-orb-core-swirl 7s linear infinite;
+}
+
+.ayunis-progress-orb__blob {
+  position: absolute;
+  border-radius: 999px;
+  filter: blur(0.28rem);
+  opacity: var(--ayunis-orb-blob-opacity);
+  will-change: transform;
+  mix-blend-mode: var(--ayunis-orb-blob-blend);
+}
+
+.ayunis-progress-orb__blob--1 {
+  width: 70%;
+  height: 48%;
+  left: 8%;
+  top: 28%;
+  background: radial-gradient(
+    ellipse 100% 80% at 50% 50%,
+    var(--ayunis-orb-brand) 0%,
+    var(--ayunis-orb-blob-brand-fade) 45%,
+    transparent 72%
+  );
+}
+
+.ayunis-progress-orb__blob--2 {
+  width: 64%;
+  height: 44%;
+  right: 4%;
+  bottom: 22%;
+  background: radial-gradient(
+    ellipse 100% 80% at 50% 50%,
+    var(--ayunis-orb-brand-deep) 0%,
+    var(--ayunis-orb-blob-deep-fade) 46%,
+    transparent 70%
+  );
+}
+
+.ayunis-progress-orb__blob--3 {
+  width: 58%;
+  height: 40%;
+  left: 20%;
+  bottom: 26%;
+  mix-blend-mode: var(--ayunis-orb-blob-3-blend);
+  opacity: var(--ayunis-orb-blob-3-opacity);
+  background: radial-gradient(
+    ellipse 100% 80% at 50% 50%,
+    var(--ayunis-orb-blob-light) 0%,
+    var(--ayunis-orb-blob-light-fade) 50%,
+    transparent 68%
+  );
+}
+
+.ayunis-progress-orb-shell--active .ayunis-progress-orb__blob--1 {
+  animation: ayunis-orb-blob-1 2.6s ease-in-out infinite;
+}
+
+.ayunis-progress-orb-shell--active .ayunis-progress-orb__blob--2 {
+  animation: ayunis-orb-blob-2 3.1s ease-in-out infinite;
+}
+
+.ayunis-progress-orb-shell--active .ayunis-progress-orb__blob--3 {
+  animation: ayunis-orb-blob-3 2.2s ease-in-out infinite;
+}
+
+/* Frosted glass plate on top — edge/recess live on .ayunis-progress-orb */
+.ayunis-progress-orb__glass {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  backdrop-filter: blur(2px) saturate(var(--ayunis-orb-backdrop-saturate));
+  background: linear-gradient(
+    180deg,
+    var(--ayunis-orb-glass-top) 0%,
+    var(--ayunis-orb-glass-mid) 28%,
+    var(--ayunis-orb-glass-tint) 55%,
+    var(--ayunis-orb-glass-bottom) 100%
+  );
+}
+
+/* Top specular band across the disc */
+.ayunis-progress-orb__glass::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(
+    180deg,
+    var(--ayunis-orb-glass-specular-strong) 0%,
+    var(--ayunis-orb-glass-specular-soft) 18%,
+    transparent 38%
+  );
+}
+
+.ayunis-progress-orb-shell--active .ayunis-progress-orb__glass {
+  animation: ayunis-orb-glass-shimmer 2.8s ease-in-out infinite;
+}
+
+.ayunis-progress-orb-shell--active .ayunis-progress-orb__glass::before {
+  animation: ayunis-orb-disc-glint 3.2s ease-in-out infinite;
+}
+
+/* Horizontal = wider ellipse; 90°/270° = round — liquid wobble */
+@keyframes ayunis-orb-disc-wobble {
+  0% {
+    transform: rotate(0deg) scale(1.16, 0.84);
+  }
+  12.5% {
+    transform: rotate(45deg) scale(1.06, 0.94);
+  }
+  25% {
+    transform: rotate(90deg) scale(1, 1);
+  }
+  37.5% {
+    transform: rotate(135deg) scale(1.06, 0.94);
+  }
+  50% {
+    transform: rotate(180deg) scale(1.16, 0.84);
+  }
+  62.5% {
+    transform: rotate(225deg) scale(1.06, 0.94);
+  }
+  75% {
+    transform: rotate(270deg) scale(1, 1);
+  }
+  87.5% {
+    transform: rotate(315deg) scale(1.06, 0.94);
+  }
+  100% {
+    transform: rotate(360deg) scale(1.16, 0.84);
+  }
+}
+
+@keyframes ayunis-orb-disc-settle-round {
+  from {
+    transform: rotate(0deg) scale(1.16, 0.84);
+  }
+  to {
+    transform: rotate(0deg) scale(1, 1);
+  }
+}
+
+@keyframes ayunis-orb-dissolve {
+  0% {
+    opacity: 1;
+    filter: blur(0);
+    transform: scale(1);
+  }
+  100% {
+    opacity: 0;
+    filter: blur(5px);
+    transform: scale(1.1);
+  }
+}
+
+@keyframes ayunis-orb-dissolve-reduced {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes ayunis-orb-core-swirl {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes ayunis-orb-blob-1 {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  25% {
+    transform: translate3d(28%, 6%, 0) scale(1.12);
+  }
+  50% {
+    transform: translate3d(6%, 18%, 0) scale(0.92);
+  }
+  75% {
+    transform: translate3d(-18%, 4%, 0) scale(1.08);
+  }
+}
+
+@keyframes ayunis-orb-blob-2 {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  33% {
+    transform: translate3d(-28%, -10%, 0) scale(1.14);
+  }
+  66% {
+    transform: translate3d(16%, -14%, 0) scale(0.94);
+  }
+}
+
+@keyframes ayunis-orb-blob-3 {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  20% {
+    transform: translate3d(20%, -16%, 0) scale(1.12);
+  }
+  55% {
+    transform: translate3d(-14%, -4%, 0) scale(0.9);
+  }
+  80% {
+    transform: translate3d(8%, 14%, 0) scale(1.06);
+  }
+}
+
+@keyframes ayunis-orb-glass-shimmer {
+  0%,
+  100% {
+    opacity: 0.88;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes ayunis-orb-disc-glint {
+  0%,
+  100% {
+    opacity: 0.82;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ayunis-progress-orb-shell--active .ayunis-progress-orb {
+    transform: scale(1.1, 0.9);
+    animation: none;
+  }
+
+  .ayunis-progress-orb-shell--active .ayunis-progress-orb__core,
+  .ayunis-progress-orb-shell--active .ayunis-progress-orb__blob--1,
+  .ayunis-progress-orb-shell--active .ayunis-progress-orb__blob--2,
+  .ayunis-progress-orb-shell--active .ayunis-progress-orb__blob--3,
+  .ayunis-progress-orb-shell--active .ayunis-progress-orb__glass,
+  .ayunis-progress-orb-shell--active .ayunis-progress-orb__glass::before {
+    animation: none;
+  }
+
+  .ayunis-progress-orb-shell--completing .ayunis-progress-orb {
+    animation: none;
+    transform: scale(1);
+  }
+
+  .ayunis-progress-orb-shell--completing {
+    animation: ayunis-orb-dissolve-reduced 0.2s ease-out forwards;
+  }
+}

--- a/ayunis-core-frontend/src/widgets/chat-input/index.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/index.ts
@@ -1,4 +1,5 @@
 import ChatInput from './ui/ChatInput';
 
-export type { ChatInputRef } from './ui/ChatInput';
+export type { ChatInputRef, ChatInputSubmissionState } from './ui/ChatInput';
+export { getChatInputSubmissionState } from './model/chatInputSubmissionState';
 export default ChatInput;

--- a/ayunis-core-frontend/src/widgets/chat-input/model/chatInputSubmissionState.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/model/chatInputSubmissionState.ts
@@ -1,0 +1,10 @@
+import type { ChatInputSubmissionState } from '../ui/ChatInput';
+
+export function getChatInputSubmissionState(
+  isStreaming: boolean,
+  pendingSubmission: string | null,
+): ChatInputSubmissionState {
+  if (isStreaming) return 'streaming';
+  if (pendingSubmission !== null) return 'submitting';
+  return 'idle';
+}

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -26,8 +26,9 @@ import { useFileDrop } from '../hooks/useFileDrop';
 import { PendingImageThumbnail } from './PendingImageThumbnail';
 import { cn } from '@/shared/lib/shadcn/utils';
 import { SourcesList } from './SourcesList';
-import { ScrollFadeContainer } from './ScrollFadeContainer';
+import { ChatInputExpandable } from './ChatInputExpandable';
 import { showError } from '@/shared/lib/toast';
+import './chat-input-glow.css';
 import { MicrophoneButton } from './MicrophoneButton';
 import type {
   IntegrationSummary,
@@ -142,7 +143,9 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
     const [isFocused, setIsFocused] = useState<boolean>(false);
     const [message, setMessage] = useState(initialMessage ?? '');
     const isSubmitting = submissionState === 'submitting';
+    const isStreaming = submissionState === 'streaming';
     const inFlight = submissionState !== 'idle';
+    const showProcessingGlow = inFlight;
     const { t } = useTranslation('common');
     const containerRef = useRef<HTMLDivElement>(null);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -253,6 +256,12 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       !inFlight &&
       !isSendDisabled;
 
+    const hasAttachmentChips =
+      sources.length > 0 ||
+      (knowledgeBases?.length ?? 0) > 0 ||
+      (mcpIntegrations?.length ?? 0) > 0;
+    const hasPendingImages = pendingImages.length > 0;
+
     function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
       // Ensure emojis are preserved when pasting
       // Get the pasted text from clipboard
@@ -288,136 +297,164 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
         className="w-full space-y-2"
         data-testid="chat-input"
       >
-        <Card
+        <div
           className={cn(
-            'py-4',
-            isDragging && 'border-2 border-dashed border-primary bg-primary/5',
+            'chat-input-shell',
+            showProcessingGlow && 'chat-input-shell--active',
           )}
+          aria-busy={showProcessingGlow}
+          data-processing={showProcessingGlow ? 'true' : undefined}
         >
-          <CardContent className="px-4">
-            <div className="flex flex-col gap-4">
-              <SourcesList
-                sources={sources}
-                knowledgeBases={knowledgeBases}
-                mcpIntegrations={mcpIntegrations}
-                onRemove={onRemoveSource}
-                onRemoveKnowledgeBase={onRemoveKnowledgeBase}
-                onRemoveIntegration={onRemoveIntegration}
-                onDownload={onDownloadSource}
-              />
-
-              {pendingImages.length > 0 && (
-                <ScrollFadeContainer>
-                  {pendingImages.map((image: PendingImage) => (
-                    <PendingImageThumbnail
-                      key={image.id}
-                      image={image}
-                      onRemove={removeImage}
-                    />
-                  ))}
-                </ScrollFadeContainer>
-              )}
-
-              <TextareaAutosize
-                ref={textareaRef}
-                maxRows={10}
-                value={message}
-                autoFocus
-                readOnly={isSubmitting}
-                onChange={(e) => setMessage(e.target.value)}
-                onPaste={handlePaste}
-                onFocus={() => setIsFocused(true)}
-                onBlur={() => setIsFocused(false)}
-                placeholder={t('chatInput.placeholder')}
-                aria-label={t('chatInput.placeholder')}
-                className={cn(
-                  'border-0 border-none bg-transparent rounded-none resize-none focus:outline-none p-0',
-                  isSubmitting && 'opacity-60 cursor-not-allowed',
-                )}
-                data-testid="input"
-              />
-
-              <div className="flex items-center justify-between">
-                {/* Left side */}
-                <div className="flex-shrink-0 flex items-center space-x-2">
-                  <OnboardingTourTarget
-                    name={TOUR_TARGET.chatUpload}
-                    settleMs={900}
-                  >
-                    <PlusButton
-                      onFileUpload={onFileUpload}
-                      onImageSelect={handleImageSelect}
-                      isFileSourceDisabled={
-                        !isEmbeddingModelEnabled || isSubmitting
-                      }
-                      isImageUploadDisabled={!isVisionEnabled || isSubmitting}
-                      onKnowledgeBaseSelect={onAddKnowledgeBase}
-                      attachedKnowledgeBaseIds={knowledgeBases?.map(
-                        (kb) => kb.id,
-                      )}
-                      onIntegrationSelect={onAddIntegration}
-                      attachedIntegrationIds={mcpIntegrations?.map(
-                        (integration) => integration.id,
-                      )}
-                    />
-                  </OnboardingTourTarget>
-                  <OnboardingTourTarget
-                    name={TOUR_TARGET.anonymousMode}
-                    settleMs={900}
-                  >
-                    <AnonymousButton
-                      isAnonymous={isAnonymous}
-                      onAnonymousChange={onAnonymousChange}
-                      isDisabled={isAnonymousChangeDisabled}
-                      isEnforced={isAnonymousEnforced}
-                    />
-                  </OnboardingTourTarget>
-                  {selectedSkillId && selectedSkillName && onSkillRemove && (
-                    <SkillBadge
-                      skillName={selectedSkillName}
-                      onRemove={() => onSkillRemove()}
-                    />
-                  )}
-                </div>
-
-                <div className="flex-shrink-0 flex space-x-2">
-                  <TooltipIf
-                    condition={isModelChangeDisabled ?? false}
-                    tooltip={t('chatInput.modelChangeDisabledTooltip')}
-                  >
-                    <OnboardingTourTarget name={TOUR_TARGET.modelSelector}>
-                      <ModelSelector
-                        isDisabled={isModelChangeDisabled ?? false}
-                        selectedModelId={modelId}
-                        onModelChange={onModelChange}
-                      />
-                    </OnboardingTourTarget>
-                  </TooltipIf>
-                  <MicrophoneButton
-                    onTranscriptionComplete={(text) => {
-                      setMessage((prev) => (prev ? `${prev} ${text}` : text));
-                      // Focus textarea and place cursor at end after transcription
-                      setTimeout(() => {
-                        const textarea = textareaRef.current;
-                        if (textarea) {
-                          textarea.focus();
-                          const length = textarea.value.length;
-                          textarea.setSelectionRange(length, length);
-                        }
-                      }, 0);
-                    }}
-                  />
-                  <SendButton
-                    inFlight={inFlight}
-                    canSend={!!canSend}
-                    onSend={handleSend}
-                    onCancel={onCancel}
-                  />
-                </div>
+          {showProcessingGlow && (
+            <div className="chat-input-shell__glow" aria-hidden="true">
+              <div className="chat-input-shell__glow-spinner">
+                <div className="chat-input-shell__glow-arc" />
+                <div className="chat-input-shell__glow-bloom" />
               </div>
             </div>
-          </CardContent>
-        </Card>
+          )}
+          <Card
+            className={cn(
+              'chat-input-shell__card py-4',
+              isDragging &&
+                'border-2 border-dashed border-primary bg-primary/5',
+              showProcessingGlow && !isDragging && 'bg-card',
+            )}
+          >
+            <CardContent className="px-4">
+              <div className="chat-input-body flex flex-col gap-4">
+                {hasAttachmentChips && (
+                  <ChatInputExpandable show>
+                    <SourcesList
+                      sources={sources}
+                      knowledgeBases={knowledgeBases}
+                      mcpIntegrations={mcpIntegrations}
+                      onRemove={onRemoveSource}
+                      onRemoveKnowledgeBase={onRemoveKnowledgeBase}
+                      onRemoveIntegration={onRemoveIntegration}
+                      onDownload={onDownloadSource}
+                    />
+                  </ChatInputExpandable>
+                )}
+
+                {hasPendingImages && (
+                  <ChatInputExpandable show>
+                    <div className="flex flex-wrap gap-2 items-center pt-0">
+                      {pendingImages.map((image: PendingImage) => (
+                        <PendingImageThumbnail
+                          key={image.id}
+                          image={image}
+                          onRemove={removeImage}
+                        />
+                      ))}
+                    </div>
+                  </ChatInputExpandable>
+                )}
+
+                <TextareaAutosize
+                  ref={textareaRef}
+                  minRows={1}
+                  maxRows={10}
+                  value={message}
+                  autoFocus
+                  readOnly={isSubmitting}
+                  onChange={(e) => setMessage(e.target.value)}
+                  onPaste={handlePaste}
+                  onFocus={() => setIsFocused(true)}
+                  onBlur={() => setIsFocused(false)}
+                  placeholder={t('chatInput.placeholder')}
+                  aria-label={t('chatInput.placeholder')}
+                  className={cn(
+                    'chat-input-shell__textarea border-0 border-none bg-transparent rounded-none resize-none focus:outline-none p-0',
+                    showProcessingGlow && 'opacity-90',
+                    isSubmitting && 'cursor-not-allowed',
+                    isStreaming && 'cursor-text',
+                  )}
+                  data-testid="input"
+                />
+
+                <div className="flex items-center justify-between">
+                  {/* Left side */}
+                  <div className="flex-shrink-0 flex items-center space-x-2">
+                    <OnboardingTourTarget
+                      name={TOUR_TARGET.chatUpload}
+                      settleMs={900}
+                    >
+                      <PlusButton
+                        onFileUpload={onFileUpload}
+                        onImageSelect={handleImageSelect}
+                        isFileSourceDisabled={
+                          !isEmbeddingModelEnabled || isSubmitting
+                        }
+                        isImageUploadDisabled={!isVisionEnabled || isSubmitting}
+                        onKnowledgeBaseSelect={onAddKnowledgeBase}
+                        attachedKnowledgeBaseIds={knowledgeBases?.map(
+                          (kb) => kb.id,
+                        )}
+                        onIntegrationSelect={onAddIntegration}
+                        attachedIntegrationIds={mcpIntegrations?.map(
+                          (integration) => integration.id,
+                        )}
+                      />
+                    </OnboardingTourTarget>
+                    <OnboardingTourTarget
+                      name={TOUR_TARGET.anonymousMode}
+                      settleMs={900}
+                    >
+                      <AnonymousButton
+                        isAnonymous={isAnonymous}
+                        onAnonymousChange={onAnonymousChange}
+                        isDisabled={isAnonymousChangeDisabled}
+                        isEnforced={isAnonymousEnforced}
+                      />
+                    </OnboardingTourTarget>
+                    {selectedSkillId && selectedSkillName && onSkillRemove && (
+                      <SkillBadge
+                        skillName={selectedSkillName}
+                        onRemove={() => onSkillRemove()}
+                      />
+                    )}
+                  </div>
+
+                  <div className="flex-shrink-0 flex space-x-2">
+                    <TooltipIf
+                      condition={isModelChangeDisabled ?? false}
+                      tooltip={t('chatInput.modelChangeDisabledTooltip')}
+                    >
+                      <OnboardingTourTarget name={TOUR_TARGET.modelSelector}>
+                        <ModelSelector
+                          isDisabled={isModelChangeDisabled ?? false}
+                          selectedModelId={modelId}
+                          onModelChange={onModelChange}
+                        />
+                      </OnboardingTourTarget>
+                    </TooltipIf>
+                    <MicrophoneButton
+                      onTranscriptionComplete={(text) => {
+                        setMessage((prev) => (prev ? `${prev} ${text}` : text));
+                        // Focus textarea and place cursor at end after transcription
+                        setTimeout(() => {
+                          const textarea = textareaRef.current;
+                          if (textarea) {
+                            textarea.focus();
+                            const length = textarea.value.length;
+                            textarea.setSelectionRange(length, length);
+                          }
+                        }, 0);
+                      }}
+                    />
+                    <SendButton
+                      inFlight={inFlight}
+                      canSend={!!canSend}
+                      onSend={handleSend}
+                      onCancel={onCancel}
+                    />
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
       </div>
     );
   },

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInputExpandable.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInputExpandable.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/shared/lib/shadcn/utils';
+
+interface ChatInputExpandableProps {
+  show: boolean;
+  children: ReactNode;
+  className?: string;
+}
+
+/** Apple-like height reveal — grid 0fr → 1fr instead of an instant layout jump */
+export function ChatInputExpandable({
+  show,
+  children,
+  className,
+}: Readonly<ChatInputExpandableProps>) {
+  return (
+    <div
+      className={cn(
+        'chat-input-expandable grid transition-[grid-template-rows,opacity,margin] duration-500 ease-[cubic-bezier(0.45,0.05,0.55,0.95)] motion-reduce:transition-none',
+        show
+          ? 'grid-rows-[1fr] opacity-100 mb-0'
+          : 'grid-rows-[0fr] opacity-0 mb-0',
+        className,
+      )}
+      aria-hidden={!show}
+    >
+      <div className="overflow-hidden min-h-0">{children}</div>
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/SendButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/SendButton.tsx
@@ -7,16 +7,16 @@ import {
 } from '@/shared/ui/shadcn/tooltip';
 import { useTranslation } from 'react-i18next';
 import { TOUR_TARGET, OnboardingTourTarget } from '@/widgets/onboarding';
+import { cn } from '@/shared/lib/shadcn/utils';
 
 interface SendButtonProps {
+  /** True while a submit is in flight (submitting or streaming). Replaces
+   *  the send icon with a stop icon wired to {@link onCancel}. */
   inFlight: boolean;
   canSend: boolean;
   onSend: () => void;
   onCancel: () => void;
 }
-
-const brandIconButtonClasses =
-  'rounded-full border border-transparent bg-brand text-brand-foreground hover:bg-brand/90';
 
 export function SendButton({
   inFlight,
@@ -33,7 +33,9 @@ export function SendButton({
           <div>
             <Button
               size="icon"
-              className={brandIconButtonClasses}
+              className={cn(
+                'chat-input-send-button chat-input-send-button--stop rounded-full',
+              )}
               onClick={onCancel}
               aria-label={t('chatInput.cancelTooltip')}
             >
@@ -53,7 +55,12 @@ export function SendButton({
           <OnboardingTourTarget name={TOUR_TARGET.sendMessage} settleMs={900}>
             <Button
               disabled={!canSend}
-              className={brandIconButtonClasses}
+              className={cn(
+                'chat-input-send-button rounded-full',
+                canSend
+                  ? 'chat-input-send-button--ready'
+                  : 'chat-input-send-button--disabled',
+              )}
               size="icon"
               data-testid="send"
               onClick={onSend}

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/chat-input-glow.css
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/chat-input-glow.css
@@ -1,0 +1,312 @@
+/* Brand: #6055A6 — smooth orbit glow + matching send/stop button */
+
+:root {
+  --chat-input-ease: cubic-bezier(0.45, 0.05, 0.55, 0.95);
+  --chat-input-duration: 0.52s;
+  --new-chat-greeting-exit-duration: 0.55s;
+  --new-chat-greeting-exit-ease: cubic-bezier(0.16, 1, 0.3, 1);
+  --new-chat-settle-duration: 1.45s;
+  --new-chat-settle-ease: cubic-bezier(0.16, 1, 0.3, 1);
+  --new-chat-disclaimer-fade-duration: 0.9s;
+  --new-chat-disclaimer-fade-ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.chat-input-shell__textarea {
+  transition: height var(--chat-input-duration) var(--chat-input-ease);
+}
+
+.chat-input-shell__card .chat-input-body {
+  transition: gap var(--chat-input-duration) var(--chat-input-ease);
+}
+
+/* Bottom-anchored compose block, lifted to visual center when idle.
+   The slide transition lives on --settling only: while idle, lift
+   re-measurements (fonts, async content) must reposition instantly —
+   otherwise the initial load animates like a landing page. */
+.new-chat-compose {
+  will-change: transform;
+}
+
+.new-chat-compose--idle {
+  transform: translate3d(0, var(--new-chat-lift, 0), 0);
+}
+
+.new-chat-compose--settling {
+  transform: translate3d(0, 0, 0);
+  transition: transform var(--new-chat-settle-duration)
+    var(--new-chat-settle-ease);
+}
+
+.new-chat-compose--settling .new-chat-compose__content {
+  gap: 0;
+  transition: gap var(--new-chat-settle-duration) var(--new-chat-settle-ease);
+}
+
+.new-chat-greeting {
+  font-weight: 600;
+  max-height: 4rem;
+  overflow: hidden;
+  transition:
+    opacity var(--new-chat-greeting-exit-duration)
+      var(--new-chat-greeting-exit-ease),
+    transform var(--new-chat-greeting-exit-duration)
+      var(--new-chat-greeting-exit-ease),
+    max-height var(--new-chat-greeting-exit-duration)
+      var(--new-chat-greeting-exit-ease);
+}
+
+.new-chat-greeting--exit {
+  max-height: 0;
+  opacity: 0;
+  transform: translate3d(0, -0.75rem, 0);
+  pointer-events: none;
+}
+
+/* Absolutely positioned — opacity/transform only, no layout shift on the input */
+.new-chat-disclaimer {
+  opacity: 0;
+  pointer-events: none;
+  transform: translate3d(0, 0.4rem, 0);
+  transition:
+    opacity var(--new-chat-disclaimer-fade-duration)
+      var(--new-chat-disclaimer-fade-ease),
+    transform var(--new-chat-disclaimer-fade-duration)
+      var(--new-chat-disclaimer-fade-ease);
+}
+
+.new-chat-disclaimer--visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate3d(0, 0, 0);
+  transition-delay: var(--new-chat-settle-duration);
+}
+
+.new-chat-dock-extras {
+  transition:
+    max-height var(--new-chat-greeting-exit-duration)
+      var(--new-chat-greeting-exit-ease),
+    opacity var(--new-chat-greeting-exit-duration)
+      var(--new-chat-greeting-exit-ease),
+    margin-top var(--new-chat-greeting-exit-duration)
+      var(--new-chat-greeting-exit-ease);
+  max-height: 24rem;
+}
+
+.new-chat-dock-extras--collapsed {
+  max-height: 0;
+  margin-top: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-input-shell__textarea,
+  .chat-input-shell__card .chat-input-body,
+  .chat-input-expandable,
+  .new-chat-compose,
+  .new-chat-compose--idle,
+  .new-chat-compose--settling,
+  .new-chat-compose--settling .new-chat-compose__content,
+  .new-chat-greeting,
+  .new-chat-greeting--exit,
+  .new-chat-dock-extras,
+  .new-chat-dock-extras--collapsed {
+    transition: none;
+    transform: none;
+    gap: 1rem;
+    opacity: 1;
+    max-height: none;
+    margin-top: 1rem;
+  }
+
+  .new-chat-disclaimer--visible {
+    transition: none;
+    transition-delay: 0ms;
+    transform: none;
+    opacity: 1;
+  }
+}
+
+.chat-input-shell {
+  --chat-input-brand: #6055a6;
+  --chat-input-brand-rgb: 96, 85, 166;
+  --chat-input-brand-light-rgb: 125, 115, 184;
+  --chat-input-glow-ring: 2px;
+  position: relative;
+  border-radius: 0.75rem;
+  /* Reserve ring space always — toggling --active must not change layout width */
+  padding: var(--chat-input-glow-ring);
+  box-sizing: border-box;
+}
+
+@keyframes chat-input-glow-orbit {
+  from {
+    transform: translate3d(-50%, -50%, 0) rotate(0deg);
+  }
+  to {
+    transform: translate3d(-50%, -50%, 0) rotate(360deg);
+  }
+}
+
+@keyframes chat-input-glow-breathe {
+  0%,
+  100% {
+    opacity: 0.78;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes chat-input-glow-halo {
+  0%,
+  100% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 0.82;
+  }
+}
+
+.chat-input-shell--active {
+  isolation: isolate;
+}
+
+.chat-input-shell__glow {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.chat-input-shell__glow-spinner {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 220%;
+  height: 220%;
+  transform: translate3d(-50%, -50%, 0);
+  transform-origin: center center;
+  will-change: transform;
+  animation: chat-input-glow-orbit 5.2s linear infinite;
+}
+
+.chat-input-shell__glow-arc {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 270deg,
+    rgba(var(--chat-input-brand-rgb), 0.55) 0deg,
+    rgba(var(--chat-input-brand-light-rgb), 0.36) 14deg,
+    rgba(var(--chat-input-brand-light-rgb), 0.14) 26deg,
+    transparent 40deg,
+    transparent 360deg
+  );
+  animation: chat-input-glow-breathe 3.6s cubic-bezier(0.45, 0.05, 0.55, 0.95)
+    infinite;
+}
+
+.chat-input-shell__glow-bloom {
+  position: absolute;
+  inset: 8%;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 270deg,
+    rgba(var(--chat-input-brand-rgb), 0.2) 0deg,
+    rgba(var(--chat-input-brand-light-rgb), 0.11) 18deg,
+    transparent 36deg,
+    transparent 360deg
+  );
+  filter: blur(8px);
+  animation: chat-input-glow-halo 3.6s cubic-bezier(0.45, 0.05, 0.55, 0.95)
+    infinite;
+}
+
+.chat-input-shell--active .chat-input-shell__card {
+  position: relative;
+  z-index: 1;
+  border-color: transparent;
+  box-shadow: 0 0 0 var(--chat-input-glow-ring)
+    rgba(var(--chat-input-brand-rgb), 0.2);
+}
+
+.chat-input-shell--active .chat-input-shell__card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: 0 0 18px rgba(var(--chat-input-brand-rgb), 0.14);
+  opacity: 0.55;
+  animation: chat-input-glow-halo 3.6s cubic-bezier(0.45, 0.05, 0.55, 0.95)
+    infinite;
+}
+
+.chat-input-send-button--stop {
+  border: 1px solid rgba(var(--chat-input-brand-rgb), 0.35) !important;
+  background-color: var(--chat-input-brand) !important;
+  color: #fff !important;
+  box-shadow:
+    0 0 0 1px rgba(var(--chat-input-brand-rgb), 0.2),
+    0 0 14px rgba(var(--chat-input-brand-rgb), 0.28);
+  transition:
+    background-color 0.25s cubic-bezier(0.45, 0.05, 0.55, 0.95),
+    box-shadow 0.25s cubic-bezier(0.45, 0.05, 0.55, 0.95);
+  animation: chat-input-glow-breathe 3.6s cubic-bezier(0.45, 0.05, 0.55, 0.95)
+    infinite;
+}
+
+.chat-input-send-button--stop:hover {
+  background-color: #524997 !important;
+  box-shadow:
+    0 0 0 1px rgba(var(--chat-input-brand-rgb), 0.28),
+    0 0 18px rgba(var(--chat-input-brand-rgb), 0.34);
+}
+
+.chat-input-send-button--disabled:disabled {
+  border: 1px solid rgba(var(--chat-input-brand-rgb), 0.16) !important;
+  background-color: rgba(var(--chat-input-brand-rgb), 0.08) !important;
+  color: rgba(var(--chat-input-brand-rgb), 0.38) !important;
+  opacity: 1 !important;
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+.chat-input-send-button--ready:not(:disabled) {
+  background-color: var(--chat-input-brand) !important;
+  color: #fff !important;
+  border: 1px solid transparent !important;
+  box-shadow: 0 1px 2px rgba(var(--chat-input-brand-rgb), 0.2);
+}
+
+.chat-input-send-button--ready:not(:disabled):hover {
+  background-color: #524997 !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-input-shell__glow-spinner {
+    animation: none;
+    transform: translate3d(-50%, -50%, 0);
+  }
+
+  .chat-input-shell__glow-arc,
+  .chat-input-shell__glow-bloom,
+  .chat-input-shell--active .chat-input-shell__card::after,
+  .chat-input-send-button--stop {
+    animation: none;
+    opacity: 0.85;
+  }
+
+  .chat-input-shell--active .chat-input-shell__card {
+    box-shadow: 0 0 0 var(--chat-input-glow-ring)
+      rgba(var(--chat-input-brand-rgb), 0.32);
+  }
+
+  .chat-input-shell--active .chat-input-shell__card::after {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
Ports the two remaining animation pieces from PR #711 (AYC-94) onto current main. Everything else from that branch had already landed via other PRs; this is a surgical port of the presentation layer only — main's MCP integrations, PII masks, onboarding tour, and initialPrompt features are untouched.

## 1. New-chat settle animation

- The compose block (greeting + input + pinned skills/privacy hint) is bottom-anchored and lifted to visual center while idle (`NewChatPageLayout` + `useComposeLift`).
- On send: greeting and extras collapse, the input slides down to the chat dock position (~1.45s), the disclaimer fades in above it, and the ambient backdrop fades out (`NewChatBackdrop` exit phase).
- `useInitiateChat` delays navigation until the settle animation completes, so the input visually stays in place across the page transition. Cancel resets the state and keeps the typed message.
- Initial page load is unchanged from before: the block appears centered with the existing subtle fade-in — the slide transition only applies while settling.

## 2. Loading animations

- New `AyunisProgressOrb` widget (animated blob orb) replaces the brand avatar in `LoadingAssistantBlock` and `AssistantRunBlock`; it's active while streaming and dissolves when the run completes.
- Orbiting glow ring around `ChatInput` while submitting/streaming, restyled send/stop button, and a grid-based reveal (`ChatInputExpandable`) for attachment chips and pending images.
- `ChatPage` now reports the `'submitting'` state (pre-stream gap) via `getChatInputSubmissionState`, and `groupMessagesIntoRuns` gained `hasPendingUserTurn` so a prior run isn't marked as streaming while an optimistic user bubble is pending (unit test included).
- `ChatThreadContent` extracted from `ChatPage` (same extraction as PR #711) to keep the file under the 500-line limit.

Verified end-to-end in the dev stack: send flow with settle + orb + glow, cancel mid-settle, streaming completion, reduced console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132TjysWQUvRaMuhrbyF24o