### PR TITLE
chore(ci): add sirolad and pavellnk to codeowners (AYC-000)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,23 +2,23 @@
 # Add top-level paths here explicitly when ownership should be enforced.
 
 # Repository automation and release management.
-/.github/ @devbydaniel
-/Dockerfile @devbydaniel
-/docker-compose.yml @devbydaniel
+/.github/ @devbydaniel @sirolad @pavellnk
+/Dockerfile @devbydaniel @sirolad @pavellnk
+/docker-compose.yml @devbydaniel @sirolad @pavellnk
 
 # AI assistant configuration and instructions.
-/.cursor/ @devbydaniel
-/.codex/ @devbydaniel
-/.claude/ @devbydaniel
+/.cursor/ @devbydaniel @sirolad @pavellnk
+/.codex/ @devbydaniel @sirolad @pavellnk
+/.claude/ @devbydaniel @sirolad @pavellnk
 
 # Ayunis Core applications.
-/ayunis-core-backend/ @devbydaniel
-/ayunis-core-frontend/ @devbydaniel
-/ayunis-core-anonymize/ @devbydaniel
-/ayunis-core-code-execution/ @devbydaniel
+/ayunis-core-backend/ @devbydaniel @sirolad @pavellnk
+/ayunis-core-frontend/ @devbydaniel @sirolad @pavellnk
+/ayunis-core-anonymize/ @devbydaniel @sirolad @pavellnk
+/ayunis-core-code-execution/ @devbydaniel @sirolad @pavellnk
 
 # Workspace packages.
-/packages/ @devbydaniel
+/packages/ @devbydaniel @sirolad @pavellnk
 
 # Dependabot-managed files - no auto-review.
 /package.json


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Process-only change to review assignment; no application or infrastructure code is modified.
> 
> **Overview**
> Expands GitHub **CODEOWNERS** so `@sirolad` and `@pavellnk` are listed alongside `@devbydaniel` on the paths that already had enforced ownership.
> 
> That covers repo automation (`.github/`, `Dockerfile`, `docker-compose.yml`), AI assistant config (`.cursor/`, `.codex/`, `.claude/`), all Ayunis Core app roots, and `/packages/`. Dependabot-managed dependency files stay without owners, unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6d27b7faa9c8d273f56b27a6024eff05cd20544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->