### PR TITLE
chore(deps): ignore node major bumps in docker updates (AYC-423)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -145,6 +145,11 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    ignore:
+      # node:26 caused severe request slowness (connection stalls); runtime is
+      # pinned to 24.16.0-alpine. Do not remove without re-validating — see AYC-423.
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
     groups:
       docker-images:
         patterns:


### PR DESCRIPTION
node:26 caused the request-slowness regression (connection stalls);
the runtime is pinned to node:24.16.0-alpine since #1001. Block
dependabot from re-proposing major node bumps (e.g. #1013) while
keeping minor/patch updates for the pinned 24.x line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to Dependabot; no application or runtime code is modified.
> 
> **Overview**
> Adds a **Dependabot `ignore`** rule on the root **docker** ecosystem so **`node` semver-major** image bumps are not proposed automatically.
> 
> **Minor and patch** updates for the pinned **24.x** line still flow through the existing `docker-images` group. The comment documents that **node:26** previously caused request slowness/connection stalls and ties the rule to **AYC-423**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2571fc0f1011d66484d338173f0d2ea0a6b6e94a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->