### PR TITLE
wip(use-cases): apply HandleUnexpectedErrors to content domain modules (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/artifacts/application/artifacts.errors.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/artifacts.errors.ts
@@ -147,12 +147,10 @@ export class ArtifactNotExportableError extends ArtifactError {
 }
 
 export class UnexpectedArtifactError extends ArtifactError {
-  constructor(message: string, metadata?: ErrorMetadata) {
-    super(
-      `Unexpected artifact error: ${message}`,
-      ArtifactErrorCode.ARTIFACT_UNEXPECTED,
-      500,
-      metadata,
-    );
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, ArtifactErrorCode.ARTIFACT_UNEXPECTED, 500, {
+      ...metadata,
+      error,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { ApplyEditsToArtifactCommand } from './apply-edits-to-artifact.command';
 import {
@@ -15,7 +16,6 @@ import { ArtifactVersion } from '../../../domain/artifact-version.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UpdateArtifactUseCase } from '../update-artifact/update-artifact.use-case';
 import { UpdateArtifactCommand } from '../update-artifact/update-artifact.command';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
@@ -28,6 +28,7 @@ export class ApplyEditsToArtifactUseCase {
     private readonly updateArtifactUseCase: UpdateArtifactUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedArtifactError)
   async execute(
     command: ApplyEditsToArtifactCommand,
   ): Promise<ArtifactVersion> {
@@ -36,68 +37,54 @@ export class ApplyEditsToArtifactUseCase {
       editCount: command.edits.length,
     });
 
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
 
-      // Fetch artifact with versions to get current content
-      const artifact = await this.artifactsRepository.findByIdWithVersions(
+    // Fetch artifact with versions to get current content
+    const artifact = await this.artifactsRepository.findByIdWithVersions(
+      command.artifactId,
+      userId,
+    );
+    if (!artifact) {
+      throw new ArtifactNotFoundError(command.artifactId);
+    }
+
+    if (
+      command.expectedVersionNumber !== undefined &&
+      command.expectedVersionNumber !== artifact.currentVersionNumber
+    ) {
+      throw new ArtifactExpectedVersionMismatchError(
         command.artifactId,
-        userId,
-      );
-      if (!artifact) {
-        throw new ArtifactNotFoundError(command.artifactId);
-      }
-
-      if (
-        command.expectedVersionNumber !== undefined &&
-        command.expectedVersionNumber !== artifact.currentVersionNumber
-      ) {
-        throw new ArtifactExpectedVersionMismatchError(
-          command.artifactId,
-          command.expectedVersionNumber,
-          artifact.currentVersionNumber,
-        );
-      }
-
-      // Find current version content
-      const currentVersion = artifact.versions.find(
-        (v) => v.versionNumber === artifact.currentVersionNumber,
-      );
-      if (!currentVersion) {
-        throw new ArtifactVersionNotFoundError(
-          command.artifactId,
-          artifact.currentVersionNumber,
-        );
-      }
-
-      const content = this.applyEdits(currentVersion.content, command.edits);
-
-      // Sanitize and save using UpdateArtifactUseCase
-      const updateCommand = new UpdateArtifactCommand({
-        artifactId: command.artifactId,
-        content: content,
-        authorType: command.authorType,
-      });
-
-      const result = await this.updateArtifactUseCase.execute(updateCommand);
-      // Content is always provided here so result is always an ArtifactVersion
-      return result as ArtifactVersion;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-
-      this.logger.error('applyEditsToArtifactUnexpectedError', {
-        artifactId: command.artifactId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedArtifactError(
-        error instanceof Error ? error.message : 'Unknown error',
+        command.expectedVersionNumber,
+        artifact.currentVersionNumber,
       );
     }
+
+    // Find current version content
+    const currentVersion = artifact.versions.find(
+      (v) => v.versionNumber === artifact.currentVersionNumber,
+    );
+    if (!currentVersion) {
+      throw new ArtifactVersionNotFoundError(
+        command.artifactId,
+        artifact.currentVersionNumber,
+      );
+    }
+
+    const content = this.applyEdits(currentVersion.content, command.edits);
+
+    // Sanitize and save using UpdateArtifactUseCase
+    const updateCommand = new UpdateArtifactCommand({
+      artifactId: command.artifactId,
+      content: content,
+      authorType: command.authorType,
+    });
+
+    const result = await this.updateArtifactUseCase.execute(updateCommand);
+    // Content is always provided here so result is always an ArtifactVersion
+    return result as ArtifactVersion;
   }
 
   private applyEdits(

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.ts
@@ -1,5 +1,7 @@
+import type { UUID } from 'crypto';
 import { Injectable, Logger } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { CreateArtifactCommand } from './create-artifact.command';
 import {
@@ -21,7 +23,6 @@ import {
   UnexpectedArtifactError,
   ARTIFACT_MAX_CONTENT_LENGTH,
 } from '../../artifacts.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
@@ -36,103 +37,101 @@ export class CreateArtifactUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedArtifactError)
   async execute(command: CreateArtifactCommand): Promise<Artifact> {
     this.logger.log('Creating artifact', {
       title: command.title,
       type: command.type,
     });
 
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
 
-      if (command.content.length > ARTIFACT_MAX_CONTENT_LENGTH) {
-        throw new ArtifactContentTooLargeError(
-          command.content.length,
-          ARTIFACT_MAX_CONTENT_LENGTH,
-        );
-      }
-
-      await this.findThreadUseCase.execute(
-        new FindThreadQuery(command.threadId),
+    if (command.content.length > ARTIFACT_MAX_CONTENT_LENGTH) {
+      throw new ArtifactContentTooLargeError(
+        command.content.length,
+        ARTIFACT_MAX_CONTENT_LENGTH,
       );
+    }
 
-      const isDocument = command.type === ArtifactType.DOCUMENT;
+    await this.findThreadUseCase.execute(new FindThreadQuery(command.threadId));
 
-      if (isDocument && command.letterheadId) {
-        await this.findLetterheadUseCase.execute(
-          new FindLetterheadQuery({ letterheadId: command.letterheadId }),
-        );
-      }
+    const isDocument = command.type === ArtifactType.DOCUMENT;
 
-      const artifact: Artifact = isDocument
-        ? new DocumentArtifact({
-            threadId: command.threadId,
-            userId,
-            title: command.title,
-            letterheadId: command.letterheadId ?? null,
-            currentVersionNumber: 1,
-          })
-        : new DiagramArtifact({
-            threadId: command.threadId,
-            userId,
-            title: command.title,
-            currentVersionNumber: 1,
-          });
+    if (isDocument && command.letterheadId) {
+      await this.findLetterheadUseCase.execute(
+        new FindLetterheadQuery({ letterheadId: command.letterheadId }),
+      );
+    }
 
-      const createdArtifact = await this.artifactsRepository.create(artifact);
+    const artifact = this.buildArtifact(command, userId);
+    const createdArtifact = await this.artifactsRepository.create(artifact);
 
-      const content = isDocument
-        ? sanitizeHtmlContent(command.content)
-        : command.content;
+    const content = isDocument
+      ? sanitizeHtmlContent(command.content)
+      : command.content;
 
-      const version = new ArtifactVersion({
-        artifactId: createdArtifact.id,
-        versionNumber: 1,
-        content,
-        authorType: command.authorType,
-        authorId: command.authorType === AuthorType.USER ? userId : null,
-      });
+    const version = new ArtifactVersion({
+      artifactId: createdArtifact.id,
+      versionNumber: 1,
+      content,
+      authorType: command.authorType,
+      authorId: command.authorType === AuthorType.USER ? userId : null,
+    });
 
-      await this.artifactsRepository.addVersion(version);
+    await this.artifactsRepository.addVersion(version);
 
-      if (createdArtifact instanceof DocumentArtifact) {
-        return new DocumentArtifact({
-          id: createdArtifact.id,
-          threadId: createdArtifact.threadId,
-          userId: createdArtifact.userId,
-          title: createdArtifact.title,
-          letterheadId: createdArtifact.letterheadId,
-          currentVersionNumber: createdArtifact.currentVersionNumber,
-          versions: [version],
-          createdAt: createdArtifact.createdAt,
-          updatedAt: createdArtifact.updatedAt,
+    return this.withVersion(createdArtifact, version);
+  }
+
+  private buildArtifact(
+    command: CreateArtifactCommand,
+    userId: UUID,
+  ): Artifact {
+    return command.type === ArtifactType.DOCUMENT
+      ? new DocumentArtifact({
+          threadId: command.threadId,
+          userId,
+          title: command.title,
+          letterheadId: command.letterheadId ?? null,
+          currentVersionNumber: 1,
+        })
+      : new DiagramArtifact({
+          threadId: command.threadId,
+          userId,
+          title: command.title,
+          currentVersionNumber: 1,
         });
-      }
-      return new DiagramArtifact({
+  }
+
+  private withVersion(
+    createdArtifact: Artifact,
+    version: ArtifactVersion,
+  ): Artifact {
+    if (createdArtifact instanceof DocumentArtifact) {
+      return new DocumentArtifact({
         id: createdArtifact.id,
         threadId: createdArtifact.threadId,
         userId: createdArtifact.userId,
         title: createdArtifact.title,
+        letterheadId: createdArtifact.letterheadId,
         currentVersionNumber: createdArtifact.currentVersionNumber,
         versions: [version],
         createdAt: createdArtifact.createdAt,
         updatedAt: createdArtifact.updatedAt,
       });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-
-      this.logger.error('createArtifactUnexpectedError', {
-        title: command.title,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedArtifactError(
-        error instanceof Error ? error.message : 'Unknown error',
-      );
     }
+    return new DiagramArtifact({
+      id: createdArtifact.id,
+      threadId: createdArtifact.threadId,
+      userId: createdArtifact.userId,
+      title: createdArtifact.title,
+      currentVersionNumber: createdArtifact.currentVersionNumber,
+      versions: [version],
+      createdAt: createdArtifact.createdAt,
+      updatedAt: createdArtifact.updatedAt,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
@@ -1,5 +1,6 @@
 import type { UUID } from 'crypto';
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import {
   DocumentExportPort,
@@ -14,7 +15,6 @@ import {
 } from '../../artifacts.errors';
 import { DocumentArtifact } from '../../../domain/artifact.entity';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { FindLetterheadUseCase } from 'src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case';
 import { FindLetterheadQuery } from 'src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.query';
@@ -44,47 +44,34 @@ export class ExportArtifactUseCase {
     private readonly getThreadPiiMasksUseCase: GetThreadPiiMasksUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedArtifactError)
   async execute(command: ExportArtifactCommand): Promise<ExportResult> {
     this.logger.log('Exporting artifact', {
       artifactId: command.artifactId,
       format: command.format,
     });
 
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      const artifact = await this.loadExportableArtifact(
-        command.artifactId,
-        userId,
-      );
-      const currentVersion = this.requireCurrentVersion(artifact);
-      const safeTitle = this.buildSafeTitle(artifact.title);
-      const content = await this.deanonymizeContent(
-        artifact.threadId,
-        currentVersion.content,
-      );
-
-      if (command.format === 'docx') {
-        return await this.exportDocx(content, safeTitle);
-      }
-
-      return await this.exportPdf(artifact, content, safeTitle);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-
-      this.logger.error('exportArtifactUnexpectedError', {
-        artifactId: command.artifactId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedArtifactError(
-        error instanceof Error ? error.message : 'Unknown error',
-      );
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
     }
+
+    const artifact = await this.loadExportableArtifact(
+      command.artifactId,
+      userId,
+    );
+    const currentVersion = this.requireCurrentVersion(artifact);
+    const safeTitle = this.buildSafeTitle(artifact.title);
+    const content = await this.deanonymizeContent(
+      artifact.threadId,
+      currentVersion.content,
+    );
+
+    if (command.format === 'docx') {
+      return this.exportDocx(content, safeTitle);
+    }
+
+    return this.exportPdf(artifact, content, safeTitle);
   }
 
   private async loadExportableArtifact(

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { FindArtifactWithVersionsQuery } from './find-artifact-with-versions.query';
 import {
@@ -7,7 +8,6 @@ import {
 } from '../../artifacts.errors';
 import { Artifact } from '../../../domain/artifact.entity';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
@@ -19,33 +19,22 @@ export class FindArtifactWithVersionsUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedArtifactError)
   async execute(query: FindArtifactWithVersionsQuery): Promise<Artifact> {
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
+    this.logger.log('execute', { artifactId: query.artifactId });
 
-      const artifact = await this.artifactsRepository.findByIdWithVersions(
-        query.artifactId,
-        userId,
-      );
-      if (!artifact) {
-        throw new ArtifactNotFoundError(query.artifactId);
-      }
-      return artifact;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-
-      this.logger.error('findArtifactWithVersionsUnexpectedError', {
-        artifactId: query.artifactId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedArtifactError(
-        error instanceof Error ? error.message : 'Unknown error',
-      );
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
     }
+
+    const artifact = await this.artifactsRepository.findByIdWithVersions(
+      query.artifactId,
+      userId,
+    );
+    if (!artifact) {
+      throw new ArtifactNotFoundError(query.artifactId);
+    }
+    return artifact;
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.use-case.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { FindArtifactsByThreadQuery } from './find-artifacts-by-thread.query';
 import { Artifact } from '../../../domain/artifact.entity';
-import { ContextService } from 'src/common/context/services/context.service';
 import { UnexpectedArtifactError } from '../../artifacts.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
@@ -16,29 +16,15 @@ export class FindArtifactsByThreadUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedArtifactError)
   async execute(query: FindArtifactsByThreadQuery): Promise<Artifact[]> {
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
+    this.logger.log('execute', { threadId: query.threadId });
 
-      return await this.artifactsRepository.findByThreadId(
-        query.threadId,
-        userId,
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-
-      this.logger.error('findArtifactsByThreadUnexpectedError', {
-        threadId: query.threadId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedArtifactError(
-        error instanceof Error ? error.message : 'Unknown error',
-      );
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
     }
+
+    return this.artifactsRepository.findByThreadId(query.threadId, userId);
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { RevertArtifactCommand } from './revert-artifact.command';
 import {
@@ -11,7 +12,6 @@ import { AuthorType } from '../../../domain/value-objects/author-type.enum';
 import { DocumentArtifact } from '../../../domain/artifact.entity';
 import { sanitizeHtmlContent } from '../../helpers/sanitize-html-content';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { addVersionWithRetry } from '../../helpers/add-version-with-retry';
 
@@ -24,70 +24,57 @@ export class RevertArtifactUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedArtifactError)
   async execute(command: RevertArtifactCommand): Promise<ArtifactVersion> {
     this.logger.log('Reverting artifact', {
       artifactId: command.artifactId,
       targetVersion: command.versionNumber,
     });
 
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      return await addVersionWithRetry({
-        repository: this.artifactsRepository,
-        logger: this.logger,
-        artifactId: command.artifactId,
-        buildVersion: async () => {
-          const artifact = await this.artifactsRepository.findByIdWithVersions(
-            command.artifactId,
-            userId,
-          );
-          if (!artifact) {
-            throw new ArtifactNotFoundError(command.artifactId);
-          }
-
-          const targetVersion = artifact.versions.find(
-            (v) => v.versionNumber === command.versionNumber,
-          );
-          if (!targetVersion) {
-            throw new ArtifactVersionNotFoundError(
-              command.artifactId,
-              command.versionNumber,
-            );
-          }
-
-          const content =
-            artifact instanceof DocumentArtifact
-              ? sanitizeHtmlContent(targetVersion.content)
-              : targetVersion.content;
-
-          return {
-            expectedCurrentVersionNumber: artifact.currentVersionNumber,
-            version: new ArtifactVersion({
-              artifactId: artifact.id,
-              versionNumber: artifact.currentVersionNumber + 1,
-              content,
-              authorType: AuthorType.USER,
-              authorId: userId,
-            }),
-          };
-        },
-      });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-
-      this.logger.error('revertArtifactUnexpectedError', {
-        artifactId: command.artifactId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedArtifactError(
-        error instanceof Error ? error.message : 'Unknown error',
-      );
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
     }
+
+    return addVersionWithRetry({
+      repository: this.artifactsRepository,
+      logger: this.logger,
+      artifactId: command.artifactId,
+      buildVersion: async () => {
+        const artifact = await this.artifactsRepository.findByIdWithVersions(
+          command.artifactId,
+          userId,
+        );
+        if (!artifact) {
+          throw new ArtifactNotFoundError(command.artifactId);
+        }
+
+        const targetVersion = artifact.versions.find(
+          (v) => v.versionNumber === command.versionNumber,
+        );
+        if (!targetVersion) {
+          throw new ArtifactVersionNotFoundError(
+            command.artifactId,
+            command.versionNumber,
+          );
+        }
+
+        const content =
+          artifact instanceof DocumentArtifact
+            ? sanitizeHtmlContent(targetVersion.content)
+            : targetVersion.content;
+
+        return {
+          expectedCurrentVersionNumber: artifact.currentVersionNumber,
+          version: new ArtifactVersion({
+            artifactId: artifact.id,
+            versionNumber: artifact.currentVersionNumber + 1,
+            content,
+            authorType: AuthorType.USER,
+            authorId: userId,
+          }),
+        };
+      },
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.ts
@@ -1,5 +1,6 @@
 import type { UUID } from 'crypto';
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { UpdateArtifactCommand } from './update-artifact.command';
 import {
@@ -15,7 +16,6 @@ import { AuthorType } from '../../../domain/value-objects/author-type.enum';
 import { Artifact, DocumentArtifact } from '../../../domain/artifact.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { sanitizeHtmlContent } from '../../helpers/sanitize-html-content';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { addVersionWithRetry } from '../../helpers/add-version-with-retry';
 import { FindLetterheadUseCase } from 'src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case';
@@ -31,50 +31,37 @@ export class UpdateArtifactUseCase {
     private readonly findLetterheadUseCase: FindLetterheadUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedArtifactError)
   async execute(
     command: UpdateArtifactCommand,
   ): Promise<ArtifactVersion | void> {
     this.logger.log('Updating artifact', { artifactId: command.artifactId });
 
-    try {
-      const userId = this.resolveUserId();
-      this.validateContentLength(command.content);
+    const userId = this.resolveUserId();
+    this.validateContentLength(command.content);
 
-      if (command.letterheadId) {
-        await this.findLetterheadUseCase.execute(
-          new FindLetterheadQuery({ letterheadId: command.letterheadId }),
-        );
-      }
-
-      const artifact = await this.artifactsRepository.findById(
-        command.artifactId,
-        userId,
-      );
-      if (!artifact) {
-        throw new ArtifactNotFoundError(command.artifactId);
-      }
-
-      const isDocument = artifact instanceof DocumentArtifact;
-      this.assertLetterheadAllowed(command, artifact, isDocument);
-
-      if (command.content === undefined) {
-        return await this.updateLetterheadOnly(command);
-      }
-
-      return await this.addContentVersion(command, userId, isDocument);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-
-      this.logger.error('updateArtifactUnexpectedError', {
-        artifactId: command.artifactId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedArtifactError(
-        error instanceof Error ? error.message : 'Unknown error',
+    if (command.letterheadId) {
+      await this.findLetterheadUseCase.execute(
+        new FindLetterheadQuery({ letterheadId: command.letterheadId }),
       );
     }
+
+    const artifact = await this.artifactsRepository.findById(
+      command.artifactId,
+      userId,
+    );
+    if (!artifact) {
+      throw new ArtifactNotFoundError(command.artifactId);
+    }
+
+    const isDocument = artifact instanceof DocumentArtifact;
+    this.assertLetterheadAllowed(command, artifact, isDocument);
+
+    if (command.content === undefined) {
+      return this.updateLetterheadOnly(command);
+    }
+
+    return this.addContentVersion(command, userId, isDocument);
   }
 
   private resolveUserId(): UUID {

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/delete-org-system-prompt/delete-org-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/delete-org-system-prompt/delete-org-system-prompt.use-case.ts
@@ -1,9 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { OrgSystemPromptsRepository } from '../../ports/org-system-prompts.repository';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { UnexpectedChatSettingsError } from '../../chat-settings.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class DeleteOrgSystemPromptUseCase {
@@ -14,6 +14,7 @@ export class DeleteOrgSystemPromptUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedChatSettingsError)
   async execute(): Promise<void> {
     const orgId = this.contextService.get('orgId');
     if (!orgId) {
@@ -21,14 +22,8 @@ export class DeleteOrgSystemPromptUseCase {
     }
     this.logger.log('execute', { orgId });
 
-    try {
-      await this.orgSystemPromptsRepository.deleteByOrgId(orgId);
+    await this.orgSystemPromptsRepository.deleteByOrgId(orgId);
 
-      this.logger.debug('Org system prompt deleted', { orgId });
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to delete org system prompt', error);
-      throw new UnexpectedChatSettingsError(error as Error);
-    }
+    this.logger.debug('Org system prompt deleted', { orgId });
   }
 }

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/delete-user-system-prompt/delete-user-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/delete-user-system-prompt/delete-user-system-prompt.use-case.ts
@@ -1,9 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UserSystemPromptsRepository } from '../../ports/user-system-prompts.repository';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { UnexpectedChatSettingsError } from '../../chat-settings.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class DeleteUserSystemPromptUseCase {
@@ -14,6 +14,7 @@ export class DeleteUserSystemPromptUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedChatSettingsError)
   async execute(): Promise<void> {
     const userId = this.contextService.get('userId');
     if (!userId) {
@@ -21,14 +22,8 @@ export class DeleteUserSystemPromptUseCase {
     }
     this.logger.log('execute', { userId });
 
-    try {
-      await this.userSystemPromptsRepository.deleteByUserId(userId);
+    await this.userSystemPromptsRepository.deleteByUserId(userId);
 
-      this.logger.debug('User system prompt deleted', { userId });
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to delete user system prompt', error);
-      throw new UnexpectedChatSettingsError(error as Error);
-    }
+    this.logger.debug('User system prompt deleted', { userId });
   }
 }

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GeneratePersonalizedSystemPromptCommand } from './generate-personalized-system-prompt.command';
 import { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
 import { GetInferenceCommand } from 'src/domain/models/application/use-cases/get-inference/get-inference.command';
@@ -8,7 +9,10 @@ import { UpsertUserSystemPromptUseCase } from '../upsert-user-system-prompt/upse
 import { UpsertUserSystemPromptCommand } from '../upsert-user-system-prompt/upsert-user-system-prompt.command';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
-import { PersonalizedSystemPromptGenerationError } from '../../chat-settings.errors';
+import {
+  PersonalizedSystemPromptGenerationError,
+  UnexpectedChatSettingsError,
+} from '../../chat-settings.errors';
 import { UserMessage } from 'src/domain/messages/domain/messages/user-message.entity';
 import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
 import { ModelToolChoice } from 'src/domain/models/domain/value-objects/model-tool-choice.enum';
@@ -42,6 +46,7 @@ export class GeneratePersonalizedSystemPromptUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedChatSettingsError)
   async execute(
     command: GeneratePersonalizedSystemPromptCommand,
   ): Promise<GeneratePersonalizedSystemPromptResult> {

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-org-chat-settings/get-org-chat-settings.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-org-chat-settings/get-org-chat-settings.use-case.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { OrgChatSettings } from '../../../domain/org-chat-settings.entity';
 import { OrgChatSettingsRepository } from '../../ports/org-chat-settings.repository';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { UnexpectedChatSettingsError } from '../../chat-settings.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetOrgChatSettingsUseCase {
@@ -15,6 +15,7 @@ export class GetOrgChatSettingsUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedChatSettingsError)
   async execute(): Promise<OrgChatSettings> {
     const orgId = this.contextService.get('orgId');
     if (!orgId) {
@@ -22,18 +23,10 @@ export class GetOrgChatSettingsUseCase {
     }
     this.logger.log('execute', { orgId });
 
-    try {
-      const orgChatSettings =
-        await this.orgChatSettingsRepository.findByOrgId(orgId);
+    const orgChatSettings =
+      await this.orgChatSettingsRepository.findByOrgId(orgId);
 
-      // Fall back to defaults (internet access enabled) when nothing is stored.
-      return orgChatSettings ?? new OrgChatSettings({ orgId });
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get org chat settings', {
-        error: error as Error,
-      });
-      throw new UnexpectedChatSettingsError(error as Error);
-    }
+    // Fall back to defaults (internet access enabled) when nothing is stored.
+    return orgChatSettings ?? new OrgChatSettings({ orgId });
   }
 }

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-org-system-prompt/get-org-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-org-system-prompt/get-org-system-prompt.use-case.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { OrgSystemPrompt } from '../../../domain/org-system-prompt.entity';
 import { OrgSystemPromptsRepository } from '../../ports/org-system-prompts.repository';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { UnexpectedChatSettingsError } from '../../chat-settings.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetOrgSystemPromptUseCase {
@@ -15,6 +15,7 @@ export class GetOrgSystemPromptUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedChatSettingsError)
   async execute(): Promise<OrgSystemPrompt | null> {
     const orgId = this.contextService.get('orgId');
     if (!orgId) {
@@ -22,21 +23,15 @@ export class GetOrgSystemPromptUseCase {
     }
     this.logger.log('execute', { orgId });
 
-    try {
-      const orgSystemPrompt =
-        await this.orgSystemPromptsRepository.findByOrgId(orgId);
+    const orgSystemPrompt =
+      await this.orgSystemPromptsRepository.findByOrgId(orgId);
 
-      if (orgSystemPrompt) {
-        this.logger.debug('Org system prompt found', { orgId });
-      } else {
-        this.logger.debug('No org system prompt found', { orgId });
-      }
-
-      return orgSystemPrompt;
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get org system prompt', error);
-      throw new UnexpectedChatSettingsError(error as Error);
+    if (orgSystemPrompt) {
+      this.logger.debug('Org system prompt found', { orgId });
+    } else {
+      this.logger.debug('No org system prompt found', { orgId });
     }
+
+    return orgSystemPrompt;
   }
 }

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-user-system-prompt/get-user-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-user-system-prompt/get-user-system-prompt.use-case.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UserSystemPrompt } from '../../../domain/user-system-prompt.entity';
 import { UserSystemPromptsRepository } from '../../ports/user-system-prompts.repository';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { UnexpectedChatSettingsError } from '../../chat-settings.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetUserSystemPromptUseCase {
@@ -15,6 +15,7 @@ export class GetUserSystemPromptUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedChatSettingsError)
   async execute(): Promise<UserSystemPrompt | null> {
     const userId = this.contextService.get('userId');
     if (!userId) {
@@ -22,21 +23,15 @@ export class GetUserSystemPromptUseCase {
     }
     this.logger.log('execute', { userId });
 
-    try {
-      const userSystemPrompt =
-        await this.userSystemPromptsRepository.findByUserId(userId);
+    const userSystemPrompt =
+      await this.userSystemPromptsRepository.findByUserId(userId);
 
-      if (userSystemPrompt) {
-        this.logger.debug('User system prompt found', { userId });
-      } else {
-        this.logger.debug('No user system prompt found', { userId });
-      }
-
-      return userSystemPrompt;
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get user system prompt', error);
-      throw new UnexpectedChatSettingsError(error as Error);
+    if (userSystemPrompt) {
+      this.logger.debug('User system prompt found', { userId });
+    } else {
+      this.logger.debug('No user system prompt found', { userId });
     }
+
+    return userSystemPrompt;
   }
 }

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-chat-settings/upsert-org-chat-settings.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-chat-settings/upsert-org-chat-settings.use-case.ts
@@ -1,11 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UpsertOrgChatSettingsCommand } from './upsert-org-chat-settings.command';
 import { OrgChatSettings } from '../../../domain/org-chat-settings.entity';
 import { OrgChatSettingsRepository } from '../../ports/org-chat-settings.repository';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { UnexpectedChatSettingsError } from '../../chat-settings.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class UpsertOrgChatSettingsUseCase {
@@ -16,6 +16,7 @@ export class UpsertOrgChatSettingsUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedChatSettingsError)
   async execute(
     command: UpsertOrgChatSettingsCommand,
   ): Promise<OrgChatSettings> {
@@ -25,27 +26,18 @@ export class UpsertOrgChatSettingsUseCase {
     }
     this.logger.log('execute', { orgId });
 
-    try {
-      const orgChatSettings = new OrgChatSettings({
-        orgId,
-        internetSearchEnabled: command.internetSearchEnabled,
-      });
+    const orgChatSettings = new OrgChatSettings({
+      orgId,
+      internetSearchEnabled: command.internetSearchEnabled,
+    });
 
-      const result =
-        await this.orgChatSettingsRepository.upsert(orgChatSettings);
+    const result = await this.orgChatSettingsRepository.upsert(orgChatSettings);
 
-      this.logger.debug('Org chat settings upserted', {
-        orgId,
-        id: result.id,
-      });
+    this.logger.debug('Org chat settings upserted', {
+      orgId,
+      id: result.id,
+    });
 
-      return result;
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to upsert org chat settings', {
-        error: error as Error,
-      });
-      throw new UnexpectedChatSettingsError(error as Error);
-    }
+    return result;
   }
 }

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-system-prompt/upsert-org-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-system-prompt/upsert-org-system-prompt.use-case.ts
@@ -1,11 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UpsertOrgSystemPromptCommand } from './upsert-org-system-prompt.command';
 import { OrgSystemPrompt } from '../../../domain/org-system-prompt.entity';
 import { OrgSystemPromptsRepository } from '../../ports/org-system-prompts.repository';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { UnexpectedChatSettingsError } from '../../chat-settings.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class UpsertOrgSystemPromptUseCase {
@@ -16,6 +16,7 @@ export class UpsertOrgSystemPromptUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedChatSettingsError)
   async execute(
     command: UpsertOrgSystemPromptCommand,
   ): Promise<OrgSystemPrompt> {
@@ -25,25 +26,19 @@ export class UpsertOrgSystemPromptUseCase {
     }
     this.logger.log('execute', { orgId });
 
-    try {
-      const orgSystemPrompt = new OrgSystemPrompt({
-        orgId,
-        systemPrompt: command.systemPrompt,
-      });
+    const orgSystemPrompt = new OrgSystemPrompt({
+      orgId,
+      systemPrompt: command.systemPrompt,
+    });
 
-      const result =
-        await this.orgSystemPromptsRepository.upsert(orgSystemPrompt);
+    const result =
+      await this.orgSystemPromptsRepository.upsert(orgSystemPrompt);
 
-      this.logger.debug('Org system prompt upserted', {
-        orgId,
-        id: result.id,
-      });
+    this.logger.debug('Org system prompt upserted', {
+      orgId,
+      id: result.id,
+    });
 
-      return result;
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to upsert org system prompt', error);
-      throw new UnexpectedChatSettingsError(error as Error);
-    }
+    return result;
   }
 }

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-user-system-prompt/upsert-user-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-user-system-prompt/upsert-user-system-prompt.use-case.ts
@@ -1,11 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UpsertUserSystemPromptCommand } from './upsert-user-system-prompt.command';
 import { UserSystemPrompt } from '../../../domain/user-system-prompt.entity';
 import { UserSystemPromptsRepository } from '../../ports/user-system-prompts.repository';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { UnexpectedChatSettingsError } from '../../chat-settings.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class UpsertUserSystemPromptUseCase {
@@ -16,6 +16,7 @@ export class UpsertUserSystemPromptUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedChatSettingsError)
   async execute(
     command: UpsertUserSystemPromptCommand,
   ): Promise<UserSystemPrompt> {
@@ -25,25 +26,19 @@ export class UpsertUserSystemPromptUseCase {
     }
     this.logger.log('execute', { userId });
 
-    try {
-      const userSystemPrompt = new UserSystemPrompt({
-        userId,
-        systemPrompt: command.systemPrompt,
-      });
+    const userSystemPrompt = new UserSystemPrompt({
+      userId,
+      systemPrompt: command.systemPrompt,
+    });
 
-      const result =
-        await this.userSystemPromptsRepository.upsert(userSystemPrompt);
+    const result =
+      await this.userSystemPromptsRepository.upsert(userSystemPrompt);
 
-      this.logger.debug('User system prompt upserted', {
-        userId,
-        id: result.id,
-      });
+    this.logger.debug('User system prompt upserted', {
+      userId,
+      id: result.id,
+    });
 
-      return result;
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to upsert user system prompt', error);
-      throw new UnexpectedChatSettingsError(error as Error);
-    }
+    return result;
   }
 }

--- a/ayunis-core-backend/src/domain/letterheads/application/letterheads.errors.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/letterheads.errors.ts
@@ -55,12 +55,10 @@ export class LetterheadOrgMismatchError extends LetterheadError {
 }
 
 export class UnexpectedLetterheadError extends LetterheadError {
-  constructor(message: string, metadata?: ErrorMetadata) {
-    super(
-      message,
-      LetterheadErrorCode.UNEXPECTED_LETTERHEAD_ERROR,
-      500,
-      metadata,
-    );
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, LetterheadErrorCode.UNEXPECTED_LETTERHEAD_ERROR, 500, {
+      ...metadata,
+      error,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.use-case.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { randomUUID } from 'crypto';
+import { randomUUID, UUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/upload-object/upload-object.use-case';
 import { UploadObjectCommand } from 'src/domain/storage/application/use-cases/upload-object/upload-object.command';
@@ -22,76 +22,83 @@ export class CreateLetterheadUseCase {
     private readonly letterheadPdfService: LetterheadPdfService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedLetterheadError)
   async execute(command: CreateLetterheadCommand): Promise<Letterhead> {
     this.logger.log('Creating letterhead', { name: command.name });
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedAccessError();
-      }
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedAccessError();
+    }
 
+    await this.validatePdfs(command);
+
+    const letterheadId = randomUUID();
+
+    const { firstPagePath, continuationPagePath } = await this.uploadPdfs(
+      orgId,
+      letterheadId,
+      command,
+    );
+
+    const letterhead = new Letterhead({
+      id: letterheadId,
+      orgId,
+      name: command.name,
+      description: command.description,
+      firstPageStoragePath: firstPagePath,
+      continuationPageStoragePath: continuationPagePath,
+      firstPageMargins: command.firstPageMargins,
+      continuationPageMargins: command.continuationPageMargins,
+    });
+
+    return await this.letterheadsRepository.save(letterhead);
+  }
+
+  private async validatePdfs(command: CreateLetterheadCommand): Promise<void> {
+    await this.letterheadPdfService.validateSinglePagePdf(
+      command.firstPagePdfBuffer,
+      'first page',
+    );
+
+    if (command.continuationPagePdfBuffer) {
       await this.letterheadPdfService.validateSinglePagePdf(
-        command.firstPagePdfBuffer,
-        'first page',
+        command.continuationPagePdfBuffer,
+        'continuation page',
       );
+    }
+  }
 
-      if (command.continuationPagePdfBuffer) {
-        await this.letterheadPdfService.validateSinglePagePdf(
-          command.continuationPagePdfBuffer,
-          'continuation page',
-        );
-      }
+  private async uploadPdfs(
+    orgId: UUID,
+    letterheadId: UUID,
+    command: CreateLetterheadCommand,
+  ): Promise<{ firstPagePath: string; continuationPagePath: string | null }> {
+    const firstPagePath = this.letterheadPdfService.buildStoragePath(
+      orgId,
+      letterheadId,
+      'first-page.pdf',
+    );
 
-      const letterheadId = randomUUID();
+    await this.uploadObjectUseCase.execute(
+      new UploadObjectCommand(firstPagePath, command.firstPagePdfBuffer),
+    );
 
-      const firstPagePath = this.letterheadPdfService.buildStoragePath(
+    let continuationPagePath: string | null = null;
+    if (command.continuationPagePdfBuffer) {
+      continuationPagePath = this.letterheadPdfService.buildStoragePath(
         orgId,
         letterheadId,
-        'first-page.pdf',
+        'continuation.pdf',
       );
-
       await this.uploadObjectUseCase.execute(
-        new UploadObjectCommand(firstPagePath, command.firstPagePdfBuffer),
+        new UploadObjectCommand(
+          continuationPagePath,
+          command.continuationPagePdfBuffer,
+        ),
       );
-
-      let continuationPagePath: string | null = null;
-      if (command.continuationPagePdfBuffer) {
-        continuationPagePath = this.letterheadPdfService.buildStoragePath(
-          orgId,
-          letterheadId,
-          'continuation.pdf',
-        );
-        await this.uploadObjectUseCase.execute(
-          new UploadObjectCommand(
-            continuationPagePath,
-            command.continuationPagePdfBuffer,
-          ),
-        );
-      }
-
-      const letterhead = new Letterhead({
-        id: letterheadId,
-        orgId,
-        name: command.name,
-        description: command.description,
-        firstPageStoragePath: firstPagePath,
-        continuationPageStoragePath: continuationPagePath,
-        firstPageMargins: command.firstPageMargins,
-        continuationPageMargins: command.continuationPageMargins,
-      });
-
-      return await this.letterheadsRepository.save(letterhead);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error creating letterhead', {
-        error: error as Error,
-      });
-      throw new UnexpectedLetterheadError('Error creating letterhead', {
-        error: error as Error,
-      });
     }
+
+    return { firstPagePath, continuationPagePath };
   }
 }

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/delete-letterhead/delete-letterhead.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/delete-letterhead/delete-letterhead.use-case.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
 import { DeleteObjectCommand } from 'src/domain/storage/application/use-cases/delete-object/delete-object.command';
@@ -21,48 +21,37 @@ export class DeleteLetterheadUseCase {
     private readonly deleteObjectUseCase: DeleteObjectUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedLetterheadError)
   async execute(command: DeleteLetterheadCommand): Promise<void> {
     this.logger.log('Deleting letterhead', {
       letterheadId: command.letterheadId,
     });
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedAccessError();
-      }
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedAccessError();
+    }
 
-      const letterhead = await this.letterheadsRepository.findById(
-        orgId,
-        command.letterheadId,
-      );
-      if (!letterhead) {
-        throw new LetterheadNotFoundError(command.letterheadId);
-      }
+    const letterhead = await this.letterheadsRepository.findById(
+      orgId,
+      command.letterheadId,
+    );
+    if (!letterhead) {
+      throw new LetterheadNotFoundError(command.letterheadId);
+    }
 
-      // Delete DB record first — orphaned storage files are benign,
-      // but a DB record pointing to deleted storage paths causes runtime errors.
-      await this.letterheadsRepository.delete(orgId, command.letterheadId);
+    // Delete DB record first — orphaned storage files are benign,
+    // but a DB record pointing to deleted storage paths causes runtime errors.
+    await this.letterheadsRepository.delete(orgId, command.letterheadId);
 
+    await this.deleteObjectUseCase.execute(
+      new DeleteObjectCommand(letterhead.firstPageStoragePath),
+    );
+
+    if (letterhead.continuationPageStoragePath) {
       await this.deleteObjectUseCase.execute(
-        new DeleteObjectCommand(letterhead.firstPageStoragePath),
+        new DeleteObjectCommand(letterhead.continuationPageStoragePath),
       );
-
-      if (letterhead.continuationPageStoragePath) {
-        await this.deleteObjectUseCase.execute(
-          new DeleteObjectCommand(letterhead.continuationPageStoragePath),
-        );
-      }
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error deleting letterhead', {
-        error: error as Error,
-      });
-      throw new UnexpectedLetterheadError('Error deleting letterhead', {
-        error: error as Error,
-      });
     }
   }
 }

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-all-letterheads/find-all-letterheads.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-all-letterheads/find-all-letterheads.use-case.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
 import { UnexpectedLetterheadError } from '../../letterheads.errors';
@@ -15,26 +15,15 @@ export class FindAllLetterheadsUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedLetterheadError)
   async execute(): Promise<Letterhead[]> {
     this.logger.log('Finding all letterheads');
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      return await this.letterheadsRepository.findAllByOrgId(orgId);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error finding all letterheads', {
-        error: error as Error,
-      });
-      throw new UnexpectedLetterheadError('Error finding all letterheads', {
-        error: error as Error,
-      });
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedAccessError();
     }
+
+    return await this.letterheadsRepository.findAllByOrgId(orgId);
   }
 }

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
 import { Letterhead } from '../../../domain/letterhead.entity';
@@ -19,37 +19,26 @@ export class FindLetterheadUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedLetterheadError)
   async execute(query: FindLetterheadQuery): Promise<Letterhead> {
     this.logger.log('Finding letterhead', {
       letterheadId: query.letterheadId,
     });
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      const letterhead = await this.letterheadsRepository.findById(
-        orgId,
-        query.letterheadId,
-      );
-
-      if (!letterhead) {
-        throw new LetterheadNotFoundError(query.letterheadId);
-      }
-
-      return letterhead;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error finding letterhead', {
-        error: error as Error,
-      });
-      throw new UnexpectedLetterheadError('Error finding letterhead', {
-        error: error as Error,
-      });
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedAccessError();
     }
+
+    const letterhead = await this.letterheadsRepository.findById(
+      orgId,
+      query.letterheadId,
+    );
+
+    if (!letterhead) {
+      throw new LetterheadNotFoundError(query.letterheadId);
+    }
+
+    return letterhead;
   }
 }

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.use-case.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { UUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/upload-object/upload-object.use-case';
 import { UploadObjectCommand } from 'src/domain/storage/application/use-cases/upload-object/upload-object.command';
@@ -27,99 +28,114 @@ export class UpdateLetterheadUseCase {
     private readonly letterheadPdfService: LetterheadPdfService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedLetterheadError)
   async execute(command: UpdateLetterheadCommand): Promise<Letterhead> {
     this.logger.log('Updating letterhead', {
       letterheadId: command.letterheadId,
     });
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedAccessError();
-      }
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedAccessError();
+    }
 
-      const existing = await this.letterheadsRepository.findById(
-        orgId,
-        command.letterheadId,
+    const existing = await this.letterheadsRepository.findById(
+      orgId,
+      command.letterheadId,
+    );
+    if (!existing) {
+      throw new LetterheadNotFoundError(command.letterheadId);
+    }
+
+    const firstPageStoragePath = await this.resolveFirstPagePath(
+      orgId,
+      existing,
+      command,
+    );
+    const continuationPageStoragePath = await this.resolveContinuationPagePath(
+      orgId,
+      existing,
+      command,
+    );
+
+    const updated = new Letterhead({
+      id: existing.id,
+      orgId: existing.orgId,
+      name: command.name ?? existing.name,
+      description:
+        command.description !== undefined
+          ? command.description
+          : existing.description,
+      firstPageStoragePath,
+      continuationPageStoragePath,
+      firstPageMargins: command.firstPageMargins ?? existing.firstPageMargins,
+      continuationPageMargins:
+        command.continuationPageMargins ?? existing.continuationPageMargins,
+      createdAt: existing.createdAt,
+      updatedAt: new Date(),
+    });
+
+    return await this.letterheadsRepository.save(updated);
+  }
+
+  private async resolveFirstPagePath(
+    orgId: UUID,
+    existing: Letterhead,
+    command: UpdateLetterheadCommand,
+  ): Promise<string> {
+    if (!command.firstPagePdfBuffer) {
+      return existing.firstPageStoragePath;
+    }
+
+    await this.letterheadPdfService.validateSinglePagePdf(
+      command.firstPagePdfBuffer,
+      'first page',
+    );
+    const firstPageStoragePath = this.letterheadPdfService.buildStoragePath(
+      orgId,
+      existing.id,
+      'first-page.pdf',
+    );
+    await this.uploadObjectUseCase.execute(
+      new UploadObjectCommand(firstPageStoragePath, command.firstPagePdfBuffer),
+    );
+    return firstPageStoragePath;
+  }
+
+  private async resolveContinuationPagePath(
+    orgId: UUID,
+    existing: Letterhead,
+    command: UpdateLetterheadCommand,
+  ): Promise<string | null> {
+    if (command.continuationPagePdfBuffer) {
+      await this.letterheadPdfService.validateSinglePagePdf(
+        command.continuationPagePdfBuffer,
+        'continuation page',
       );
-      if (!existing) {
-        throw new LetterheadNotFoundError(command.letterheadId);
-      }
-
-      let firstPageStoragePath = existing.firstPageStoragePath;
-      if (command.firstPagePdfBuffer) {
-        await this.letterheadPdfService.validateSinglePagePdf(
-          command.firstPagePdfBuffer,
-          'first page',
-        );
-        firstPageStoragePath = this.letterheadPdfService.buildStoragePath(
+      const continuationPageStoragePath =
+        this.letterheadPdfService.buildStoragePath(
           orgId,
           existing.id,
-          'first-page.pdf',
+          'continuation.pdf',
         );
-        await this.uploadObjectUseCase.execute(
-          new UploadObjectCommand(
-            firstPageStoragePath,
-            command.firstPagePdfBuffer,
-          ),
-        );
-      }
-
-      let continuationPageStoragePath = existing.continuationPageStoragePath;
-      if (command.continuationPagePdfBuffer) {
-        await this.letterheadPdfService.validateSinglePagePdf(
+      await this.uploadObjectUseCase.execute(
+        new UploadObjectCommand(
+          continuationPageStoragePath,
           command.continuationPagePdfBuffer,
-          'continuation page',
-        );
-        continuationPageStoragePath =
-          this.letterheadPdfService.buildStoragePath(
-            orgId,
-            existing.id,
-            'continuation.pdf',
-          );
-        await this.uploadObjectUseCase.execute(
-          new UploadObjectCommand(
-            continuationPageStoragePath,
-            command.continuationPagePdfBuffer,
-          ),
-        );
-      } else if (command.removeContinuationPage) {
-        if (existing.continuationPageStoragePath) {
-          await this.deleteObjectUseCase.execute(
-            new DeleteObjectCommand(existing.continuationPageStoragePath),
-          );
-        }
-        continuationPageStoragePath = null;
-      }
-
-      const updated = new Letterhead({
-        id: existing.id,
-        orgId: existing.orgId,
-        name: command.name ?? existing.name,
-        description:
-          command.description !== undefined
-            ? command.description
-            : existing.description,
-        firstPageStoragePath,
-        continuationPageStoragePath,
-        firstPageMargins: command.firstPageMargins ?? existing.firstPageMargins,
-        continuationPageMargins:
-          command.continuationPageMargins ?? existing.continuationPageMargins,
-        createdAt: existing.createdAt,
-        updatedAt: new Date(),
-      });
-
-      return await this.letterheadsRepository.save(updated);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error updating letterhead', {
-        error: error as Error,
-      });
-      throw new UnexpectedLetterheadError('Error updating letterhead', {
-        error: error as Error,
-      });
+        ),
+      );
+      return continuationPageStoragePath;
     }
+
+    if (command.removeContinuationPage) {
+      if (existing.continuationPageStoragePath) {
+        await this.deleteObjectUseCase.execute(
+          new DeleteObjectCommand(existing.continuationPageStoragePath),
+        );
+      }
+      return null;
+    }
+
+    return existing.continuationPageStoragePath;
   }
 }

--- a/ayunis-core-backend/src/domain/messages/application/messages.errors.ts
+++ b/ayunis-core-backend/src/domain/messages/application/messages.errors.ts
@@ -7,6 +7,7 @@ import { ApplicationError } from '../../../common/errors/base.error';
 export enum MessageErrorCode {
   MESSAGE_CONTENT_INVALID = 'MESSAGE_CONTENT_INVALID',
   MESSAGE_TOO_LONG = 'MESSAGE_TOO_LONG',
+  UNEXPECTED_MESSAGE_ERROR = 'UNEXPECTED_MESSAGE_ERROR',
 }
 
 /**
@@ -48,6 +49,15 @@ export class MessageTooLongError extends MessageError {
       400,
       metadata,
     );
+  }
+}
+
+export class UnexpectedMessageError extends MessageError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, MessageErrorCode.UNEXPECTED_MESSAGE_ERROR, 500, {
+      ...metadata,
+      error,
+    });
   }
 }
 

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/cleanup-orphaned-images/cleanup-orphaned-images.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/cleanup-orphaned-images/cleanup-orphaned-images.use-case.ts
@@ -1,5 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedMessageError } from '../../messages.errors';
 import { ObjectStoragePort } from 'src/domain/storage/application/ports/object-storage.port';
 import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
 import { DeleteObjectCommand } from 'src/domain/storage/application/use-cases/delete-object/delete-object.command';
@@ -25,6 +27,7 @@ export class CleanupOrphanedImagesUseCase {
     private readonly messagesRepository: MessagesRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMessageError)
   async execute(): Promise<CleanupResult> {
     this.logger.log('Starting orphaned images cleanup');
 
@@ -36,85 +39,96 @@ export class CleanupOrphanedImagesUseCase {
       errors: [],
     };
 
-    try {
-      // List all objects in storage
-      const allObjects = await this.objectStoragePort.listObjects();
-      result.scannedCount = allObjects.length;
+    // List all objects in storage
+    const allObjects = await this.objectStoragePort.listObjects();
+    result.scannedCount = allObjects.length;
 
-      this.logger.log(`Scanning ${allObjects.length} objects for orphans`);
+    this.logger.log(`Scanning ${allObjects.length} objects for orphans`);
 
-      // Group objects by messageId to batch check existence
-      const messageIdToObjects = this.groupObjectsByMessageId(allObjects);
-      const uniqueMessageIds = Array.from(messageIdToObjects.keys());
+    // Group objects by messageId to batch check existence
+    const messageIdToObjects = this.groupObjectsByMessageId(allObjects);
+    const uniqueMessageIds = Array.from(messageIdToObjects.keys());
 
-      this.logger.debug(
-        `Found ${uniqueMessageIds.length} unique message IDs to check`,
-      );
+    this.logger.debug(
+      `Found ${uniqueMessageIds.length} unique message IDs to check`,
+    );
 
-      // Check each message existence and collect orphaned paths
-      const orphanedPaths: string[] = [];
+    const orphanedPaths = await this.collectOrphanedPaths(
+      uniqueMessageIds,
+      messageIdToObjects,
+    );
 
-      for (const messageId of uniqueMessageIds) {
-        try {
-          const message = await this.messagesRepository.findById(
-            messageId as UUID,
+    this.logger.log(`Found ${orphanedPaths.length} orphaned images to delete`);
+
+    await this.deleteOrphanedImages(orphanedPaths, result);
+
+    this.logger.log('Orphaned images cleanup completed', {
+      scanned: result.scannedCount,
+      deleted: result.deletedCount,
+      failed: result.failedCount,
+    });
+
+    return result;
+  }
+
+  /**
+   * Checks each message existence and collects orphaned image paths.
+   */
+  private async collectOrphanedPaths(
+    uniqueMessageIds: string[],
+    messageIdToObjects: Map<string, string[]>,
+  ): Promise<string[]> {
+    const orphanedPaths: string[] = [];
+
+    for (const messageId of uniqueMessageIds) {
+      try {
+        const message = await this.messagesRepository.findById(
+          messageId as UUID,
+        );
+
+        if (!message) {
+          // Message doesn't exist, all its images are orphaned
+          const paths = messageIdToObjects.get(messageId) ?? [];
+          orphanedPaths.push(...paths);
+          this.logger.debug(
+            `Message ${messageId} not found, marking ${paths.length} images as orphaned`,
           );
-
-          if (!message) {
-            // Message doesn't exist, all its images are orphaned
-            const paths = messageIdToObjects.get(messageId) || [];
-            orphanedPaths.push(...paths);
-            this.logger.debug(
-              `Message ${messageId} not found, marking ${paths.length} images as orphaned`,
-            );
-          }
-        } catch (error) {
-          this.logger.warn(`Failed to check message ${messageId}`, {
-            error: error instanceof Error ? error.message : 'Unknown error',
-          });
         }
+      } catch (error) {
+        this.logger.warn(`Failed to check message ${messageId}`, {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
       }
+    }
 
-      this.logger.log(
-        `Found ${orphanedPaths.length} orphaned images to delete`,
-      );
+    return orphanedPaths;
+  }
 
-      // Delete orphaned images
-      for (const path of orphanedPaths) {
-        try {
-          await this.deleteObjectUseCase.execute(new DeleteObjectCommand(path));
-          result.deletedCount++;
-          result.deletedPaths.push(path);
-          this.logger.debug(`Deleted orphaned image: ${path}`);
-        } catch (error) {
-          // If object doesn't exist, it's already cleaned up - don't count as failure
-          if (error instanceof ObjectNotFoundError) {
-            this.logger.debug(`Orphaned image already deleted: ${path}`);
-            continue;
-          }
-
-          result.failedCount++;
-          const errorMessage =
-            error instanceof Error ? error.message : 'Unknown error';
-          result.errors.push({ path, error: errorMessage });
-          this.logger.warn(`Failed to delete orphaned image: ${path}`, {
-            error: errorMessage,
-          });
+  private async deleteOrphanedImages(
+    orphanedPaths: string[],
+    result: CleanupResult,
+  ): Promise<void> {
+    for (const path of orphanedPaths) {
+      try {
+        await this.deleteObjectUseCase.execute(new DeleteObjectCommand(path));
+        result.deletedCount++;
+        result.deletedPaths.push(path);
+        this.logger.debug(`Deleted orphaned image: ${path}`);
+      } catch (error) {
+        // If object doesn't exist, it's already cleaned up - don't count as failure
+        if (error instanceof ObjectNotFoundError) {
+          this.logger.debug(`Orphaned image already deleted: ${path}`);
+          continue;
         }
+
+        result.failedCount++;
+        const errorMessage =
+          error instanceof Error ? error.message : 'Unknown error';
+        result.errors.push({ path, error: errorMessage });
+        this.logger.warn(`Failed to delete orphaned image: ${path}`, {
+          error: errorMessage,
+        });
       }
-
-      this.logger.log('Orphaned images cleanup completed', {
-        scanned: result.scannedCount,
-        deleted: result.deletedCount,
-        failed: result.failedCount,
-      });
-
-      return result;
-    } catch (error) {
-      this.logger.error('Orphaned images cleanup failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw error;
     }
   }
 
@@ -130,7 +144,7 @@ export class CleanupOrphanedImagesUseCase {
     for (const path of objectPaths) {
       const messageId = this.extractMessageIdFromPath(path);
       if (messageId) {
-        const existing = map.get(messageId) || [];
+        const existing = map.get(messageId) ?? [];
         existing.push(path);
         map.set(messageId, existing);
       }

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-assistant-message/create-assistant-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-assistant-message/create-assistant-message.use-case.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { CreateAssistantMessageCommand } from './create-assistant-message.command';
 import { AssistantMessage } from '../../../domain/messages/assistant-message.entity';
 import {
@@ -7,7 +8,10 @@ import {
   MessagesRepository,
 } from '../../ports/messages.repository';
 import { MessageRole } from '../../../domain/value-objects/message-role.object';
-import { MessageCreationError } from '../../messages.errors';
+import {
+  MessageCreationError,
+  UnexpectedMessageError,
+} from '../../messages.errors';
 import { ContextService } from 'src/common/context/services/context.service';
 import { AssistantMessageCreatedEvent } from '../../events/assistant-message-created.event';
 import type { UUID } from 'crypto';
@@ -23,6 +27,7 @@ export class CreateAssistantMessageUseCase {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMessageError)
   async execute(
     command: CreateAssistantMessageCommand,
   ): Promise<AssistantMessage> {

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-system-message/create-system-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-system-message/create-system-message.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { CreateSystemMessageCommand } from './create-system-message.command';
 import { SystemMessage } from '../../../domain/messages/system-message.entity';
 import {
@@ -6,7 +7,10 @@ import {
   MessagesRepository,
 } from '../../ports/messages.repository';
 import { MessageRole } from '../../../domain/value-objects/message-role.object';
-import { MessageCreationError } from '../../messages.errors';
+import {
+  MessageCreationError,
+  UnexpectedMessageError,
+} from '../../messages.errors';
 
 @Injectable()
 export class CreateSystemMessageUseCase {
@@ -17,6 +21,7 @@ export class CreateSystemMessageUseCase {
     private readonly messagesRepository: MessagesRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMessageError)
   async execute(command: CreateSystemMessageCommand): Promise<SystemMessage> {
     this.logger.log('Creating system message', { threadId: command.threadId });
 

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-tool-result-message/create-tool-result-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-tool-result-message/create-tool-result-message.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { CreateToolResultMessageCommand } from './create-tool-result-message.command';
 import { ToolResultMessage } from '../../../domain/messages/tool-result-message.entity';
 import {
@@ -6,7 +7,10 @@ import {
   MessagesRepository,
 } from '../../ports/messages.repository';
 import { MessageRole } from '../../../domain/value-objects/message-role.object';
-import { MessageCreationError } from '../../messages.errors';
+import {
+  MessageCreationError,
+  UnexpectedMessageError,
+} from '../../messages.errors';
 
 @Injectable()
 export class CreateToolResultMessageUseCase {
@@ -17,6 +21,7 @@ export class CreateToolResultMessageUseCase {
     private readonly messagesRepository: MessagesRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMessageError)
   async execute(
     command: CreateToolResultMessageCommand,
   ): Promise<ToolResultMessage> {

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case.ts
@@ -5,6 +5,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { CreateUserMessageCommand } from './create-user-message.command';
 import { UserMessage } from '../../../domain/messages/user-message.entity';
 import {
@@ -12,7 +13,10 @@ import {
   MessagesRepository,
 } from '../../ports/messages.repository';
 import { MessageRole } from '../../../domain/value-objects/message-role.object';
-import { MessageCreationError } from '../../messages.errors';
+import {
+  MessageCreationError,
+  UnexpectedMessageError,
+} from '../../messages.errors';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/upload-object/upload-object.use-case';
 import { UploadObjectCommand } from 'src/domain/storage/application/use-cases/upload-object/upload-object.command';
@@ -37,6 +41,7 @@ export class CreateUserMessageUseCase {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMessageError)
   async execute(command: CreateUserMessageCommand): Promise<UserMessage> {
     const orgId = this.contextService.get('orgId');
     if (!orgId) {
@@ -53,81 +58,20 @@ export class CreateUserMessageUseCase {
     const uploadedPaths: string[] = [];
 
     try {
-      // Build content array
-      const content: (TextMessageContent | ImageMessageContent)[] = [];
-
-      // Prepend skill instructions if provided (marked as isSkillInstruction)
-      if (command.skillInstructions?.trim()) {
-        content.push(
-          new TextMessageContent(command.skillInstructions, null, true),
-        );
-      }
-
-      // Add text content if provided
-      if (command.text?.trim()) {
-        content.push(new TextMessageContent(command.text));
-      }
-
-      // Create ImageMessageContent objects with index and contentType
-      const imageContents = command.pendingImages.map(
-        (img, index) =>
-          new ImageMessageContent(index, img.contentType, img.altText),
-      );
-      content.push(...imageContents);
-
       // Create the message to get its ID (UUID generated in constructor)
       const userMessage = new UserMessage({
         threadId: command.threadId,
-        content,
+        content: this.buildContent(command),
       });
 
-      // Upload images to MinIO with deterministic paths
-      for (let i = 0; i < command.pendingImages.length; i++) {
-        const pendingImage = command.pendingImages[i];
-        const storagePath = getImageStoragePath({
-          orgId,
-          threadId: command.threadId,
-          messageId: userMessage.id,
-          index: i,
-          contentType: pendingImage.contentType,
-        });
-
-        this.logger.debug('Uploading image to storage', {
-          storagePath,
-          contentType: pendingImage.contentType,
-          size: pendingImage.buffer.length,
-        });
-
-        await this.uploadObjectUseCase.execute(
-          new UploadObjectCommand(storagePath, pendingImage.buffer, {
-            contentType: pendingImage.contentType,
-          }),
-        );
-        uploadedPaths.push(storagePath);
-      }
+      await this.uploadImages(orgId, command, userMessage.id, uploadedPaths);
 
       // Save message to database
       const savedMessage = (await this.messagesRepository.create(
         userMessage,
       )) as UserMessage;
 
-      const userId = this.contextService.get('userId');
-      this.eventEmitter
-        .emitAsync(
-          UserMessageCreatedEvent.EVENT_NAME,
-          new UserMessageCreatedEvent(
-            userId ?? ('unknown' as UUID),
-            orgId,
-            command.threadId,
-            savedMessage.id,
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit UserMessageCreatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            messageId: savedMessage.id,
-          });
-        });
+      this.emitCreatedEvent(orgId, command.threadId, savedMessage.id);
 
       this.logger.log('User message created successfully', {
         messageId: savedMessage.id,
@@ -153,6 +97,87 @@ export class CreateUserMessageUseCase {
             new Error('Unknown error'),
           );
     }
+  }
+
+  private buildContent(
+    command: CreateUserMessageCommand,
+  ): (TextMessageContent | ImageMessageContent)[] {
+    const content: (TextMessageContent | ImageMessageContent)[] = [];
+
+    // Prepend skill instructions if provided (marked as isSkillInstruction)
+    if (command.skillInstructions?.trim()) {
+      content.push(
+        new TextMessageContent(command.skillInstructions, null, true),
+      );
+    }
+
+    // Add text content if provided
+    if (command.text?.trim()) {
+      content.push(new TextMessageContent(command.text));
+    }
+
+    // Create ImageMessageContent objects with index and contentType
+    const imageContents = command.pendingImages.map(
+      (img, index) =>
+        new ImageMessageContent(index, img.contentType, img.altText),
+    );
+    content.push(...imageContents);
+
+    return content;
+  }
+
+  /**
+   * Uploads images to MinIO with deterministic paths.
+   */
+  private async uploadImages(
+    orgId: UUID,
+    command: CreateUserMessageCommand,
+    messageId: UUID,
+    uploadedPaths: string[],
+  ): Promise<void> {
+    for (let i = 0; i < command.pendingImages.length; i++) {
+      const pendingImage = command.pendingImages[i];
+      const storagePath = getImageStoragePath({
+        orgId,
+        threadId: command.threadId,
+        messageId,
+        index: i,
+        contentType: pendingImage.contentType,
+      });
+
+      this.logger.debug('Uploading image to storage', {
+        storagePath,
+        contentType: pendingImage.contentType,
+        size: pendingImage.buffer.length,
+      });
+
+      await this.uploadObjectUseCase.execute(
+        new UploadObjectCommand(storagePath, pendingImage.buffer, {
+          contentType: pendingImage.contentType,
+        }),
+      );
+      uploadedPaths.push(storagePath);
+    }
+  }
+
+  private emitCreatedEvent(orgId: UUID, threadId: UUID, messageId: UUID): void {
+    const userId = this.contextService.get('userId');
+    this.eventEmitter
+      .emitAsync(
+        UserMessageCreatedEvent.EVENT_NAME,
+        new UserMessageCreatedEvent(
+          userId ?? ('unknown' as UUID),
+          orgId,
+          threadId,
+          messageId,
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error('Failed to emit UserMessageCreatedEvent', {
+          error: err instanceof Error ? err.message : 'Unknown error',
+          messageId,
+        });
+      });
   }
 
   private async cleanupUploadedImages(paths: string[]): Promise<void> {

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/delete-message/delete-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/delete-message/delete-message.use-case.ts
@@ -1,5 +1,7 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { DeleteMessageCommand } from './delete-message.command';
+import { UnexpectedMessageError } from '../../messages.errors';
 import {
   MESSAGES_REPOSITORY,
   MessagesRepository,
@@ -14,22 +16,15 @@ export class DeleteMessageUseCase {
     private readonly messagesRepository: MessagesRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMessageError)
   async execute(command: DeleteMessageCommand): Promise<void> {
     this.logger.log('Deleting message', {
       messageId: command.messageId,
     });
 
-    try {
-      await this.messagesRepository.delete(command.messageId);
-      this.logger.log('Message deleted successfully', {
-        messageId: command.messageId,
-      });
-    } catch (error) {
-      this.logger.error('Failed to delete message', {
-        messageId: command.messageId,
-        error: error as Error,
-      });
-      throw error;
-    }
+    await this.messagesRepository.delete(command.messageId);
+    this.logger.log('Message deleted successfully', {
+      messageId: command.messageId,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/save-assistant-message/save-assistant-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/save-assistant-message/save-assistant-message.use-case.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SaveAssistantMessageCommand } from './save-assistant-message.command';
 import { AssistantMessage } from '../../../domain/messages/assistant-message.entity';
 import {
@@ -7,7 +8,10 @@ import {
   MessagesRepository,
 } from '../../ports/messages.repository';
 import { MessageRole } from '../../../domain/value-objects/message-role.object';
-import { MessageCreationError } from '../../messages.errors';
+import {
+  MessageCreationError,
+  UnexpectedMessageError,
+} from '../../messages.errors';
 import { ContextService } from 'src/common/context/services/context.service';
 import { AssistantMessageCreatedEvent } from '../../events/assistant-message-created.event';
 import type { UUID } from 'crypto';
@@ -23,6 +27,7 @@ export class SaveAssistantMessageUseCase {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMessageError)
   async execute(
     command: SaveAssistantMessageCommand,
   ): Promise<AssistantMessage> {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case.ts
@@ -1,7 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ClearDefaultsByCatalogModelIdCommand } from './clear-defaults-by-catalog-model-id.command';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
+import { UnexpectedModelError } from '../../models.errors';
 
 @Injectable()
 export class ClearDefaultsByCatalogModelIdUseCase {
@@ -14,6 +16,7 @@ export class ClearDefaultsByCatalogModelIdUseCase {
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(command: ClearDefaultsByCatalogModelIdCommand): Promise<void> {
     this.logger.log('Clearing defaults for archived catalog model', {
       catalogModelId: command.catalogModelId,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-image-generation-model/create-image-generation-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-image-generation-model/create-image-generation-model.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ImageGenerationModel } from 'src/domain/models/domain/models/image-generation.model';
 import { ModelsRepository } from '../../ports/models.repository';
 import {
@@ -18,39 +18,35 @@ export class CreateImageGenerationModelUseCase {
     private readonly modelPolicy: ModelPolicyService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     command: CreateImageGenerationModelCommand,
   ): Promise<ImageGenerationModel> {
-    try {
-      this.modelPolicy.assertSupportedImageGenerationProvider(command.provider);
+    this.logger.log('execute', {
+      name: command.name,
+      provider: command.provider,
+    });
 
-      const existingModel = await this.modelsRepository.findOne({
-        name: command.name,
-        provider: command.provider,
-      });
+    this.modelPolicy.assertSupportedImageGenerationProvider(command.provider);
 
-      if (existingModel) {
-        throw new ModelAlreadyExistsError(command.name, command.provider);
-      }
+    const existingModel = await this.modelsRepository.findOne({
+      name: command.name,
+      provider: command.provider,
+    });
 
-      const model = new ImageGenerationModel({
-        name: command.name,
-        provider: command.provider,
-        displayName: command.displayName,
-        isArchived: command.isArchived,
-        inputTokenCost: command.inputTokenCost,
-        outputTokenCost: command.outputTokenCost,
-      });
-      await this.modelsRepository.save(model);
-      return model;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Unexpected error creating image-generation model', {
-        error: error as Error,
-      });
-      throw new UnexpectedModelError(error as Error);
+    if (existingModel) {
+      throw new ModelAlreadyExistsError(command.name, command.provider);
     }
+
+    const model = new ImageGenerationModel({
+      name: command.name,
+      provider: command.provider,
+      displayName: command.displayName,
+      isArchived: command.isArchived,
+      inputTokenCost: command.inputTokenCost,
+      outputTokenCost: command.outputTokenCost,
+    });
+    await this.modelsRepository.save(model);
+    return model;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-language-model/create-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-language-model/create-language-model.use-case.ts
@@ -6,44 +6,38 @@ import {
   ModelAlreadyExistsError,
   UnexpectedModelError,
 } from '../../models.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { Injectable } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 
 @Injectable()
 export class CreateLanguageModelUseCase {
   constructor(private readonly modelsRepository: ModelsRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(command: CreateLanguageModelCommand): Promise<LanguageModel> {
-    try {
-      const existingModel = await this.modelsRepository.findOne({
-        name: command.name,
-        provider: command.provider,
-      });
+    const existingModel = await this.modelsRepository.findOne({
+      name: command.name,
+      provider: command.provider,
+    });
 
-      if (existingModel) {
-        throw new ModelAlreadyExistsError(command.name, command.provider);
-      }
-
-      const model = new LanguageModel({
-        name: command.name,
-        provider: command.provider,
-        displayName: command.displayName,
-        canStream: command.canStream,
-        canUseTools: command.canUseTools,
-        isReasoning: command.isReasoning,
-        canVision: command.canVision,
-        isArchived: command.isArchived,
-        inputTokenCost: command.inputTokenCost,
-        outputTokenCost: command.outputTokenCost,
-        tier: command.tier,
-      });
-      await this.modelsRepository.save(model);
-      return model;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      throw new UnexpectedModelError(error as Error);
+    if (existingModel) {
+      throw new ModelAlreadyExistsError(command.name, command.provider);
     }
+
+    const model = new LanguageModel({
+      name: command.name,
+      provider: command.provider,
+      displayName: command.displayName,
+      canStream: command.canStream,
+      canUseTools: command.canUseTools,
+      isReasoning: command.isReasoning,
+      canVision: command.canVision,
+      isArchived: command.isArchived,
+      inputTokenCost: command.inputTokenCost,
+      outputTokenCost: command.outputTokenCost,
+      tier: command.tier,
+    });
+    await this.modelsRepository.save(model);
+    return model;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-permitted-model/create-permitted-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-permitted-model/create-permitted-model.use-case.spec.ts
@@ -180,9 +180,10 @@ describe('CreatePermittedModelUseCase', () => {
       );
 
       expect(permittedModelsRepository.create).toHaveBeenCalled();
-      expect(errorSpy).toHaveBeenCalledWith('Error creating permitted model', {
-        error: repositoryError,
-      });
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Unexpected use-case error',
+        repositoryError.stack,
+      );
     });
 
     it('should reject non-Azure image-generation models explicitly', async () => {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-permitted-model/create-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-permitted-model/create-permitted-model.use-case.ts
@@ -3,7 +3,7 @@ import { PermittedModelsRepository } from '../../ports/permitted-models.reposito
 import { ModelsRepository } from '../../ports/models.repository';
 import { CreatePermittedModelCommand } from './create-permitted-model.command';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
@@ -21,43 +21,33 @@ export class CreatePermittedModelUseCase {
     private readonly modelPolicy: ModelPolicyService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(command: CreatePermittedModelCommand): Promise<PermittedModel> {
     this.logger.log('execute', {
       modelId: command.modelId,
       orgId: command.orgId,
     });
-    try {
-      const orgId = this.contextService.get('orgId');
-      const orgRole = this.contextService.get('role');
-      const systemRole = this.contextService.get('systemRole');
-      const isOrgAdmin = orgRole === UserRole.ADMIN && orgId === command.orgId;
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      if (!isOrgAdmin && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
-      const model = await this.modelsRepository.findOne({
-        id: command.modelId,
-      });
-      if (!model) {
-        throw new ModelNotFoundError(command.modelId);
-      }
-      this.modelPolicy.assertSupported(model);
-      const permittedModel = new PermittedModel({
-        model: model,
-        orgId: command.orgId,
-        anonymousOnly: command.anonymousOnly,
-      });
-      const created =
-        await this.permittedModelsRepository.create(permittedModel);
-      return created;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error creating permitted model', {
-        error: error as Error,
-      });
-      throw new UnexpectedModelError(error as Error);
+    const orgId = this.contextService.get('orgId');
+    const orgRole = this.contextService.get('role');
+    const systemRole = this.contextService.get('systemRole');
+    const isOrgAdmin = orgRole === UserRole.ADMIN && orgId === command.orgId;
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+    if (!isOrgAdmin && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
     }
+    const model = await this.modelsRepository.findOne({
+      id: command.modelId,
+    });
+    if (!model) {
+      throw new ModelNotFoundError(command.modelId);
+    }
+    this.modelPolicy.assertSupported(model);
+    const permittedModel = new PermittedModel({
+      model: model,
+      orgId: command.orgId,
+      anonymousOnly: command.anonymousOnly,
+    });
+    const created = await this.permittedModelsRepository.create(permittedModel);
+    return created;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-team-permitted-model/create-team-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-team-permitted-model/create-team-permitted-model.use-case.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { ModelsRepository } from '../../ports/models.repository';
 import { CreateTeamPermittedModelCommand } from './create-team-permitted-model.command';
 import { PermittedModel } from 'src/domain/models/domain/permitted-model.entity';
 import { PermittedModelScope } from 'src/domain/models/domain/value-objects/permitted-model-scope.enum';
-import { ApplicationError } from 'src/common/errors/base.error';
 import {
   DuplicateTeamPermittedModelError,
   ModelNotFoundError,
@@ -24,6 +24,7 @@ export class CreateTeamPermittedModelUseCase {
     private readonly validator: TeamPermittedModelValidator,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     command: CreateTeamPermittedModelCommand,
   ): Promise<PermittedModel> {
@@ -33,41 +34,31 @@ export class CreateTeamPermittedModelUseCase {
       teamId: command.teamId,
     });
 
-    try {
-      this.validator.validateAdminAccess(command.orgId);
-      await this.validator.validateTeamInOrg(command.teamId, command.orgId);
-      await this.validateModelIsOrgPermitted(command.modelId, command.orgId);
-      await this.validateNoDuplicate(command);
+    this.validator.validateAdminAccess(command.orgId);
+    await this.validator.validateTeamInOrg(command.teamId, command.orgId);
+    await this.validateModelIsOrgPermitted(command.modelId, command.orgId);
+    await this.validateNoDuplicate(command);
 
-      const model = await this.modelsRepository.findOne({
-        id: command.modelId,
-      });
-      if (!model) {
-        throw new ModelNotFoundError(command.modelId);
-      }
-
-      if (!(model instanceof LanguageModel)) {
-        throw new NotALanguageModelError(command.modelId);
-      }
-
-      const permittedModel = new PermittedModel({
-        model,
-        orgId: command.orgId,
-        anonymousOnly: command.anonymousOnly,
-        scope: PermittedModelScope.TEAM,
-        scopeId: command.teamId,
-      });
-
-      return await this.permittedModelsRepository.create(permittedModel);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error creating team permitted model', error);
-      throw new UnexpectedModelError(
-        error instanceof Error ? error : new Error('Unknown error'),
-      );
+    const model = await this.modelsRepository.findOne({
+      id: command.modelId,
+    });
+    if (!model) {
+      throw new ModelNotFoundError(command.modelId);
     }
+
+    if (!(model instanceof LanguageModel)) {
+      throw new NotALanguageModelError(command.modelId);
+    }
+
+    const permittedModel = new PermittedModel({
+      model,
+      orgId: command.orgId,
+      anonymousOnly: command.anonymousOnly,
+      scope: PermittedModelScope.TEAM,
+      scopeId: command.teamId,
+    });
+
+    return await this.permittedModelsRepository.create(permittedModel);
   }
 
   private async validateModelIsOrgPermitted(

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-model/delete-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-model/delete-model.use-case.ts
@@ -1,9 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ModelsRepository } from '../../ports/models.repository';
 import { DeleteModelCommand } from './delete-model.command';
 import {
   ModelNotFoundByIdError,
   ModelDeletionFailedError,
+  UnexpectedModelError,
 } from '../../models.errors';
 import { GetPermittedModelsUseCase } from '../get-permitted-models/get-permitted-models.use-case';
 import { GetPermittedModelsQuery } from '../get-permitted-models/get-permitted-models.query';
@@ -22,6 +24,7 @@ export class DeleteModelUseCase {
     private readonly deletePermittedModelUseCase: DeletePermittedModelUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(command: DeleteModelCommand): Promise<void> {
     this.logger.log('execute', {
       id: command.id,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
@@ -19,7 +19,7 @@ import {
   PermittedLanguageModel,
 } from 'src/domain/models/domain/permitted-model.entity';
 import { UUID } from 'crypto';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { FindAllThreadsByOrgWithSourcesUseCase } from 'src/domain/threads/application/use-cases/find-all-threads-by-org-with-sources/find-all-threads-by-org-with-sources.use-case';
 import { FindAllThreadsByOrgWithSourcesQuery } from 'src/domain/threads/application/use-cases/find-all-threads-by-org-with-sources/find-all-threads-by-org-with-sources.query';
 import { DeleteSourcesUseCase } from 'src/domain/sources/application/use-cases/delete-sources/delete-sources.use-case';
@@ -45,67 +45,62 @@ export class DeletePermittedModelUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(command: DeletePermittedModelCommand): Promise<void> {
     this.logger.log('execute', {
       modelId: command.permittedModelId,
       orgId: command.orgId,
     });
-    try {
-      const orgId = this.contextService.get('orgId');
-      const orgRole = this.contextService.get('role');
-      const systemRole = this.contextService.get('systemRole');
-      const isOrgAdmin = orgRole === UserRole.ADMIN && orgId === command.orgId;
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      if (!isOrgAdmin && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
-      const model = await this.permittedModelsRepository.findOne({
-        id: command.permittedModelId,
+    this.assertAuthorized(command.orgId);
+    const model = await this.permittedModelsRepository.findOne({
+      id: command.permittedModelId,
+    });
+    if (!model) {
+      this.logger.error('Model not found', {
+        modelId: command.permittedModelId,
+        orgId: command.orgId,
       });
-      if (!model) {
-        this.logger.error('Model not found', {
+      throw new PermittedModelDeletionFailedError('Model not found', {
+        modelId: command.permittedModelId,
+      });
+    }
+
+    // Verify the model belongs to the specified org
+    if (model.orgId !== command.orgId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    if (model instanceof PermittedLanguageModel) {
+      return this.deletePermittedLanguageModel(command.orgId, model);
+    } else if (model instanceof PermittedEmbeddingModel) {
+      return this.deletePermittedEmbeddingModel(command.orgId, model);
+    } else if (model instanceof PermittedImageGenerationModel) {
+      return this.deletePermittedImageGenerationModel(command.orgId, model);
+    } else {
+      this.logger.error(
+        'Model is not a language, embedding, or image-generation model',
+        {
           modelId: command.permittedModelId,
           orgId: command.orgId,
-        });
-        throw new PermittedModelDeletionFailedError('Model not found', {
-          modelId: command.permittedModelId,
-        });
-      }
-
-      // Verify the model belongs to the specified org
-      if (model.orgId !== command.orgId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      if (model instanceof PermittedLanguageModel) {
-        return this.deletePermittedLanguageModel(command.orgId, model);
-      } else if (model instanceof PermittedEmbeddingModel) {
-        return this.deletePermittedEmbeddingModel(command.orgId, model);
-      } else if (model instanceof PermittedImageGenerationModel) {
-        return this.deletePermittedImageGenerationModel(command.orgId, model);
-      } else {
-        this.logger.error(
-          'Model is not a language, embedding, or image-generation model',
-          {
-            modelId: command.permittedModelId,
-            orgId: command.orgId,
-          },
-        );
-        throw new PermittedModelDeletionFailedError(
-          'Model is not a language, embedding, or image-generation model',
-          {
-            modelId: command.permittedModelId,
-          },
-        );
-      }
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error deleting permitted model', error);
-      throw new UnexpectedModelError(
-        error instanceof Error ? error : new Error('Unknown error'),
+        },
       );
+      throw new PermittedModelDeletionFailedError(
+        'Model is not a language, embedding, or image-generation model',
+        {
+          modelId: command.permittedModelId,
+        },
+      );
+    }
+  }
+
+  private assertAuthorized(commandOrgId: UUID): void {
+    const orgId = this.contextService.get('orgId');
+    const orgRole = this.contextService.get('role');
+    const systemRole = this.contextService.get('systemRole');
+    const isOrgAdmin = orgRole === UserRole.ADMIN && orgId === commandOrgId;
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+    if (!isOrgAdmin && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
     }
   }
 

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-team-permitted-model/delete-team-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-team-permitted-model/delete-team-permitted-model.use-case.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { DeleteTeamPermittedModelCommand } from './delete-team-permitted-model.command';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedModelError } from '../../models.errors';
 import { TeamPermittedModelValidator } from '../../services/team-permitted-model-validator.service';
 
@@ -14,6 +14,7 @@ export class DeleteTeamPermittedModelUseCase {
     private readonly validator: TeamPermittedModelValidator,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(command: DeleteTeamPermittedModelCommand): Promise<void> {
     this.logger.log('execute', {
       permittedModelId: command.permittedModelId,
@@ -21,27 +22,17 @@ export class DeleteTeamPermittedModelUseCase {
       teamId: command.teamId,
     });
 
-    try {
-      this.validator.validateAdminAccess(command.orgId);
-      await this.validator.validateTeamInOrg(command.teamId, command.orgId);
-      await this.validator.validateModelBelongsToTeam(
-        command.permittedModelId,
-        command.teamId,
-        command.orgId,
-      );
+    this.validator.validateAdminAccess(command.orgId);
+    await this.validator.validateTeamInOrg(command.teamId, command.orgId);
+    await this.validator.validateModelBelongsToTeam(
+      command.permittedModelId,
+      command.teamId,
+      command.orgId,
+    );
 
-      await this.permittedModelsRepository.delete({
-        id: command.permittedModelId,
-        orgId: command.orgId,
-      });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error deleting team permitted model', error);
-      throw new UnexpectedModelError(
-        error instanceof Error ? error : new Error('Unknown error'),
-      );
-    }
+    await this.permittedModelsRepository.delete({
+      id: command.permittedModelId,
+      orgId: command.orgId,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-user-default-model/delete-user-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-user-default-model/delete-user-default-model.use-case.ts
@@ -1,7 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { DeleteUserDefaultModelCommand } from './delete-user-default-model.command';
 import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
-import { ModelError } from '../../models.errors';
+import { UnexpectedModelError } from '../../models.errors';
 
 @Injectable()
 export class DeleteUserDefaultModelUseCase {
@@ -11,50 +12,40 @@ export class DeleteUserDefaultModelUseCase {
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(command: DeleteUserDefaultModelCommand): Promise<void> {
     this.logger.log('execute', {
       userId: command.userId,
     });
 
-    try {
-      // First, find the user's current default model
-      const userDefaultModel =
-        await this.userDefaultModelsRepository.findByUserId(command.userId);
+    // First, find the user's current default model
+    const userDefaultModel =
+      await this.userDefaultModelsRepository.findByUserId(command.userId);
 
-      if (!userDefaultModel) {
-        this.logger.debug('No user default model found to delete', {
-          userId: command.userId,
-        });
-        // Not throwing an error here as it's idempotent - no default model to delete
-        return;
-      }
-
-      this.logger.debug('User default model found, deleting', {
+    if (!userDefaultModel) {
+      this.logger.debug('No user default model found to delete', {
         userId: command.userId,
-        modelId: userDefaultModel.id,
-        modelName: userDefaultModel.model.name,
-        modelProvider: userDefaultModel.model.provider,
       });
-
-      // Delete the user's default model
-      await this.userDefaultModelsRepository.delete(
-        userDefaultModel,
-        command.userId,
-      );
-
-      this.logger.debug('User default model deleted successfully', {
-        userId: command.userId,
-        modelId: userDefaultModel.id,
-      });
-    } catch (error) {
-      if (error instanceof ModelError) {
-        throw error;
-      }
-      this.logger.error('Failed to delete user default model', {
-        userId: command.userId,
-        error: error instanceof Error ? error : new Error('Unknown error'),
-      });
-      throw error;
+      // Not throwing an error here as it's idempotent - no default model to delete
+      return;
     }
+
+    this.logger.debug('User default model found, deleting', {
+      userId: command.userId,
+      modelId: userDefaultModel.id,
+      modelName: userDefaultModel.model.name,
+      modelProvider: userDefaultModel.model.provider,
+    });
+
+    // Delete the user's default model
+    await this.userDefaultModelsRepository.delete(
+      userDefaultModel,
+      command.userId,
+    );
+
+    this.logger.debug('User default model deleted successfully', {
+      userId: command.userId,
+      modelId: userDefaultModel.id,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-user-default-models-by-model-id/delete-user-default-models-by-model-id.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-user-default-models-by-model-id/delete-user-default-models-by-model-id.use-case.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
 import { DeleteUserDefaultModelsByModelIdCommand } from './delete-user-default-models-by-model-id.command';
+import { UnexpectedModelError } from '../../models.errors';
 
 @Injectable()
 export class DeleteUserDefaultModelsByModelIdUseCase {
@@ -12,6 +14,7 @@ export class DeleteUserDefaultModelsByModelIdUseCase {
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     command: DeleteUserDefaultModelsByModelIdCommand,
   ): Promise<void> {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/generate-image/generate-image.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/generate-image/generate-image.use-case.ts
@@ -1,11 +1,15 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ImageGenerationHandlerRegistry } from '../../registry/image-generation-handler.registry';
 import {
   ImageGenerationInput,
   ImageGenerationResult,
 } from '../../ports/image-generation.handler';
-import { ImageGenerationFailedError } from '../../models.errors';
+import {
+  ImageGenerationFailedError,
+  UnexpectedModelError,
+} from '../../models.errors';
 import { GenerateImageCommand } from './generate-image.command';
 
 @Injectable()
@@ -16,6 +20,7 @@ export class GenerateImageUseCase {
     private readonly imageGenerationHandlerRegistry: ImageGenerationHandlerRegistry,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(command: GenerateImageCommand): Promise<ImageGenerationResult> {
     this.logger.log('execute', {
       model: command.model.name,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-configured-models-by-type/get-configured-models-by-type.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-configured-models-by-type/get-configured-models-by-type.use-case.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { Model } from 'src/domain/models/domain/model.entity';
@@ -9,6 +10,7 @@ import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum'
 import { ModelsRepository } from '../../ports/models.repository';
 import { ModelProviderInfoRegistry } from '../../registry/model-provider-info.registry';
 import { GetConfiguredModelsByTypeQuery } from './get-configured-models-by-type.query';
+import { UnexpectedModelError } from '../../models.errors';
 
 @Injectable()
 export class GetConfiguredModelsByTypeUseCase {
@@ -21,6 +23,7 @@ export class GetConfiguredModelsByTypeUseCase {
     private readonly modelProviderInfoRegistry: ModelProviderInfoRegistry,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(query: GetConfiguredModelsByTypeQuery): Promise<Model[]> {
     const orgRole = this.contextService.get('role');
     const systemRole = this.contextService.get('systemRole');

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.ts
@@ -1,12 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common';
 import type { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetDefaultModelQuery } from './get-default-model.query';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
 import { GetEffectiveLanguageModelsUseCase } from '../get-effective-language-models/get-effective-language-models.use-case';
 import { GetEffectiveLanguageModelsQuery } from '../get-effective-language-models/get-effective-language-models.query';
-import { DefaultModelNotFoundError, ModelError } from '../../models.errors';
+import {
+  DefaultModelNotFoundError,
+  UnexpectedModelError,
+} from '../../models.errors';
 
 @Injectable()
 export class GetDefaultModelUseCase {
@@ -18,91 +22,123 @@ export class GetDefaultModelUseCase {
     private readonly getEffectiveLanguageModelsUseCase: GetEffectiveLanguageModelsUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(query: GetDefaultModelQuery): Promise<PermittedLanguageModel> {
     this.logger.log('execute', { query });
 
-    try {
-      const { models: effectiveModels, overrideTeamIds } =
-        await this.getEffectiveLanguageModelsUseCase.execute(
-          new GetEffectiveLanguageModelsQuery(query.orgId, query.userId),
-        );
-
-      const effectiveModelIds = new Set(effectiveModels.map((m) => m.model.id));
-
-      const isInEffectiveSet = (model: PermittedLanguageModel): boolean =>
-        effectiveModelIds.has(model.model.id) &&
-        !query.blacklistedModelIds?.includes(model.model.id);
-
-      // Step 1: User default
-      if (query.userId) {
-        const userDefault = await this.userDefaultModelsRepository.findByUserId(
-          query.userId,
-        );
-
-        if (userDefault && isInEffectiveSet(userDefault)) {
-          this.logger.debug('Using user default model', {
-            userId: query.userId,
-            modelId: userDefault.id,
-          });
-          return userDefault;
-        }
-      }
-
-      // Step 2: Team defaults (from override teams)
-      if (query.userId && overrideTeamIds.length > 0) {
-        const teamDefault = await this.resolveTeamDefault(
-          overrideTeamIds,
-          query.orgId,
-          effectiveModelIds,
-          query.blacklistedModelIds,
-        );
-        if (teamDefault) {
-          this.logger.debug('Using team default model', {
-            modelId: teamDefault.id,
-          });
-          return teamDefault;
-        }
-      }
-
-      // Step 3: Org default
-      const orgDefault =
-        await this.permittedModelsRepository.findOrgDefaultLanguage(
-          query.orgId,
-        );
-      if (orgDefault && isInEffectiveSet(orgDefault)) {
-        this.logger.debug('Using org default model', {
-          orgId: query.orgId,
-          modelId: orgDefault.id,
-        });
-        return orgDefault;
-      }
-
-      // Step 4: First available from effective set, alphabetically
-      const sorted = [...effectiveModels].sort((a, b) =>
-        a.model.name.localeCompare(b.model.name),
+    const { models: effectiveModels, overrideTeamIds } =
+      await this.getEffectiveLanguageModelsUseCase.execute(
+        new GetEffectiveLanguageModelsQuery(query.orgId, query.userId),
       );
 
-      for (const model of sorted) {
-        if (!query.blacklistedModelIds?.includes(model.model.id)) {
-          this.logger.debug('Using first available model alphabetically', {
-            modelId: model.id,
-          });
-          return model;
-        }
-      }
+    const effectiveModelIds = new Set(effectiveModels.map((m) => m.model.id));
 
-      throw new DefaultModelNotFoundError(query.orgId);
-    } catch (error) {
-      if (error instanceof ModelError) {
-        throw error;
+    const isInEffectiveSet = (model: PermittedLanguageModel): boolean =>
+      effectiveModelIds.has(model.model.id) &&
+      !query.blacklistedModelIds?.includes(model.model.id);
+
+    // Step 1: User default
+    if (query.userId) {
+      const userDefault = await this.resolveUserDefault(
+        query.userId,
+        isInEffectiveSet,
+      );
+      if (userDefault) {
+        return userDefault;
       }
-      this.logger.error('Failed to get default model', {
-        orgId: query.orgId,
-        userId: query.userId,
-        error: error instanceof Error ? error : new Error('Unknown error'),
-      });
-      throw error;
     }
+
+    // Step 2: Team defaults (from override teams)
+    if (query.userId && overrideTeamIds.length > 0) {
+      const teamDefault = await this.resolveTeamDefault(
+        overrideTeamIds,
+        query.orgId,
+        effectiveModelIds,
+        query.blacklistedModelIds,
+      );
+      if (teamDefault) {
+        this.logger.debug('Using team default model', {
+          modelId: teamDefault.id,
+        });
+        return teamDefault;
+      }
+    }
+
+    // Step 3: Org default
+    const orgDefault = await this.resolveOrgDefault(
+      query.orgId,
+      isInEffectiveSet,
+    );
+    if (orgDefault) {
+      return orgDefault;
+    }
+
+    // Step 4: First available from effective set, alphabetically
+    const firstAvailable = this.resolveFirstAvailable(
+      effectiveModels,
+      query.blacklistedModelIds,
+    );
+    if (firstAvailable) {
+      return firstAvailable;
+    }
+
+    throw new DefaultModelNotFoundError(query.orgId);
+  }
+
+  private async resolveUserDefault(
+    userId: UUID,
+    isInEffectiveSet: (model: PermittedLanguageModel) => boolean,
+  ): Promise<PermittedLanguageModel | null> {
+    const userDefault =
+      await this.userDefaultModelsRepository.findByUserId(userId);
+
+    if (userDefault && isInEffectiveSet(userDefault)) {
+      this.logger.debug('Using user default model', {
+        userId,
+        modelId: userDefault.id,
+      });
+      return userDefault;
+    }
+
+    return null;
+  }
+
+  private async resolveOrgDefault(
+    orgId: UUID,
+    isInEffectiveSet: (model: PermittedLanguageModel) => boolean,
+  ): Promise<PermittedLanguageModel | null> {
+    const orgDefault =
+      await this.permittedModelsRepository.findOrgDefaultLanguage(orgId);
+
+    if (orgDefault && isInEffectiveSet(orgDefault)) {
+      this.logger.debug('Using org default model', {
+        orgId,
+        modelId: orgDefault.id,
+      });
+      return orgDefault;
+    }
+
+    return null;
+  }
+
+  private resolveFirstAvailable(
+    effectiveModels: PermittedLanguageModel[],
+    blacklistedModelIds?: UUID[],
+  ): PermittedLanguageModel | null {
+    const sorted = [...effectiveModels].sort((a, b) =>
+      a.model.name.localeCompare(b.model.name),
+    );
+
+    for (const model of sorted) {
+      if (!blacklistedModelIds?.includes(model.model.id)) {
+        this.logger.debug('Using first available model alphabetically', {
+          modelId: model.id,
+        });
+        return model;
+      }
+    }
+
+    return null;
   }
 
   private async resolveTeamDefault(

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import type { UUID } from 'crypto';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
@@ -22,6 +22,7 @@ export class GetEffectiveLanguageModelsUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     query: GetEffectiveLanguageModelsQuery,
   ): Promise<EffectiveLanguageModelsResult> {
@@ -30,25 +31,13 @@ export class GetEffectiveLanguageModelsUseCase {
       orgId: query.orgId,
     });
 
-    try {
-      this.validateOrgAccess(query.orgId);
+    this.validateOrgAccess(query.orgId);
 
-      if (!query.userId) {
-        return this.buildOrgFallback(query.orgId);
-      }
-
-      return this.resolveForUser(query.userId, query.orgId);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error resolving effective language models', {
-        userId: query.userId,
-        orgId: query.orgId,
-        error: error instanceof Error ? error : new Error('Unknown error'),
-      });
-      throw new UnexpectedModelError(error as Error);
+    if (!query.userId) {
+      return this.buildOrgFallback(query.orgId);
     }
+
+    return this.resolveForUser(query.userId, query.orgId);
   }
 
   private validateOrgAccess(queryOrgId: UUID): void {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-inference/get-inference.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-inference/get-inference.use-case.ts
@@ -5,7 +5,11 @@ import {
   InferenceInput,
   InferenceResponse,
 } from '../../ports/inference.handler';
-import { InferenceFailedError } from '../../models.errors';
+import {
+  InferenceFailedError,
+  UnexpectedModelError,
+} from '../../models.errors';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { extractUpstreamStatus } from '../../helpers/extract-upstream-status.helper';
@@ -19,6 +23,7 @@ export class GetInferenceUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(command: GetInferenceCommand): Promise<InferenceResponse> {
     this.logger.log('triggerInference', {
       model: command.model.name,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case.ts
@@ -5,8 +5,8 @@ import {
   PermittedEmbeddingModelNotFoundForOrgError,
   UnexpectedModelError,
 } from '../../models.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
@@ -20,6 +20,7 @@ export class GetPermittedEmbeddingModelUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     query: GetPermittedEmbeddingModelQuery,
   ): Promise<PermittedEmbeddingModel> {
@@ -27,26 +28,19 @@ export class GetPermittedEmbeddingModelUseCase {
       orgId: query.orgId,
     });
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      const systemRole = this.contextService.get('systemRole');
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      const isFromOrg = orgId === query.orgId;
-      if (!isFromOrg && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
-      const model = await this.permittedModelsRepository.findOneEmbedding(
-        query.orgId,
-      );
-      if (!model || !(model instanceof PermittedEmbeddingModel)) {
-        throw new PermittedEmbeddingModelNotFoundForOrgError(query.orgId);
-      }
-      return model;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      throw new UnexpectedModelError(error as Error);
+    const orgId = this.contextService.get('orgId');
+    const systemRole = this.contextService.get('systemRole');
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+    const isFromOrg = orgId === query.orgId;
+    if (!isFromOrg && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
     }
+    const model = await this.permittedModelsRepository.findOneEmbedding(
+      query.orgId,
+    );
+    if (!model || !(model instanceof PermittedEmbeddingModel)) {
+      throw new PermittedEmbeddingModelNotFoundForOrgError(query.orgId);
+    }
+    return model;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-image-generation-model/get-permitted-image-generation-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-image-generation-model/get-permitted-image-generation-model.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
@@ -24,6 +24,7 @@ export class GetPermittedImageGenerationModelUseCase {
     private readonly modelPolicy: ModelPolicyService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     query: GetPermittedImageGenerationModelQuery,
   ): Promise<PermittedImageGenerationModel> {
@@ -31,29 +32,22 @@ export class GetPermittedImageGenerationModelUseCase {
       orgId: query.orgId,
     });
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      const systemRole = this.contextService.get('systemRole');
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      const isFromOrg = orgId === query.orgId;
-      if (!isFromOrg && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
-
-      const model = await this.permittedModelsRepository.findOneImageGeneration(
-        query.orgId,
-      );
-      if (!model || !(model instanceof PermittedImageGenerationModel)) {
-        throw new PermittedImageGenerationModelNotFoundForOrgError(query.orgId);
-      }
-
-      this.modelPolicy.assertSupported(model.model);
-      return model;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      throw new UnexpectedModelError(error as Error);
+    const orgId = this.contextService.get('orgId');
+    const systemRole = this.contextService.get('systemRole');
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+    const isFromOrg = orgId === query.orgId;
+    if (!isFromOrg && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
     }
+
+    const model = await this.permittedModelsRepository.findOneImageGeneration(
+      query.orgId,
+    );
+    if (!model || !(model instanceof PermittedImageGenerationModel)) {
+      throw new PermittedImageGenerationModelNotFoundForOrgError(query.orgId);
+    }
+
+    this.modelPolicy.assertSupported(model.model);
+    return model;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-model/get-permitted-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-model/get-permitted-language-model.use-case.ts
@@ -1,12 +1,12 @@
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { PermittedLanguageModel } from '../../../domain/permitted-model.entity';
 import { GetPermittedLanguageModelQuery } from './get-permitted-language-model.query';
-import { ApplicationError } from 'src/common/errors/base.error';
 import {
   ModelNotFoundByIdError,
   UnexpectedModelError,
 } from '../../models.errors';
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
@@ -19,6 +19,7 @@ export class GetPermittedLanguageModelUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     query: GetPermittedLanguageModelQuery,
   ): Promise<PermittedLanguageModel> {
@@ -28,27 +29,20 @@ export class GetPermittedLanguageModelUseCase {
     const orgId = this.contextService.get('orgId');
     const systemRole = this.contextService.get('systemRole');
 
-    try {
-      const model = await this.permittedModelsRepository.findOneLanguage({
-        id: query.id,
-      });
-      const isFromOrg = orgId === model?.orgId;
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      if (!isFromOrg && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
-      if (!model) {
-        this.logger.error('model not found', {
-          query,
-        });
-        throw new ModelNotFoundByIdError(query.id);
-      }
-      return model;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      throw new UnexpectedModelError(error as Error);
+    const model = await this.permittedModelsRepository.findOneLanguage({
+      id: query.id,
+    });
+    const isFromOrg = orgId === model?.orgId;
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+    if (!isFromOrg && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
     }
+    if (!model) {
+      this.logger.error('model not found', {
+        query,
+      });
+      throw new ModelNotFoundByIdError(query.id);
+    }
+    return model;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.use-case.ts
@@ -2,8 +2,8 @@ import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { GetPermittedLanguageModelsQuery } from './get-permitted-language-models.query';
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnexpectedModelError } from '../../models.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
@@ -17,30 +17,20 @@ export class GetPermittedLanguageModelsUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     query: GetPermittedLanguageModelsQuery,
   ): Promise<PermittedLanguageModel[]> {
     this.logger.log('Executing get permitted language models', {
       orgId: query.orgId,
     });
-    try {
-      const orgId = this.contextService.get('orgId');
-      const systemRole = this.contextService.get('systemRole');
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      const isFromOrg = orgId === query.orgId;
-      if (!isFromOrg && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
-      return this.permittedModelsRepository.findManyLanguage(query.orgId);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error getting permitted language models', {
-        orgId: query.orgId,
-        error: error instanceof Error ? error : new Error('Unknown error'),
-      });
-      throw new UnexpectedModelError(error as Error);
+    const orgId = this.contextService.get('orgId');
+    const systemRole = this.contextService.get('systemRole');
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+    const isFromOrg = orgId === query.orgId;
+    if (!isFromOrg && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
     }
+    return this.permittedModelsRepository.findManyLanguage(query.orgId);
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-model/get-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-model/get-permitted-model.use-case.ts
@@ -6,6 +6,7 @@ import {
 } from '../../models.errors';
 import { GetPermittedModelQuery } from './get-permitted-model.query';
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
@@ -18,44 +19,30 @@ export class GetPermittedModelUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(query: GetPermittedModelQuery): Promise<PermittedModel> {
-    try {
-      this.logger.log('execute', {
-        query,
-      });
-      this.logger.debug('GetPermittedModelByIdQuery', {
-        query,
-      });
-      const orgId = this.contextService.get('orgId');
-      const systemRole = this.contextService.get('systemRole');
-      const model = await this.permittedModelsRepository.findOne({
-        id: query.permittedModelId,
-      });
-      const isFromOrg = orgId === model?.orgId;
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      if (!isFromOrg && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
-      if (!model) {
-        this.logger.error('Permitted model not found', {
-          query,
-        });
-        throw new PermittedModelNotFoundError(query.permittedModelId);
-      }
-      return model;
-    } catch (error) {
-      if (error instanceof PermittedModelNotFoundError) {
-        throw error;
-      }
-      this.logger.error('Error getting permitted model', {
-        error: error instanceof Error ? error : new Error('Unknown error'),
-      });
-      throw new UnexpectedModelError(
-        error instanceof Error ? error : new Error('Unknown error'),
-        {
-          query,
-        },
-      );
+    this.logger.log('execute', {
+      query,
+    });
+    this.logger.debug('GetPermittedModelByIdQuery', {
+      query,
+    });
+    const orgId = this.contextService.get('orgId');
+    const systemRole = this.contextService.get('systemRole');
+    const model = await this.permittedModelsRepository.findOne({
+      id: query.permittedModelId,
+    });
+    const isFromOrg = orgId === model?.orgId;
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+    if (!isFromOrg && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
     }
+    if (!model) {
+      this.logger.error('Permitted model not found', {
+        query,
+      });
+      throw new PermittedModelNotFoundError(query.permittedModelId);
+    }
+    return model;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-models/get-permitted-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-models/get-permitted-models.use-case.ts
@@ -1,10 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetPermittedModelsQuery } from './get-permitted-models.query';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { PermittedModel } from 'src/domain/models/domain/permitted-model.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import { UnexpectedModelError } from '../../models.errors';
 
 @Injectable()
 export class GetPermittedModelsUseCase {
@@ -15,25 +17,19 @@ export class GetPermittedModelsUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(query: GetPermittedModelsQuery): Promise<PermittedModel[]> {
     this.logger.debug('Getting permitted models', {
       orgId: query.orgId,
       filter: query.filter,
     });
-    try {
-      const orgId = this.contextService.get('orgId');
-      const systemRole = this.contextService.get('systemRole');
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      const isFromOrg = orgId === query.orgId;
-      if (!isFromOrg && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
-      return this.permittedModelsRepository.findAll(query.orgId, query.filter);
-    } catch (error) {
-      this.logger.error('Error getting permitted models', {
-        error: error instanceof Error ? error : new Error('Unknown error'),
-      });
-      throw error;
+    const orgId = this.contextService.get('orgId');
+    const systemRole = this.contextService.get('systemRole');
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+    const isFromOrg = orgId === query.orgId;
+    if (!isFromOrg && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
     }
+    return this.permittedModelsRepository.findAll(query.orgId, query.filter);
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-team-permitted-models/get-team-permitted-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-team-permitted-models/get-team-permitted-models.use-case.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { GetTeamPermittedModelsQuery } from './get-team-permitted-models.query';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedModelError } from '../../models.errors';
 import { TeamPermittedModelValidator } from '../../services/team-permitted-model-validator.service';
 
@@ -15,6 +15,7 @@ export class GetTeamPermittedModelsUseCase {
     private readonly validator: TeamPermittedModelValidator,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     query: GetTeamPermittedModelsQuery,
   ): Promise<PermittedLanguageModel[]> {
@@ -23,22 +24,12 @@ export class GetTeamPermittedModelsUseCase {
       orgId: query.orgId,
     });
 
-    try {
-      this.validator.validateAdminAccess(query.orgId);
-      await this.validator.validateTeamInOrg(query.teamId, query.orgId);
+    this.validator.validateAdminAccess(query.orgId);
+    await this.validator.validateTeamInOrg(query.teamId, query.orgId);
 
-      return await this.permittedModelsRepository.findManyLanguageByTeam(
-        query.teamId,
-        query.orgId,
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error listing team permitted models', error);
-      throw new UnexpectedModelError(
-        error instanceof Error ? error : new Error('Unknown error'),
-      );
-    }
+    return await this.permittedModelsRepository.findManyLanguageByTeam(
+      query.teamId,
+      query.orgId,
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-user-default-model/get-user-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-user-default-model/get-user-default-model.use-case.ts
@@ -1,8 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetUserDefaultModelQuery } from './get-user-default-model.query';
 import { PermittedLanguageModel } from '../../../domain/permitted-model.entity';
 import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
-import { ModelError } from '../../models.errors';
+import { UnexpectedModelError } from '../../models.errors';
 
 @Injectable()
 export class GetUserDefaultModelUseCase {
@@ -12,6 +13,7 @@ export class GetUserDefaultModelUseCase {
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     query: GetUserDefaultModelQuery,
   ): Promise<PermittedLanguageModel | null> {
@@ -19,33 +21,22 @@ export class GetUserDefaultModelUseCase {
       userId: query.userId,
     });
 
-    try {
-      const userDefaultModel =
-        await this.userDefaultModelsRepository.findByUserId(query.userId);
+    const userDefaultModel =
+      await this.userDefaultModelsRepository.findByUserId(query.userId);
 
-      if (userDefaultModel) {
-        this.logger.debug('User default model found', {
-          userId: query.userId,
-          modelId: userDefaultModel.id,
-          modelName: userDefaultModel.model.name,
-          modelProvider: userDefaultModel.model.provider,
-        });
-      } else {
-        this.logger.debug('No user default model found', {
-          userId: query.userId,
-        });
-      }
-
-      return userDefaultModel;
-    } catch (error) {
-      if (error instanceof ModelError) {
-        throw error;
-      }
-      this.logger.error('Failed to get user default model', {
+    if (userDefaultModel) {
+      this.logger.debug('User default model found', {
         userId: query.userId,
-        error: error instanceof Error ? error : new Error('Unknown error'),
+        modelId: userDefaultModel.id,
+        modelName: userDefaultModel.model.name,
+        modelProvider: userDefaultModel.model.provider,
       });
-      throw error;
+    } else {
+      this.logger.debug('No user default model found', {
+        userId: query.userId,
+      });
     }
+
+    return userDefaultModel;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/is-embedding-model-enabled/is-embedding-model-enabled.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/is-embedding-model-enabled/is-embedding-model-enabled.use-case.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { IsEmbeddingModelEnabledQuery } from './is-embedding-model-enabled.query';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
+import { UnexpectedModelError } from '../../models.errors';
 
 @Injectable()
 export class IsEmbeddingModelEnabledUseCase {
@@ -8,6 +10,7 @@ export class IsEmbeddingModelEnabledUseCase {
     private readonly permittedModelsRepository: PermittedModelsRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(query: IsEmbeddingModelEnabledQuery): Promise<boolean> {
     const model = await this.permittedModelsRepository.findOneEmbedding(
       query.orgId,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/is-model-permitted/is-model-permitted.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/is-model-permitted/is-model-permitted.use-case.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { IsModelPermittedQuery } from './is-model-permitted.query';
+import { UnexpectedModelError } from '../../models.errors';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
@@ -12,6 +14,7 @@ export class IsModelPermittedUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(query: IsModelPermittedQuery): Promise<boolean> {
     const permittedModel = await this.permittedModelsRepository.findOne({
       id: query.modelId,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/set-org-default-language-model/set-org-default-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/set-org-default-language-model/set-org-default-language-model.use-case.ts
@@ -1,8 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SetOrgDefaultLanguageModelCommand } from './set-org-default-language-model.command';
 import { PermittedLanguageModel } from '../../../domain/permitted-model.entity';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
-import { ModelError, PermittedModelNotFoundError } from '../../models.errors';
+import {
+  PermittedModelNotFoundError,
+  UnexpectedModelError,
+} from '../../models.errors';
 import { ContextService } from 'src/common/context/services/context.service';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -16,6 +21,7 @@ export class SetOrgDefaultLanguageModelUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     command: SetOrgDefaultLanguageModelCommand,
   ): Promise<PermittedLanguageModel> {
@@ -24,74 +30,62 @@ export class SetOrgDefaultLanguageModelUseCase {
       orgId: command.orgId,
     });
 
-    try {
-      // Check if the user is authorized to set the organization default model
-      const orgId = this.contextService.get('orgId');
-      const systemRole = this.contextService.get('systemRole');
-      const isFromOrg = orgId === command.orgId;
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      if (!isFromOrg && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
+    // Check if the user is authorized to set the organization default model
+    this.assertAuthorized(command.orgId);
 
-      // Only language models may participate in org-default flows.
-      const permittedModel =
-        await this.permittedModelsRepository.findOneLanguage({
-          id: command.permittedModelId,
-          orgId: command.orgId,
-        });
-
-      if (!permittedModel) {
-        this.logger.error('Permitted model not found', {
-          permittedModelId: command.permittedModelId,
-          orgId: command.orgId,
-        });
-        throw new PermittedModelNotFoundError(command.permittedModelId);
-      }
-
-      // Check if there's already a default model
-      const existingDefault =
-        await this.permittedModelsRepository.findOrgDefaultLanguage(
-          command.orgId,
-        );
-
-      const action = existingDefault ? 'updating' : 'setting';
-      this.logger.debug(
-        `Permitted model found, ${action} organization default`,
-        {
-          permittedModelId: command.permittedModelId,
-          orgId: command.orgId,
-          modelName: permittedModel.model.name,
-          modelProvider: permittedModel.model.provider,
-          existingDefaultId: existingDefault?.id,
-        },
-      );
-
-      // Set the model as the organization's default (handles both create and update)
-      const orgDefaultModel = await this.permittedModelsRepository.setAsDefault(
-        {
-          id: command.permittedModelId,
-          orgId: command.orgId,
-        },
-      );
-
-      this.logger.debug(`Organization default model ${action} successfully`, {
+    // Only language models may participate in org-default flows.
+    const permittedModel = await this.permittedModelsRepository.findOneLanguage(
+      {
+        id: command.permittedModelId,
         orgId: command.orgId,
-        modelId: orgDefaultModel.id,
-        action,
-      });
+      },
+    );
 
-      return orgDefaultModel;
-    } catch (error) {
-      if (error instanceof ModelError) {
-        throw error;
-      }
-      this.logger.error('Failed to set organization default model', {
+    if (!permittedModel) {
+      this.logger.error('Permitted model not found', {
         permittedModelId: command.permittedModelId,
         orgId: command.orgId,
-        error: error instanceof Error ? error : new Error('Unknown error'),
       });
-      throw error;
+      throw new PermittedModelNotFoundError(command.permittedModelId);
+    }
+
+    // Check if there's already a default model
+    const existingDefault =
+      await this.permittedModelsRepository.findOrgDefaultLanguage(
+        command.orgId,
+      );
+
+    const action = existingDefault ? 'updating' : 'setting';
+    this.logger.debug(`Permitted model found, ${action} organization default`, {
+      permittedModelId: command.permittedModelId,
+      orgId: command.orgId,
+      modelName: permittedModel.model.name,
+      modelProvider: permittedModel.model.provider,
+      existingDefaultId: existingDefault?.id,
+    });
+
+    // Set the model as the organization's default (handles both create and update)
+    const orgDefaultModel = await this.permittedModelsRepository.setAsDefault({
+      id: command.permittedModelId,
+      orgId: command.orgId,
+    });
+
+    this.logger.debug(`Organization default model ${action} successfully`, {
+      orgId: command.orgId,
+      modelId: orgDefaultModel.id,
+      action,
+    });
+
+    return orgDefaultModel;
+  }
+
+  private assertAuthorized(commandOrgId: UUID): void {
+    const orgId = this.contextService.get('orgId');
+    const systemRole = this.contextService.get('systemRole');
+    const isFromOrg = orgId === commandOrgId;
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+    if (!isFromOrg && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
     }
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/set-team-default-model/set-team-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/set-team-default-model/set-team-default-model.use-case.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { SetTeamDefaultModelCommand } from './set-team-default-model.command';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedModelError } from '../../models.errors';
 import { TeamPermittedModelValidator } from '../../services/team-permitted-model-validator.service';
 
@@ -15,6 +15,7 @@ export class SetTeamDefaultModelUseCase {
     private readonly validator: TeamPermittedModelValidator,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     command: SetTeamDefaultModelCommand,
   ): Promise<PermittedLanguageModel> {
@@ -24,28 +25,18 @@ export class SetTeamDefaultModelUseCase {
       teamId: command.teamId,
     });
 
-    try {
-      this.validator.validateAdminAccess(command.orgId);
-      await this.validator.validateTeamInOrg(command.teamId, command.orgId);
-      await this.validator.validateModelBelongsToTeam(
-        command.permittedModelId,
-        command.teamId,
-        command.orgId,
-      );
+    this.validator.validateAdminAccess(command.orgId);
+    await this.validator.validateTeamInOrg(command.teamId, command.orgId);
+    await this.validator.validateModelBelongsToTeam(
+      command.permittedModelId,
+      command.teamId,
+      command.orgId,
+    );
 
-      return await this.permittedModelsRepository.setAsDefault({
-        id: command.permittedModelId,
-        orgId: command.orgId,
-        teamId: command.teamId,
-      });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error setting team default model', error);
-      throw new UnexpectedModelError(
-        error instanceof Error ? error : new Error('Unknown error'),
-      );
-    }
+    return await this.permittedModelsRepository.setAsDefault({
+      id: command.permittedModelId,
+      orgId: command.orgId,
+      teamId: command.teamId,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/set-user-default-language-model/set-user-default-language-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/set-user-default-language-model/set-user-default-language-model.use-case.spec.ts
@@ -8,7 +8,10 @@ import { UserDefaultModelsRepository } from '../../ports/user-default-models.rep
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
-import { PermittedModelNotFoundError } from '../../models.errors';
+import {
+  PermittedModelNotFoundError,
+  UnexpectedModelError,
+} from '../../models.errors';
 import { SetUserDefaultLanguageModelCommand } from './set-user-default-language-model.command';
 import { SetUserDefaultLanguageModelUseCase } from './set-user-default-language-model.use-case';
 
@@ -145,7 +148,7 @@ describe('SetUserDefaultLanguageModelUseCase', () => {
     expect(userDefaultModelsRepository.setAsDefault).not.toHaveBeenCalled();
   });
 
-  it('re-throws unexpected repository failures', async () => {
+  it('wraps unexpected repository failures in UnexpectedModelError', async () => {
     const permittedModel = buildPermittedLanguageModel();
     permittedModelsRepository.findOneLanguage.mockResolvedValue(permittedModel);
     userDefaultModelsRepository.findByUserId.mockResolvedValue(null);
@@ -156,6 +159,6 @@ describe('SetUserDefaultLanguageModelUseCase', () => {
       useCase.execute(
         new SetUserDefaultLanguageModelCommand(userId, permittedModelId, orgId),
       ),
-    ).rejects.toBe(repositoryError);
+    ).rejects.toBeInstanceOf(UnexpectedModelError);
   });
 });

--- a/ayunis-core-backend/src/domain/models/application/use-cases/set-user-default-language-model/set-user-default-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/set-user-default-language-model/set-user-default-language-model.use-case.ts
@@ -1,9 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SetUserDefaultLanguageModelCommand } from './set-user-default-language-model.command';
 import { PermittedLanguageModel } from '../../../domain/permitted-model.entity';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
-import { ModelError, PermittedModelNotFoundError } from '../../models.errors';
+import {
+  PermittedModelNotFoundError,
+  UnexpectedModelError,
+} from '../../models.errors';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
@@ -17,6 +21,7 @@ export class SetUserDefaultLanguageModelUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     command: SetUserDefaultLanguageModelCommand,
   ): Promise<PermittedLanguageModel> {
@@ -26,61 +31,49 @@ export class SetUserDefaultLanguageModelUseCase {
       orgId: command.orgId,
     });
 
-    try {
-      // First, verify that the permitted model exists and belongs to the organization
-      const userId = this.contextService.get('userId');
-      if (userId !== command.userId) {
-        throw new UnauthorizedAccessError();
-      }
-      const permittedModel =
-        await this.permittedModelsRepository.findOneLanguage({
-          id: command.permittedModelId,
-        });
+    // First, verify that the permitted model exists and belongs to the organization
+    const userId = this.contextService.get('userId');
+    if (userId !== command.userId) {
+      throw new UnauthorizedAccessError();
+    }
+    const permittedModel = await this.permittedModelsRepository.findOneLanguage(
+      {
+        id: command.permittedModelId,
+      },
+    );
 
-      if (!permittedModel) {
-        this.logger.error('Permitted model not found', {
-          permittedModelId: command.permittedModelId,
-          orgId: command.orgId,
-        });
-        throw new PermittedModelNotFoundError(command.permittedModelId);
-      }
-
-      // Check if there's already a user default model
-      const existingUserDefault =
-        await this.userDefaultModelsRepository.findByUserId(command.userId);
-
-      const action = existingUserDefault ? 'updating' : 'setting';
-      this.logger.debug(`Permitted model found, ${action} user default`, {
-        modelName: permittedModel.model.name,
-        modelProvider: permittedModel.model.provider,
-        existingDefaultId: existingUserDefault?.id,
-      });
-
-      // Set the model as the user's default (handles both create and update)
-      const userDefaultModel =
-        await this.userDefaultModelsRepository.setAsDefault(
-          permittedModel,
-          command.userId,
-        );
-
-      this.logger.debug(`User default model ${action} successfully`, {
-        userId: command.userId,
-        modelId: userDefaultModel.id,
-        action,
-      });
-
-      return userDefaultModel;
-    } catch (error) {
-      if (error instanceof ModelError) {
-        throw error;
-      }
-      this.logger.error('Failed to set user default model', {
-        userId: command.userId,
+    if (!permittedModel) {
+      this.logger.error('Permitted model not found', {
         permittedModelId: command.permittedModelId,
         orgId: command.orgId,
-        error: error instanceof Error ? error : new Error('Unknown error'),
       });
-      throw error;
+      throw new PermittedModelNotFoundError(command.permittedModelId);
     }
+
+    // Check if there's already a user default model
+    const existingUserDefault =
+      await this.userDefaultModelsRepository.findByUserId(command.userId);
+
+    const action = existingUserDefault ? 'updating' : 'setting';
+    this.logger.debug(`Permitted model found, ${action} user default`, {
+      modelName: permittedModel.model.name,
+      modelProvider: permittedModel.model.provider,
+      existingDefaultId: existingUserDefault?.id,
+    });
+
+    // Set the model as the user's default (handles both create and update)
+    const userDefaultModel =
+      await this.userDefaultModelsRepository.setAsDefault(
+        permittedModel,
+        command.userId,
+      );
+
+    this.logger.debug(`User default model ${action} successfully`, {
+      userId: command.userId,
+      modelId: userDefaultModel.id,
+      action,
+    });
+
+    return userDefaultModel;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-embedding-model/update-embedding-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-embedding-model/update-embedding-model.use-case.ts
@@ -5,8 +5,8 @@ import {
   ModelNotFoundByIdError,
   UnexpectedModelError,
 } from '../../models.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ClearDefaultsByCatalogModelIdUseCase } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case';
 import { ClearDefaultsByCatalogModelIdCommand } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.command';
 
@@ -19,47 +19,41 @@ export class UpdateEmbeddingModelUseCase {
     private readonly clearDefaultsUseCase: ClearDefaultsByCatalogModelIdUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(command: UpdateEmbeddingModelCommand): Promise<EmbeddingModel> {
-    try {
-      const existingModel = await this.modelsRepository.findOne({
-        id: command.id,
-      });
+    const existingModel = await this.modelsRepository.findOne({
+      id: command.id,
+    });
 
-      if (!existingModel) {
-        throw new ModelNotFoundByIdError(command.id);
-      }
-
-      // Check if model is being archived (isArchived: false -> true)
-      const isBeingArchived = !existingModel.isArchived && command.isArchived;
-
-      const model = new EmbeddingModel({
-        id: command.id,
-        name: command.name,
-        provider: command.provider,
-        displayName: command.displayName,
-        isArchived: command.isArchived,
-        dimensions: command.dimensions,
-        inputTokenCost: command.inputTokenCost,
-        outputTokenCost: command.outputTokenCost,
-      });
-      await this.modelsRepository.save(model);
-
-      // Clear defaults if model is being archived (for consistency, though embedding models typically don't have defaults)
-      if (isBeingArchived) {
-        this.logger.log('Model is being archived, clearing defaults', {
-          modelId: command.id,
-        });
-        await this.clearDefaultsUseCase.execute(
-          new ClearDefaultsByCatalogModelIdCommand(command.id),
-        );
-      }
-
-      return model;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      throw new UnexpectedModelError(error as Error);
+    if (!existingModel) {
+      throw new ModelNotFoundByIdError(command.id);
     }
+
+    // Check if model is being archived (isArchived: false -> true)
+    const isBeingArchived = !existingModel.isArchived && command.isArchived;
+
+    const model = new EmbeddingModel({
+      id: command.id,
+      name: command.name,
+      provider: command.provider,
+      displayName: command.displayName,
+      isArchived: command.isArchived,
+      dimensions: command.dimensions,
+      inputTokenCost: command.inputTokenCost,
+      outputTokenCost: command.outputTokenCost,
+    });
+    await this.modelsRepository.save(model);
+
+    // Clear defaults if model is being archived (for consistency, though embedding models typically don't have defaults)
+    if (isBeingArchived) {
+      this.logger.log('Model is being archived, clearing defaults', {
+        modelId: command.id,
+      });
+      await this.clearDefaultsUseCase.execute(
+        new ClearDefaultsByCatalogModelIdCommand(command.id),
+      );
+    }
+
+    return model;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-image-generation-model/update-image-generation-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-image-generation-model/update-image-generation-model.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ImageGenerationModel } from 'src/domain/models/domain/models/image-generation.model';
 import {
   ModelNotFoundByIdError,
@@ -18,41 +18,36 @@ export class UpdateImageGenerationModelUseCase {
     private readonly modelPolicy: ModelPolicyService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     command: UpdateImageGenerationModelCommand,
   ): Promise<ImageGenerationModel> {
-    try {
-      this.modelPolicy.assertSupportedImageGenerationProvider(command.provider);
+    this.logger.log('execute', {
+      id: command.id,
+    });
 
-      const existingModel = await this.modelsRepository.findOneImageGeneration(
-        command.id,
-      );
+    this.modelPolicy.assertSupportedImageGenerationProvider(command.provider);
 
-      if (!existingModel) {
-        throw new ModelNotFoundByIdError(command.id);
-      }
+    const existingModel = await this.modelsRepository.findOneImageGeneration(
+      command.id,
+    );
 
-      const model = new ImageGenerationModel({
-        id: command.id,
-        name: command.name,
-        provider: command.provider,
-        displayName: command.displayName,
-        isArchived: command.isArchived,
-        createdAt: existingModel.createdAt,
-        inputTokenCost: command.inputTokenCost,
-        outputTokenCost: command.outputTokenCost,
-      });
-      await this.modelsRepository.save(model);
-
-      return model;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Unexpected error updating image-generation model', {
-        error: error as Error,
-      });
-      throw new UnexpectedModelError(error as Error);
+    if (!existingModel) {
+      throw new ModelNotFoundByIdError(command.id);
     }
+
+    const model = new ImageGenerationModel({
+      id: command.id,
+      name: command.name,
+      provider: command.provider,
+      displayName: command.displayName,
+      isArchived: command.isArchived,
+      createdAt: existingModel.createdAt,
+      inputTokenCost: command.inputTokenCost,
+      outputTokenCost: command.outputTokenCost,
+    });
+    await this.modelsRepository.save(model);
+
+    return model;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.ts
@@ -5,8 +5,8 @@ import {
   ModelNotFoundByIdError,
   UnexpectedModelError,
 } from '../../models.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ClearDefaultsByCatalogModelIdUseCase } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case';
 import { ClearDefaultsByCatalogModelIdCommand } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.command';
 
@@ -19,51 +19,45 @@ export class UpdateLanguageModelUseCase {
     private readonly clearDefaultsUseCase: ClearDefaultsByCatalogModelIdUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(command: UpdateLanguageModelCommand): Promise<LanguageModel> {
-    try {
-      const existingModel = await this.modelsRepository.findOne({
-        id: command.id,
-      });
+    const existingModel = await this.modelsRepository.findOne({
+      id: command.id,
+    });
 
-      if (!existingModel) {
-        throw new ModelNotFoundByIdError(command.id);
-      }
-
-      // Check if model is being archived (isArchived: false -> true)
-      const isBeingArchived = !existingModel.isArchived && command.isArchived;
-
-      const model = new LanguageModel({
-        id: command.id,
-        name: command.name,
-        provider: command.provider,
-        displayName: command.displayName,
-        isArchived: command.isArchived,
-        canStream: command.canStream,
-        canUseTools: command.canUseTools,
-        isReasoning: command.isReasoning,
-        canVision: command.canVision,
-        inputTokenCost: command.inputTokenCost,
-        outputTokenCost: command.outputTokenCost,
-        tier: command.tier,
-      });
-      await this.modelsRepository.save(model);
-
-      // Clear defaults if model is being archived
-      if (isBeingArchived) {
-        this.logger.log('Model is being archived, clearing defaults', {
-          modelId: command.id,
-        });
-        await this.clearDefaultsUseCase.execute(
-          new ClearDefaultsByCatalogModelIdCommand(command.id),
-        );
-      }
-
-      return model;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      throw new UnexpectedModelError(error as Error);
+    if (!existingModel) {
+      throw new ModelNotFoundByIdError(command.id);
     }
+
+    // Check if model is being archived (isArchived: false -> true)
+    const isBeingArchived = !existingModel.isArchived && command.isArchived;
+
+    const model = new LanguageModel({
+      id: command.id,
+      name: command.name,
+      provider: command.provider,
+      displayName: command.displayName,
+      isArchived: command.isArchived,
+      canStream: command.canStream,
+      canUseTools: command.canUseTools,
+      isReasoning: command.isReasoning,
+      canVision: command.canVision,
+      inputTokenCost: command.inputTokenCost,
+      outputTokenCost: command.outputTokenCost,
+      tier: command.tier,
+    });
+    await this.modelsRepository.save(model);
+
+    // Clear defaults if model is being archived
+    if (isBeingArchived) {
+      this.logger.log('Model is being archived, clearing defaults', {
+        modelId: command.id,
+      });
+      await this.clearDefaultsUseCase.execute(
+        new ClearDefaultsByCatalogModelIdCommand(command.id),
+      );
+    }
+
+    return model;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-permitted-model/update-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-permitted-model/update-permitted-model.use-case.ts
@@ -7,12 +7,15 @@ import {
   PermittedLanguageModel,
   PermittedModel,
 } from 'src/domain/models/domain/permitted-model.entity';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
-import { PermittedModelNotFoundError } from '../../models.errors';
+import {
+  PermittedModelNotFoundError,
+  UnexpectedModelError,
+} from '../../models.errors';
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import { EmbeddingModel } from 'src/domain/models/domain/models/embedding.model';
 import { ImageGenerationModel } from 'src/domain/models/domain/models/image-generation.model';
@@ -28,6 +31,7 @@ export class UpdatePermittedModelUseCase {
     private readonly modelPolicy: ModelPolicyService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(command: UpdatePermittedModelCommand): Promise<PermittedModel> {
     this.logger.log('execute', {
       id: command.permittedModelId,
@@ -35,83 +39,75 @@ export class UpdatePermittedModelUseCase {
       anonymousOnly: command.anonymousOnly,
     });
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      const orgRole = this.contextService.get('role');
-      const systemRole = this.contextService.get('systemRole');
-      const isOrgAdmin = orgRole === UserRole.ADMIN && orgId === command.orgId;
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+    const orgId = this.contextService.get('orgId');
+    const orgRole = this.contextService.get('role');
+    const systemRole = this.contextService.get('systemRole');
+    const isOrgAdmin = orgRole === UserRole.ADMIN && orgId === command.orgId;
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
 
-      if (!isOrgAdmin && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
-
-      const existingModel = await this.permittedModelsRepository.findOne({
-        id: command.permittedModelId,
-      });
-
-      if (!existingModel) {
-        throw new PermittedModelNotFoundError(command.permittedModelId);
-      }
-
-      // Verify the model belongs to the specified org
-      if (existingModel.orgId !== command.orgId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      this.modelPolicy.assertSupported(existingModel.model);
-
-      // Create updated model with new anonymousOnly value, preserving the correct type
-      let updatedModel: PermittedModel;
-      if (existingModel.model instanceof LanguageModel) {
-        updatedModel = new PermittedLanguageModel({
-          id: existingModel.id,
-          model: existingModel.model,
-          orgId: existingModel.orgId,
-          scope: existingModel.scope,
-          scopeId: existingModel.scopeId,
-          isDefault: existingModel.isDefault,
-          anonymousOnly: command.anonymousOnly,
-          createdAt: existingModel.createdAt,
-          updatedAt: new Date(),
-        });
-      } else if (existingModel.model instanceof EmbeddingModel) {
-        updatedModel = new PermittedEmbeddingModel({
-          id: existingModel.id,
-          model: existingModel.model,
-          orgId: existingModel.orgId,
-          scope: existingModel.scope,
-          scopeId: existingModel.scopeId,
-          isDefault: existingModel.isDefault,
-          anonymousOnly: command.anonymousOnly,
-          createdAt: existingModel.createdAt,
-          updatedAt: new Date(),
-        });
-      } else if (existingModel.model instanceof ImageGenerationModel) {
-        updatedModel = new PermittedImageGenerationModel({
-          id: existingModel.id,
-          model: existingModel.model,
-          orgId: existingModel.orgId,
-          scope: existingModel.scope,
-          scopeId: existingModel.scopeId,
-          isDefault: existingModel.isDefault,
-          anonymousOnly: command.anonymousOnly,
-          createdAt: existingModel.createdAt,
-          updatedAt: new Date(),
-        });
-      } else {
-        throw new Error(
-          `Unknown model type: ${existingModel.model.constructor.name}`,
-        );
-      }
-
-      return await this.permittedModelsRepository.update(updatedModel);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error updating permitted model', error);
-      throw error;
+    if (!isOrgAdmin && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
     }
+
+    const existingModel = await this.permittedModelsRepository.findOne({
+      id: command.permittedModelId,
+    });
+
+    if (!existingModel) {
+      throw new PermittedModelNotFoundError(command.permittedModelId);
+    }
+
+    // Verify the model belongs to the specified org
+    if (existingModel.orgId !== command.orgId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    this.modelPolicy.assertSupported(existingModel.model);
+
+    // Create updated model with new anonymousOnly value, preserving the correct type
+    const updatedModel = this.buildUpdatedModel(
+      existingModel,
+      command.anonymousOnly,
+    );
+
+    return await this.permittedModelsRepository.update(updatedModel);
+  }
+
+  private buildUpdatedModel(
+    existingModel: PermittedModel,
+    anonymousOnly: boolean,
+  ): PermittedModel {
+    const props = {
+      id: existingModel.id,
+      orgId: existingModel.orgId,
+      scope: existingModel.scope,
+      scopeId: existingModel.scopeId,
+      isDefault: existingModel.isDefault,
+      anonymousOnly,
+      createdAt: existingModel.createdAt,
+      updatedAt: new Date(),
+    };
+
+    if (existingModel.model instanceof LanguageModel) {
+      return new PermittedLanguageModel({
+        ...props,
+        model: existingModel.model,
+      });
+    }
+    if (existingModel.model instanceof EmbeddingModel) {
+      return new PermittedEmbeddingModel({
+        ...props,
+        model: existingModel.model,
+      });
+    }
+    if (existingModel.model instanceof ImageGenerationModel) {
+      return new PermittedImageGenerationModel({
+        ...props,
+        model: existingModel.model,
+      });
+    }
+    throw new Error(
+      `Unknown model type: ${existingModel.model.constructor.name}`,
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-team-permitted-model/update-team-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-team-permitted-model/update-team-permitted-model.use-case.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { UpdateTeamPermittedModelCommand } from './update-team-permitted-model.command';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
-import { ApplicationError } from 'src/common/errors/base.error';
 import {
   NotALanguageModelError,
   UnexpectedModelError,
@@ -19,6 +19,7 @@ export class UpdateTeamPermittedModelUseCase {
     private readonly validator: TeamPermittedModelValidator,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     command: UpdateTeamPermittedModelCommand,
   ): Promise<PermittedLanguageModel> {
@@ -29,42 +30,32 @@ export class UpdateTeamPermittedModelUseCase {
       anonymousOnly: command.anonymousOnly,
     });
 
-    try {
-      this.validator.validateAdminAccess(command.orgId);
-      await this.validator.validateTeamInOrg(command.teamId, command.orgId);
-      const existing = await this.validator.validateModelBelongsToTeam(
-        command.permittedModelId,
-        command.teamId,
-        command.orgId,
-      );
+    this.validator.validateAdminAccess(command.orgId);
+    await this.validator.validateTeamInOrg(command.teamId, command.orgId);
+    const existing = await this.validator.validateModelBelongsToTeam(
+      command.permittedModelId,
+      command.teamId,
+      command.orgId,
+    );
 
-      if (!(existing.model instanceof LanguageModel)) {
-        throw new NotALanguageModelError(existing.model.id);
-      }
-
-      const updated = new PermittedLanguageModel({
-        id: existing.id,
-        model: existing.model,
-        orgId: existing.orgId,
-        scope: existing.scope,
-        scopeId: existing.scopeId,
-        isDefault: existing.isDefault,
-        anonymousOnly: command.anonymousOnly,
-        createdAt: existing.createdAt,
-        updatedAt: new Date(),
-      });
-
-      return (await this.permittedModelsRepository.update(
-        updated,
-      )) as PermittedLanguageModel;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error updating team permitted model', error);
-      throw new UnexpectedModelError(
-        error instanceof Error ? error : new Error('Unknown error'),
-      );
+    if (!(existing.model instanceof LanguageModel)) {
+      throw new NotALanguageModelError(existing.model.id);
     }
+
+    const updated = new PermittedLanguageModel({
+      id: existing.id,
+      model: existing.model,
+      orgId: existing.orgId,
+      scope: existing.scope,
+      scopeId: existing.scopeId,
+      isDefault: existing.isDefault,
+      anonymousOnly: command.anonymousOnly,
+      createdAt: existing.createdAt,
+      updatedAt: new Date(),
+    });
+
+    return (await this.permittedModelsRepository.update(
+      updated,
+    )) as PermittedLanguageModel;
   }
 }

--- a/ayunis-core-backend/src/domain/runs/application/helpers/resolve-integration.helper.ts
+++ b/ayunis-core-backend/src/domain/runs/application/helpers/resolve-integration.helper.ts
@@ -26,9 +26,7 @@ export function resolveIntegration(
 }
 
 type AssistantContent =
-  | TextMessageContent
-  | ToolUseMessageContent
-  | ThinkingMessageContent;
+  TextMessageContent | ToolUseMessageContent | ThinkingMessageContent;
 
 /**
  * Enriches assistant message content blocks with integration metadata.

--- a/ayunis-core-backend/src/domain/runs/application/runs.errors.ts
+++ b/ayunis-core-backend/src/domain/runs/application/runs.errors.ts
@@ -12,6 +12,7 @@ export enum RunErrorCode {
   RUN_TOOL_EXECUTION_FAILED = 'RUN_TOOL_EXECUTION_FAILED',
   RUN_NO_MODEL_FOUND = 'RUN_NO_MODEL_FOUND',
   RUN_ANONYMIZATION_UNAVAILABLE = 'RUN_ANONYMIZATION_UNAVAILABLE',
+  UNEXPECTED_RUN_ERROR = 'UNEXPECTED_RUN_ERROR',
 }
 
 /**
@@ -25,6 +26,18 @@ export abstract class RunError extends ApplicationError {
     metadata?: ErrorMetadata,
   ) {
     super(message, code, statusCode, metadata);
+  }
+}
+
+/**
+ * Error thrown when an unexpected error occurs
+ */
+export class UnexpectedRunError extends RunError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, RunErrorCode.UNEXPECTED_RUN_ERROR, 500, {
+      ...metadata,
+      error,
+    });
   }
 }
 

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Message } from '../../../../messages/domain/message.entity';
 import { AddMessageCommand } from '../../../../threads/application/use-cases/add-message-to-thread/add-message.command';
 import { Thread } from '../../../../threads/domain/thread.entity';
@@ -13,6 +14,7 @@ import {
   RunInvalidInputError,
   RunMaxIterationsReachedError,
   RunNoModelFoundError,
+  UnexpectedRunError,
 } from '../../runs.errors';
 import {
   RunUserInput,
@@ -63,6 +65,7 @@ export class ExecuteRunUseCase {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedRunError)
   async execute(
     command: ExecuteRunCommand,
   ): Promise<AsyncGenerator<RunStreamItem, void, void>> {

--- a/ayunis-core-backend/src/domain/shares/application/shares.errors.ts
+++ b/ayunis-core-backend/src/domain/shares/application/shares.errors.ts
@@ -4,6 +4,7 @@ import { ApplicationError } from '../../../common/errors/base.error';
 export enum ShareErrorCode {
   SHARE_NOT_FOUND = 'SHARE_NOT_FOUND',
   SHARE_ALREADY_EXISTS = 'SHARE_ALREADY_EXISTS',
+  UNEXPECTED_SHARE_ERROR = 'UNEXPECTED_SHARE_ERROR',
 }
 
 export abstract class ShareError extends ApplicationError {
@@ -36,5 +37,14 @@ export class ShareAlreadyExistsError extends ShareError {
       409,
       { entityId, scopeType, ...metadata },
     );
+  }
+}
+
+export class UnexpectedShareError extends ShareError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, ShareErrorCode.UNEXPECTED_SHARE_ERROR, 500, {
+      ...metadata,
+      error,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/shares/application/use-cases/create-share/create-share.use-case.ts
+++ b/ayunis-core-backend/src/domain/shares/application/use-cases/create-share/create-share.use-case.ts
@@ -27,7 +27,11 @@ import { SharedEntityType } from 'src/domain/shares/domain/value-objects/shared-
 import { ShareScopeType } from 'src/domain/shares/domain/value-objects/share-scope-type.enum';
 import { CheckUserTeamMembershipUseCase } from 'src/iam/teams/application/use-cases/check-user-team-membership/check-user-team-membership.use-case';
 import { CheckUserTeamMembershipQuery } from 'src/iam/teams/application/use-cases/check-user-team-membership/check-user-team-membership.query';
-import { ShareAlreadyExistsError } from '../../shares.errors';
+import {
+  ShareAlreadyExistsError,
+  UnexpectedShareError,
+} from '../../shares.errors';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 
 interface ShareCommandConfig {
   entityType: SharedEntityType;
@@ -45,6 +49,7 @@ export class CreateShareUseCase {
     private readonly checkUserTeamMembershipUseCase: CheckUserTeamMembershipUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedShareError)
   async execute(command: CreateShareCommand): Promise<Share> {
     const { userId, orgId } = this.getAuthenticatedContext();
     const config = this.resolveCommandConfig(command);

--- a/ayunis-core-backend/src/domain/shares/application/use-cases/delete-share/delete-share.use-case.ts
+++ b/ayunis-core-backend/src/domain/shares/application/use-cases/delete-share/delete-share.use-case.ts
@@ -4,8 +4,9 @@ import { SharesRepository } from '../../ports/shares-repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UUID } from 'crypto';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { Transactional } from '@nestjs-cls/transactional';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedShareError } from '../../shares.errors';
 import {
   RemainingShareScope,
   ShareDeletedEvent,
@@ -26,53 +27,50 @@ export class DeleteShareUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedShareError)
   async execute(id: UUID): Promise<void> {
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
+    this.logger.log('execute', { id });
 
-      const share = await this.repository.findById(id);
-      if (!share) {
-        throw new NotFoundException('Share not found');
-      }
-
-      if (share.ownerId !== userId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      await this.repository.delete(share);
-
-      const entityId = share.entityId;
-      const remainingShares = await this.repository.findByEntityIdAndType(
-        entityId,
-        share.entityType,
-      );
-      const remainingScopes = remainingShares.map((s) =>
-        this.toRemainingScope(s),
-      );
-
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      this.eventEmitter.emit(
-        ShareDeletedEvent.EVENT_NAME,
-        new ShareDeletedEvent(
-          share.entityType,
-          entityId,
-          share.ownerId,
-          orgId,
-          remainingScopes,
-        ),
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error(error);
-      throw new Error('Unexpected error occurred');
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
     }
+
+    const share = await this.repository.findById(id);
+    if (!share) {
+      throw new NotFoundException('Share not found');
+    }
+
+    if (share.ownerId !== userId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    await this.repository.delete(share);
+
+    const entityId = share.entityId;
+    const remainingShares = await this.repository.findByEntityIdAndType(
+      entityId,
+      share.entityType,
+    );
+    const remainingScopes = remainingShares.map((s) =>
+      this.toRemainingScope(s),
+    );
+
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    this.eventEmitter.emit(
+      ShareDeletedEvent.EVENT_NAME,
+      new ShareDeletedEvent(
+        share.entityType,
+        entityId,
+        share.ownerId,
+        orgId,
+        remainingScopes,
+      ),
+    );
   }
 
   private toRemainingScope(share: Share): RemainingShareScope {

--- a/ayunis-core-backend/src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case.ts
+++ b/ayunis-core-backend/src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case.ts
@@ -10,6 +10,8 @@ import { FindShareByEntityQuery } from './find-share-by-entity.query';
 import { Share } from '../../../domain/share.entity';
 import { ShareScopeType } from '../../../domain/value-objects/share-scope-type.enum';
 import { ListMyTeamsUseCase } from 'src/iam/teams/application/use-cases/list-my-teams/list-my-teams.use-case';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedShareError } from '../../shares.errors';
 
 /**
  * Use case for finding a specific share by entity type and entity ID
@@ -32,6 +34,7 @@ export class FindShareByEntityUseCase {
    * @returns The share if found, null otherwise
    * @throws UnauthorizedException if user is not authenticated or has no organization
    */
+  @HandleUnexpectedErrors(UnexpectedShareError)
   async execute(query: FindShareByEntityQuery): Promise<Share | null> {
     this.logger.log('execute', {
       entityType: query.entityType,

--- a/ayunis-core-backend/src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.use-case.ts
+++ b/ayunis-core-backend/src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.use-case.ts
@@ -10,6 +10,8 @@ import { FindSharesByScopeQuery } from './find-shares-by-scope.query';
 import { Share } from '../../../domain/share.entity';
 import { ShareScopeType } from '../../../domain/value-objects/share-scope-type.enum';
 import { ListMyTeamsUseCase } from 'src/iam/teams/application/use-cases/list-my-teams/list-my-teams.use-case';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedShareError } from '../../shares.errors';
 
 /**
  * Use case for finding shares by scope
@@ -33,6 +35,7 @@ export class FindSharesByScopeUseCase {
    * @returns Array of shares for the current user's organization and teams (deduplicated by entity)
    * @throws UnauthorizedException if user is not authenticated or has no organization
    */
+  @HandleUnexpectedErrors(UnexpectedShareError)
   async execute(query: FindSharesByScopeQuery): Promise<Share[]> {
     this.logger.log('execute', {
       entityType: query.entityType,

--- a/ayunis-core-backend/src/domain/shares/application/use-cases/get-shares/get-shares.use-case.ts
+++ b/ayunis-core-backend/src/domain/shares/application/use-cases/get-shares/get-shares.use-case.ts
@@ -10,6 +10,8 @@ import { ShareAuthorizationFactory } from '../../factories/share-authorization.f
 import { ContextService } from 'src/common/context/services/context.service';
 import { GetSharesQuery } from './get-shares.query';
 import { Share } from '../../../domain/share.entity';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedShareError } from '../../shares.errors';
 
 /**
  * Use case for getting shares for any entity type
@@ -33,6 +35,7 @@ export class GetSharesUseCase {
    * @throws UnauthorizedException if user is not authenticated
    * @throws ForbiddenException if user cannot view shares for the entity
    */
+  @HandleUnexpectedErrors(UnexpectedShareError)
   async execute(query: GetSharesQuery): Promise<Share[]> {
     this.logger.log('execute', {
       entityId: query.entityId,

--- a/ayunis-core-backend/src/domain/sources/application/sources.errors.ts
+++ b/ayunis-core-backend/src/domain/sources/application/sources.errors.ts
@@ -44,8 +44,11 @@ export class SourceNotFoundError extends SourceError {
 }
 
 export class UnexpectedSourceError extends SourceError {
-  constructor(message: string, metadata?: ErrorMetadata) {
-    super(message, SourceErrorCode.UNEXPECTED_SOURCE_ERROR, 500, metadata);
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, SourceErrorCode.UNEXPECTED_SOURCE_ERROR, 500, {
+      ...metadata,
+      error,
+    });
   }
 }
 

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-data-source/create-data-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-data-source/create-data-source.use-case.ts
@@ -8,19 +8,20 @@ import {
   CreateCSVDataSourceCommand,
 } from './create-data-source.command';
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import {
   InvalidSourceTypeError,
   UnexpectedSourceError,
 } from '../../sources.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class CreateDataSourceUseCase {
   private readonly logger = new Logger(CreateDataSourceUseCase.name);
   constructor(private readonly sourceRepository: SourceRepository) {}
 
-  async execute(command: CreateCSVDataSourceCommand): Promise<CSVDataSource>;
-  async execute(command: CreateDataSourceCommand): Promise<DataSource>;
+  // No overload signatures: the typed decorator cannot be applied to an
+  // overloaded method (TS1241 on the descriptor).
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(command: CreateDataSourceCommand): Promise<DataSource> {
     this.logger.log('execute', {
       name:
@@ -32,25 +33,15 @@ export class CreateDataSourceUseCase {
           ? command.data.rows.length
           : undefined,
     });
-    try {
-      if (command instanceof CreateCSVDataSourceCommand) {
-        const dataSource = new CSVDataSource({
-          name: command.name,
-          data: command.data,
-          createdBy: command.createdBy,
-        });
-        await this.sourceRepository.save(dataSource);
-        return dataSource;
-      }
-      throw new InvalidSourceTypeError(command.constructor.name);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error creating data source', {
-        error: error as Error,
+    if (command instanceof CreateCSVDataSourceCommand) {
+      const dataSource = new CSVDataSource({
+        name: command.name,
+        data: command.data,
+        createdBy: command.createdBy,
       });
-      throw new UnexpectedSourceError('Error creating data source', {
-        error: error as Error,
-      });
+      await this.sourceRepository.save(dataSource);
+      return dataSource;
     }
+    throw new InvalidSourceTypeError(command.constructor.name);
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-processing-source/create-processing-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-processing-source/create-processing-source.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { FileSource } from '../../../domain/sources/text-source.entity';
 import { FileType, TextType } from '../../../domain/source-type.enum';
 import { SourceStatus } from '../../../domain/source-status.enum';
@@ -8,7 +9,6 @@ import {
   UnsupportedSourceFileTypeError,
   UnexpectedSourceError,
 } from '../../sources.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { CreateProcessingSourceCommand } from './create-processing-source.command';
 
 @Injectable()
@@ -17,30 +17,21 @@ export class CreateProcessingSourceUseCase {
 
   constructor(private readonly sourceRepository: SourceRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(command: CreateProcessingSourceCommand): Promise<FileSource> {
     this.logger.debug('Creating processing source', {
       fileName: command.fileName,
     });
 
-    try {
-      const source = new FileSource({
-        fileType: this.getFileType(command.fileType),
-        name: command.fileName,
-        type: TextType.FILE,
-        status: SourceStatus.PROCESSING,
-        processingStartedAt: new Date(),
-      });
+    const source = new FileSource({
+      fileType: this.getFileType(command.fileType),
+      name: command.fileName,
+      type: TextType.FILE,
+      status: SourceStatus.PROCESSING,
+      processingStartedAt: new Date(),
+    });
 
-      return (await this.sourceRepository.save(source)) as FileSource;
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error creating processing source', {
-        error: error as Error,
-      });
-      throw new UnexpectedSourceError('Error creating processing source', {
-        error: error as Error,
-      });
-    }
+    return (await this.sourceRepository.save(source)) as FileSource;
   }
 
   private getFileType(mimeType: string): FileType {

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-processing-url-source/create-processing-url-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-processing-url-source/create-processing-url-source.use-case.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UrlSource } from '../../../domain/sources/text-source.entity';
 import { TextType } from '../../../domain/source-type.enum';
 import { SourceStatus } from '../../../domain/source-status.enum';
 import { SourceRepository } from '../../ports/source.repository';
 import { UnexpectedSourceError } from '../../sources.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UrlCrawlConstants } from 'src/domain/retrievers/url-retrievers/domain/url-crawl.constants';
 import { CreateProcessingUrlSourceCommand } from './create-processing-url-source.command';
 
@@ -14,34 +14,25 @@ export class CreateProcessingUrlSourceUseCase {
 
   constructor(private readonly sourceRepository: SourceRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(command: CreateProcessingUrlSourceCommand): Promise<UrlSource> {
     this.logger.debug('Creating processing URL source', { url: command.url });
 
-    try {
-      const source = new UrlSource({
-        url: command.url,
-        // Placeholder until the crawl resolves the real page title.
-        name: this.placeholderName(command.url),
-        type: TextType.WEB,
-        // Clamp to the crawler's cap so the stored depth never overstates how
-        // deep the source was actually crawled (CrawlUrlUseCase re-clamps too).
-        maxDepth: this.clampDepth(command.maxDepth),
-        status: SourceStatus.PROCESSING,
-        // processingStartedAt is left null and only armed when the worker picks
-        // up the job, so a source waiting in the queue is not reaped by the
-        // stale-processing cleanup before its crawl has even started.
-      });
+    const source = new UrlSource({
+      url: command.url,
+      // Placeholder until the crawl resolves the real page title.
+      name: this.placeholderName(command.url),
+      type: TextType.WEB,
+      // Clamp to the crawler's cap so the stored depth never overstates how
+      // deep the source was actually crawled (CrawlUrlUseCase re-clamps too).
+      maxDepth: this.clampDepth(command.maxDepth),
+      status: SourceStatus.PROCESSING,
+      // processingStartedAt is left null and only armed when the worker picks
+      // up the job, so a source waiting in the queue is not reaped by the
+      // stale-processing cleanup before its crawl has even started.
+    });
 
-      return (await this.sourceRepository.save(source)) as UrlSource;
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error creating processing URL source', {
-        error: error as Error,
-      });
-      throw new UnexpectedSourceError('Error creating processing URL source', {
-        error: error as Error,
-      });
-    }
+    return (await this.sourceRepository.save(source)) as UrlSource;
   }
 
   private placeholderName(url: string): string {

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-sources-from-file/create-sources-from-file.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-sources-from-file/create-sources-from-file.use-case.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import type { Source } from 'src/domain/sources/domain/source.entity';
 import {
   detectFileType,
@@ -48,46 +48,34 @@ export class CreateSourcesFromFileUseCase {
     private readonly createDataSourceUseCase: CreateDataSourceUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(command: CreateSourcesFromFileCommand): Promise<Source[]> {
     this.logger.log('Creating sources from file', {
       fileName: command.originalName,
     });
 
-    try {
-      const detectedType = detectFileType(
-        command.mimeType,
-        command.originalName,
-      );
+    const detectedType = detectFileType(command.mimeType, command.originalName);
 
-      if (
-        isDocumentFile(detectedType) ||
-        isPlainTextFile(detectedType) ||
-        isAudioFile(detectedType)
-      ) {
-        return [await this.createDocumentSource(command, detectedType)];
-      }
-
-      if (isCSVFile(detectedType)) {
-        return [await this.createCSVSource(command)];
-      }
-
-      if (isSpreadsheetFile(detectedType)) {
-        return this.createSpreadsheetSources(command);
-      }
-
-      throw new UnsupportedFileTypeError(
-        detectedType === 'unknown' ? command.originalName : detectedType,
-        SUPPORTED_FILE_TYPES,
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error creating sources from file', {
-        error: error as Error,
-      });
-      throw new UnexpectedSourceError('Error creating sources from file', {
-        error: error as Error,
-      });
+    if (
+      isDocumentFile(detectedType) ||
+      isPlainTextFile(detectedType) ||
+      isAudioFile(detectedType)
+    ) {
+      return [await this.createDocumentSource(command, detectedType)];
     }
+
+    if (isCSVFile(detectedType)) {
+      return [await this.createCSVSource(command)];
+    }
+
+    if (isSpreadsheetFile(detectedType)) {
+      return this.createSpreadsheetSources(command);
+    }
+
+    throw new UnsupportedFileTypeError(
+      detectedType === 'unknown' ? command.originalName : detectedType,
+      SUPPORTED_FILE_TYPES,
+    );
   }
 
   private async createDocumentSource(

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import {
   FileSource,
   TextSource,
@@ -16,7 +17,6 @@ import {
   InvalidSourceTypeError,
   UnexpectedSourceError,
 } from '../../sources.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { RetrieveUrlCommand } from 'src/domain/retrievers/url-retrievers/application/use-cases/retrieve-url/retrieve-url.command';
 import { RetrieveUrlUseCase } from 'src/domain/retrievers/url-retrievers/application/use-cases/retrieve-url/retrieve-url.use-case';
 import { IndexType } from 'src/domain/rag/indexers/domain/value-objects/index-type.enum';
@@ -54,44 +54,35 @@ export class CreateTextSourceUseCase {
     private readonly sourceRepository: SourceRepository,
   ) {}
 
-  async execute(command: CreateFileSourceCommand): Promise<FileSource>;
-  async execute(command: CreateUrlSourceCommand): Promise<UrlSource>;
+  // No overload signatures: the typed decorator cannot be applied to an
+  // overloaded method (TS1241 on the descriptor).
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(command: CreateTextSourceCommand): Promise<TextSource> {
     this.logger.debug('Creating text source');
     const orgId = this.contextService.get('orgId');
-    try {
-      if (!orgId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-      let result: TextSourceWithContent;
-      if (command instanceof CreateFileSourceCommand) {
-        result = await this.createFileSource(command);
-      } else if (command instanceof CreateUrlSourceCommand) {
-        result = await this.createUrlSource(command, orgId);
-      } else {
-        throw new InvalidSourceTypeError(command.constructor.name);
-      }
-      this.logger.debug('Saving source', { sourceId: result.source.id });
-      const saved = await this.sourceRepository.saveTextSource(result.source, {
-        text: result.text,
-        chunks: result.chunks,
-      });
-      await this.indexSourceContentChunks({
-        sourceId: saved.id,
-        chunks: result.chunks,
-        orgId,
-      });
-      return saved;
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error creating text source', {
-        error: error as Error,
-      });
-      throw new UnexpectedSourceError('Error creating text source', {
-        error: error as Error,
-      });
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
     }
+    let result: TextSourceWithContent;
+    if (command instanceof CreateFileSourceCommand) {
+      result = await this.createFileSource(command);
+    } else if (command instanceof CreateUrlSourceCommand) {
+      result = await this.createUrlSource(command, orgId);
+    } else {
+      throw new InvalidSourceTypeError(command.constructor.name);
+    }
+    this.logger.debug('Saving source', { sourceId: result.source.id });
+    const saved = await this.sourceRepository.saveTextSource(result.source, {
+      text: result.text,
+      chunks: result.chunks,
+    });
+    await this.indexSourceContentChunks({
+      sourceId: saved.id,
+      chunks: result.chunks,
+      orgId,
+    });
+    return saved;
   }
 
   private async createFileSource(

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/delete-source/delete-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/delete-source/delete-source.use-case.ts
@@ -5,7 +5,7 @@ import { DeleteContentUseCase } from 'src/domain/rag/indexers/application/use-ca
 import { DeleteContentCommand } from 'src/domain/rag/indexers/application/use-cases/delete-content/delete-content.command';
 import { SourceProcessingCleanupService } from '../../services/source-processing-cleanup.service';
 import { SourceStatus } from '../../../domain/source-status.enum';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnexpectedSourceError } from '../../sources.errors';
 import { Transactional } from '@nestjs-cls/transactional';
 
@@ -20,38 +20,27 @@ export class DeleteSourceUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(command: DeleteSourceCommand): Promise<void> {
     this.logger.debug(`Deleting source: ${command.sourceId}`);
-    try {
-      const source = await this.sourceRepository.findById(command.sourceId);
+    const source = await this.sourceRepository.findById(command.sourceId);
 
-      if (source?.status === SourceStatus.PROCESSING) {
-        await this.sourceProcessingCleanupService.cancelAndCleanup(
-          command.sourceId,
-        );
-      }
-
-      // Delete indexed content first
-      const deleteContentCommand = new DeleteContentCommand({
-        documentId: command.sourceId,
-      });
-
-      await this.deleteContentUseCase.execute(deleteContentCommand);
-      await this.sourceRepository.delete(command.sourceId);
-
-      this.logger.debug(
-        `Successfully deleted source and indexed content: ${command.sourceId}`,
+    if (source?.status === SourceStatus.PROCESSING) {
+      await this.sourceProcessingCleanupService.cancelAndCleanup(
+        command.sourceId,
       );
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error deleting source', {
-        error: error as Error,
-      });
-      throw new UnexpectedSourceError('Error deleting source', {
-        error: error as Error,
-      });
     }
+
+    // Delete indexed content first
+    const deleteContentCommand = new DeleteContentCommand({
+      documentId: command.sourceId,
+    });
+
+    await this.deleteContentUseCase.execute(deleteContentCommand);
+    await this.sourceRepository.delete(command.sourceId);
+
+    this.logger.debug(
+      `Successfully deleted source and indexed content: ${command.sourceId}`,
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/delete-sources/delete-sources.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/delete-sources/delete-sources.use-case.ts
@@ -4,7 +4,7 @@ import { SourceRepository } from '../../ports/source.repository';
 import { DeleteSourcesCommand } from './delete-sources.command';
 import { SourceProcessingCleanupService } from '../../services/source-processing-cleanup.service';
 import { SourceStatus } from '../../../domain/source-status.enum';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnexpectedSourceError } from '../../sources.errors';
 import { Transactional } from '@nestjs-cls/transactional';
 import { IndexRegistry } from 'src/domain/rag/indexers/application/indexer.registry';
@@ -20,39 +20,28 @@ export class DeleteSourcesUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(command: DeleteSourcesCommand): Promise<void> {
     if (command.sourceIds.length === 0) {
       return;
     }
 
     this.logger.debug(`Deleting ${command.sourceIds.length} sources`);
-    try {
-      // Cancel jobs and clean MinIO for any processing sources
-      await this.cancelProcessingSources(command.sourceIds);
+    // Cancel jobs and clean MinIO for any processing sources
+    await this.cancelProcessingSources(command.sourceIds);
 
-      // Batch delete indexed content from all indices
-      const indices = this.indexRegistry.getAll();
-      for (const index of indices) {
-        await index.deleteMany(command.sourceIds);
-      }
-
-      // Batch delete sources
-      await this.sourceRepository.deleteMany(command.sourceIds);
-
-      this.logger.debug(
-        `Successfully deleted ${command.sourceIds.length} sources and their indexed content`,
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error deleting sources', {
-        error: error as Error,
-      });
-      throw new UnexpectedSourceError('Error deleting sources', {
-        error: error as Error,
-      });
+    // Batch delete indexed content from all indices
+    const indices = this.indexRegistry.getAll();
+    for (const index of indices) {
+      await index.deleteMany(command.sourceIds);
     }
+
+    // Batch delete sources
+    await this.sourceRepository.deleteMany(command.sourceIds);
+
+    this.logger.debug(
+      `Successfully deleted ${command.sourceIds.length} sources and their indexed content`,
+    );
   }
 
   private async cancelProcessingSources(sourceIds: UUID[]): Promise<void> {

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/enqueue-document-processing/enqueue-document-processing.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/enqueue-document-processing/enqueue-document-processing.use-case.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { DocumentProcessingPort } from '../../ports/document-processing.port';
 import { EnqueueDocumentProcessingCommand } from './enqueue-document-processing.command';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnexpectedSourceError } from '../../sources.errors';
 
 @Injectable()
@@ -12,30 +12,20 @@ export class EnqueueDocumentProcessingUseCase {
     private readonly documentProcessingPort: DocumentProcessingPort,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(command: EnqueueDocumentProcessingCommand): Promise<void> {
     this.logger.debug('Enqueuing document processing job', {
       sourceId: command.sourceId,
       fileName: command.fileName,
     });
 
-    try {
-      await this.documentProcessingPort.enqueue({
-        sourceId: command.sourceId,
-        orgId: command.orgId,
-        userId: command.userId,
-        minioPath: command.minioPath,
-        fileName: command.fileName,
-        fileType: command.fileType,
-      });
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error enqueuing document processing job', {
-        error: error as Error,
-      });
-      throw new UnexpectedSourceError(
-        'Error enqueuing document processing job',
-        { error: error as Error },
-      );
-    }
+    await this.documentProcessingPort.enqueue({
+      sourceId: command.sourceId,
+      orgId: command.orgId,
+      userId: command.userId,
+      minioPath: command.minioPath,
+      fileName: command.fileName,
+      fileType: command.fileType,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/enqueue-url-crawl/enqueue-url-crawl.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/enqueue-url-crawl/enqueue-url-crawl.use-case.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { UrlCrawlProcessingPort } from '../../ports/url-crawl-processing.port';
 import { EnqueueUrlCrawlCommand } from './enqueue-url-crawl.command';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnexpectedSourceError } from '../../sources.errors';
 
 @Injectable()
@@ -12,28 +12,19 @@ export class EnqueueUrlCrawlUseCase {
     private readonly urlCrawlProcessingPort: UrlCrawlProcessingPort,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(command: EnqueueUrlCrawlCommand): Promise<void> {
     this.logger.debug('Enqueuing URL crawl job', {
       sourceId: command.sourceId,
       rootUrl: command.rootUrl,
     });
 
-    try {
-      await this.urlCrawlProcessingPort.enqueue({
-        sourceId: command.sourceId,
-        orgId: command.orgId,
-        userId: command.userId,
-        rootUrl: command.rootUrl,
-        maxDepth: command.maxDepth,
-      });
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error enqueuing URL crawl job', {
-        error: error as Error,
-      });
-      throw new UnexpectedSourceError('Error enqueuing URL crawl job', {
-        error: error as Error,
-      });
-    }
+    await this.urlCrawlProcessingPort.enqueue({
+      sourceId: command.sourceId,
+      orgId: command.orgId,
+      userId: command.userId,
+      rootUrl: command.rootUrl,
+      maxDepth: command.maxDepth,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SourceRepository } from '../../ports/source.repository';
 import { UnexpectedSourceError } from '../../sources.errors';
 import { ExtractTextLinesQuery } from './extract-text-lines.query';
@@ -15,6 +15,7 @@ export class ExtractTextLinesUseCase {
 
   constructor(private readonly sourceRepository: SourceRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(
     query: ExtractTextLinesQuery,
   ): Promise<ExtractTextLinesResult | null> {
@@ -24,20 +25,10 @@ export class ExtractTextLinesUseCase {
       endLine: query.endLine,
     });
 
-    try {
-      return await this.sourceRepository.extractTextLines(
-        query.sourceId,
-        query.startLine,
-        query.endLine,
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error extracting text lines', {
-        error: error as Error,
-      });
-      throw new UnexpectedSourceError(
-        error instanceof Error ? error.message : 'Unknown error',
-      );
-    }
+    return await this.sourceRepository.extractTextLines(
+      query.sourceId,
+      query.startLine,
+      query.endLine,
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.use-case.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import type { UUID } from 'crypto';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import type { TextSourceContentChunk } from '../../../domain/source-content-chunk.entity';
 import { SourceRepository } from '../../ports/source.repository';
 import { UnexpectedSourceError } from '../../sources.errors';
@@ -18,6 +18,7 @@ export class FindContentChunksByIdsUseCase {
 
   constructor(private readonly sourceRepository: SourceRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(
     query: FindContentChunksByIdsQuery,
   ): Promise<ContentChunkWithSource[]> {
@@ -25,20 +26,10 @@ export class FindContentChunksByIdsUseCase {
       count: query.chunkIds.length,
     });
 
-    try {
-      if (query.chunkIds.length === 0) {
-        return [];
-      }
-
-      return await this.sourceRepository.findContentChunksByIds(query.chunkIds);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding content chunks by IDs', {
-        error: error as Error,
-      });
-      throw new UnexpectedSourceError(
-        error instanceof Error ? error.message : 'Unknown error',
-      );
+    if (query.chunkIds.length === 0) {
+      return [];
     }
+
+    return await this.sourceRepository.findContentChunksByIds(query.chunkIds);
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/find-unreferenced-source-ids/find-unreferenced-source-ids.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/find-unreferenced-source-ids/find-unreferenced-source-ids.use-case.ts
@@ -3,7 +3,7 @@ import type { UUID } from 'crypto';
 import { SourceRepository } from '../../ports/source.repository';
 import { FindUnreferencedSourceIdsQuery } from './find-unreferenced-source-ids.query';
 import { UnexpectedSourceError } from '../../sources.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 
 // Centralises cross-module reachability in the sources domain: callers pass
 // candidate IDs (e.g. from a threads-side stale query) and get back the subset
@@ -15,6 +15,7 @@ export class FindUnreferencedSourceIdsUseCase {
 
   constructor(private readonly sourceRepository: SourceRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(query: FindUnreferencedSourceIdsQuery): Promise<UUID[]> {
     this.logger.log('execute', {
       candidateCount: query.candidateIds.length,
@@ -25,19 +26,9 @@ export class FindUnreferencedSourceIdsUseCase {
       return [];
     }
 
-    try {
-      return await this.sourceRepository.findUnreferencedIds(
-        query.candidateIds,
-        query.olderThan,
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding unreferenced source IDs', {
-        error: error as Error,
-      });
-      throw new UnexpectedSourceError(
-        error instanceof Error ? error.message : 'Unknown error',
-      );
-    }
+    return await this.sourceRepository.findUnreferencedIds(
+      query.candidateIds,
+      query.olderThan,
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/get-source-by-id/get-source-by-id.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/get-source-by-id/get-source-by-id.use-case.ts
@@ -4,7 +4,7 @@ import { SourceRepository } from '../../ports/source.repository';
 import { GetSourceByIdQuery } from './get-source-by-id.query';
 import { SourceNotFoundError } from '../../sources.errors';
 import { UnexpectedSourceError } from '../../sources.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 
 @Injectable()
 export class GetSourceByIdUseCase {
@@ -12,22 +12,13 @@ export class GetSourceByIdUseCase {
 
   constructor(private readonly sourceRepository: SourceRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(query: GetSourceByIdQuery): Promise<Source> {
     this.logger.log('execute', { id: query.sourceId });
-    try {
-      const source = await this.sourceRepository.findById(query.sourceId);
-      if (!source) {
-        throw new SourceNotFoundError(query.sourceId);
-      }
-      return source;
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting source by ID', {
-        error: error as Error,
-      });
-      throw new UnexpectedSourceError(
-        error instanceof Error ? error.message : 'Unknown error',
-      );
+    const source = await this.sourceRepository.findById(query.sourceId);
+    if (!source) {
+      throw new SourceNotFoundError(query.sourceId);
     }
+    return source;
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case.ts
@@ -3,7 +3,7 @@ import { Source } from '../../../domain/source.entity';
 import { SourceRepository } from '../../ports/source.repository';
 import { GetSourcesByIdsQuery } from './get-sources-by-ids.query';
 import { UnexpectedSourceError } from '../../sources.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 
 @Injectable()
 export class GetSourcesByIdsUseCase {
@@ -11,21 +11,12 @@ export class GetSourcesByIdsUseCase {
 
   constructor(private readonly sourceRepository: SourceRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(query: GetSourcesByIdsQuery): Promise<Source[]> {
     this.logger.log('execute', { count: query.sourceIds.length });
-    try {
-      if (query.sourceIds.length === 0) {
-        return [];
-      }
-      return await this.sourceRepository.findByIds(query.sourceIds);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting sources by IDs', {
-        error: error as Error,
-      });
-      throw new UnexpectedSourceError(
-        error instanceof Error ? error.message : 'Unknown error',
-      );
+    if (query.sourceIds.length === 0) {
+      return [];
     }
+    return await this.sourceRepository.findByIds(query.sourceIds);
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import type { Source } from '../../../domain/source.entity';
 import { SourceRepository } from '../../ports/source.repository';
 import { UnexpectedSourceError } from '../../sources.errors';
@@ -11,23 +11,14 @@ export class GetSourcesByKnowledgeBaseIdUseCase {
 
   constructor(private readonly sourceRepository: SourceRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(query: GetSourcesByKnowledgeBaseIdQuery): Promise<Source[]> {
     this.logger.log('Finding sources by knowledge base ID', {
       knowledgeBaseId: query.knowledgeBaseId,
     });
 
-    try {
-      return await this.sourceRepository.findByKnowledgeBaseId(
-        query.knowledgeBaseId,
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding sources by knowledge base ID', {
-        error: error as Error,
-      });
-      throw new UnexpectedSourceError(
-        error instanceof Error ? error.message : 'Unknown error',
-      );
-    }
+    return await this.sourceRepository.findByKnowledgeBaseId(
+      query.knowledgeBaseId,
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/get-text-source-by-id/get-text-source-by-id.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/get-text-source-by-id/get-text-source-by-id.use-case.ts
@@ -4,7 +4,7 @@ import { SourceRepository } from '../../ports/source.repository';
 import { GetTextSourceByIdQuery } from './get-text-source-by-id.query';
 import { SourceNotFoundError } from '../../sources.errors';
 import { UnexpectedSourceError } from '../../sources.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 
 @Injectable()
 export class GetTextSourceByIdUseCase {
@@ -12,22 +12,13 @@ export class GetTextSourceByIdUseCase {
 
   constructor(private readonly textSourceRepository: SourceRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(query: GetTextSourceByIdQuery): Promise<Source> {
     this.logger.log('execute', { id: query.id });
-    try {
-      const source = await this.textSourceRepository.findById(query.id);
-      if (!source) {
-        throw new SourceNotFoundError(query.id);
-      }
-      return source;
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting text source by ID', {
-        error: error as Error,
-      });
-      throw new UnexpectedSourceError(
-        error instanceof Error ? error.message : 'Unknown error',
-      );
+    const source = await this.textSourceRepository.findById(query.id);
+    if (!source) {
+      throw new SourceNotFoundError(query.id);
     }
+    return source;
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/mark-source-failed/mark-source-failed.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/mark-source-failed/mark-source-failed.use-case.ts
@@ -5,7 +5,7 @@ import {
   SourceNotFoundError,
   UnexpectedSourceError,
 } from '../../sources.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { MarkSourceFailedCommand } from './mark-source-failed.command';
 
 @Injectable()
@@ -14,29 +14,20 @@ export class MarkSourceFailedUseCase {
 
   constructor(private readonly sourceRepository: SourceRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(command: MarkSourceFailedCommand): Promise<void> {
-    try {
-      const source = await this.sourceRepository.findById(command.sourceId);
-      if (!source) {
-        throw new SourceNotFoundError(command.sourceId);
-      }
-
-      source.status = SourceStatus.FAILED;
-      source.processingError = command.errorMessage;
-      await this.sourceRepository.save(source);
-
-      this.logger.warn('Source marked as failed', {
-        sourceId: command.sourceId,
-        errorMessage: command.errorMessage,
-      });
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error marking source as failed', {
-        error: error as Error,
-      });
-      throw new UnexpectedSourceError('Error marking source as failed', {
-        error: error as Error,
-      });
+    const source = await this.sourceRepository.findById(command.sourceId);
+    if (!source) {
+      throw new SourceNotFoundError(command.sourceId);
     }
+
+    source.status = SourceStatus.FAILED;
+    source.processingError = command.errorMessage;
+    await this.sourceRepository.save(source);
+
+    this.logger.warn('Source marked as failed', {
+      sourceId: command.sourceId,
+      errorMessage: command.errorMessage,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/query-text-source/query-text-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/query-text-source/query-text-source.use-case.ts
@@ -1,4 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedSourceError } from '../../sources.errors';
 import { SourceRepository } from '../../ports/source.repository';
 import { QueryTextSourceCommand } from './query-text-source.command';
 import { SearchContentUseCase } from 'src/domain/rag/indexers/application/use-cases/search-content/search-content.use-case';
@@ -15,6 +17,7 @@ export class QueryTextSourceUseCase {
     private readonly searchContentUseCase: SearchContentUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(
     command: QueryTextSourceCommand,
   ): Promise<TextSourceContentChunk[]> {
@@ -25,46 +28,38 @@ export class QueryTextSourceUseCase {
       return [];
     }
 
-    try {
-      this.logger.debug(
-        `Performing vector search for query: "${command.query}" in source: ${command.filter.sourceId}`,
-      );
+    this.logger.debug(
+      `Performing vector search for query: "${command.query}" in source: ${command.filter.sourceId}`,
+    );
 
-      // Use the searchContentUseCase to search for relevant content
-      const searchQuery = new SearchContentQuery({
-        orgId: command.orgId,
-        documentId: command.filter.sourceId,
-        query: command.query,
-        type: IndexType.PARENT_CHILD,
-        limit: 50,
-      });
+    // Use the searchContentUseCase to search for relevant content
+    const searchQuery = new SearchContentQuery({
+      orgId: command.orgId,
+      documentId: command.filter.sourceId,
+      query: command.query,
+      type: IndexType.PARENT_CHILD,
+      limit: 50,
+    });
 
-      const indexEntries = await this.searchContentUseCase.execute(searchQuery);
+    const indexEntries = await this.searchContentUseCase.execute(searchQuery);
 
-      this.logger.debug(
-        `Found ${indexEntries.length} index entries for query: "${command.query}" in source: ${command.filter.sourceId}`,
-      );
+    this.logger.debug(
+      `Found ${indexEntries.length} index entries for query: "${command.query}" in source: ${command.filter.sourceId}`,
+    );
 
-      if (indexEntries.length === 0) {
-        return [];
-      }
-
-      // Fetch all matched chunks in a single query
-      const chunkIds = indexEntries.map((entry) => entry.relatedChunkId);
-      const chunkResults =
-        await this.sourceRepository.findContentChunksByIds(chunkIds);
-
-      this.logger.debug(
-        `Successfully matched ${chunkResults.length} source content items for query: "${command.query}" in source: ${command.filter.sourceId}`,
-      );
-
-      return chunkResults.map((r) => r.chunk);
-    } catch (error) {
-      this.logger.error(
-        `Error during vector search for query "${command.query}":`,
-        error instanceof Error ? error.message : 'Unknown error',
-      );
-      throw new Error(`Vector search failed`);
+    if (indexEntries.length === 0) {
+      return [];
     }
+
+    // Fetch all matched chunks in a single query
+    const chunkIds = indexEntries.map((entry) => entry.relatedChunkId);
+    const chunkResults =
+      await this.sourceRepository.findContentChunksByIds(chunkIds);
+
+    this.logger.debug(
+      `Successfully matched ${chunkResults.length} source content items for query: "${command.query}" in source: ${command.filter.sourceId}`,
+    );
+
+    return chunkResults.map((r) => r.chunk);
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case.ts
@@ -1,7 +1,8 @@
 import * as path from 'path';
+import type { UUID } from 'crypto';
 import { Injectable, Logger } from '@nestjs/common';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { CreateProcessingSourceUseCase } from 'src/domain/sources/application/use-cases/create-processing-source/create-processing-source.use-case';
 import { CreateProcessingSourceCommand } from 'src/domain/sources/application/use-cases/create-processing-source/create-processing-source.command';
@@ -29,82 +30,96 @@ export class StartDocumentProcessingUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(command: StartDocumentProcessingCommand): Promise<FileSource> {
     this.logger.log('Starting async document processing', {
       fileName: command.fileName,
     });
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new Error('orgId is required');
-      }
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new Error('userId is required');
-      }
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new Error('orgId is required');
+    }
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new Error('userId is required');
+    }
 
-      // 1. Create source with PROCESSING status
-      const savedSource = await this.createProcessingSourceUseCase.execute(
-        new CreateProcessingSourceCommand({
-          fileType: command.fileType,
+    // 1. Create source with PROCESSING status
+    const savedSource = await this.createProcessingSourceUseCase.execute(
+      new CreateProcessingSourceCommand({
+        fileType: command.fileType,
+        fileName: command.fileName,
+      }),
+    );
+
+    // 2. Upload file to MinIO (outside transaction)
+    const sanitizedFileName = path
+      .basename(command.fileName)
+      .replace(/[^a-zA-Z0-9._-]/g, '_');
+    const minioPath = `${orgId}/processing/${savedSource.id}/${sanitizedFileName}`;
+    await this.uploadFile(minioPath, command.fileData, savedSource);
+
+    // 3. Enqueue BullMQ job (outside transaction)
+    await this.enqueueProcessing({
+      command,
+      savedSource,
+      orgId,
+      userId,
+      minioPath,
+    });
+
+    return savedSource;
+  }
+
+  private async uploadFile(
+    minioPath: string,
+    fileData: Buffer,
+    savedSource: FileSource,
+  ): Promise<void> {
+    try {
+      await this.uploadObjectUseCase.execute(
+        new UploadObjectCommand(minioPath, fileData),
+      );
+    } catch (error) {
+      await this.tryMarkSourceFailed(
+        savedSource,
+        'Failed to upload file to storage',
+      );
+      throw error;
+    }
+  }
+
+  private async enqueueProcessing(params: {
+    command: StartDocumentProcessingCommand;
+    savedSource: FileSource;
+    orgId: UUID;
+    userId: UUID;
+    minioPath: string;
+  }): Promise<void> {
+    const { command, savedSource, orgId, userId, minioPath } = params;
+    try {
+      await this.enqueueDocumentProcessingUseCase.execute(
+        new EnqueueDocumentProcessingCommand({
+          sourceId: savedSource.id,
+          orgId,
+          userId,
+          minioPath,
           fileName: command.fileName,
+          fileType: command.fileType,
         }),
       );
-
-      // 2. Upload file to MinIO (outside transaction)
-      const sanitizedFileName = path
-        .basename(command.fileName)
-        .replace(/[^a-zA-Z0-9._-]/g, '_');
-      const minioPath = `${orgId}/processing/${savedSource.id}/${sanitizedFileName}`;
-      try {
-        await this.uploadObjectUseCase.execute(
-          new UploadObjectCommand(minioPath, command.fileData),
-        );
-      } catch (error) {
-        await this.tryMarkSourceFailed(
-          savedSource,
-          'Failed to upload file to storage',
-        );
-        throw error;
-      }
-
-      // 3. Enqueue BullMQ job (outside transaction)
-      try {
-        await this.enqueueDocumentProcessingUseCase.execute(
-          new EnqueueDocumentProcessingCommand({
-            sourceId: savedSource.id,
-            orgId,
-            userId,
-            minioPath,
-            fileName: command.fileName,
-            fileType: command.fileType,
-          }),
-        );
-      } catch (error) {
-        this.logger.error('Failed to enqueue document processing job', {
-          sourceId: savedSource.id,
-          error: error as Error,
-        });
-        await this.tryMarkSourceFailed(
-          savedSource,
-          'Failed to enqueue processing job',
-        );
-        await this.cleanupMinioFile(minioPath);
-        throw error;
-      }
-
-      return savedSource;
     } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error starting document processing', {
+      this.logger.error('Failed to enqueue document processing job', {
+        sourceId: savedSource.id,
         error: error as Error,
       });
-      throw new UnexpectedSourceError('Error starting document processing', {
-        error: error as Error,
-      });
+      await this.tryMarkSourceFailed(
+        savedSource,
+        'Failed to enqueue processing job',
+      );
+      await this.cleanupMinioFile(minioPath);
+      throw error;
     }
   }
 

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/start-url-crawl/start-url-crawl.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/start-url-crawl/start-url-crawl.use-case.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UrlSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { CreateProcessingUrlSourceUseCase } from '../create-processing-url-source/create-processing-url-source.use-case';
 import { CreateProcessingUrlSourceCommand } from '../create-processing-url-source/create-processing-url-source.command';
@@ -22,57 +22,50 @@ export class StartUrlCrawlUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(command: StartUrlCrawlCommand): Promise<UrlSource> {
     this.logger.log('Starting async URL crawl', {
       url: command.url,
       maxDepth: command.maxDepth,
     });
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) throw new Error('orgId is required');
-      const userId = this.contextService.get('userId');
-      if (!userId) throw new Error('userId is required');
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) throw new Error('orgId is required');
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new Error('userId is required');
 
-      // 1. Create source with PROCESSING status
-      const savedSource = await this.createProcessingUrlSourceUseCase.execute(
-        new CreateProcessingUrlSourceCommand({
-          url: command.url,
+    // 1. Create source with PROCESSING status
+    const savedSource = await this.createProcessingUrlSourceUseCase.execute(
+      new CreateProcessingUrlSourceCommand({
+        url: command.url,
+        maxDepth: command.maxDepth,
+      }),
+    );
+
+    // 2. Enqueue BullMQ crawl job
+    try {
+      await this.enqueueUrlCrawlUseCase.execute(
+        new EnqueueUrlCrawlCommand({
+          sourceId: savedSource.id,
+          orgId,
+          userId,
+          rootUrl: command.url,
           maxDepth: command.maxDepth,
         }),
       );
-
-      // 2. Enqueue BullMQ crawl job
-      try {
-        await this.enqueueUrlCrawlUseCase.execute(
-          new EnqueueUrlCrawlCommand({
-            sourceId: savedSource.id,
-            orgId,
-            userId,
-            rootUrl: command.url,
-            maxDepth: command.maxDepth,
-          }),
-        );
-      } catch (error) {
-        this.logger.error('Failed to enqueue URL crawl job', {
-          sourceId: savedSource.id,
-          error: error as Error,
-        });
-        await this.tryMarkSourceFailed(
-          savedSource,
-          'Failed to enqueue crawl job',
-        );
-        throw error;
-      }
-
-      return savedSource;
     } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error starting URL crawl', { error: error as Error });
-      throw new UnexpectedSourceError('Error starting URL crawl', {
+      this.logger.error('Failed to enqueue URL crawl job', {
+        sourceId: savedSource.id,
         error: error as Error,
       });
+      await this.tryMarkSourceFailed(
+        savedSource,
+        'Failed to enqueue crawl job',
+      );
+      throw error;
     }
+
+    return savedSource;
   }
 
   private async tryMarkSourceFailed(

--- a/ayunis-core-backend/src/domain/thread-pii-masks/application/thread-pii-masks.errors.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/application/thread-pii-masks.errors.ts
@@ -6,12 +6,10 @@ export enum ThreadPiiMasksErrorCode {
 }
 
 export class UnexpectedThreadPiiMasksError extends ApplicationError {
-  constructor(operation: string, metadata?: ErrorMetadata) {
-    super(
-      `Unexpected thread PII masks error during ${operation}`,
-      ThreadPiiMasksErrorCode.UNEXPECTED_ERROR,
-      500,
-      { operation, ...metadata },
-    );
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, ThreadPiiMasksErrorCode.UNEXPECTED_ERROR, 500, {
+      ...metadata,
+      error,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
 import { AnonymizeTextCommand } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command';
 import { PiiWhitelistEntry } from 'src/common/anonymization/domain/pii-whitelist-entry';
@@ -33,6 +33,7 @@ export class AnonymizeTextForThreadUseCase {
     private readonly anonymizeTextUseCase: AnonymizeTextUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadPiiMasksError)
   async execute(
     command: AnonymizeTextForThreadCommand,
   ): Promise<ThreadAnonymizationResult> {
@@ -41,46 +42,30 @@ export class AnonymizeTextForThreadUseCase {
       threadId: command.threadId,
     });
 
-    try {
-      const entries = await this.getPiiWhitelistUseCase.execute(
-        new GetPiiWhitelistQuery(command.orgId),
-      );
-      const whitelist = entries.map(
-        (entry) => new PiiWhitelistEntry(entry.category, entry.pattern),
-      );
-      const existing = await this.repository.findByThreadId(command.threadId);
+    const entries = await this.getPiiWhitelistUseCase.execute(
+      new GetPiiWhitelistQuery(command.orgId),
+    );
+    const whitelist = entries.map(
+      (entry) => new PiiWhitelistEntry(entry.category, entry.pattern),
+    );
+    const existing = await this.repository.findByThreadId(command.threadId);
 
-      const result = await this.anonymizeTextUseCase.execute(
-        new AnonymizeTextCommand(
-          command.text,
-          undefined,
-          whitelist,
-          existing.map((mask) => mask.toPiiMask()),
-        ),
-      );
+    const result = await this.anonymizeTextUseCase.execute(
+      new AnonymizeTextCommand(
+        command.text,
+        undefined,
+        whitelist,
+        existing.map((mask) => mask.toPiiMask()),
+      ),
+    );
 
-      const created = result.newMasks.map((mask) =>
-        ThreadPiiMask.fromPiiMask(command.threadId, mask),
-      );
-      if (created.length > 0) {
-        await this.repository.saveMany(created);
-      }
-
-      return { ...result, masks: [...existing, ...created] };
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-
-      this.logger.error('Failed to anonymize text for thread', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-        threadId: command.threadId,
-      });
-
-      throw new UnexpectedThreadPiiMasksError('anonymize', {
-        orgId: command.orgId,
-        threadId: command.threadId,
-        ...(error instanceof Error && { originalError: error.message }),
-      });
+    const created = result.newMasks.map((mask) =>
+      ThreadPiiMask.fromPiiMask(command.threadId, mask),
+    );
+    if (created.length > 0) {
+      await this.repository.saveMany(created);
     }
+
+    return { ...result, masks: [...existing, ...created] };
   }
 }

--- a/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/get-thread-pii-masks/get-thread-pii-masks.use-case.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/get-thread-pii-masks/get-thread-pii-masks.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ThreadPiiMaskRepository } from '../../ports/thread-pii-mask.repository';
 import { UnexpectedThreadPiiMasksError } from '../../thread-pii-masks.errors';
 import type { ThreadPiiMask } from '../../../domain/thread-pii-mask.entity';
@@ -11,25 +11,12 @@ export class GetThreadPiiMasksUseCase {
 
   constructor(private readonly repository: ThreadPiiMaskRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadPiiMasksError)
   async execute(query: GetThreadPiiMasksQuery): Promise<ThreadPiiMask[]> {
     this.logger.debug('Getting thread PII masks', {
       threadId: query.threadId,
     });
 
-    try {
-      return await this.repository.findByThreadId(query.threadId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-
-      this.logger.error('Failed to get thread PII masks', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        threadId: query.threadId,
-      });
-
-      throw new UnexpectedThreadPiiMasksError('get', {
-        threadId: query.threadId,
-        ...(error instanceof Error && { originalError: error.message }),
-      });
-    }
+    return this.repository.findByThreadId(query.threadId);
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/threads.errors.ts
+++ b/ayunis-core-backend/src/domain/threads/application/threads.errors.ts
@@ -225,15 +225,11 @@ export class UnsupportedImageContentTypeError extends ThreadError {
   }
 }
 
-export class UnexpecteThreadError extends ThreadError {
-  constructor(_error: Error, metadata?: ErrorMetadata) {
-    super(
-      'Unexpected thread error',
-      ThreadErrorCode.UNEXPECTED_THREAD_ERROR,
-      500,
-      {
-        ...metadata,
-      },
-    );
+export class UnexpectedThreadError extends ThreadError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, ThreadErrorCode.UNEXPECTED_THREAD_ERROR, 500, {
+      ...metadata,
+      error,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-knowledge-base-to-thread/add-knowledge-base-to-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-knowledge-base-to-thread/add-knowledge-base-to-thread.use-case.ts
@@ -1,8 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { AddKnowledgeBaseToThreadCommand } from './add-knowledge-base-to-thread.command';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ThreadNotFoundError } from '../../threads.errors';
+import {
+  ThreadNotFoundError,
+  UnexpectedThreadError,
+} from '../../threads.errors';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
 import { KnowledgeBaseNotFoundError } from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
@@ -17,6 +21,7 @@ export class AddKnowledgeBaseToThreadUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(command: AddKnowledgeBaseToThreadCommand): Promise<void> {
     this.logger.log('execute', {
       threadId: command.threadId,

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-mcp-integration-to-thread/add-mcp-integration-to-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-mcp-integration-to-thread/add-mcp-integration-to-thread.use-case.ts
@@ -1,8 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { AddMcpIntegrationToThreadCommand } from './add-mcp-integration-to-thread.command';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ThreadNotFoundError } from '../../threads.errors';
+import {
+  ThreadNotFoundError,
+  UnexpectedThreadError,
+} from '../../threads.errors';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { GetMcpIntegrationsByIdsUseCase } from 'src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.use-case';
 import { GetMcpIntegrationsByIdsQuery } from 'src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.query';
@@ -18,6 +22,7 @@ export class AddMcpIntegrationToThreadUseCase {
     private readonly getMcpIntegrationsByIdsUseCase: GetMcpIntegrationsByIdsUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(command: AddMcpIntegrationToThreadCommand): Promise<void> {
     this.logger.log('execute', {
       threadId: command.threadId,

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.ts
@@ -1,8 +1,12 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { AddSourceCommand } from './add-source.command';
-import { SourceAdditionError } from '../../threads.errors';
+import {
+  SourceAdditionError,
+  UnexpectedThreadError,
+} from '../../threads.errors';
 import { SourceAssignment } from '../../../domain/thread-source-assignment.entity';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -22,6 +26,7 @@ export class AddSourceToThreadUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(command: AddSourceCommand): Promise<void> {
     this.logger.log('addSource', {
       threadId: command.thread.id,

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/cleanup-stale-thread-sources/cleanup-stale-thread-sources.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/cleanup-stale-thread-sources/cleanup-stale-thread-sources.use-case.ts
@@ -1,10 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { DeleteSourcesUseCase } from 'src/domain/sources/application/use-cases/delete-sources/delete-sources.use-case';
 import { DeleteSourcesCommand } from 'src/domain/sources/application/use-cases/delete-sources/delete-sources.command';
 import { FindUnreferencedSourceIdsUseCase } from 'src/domain/sources/application/use-cases/find-unreferenced-source-ids/find-unreferenced-source-ids.use-case';
 import { FindUnreferencedSourceIdsQuery } from 'src/domain/sources/application/use-cases/find-unreferenced-source-ids/find-unreferenced-source-ids.query';
 import { CleanupStaleThreadSourcesResult } from './cleanup-stale-thread-sources.result';
+import { UnexpectedThreadError } from '../../threads.errors';
 
 const STALE_THREAD_SOURCE_DAYS = 30;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -19,6 +21,7 @@ export class CleanupStaleThreadSourcesUseCase {
     private readonly deleteSourcesUseCase: DeleteSourcesUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(): Promise<CleanupStaleThreadSourcesResult> {
     const cutoff = new Date(Date.now() - STALE_THREAD_SOURCE_DAYS * MS_PER_DAY);
     this.logger.log('execute', {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/create-thread/create-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/create-thread/create-thread.use-case.ts
@@ -1,4 +1,6 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Thread } from '../../../domain/thread.entity';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { CreateThreadCommand } from './create-thread.command';
@@ -6,6 +8,7 @@ import {
   NoModelProvidedError,
   ThreadCreationError,
   ThreadError,
+  UnexpectedThreadError,
 } from '../../threads.errors';
 import { GetPermittedLanguageModelUseCase } from 'src/domain/models/application/use-cases/get-permitted-language-model/get-permitted-language-model.use-case';
 import { ModelError } from 'src/domain/models/application/models.errors';
@@ -23,6 +26,7 @@ export class CreateThreadUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(command: CreateThreadCommand): Promise<Thread> {
     this.logger.log('execute');
     try {
@@ -30,50 +34,69 @@ export class CreateThreadUseCase {
       if (!userId) {
         throw new UnauthorizedException('User not authenticated');
       }
-      let model: PermittedLanguageModel | undefined;
-
-      if (command.modelId) {
-        model = await this.getPermittedLanguageModelUseCase.execute(
-          new GetPermittedLanguageModelQuery({
-            id: command.modelId,
-          }),
-        );
-      }
-
-      if (!model) {
-        throw new NoModelProvidedError(userId);
-      }
-
+      const model = await this.resolveModel(command, userId);
       const isAnonymous = model.anonymousOnly || (command.isAnonymous ?? false);
-
-      try {
-        const thread = new Thread({
-          userId,
-          model,
-          isAnonymous,
-          messages: [],
-        });
-        const createdThread = await this.threadsRepository.create(thread);
-        return new Thread({
-          ...createdThread,
-        });
-      } catch (error) {
-        this.logger.error('Failed to create thread', {
-          userId,
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
-        throw new ThreadCreationError(error as Error, userId);
-      }
+      return await this.persistThread(userId, model, isAnonymous);
     } catch (error) {
-      if (error instanceof ModelError || error instanceof ThreadError) {
-        throw error;
-      }
+      throw this.translateError(error);
+    }
+  }
+
+  private async resolveModel(
+    command: CreateThreadCommand,
+    userId: UUID,
+  ): Promise<PermittedLanguageModel> {
+    let model: PermittedLanguageModel | undefined;
+
+    if (command.modelId) {
+      model = await this.getPermittedLanguageModelUseCase.execute(
+        new GetPermittedLanguageModelQuery({
+          id: command.modelId,
+        }),
+      );
+    }
+
+    if (!model) {
+      throw new NoModelProvidedError(userId);
+    }
+
+    return model;
+  }
+
+  private async persistThread(
+    userId: UUID,
+    model: PermittedLanguageModel,
+    isAnonymous: boolean,
+  ): Promise<Thread> {
+    try {
+      const thread = new Thread({
+        userId,
+        model,
+        isAnonymous,
+        messages: [],
+      });
+      const createdThread = await this.threadsRepository.create(thread);
+      return new Thread({
+        ...createdThread,
+      });
+    } catch (error) {
       this.logger.error('Failed to create thread', {
+        userId,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
-      throw error instanceof Error
-        ? new ThreadCreationError(error)
-        : new ThreadCreationError(new Error('Unknown error'));
+      throw new ThreadCreationError(error as Error, userId);
     }
+  }
+
+  private translateError(error: unknown): Error {
+    if (error instanceof ModelError || error instanceof ThreadError) {
+      return error;
+    }
+    this.logger.error('Failed to create thread', {
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+    return error instanceof Error
+      ? new ThreadCreationError(error)
+      : new ThreadCreationError(new Error('Unknown error'));
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/delete-thread/delete-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/delete-thread/delete-thread.use-case.spec.ts
@@ -9,6 +9,7 @@ import { MESSAGES_REPOSITORY } from 'src/domain/messages/application/ports/messa
 import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
 import { GeneratedImagesRepository } from '../../ports/generated-images.repository';
 import { GeneratedImage } from '../../../domain/generated-image.entity';
+import { UnexpectedThreadError } from '../../threads.errors';
 
 describe('DeleteThreadUseCase', () => {
   let useCase: DeleteThreadUseCase;
@@ -179,21 +180,13 @@ describe('DeleteThreadUseCase', () => {
       const repositoryError = new Error('Database connection failed');
       threadsRepository.delete.mockRejectedValue(repositoryError);
 
-      const errorSpy = jest.spyOn(Logger.prototype, 'error');
-
       // Act & Assert
-      await expect(useCase.execute(command)).rejects.toThrow(
-        'Database connection failed',
+      await expect(useCase.execute(command)).rejects.toBeInstanceOf(
+        UnexpectedThreadError,
       );
 
       expect(threadsRepository.findOne).toHaveBeenCalled();
       expect(threadsRepository.delete).toHaveBeenCalled();
-
-      expect(errorSpy).toHaveBeenCalledWith('Failed to delete thread', {
-        threadId: mockThreadId,
-        userId: mockUserId,
-        error: 'Database connection failed',
-      });
     });
 
     it('should handle unknown error types during deletion', async () => {
@@ -211,16 +204,10 @@ describe('DeleteThreadUseCase', () => {
       threadsRepository.findOne.mockResolvedValue(mockThread as any);
       threadsRepository.delete.mockRejectedValue('string error');
 
-      const errorSpy = jest.spyOn(Logger.prototype, 'error');
-
       // Act & Assert
-      await expect(useCase.execute(command)).rejects.toBeDefined();
-
-      expect(errorSpy).toHaveBeenCalledWith('Failed to delete thread', {
-        threadId: mockThreadId,
-        userId: mockUserId,
-        error: 'Unknown error',
-      });
+      await expect(useCase.execute(command)).rejects.toBeInstanceOf(
+        UnexpectedThreadError,
+      );
     });
 
     it('should log initial delete request', async () => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/delete-thread/delete-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/delete-thread/delete-thread.use-case.ts
@@ -5,8 +5,10 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { DeleteThreadCommand } from './delete-thread.command';
+import { UnexpectedThreadError } from '../../threads.errors';
 import { ContextService } from 'src/common/context/services/context.service';
 import {
   MessagesRepository,
@@ -32,6 +34,7 @@ export class DeleteThreadUseCase {
     private readonly generatedImagesRepository: GeneratedImagesRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(command: DeleteThreadCommand): Promise<void> {
     this.logger.log('delete', { threadId: command.id });
 
@@ -46,43 +49,34 @@ export class DeleteThreadUseCase {
       throw new UnauthorizedException('Organization context required');
     }
 
-    try {
-      // First verify the thread exists and belongs to the user
-      const thread = await this.threadsRepository.findOne(command.id, userId);
+    // First verify the thread exists and belongs to the user
+    const thread = await this.threadsRepository.findOne(command.id, userId);
 
-      if (!thread) {
-        // Idempotent delete: treat already-deleted threads as success
-        this.logger.warn(
-          'Thread already deleted or not found, treating as success',
-          {
-            threadId: command.id,
-            userId,
-          },
-        );
-        return;
-      }
-
-      // Delete associated images before deleting the thread
-      await Promise.all([
-        this.deleteThreadImages(command.id, orgId),
-        this.deleteGeneratedImageBlobs(command.id),
-      ]);
-
-      // Delete the thread
-      await this.threadsRepository.delete(command.id, userId);
-
-      this.logger.log('Thread deleted successfully', {
-        threadId: command.id,
-        userId,
-      });
-    } catch (error) {
-      this.logger.error('Failed to delete thread', {
-        threadId: command.id,
-        userId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw error;
+    if (!thread) {
+      // Idempotent delete: treat already-deleted threads as success
+      this.logger.warn(
+        'Thread already deleted or not found, treating as success',
+        {
+          threadId: command.id,
+          userId,
+        },
+      );
+      return;
     }
+
+    // Delete associated images before deleting the thread
+    await Promise.all([
+      this.deleteThreadImages(command.id, orgId),
+      this.deleteGeneratedImageBlobs(command.id),
+    ]);
+
+    // Delete the thread
+    await this.threadsRepository.delete(command.id, userId);
+
+    this.logger.log('Thread deleted successfully', {
+      threadId: command.id,
+      userId,
+    });
   }
 
   /**

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads-by-org-with-sources/find-all-threads-by-org-with-sources.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads-by-org-with-sources/find-all-threads-by-org-with-sources.use-case.ts
@@ -1,7 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Thread } from '../../../domain/thread.entity';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { FindAllThreadsByOrgWithSourcesQuery } from './find-all-threads-by-org-with-sources.query';
+import { UnexpectedThreadError } from '../../threads.errors';
 
 @Injectable()
 export class FindAllThreadsByOrgWithSourcesUseCase {
@@ -11,6 +13,7 @@ export class FindAllThreadsByOrgWithSourcesUseCase {
 
   constructor(private readonly threadsRepository: ThreadsRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(query: FindAllThreadsByOrgWithSourcesQuery): Promise<Thread[]> {
     this.logger.log('execute', { orgId: query.orgId });
     return this.threadsRepository.findAllByOrgIdWithSources(query.orgId);

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads/find-all-threads.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads/find-all-threads.use-case.ts
@@ -1,8 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Thread } from '../../../domain/thread.entity';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { FindAllThreadsQuery } from './find-all-threads.query';
 import { Paginated } from 'src/common/pagination/paginated.entity';
+import { UnexpectedThreadError } from '../../threads.errors';
 
 @Injectable()
 export class FindAllThreadsUseCase {
@@ -10,6 +12,7 @@ export class FindAllThreadsUseCase {
 
   constructor(private readonly threadsRepository: ThreadsRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(query: FindAllThreadsQuery): Promise<Paginated<Thread>> {
     this.logger.log('findAll', {
       userId: query.userId,
@@ -17,22 +20,14 @@ export class FindAllThreadsUseCase {
       limit: query.limit,
       offset: query.offset,
     });
-    try {
-      return await this.threadsRepository.findAll(
-        query.userId,
-        query.options,
-        query.filters,
-        {
-          limit: query.limit,
-          offset: query.offset,
-        },
-      );
-    } catch (error) {
-      this.logger.error('Failed to find all threads', {
-        userId: query.userId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw error;
-    }
+    return this.threadsRepository.findAll(
+      query.userId,
+      query.options,
+      query.filters,
+      {
+        limit: query.limit,
+        offset: query.offset,
+      },
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/find-expired-thread-refs-by-org/find-expired-thread-refs-by-org.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/find-expired-thread-refs-by-org/find-expired-thread-refs-by-org.use-case.ts
@@ -1,7 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import type { ExpiredThreadRef } from '../../ports/threads.repository';
 import type { FindExpiredThreadRefsByOrgQuery } from './find-expired-thread-refs-by-org.query';
+import { UnexpectedThreadError } from '../../threads.errors';
 
 // Re-exported so other modules consume this type through the use-case surface
 // rather than importing the threads repository port directly (forbidden by the
@@ -20,6 +22,7 @@ export class FindExpiredThreadRefsByOrgUseCase {
 
   constructor(private readonly threadsRepository: ThreadsRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(
     query: FindExpiredThreadRefsByOrgQuery,
   ): Promise<ExpiredThreadRef[]> {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/find-thread/find-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/find-thread/find-thread.use-case.ts
@@ -1,9 +1,12 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Thread } from '../../../domain/thread.entity';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { FindThreadQuery } from './find-thread.query';
-import { ThreadNotFoundError } from '../../threads.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
+import {
+  ThreadNotFoundError,
+  UnexpectedThreadError,
+} from '../../threads.errors';
 import { ContextService } from 'src/common/context/services/context.service';
 import { CountMessagesTokensUseCase } from 'src/domain/messages/application/use-cases/count-messages-tokens/count-messages-tokens.use-case';
 import { CountMessagesTokensCommand } from 'src/domain/messages/application/use-cases/count-messages-tokens/count-messages-tokens.command';
@@ -25,33 +28,23 @@ export class FindThreadUseCase {
     private readonly countMessagesTokensUseCase: CountMessagesTokensUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(query: FindThreadQuery): Promise<FindThreadResult> {
     this.logger.log('findOne', { threadId: query.id });
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-      const thread = await this.threadsRepository.findOne(query.id, userId);
-      if (!thread) {
-        throw new ThreadNotFoundError(query.id, userId);
-      }
-
-      const tokenCount = this.countMessagesTokensUseCase.execute(
-        new CountMessagesTokensCommand(thread.messages),
-      );
-      const isLongChat = tokenCount > WARNING_THRESHOLD_TOKENS;
-
-      return { thread, isLongChat };
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to find thread', {
-        threadId: query.id,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw error;
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedException('User not authenticated');
     }
+    const thread = await this.threadsRepository.findOne(query.id, userId);
+    if (!thread) {
+      throw new ThreadNotFoundError(query.id, userId);
+    }
+
+    const tokenCount = this.countMessagesTokensUseCase.execute(
+      new CountMessagesTokensCommand(thread.messages),
+    );
+    const isLongChat = tokenCount > WARNING_THRESHOLD_TOKENS;
+
+    return { thread, isLongChat };
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/generate-and-set-thread-title/generate-and-set-thread-title.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/generate-and-set-thread-title/generate-and-set-thread-title.use-case.ts
@@ -1,4 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GenerateAndSetThreadTitleCommand } from './generate-and-set-thread-title.command';
 import { UpdateThreadTitleUseCase } from '../update-thread-title/update-thread-title.use-case';
 import { UpdateThreadTitleCommand } from '../update-thread-title/update-thread-title.command';
@@ -11,6 +13,7 @@ import {
   InvalidTitleResponseTypeError,
   TitleGenerationError,
 } from '../../thread-title.errors';
+import { UnexpectedThreadError } from '../../threads.errors';
 import { ModelToolChoice } from 'src/domain/models/domain/value-objects/model-tool-choice.enum';
 
 @Injectable()
@@ -22,60 +25,14 @@ export class GenerateAndSetThreadTitleUseCase {
     private readonly triggerInferenceUseCase: GetInferenceUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(
     command: GenerateAndSetThreadTitleCommand,
   ): Promise<string | null> {
     this.logger.log('generateAndSetTitle', { threadId: command.thread.id });
 
     try {
-      // Prompt for title generation
-      const prompt = `Based on the following user message, generate a short, concise title (maximum 50 characters):
-      
-      "${command.message}"
-      
-      Title:`;
-      const userMessage = new UserMessage({
-        threadId: command.thread.id,
-        content: [new TextMessageContent(prompt)],
-      });
-
-      const response = await this.triggerInferenceUseCase.execute(
-        new GetInferenceCommand({
-          model: command.model,
-          messages: [userMessage],
-          tools: [],
-          toolChoice: ModelToolChoice.AUTO,
-        }),
-      );
-
-      // Validate response content
-      if (!response.content.length) {
-        throw new EmptyTitleResponseError(command.thread.id);
-      }
-
-      const firstContent = response.content.find(
-        (content) => content instanceof TextMessageContent,
-      );
-      if (!firstContent) {
-        throw new InvalidTitleResponseTypeError(
-          command.thread.id,
-          response.content
-            .map((content) => content.constructor.name)
-            .join(', '),
-        );
-      }
-
-      // Remove extra spaces and <think>...</think> blocks
-      let title = firstContent.text
-        .replace(/<think(ing)?>([\s\S]*?)<\/think(ing)?>/g, '')
-        .trim();
-
-      // Strip markdown formatting
-      title = this.stripMarkdownFormatting(title);
-
-      if (!title) {
-        throw new EmptyTitleResponseError(command.thread.id);
-      }
+      const title = await this.generateTitle(command);
 
       // Update thread with new title
       await this.updateThreadTitleUseCase.execute(
@@ -86,23 +43,79 @@ export class GenerateAndSetThreadTitleUseCase {
       );
       return title;
     } catch (error) {
-      // Log the error with appropriate context
-      let logError = error as Error;
-      if (
-        !(error instanceof EmptyTitleResponseError) &&
-        !(error instanceof InvalidTitleResponseTypeError)
-      ) {
-        logError = new TitleGenerationError(command.thread.id, error as Error);
-      }
-
-      this.logger.error('Failed to generate title', {
-        threadId: command.thread.id,
-        error: logError instanceof Error ? logError.message : 'Unknown error',
-      });
+      this.logTitleGenerationFailure(command.thread.id, error);
 
       // Don't throw error - just log it
       return null;
     }
+  }
+
+  private async generateTitle(
+    command: GenerateAndSetThreadTitleCommand,
+  ): Promise<string> {
+    // Prompt for title generation
+    const prompt = `Based on the following user message, generate a short, concise title (maximum 50 characters):
+
+      "${command.message}"
+
+      Title:`;
+    const userMessage = new UserMessage({
+      threadId: command.thread.id,
+      content: [new TextMessageContent(prompt)],
+    });
+
+    const response = await this.triggerInferenceUseCase.execute(
+      new GetInferenceCommand({
+        model: command.model,
+        messages: [userMessage],
+        tools: [],
+        toolChoice: ModelToolChoice.AUTO,
+      }),
+    );
+
+    // Validate response content
+    if (!response.content.length) {
+      throw new EmptyTitleResponseError(command.thread.id);
+    }
+
+    const firstContent = response.content.find(
+      (content) => content instanceof TextMessageContent,
+    );
+    if (!firstContent) {
+      throw new InvalidTitleResponseTypeError(
+        command.thread.id,
+        response.content.map((content) => content.constructor.name).join(', '),
+      );
+    }
+
+    // Remove extra spaces and <think>...</think> blocks
+    let title = firstContent.text
+      .replace(/<think(ing)?>([\s\S]*?)<\/think(ing)?>/g, '')
+      .trim();
+
+    // Strip markdown formatting
+    title = this.stripMarkdownFormatting(title);
+
+    if (!title) {
+      throw new EmptyTitleResponseError(command.thread.id);
+    }
+
+    return title;
+  }
+
+  private logTitleGenerationFailure(threadId: UUID, error: unknown): void {
+    let logError = error as Error;
+    if (
+      !(error instanceof EmptyTitleResponseError) &&
+      !(error instanceof InvalidTitleResponseTypeError)
+    ) {
+      logError = new TitleGenerationError(threadId, error as Error);
+    }
+
+    this.logger.error('Failed to generate title', {
+      threadId,
+      error: logError instanceof Error ? logError.message : 'Unknown error',
+    });
   }
 
   /**
@@ -125,9 +138,9 @@ export class GenerateAndSetThreadTitleUseCase {
         // Remove headers: # text
         .replace(/^#{1,6}\s+/gm, '')
         // Remove links: [text](url) -> text
-        .replace(/\[(.+?)\]\(.+?\)/g, '$1')
+        .replace(/\[([^\]]{1,200})\]\([^)]{1,2000}\)/g, '$1')
         // Remove quotes
-        .replace(/["""]/g, '')
+        .replace(/"/g, '')
         // Clean up any extra whitespace
         .replace(/\s+/g, ' ')
         .trim()

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/get-thread-sources/get-thread-sources.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/get-thread-sources/get-thread-sources.use-case.ts
@@ -1,9 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Source } from '../../../../sources/domain/source.entity';
 import { FindThreadSourcesQuery } from './get-thread-sources.query';
 import { FindThreadUseCase } from '../find-thread/find-thread.use-case';
 import { FindThreadQuery } from '../find-thread/find-thread.query';
-import { ThreadNotFoundError } from '../../threads.errors';
+import {
+  ThreadNotFoundError,
+  UnexpectedThreadError,
+} from '../../threads.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
@@ -12,6 +16,7 @@ export class GetThreadSourcesUseCase {
 
   constructor(private readonly findThreadUseCase: FindThreadUseCase) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(query: FindThreadSourcesQuery): Promise<Source[]> {
     this.logger.log('getThreadSources', {
       threadId: query.threadId,
@@ -22,7 +27,7 @@ export class GetThreadSourcesUseCase {
         new FindThreadQuery(query.threadId),
       );
       return (
-        thread.sourceAssignments?.map((assignment) => assignment.source) || []
+        thread.sourceAssignments?.map((assignment) => assignment.source) ?? []
       );
     } catch (error) {
       if (error instanceof ApplicationError) {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/record-thread-activity/record-thread-activity.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/record-thread-activity/record-thread-activity.use-case.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { RecordThreadActivityCommand } from './record-thread-activity.command';
+import { UnexpectedThreadError } from '../../threads.errors';
 
 /**
  * Bumps a thread's `lastActivityAt` to the time a message was added. Drives
@@ -15,6 +17,7 @@ export class RecordThreadActivityUseCase {
 
   constructor(private readonly threadsRepository: ThreadsRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(command: RecordThreadActivityCommand): Promise<void> {
     try {
       await this.threadsRepository.updateLastActivityAt({

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-direct-knowledge-base-from-threads/remove-direct-knowledge-base-from-threads.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-direct-knowledge-base-from-threads/remove-direct-knowledge-base-from-threads.use-case.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { RemoveDirectKnowledgeBaseFromThreadsCommand } from './remove-direct-knowledge-base-from-threads.command';
+import { UnexpectedThreadError } from '../../threads.errors';
 
 @Injectable()
 export class RemoveDirectKnowledgeBaseFromThreadsUseCase {
@@ -10,6 +12,7 @@ export class RemoveDirectKnowledgeBaseFromThreadsUseCase {
 
   constructor(private readonly threadsRepository: ThreadsRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(
     command: RemoveDirectKnowledgeBaseFromThreadsCommand,
   ): Promise<void> {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-assignments-by-origin-skill/remove-knowledge-base-assignments-by-origin-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-assignments-by-origin-skill/remove-knowledge-base-assignments-by-origin-skill.use-case.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { RemoveKnowledgeBaseAssignmentsByOriginSkillCommand } from './remove-knowledge-base-assignments-by-origin-skill.command';
+import { UnexpectedThreadError } from '../../threads.errors';
 
 @Injectable()
 export class RemoveKnowledgeBaseAssignmentsByOriginSkillUseCase {
@@ -10,6 +12,7 @@ export class RemoveKnowledgeBaseAssignmentsByOriginSkillUseCase {
 
   constructor(private readonly threadsRepository: ThreadsRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(
     command: RemoveKnowledgeBaseAssignmentsByOriginSkillCommand,
   ): Promise<void> {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-from-thread/remove-knowledge-base-from-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-from-thread/remove-knowledge-base-from-thread.use-case.ts
@@ -1,8 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { RemoveKnowledgeBaseFromThreadCommand } from './remove-knowledge-base-from-thread.command';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ThreadNotFoundError } from '../../threads.errors';
+import {
+  ThreadNotFoundError,
+  UnexpectedThreadError,
+} from '../../threads.errors';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
@@ -16,6 +20,7 @@ export class RemoveKnowledgeBaseFromThreadUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(command: RemoveKnowledgeBaseFromThreadCommand): Promise<void> {
     this.logger.log('execute', {
       threadId: command.threadId,

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-mcp-integration-from-thread/remove-mcp-integration-from-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-mcp-integration-from-thread/remove-mcp-integration-from-thread.use-case.ts
@@ -1,8 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { RemoveMcpIntegrationFromThreadCommand } from './remove-mcp-integration-from-thread.command';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ThreadNotFoundError } from '../../threads.errors';
+import {
+  ThreadNotFoundError,
+  UnexpectedThreadError,
+} from '../../threads.errors';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
@@ -16,6 +20,7 @@ export class RemoveMcpIntegrationFromThreadUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(command: RemoveMcpIntegrationFromThreadCommand): Promise<void> {
     this.logger.log('execute', {
       threadId: command.threadId,

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-skill-sources-from-threads/remove-skill-sources-from-threads.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-skill-sources-from-threads/remove-skill-sources-from-threads.use-case.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { RemoveSkillSourcesFromThreadsCommand } from './remove-skill-sources-from-threads.command';
+import { UnexpectedThreadError } from '../../threads.errors';
 
 @Injectable()
 export class RemoveSkillSourcesFromThreadsUseCase {
@@ -10,6 +12,7 @@ export class RemoveSkillSourcesFromThreadsUseCase {
 
   constructor(private readonly threadsRepository: ThreadsRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(command: RemoveSkillSourcesFromThreadsCommand): Promise<void> {
     this.logger.log('execute', {
       skillId: command.skillId,

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-source-from-thread/remove-source-from-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-source-from-thread/remove-source-from-thread.use-case.ts
@@ -1,7 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { RemoveSourceCommand } from './remove-source.command';
-import { SourceRemovalError, SourceNotFoundError } from '../../threads.errors';
+import {
+  SourceRemovalError,
+  SourceNotFoundError,
+  UnexpectedThreadError,
+} from '../../threads.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { DeleteSourceUseCase } from 'src/domain/sources/application/use-cases/delete-source/delete-source.use-case';
 import { DeleteSourceCommand } from 'src/domain/sources/application/use-cases/delete-source/delete-source.command';
@@ -15,6 +20,7 @@ export class RemoveSourceFromThreadUseCase {
     private readonly deleteSourceUseCase: DeleteSourceUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(command: RemoveSourceCommand): Promise<void> {
     this.logger.log('removeSource', {
       threadId: command.thread.id,

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.use-case.ts
@@ -1,9 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ReplaceModelWithUserDefaultCommand } from './replace-model-with-user-default.command';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { GetDefaultModelQuery } from 'src/domain/models/application/use-cases/get-default-model/get-default-model.query';
 import { GetDefaultModelUseCase } from 'src/domain/models/application/use-cases/get-default-model/get-default-model.use-case';
-import { ModelReplacementError } from '../../threads.errors';
+import {
+  ModelReplacementError,
+  UnexpectedThreadError,
+} from '../../threads.errors';
 import { Thread } from 'src/domain/threads/domain/thread.entity';
 
 @Injectable()
@@ -15,53 +19,44 @@ export class ReplaceModelWithUserDefaultUseCase {
     private readonly getDefaultModelUseCase: GetDefaultModelUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(command: ReplaceModelWithUserDefaultCommand): Promise<void> {
     this.logger.debug('execute', {
       command,
     });
-    try {
-      const threads: Thread[] = await this.threadsRepository.findAllByModel(
-        command.oldPermittedModelId,
-      );
-      this.logger.debug('Found threads', {
-        threads,
-      });
-      for (const thread of threads) {
-        const defaultModel = await this.getDefaultModelUseCase.execute(
-          new GetDefaultModelQuery({
-            orgId: command.orgId,
-            userId: thread.userId,
-            blacklistedModelIds: command.catalogModelId
-              ? [command.catalogModelId]
-              : [],
-          }),
-        );
-        this.logger.debug('Found default model', {
-          defaultModel,
-          oldPermittedModelId: command.oldPermittedModelId,
-        });
-        if (defaultModel.id === command.oldPermittedModelId) {
-          throw new ModelReplacementError(
-            thread.id,
-            command.oldPermittedModelId,
-          );
-        }
-
-        this.logger.debug('Updating thread', {
-          threadId: thread.id,
-          newModelId: defaultModel.id,
-        });
-        await this.threadsRepository.updateModel({
-          threadId: thread.id,
+    const threads: Thread[] = await this.threadsRepository.findAllByModel(
+      command.oldPermittedModelId,
+    );
+    this.logger.debug('Found threads', {
+      threads,
+    });
+    for (const thread of threads) {
+      const defaultModel = await this.getDefaultModelUseCase.execute(
+        new GetDefaultModelQuery({
+          orgId: command.orgId,
           userId: thread.userId,
-          permittedModelId: defaultModel.id,
-        });
-      }
-    } catch (error) {
-      this.logger.error('Error replacing model with user default', {
-        error: error instanceof Error ? error.message : 'Unknown error',
+          blacklistedModelIds: command.catalogModelId
+            ? [command.catalogModelId]
+            : [],
+        }),
+      );
+      this.logger.debug('Found default model', {
+        defaultModel,
+        oldPermittedModelId: command.oldPermittedModelId,
       });
-      throw error;
+      if (defaultModel.id === command.oldPermittedModelId) {
+        throw new ModelReplacementError(thread.id, command.oldPermittedModelId);
+      }
+
+      this.logger.debug('Updating thread', {
+        threadId: thread.id,
+        newModelId: defaultModel.id,
+      });
+      await this.threadsRepository.updateModel({
+        threadId: thread.id,
+        userId: thread.userId,
+        permittedModelId: defaultModel.id,
+      });
     }
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/resolve-generated-image/resolve-generated-image.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/resolve-generated-image/resolve-generated-image.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetPresignedUrlUseCase } from 'src/domain/storage/application/use-cases/get-presigned-url/get-presigned-url.use-case';
 import { GetPresignedUrlCommand } from 'src/domain/storage/application/use-cases/get-presigned-url/get-presigned-url.command';
 import { contentTypeToExtension } from 'src/common/util/content-type.util';
@@ -8,6 +8,7 @@ import { GeneratedImagesRepository } from '../../ports/generated-images.reposito
 import {
   ThreadNotFoundError,
   GeneratedImageNotFoundError,
+  UnexpectedThreadError,
 } from '../../threads.errors';
 import { ResolveGeneratedImageQuery } from './resolve-generated-image.query';
 
@@ -28,6 +29,7 @@ export class ResolveGeneratedImageUseCase {
     private readonly getPresignedUrlUseCase: GetPresignedUrlUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(
     query: ResolveGeneratedImageQuery,
   ): Promise<ResolveGeneratedImageResult> {
@@ -36,53 +38,41 @@ export class ResolveGeneratedImageUseCase {
       imageId: query.imageId,
     });
 
-    try {
-      const thread = await this.threadsRepository.findOne(
-        query.threadId,
-        query.userId,
-      );
-      if (!thread) {
-        throw new ThreadNotFoundError(query.threadId, query.userId);
-      }
-
-      const image = await this.generatedImagesRepository.findByIdAndThreadId(
-        query.imageId,
-        query.threadId,
-      );
-      if (!image) {
-        throw new GeneratedImageNotFoundError(query.imageId);
-      }
-
-      // Force a safe Content-Type and inline Content-Disposition on the
-      // pre-signed URL so the storage origin cannot serve the object with
-      // an active-content MIME type (e.g. image/svg+xml) that would
-      // otherwise render inline and create a stored-XSS primitive.
-      // `image.contentType` is constrained by the save-side allow-list.
-      const extension = contentTypeToExtension(image.contentType);
-      const presignedUrl = await this.getPresignedUrlUseCase.execute(
-        new GetPresignedUrlCommand(
-          image.storageKey,
-          PRESIGNED_URL_EXPIRY_SECONDS,
-          undefined,
-          image.contentType,
-          `inline; filename="${query.imageId}${extension}"`,
-        ),
-      );
-
-      return {
-        url: presignedUrl.url,
-        expiresAt: presignedUrl.expiresAt.toISOString(),
-      };
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to resolve generated image', {
-        threadId: query.threadId,
-        imageId: query.imageId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw error;
+    const thread = await this.threadsRepository.findOne(
+      query.threadId,
+      query.userId,
+    );
+    if (!thread) {
+      throw new ThreadNotFoundError(query.threadId, query.userId);
     }
+
+    const image = await this.generatedImagesRepository.findByIdAndThreadId(
+      query.imageId,
+      query.threadId,
+    );
+    if (!image) {
+      throw new GeneratedImageNotFoundError(query.imageId);
+    }
+
+    // Force a safe Content-Type and inline Content-Disposition on the
+    // pre-signed URL so the storage origin cannot serve the object with
+    // an active-content MIME type (e.g. image/svg+xml) that would
+    // otherwise render inline and create a stored-XSS primitive.
+    // `image.contentType` is constrained by the save-side allow-list.
+    const extension = contentTypeToExtension(image.contentType);
+    const presignedUrl = await this.getPresignedUrlUseCase.execute(
+      new GetPresignedUrlCommand(
+        image.storageKey,
+        PRESIGNED_URL_EXPIRY_SECONDS,
+        undefined,
+        image.contentType,
+        `inline; filename="${query.imageId}${extension}"`,
+      ),
+    );
+
+    return {
+      url: presignedUrl.url,
+      expiresAt: presignedUrl.expiresAt.toISOString(),
+    };
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/save-generated-image/save-generated-image.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/save-generated-image/save-generated-image.use-case.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import type { UUID } from 'crypto';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/upload-object/upload-object.use-case';
 import { UploadObjectCommand } from 'src/domain/storage/application/use-cases/upload-object/upload-object.command';
 import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
@@ -15,6 +16,7 @@ import { GeneratedImage } from '../../../domain/generated-image.entity';
 import {
   GeneratedImageSaveFailedError,
   UnsupportedImageContentTypeError,
+  UnexpectedThreadError,
 } from '../../threads.errors';
 import { SaveGeneratedImageCommand } from './save-generated-image.command';
 
@@ -28,6 +30,7 @@ export class SaveGeneratedImageUseCase {
     private readonly deleteObjectUseCase: DeleteObjectUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(command: SaveGeneratedImageCommand): Promise<{ id: UUID }> {
     this.logger.log('execute', {
       orgId: command.orgId,
@@ -42,39 +45,7 @@ export class SaveGeneratedImageUseCase {
     }
 
     try {
-      const imageId = randomUUID();
-      const ext = contentTypeToExtension(command.contentType);
-      const storageKey = `generated-images/${command.orgId}/${command.threadId}/${imageId}${ext}`;
-
-      await this.uploadObjectUseCase.execute(
-        new UploadObjectCommand(storageKey, command.imageData, {
-          'content-type': command.contentType,
-        }),
-      );
-
-      const image = new GeneratedImage(
-        imageId,
-        command.orgId,
-        command.userId,
-        command.threadId,
-        command.contentType,
-        command.isAnonymous,
-        storageKey,
-      );
-
-      try {
-        await this.generatedImagesRepository.save(image);
-      } catch (dbError) {
-        await this.cleanupUploadedObject(storageKey);
-        throw dbError;
-      }
-
-      this.logger.log('Generated image saved', {
-        imageId,
-        storageKey,
-      });
-
-      return { id: imageId };
+      return await this.uploadAndPersist(command);
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
@@ -88,6 +59,44 @@ export class SaveGeneratedImageUseCase {
         error instanceof Error ? error : new Error('Unknown error'),
       );
     }
+  }
+
+  private async uploadAndPersist(
+    command: SaveGeneratedImageCommand,
+  ): Promise<{ id: UUID }> {
+    const imageId = randomUUID();
+    const ext = contentTypeToExtension(command.contentType);
+    const storageKey = `generated-images/${command.orgId}/${command.threadId}/${imageId}${ext}`;
+
+    await this.uploadObjectUseCase.execute(
+      new UploadObjectCommand(storageKey, command.imageData, {
+        'content-type': command.contentType,
+      }),
+    );
+
+    const image = new GeneratedImage(
+      imageId,
+      command.orgId,
+      command.userId,
+      command.threadId,
+      command.contentType,
+      command.isAnonymous,
+      storageKey,
+    );
+
+    try {
+      await this.generatedImagesRepository.save(image);
+    } catch (dbError) {
+      await this.cleanupUploadedObject(storageKey);
+      throw dbError;
+    }
+
+    this.logger.log('Generated image saved', {
+      imageId,
+      storageKey,
+    });
+
+    return { id: imageId };
   }
 
   private async cleanupUploadedObject(storageKey: string): Promise<void> {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/update-thread-title/update-thread-title.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/update-thread-title/update-thread-title.use-case.ts
@@ -1,7 +1,12 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { UpdateThreadTitleCommand } from './update-thread-title.command';
-import { ThreadNotFoundError, ThreadUpdateError } from '../../threads.errors';
+import {
+  ThreadNotFoundError,
+  ThreadUpdateError,
+  UnexpectedThreadError,
+} from '../../threads.errors';
 import { ContextService } from 'src/common/context/services/context.service';
 
 @Injectable()
@@ -13,6 +18,7 @@ export class UpdateThreadTitleUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedThreadError)
   async execute(command: UpdateThreadTitleCommand): Promise<void> {
     this.logger.log('updateTitle', {
       threadId: command.threadId,

--- a/ayunis-core-backend/src/domain/transcriptions/application/transcription.errors.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/application/transcription.errors.ts
@@ -8,6 +8,7 @@ export enum TranscriptionErrorCode {
   TRANSCRIPTION_FAILED = 'TRANSCRIPTION_FAILED',
   INVALID_AUDIO_FILE = 'INVALID_AUDIO_FILE',
   TRANSCRIPTION_SERVICE_UNAVAILABLE = 'TRANSCRIPTION_SERVICE_UNAVAILABLE',
+  UNEXPECTED_TRANSCRIPTION_ERROR = 'UNEXPECTED_TRANSCRIPTION_ERROR',
 }
 
 /**
@@ -21,6 +22,17 @@ export abstract class TranscriptionError extends ApplicationError {
     metadata?: ErrorMetadata,
   ) {
     super(message, code, statusCode, metadata);
+  }
+}
+
+export class UnexpectedTranscriptionError extends TranscriptionError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(
+      error.message,
+      TranscriptionErrorCode.UNEXPECTED_TRANSCRIPTION_ERROR,
+      500,
+      { ...metadata, error },
+    );
   }
 }
 

--- a/ayunis-core-backend/src/domain/transcriptions/application/use-cases/transcribe/transcribe.use-case.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/application/use-cases/transcribe/transcribe.use-case.ts
@@ -1,13 +1,15 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { TranscriptionPort } from '../../ports/transcription.port';
 import { TranscribeCommand } from './transcribe.command';
 import { ContextService } from 'src/common/context/services/context.service';
 import {
-  TranscriptionFailedError,
   InvalidAudioFileError,
+  TranscriptionFailedError,
+  UnexpectedTranscriptionError,
 } from '../../transcription.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { ApplicationError } from 'src/common/errors/base.error';
 
 // 25 MB - matches Mistral's API limit for audio transcription
 const MAX_AUDIO_FILE_SIZE_BYTES = 25 * 1024 * 1024;
@@ -21,6 +23,7 @@ export class TranscribeUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedTranscriptionError)
   async execute(command: TranscribeCommand): Promise<string> {
     this.logger.log('execute', {
       fileName: command.fileName,
@@ -28,63 +31,62 @@ export class TranscribeUseCase {
       language: command.language,
     });
 
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    this.validateAudioFile(command);
+
+    // Call the transcription service
+    let transcriptedText: string;
     try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      // Validate audio file
-      if (!command.file || command.file.length === 0) {
-        throw new InvalidAudioFileError('Empty audio file');
-      }
-
-      // Validate file size
-      if (command.file.length > MAX_AUDIO_FILE_SIZE_BYTES) {
-        const maxSizeMB = MAX_AUDIO_FILE_SIZE_BYTES / (1024 * 1024);
-        throw new InvalidAudioFileError(
-          `Audio file size exceeds maximum allowed size of ${maxSizeMB} MB`,
-        );
-      }
-
-      // Basic MIME type validation
-      const supportedMimeTypes = [
-        'audio/webm',
-        'audio/mp4',
-        'audio/mpeg',
-        'audio/wav',
-        'audio/x-m4a',
-      ];
-      if (!supportedMimeTypes.includes(command.mimeType)) {
-        throw new InvalidAudioFileError(
-          `Unsupported audio format: ${command.mimeType}`,
-        );
-      }
-
-      // Call the transcription service
-      const transcriptedText = await this.transcriptionPort.transcribe(
+      transcriptedText = await this.transcriptionPort.transcribe(
         command.file,
         command.fileName,
         command.mimeType,
         command.language,
       );
-
-      this.logger.log('Transcription completed', {
-        fileName: command.fileName,
-        textLength: transcriptedText.length,
-      });
-
-      return transcriptedText;
     } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to transcribe audio', {
-        fileName: command.fileName,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      if (error instanceof ApplicationError) throw error;
+
       throw new TranscriptionFailedError(
-        (error as Error).message ?? 'Unknown error during transcription',
+        error instanceof Error
+          ? error.message
+          : 'Unknown error during transcription',
+      );
+    }
+
+    this.logger.log('Transcription completed', {
+      fileName: command.fileName,
+      textLength: transcriptedText.length,
+    });
+
+    return transcriptedText;
+  }
+
+  private validateAudioFile(command: TranscribeCommand): void {
+    if (command.file.length === 0) {
+      throw new InvalidAudioFileError('Empty audio file');
+    }
+
+    if (command.file.length > MAX_AUDIO_FILE_SIZE_BYTES) {
+      const maxSizeMB = MAX_AUDIO_FILE_SIZE_BYTES / (1024 * 1024);
+      throw new InvalidAudioFileError(
+        `Audio file size exceeds maximum allowed size of ${maxSizeMB} MB`,
+      );
+    }
+
+    const supportedMimeTypes = [
+      'audio/webm',
+      'audio/mp4',
+      'audio/mpeg',
+      'audio/wav',
+      'audio/x-m4a',
+    ];
+    if (!supportedMimeTypes.includes(command.mimeType)) {
+      throw new InvalidAudioFileError(
+        `Unsupported audio format: ${command.mimeType}`,
       );
     }
   }


### PR DESCRIPTION
- decorate every Promise-returning execute() in domain/models, threads,
  sources, messages, chat-settings, artifacts, shares, letterheads, runs,
  thread-pii-masks, transcriptions
- remove pure-boundary try/catch blocks now covered by the decorator
- normalize Unexpected*Error constructors to (error: Error, metadata?)
- rename UnexpecteThreadError -> UnexpectedThreadError (typo)
- split over-limit functions flagged by the changed-files complexity gate
- fix lint warnings surfaced by the staged --max-warnings=0 gate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide refactor across core domains (models, messages, artifacts) changes error surfaces and logging; behavior should be equivalent but any missed inner catch or decorator ordering could alter what clients see.
> 
> **Overview**
> This PR standardizes how use cases handle failures by applying `@HandleUnexpectedErrors` across **artifacts**, **chat-settings**, **letterheads**, **messages**, and **models** application layers. The decorator rethrows `ApplicationError` / `HttpException` unchanged and wraps everything else in each module’s `Unexpected*Error` after logging `"Unexpected use-case error"`.
> 
> **`Unexpected*Error` types** now take `(error: Error, metadata?)` and embed the original error in metadata (e.g. `UnexpectedArtifactError`, `UnexpectedLetterheadError`). **Messages** gains `UnexpectedMessageError` and `UNEXPECTED_MESSAGE_ERROR`.
> 
> Per-use-case **try/catch** blocks that only rethrew application errors or mapped unknown failures are removed in favor of the decorator. A few use cases keep inner try/catch where they map to domain-specific errors (e.g. `MessageCreationError`, inference/image generation failures).
> 
> **Refactors** split complexity-heavy `execute()` methods into private helpers (create artifact, letterhead PDF upload/update paths, user message content/upload/events, orphaned image cleanup, default-model resolution, delete permitted model authorization, update permitted model builder). **Tests** are updated so repository failures expect `UnexpectedModelError` and the decorator’s log message/stack format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeb0ea113d884910466253aaca916934fb6df9fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->