### PR TITLE
fix(new-chat): show explanatory help link when no skills are pinned (AYC-429)

### DIFF
--- a/ayunis-core-frontend/src/pages/new-chat/ui/PinnedSkills.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/PinnedSkills.tsx
@@ -31,6 +31,19 @@ export function PinnedSkills({
     return null;
   }
 
+  const skillsHelpPath =
+    'skills/name-and-description/#f%C3%A4higkeiten-anheften--manuelle-aktivierung';
+
+  // Without any pinned skills, a lone (?) icon reads like a UI bug. Show an
+  // explanatory link that teases the "pin skills" capability instead.
+  if (pinnedSkills.length === 0) {
+    return (
+      <div className="flex justify-center items-center">
+        <HelpLink path={skillsHelpPath} label={t('pinnedSkills.pinHint')} />
+      </div>
+    );
+  }
+
   return (
     <div className="flex justify-center items-center gap-2 flex-wrap">
       {pinnedSkills.map((skill) => (
@@ -48,10 +61,7 @@ export function PinnedSkills({
           <TooltipContent>{t('pinnedSkills.activateTooltip')}</TooltipContent>
         </Tooltip>
       ))}
-      <HelpLink
-        path="skills/name-and-description/#f%C3%A4higkeiten-anheften--manuelle-aktivierung"
-        variant="icon"
-      />
+      <HelpLink path={skillsHelpPath} variant="icon" />
     </div>
   );
 }

--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -99,7 +99,8 @@
   },
   "pinnedSkills": {
     "empty": "Keine angehefteten Fähigkeiten",
-    "activateTooltip": "Fähigkeit aktivieren"
+    "activateTooltip": "Fähigkeit aktivieren",
+    "pinHint": "Fähigkeiten für schnellen Zugriff anheften"
   },
   "common": {
     "loading": "Laden...",

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -99,7 +99,8 @@
   },
   "pinnedSkills": {
     "empty": "No pinned skills",
-    "activateTooltip": "Activate skill"
+    "activateTooltip": "Activate skill",
+    "pinHint": "Pin skills for quick access"
   },
   "common": {
     "loading": "Loading...",

--- a/ayunis-core-frontend/src/shared/ui/help-link/HelpLink.tsx
+++ b/ayunis-core-frontend/src/shared/ui/help-link/HelpLink.tsx
@@ -12,12 +12,18 @@ interface HelpLinkProps {
   readonly path: string;
   /** Use "icon" for card-level links (icon-only with tooltip) */
   readonly variant?: 'default' | 'icon';
+  /** Override the default "Help" label (used for both text and tooltip) */
+  readonly label?: string;
 }
 
-export function HelpLink({ path, variant = 'default' }: HelpLinkProps) {
+export function HelpLink({
+  path,
+  variant = 'default',
+  label: labelOverride,
+}: HelpLinkProps) {
   const { t } = useTranslation('common');
   const url = getHelpCenterUrl(path);
-  const label = t('common.helpLink');
+  const label = labelOverride ?? t('common.helpLink');
 
   if (variant === 'icon') {
     return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the new-chat start page, a lone question-mark (`?`) icon rendered below the `ChatInput` even when no skills were pinned. Together with the primary **Help** button in the top-right corner, this looked inconsistent and read like a UI bug (AYC-429).

The icon lives in `PinnedSkills` — it's the icon-only `HelpLink` that normally sits alongside the pinned-skill buttons. When there are no pinned skills, it appears alone "in empty space".

## Solution

Following the ticket's guidance:

- **No pinned skills:** render a self-explanatory help link (`HelpLink` default variant — icon **+** text label) that teases the skill-pinning capability, instead of a bare `?` icon.
- **Skills pinned:** keep the existing compact icon-only help link next to the pinned-skill buttons.

## Changes

- `PinnedSkills.tsx`: branch on `pinnedSkills.length`; extract the shared help-doc path.
- `HelpLink.tsx`: add an optional `label` prop to override the default "Help" text (used for both the button text and the tooltip).
- Added `pinnedSkills.pinHint` copy in `en`/`de` common locales ("Pin skills for quick access" / "Fähigkeiten für schnellen Zugriff anheften").

## Validation

- `pnpm run build` — succeeds
- `pnpm run lint` — 0 errors (only pre-existing, unrelated warnings)
- Pre-commit hooks (prettier, eslint, typecheck, dep/duplication/file-size checks) — all passed
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-429](https://linear.app/ayunis/issue/AYC-429/review-help-button-placement)

<div><a href="https://cursor.com/agents/bc-54118ff7-61b6-4f55-93e2-ca50cf113f45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54118ff7-61b6-4f55-93e2-ca50cf113f45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

