### PR TITLE
fix(chat): stop chat input mount flicker and inline loading orb at text start (AYC-94)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/ui/AssistantRunBlock.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/AssistantRunBlock.tsx
@@ -1,20 +1,20 @@
 import { useRef } from 'react';
 import { cn } from '@/shared/lib/shadcn/utils';
-import { AyunisProgressOrb } from '@/widgets/ayunis-progress-orb';
 import { AgentRunTimeline } from '@/pages/chat/ui/agent-run-timeline';
 import type { AgentRunUnit } from '@/pages/chat/ui/agent-run-timeline';
 import CopyAssistantTextButton from './CopyAssistantTextButton';
 
 interface AssistantRunBlockProps {
   unit: AgentRunUnit;
-  hideAvatar: boolean;
+  /** Tightens the top spacing when the previous unit is also an agent run. */
+  isGroupedWithPrevious: boolean;
   threadId?: string;
   onOpenArtifact?: (artifactId: string) => void;
 }
 
 export default function AssistantRunBlock({
   unit,
-  hideAvatar,
+  isGroupedWithPrevious,
   threadId,
   onOpenArtifact,
 }: Readonly<AssistantRunBlockProps>) {
@@ -23,11 +23,11 @@ export default function AssistantRunBlock({
 
   return (
     <div
-      className={cn('flex flex-col items-start gap-2', !hideAvatar && 'mt-4')}
-    >
-      {!hideAvatar && (
-        <AyunisProgressOrb isActive={unit.isStreaming} aria-label="Ayunis" />
+      className={cn(
+        'flex flex-col items-start gap-2',
+        !isGroupedWithPrevious && 'mt-4',
       )}
+    >
       <div className="max-w-2xl min-w-0 space-y-1 w-full">
         <div
           ref={contentRef}

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatThreadContent.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatThreadContent.tsx
@@ -28,12 +28,12 @@ export function ChatThreadContent({
           return <ChatMessage key={unit.key} message={unit.message} />;
         }
         const previousUnit = i > 0 ? renderUnits[i - 1] : undefined;
-        const hideAvatar = previousUnit?.kind === 'agent-run';
+        const isGroupedWithPrevious = previousUnit?.kind === 'agent-run';
         return (
           <AssistantRunBlock
             key={unit.key}
             unit={unit}
-            hideAvatar={hideAvatar}
+            isGroupedWithPrevious={isGroupedWithPrevious}
             threadId={threadId}
             onOpenArtifact={onOpenArtifact}
           />

--- a/ayunis-core-frontend/src/pages/chat/ui/LoadingAssistantBlock.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/LoadingAssistantBlock.tsx
@@ -1,9 +1,14 @@
-import { AyunisProgressOrb } from '@/widgets/ayunis-progress-orb';
+import ResponseStartOrb from '@/pages/chat/ui/ResponseStartOrb';
 
+/**
+ * Placeholder shown before the first assistant message event arrives.
+ * Mirrors AssistantRunBlock's outer spacing so the orb sits exactly where
+ * the response's first text line will render.
+ */
 export default function LoadingAssistantBlock() {
   return (
-    <div className="flex flex-col items-start gap-2 mt-4">
-      <AyunisProgressOrb isActive aria-label="Ayunis arbeitet" />
+    <div className="mt-4">
+      <ResponseStartOrb />
     </div>
   );
 }

--- a/ayunis-core-frontend/src/pages/chat/ui/ResponseStartOrb.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ResponseStartOrb.tsx
@@ -1,0 +1,19 @@
+import { AyunisProgressOrb } from '@/widgets/ayunis-progress-orb';
+
+/**
+ * Loading orb occupying the exact spot where the first line of assistant
+ * text will render: h-6 matches the prose-sm line box (24px), and -ml-1
+ * compensates the orb shell's 4px inset so the disc's left edge sits at
+ * the first letter's x-position.
+ */
+export default function ResponseStartOrb() {
+  return (
+    <div className="flex h-6 items-center">
+      <AyunisProgressOrb
+        isActive
+        className="-ml-1"
+        aria-label="Ayunis arbeitet"
+      />
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimeline.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimeline.tsx
@@ -9,6 +9,7 @@ import {
   CollapsibleTrigger,
 } from '@/shared/ui/shadcn/collapsible';
 import type { AgentRunUnit } from '../model/types';
+import ResponseStartOrb from '@/pages/chat/ui/ResponseStartOrb';
 import AgentRunTimelineRow from './AgentRunTimelineRow';
 import { renderRichToolCard } from '../lib/render-rich-tool-card';
 
@@ -96,12 +97,14 @@ export default function AgentRunTimeline({
         return node ? <div key={card.key}>{node}</div> : null;
       })}
 
-      {unit.finalText.length > 0 && (
+      {unit.finalText.length > 0 ? (
         <div data-copyable="true" className="space-y-2">
           {unit.finalText.map((text, i) => (
             <Markdown key={`final-text-${i}`}>{text.text}</Markdown>
           ))}
         </div>
+      ) : (
+        unit.isStreaming && <ResponseStartOrb />
       )}
     </div>
   );

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -1,4 +1,10 @@
-import { useState, forwardRef, useImperativeHandle, useRef } from 'react';
+import {
+  useState,
+  useEffect,
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+} from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 import { Card, CardContent } from '@/shared/ui/shadcn/card';
 import { OnboardingTourTarget, TOUR_TARGET } from '@/widgets/onboarding';
@@ -149,6 +155,27 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
     const { t } = useTranslation('common');
     const containerRef = useRef<HTMLDivElement>(null);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    // TextareaAutosize corrects its height during mount; the height transition
+    // must not be active yet or that correction animates as a visible shrink
+    // (flickers on every navigation because ChatPage keys the input by thread).
+    // Double rAF: the class may only land after the corrected height has been
+    // painted once — a plain effect flushes into the same style recalc and the
+    // browser still animates from the pre-correction height.
+    const [isHeightAnimationEnabled, setIsHeightAnimationEnabled] =
+      useState(false);
+    useEffect(() => {
+      let secondFrame = 0;
+      const firstFrame = requestAnimationFrame(() => {
+        secondFrame = requestAnimationFrame(() =>
+          setIsHeightAnimationEnabled(true),
+        );
+      });
+      return () => {
+        cancelAnimationFrame(firstFrame);
+        cancelAnimationFrame(secondFrame);
+      };
+    }, []);
 
     const { pendingImages, addImages, removeImage, clearImages } =
       usePendingImages();
@@ -366,6 +393,8 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
                   aria-label={t('chatInput.placeholder')}
                   className={cn(
                     'chat-input-shell__textarea border-0 border-none bg-transparent rounded-none resize-none focus:outline-none p-0',
+                    isHeightAnimationEnabled &&
+                      'chat-input-shell__textarea--animate',
                     showProcessingGlow && 'opacity-90',
                     isSubmitting && 'cursor-not-allowed',
                     isStreaming && 'cursor-text',

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/chat-input-glow.css
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/chat-input-glow.css
@@ -11,7 +11,11 @@
   --new-chat-disclaimer-fade-ease: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.chat-input-shell__textarea {
+/* Height transition is opt-in via the --animate modifier: TextareaAutosize
+   renders at the browser default height and corrects it during mount, so a
+   transition present at mount animates that correction — the input visibly
+   shrinks on every navigation. The modifier is added one frame after mount. */
+.chat-input-shell__textarea--animate {
   transition: height var(--chat-input-duration) var(--chat-input-ease);
 }
 
@@ -100,7 +104,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .chat-input-shell__textarea,
+  .chat-input-shell__textarea--animate,
   .chat-input-shell__card .chat-input-body,
   .chat-input-expandable,
   .new-chat-compose,


### PR DESCRIPTION
- gate the chat input height transition behind a post-paint class
  (double rAF) so TextareaAutosize's mount correction no longer
  animates as a visible shrink when navigating to a new chat
- remove the progress orb above the assistant response; a new
  ResponseStartOrb occupies the exact slot of the first text line
  (pre-stream placeholder and streaming timeline) and unmounts the
  moment the first text content arrives

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017JvcJ1yz9gBUnE8R1m1koS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only spacing, CSS transition timing, and loading placeholder layout; no auth, data, or API changes.
> 
> **Overview**
> Fixes two chat UX glitches: **chat input height flicker on thread navigation** and **loading indicator placement** during assistant responses.
> 
> **Chat input:** Height transitions are no longer applied on first paint. `ChatInput` enables them only after a **double `requestAnimationFrame`**, and CSS moves the transition from `.chat-input-shell__textarea` to an opt-in `.chat-input-shell__textarea--animate` class so `TextareaAutosize`'s mount height correction does not animate as a visible shrink when the input remounts per thread.
> 
> **Assistant loading:** The progress orb above each assistant block is removed. A shared **`ResponseStartOrb`** sits on the **first text line** (`h-6`, `-ml-1` alignment) in both the pre-stream placeholder (`LoadingAssistantBlock`) and while streaming in `AgentRunTimeline` when there is no `finalText` yet; it disappears once text arrives. `hideAvatar` is renamed to **`isGroupedWithPrevious`**—spacing only, no avatar row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be4735898d6e698cf6f1d38212edb9d03cc91b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->