### PR TITLE
fix(dev): export infra secrets before compose in down, status, and logs (AYC-000)

### DIFF
--- a/dev
+++ b/dev
@@ -82,6 +82,22 @@ dc() {
   docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" "$@"
 }
 
+# compose.dev.yml requires MINIO_ROOT_USER/MINIO_ROOT_PASSWORD/REDIS_PASSWORD
+# (`:?` interpolation), so every compose invocation needs them exported —
+# including down/ps/logs, where the actual values are irrelevant. Reuse the
+# persisted secrets from .env.dev; fall back to placeholders when the file
+# doesn't exist yet (cmd_up generates and exports real values itself).
+_export_infra_env() {
+  local env_dev="$REPO_DIR/ayunis-core-backend/.env.dev"
+  local minio_user minio_password redis_password
+  minio_user="$(_read_env_var "$env_dev" MINIO_ACCESS_KEY)"
+  minio_password="$(_read_env_var "$env_dev" MINIO_SECRET_KEY)"
+  redis_password="$(_read_env_var "$env_dev" REDIS_PASSWORD)"
+  export MINIO_ROOT_USER="${minio_user:-placeholder}"
+  export MINIO_ROOT_PASSWORD="${minio_password:-placeholder}"
+  export REDIS_PASSWORD="${redis_password:-placeholder}"
+}
+
 _tmux_session_alive() {
   local session="$1"
   command -v tmux >/dev/null 2>&1 || return 1
@@ -249,6 +265,7 @@ EOF
 
 cmd_down() {
   info "Stopping slot $SLOT …"
+  _export_infra_env
 
   # Stop native processes (pass ports to kill orphaned grandchild processes)
   _kill_pid "$STATE_DIR/frontend.pid" "Frontend" "$FRONTEND_PORT" "$FRONTEND_SESSION"
@@ -261,6 +278,7 @@ cmd_down() {
 }
 
 cmd_status() {
+  _export_infra_env
   echo "Slot $SLOT"
   echo ""
 
@@ -291,6 +309,7 @@ cmd_status() {
 }
 
 cmd_logs() {
+  _export_infra_env
   local tail_lines=80
   local target="all"
 


### PR DESCRIPTION
compose.dev.yml requires MINIO_ROOT_USER, MINIO_ROOT_PASSWORD, and
REDIS_PASSWORD via :? interpolation, but only cmd_up exported them.
Every other compose invocation failed to parse the file: ./dev down
left the infra containers running, and ./dev status silently reported
'not running' while containers were up. Reuse the persisted secrets
from .env.dev, with placeholders when the file doesn't exist yet.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017JvcJ1yz9gBUnE8R1m1koS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-script-only change; no production paths, with placeholder fallbacks only when `.env.dev` is missing (same compose requirement as before).
> 
> **Overview**
> **Fixes `./dev down`, `status`, and `logs` failing or misreporting Docker infra** because `compose.dev.yml` requires `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, and `REDIS_PASSWORD` via `:?` interpolation, and only `cmd_up` exported them before.
> 
> Adds `_export_infra_env()` to load those values from `ayunis-core-backend/.env.dev` (mapping MinIO access/secret keys) or use `placeholder` when the file is not there yet, and calls it at the start of **`down`**, **`status`**, and **`logs`** so every `docker compose` invocation can parse the file. **`down`** can tear down containers again; **`status`** can run `dc ps` accurately instead of showing infra as not running while containers are up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc09020d10f8ed7ad827b26a3b5557af7f2adf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->