### PR TITLE
ci(mfa): add mfa encryption key to schema drift workflow env (AYC-62)

### DIFF
--- a/.github/workflows/api-schema-drift.yml
+++ b/.github/workflows/api-schema-drift.yml
@@ -84,6 +84,7 @@ jobs:
           DISABLE_REGISTRATION=false
           DISABLE_EMAIL_CONFIRMATION=true
           MCP_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          MFA_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           OPENAI_API_KEY=sk-test-dummy-key-for-ci
           ANTHROPIC_API_KEY=sk-ant-test-dummy-key-for-ci
           MISTRAL_API_KEY=test-dummy-key-for-ci


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow env change with a fixed test key; no production or application logic changes.
> 
> **Overview**
> Adds **`MFA_ENCRYPTION_KEY`** to the backend `.env` block in the **Schema Drift** GitHub Actions workflow, alongside the existing `MCP_ENCRYPTION_KEY` dummy hex value used in CI.
> 
> This aligns the workflow with backend startup requirements for MFA TOTP secret encryption so schema drift checks (build, migrations, backend boot) do not fail when the MFA module loads `TotpSecretEncryptionService`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6087435f6ffc9fe80109d11ed6290bb01eb17134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->