### PR TITLE
wip(use-cases): apply HandleUnexpectedErrors to knowledge and platform domain modules (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/common/anonymization/application/anonymization.errors.ts
+++ b/ayunis-core-backend/src/common/anonymization/application/anonymization.errors.ts
@@ -3,6 +3,7 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 export enum AnonymizationErrorCode {
   ANONYMIZATION_FAILED = 'ANONYMIZATION_FAILED',
+  UNEXPECTED_ANONYMIZATION_ERROR = 'UNEXPECTED_ANONYMIZATION_ERROR',
 }
 
 export abstract class AnonymizationError extends ApplicationError {
@@ -23,6 +24,20 @@ export class AnonymizationFailedError extends AnonymizationError {
       AnonymizationErrorCode.ANONYMIZATION_FAILED,
       500,
       metadata,
+    );
+  }
+}
+
+export class UnexpectedAnonymizationError extends AnonymizationError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(
+      error.message,
+      AnonymizationErrorCode.UNEXPECTED_ANONYMIZATION_ERROR,
+      500,
+      {
+        ...metadata,
+        error,
+      },
     );
   }
 }

--- a/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case.ts
+++ b/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case.ts
@@ -1,8 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import {
   AnonymizationPort,
   AnonymizationResult,
 } from '../../ports/anonymization.port';
+import { UnexpectedAnonymizationError } from '../../anonymization.errors';
 import { AnonymizeTextCommand } from './anonymize-text.command';
 import { filterWhitelistedDetections } from '../../../domain/whitelist-filter';
 import { applyReplacements } from '../../../domain/apply-replacements';
@@ -16,6 +18,7 @@ export class AnonymizeTextUseCase {
 
   constructor(private readonly anonymizationPort: AnonymizationPort) {}
 
+  @HandleUnexpectedErrors(UnexpectedAnonymizationError)
   async execute(command: AnonymizeTextCommand): Promise<AnonymizationResult> {
     this.logger.log('Executing anonymize text', {
       textLength: command.text.length,

--- a/ayunis-core-backend/src/common/emails/application/emails.errors.ts
+++ b/ayunis-core-backend/src/common/emails/application/emails.errors.ts
@@ -3,6 +3,7 @@ import type { ErrorMetadata } from 'src/common/errors/base.error';
 
 export enum EmailErrorCode {
   EMAIL_SEND_FAILED = 'EMAIL_SEND_FAILED',
+  UNEXPECTED_EMAIL_ERROR = 'UNEXPECTED_EMAIL_ERROR',
 }
 
 export abstract class EmailError extends ApplicationError {
@@ -19,5 +20,14 @@ export abstract class EmailError extends ApplicationError {
 export class EmailSendFailedError extends EmailError {
   constructor(reason: string, metadata?: ErrorMetadata) {
     super(reason, EmailErrorCode.EMAIL_SEND_FAILED, 500, metadata);
+  }
+}
+
+export class UnexpectedEmailError extends EmailError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, EmailErrorCode.UNEXPECTED_EMAIL_ERROR, 500, {
+      ...metadata,
+      error,
+    });
   }
 }

--- a/ayunis-core-backend/src/common/emails/application/use-cases/send-email/send-email.use-case.ts
+++ b/ayunis-core-backend/src/common/emails/application/use-cases/send-email/send-email.use-case.ts
@@ -1,13 +1,19 @@
 import { Injectable } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SendEmailCommand } from './send-email.command';
 import { EmailHandlerPort } from '../../ports/email-handler.port';
 import { Email } from 'src/common/emails/domain/email.entity';
-import { EmailSendFailedError } from '../../emails.errors';
+import { ApplicationError } from 'src/common/errors/base.error';
+import {
+  EmailSendFailedError,
+  UnexpectedEmailError,
+} from '../../emails.errors';
 
 @Injectable()
 export class SendEmailUseCase {
   constructor(private readonly emailHandler: EmailHandlerPort) {}
 
+  @HandleUnexpectedErrors(UnexpectedEmailError)
   async execute(command: SendEmailCommand): Promise<void> {
     try {
       const email = new Email({
@@ -17,15 +23,14 @@ export class SendEmailUseCase {
         html: command.html,
       });
       await this.emailHandler.sendEmail(email);
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        throw new EmailSendFailedError(error.message, {
-          error: error,
-        });
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
       }
-      throw new EmailSendFailedError('Unknown error', {
-        error: error,
-      });
+      throw new EmailSendFailedError(
+        error instanceof Error ? error.message : 'Unknown error',
+        { error },
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/academy/application/academy.errors.ts
+++ b/ayunis-core-backend/src/domain/academy/application/academy.errors.ts
@@ -91,12 +91,10 @@ export class InvalidQuizSubmissionError extends AcademyError {
 }
 
 export class UnexpectedAcademyError extends AcademyError {
-  constructor(error: unknown) {
-    super(
-      'Unexpected error occurred',
-      AcademyErrorCode.UNEXPECTED_ACADEMY_ERROR,
-      500,
-      { error },
-    );
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, AcademyErrorCode.UNEXPECTED_ACADEMY_ERROR, 500, {
+      ...metadata,
+      error,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/create-chapter/create-chapter.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/create-chapter/create-chapter.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyChapter } from '../../../domain/academy-chapter.entity';
 import { UnexpectedAcademyError } from '../../academy.errors';
@@ -11,22 +11,15 @@ export class CreateChapterUseCase {
 
   constructor(private readonly chapterRepository: AcademyChapterRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedAcademyError)
   async execute(command: CreateChapterCommand): Promise<AcademyChapter> {
     this.logger.log('Creating academy chapter', { title: command.title });
-    try {
-      const maxPosition = await this.chapterRepository.findMaxPosition();
-      const chapter = new AcademyChapter({
-        title: command.title,
-        description: command.description,
-        position: (maxPosition ?? -1) + 1,
-      });
-      return await this.chapterRepository.create(chapter);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error creating academy chapter', {
-        error: error as Error,
-      });
-      throw new UnexpectedAcademyError(error);
-    }
+    const maxPosition = await this.chapterRepository.findMaxPosition();
+    const chapter = new AcademyChapter({
+      title: command.title,
+      description: command.description,
+      position: (maxPosition ?? -1) + 1,
+    });
+    return this.chapterRepository.create(chapter);
   }
 }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/create-course-module/create-course-module.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/create-course-module/create-course-module.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyCourseModuleRepository } from '../../ports/academy-course-module.repository';
 import { AcademyCourseModule } from '../../../domain/academy-course-module.entity';
@@ -18,6 +18,7 @@ export class CreateCourseModuleUseCase {
     private readonly courseModuleRepository: AcademyCourseModuleRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAcademyError)
   async execute(
     command: CreateCourseModuleCommand,
   ): Promise<AcademyCourseModule> {
@@ -25,28 +26,20 @@ export class CreateCourseModuleUseCase {
       chapterId: command.chapterId,
       title: command.title,
     });
-    try {
-      const chapter = await this.chapterRepository.findOne(command.chapterId);
-      if (!chapter) {
-        throw new ChapterNotFoundError(command.chapterId);
-      }
-      const maxPosition = await this.courseModuleRepository.findMaxPosition(
-        command.chapterId,
-      );
-      const courseModule = new AcademyCourseModule({
-        chapterId: command.chapterId,
-        title: command.title,
-        description: command.description,
-        loomUrl: command.loomUrl,
-        position: (maxPosition ?? -1) + 1,
-      });
-      return await this.courseModuleRepository.create(courseModule);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error creating academy module', {
-        error: error as Error,
-      });
-      throw new UnexpectedAcademyError(error);
+    const chapter = await this.chapterRepository.findOne(command.chapterId);
+    if (!chapter) {
+      throw new ChapterNotFoundError(command.chapterId);
     }
+    const maxPosition = await this.courseModuleRepository.findMaxPosition(
+      command.chapterId,
+    );
+    const courseModule = new AcademyCourseModule({
+      chapterId: command.chapterId,
+      title: command.title,
+      description: command.description,
+      loomUrl: command.loomUrl,
+      position: (maxPosition ?? -1) + 1,
+    });
+    return this.courseModuleRepository.create(courseModule);
   }
 }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/create-quiz-question/create-quiz-question.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/create-quiz-question/create-quiz-question.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
 import { AcademyQuizQuestion } from '../../../domain/academy-quiz-question.entity';
@@ -19,34 +19,27 @@ export class CreateQuizQuestionUseCase {
     private readonly quizQuestionRepository: AcademyQuizQuestionRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAcademyError)
   async execute(
     command: CreateQuizQuestionCommand,
   ): Promise<AcademyQuizQuestion> {
     this.logger.log('Creating academy quiz question', {
       chapterId: command.chapterId,
     });
-    try {
-      assertValidQuizOptions(command.options);
-      const chapter = await this.chapterRepository.findOne(command.chapterId);
-      if (!chapter) {
-        throw new ChapterNotFoundError(command.chapterId);
-      }
-      const maxPosition = await this.quizQuestionRepository.findMaxPosition(
-        command.chapterId,
-      );
-      const quizQuestion = new AcademyQuizQuestion({
-        chapterId: command.chapterId,
-        text: command.text,
-        options: command.options,
-        position: (maxPosition ?? -1) + 1,
-      });
-      return await this.quizQuestionRepository.create(quizQuestion);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error creating academy quiz question', {
-        error: error as Error,
-      });
-      throw new UnexpectedAcademyError(error);
+    assertValidQuizOptions(command.options);
+    const chapter = await this.chapterRepository.findOne(command.chapterId);
+    if (!chapter) {
+      throw new ChapterNotFoundError(command.chapterId);
     }
+    const maxPosition = await this.quizQuestionRepository.findMaxPosition(
+      command.chapterId,
+    );
+    const quizQuestion = new AcademyQuizQuestion({
+      chapterId: command.chapterId,
+      text: command.text,
+      options: command.options,
+      position: (maxPosition ?? -1) + 1,
+    });
+    return this.quizQuestionRepository.create(quizQuestion);
   }
 }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/delete-chapter/delete-chapter.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/delete-chapter/delete-chapter.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { UnexpectedAcademyError } from '../../academy.errors';
 import { DeleteChapterCommand } from './delete-chapter.command';
@@ -10,18 +10,11 @@ export class DeleteChapterUseCase {
 
   constructor(private readonly chapterRepository: AcademyChapterRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedAcademyError)
   async execute(command: DeleteChapterCommand): Promise<void> {
     this.logger.log('Deleting academy chapter', {
       chapterId: command.chapterId,
     });
-    try {
-      await this.chapterRepository.delete(command.chapterId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error deleting academy chapter', {
-        error: error as Error,
-      });
-      throw new UnexpectedAcademyError(error);
-    }
+    await this.chapterRepository.delete(command.chapterId);
   }
 }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/delete-course-module/delete-course-module.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/delete-course-module/delete-course-module.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyCourseModuleRepository } from '../../ports/academy-course-module.repository';
 import { UnexpectedAcademyError } from '../../academy.errors';
 import { DeleteCourseModuleCommand } from './delete-course-module.command';
@@ -12,18 +12,11 @@ export class DeleteCourseModuleUseCase {
     private readonly courseModuleRepository: AcademyCourseModuleRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAcademyError)
   async execute(command: DeleteCourseModuleCommand): Promise<void> {
     this.logger.log('Deleting academy module', {
       courseModuleId: command.courseModuleId,
     });
-    try {
-      await this.courseModuleRepository.delete(command.courseModuleId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error deleting academy module', {
-        error: error as Error,
-      });
-      throw new UnexpectedAcademyError(error);
-    }
+    await this.courseModuleRepository.delete(command.courseModuleId);
   }
 }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/delete-quiz-question/delete-quiz-question.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/delete-quiz-question/delete-quiz-question.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
 import { UnexpectedAcademyError } from '../../academy.errors';
 import { DeleteQuizQuestionCommand } from './delete-quiz-question.command';
@@ -12,18 +12,11 @@ export class DeleteQuizQuestionUseCase {
     private readonly quizQuestionRepository: AcademyQuizQuestionRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAcademyError)
   async execute(command: DeleteQuizQuestionCommand): Promise<void> {
     this.logger.log('Deleting academy quiz question', {
       quizQuestionId: command.quizQuestionId,
     });
-    try {
-      await this.quizQuestionRepository.delete(command.quizQuestionId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error deleting academy quiz question', {
-        error: error as Error,
-      });
-      throw new UnexpectedAcademyError(error);
-    }
+    await this.quizQuestionRepository.delete(command.quizQuestionId);
   }
 }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-content/get-academy-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-content/get-academy-content.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyChapter } from '../../../domain/academy-chapter.entity';
 import { UnexpectedAcademyError } from '../../academy.errors';
@@ -11,17 +11,10 @@ export class GetAcademyContentUseCase {
 
   constructor(private readonly chapterRepository: AcademyChapterRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedAcademyError)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async execute(_query: GetAcademyContentQuery): Promise<AcademyChapter[]> {
     this.logger.log('Getting academy content');
-    try {
-      return await this.chapterRepository.findAllWithCourseModules();
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting academy content', {
-        error: error as Error,
-      });
-      throw new UnexpectedAcademyError(error);
-    }
+    return this.chapterRepository.findAllWithCourseModules();
   }
 }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-management-content/get-academy-management-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-management-content/get-academy-management-content.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyChapter } from '../../../domain/academy-chapter.entity';
 import { UnexpectedAcademyError } from '../../academy.errors';
@@ -17,19 +17,12 @@ export class GetAcademyManagementContentUseCase {
 
   constructor(private readonly chapterRepository: AcademyChapterRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedAcademyError)
   async execute(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _query: GetAcademyManagementContentQuery,
   ): Promise<AcademyChapter[]> {
     this.logger.log('Getting academy management content');
-    try {
-      return await this.chapterRepository.findAllWithQuizContent();
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting academy management content', {
-        error: error as Error,
-      });
-      throw new UnexpectedAcademyError(error);
-    }
+    return this.chapterRepository.findAllWithQuizContent();
   }
 }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-progress/get-academy-progress.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-progress/get-academy-progress.use-case.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import type { UUID } from 'crypto';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyChapterProgressRepository } from '../../ports/academy-chapter-progress.repository';
 import { AcademyCompletionRepository } from '../../ports/academy-completion.repository';
 import { UnexpectedAcademyError } from '../../academy.errors';
@@ -27,30 +27,19 @@ export class GetAcademyProgressUseCase {
     private readonly completionRepository: AcademyCompletionRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAcademyError)
   async execute(query: GetAcademyProgressQuery): Promise<AcademyProgressView> {
     this.logger.log('Getting academy progress', { userId: query.userId });
-    try {
-      const progress = await this.progressRepository.findAllByUser(
-        query.userId,
-      );
-      const completion = await this.completionRepository.findByUser(
-        query.userId,
-      );
-      return {
-        chapters: progress.map((p) => ({
-          chapterId: p.chapterId,
-          passed: p.passed,
-          lastScore: p.lastScore,
-          lastPassedAt: p.passedAt,
-        })),
-        academyCompletedAt: completion?.completedAt ?? null,
-      };
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting academy progress', {
-        error: error as Error,
-      });
-      throw new UnexpectedAcademyError(error);
-    }
+    const progress = await this.progressRepository.findAllByUser(query.userId);
+    const completion = await this.completionRepository.findByUser(query.userId);
+    return {
+      chapters: progress.map((p) => ({
+        chapterId: p.chapterId,
+        passed: p.passed,
+        lastScore: p.lastScore,
+        lastPassedAt: p.passedAt,
+      })),
+      academyCompletedAt: completion?.completedAt ?? null,
+    };
   }
 }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-chapter-quiz/get-chapter-quiz.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-chapter-quiz/get-chapter-quiz.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
 import { AcademyQuizQuestion } from '../../../domain/academy-quiz-question.entity';
@@ -20,30 +20,23 @@ export class GetChapterQuizUseCase {
     private readonly quizQuestionRepository: AcademyQuizQuestionRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAcademyError)
   async execute(query: GetChapterQuizQuery): Promise<AcademyQuizQuestion[]> {
     this.logger.log('Getting chapter quiz', { chapterId: query.chapterId });
-    try {
-      const chapter = await this.chapterRepository.findOne(query.chapterId);
-      if (!chapter) {
-        throw new ChapterNotFoundError(query.chapterId);
-      }
-      if (!chapter.quizEnabled) {
-        throw new QuizNotAvailableError(query.chapterId);
-      }
-      const pool = await this.quizQuestionRepository.findAllByChapter(
-        query.chapterId,
-      );
-      if (pool.length === 0) {
-        throw new QuizNotAvailableError(query.chapterId);
-      }
-      return this.drawRandom(pool, DRAWN_QUESTION_COUNT);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting chapter quiz', {
-        error: error as Error,
-      });
-      throw new UnexpectedAcademyError(error);
+    const chapter = await this.chapterRepository.findOne(query.chapterId);
+    if (!chapter) {
+      throw new ChapterNotFoundError(query.chapterId);
     }
+    if (!chapter.quizEnabled) {
+      throw new QuizNotAvailableError(query.chapterId);
+    }
+    const pool = await this.quizQuestionRepository.findAllByChapter(
+      query.chapterId,
+    );
+    if (pool.length === 0) {
+      throw new QuizNotAvailableError(query.chapterId);
+    }
+    return this.drawRandom(pool, DRAWN_QUESTION_COUNT);
   }
 
   // Fisher–Yates shuffle over a copy, returning the first `count` items (or the

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-chapters/reorder-chapters.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-chapters/reorder-chapters.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { UnexpectedAcademyError } from '../../academy.errors';
 import { assertSameIdSet } from '../../reorder-validation';
@@ -11,20 +11,13 @@ export class ReorderChaptersUseCase {
 
   constructor(private readonly chapterRepository: AcademyChapterRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedAcademyError)
   async execute(command: ReorderChaptersCommand): Promise<void> {
     this.logger.log('Reordering academy chapters', {
       count: command.chapterIds.length,
     });
-    try {
-      const currentIds = await this.chapterRepository.findAllIds();
-      assertSameIdSet(currentIds, command.chapterIds);
-      await this.chapterRepository.updatePositions(command.chapterIds);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error reordering academy chapters', {
-        error: error as Error,
-      });
-      throw new UnexpectedAcademyError(error);
-    }
+    const currentIds = await this.chapterRepository.findAllIds();
+    assertSameIdSet(currentIds, command.chapterIds);
+    await this.chapterRepository.updatePositions(command.chapterIds);
   }
 }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-course-modules/reorder-course-modules.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-course-modules/reorder-course-modules.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyCourseModuleRepository } from '../../ports/academy-course-module.repository';
 import {
@@ -18,30 +18,23 @@ export class ReorderCourseModulesUseCase {
     private readonly courseModuleRepository: AcademyCourseModuleRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAcademyError)
   async execute(command: ReorderCourseModulesCommand): Promise<void> {
     this.logger.log('Reordering academy modules', {
       chapterId: command.chapterId,
       count: command.courseModuleIds.length,
     });
-    try {
-      const chapter = await this.chapterRepository.findOne(command.chapterId);
-      if (!chapter) {
-        throw new ChapterNotFoundError(command.chapterId);
-      }
-      const currentIds = await this.courseModuleRepository.findIdsByChapterId(
-        command.chapterId,
-      );
-      assertSameIdSet(currentIds, command.courseModuleIds);
-      await this.courseModuleRepository.updatePositions(
-        command.chapterId,
-        command.courseModuleIds,
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error reordering academy modules', {
-        error: error as Error,
-      });
-      throw new UnexpectedAcademyError(error);
+    const chapter = await this.chapterRepository.findOne(command.chapterId);
+    if (!chapter) {
+      throw new ChapterNotFoundError(command.chapterId);
     }
+    const currentIds = await this.courseModuleRepository.findIdsByChapterId(
+      command.chapterId,
+    );
+    assertSameIdSet(currentIds, command.courseModuleIds);
+    await this.courseModuleRepository.updatePositions(
+      command.chapterId,
+      command.courseModuleIds,
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/submit-chapter-quiz/submit-chapter-quiz.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/submit-chapter-quiz/submit-chapter-quiz.use-case.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import type { UUID } from 'crypto';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyChapterProgressRepository } from '../../ports/academy-chapter-progress.repository';
 import { AcademyCompletionRepository } from '../../ports/academy-completion.repository';
@@ -41,32 +41,25 @@ export class SubmitChapterQuizUseCase {
     private readonly completionRepository: AcademyCompletionRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAcademyError)
   async execute(command: SubmitChapterQuizCommand): Promise<QuizAttemptResult> {
     this.logger.log('Submitting chapter quiz', {
       userId: command.userId,
       chapterId: command.chapterId,
     });
-    try {
-      const chapter = await this.loadQuizChapter(command.chapterId);
-      const pool = await this.quizQuestionRepository.findAllByChapter(
-        command.chapterId,
-      );
-      if (pool.length === 0) {
-        throw new QuizNotAvailableError(command.chapterId);
-      }
-      const grade = this.grade(pool, command.answers, chapter.passThreshold);
-      await this.persistProgress(command, grade);
-      const academyCompleted = grade.passed
-        ? await this.recomputeCompletion(command.userId)
-        : false;
-      return { ...grade, academyCompleted };
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error submitting chapter quiz', {
-        error: error as Error,
-      });
-      throw new UnexpectedAcademyError(error);
+    const chapter = await this.loadQuizChapter(command.chapterId);
+    const pool = await this.quizQuestionRepository.findAllByChapter(
+      command.chapterId,
+    );
+    if (pool.length === 0) {
+      throw new QuizNotAvailableError(command.chapterId);
     }
+    const grade = this.grade(pool, command.answers, chapter.passThreshold);
+    await this.persistProgress(command, grade);
+    const academyCompleted = grade.passed
+      ? await this.recomputeCompletion(command.userId)
+      : false;
+    return { ...grade, academyCompleted };
   }
 
   private async loadQuizChapter(chapterId: UUID): Promise<AcademyChapter> {

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-chapter/update-chapter.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-chapter/update-chapter.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyChapter } from '../../../domain/academy-chapter.entity';
 import {
@@ -14,46 +14,39 @@ export class UpdateChapterUseCase {
 
   constructor(private readonly chapterRepository: AcademyChapterRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedAcademyError)
   async execute(command: UpdateChapterCommand): Promise<AcademyChapter> {
     this.logger.log('Updating academy chapter', {
       chapterId: command.chapterId,
     });
-    try {
-      const existing = await this.chapterRepository.findOne(command.chapterId);
-      if (!existing) {
-        throw new ChapterNotFoundError(command.chapterId);
-      }
-      const updated = new AcademyChapter({
-        id: existing.id,
-        title: command.title,
-        description: command.description,
-        position: existing.position,
-        quizEnabled: command.quizEnabled ?? existing.quizEnabled,
-        passThreshold: command.passThreshold ?? existing.passThreshold,
-        courseModules: existing.courseModules,
-        quizQuestions: existing.quizQuestions,
-        createdAt: existing.createdAt,
-        updatedAt: new Date(),
-      });
-      const persisted = await this.chapterRepository.update(updated);
-      return new AcademyChapter({
-        id: persisted.id,
-        title: persisted.title,
-        description: persisted.description,
-        position: persisted.position,
-        quizEnabled: persisted.quizEnabled,
-        passThreshold: persisted.passThreshold,
-        courseModules: existing.courseModules,
-        quizQuestions: existing.quizQuestions,
-        createdAt: persisted.createdAt,
-        updatedAt: persisted.updatedAt,
-      });
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error updating academy chapter', {
-        error: error as Error,
-      });
-      throw new UnexpectedAcademyError(error);
+    const existing = await this.chapterRepository.findOne(command.chapterId);
+    if (!existing) {
+      throw new ChapterNotFoundError(command.chapterId);
     }
+    const updated = new AcademyChapter({
+      id: existing.id,
+      title: command.title,
+      description: command.description,
+      position: existing.position,
+      quizEnabled: command.quizEnabled ?? existing.quizEnabled,
+      passThreshold: command.passThreshold ?? existing.passThreshold,
+      courseModules: existing.courseModules,
+      quizQuestions: existing.quizQuestions,
+      createdAt: existing.createdAt,
+      updatedAt: new Date(),
+    });
+    const persisted = await this.chapterRepository.update(updated);
+    return new AcademyChapter({
+      id: persisted.id,
+      title: persisted.title,
+      description: persisted.description,
+      position: persisted.position,
+      quizEnabled: persisted.quizEnabled,
+      passThreshold: persisted.passThreshold,
+      courseModules: existing.courseModules,
+      quizQuestions: existing.quizQuestions,
+      createdAt: persisted.createdAt,
+      updatedAt: persisted.updatedAt,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-course-module/update-course-module.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-course-module/update-course-module.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyCourseModuleRepository } from '../../ports/academy-course-module.repository';
 import { AcademyCourseModule } from '../../../domain/academy-course-module.entity';
 import {
@@ -16,39 +16,32 @@ export class UpdateCourseModuleUseCase {
     private readonly courseModuleRepository: AcademyCourseModuleRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAcademyError)
   async execute(
     command: UpdateCourseModuleCommand,
   ): Promise<AcademyCourseModule> {
     this.logger.log('Updating academy module', {
       courseModuleId: command.courseModuleId,
     });
-    try {
-      const existing = await this.courseModuleRepository.findOne(
-        command.courseModuleId,
-      );
-      if (!existing) {
-        throw new CourseModuleNotFoundError(command.courseModuleId);
-      }
-      const updated = new AcademyCourseModule({
-        id: existing.id,
-        chapterId: existing.chapterId,
-        title: command.title,
-        description:
-          command.description === undefined
-            ? existing.description
-            : command.description,
-        loomUrl: command.loomUrl,
-        position: existing.position,
-        createdAt: existing.createdAt,
-        updatedAt: new Date(),
-      });
-      return await this.courseModuleRepository.update(updated);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error updating academy module', {
-        error: error as Error,
-      });
-      throw new UnexpectedAcademyError(error);
+    const existing = await this.courseModuleRepository.findOne(
+      command.courseModuleId,
+    );
+    if (!existing) {
+      throw new CourseModuleNotFoundError(command.courseModuleId);
     }
+    const updated = new AcademyCourseModule({
+      id: existing.id,
+      chapterId: existing.chapterId,
+      title: command.title,
+      description:
+        command.description === undefined
+          ? existing.description
+          : command.description,
+      loomUrl: command.loomUrl,
+      position: existing.position,
+      createdAt: existing.createdAt,
+      updatedAt: new Date(),
+    });
+    return this.courseModuleRepository.update(updated);
   }
 }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-quiz-question/update-quiz-question.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-quiz-question/update-quiz-question.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
 import { AcademyQuizQuestion } from '../../../domain/academy-quiz-question.entity';
 import {
@@ -17,36 +17,29 @@ export class UpdateQuizQuestionUseCase {
     private readonly quizQuestionRepository: AcademyQuizQuestionRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAcademyError)
   async execute(
     command: UpdateQuizQuestionCommand,
   ): Promise<AcademyQuizQuestion> {
     this.logger.log('Updating academy quiz question', {
       quizQuestionId: command.quizQuestionId,
     });
-    try {
-      assertValidQuizOptions(command.options);
-      const existing = await this.quizQuestionRepository.findOne(
-        command.quizQuestionId,
-      );
-      if (!existing) {
-        throw new QuizQuestionNotFoundError(command.quizQuestionId);
-      }
-      const updated = new AcademyQuizQuestion({
-        id: existing.id,
-        chapterId: existing.chapterId,
-        text: command.text,
-        options: command.options,
-        position: existing.position,
-        createdAt: existing.createdAt,
-        updatedAt: new Date(),
-      });
-      return await this.quizQuestionRepository.update(updated);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error updating academy quiz question', {
-        error: error as Error,
-      });
-      throw new UnexpectedAcademyError(error);
+    assertValidQuizOptions(command.options);
+    const existing = await this.quizQuestionRepository.findOne(
+      command.quizQuestionId,
+    );
+    if (!existing) {
+      throw new QuizQuestionNotFoundError(command.quizQuestionId);
     }
+    const updated = new AcademyQuizQuestion({
+      id: existing.id,
+      chapterId: existing.chapterId,
+      text: command.text,
+      options: command.options,
+      position: existing.position,
+      createdAt: existing.createdAt,
+      updatedAt: new Date(),
+    });
+    return this.quizQuestionRepository.update(updated);
   }
 }

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/anonymization-settings.errors.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/anonymization-settings.errors.ts
@@ -31,12 +31,10 @@ export class DuplicateCategoryError extends ApplicationError {
 }
 
 export class UnexpectedAnonymizationSettingsError extends ApplicationError {
-  constructor(operation: string, metadata?: ErrorMetadata) {
-    super(
-      `Unexpected anonymization settings error during ${operation}`,
-      AnonymizationSettingsErrorCode.UNEXPECTED_ERROR,
-      500,
-      { operation, ...metadata },
-    );
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, AnonymizationSettingsErrorCode.UNEXPECTED_ERROR, 500, {
+      ...metadata,
+      error,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
 import { AnonymizeTextCommand } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command';
 import { PiiWhitelistEntry } from 'src/common/anonymization/domain/pii-whitelist-entry';
@@ -22,32 +22,19 @@ export class AnonymizeTextForOrgUseCase {
     private readonly anonymizeTextUseCase: AnonymizeTextUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAnonymizationSettingsError)
   async execute(
     command: AnonymizeTextForOrgCommand,
   ): Promise<AnonymizationResult> {
     this.logger.debug('Anonymizing text for org', { orgId: command.orgId });
 
-    try {
-      const entries = await this.repository.findByOrgId(command.orgId);
-      const whitelist = entries.map(
-        (entry) => new PiiWhitelistEntry(entry.category, entry.pattern),
-      );
+    const entries = await this.repository.findByOrgId(command.orgId);
+    const whitelist = entries.map(
+      (entry) => new PiiWhitelistEntry(entry.category, entry.pattern),
+    );
 
-      return await this.anonymizeTextUseCase.execute(
-        new AnonymizeTextCommand(command.text, undefined, whitelist),
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-
-      this.logger.error('Failed to anonymize text for org', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-      });
-
-      throw new UnexpectedAnonymizationSettingsError('anonymize', {
-        orgId: command.orgId,
-        ...(error instanceof Error && { originalError: error.message }),
-      });
-    }
+    return this.anonymizeTextUseCase.execute(
+      new AnonymizeTextCommand(command.text, undefined, whitelist),
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/get-pii-whitelist/get-pii-whitelist.use-case.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/get-pii-whitelist/get-pii-whitelist.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AnonymizationWhitelistRepository } from '../../ports/anonymization-whitelist.repository';
 import { UnexpectedAnonymizationSettingsError } from '../../anonymization-settings.errors';
 import type { GetPiiWhitelistQuery } from './get-pii-whitelist.query';
@@ -11,25 +11,12 @@ export class GetPiiWhitelistUseCase {
 
   constructor(private readonly repository: AnonymizationWhitelistRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedAnonymizationSettingsError)
   async execute(
     query: GetPiiWhitelistQuery,
   ): Promise<AnonymizationWhitelistEntry[]> {
     this.logger.debug('Getting PII whitelist', { orgId: query.orgId });
 
-    try {
-      return await this.repository.findByOrgId(query.orgId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-
-      this.logger.error('Failed to get PII whitelist', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: query.orgId,
-      });
-
-      throw new UnexpectedAnonymizationSettingsError('get', {
-        orgId: query.orgId,
-        ...(error instanceof Error && { originalError: error.message }),
-      });
-    }
+    return this.repository.findByOrgId(query.orgId);
   }
 }

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/update-pii-whitelist/update-pii-whitelist.use-case.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/update-pii-whitelist/update-pii-whitelist.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AnonymizationWhitelistRepository } from '../../ports/anonymization-whitelist.repository';
 import {
   DuplicateCategoryError,
@@ -20,6 +20,7 @@ export class UpdatePiiWhitelistUseCase {
 
   constructor(private readonly repository: AnonymizationWhitelistRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedAnonymizationSettingsError)
   async execute(
     command: UpdatePiiWhitelistCommand,
   ): Promise<AnonymizationWhitelistEntry[]> {
@@ -28,25 +29,11 @@ export class UpdatePiiWhitelistUseCase {
       entryCount: command.entries.length,
     });
 
-    try {
-      this.validateEntries(command.entries);
-      const entities = command.entries.map((entry) =>
-        this.toEntity(command.orgId, entry),
-      );
-      return await this.repository.replaceForOrg(command.orgId, entities);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-
-      this.logger.error('Failed to update PII whitelist', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-      });
-
-      throw new UnexpectedAnonymizationSettingsError('update', {
-        orgId: command.orgId,
-        ...(error instanceof Error && { originalError: error.message }),
-      });
-    }
+    this.validateEntries(command.entries);
+    const entities = command.entries.map((entry) =>
+      this.toEntity(command.orgId, entry),
+    );
+    return this.repository.replaceForOrg(command.orgId, entities);
   }
 
   private validateEntries(entries: UpdatePiiWhitelistEntryInput[]): void {

--- a/ayunis-core-backend/src/domain/crawl-domain-grants/application/crawl-domain-grants.errors.ts
+++ b/ayunis-core-backend/src/domain/crawl-domain-grants/application/crawl-domain-grants.errors.ts
@@ -54,12 +54,10 @@ export class CrawlDomainGrantNotFoundError extends ApplicationError {
 }
 
 export class UnexpectedCrawlDomainGrantError extends ApplicationError {
-  constructor(operation: string, metadata?: ErrorMetadata) {
-    super(
-      `Unexpected crawl domain grant error during ${operation}`,
-      CrawlDomainGrantErrorCode.UNEXPECTED_ERROR,
-      500,
-      { operation, ...metadata },
-    );
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, CrawlDomainGrantErrorCode.UNEXPECTED_ERROR, 500, {
+      ...metadata,
+      error,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/assert-crawl-domain-access/assert-crawl-domain-access.use-case.ts
+++ b/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/assert-crawl-domain-access/assert-crawl-domain-access.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { CrawlDomainGrantRepository } from '../../ports/crawl-domain-grant.repository';
 import {
   CrawlDomainAccessDeniedError,
@@ -24,31 +24,22 @@ export class AssertCrawlDomainAccessUseCase {
     private readonly crawlDomainGrantRepository: CrawlDomainGrantRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedCrawlDomainGrantError)
   async execute(command: AssertCrawlDomainAccessCommand): Promise<void> {
-    try {
-      const host = this.extractHost(command.url);
-      if (!host) {
-        // Unparseable URL cannot equal a normalized grant — leave it to the
-        // retriever to fail naturally rather than blocking here.
-        return;
-      }
+    const host = this.extractHost(command.url);
+    if (!host) {
+      // Unparseable URL cannot equal a normalized grant — leave it to the
+      // retriever to fail naturally rather than blocking here.
+      return;
+    }
 
-      const grant = await this.crawlDomainGrantRepository.findByDomain(host);
-      if (grant && grant.orgId !== command.orgId) {
-        this.logger.warn('Blocked cross-org crawl of a restricted domain', {
-          host,
-          orgId: command.orgId,
-        });
-        throw new CrawlDomainAccessDeniedError({ domain: host });
-      }
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error asserting crawl domain access', {
-        error: error as Error,
+    const grant = await this.crawlDomainGrantRepository.findByDomain(host);
+    if (grant && grant.orgId !== command.orgId) {
+      this.logger.warn('Blocked cross-org crawl of a restricted domain', {
+        host,
+        orgId: command.orgId,
       });
-      throw new UnexpectedCrawlDomainGrantError('assert', {
-        error: error as Error,
-      });
+      throw new CrawlDomainAccessDeniedError({ domain: host });
     }
   }
 

--- a/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/grant-crawl-domain/grant-crawl-domain.use-case.ts
+++ b/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/grant-crawl-domain/grant-crawl-domain.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { CrawlDomainGrant } from '../../../domain/crawl-domain-grant.entity';
 import { normalizeHost } from '../../../domain/crawl-domain.util';
 import { InvalidCrawlDomainError } from '../../../domain/crawl-domain.errors';
@@ -19,36 +19,26 @@ export class GrantCrawlDomainUseCase {
     private readonly crawlDomainGrantRepository: CrawlDomainGrantRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedCrawlDomainGrantError)
   async execute(command: GrantCrawlDomainCommand): Promise<CrawlDomainGrant> {
     this.logger.log('Granting crawl domain', {
       orgId: command.orgId,
       domain: command.domain,
     });
 
-    try {
-      const domain = this.normalize(command.domain);
+    const domain = this.normalize(command.domain);
 
-      const existing =
-        await this.crawlDomainGrantRepository.findByDomain(domain);
-      if (existing) {
-        if (existing.orgId === command.orgId) {
-          // Already granted to this org — idempotent.
-          return existing;
-        }
-        throw new CrawlDomainAlreadyAssignedError({ domain });
+    const existing = await this.crawlDomainGrantRepository.findByDomain(domain);
+    if (existing) {
+      if (existing.orgId === command.orgId) {
+        // Already granted to this org — idempotent.
+        return existing;
       }
-
-      const grant = new CrawlDomainGrant({ orgId: command.orgId, domain });
-      return await this.crawlDomainGrantRepository.create(grant);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error granting crawl domain', {
-        error: error as Error,
-      });
-      throw new UnexpectedCrawlDomainGrantError('grant', {
-        error: error as Error,
-      });
+      throw new CrawlDomainAlreadyAssignedError({ domain });
     }
+
+    const grant = new CrawlDomainGrant({ orgId: command.orgId, domain });
+    return await this.crawlDomainGrantRepository.create(grant);
   }
 
   private normalize(input: string): string {

--- a/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/list-org-crawl-domains/list-org-crawl-domains.use-case.ts
+++ b/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/list-org-crawl-domains/list-org-crawl-domains.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { CrawlDomainGrant } from '../../../domain/crawl-domain-grant.entity';
 import { CrawlDomainGrantRepository } from '../../ports/crawl-domain-grant.repository';
 import { UnexpectedCrawlDomainGrantError } from '../../crawl-domain-grants.errors';
@@ -13,19 +13,10 @@ export class ListOrgCrawlDomainsUseCase {
     private readonly crawlDomainGrantRepository: CrawlDomainGrantRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedCrawlDomainGrantError)
   async execute(query: ListOrgCrawlDomainsQuery): Promise<CrawlDomainGrant[]> {
     this.logger.log('Listing crawl domains', { orgId: query.orgId });
 
-    try {
-      return await this.crawlDomainGrantRepository.findAllByOrgId(query.orgId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error listing crawl domains', {
-        error: error as Error,
-      });
-      throw new UnexpectedCrawlDomainGrantError('list', {
-        error: error as Error,
-      });
-    }
+    return await this.crawlDomainGrantRepository.findAllByOrgId(query.orgId);
   }
 }

--- a/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/revoke-crawl-domain/revoke-crawl-domain.use-case.ts
+++ b/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/revoke-crawl-domain/revoke-crawl-domain.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { CrawlDomainGrantRepository } from '../../ports/crawl-domain-grant.repository';
 import {
   CrawlDomainGrantNotFoundError,
@@ -15,31 +15,22 @@ export class RevokeCrawlDomainUseCase {
     private readonly crawlDomainGrantRepository: CrawlDomainGrantRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedCrawlDomainGrantError)
   async execute(command: RevokeCrawlDomainCommand): Promise<void> {
     this.logger.log('Revoking crawl domain', {
       orgId: command.orgId,
       grantId: command.grantId,
     });
 
-    try {
-      const grant = await this.crawlDomainGrantRepository.findById(
-        command.grantId,
-      );
-      // Scope the revoke to the named org so a grant can't be removed via the
-      // wrong org's route, and return 404 (not 403) for a foreign/absent grant.
-      if (grant?.orgId !== command.orgId) {
-        throw new CrawlDomainGrantNotFoundError(command.grantId);
-      }
-
-      await this.crawlDomainGrantRepository.delete(command.grantId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error revoking crawl domain', {
-        error: error as Error,
-      });
-      throw new UnexpectedCrawlDomainGrantError('revoke', {
-        error: error as Error,
-      });
+    const grant = await this.crawlDomainGrantRepository.findById(
+      command.grantId,
+    );
+    // Scope the revoke to the named org so a grant can't be removed via the
+    // wrong org's route, and return 404 (not 403) for a foreign/absent grant.
+    if (grant?.orgId !== command.orgId) {
+      throw new CrawlDomainGrantNotFoundError(command.grantId);
     }
+
+    await this.crawlDomainGrantRepository.delete(command.grantId);
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/knowledge-bases.errors.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/knowledge-bases.errors.ts
@@ -32,12 +32,12 @@ export class KnowledgeBaseNotFoundError extends KnowledgeBaseError {
 }
 
 export class UnexpectedKnowledgeBaseError extends KnowledgeBaseError {
-  constructor(message: string, metadata?: ErrorMetadata) {
+  constructor(error: Error, metadata?: ErrorMetadata) {
     super(
-      message,
+      error.message,
       KnowledgeBaseErrorCode.UNEXPECTED_KNOWLEDGE_BASE_ERROR,
       500,
-      metadata,
+      { ...metadata, error },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { StartDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case';
 import { StartDocumentProcessingCommand } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.command';
@@ -24,6 +24,7 @@ export class AddDocumentToKnowledgeBaseUseCase {
     private readonly txHost: TransactionHost<TransactionalAdapterTypeOrm>,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedKnowledgeBaseError)
   async execute(
     command: AddDocumentToKnowledgeBaseCommand,
   ): Promise<FileSource> {
@@ -32,54 +33,41 @@ export class AddDocumentToKnowledgeBaseUseCase {
       fileName: command.fileName,
     });
 
-    try {
-      // 1. Validate KB exists and belongs to user, enforce source limit
-      await this.txHost.withTransaction(async () => {
-        const knowledgeBase = await this.knowledgeBaseRepository.findById(
-          command.knowledgeBaseId,
-        );
-        if (knowledgeBase?.userId !== command.userId) {
-          throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
-        }
-
-        const sourceCount =
-          await this.knowledgeBaseRepository.countSourcesByKnowledgeBaseId(
-            command.knowledgeBaseId,
-          );
-        if (sourceCount >= KnowledgeBasesConstants.MAX_SOURCES) {
-          throw new KnowledgeBaseSourceLimitExceededError(
-            KnowledgeBasesConstants.MAX_SOURCES,
-          );
-        }
-      });
-
-      // 2. Start async document processing (creates PROCESSING source, uploads to MinIO, enqueues job)
-      const savedSource = await this.startDocumentProcessingUseCase.execute(
-        new StartDocumentProcessingCommand({
-          fileData: command.fileData,
-          fileName: command.fileName,
-          fileType: command.fileType,
-        }),
-      );
-
-      // 3. Assign source to KB
-      await this.knowledgeBaseRepository.assignSourceToKnowledgeBase(
-        savedSource.id,
+    // 1. Validate KB exists and belongs to user, enforce source limit
+    await this.txHost.withTransaction(async () => {
+      const knowledgeBase = await this.knowledgeBaseRepository.findById(
         command.knowledgeBaseId,
       );
-
-      return savedSource;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
+      if (knowledgeBase?.userId !== command.userId) {
+        throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
       }
-      this.logger.error('Error adding document to knowledge base', {
-        error: error as Error,
-      });
-      throw new UnexpectedKnowledgeBaseError(
-        'Error adding document to knowledge base',
-        { error: error as Error },
-      );
-    }
+
+      const sourceCount =
+        await this.knowledgeBaseRepository.countSourcesByKnowledgeBaseId(
+          command.knowledgeBaseId,
+        );
+      if (sourceCount >= KnowledgeBasesConstants.MAX_SOURCES) {
+        throw new KnowledgeBaseSourceLimitExceededError(
+          KnowledgeBasesConstants.MAX_SOURCES,
+        );
+      }
+    });
+
+    // 2. Start async document processing (creates PROCESSING source, uploads to MinIO, enqueues job)
+    const savedSource = await this.startDocumentProcessingUseCase.execute(
+      new StartDocumentProcessingCommand({
+        fileData: command.fileData,
+        fileName: command.fileName,
+        fileType: command.fileType,
+      }),
+    );
+
+    // 3. Assign source to KB
+    await this.knowledgeBaseRepository.assignSourceToKnowledgeBase(
+      savedSource.id,
+      command.knowledgeBaseId,
+    );
+
+    return savedSource;
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import type { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { StartUrlCrawlUseCase } from 'src/domain/sources/application/use-cases/start-url-crawl/start-url-crawl.use-case';
 import { StartUrlCrawlCommand } from 'src/domain/sources/application/use-cases/start-url-crawl/start-url-crawl.command';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import {
   KnowledgeBaseNotFoundError,
@@ -24,6 +24,7 @@ export class AddUrlToKnowledgeBaseUseCase {
     private readonly txHost: TransactionHost<TransactionalAdapterTypeOrm>,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedKnowledgeBaseError)
   async execute(command: AddUrlToKnowledgeBaseCommand): Promise<TextSource> {
     this.logger.log('Adding URL to knowledge base (async)', {
       knowledgeBaseId: command.knowledgeBaseId,
@@ -31,53 +32,40 @@ export class AddUrlToKnowledgeBaseUseCase {
       maxDepth: command.maxDepth,
     });
 
-    try {
-      // 1. Validate KB exists and belongs to user, enforce source limit
-      await this.txHost.withTransaction(async () => {
-        const knowledgeBase = await this.knowledgeBaseRepository.findById(
-          command.knowledgeBaseId,
-        );
-        if (knowledgeBase?.userId !== command.userId) {
-          throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
-        }
-
-        const sourceCount =
-          await this.knowledgeBaseRepository.countSourcesByKnowledgeBaseId(
-            command.knowledgeBaseId,
-          );
-        if (sourceCount >= KnowledgeBasesConstants.MAX_SOURCES) {
-          throw new KnowledgeBaseSourceLimitExceededError(
-            KnowledgeBasesConstants.MAX_SOURCES,
-          );
-        }
-      });
-
-      // 2. Start async crawl (creates PROCESSING source, enqueues job)
-      const source = await this.startUrlCrawlUseCase.execute(
-        new StartUrlCrawlCommand({
-          url: command.url,
-          maxDepth: command.maxDepth,
-        }),
-      );
-
-      // 3. Assign source to KB
-      await this.knowledgeBaseRepository.assignSourceToKnowledgeBase(
-        source.id,
+    // 1. Validate KB exists and belongs to user, enforce source limit
+    await this.txHost.withTransaction(async () => {
+      const knowledgeBase = await this.knowledgeBaseRepository.findById(
         command.knowledgeBaseId,
       );
-
-      return source;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
+      if (knowledgeBase?.userId !== command.userId) {
+        throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
       }
-      this.logger.error('Error adding URL to knowledge base', {
-        error: error as Error,
-      });
-      throw new UnexpectedKnowledgeBaseError(
-        'Error adding URL to knowledge base',
-        { error: error as Error },
-      );
-    }
+
+      const sourceCount =
+        await this.knowledgeBaseRepository.countSourcesByKnowledgeBaseId(
+          command.knowledgeBaseId,
+        );
+      if (sourceCount >= KnowledgeBasesConstants.MAX_SOURCES) {
+        throw new KnowledgeBaseSourceLimitExceededError(
+          KnowledgeBasesConstants.MAX_SOURCES,
+        );
+      }
+    });
+
+    // 2. Start async crawl (creates PROCESSING source, enqueues job)
+    const source = await this.startUrlCrawlUseCase.execute(
+      new StartUrlCrawlCommand({
+        url: command.url,
+        maxDepth: command.maxDepth,
+      }),
+    );
+
+    // 3. Assign source to KB
+    await this.knowledgeBaseRepository.assignSourceToKnowledgeBase(
+      source.id,
+      command.knowledgeBaseId,
+    );
+
+    return source;
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/create-knowledge-base/create-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/create-knowledge-base/create-knowledge-base.use-case.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { KnowledgeBase } from '../../../domain/knowledge-base.entity';
 import { CreateKnowledgeBaseCommand } from './create-knowledge-base.command';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedKnowledgeBaseError } from '../../knowledge-bases.errors';
 
 @Injectable()
@@ -13,31 +13,20 @@ export class CreateKnowledgeBaseUseCase {
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedKnowledgeBaseError)
   async execute(command: CreateKnowledgeBaseCommand): Promise<KnowledgeBase> {
     this.logger.log('Creating knowledge base', {
       name: command.name,
       userId: command.userId,
     });
 
-    try {
-      const knowledgeBase = new KnowledgeBase({
-        name: command.name,
-        description: command.description,
-        orgId: command.orgId,
-        userId: command.userId,
-      });
+    const knowledgeBase = new KnowledgeBase({
+      name: command.name,
+      description: command.description,
+      orgId: command.orgId,
+      userId: command.userId,
+    });
 
-      return await this.knowledgeBaseRepository.save(knowledgeBase);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error creating knowledge base', {
-        error: error as Error,
-      });
-      throw new UnexpectedKnowledgeBaseError('Error creating knowledge base', {
-        error: error as Error,
-      });
-    }
+    return await this.knowledgeBaseRepository.save(knowledgeBase);
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { DeleteSourcesUseCase } from 'src/domain/sources/application/use-cases/delete-sources/delete-sources.use-case';
 import { DeleteSourcesCommand } from 'src/domain/sources/application/use-cases/delete-sources/delete-sources.command';
@@ -10,7 +11,6 @@ import {
   KnowledgeBaseNotFoundError,
   UnexpectedKnowledgeBaseError,
 } from '../../knowledge-bases.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class DeleteKnowledgeBaseUseCase {
@@ -23,39 +23,28 @@ export class DeleteKnowledgeBaseUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedKnowledgeBaseError)
   async execute(command: DeleteKnowledgeBaseCommand): Promise<void> {
     this.logger.log('Deleting knowledge base', {
       knowledgeBaseId: command.knowledgeBaseId,
       userId: command.userId,
     });
 
-    try {
-      const existing = await this.knowledgeBaseRepository.findById(
-        command.knowledgeBaseId,
-      );
-      if (existing?.userId !== command.userId) {
-        throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
-      }
-
-      const sources = await this.getSourcesByKnowledgeBaseIdUseCase.execute(
-        new GetSourcesByKnowledgeBaseIdQuery(command.knowledgeBaseId),
-      );
-      const sourceIds = sources.map((s) => s.id);
-      await this.deleteSourcesUseCase.execute(
-        new DeleteSourcesCommand(sourceIds),
-      );
-
-      await this.knowledgeBaseRepository.delete(existing);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error deleting knowledge base', {
-        error: error as Error,
-      });
-      throw new UnexpectedKnowledgeBaseError('Error deleting knowledge base', {
-        error: error as Error,
-      });
+    const existing = await this.knowledgeBaseRepository.findById(
+      command.knowledgeBaseId,
+    );
+    if (existing?.userId !== command.userId) {
+      throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
     }
+
+    const sources = await this.getSourcesByKnowledgeBaseIdUseCase.execute(
+      new GetSourcesByKnowledgeBaseIdQuery(command.knowledgeBaseId),
+    );
+    const sourceIds = sources.map((s) => s.id);
+    await this.deleteSourcesUseCase.execute(
+      new DeleteSourcesCommand(sourceIds),
+    );
+
+    await this.knowledgeBaseRepository.delete(existing);
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/find-knowledge-base/find-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/find-knowledge-base/find-knowledge-base.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { KnowledgeBase } from '../../../domain/knowledge-base.entity';
 import { FindKnowledgeBaseQuery } from './find-knowledge-base.query';
@@ -6,7 +7,6 @@ import {
   KnowledgeBaseNotFoundError,
   UnexpectedKnowledgeBaseError,
 } from '../../knowledge-bases.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class FindKnowledgeBaseUseCase {
@@ -16,31 +16,18 @@ export class FindKnowledgeBaseUseCase {
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedKnowledgeBaseError)
   async execute(query: FindKnowledgeBaseQuery): Promise<KnowledgeBase> {
     this.logger.log('Finding knowledge base', {
       id: query.id,
       userId: query.userId,
     });
 
-    try {
-      const knowledgeBase = await this.knowledgeBaseRepository.findById(
-        query.id,
-      );
-      if (knowledgeBase?.userId !== query.userId) {
-        throw new KnowledgeBaseNotFoundError(query.id);
-      }
-
-      return knowledgeBase;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error finding knowledge base', {
-        error: error as Error,
-      });
-      throw new UnexpectedKnowledgeBaseError('Error finding knowledge base', {
-        error: error as Error,
-      });
+    const knowledgeBase = await this.knowledgeBaseRepository.findById(query.id);
+    if (knowledgeBase?.userId !== query.userId) {
+      throw new KnowledgeBaseNotFoundError(query.id);
     }
+
+    return knowledgeBase;
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-base-document-text/get-knowledge-base-document-text.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-base-document-text/get-knowledge-base-document-text.use-case.ts
@@ -1,9 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { GetKnowledgeBaseDocumentTextQuery } from './get-knowledge-base-document-text.query';
 import {
   KnowledgeBaseNotFoundError,
   DocumentNotInKnowledgeBaseError,
+  UnexpectedKnowledgeBaseError,
 } from '../../knowledge-bases.errors';
 import type { Source } from 'src/domain/sources/domain/source.entity';
 import { KnowledgeBaseAccessService } from '../../services/knowledge-base-access.service';
@@ -19,6 +21,7 @@ export class GetKnowledgeBaseDocumentTextUseCase {
     private readonly knowledgeBaseAccessService: KnowledgeBaseAccessService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedKnowledgeBaseError)
   async execute(query: GetKnowledgeBaseDocumentTextQuery): Promise<Source> {
     this.logger.debug('Getting document text from knowledge base', {
       knowledgeBaseId: query.knowledgeBaseId,

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.use-case.ts
@@ -1,10 +1,10 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetKnowledgeBasesByIdsQuery } from './get-knowledge-bases-by-ids.query';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { ContextService } from 'src/common/context/services/context.service';
 import { KnowledgeBase } from '../../../domain/knowledge-base.entity';
 import { UnexpectedKnowledgeBaseError } from '../../knowledge-bases.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 /**
@@ -27,34 +27,25 @@ export class GetKnowledgeBasesByIdsUseCase {
    * @param query Query containing the knowledge base IDs
    * @returns Array of KnowledgeBase entities (missing/unauthorized IDs omitted)
    */
+  @HandleUnexpectedErrors(UnexpectedKnowledgeBaseError)
   async execute(query: GetKnowledgeBasesByIdsQuery): Promise<KnowledgeBase[]> {
     this.logger.log('getKnowledgeBasesByIds', {
       count: query.knowledgeBaseIds.length,
     });
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      if (query.knowledgeBaseIds.length === 0) {
-        return [];
-      }
-
-      const knowledgeBases = await this.knowledgeBaseRepository.findByIds(
-        query.knowledgeBaseIds,
-      );
-
-      return knowledgeBases.filter((kb) => kb.orgId === orgId);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Unexpected error getting knowledge bases by IDs', {
-        error: error as Error,
-      });
-      throw new UnexpectedKnowledgeBaseError('Unexpected error occurred');
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedAccessError();
     }
+
+    if (query.knowledgeBaseIds.length === 0) {
+      return [];
+    }
+
+    const knowledgeBases = await this.knowledgeBaseRepository.findByIds(
+      query.knowledgeBaseIds,
+    );
+
+    return knowledgeBases.filter((kb) => kb.orgId === orgId);
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import type { Source } from 'src/domain/sources/domain/source.entity';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import {
   KnowledgeBaseNotFoundError,
@@ -16,33 +16,21 @@ export class ListKnowledgeBaseDocumentsUseCase {
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedKnowledgeBaseError)
   async execute(query: ListKnowledgeBaseDocumentsQuery): Promise<Source[]> {
     this.logger.log('Listing knowledge base documents', {
       knowledgeBaseId: query.knowledgeBaseId,
     });
 
-    try {
-      const knowledgeBase = await this.knowledgeBaseRepository.findById(
-        query.knowledgeBaseId,
-      );
-      if (!knowledgeBase) {
-        throw new KnowledgeBaseNotFoundError(query.knowledgeBaseId);
-      }
-
-      return await this.knowledgeBaseRepository.findSourcesByKnowledgeBaseId(
-        query.knowledgeBaseId,
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error listing knowledge base documents', {
-        error: error as Error,
-      });
-      throw new UnexpectedKnowledgeBaseError(
-        'Error listing knowledge base documents',
-        { error: error as Error },
-      );
+    const knowledgeBase = await this.knowledgeBaseRepository.findById(
+      query.knowledgeBaseId,
+    );
+    if (!knowledgeBase) {
+      throw new KnowledgeBaseNotFoundError(query.knowledgeBaseId);
     }
+
+    return await this.knowledgeBaseRepository.findSourcesByKnowledgeBaseId(
+      query.knowledgeBaseId,
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-bases/list-knowledge-bases.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-bases/list-knowledge-bases.use-case.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { KnowledgeBase } from '../../../domain/knowledge-base.entity';
 import { ListKnowledgeBasesQuery } from './list-knowledge-bases.query';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedKnowledgeBaseError } from '../../knowledge-bases.errors';
 
 @Injectable()
@@ -13,21 +13,10 @@ export class ListKnowledgeBasesUseCase {
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedKnowledgeBaseError)
   async execute(query: ListKnowledgeBasesQuery): Promise<KnowledgeBase[]> {
     this.logger.log('Listing knowledge bases', { userId: query.userId });
 
-    try {
-      return await this.knowledgeBaseRepository.findAllByUserId(query.userId);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error listing knowledge bases', {
-        error: error as Error,
-      });
-      throw new UnexpectedKnowledgeBaseError('Error listing knowledge bases', {
-        error: error as Error,
-      });
-    }
+    return await this.knowledgeBaseRepository.findAllByUserId(query.userId);
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { QueryKnowledgeBaseQuery } from './query-knowledge-base.query';
 import {
@@ -8,9 +9,9 @@ import {
 import { SearchContentUseCase } from 'src/domain/rag/indexers/application/use-cases/search-content/search-content.use-case';
 import { SearchMultiContentQuery } from 'src/domain/rag/indexers/application/use-cases/search-content/search-content.query';
 import { IndexType } from 'src/domain/rag/indexers/domain/value-objects/index-type.enum';
+import type { IndexEntry } from 'src/domain/rag/indexers/domain/index-entry.entity';
 import type { TextSourceContentChunk } from 'src/domain/sources/domain/source-content-chunk.entity';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { KnowledgeBaseAccessService } from '../../services/knowledge-base-access.service';
 import { FindContentChunksByIdsUseCase } from 'src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.use-case';
 import { FindContentChunksByIdsQuery } from 'src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.query';
@@ -33,25 +34,8 @@ export class QueryKnowledgeBaseUseCase {
     private readonly knowledgeBaseAccessService: KnowledgeBaseAccessService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedKnowledgeBaseError)
   async execute(
-    query: QueryKnowledgeBaseQuery,
-  ): Promise<KnowledgeBaseQueryResult[]> {
-    try {
-      return await this.executeInternal(query);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error querying knowledge base', {
-        error: error as Error,
-      });
-      throw new UnexpectedKnowledgeBaseError('Error querying knowledge base', {
-        error: error as Error,
-      });
-    }
-  }
-
-  private async executeInternal(
     query: QueryKnowledgeBaseQuery,
   ): Promise<KnowledgeBaseQueryResult[]> {
     const orgId = this.contextService.get('orgId');
@@ -95,6 +79,18 @@ export class QueryKnowledgeBaseUseCase {
       return [];
     }
 
+    const results = await this.resolveChunks(indexEntries);
+
+    this.logger.debug(
+      `Found ${results.length} results for knowledge base query`,
+    );
+
+    return results;
+  }
+
+  private async resolveChunks(
+    indexEntries: IndexEntry[],
+  ): Promise<KnowledgeBaseQueryResult[]> {
     // Fetch only the matched chunks by ID (single query)
     const chunkIds = indexEntries.map((entry) => entry.relatedChunkId);
     const chunkResults = await this.findContentChunksByIdsUseCase.execute(
@@ -116,10 +112,6 @@ export class QueryKnowledgeBaseUseCase {
         });
       }
     }
-
-    this.logger.debug(
-      `Found ${results.length} results for knowledge base query`,
-    );
 
     return results;
   }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { DeleteSourceUseCase } from 'src/domain/sources/application/use-cases/delete-source/delete-source.use-case';
 import { DeleteSourceCommand } from 'src/domain/sources/application/use-cases/delete-source/delete-source.command';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import {
   KnowledgeBaseNotFoundError,
@@ -23,6 +23,7 @@ export class RemoveDocumentFromKnowledgeBaseUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedKnowledgeBaseError)
   async execute(
     command: RemoveDocumentFromKnowledgeBaseCommand,
   ): Promise<void> {
@@ -31,40 +32,27 @@ export class RemoveDocumentFromKnowledgeBaseUseCase {
       documentId: command.documentId,
     });
 
-    try {
-      const knowledgeBase = await this.knowledgeBaseRepository.findById(
+    const knowledgeBase = await this.knowledgeBaseRepository.findById(
+      command.knowledgeBaseId,
+    );
+    if (knowledgeBase?.userId !== command.userId) {
+      throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
+    }
+
+    const source =
+      await this.knowledgeBaseRepository.findSourceByIdAndKnowledgeBaseId(
+        command.documentId,
         command.knowledgeBaseId,
       );
-      if (knowledgeBase?.userId !== command.userId) {
-        throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
-      }
-
-      const source =
-        await this.knowledgeBaseRepository.findSourceByIdAndKnowledgeBaseId(
-          command.documentId,
-          command.knowledgeBaseId,
-        );
-      if (!source) {
-        throw new DocumentNotInKnowledgeBaseError(
-          command.documentId,
-          command.knowledgeBaseId,
-        );
-      }
-
-      await this.deleteSourceUseCase.execute(
-        new DeleteSourceCommand(command.documentId),
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error removing document from knowledge base', {
-        error: error as Error,
-      });
-      throw new UnexpectedKnowledgeBaseError(
-        'Error removing document from knowledge base',
-        { error: error as Error },
+    if (!source) {
+      throw new DocumentNotInKnowledgeBaseError(
+        command.documentId,
+        command.knowledgeBaseId,
       );
     }
+
+    await this.deleteSourceUseCase.execute(
+      new DeleteSourceCommand(command.documentId),
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/update-knowledge-base/update-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/update-knowledge-base/update-knowledge-base.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { KnowledgeBase } from '../../../domain/knowledge-base.entity';
 import { UpdateKnowledgeBaseCommand } from './update-knowledge-base.command';
@@ -6,7 +7,6 @@ import {
   KnowledgeBaseNotFoundError,
   UnexpectedKnowledgeBaseError,
 } from '../../knowledge-bases.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class UpdateKnowledgeBaseUseCase {
@@ -16,41 +16,30 @@ export class UpdateKnowledgeBaseUseCase {
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedKnowledgeBaseError)
   async execute(command: UpdateKnowledgeBaseCommand): Promise<KnowledgeBase> {
     this.logger.log('Updating knowledge base', {
       knowledgeBaseId: command.knowledgeBaseId,
       userId: command.userId,
     });
 
-    try {
-      const existing = await this.knowledgeBaseRepository.findById(
-        command.knowledgeBaseId,
-      );
-      if (existing?.userId !== command.userId) {
-        throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
-      }
-
-      const updated = new KnowledgeBase({
-        id: existing.id,
-        name: command.name ?? existing.name,
-        description: command.description ?? existing.description,
-        orgId: existing.orgId,
-        userId: existing.userId,
-        createdAt: existing.createdAt,
-        updatedAt: new Date(),
-      });
-
-      return await this.knowledgeBaseRepository.save(updated);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error updating knowledge base', {
-        error: error as Error,
-      });
-      throw new UnexpectedKnowledgeBaseError('Error updating knowledge base', {
-        error: error as Error,
-      });
+    const existing = await this.knowledgeBaseRepository.findById(
+      command.knowledgeBaseId,
+    );
+    if (existing?.userId !== command.userId) {
+      throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
     }
+
+    const updated = new KnowledgeBase({
+      id: existing.id,
+      name: command.name ?? existing.name,
+      description: command.description ?? existing.description,
+      orgId: existing.orgId,
+      userId: existing.userId,
+      createdAt: existing.createdAt,
+      updatedAt: new Date(),
+    });
+
+    return await this.knowledgeBaseRepository.save(updated);
   }
 }

--- a/ayunis-core-backend/src/domain/marketplace/application/marketplace.errors.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/marketplace.errors.ts
@@ -1,30 +1,63 @@
+import type { ErrorMetadata } from 'src/common/errors/base.error';
 import { ApplicationError } from 'src/common/errors/base.error';
 
-export class MarketplaceSkillNotFoundError extends ApplicationError {
+export enum MarketplaceErrorCode {
+  MARKETPLACE_SKILL_NOT_FOUND = 'MARKETPLACE_SKILL_NOT_FOUND',
+  MARKETPLACE_INTEGRATION_NOT_FOUND = 'MARKETPLACE_INTEGRATION_NOT_FOUND',
+  MARKETPLACE_UNAVAILABLE = 'MARKETPLACE_UNAVAILABLE',
+  UNEXPECTED_MARKETPLACE_ERROR = 'UNEXPECTED_MARKETPLACE_ERROR',
+}
+
+export abstract class MarketplaceError extends ApplicationError {
+  constructor(
+    message: string,
+    code: MarketplaceErrorCode,
+    statusCode: number = 400,
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, code, statusCode, metadata);
+  }
+}
+
+export class UnexpectedMarketplaceError extends MarketplaceError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(
+      error.message,
+      MarketplaceErrorCode.UNEXPECTED_MARKETPLACE_ERROR,
+      500,
+      {
+        ...metadata,
+        error,
+      },
+    );
+  }
+}
+
+export class MarketplaceSkillNotFoundError extends MarketplaceError {
   constructor(identifier: string) {
     super(
       `Marketplace skill not found: ${identifier}`,
-      'MARKETPLACE_SKILL_NOT_FOUND',
+      MarketplaceErrorCode.MARKETPLACE_SKILL_NOT_FOUND,
       404,
     );
   }
 }
 
-export class MarketplaceIntegrationNotFoundError extends ApplicationError {
+export class MarketplaceIntegrationNotFoundError extends MarketplaceError {
   constructor(identifier: string) {
     super(
       `Marketplace integration not found: ${identifier}`,
-      'MARKETPLACE_INTEGRATION_NOT_FOUND',
+      MarketplaceErrorCode.MARKETPLACE_INTEGRATION_NOT_FOUND,
       404,
     );
   }
 }
 
-export class MarketplaceUnavailableError extends ApplicationError {
+export class MarketplaceUnavailableError extends MarketplaceError {
   constructor() {
     super(
       'Marketplace service is currently unavailable',
-      'MARKETPLACE_UNAVAILABLE',
+      MarketplaceErrorCode.MARKETPLACE_UNAVAILABLE,
       503,
     );
   }

--- a/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { MarketplaceClient } from '../../ports/marketplace-client.port';
 import { GetMarketplaceIntegrationQuery } from './get-marketplace-integration.query';
 import { IntegrationResponseDto } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
@@ -6,6 +7,7 @@ import { ApplicationError } from 'src/common/errors/base.error';
 import {
   MarketplaceIntegrationNotFoundError,
   MarketplaceUnavailableError,
+  UnexpectedMarketplaceError,
 } from '../../marketplace.errors';
 
 @Injectable()
@@ -14,6 +16,7 @@ export class GetMarketplaceIntegrationUseCase {
 
   constructor(private readonly marketplaceClient: MarketplaceClient) {}
 
+  @HandleUnexpectedErrors(UnexpectedMarketplaceError)
   async execute(
     query: GetMarketplaceIntegrationQuery,
   ): Promise<IntegrationResponseDto> {

--- a/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { MarketplaceClient } from '../../ports/marketplace-client.port';
 import { GetMarketplaceSkillQuery } from './get-marketplace-skill.query';
 import { SkillResponseDto } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
@@ -6,6 +7,7 @@ import { ApplicationError } from 'src/common/errors/base.error';
 import {
   MarketplaceSkillNotFoundError,
   MarketplaceUnavailableError,
+  UnexpectedMarketplaceError,
 } from '../../marketplace.errors';
 
 @Injectable()
@@ -14,6 +16,7 @@ export class GetMarketplaceSkillUseCase {
 
   constructor(private readonly marketplaceClient: MarketplaceClient) {}
 
+  @HandleUnexpectedErrors(UnexpectedMarketplaceError)
   async execute(query: GetMarketplaceSkillQuery): Promise<SkillResponseDto> {
     this.logger.log('execute', { identifier: query.identifier });
 

--- a/ayunis-core-backend/src/domain/mcp/application/mcp.errors.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/mcp.errors.ts
@@ -86,8 +86,11 @@ export class McpIntegrationAccessDeniedError extends McpError {
 }
 
 export class UnexpectedMcpError extends McpError {
-  constructor(message: string, metadata?: ErrorMetadata) {
-    super(message, McpErrorCode.UNEXPECTED_MCP_ERROR, 500, metadata);
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, McpErrorCode.UNEXPECTED_MCP_ERROR, 500, {
+      ...metadata,
+      error,
+    });
   }
 }
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { CreatePredefinedMcpIntegrationCommand } from './create-predefined-mcp-integration.command';
 import { CreateCustomMcpIntegrationCommand } from './create-custom-mcp-integration.command';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
@@ -18,11 +19,13 @@ import {
   DuplicateMcpIntegrationError,
   McpValidationFailedError,
 } from '../../mcp.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UUID } from 'crypto';
 import { PredefinedMcpIntegration } from '../../../domain/integrations/predefined-mcp-integration.entity';
 import { CustomMcpIntegration } from '../../../domain/integrations/custom-mcp-integration.entity';
-import { CredentialFieldType } from 'src/domain/mcp/domain/predefined-mcp-integration-config';
+import {
+  CredentialFieldType,
+  PredefinedMcpIntegrationConfig,
+} from 'src/domain/mcp/domain/predefined-mcp-integration-config';
 import { McpIntegrationAuth } from 'src/domain/mcp/domain';
 
 @Injectable()
@@ -47,11 +50,11 @@ export class CreateMcpIntegrationUseCase {
     command: CreateCustomMcpIntegrationCommand,
   ): Promise<CustomMcpIntegration>;
 
-  // Implementation
+  // Implementation. TS1241 forbids decorating an overloaded method, so the
+  // error boundary sits on the two async delegates below instead.
   async execute(
     command:
-      | CreatePredefinedMcpIntegrationCommand
-      | CreateCustomMcpIntegrationCommand,
+      CreatePredefinedMcpIntegrationCommand | CreateCustomMcpIntegrationCommand,
   ): Promise<PredefinedMcpIntegration | CustomMcpIntegration> {
     // Get orgId from context first (common for both types)
     const orgId = this.contextService.get('orgId');
@@ -67,136 +70,136 @@ export class CreateMcpIntegrationUseCase {
     }
   }
 
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   private async createPredefinedIntegration(
     command: CreatePredefinedMcpIntegrationCommand,
     orgId: UUID,
   ): Promise<PredefinedMcpIntegration> {
     this.logger.log('createPredefinedIntegration', { slug: command.slug });
 
-    try {
-      // Validate slug exists in registry
-      if (!this.registryService.isValidSlug(command.slug)) {
-        throw new InvalidPredefinedSlugError(command.slug);
+    // Validate slug exists in registry
+    if (!this.registryService.isValidSlug(command.slug)) {
+      throw new InvalidPredefinedSlugError(command.slug);
+    }
+
+    // Get configuration from registry
+    const config = this.registryService.getConfig(command.slug);
+
+    // Check for duplicates
+    const existing = await this.repository.findByOrgIdAndSlug(
+      orgId,
+      command.slug,
+    );
+    if (existing) {
+      throw new DuplicateMcpIntegrationError(command.slug);
+    }
+
+    const integrationAuth = await this.buildPredefinedAuth(config, command);
+
+    const integration = this.factory.createIntegration({
+      kind: McpIntegrationKind.PREDEFINED,
+      orgId,
+      slug: config.slug,
+      name: config.displayName,
+      serverUrl: config.serverUrl,
+      auth: integrationAuth,
+      returnsPii: command.returnsPii,
+    });
+
+    // Save integration first to get ID
+    const savedIntegration = await this.repository.save(integration);
+
+    // Validate connection (don't throw on failure)
+    await this.connectionValidationService.validateAndUpdateStatus(
+      savedIntegration,
+    );
+
+    // Return the updated integration
+    return savedIntegration;
+  }
+
+  private async buildPredefinedAuth(
+    config: PredefinedMcpIntegrationConfig,
+    command: CreatePredefinedMcpIntegrationCommand,
+  ): Promise<McpIntegrationAuth> {
+    switch (config.authType) {
+      case McpAuthMethod.NO_AUTH:
+        return this.authFactory.createAuth({
+          method: McpAuthMethod.NO_AUTH,
+        });
+      case McpAuthMethod.BEARER_TOKEN:
+        return this.buildPredefinedBearerAuth(config, command);
+      case McpAuthMethod.OAUTH:
+        return this.authFactory.createAuth({
+          method: McpAuthMethod.OAUTH,
+          clientId:
+            command.credentialFields.find(
+              (field) => field.name === CredentialFieldType.CLIENT_ID,
+            )?.value ?? '',
+          clientSecret:
+            command.credentialFields.find(
+              (field) => field.name === CredentialFieldType.CLIENT_SECRET,
+            )?.value ?? '',
+        });
+      case McpAuthMethod.CUSTOM_HEADER:
+        return this.buildPredefinedCustomHeaderAuth(config, command);
+      default: {
+        const exhaustiveCheck: never = config.authType;
+        throw new Error(`Unknown MCP auth type: ${String(exhaustiveCheck)}`);
       }
-
-      // Get configuration from registry
-      const config = this.registryService.getConfig(command.slug);
-
-      // Check for duplicates
-      const existing = await this.repository.findByOrgIdAndSlug(
-        orgId,
-        command.slug,
-      );
-      if (existing) {
-        throw new DuplicateMcpIntegrationError(command.slug);
-      }
-
-      let integrationAuth: McpIntegrationAuth;
-      switch (config.authType) {
-        case McpAuthMethod.NO_AUTH:
-          integrationAuth = this.authFactory.createAuth({
-            method: McpAuthMethod.NO_AUTH,
-          });
-          break;
-        case McpAuthMethod.BEARER_TOKEN: {
-          const tokenField = command.credentialFields.find(
-            (field) => field.name === CredentialFieldType.TOKEN,
-          );
-          const rawToken = tokenField?.value.trim();
-
-          if (!rawToken) {
-            throw new McpValidationFailedError(
-              '',
-              config.displayName,
-              'Bearer token credentials are required',
-              CredentialFieldType.TOKEN,
-            );
-          }
-
-          integrationAuth = this.authFactory.createAuth({
-            method: McpAuthMethod.BEARER_TOKEN,
-            authToken: await this.credentialEncryption.encrypt(rawToken),
-          });
-          break;
-        }
-        case McpAuthMethod.OAUTH:
-          integrationAuth = this.authFactory.createAuth({
-            method: McpAuthMethod.OAUTH,
-            clientId:
-              command.credentialFields.find(
-                (field) => field.name === CredentialFieldType.CLIENT_ID,
-              )?.value ?? '',
-            clientSecret:
-              command.credentialFields.find(
-                (field) => field.name === CredentialFieldType.CLIENT_SECRET,
-              )?.value ?? '',
-          });
-          break;
-        case McpAuthMethod.CUSTOM_HEADER: {
-          const secretField = command.credentialFields.find(
-            (field) => field.name === CredentialFieldType.TOKEN,
-          );
-          const rawSecret = secretField?.value.trim();
-
-          if (!rawSecret) {
-            throw new McpValidationFailedError(
-              '',
-              config.displayName,
-              'Custom header secret is required',
-              CredentialFieldType.TOKEN,
-            );
-          }
-
-          integrationAuth = this.authFactory.createAuth({
-            method: McpAuthMethod.CUSTOM_HEADER,
-            secret: await this.credentialEncryption.encrypt(rawSecret),
-            headerName: config.authHeaderName ?? 'X-API-Key',
-          });
-          break;
-        }
-        default: {
-          const exhaustiveCheck: never = config.authType;
-          throw new Error(`Unknown MCP auth type: ${String(exhaustiveCheck)}`);
-        }
-      }
-
-      const integration = this.factory.createIntegration({
-        kind: McpIntegrationKind.PREDEFINED,
-        orgId,
-        slug: config.slug,
-        name: config.displayName,
-        serverUrl: config.serverUrl,
-        auth: integrationAuth,
-        returnsPii: command.returnsPii,
-      });
-
-      // Save integration first to get ID
-      const savedIntegration = await this.repository.save(integration);
-
-      // Validate connection (don't throw on failure)
-      await this.connectionValidationService.validateAndUpdateStatus(
-        savedIntegration,
-      );
-
-      // Return the updated integration
-      return savedIntegration;
-    } catch (error) {
-      // Re-throw application errors and auth errors
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-
-      // Log and wrap unexpected errors
-      this.logger.error('Unexpected error creating predefined integration', {
-        error: error as Error,
-      });
-      throw new UnexpectedMcpError('Unexpected error occurred');
     }
   }
 
+  private async buildPredefinedBearerAuth(
+    config: PredefinedMcpIntegrationConfig,
+    command: CreatePredefinedMcpIntegrationCommand,
+  ): Promise<McpIntegrationAuth> {
+    const tokenField = command.credentialFields.find(
+      (field) => field.name === CredentialFieldType.TOKEN,
+    );
+    const rawToken = tokenField?.value.trim();
+
+    if (!rawToken) {
+      throw new McpValidationFailedError(
+        '',
+        config.displayName,
+        'Bearer token credentials are required',
+        CredentialFieldType.TOKEN,
+      );
+    }
+
+    return this.authFactory.createAuth({
+      method: McpAuthMethod.BEARER_TOKEN,
+      authToken: await this.credentialEncryption.encrypt(rawToken),
+    });
+  }
+
+  private async buildPredefinedCustomHeaderAuth(
+    config: PredefinedMcpIntegrationConfig,
+    command: CreatePredefinedMcpIntegrationCommand,
+  ): Promise<McpIntegrationAuth> {
+    const secretField = command.credentialFields.find(
+      (field) => field.name === CredentialFieldType.TOKEN,
+    );
+    const rawSecret = secretField?.value.trim();
+
+    if (!rawSecret) {
+      throw new McpValidationFailedError(
+        '',
+        config.displayName,
+        'Custom header secret is required',
+        CredentialFieldType.TOKEN,
+      );
+    }
+
+    return this.authFactory.createAuth({
+      method: McpAuthMethod.CUSTOM_HEADER,
+      secret: await this.credentialEncryption.encrypt(rawSecret),
+      headerName: config.authHeaderName ?? 'X-API-Key',
+    });
+  }
+
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   private async createCustomIntegration(
     command: CreateCustomMcpIntegrationCommand,
     orgId: UUID,
@@ -205,117 +208,89 @@ export class CreateMcpIntegrationUseCase {
       serverUrl: command.serverUrl,
     });
 
-    try {
-      // Validate URL format
-      if (!this.isValidUrl(command.serverUrl)) {
-        throw new InvalidServerUrlError(command.serverUrl);
-      }
+    // Validate URL format
+    if (!this.isValidUrl(command.serverUrl)) {
+      throw new InvalidServerUrlError(command.serverUrl);
+    }
 
-      // Determine auth type (default to NO_AUTH if not provided)
-      const authType = command.authMethod ?? McpAuthMethod.NO_AUTH;
+    // Determine auth type (default to NO_AUTH if not provided)
+    const authType = command.authMethod ?? McpAuthMethod.NO_AUTH;
 
-      // Handle OAUTH - not implemented yet
-      if (authType === McpAuthMethod.OAUTH) {
-        throw new McpAuthNotImplementedError(McpAuthMethod.OAUTH);
-      }
+    // Handle OAUTH - not implemented yet
+    if (authType === McpAuthMethod.OAUTH) {
+      throw new McpAuthNotImplementedError(McpAuthMethod.OAUTH);
+    }
 
-      // Create integration using factory and handle credentials based on auth type
-      let integration: CustomMcpIntegration;
+    const auth = await this.buildCustomAuth(authType, command);
 
-      if (authType === McpAuthMethod.BEARER_TOKEN) {
-        if (!command.credentials) {
-          throw new McpValidationFailedError(
-            '',
-            command.name,
-            'Bearer token credentials are required',
-          );
-        }
+    const integration = this.factory.createIntegration({
+      kind: McpIntegrationKind.CUSTOM,
+      orgId,
+      name: command.name,
+      serverUrl: command.serverUrl,
+      auth,
+      returnsPii: command.returnsPii,
+    });
 
-        const encryptedToken = await this.credentialEncryption.encrypt(
-          command.credentials,
+    // Save integration first to get ID
+    const savedIntegration = await this.repository.save(integration);
+
+    // Validate connection (don't throw on failure)
+    await this.connectionValidationService.validateAndUpdateStatus(
+      savedIntegration,
+    );
+
+    // Return the updated integration
+    return savedIntegration;
+  }
+
+  private async buildCustomAuth(
+    authType: McpAuthMethod,
+    command: CreateCustomMcpIntegrationCommand,
+  ): Promise<McpIntegrationAuth> {
+    if (authType === McpAuthMethod.BEARER_TOKEN) {
+      if (!command.credentials) {
+        throw new McpValidationFailedError(
+          '',
+          command.name,
+          'Bearer token credentials are required',
         );
-
-        const auth = this.authFactory.createAuth({
-          method: McpAuthMethod.BEARER_TOKEN,
-          authToken: encryptedToken,
-        });
-
-        integration = this.factory.createIntegration({
-          kind: McpIntegrationKind.CUSTOM,
-          orgId,
-          name: command.name,
-          serverUrl: command.serverUrl,
-          auth,
-          returnsPii: command.returnsPii,
-        });
-      } else if (authType === McpAuthMethod.CUSTOM_HEADER) {
-        if (!command.credentials) {
-          throw new McpValidationFailedError(
-            '',
-            command.name,
-            'Header credentials are required',
-          );
-        }
-
-        const encryptedKey = await this.credentialEncryption.encrypt(
-          command.credentials,
-        );
-
-        const headerName = command.authHeaderName ?? 'X-API-Key';
-        const auth = this.authFactory.createAuth({
-          method: McpAuthMethod.CUSTOM_HEADER,
-          secret: encryptedKey,
-          headerName,
-        });
-
-        integration = this.factory.createIntegration({
-          kind: McpIntegrationKind.CUSTOM,
-          orgId,
-          name: command.name,
-          serverUrl: command.serverUrl,
-          auth,
-          returnsPii: command.returnsPii,
-        });
-      } else {
-        // NO_AUTH doesn't need any credentials
-        const auth = this.authFactory.createAuth({
-          method: McpAuthMethod.NO_AUTH,
-        });
-        integration = this.factory.createIntegration({
-          kind: McpIntegrationKind.CUSTOM,
-          orgId,
-          name: command.name,
-          serverUrl: command.serverUrl,
-          auth,
-          returnsPii: command.returnsPii,
-        });
       }
 
-      // Save integration first to get ID
-      const savedIntegration = await this.repository.save(integration);
-
-      // Validate connection (don't throw on failure)
-      await this.connectionValidationService.validateAndUpdateStatus(
-        savedIntegration,
+      const encryptedToken = await this.credentialEncryption.encrypt(
+        command.credentials,
       );
 
-      // Return the updated integration
-      return savedIntegration;
-    } catch (error) {
-      // Re-throw application errors and auth errors
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
+      return this.authFactory.createAuth({
+        method: McpAuthMethod.BEARER_TOKEN,
+        authToken: encryptedToken,
+      });
+    }
+
+    if (authType === McpAuthMethod.CUSTOM_HEADER) {
+      if (!command.credentials) {
+        throw new McpValidationFailedError(
+          '',
+          command.name,
+          'Header credentials are required',
+        );
       }
 
-      // Log and wrap unexpected errors
-      this.logger.error('Unexpected error creating custom integration', {
-        error: error as Error,
+      const encryptedKey = await this.credentialEncryption.encrypt(
+        command.credentials,
+      );
+
+      return this.authFactory.createAuth({
+        method: McpAuthMethod.CUSTOM_HEADER,
+        secret: encryptedKey,
+        headerName: command.authHeaderName ?? 'X-API-Key',
       });
-      throw new UnexpectedMcpError('Unexpected error occurred');
     }
+
+    // NO_AUTH doesn't need any credentials
+    return this.authFactory.createAuth({
+      method: McpAuthMethod.NO_AUTH,
+    });
   }
 
   private isValidUrl(url: string): boolean {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.spec.ts
@@ -219,8 +219,8 @@ describe('DeleteMcpIntegrationUseCase', () => {
         UnexpectedMcpError,
       );
       expect(loggerErrorSpy).toHaveBeenCalledWith(
-        'Unexpected error deleting integration',
-        { error: unexpectedError },
+        'Unexpected use-case error',
+        expect.any(String),
       );
     });
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { DeleteMcpIntegrationCommand } from './delete-mcp-integration.command';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
@@ -8,7 +9,6 @@ import {
   McpIntegrationAccessDeniedError,
   UnexpectedMcpError,
 } from '../../mcp.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 /**
  * Use case for deleting an MCP integration.
@@ -30,48 +30,33 @@ export class DeleteMcpIntegrationUseCase {
    * @throws McpIntegrationAccessDeniedError if integration belongs to different org
    * @throws UnauthorizedException if user not authenticated
    */
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(command: DeleteMcpIntegrationCommand): Promise<void> {
     this.logger.log('deleteMcpIntegration', { id: command.integrationId });
 
-    try {
-      // Get organization ID from context
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-
-      // Fetch existing integration
-      const integration = await this.repository.findById(command.integrationId);
-      if (!integration) {
-        throw new McpIntegrationNotFoundError(command.integrationId);
-      }
-
-      // Verify access
-      if (integration.orgId !== orgId) {
-        throw new McpIntegrationAccessDeniedError(command.integrationId);
-      }
-
-      // Delete associated user configs before deleting the integration
-      await this.userConfigRepository.deleteByIntegrationId(
-        command.integrationId,
-      );
-
-      // Delete integration
-      await this.repository.delete(command.integrationId);
-    } catch (error) {
-      // Re-throw application errors and auth errors
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-
-      // Log and wrap unexpected errors
-      this.logger.error('Unexpected error deleting integration', {
-        error: error as Error,
-      });
-      throw new UnexpectedMcpError('Unexpected error occurred');
+    // Get organization ID from context
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
     }
+
+    // Fetch existing integration
+    const integration = await this.repository.findById(command.integrationId);
+    if (!integration) {
+      throw new McpIntegrationNotFoundError(command.integrationId);
+    }
+
+    // Verify access
+    if (integration.orgId !== orgId) {
+      throw new McpIntegrationAccessDeniedError(command.integrationId);
+    }
+
+    // Delete associated user configs before deleting the integration
+    await this.userConfigRepository.deleteByIntegrationId(
+      command.integrationId,
+    );
+
+    // Delete integration
+    await this.repository.delete(command.integrationId);
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/disable-mcp-integration/disable-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/disable-mcp-integration/disable-mcp-integration.use-case.spec.ts
@@ -237,8 +237,8 @@ describe('DisableMcpIntegrationUseCase', () => {
         UnexpectedMcpError,
       );
       expect(loggerErrorSpy).toHaveBeenCalledWith(
-        'Unexpected error disabling integration',
-        { error: unexpectedError },
+        'Unexpected use-case error',
+        expect.any(String),
       );
     });
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/disable-mcp-integration/disable-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/disable-mcp-integration/disable-mcp-integration.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { DisableMcpIntegrationCommand } from './disable-mcp-integration.command';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -8,7 +9,6 @@ import {
   McpIntegrationAccessDeniedError,
   UnexpectedMcpError,
 } from '../../mcp.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class DisableMcpIntegrationUseCase {
@@ -19,43 +19,31 @@ export class DisableMcpIntegrationUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(
     command: DisableMcpIntegrationCommand,
   ): Promise<McpIntegration> {
     this.logger.log('disableMcpIntegration', { id: command.integrationId });
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-
-      const integration = await this.repository.findById(command.integrationId);
-      if (!integration) {
-        throw new McpIntegrationNotFoundError(command.integrationId);
-      }
-
-      // Verify organization access
-      if (integration.orgId !== orgId) {
-        throw new McpIntegrationAccessDeniedError(command.integrationId);
-      }
-
-      // Disable the integration (domain entity method)
-      integration.disable();
-
-      // Save and return the updated integration
-      return await this.repository.save(integration);
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-      this.logger.error('Unexpected error disabling integration', {
-        error: error as Error,
-      });
-      throw new UnexpectedMcpError('Unexpected error occurred');
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
     }
+
+    const integration = await this.repository.findById(command.integrationId);
+    if (!integration) {
+      throw new McpIntegrationNotFoundError(command.integrationId);
+    }
+
+    // Verify organization access
+    if (integration.orgId !== orgId) {
+      throw new McpIntegrationAccessDeniedError(command.integrationId);
+    }
+
+    // Disable the integration (domain entity method)
+    integration.disable();
+
+    // Save and return the updated integration
+    return await this.repository.save(integration);
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.spec.ts
@@ -25,7 +25,6 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
   let mcpClientService: jest.Mocked<McpClientService>;
   let contextService: jest.Mocked<ContextService>;
   let loggerLogSpy: jest.SpyInstance;
-  let loggerWarnSpy: jest.SpyInstance;
   let loggerErrorSpy: jest.SpyInstance;
 
   const mockOrgId = randomUUID();
@@ -113,7 +112,7 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
     contextService = module.get(ContextService);
 
     loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    loggerWarnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
     loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
@@ -232,10 +231,6 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
       ).rejects.toThrow(McpIntegrationNotFoundError);
 
       expect(mcpClientService.listTools).not.toHaveBeenCalled();
-      expect(loggerWarnSpy).toHaveBeenCalledWith(
-        'discoverMcpCapabilitiesFailed',
-        expect.objectContaining({ id: mockIntegrationId }),
-      );
     });
 
     it('throws McpIntegrationAccessDeniedError for different organization', async () => {
@@ -287,11 +282,8 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
       ).rejects.toThrow(UnexpectedMcpError);
 
       expect(loggerErrorSpy).toHaveBeenCalledWith(
-        'discoverMcpCapabilitiesUnexpectedError',
-        expect.objectContaining({
-          id: mockIntegrationId,
-          error: 'Connection timeout',
-        }),
+        'Unexpected use-case error',
+        expect.any(String),
       );
     });
   });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { DiscoverMcpCapabilitiesQuery } from './discover-mcp-capabilities.query';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import {
@@ -14,7 +15,6 @@ import {
   McpIntegrationDisabledError,
   UnexpectedMcpError,
 } from '../../mcp.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { McpTool } from '../../../domain/mcp-tool.entity';
 import {
   McpResource,
@@ -47,99 +47,96 @@ export class DiscoverMcpCapabilitiesUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(
     query: DiscoverMcpCapabilitiesQuery,
   ): Promise<CapabilitiesResult> {
     this.logger.log('discoverMcpCapabilities', { id: query.integrationId });
 
-    try {
-      // Get current user's organization
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
+    // Get current user's organization
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
+    }
 
-      // Fetch integration
-      const integration = await this.repository.findById(query.integrationId);
-      if (!integration) {
-        throw new McpIntegrationNotFoundError(query.integrationId);
-      }
+    // Fetch integration
+    const integration = await this.repository.findById(query.integrationId);
+    if (!integration) {
+      throw new McpIntegrationNotFoundError(query.integrationId);
+    }
 
-      // Verify organization access
-      if (integration.orgId !== orgId) {
-        throw new McpIntegrationAccessDeniedError(
-          query.integrationId,
-          integration.name,
-        );
-      }
-
-      // Verify integration is enabled
-      if (!integration.enabled) {
-        throw new McpIntegrationDisabledError(
-          query.integrationId,
-          integration.name,
-        );
-      }
-
-      // Discover capabilities from MCP server
-      const userId = this.contextService.get('userId');
-      const [tools, resources, resourceTemplates, prompts] = await Promise.all([
-        this.mcpClientService.listTools(integration, userId),
-        this.mcpClientService.listResources(integration, userId),
-        this.mcpClientService.listResourceTemplates(integration, userId),
-        this.mcpClientService.listPrompts(integration, userId),
-      ]);
-
-      // Map to domain entities
-      const mcpTools = tools.map((tool) =>
-        this.mapToMcpTool(tool, query.integrationId),
-      );
-      const mcpResources = resources.map((resource) =>
-        this.mapToMcpResource(resource, query.integrationId),
-      );
-      const mcpResourceTemplates = resourceTemplates.map((resourceTemplate) =>
-        this.mapToMcpResource(resourceTemplate, query.integrationId),
-      );
-      const mcpPrompts = prompts.map((prompt) =>
-        this.mapToMcpPrompt(prompt, query.integrationId),
-      );
-
-      this.logger.log('discoverMcpCapabilitiesSucceeded', {
-        id: query.integrationId,
-        name: integration.name,
-        tools: mcpTools.length,
-        resources: mcpResources.length + mcpResourceTemplates.length,
-        prompts: mcpPrompts.length,
-      });
-
-      return {
-        tools: mcpTools,
-        resources: mcpResources.concat(mcpResourceTemplates),
-        prompts: mcpPrompts,
-        returnsPii: integration.returnsPii,
-      };
-    } catch (error) {
-      // Re-throw expected errors
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        this.logger.warn('discoverMcpCapabilitiesFailed', {
-          id: query.integrationId,
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
-        throw error;
-      }
-
-      // Wrap unexpected errors
-      this.logger.error('discoverMcpCapabilitiesUnexpectedError', {
-        id: query.integrationId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedMcpError(
-        error instanceof Error ? error.message : 'Unknown error',
+    // Verify organization access
+    if (integration.orgId !== orgId) {
+      throw new McpIntegrationAccessDeniedError(
+        query.integrationId,
+        integration.name,
       );
     }
+
+    // Verify integration is enabled
+    if (!integration.enabled) {
+      throw new McpIntegrationDisabledError(
+        query.integrationId,
+        integration.name,
+      );
+    }
+
+    // Discover capabilities from MCP server
+    const userId = this.contextService.get('userId');
+    const [tools, resources, resourceTemplates, prompts] = await Promise.all([
+      this.mcpClientService.listTools(integration, userId),
+      this.mcpClientService.listResources(integration, userId),
+      this.mcpClientService.listResourceTemplates(integration, userId),
+      this.mcpClientService.listPrompts(integration, userId),
+    ]);
+
+    return this.buildCapabilitiesResult(query.integrationId, integration, {
+      tools,
+      resources,
+      resourceTemplates,
+      prompts,
+    });
+  }
+
+  private buildCapabilitiesResult(
+    integrationId: UUID,
+    integration: { name: string; returnsPii: boolean },
+    discovered: {
+      tools: McpToolDto[];
+      resources: McpResourceDto[];
+      resourceTemplates: McpResourceDto[];
+      prompts: McpPromptDto[];
+    },
+  ): CapabilitiesResult {
+    // Map to domain entities
+    const mcpTools = discovered.tools.map((tool) =>
+      this.mapToMcpTool(tool, integrationId),
+    );
+    const mcpResources = discovered.resources.map((resource) =>
+      this.mapToMcpResource(resource, integrationId),
+    );
+    const mcpResourceTemplates = discovered.resourceTemplates.map(
+      (resourceTemplate) =>
+        this.mapToMcpResource(resourceTemplate, integrationId),
+    );
+    const mcpPrompts = discovered.prompts.map((prompt) =>
+      this.mapToMcpPrompt(prompt, integrationId),
+    );
+
+    this.logger.log('discoverMcpCapabilitiesSucceeded', {
+      id: integrationId,
+      name: integration.name,
+      tools: mcpTools.length,
+      resources: mcpResources.length + mcpResourceTemplates.length,
+      prompts: mcpPrompts.length,
+    });
+
+    return {
+      tools: mcpTools,
+      resources: mcpResources.concat(mcpResourceTemplates),
+      prompts: mcpPrompts,
+      returnsPii: integration.returnsPii,
+    };
   }
 
   /**

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/enable-mcp-integration/enable-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/enable-mcp-integration/enable-mcp-integration.use-case.spec.ts
@@ -242,8 +242,8 @@ describe('EnableMcpIntegrationUseCase', () => {
         UnexpectedMcpError,
       );
       expect(loggerErrorSpy).toHaveBeenCalledWith(
-        'Unexpected error enabling integration',
-        { error: unexpectedError },
+        'Unexpected use-case error',
+        expect.any(String),
       );
     });
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/enable-mcp-integration/enable-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/enable-mcp-integration/enable-mcp-integration.use-case.ts
@@ -1,9 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { EnableMcpIntegrationCommand } from './enable-mcp-integration.command';
 import { McpIntegration } from '../../../domain/mcp-integration.entity';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { UnexpectedMcpError } from '../../mcp.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
 
 @Injectable()
@@ -15,26 +15,17 @@ export class EnableMcpIntegrationUseCase {
     private readonly validateIntegrationAccess: ValidateIntegrationAccessService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(command: EnableMcpIntegrationCommand): Promise<McpIntegration> {
     this.logger.log('enableMcpIntegration', { id: command.integrationId });
 
-    try {
-      const integration = await this.validateIntegrationAccess.validate(
-        command.integrationId,
-        { requireEnabled: false },
-      );
+    const integration = await this.validateIntegrationAccess.validate(
+      command.integrationId,
+      { requireEnabled: false },
+    );
 
-      integration.enable();
+    integration.enable();
 
-      return await this.repository.save(integration);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Unexpected error enabling integration', {
-        error: error as Error,
-      });
-      throw new UnexpectedMcpError('Unexpected error occurred');
-    }
+    return await this.repository.save(integration);
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ExecuteMcpToolCommand } from './execute-mcp-tool.command';
 import { McpToolCall } from '../../ports/mcp-client.port';
 import { McpClientService } from '../../services/mcp-client.service';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnexpectedMcpError } from '../../mcp.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
 
 /**
@@ -26,74 +26,55 @@ export class ExecuteMcpToolUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(command: ExecuteMcpToolCommand): Promise<ToolExecutionResult> {
     const startTime = Date.now();
     this.logger.log(
       `[MCP] operation=execute_tool integration=${command.integrationId} tool="${command.toolName}" status=started`,
     );
 
+    const integration = await this.validateIntegrationAccess.validate(
+      command.integrationId,
+    );
+
+    // Execute tool (errors are caught and returned, not thrown)
     try {
-      const integration = await this.validateIntegrationAccess.validate(
-        command.integrationId,
+      const userId = this.contextService.get('userId');
+      const toolCall: McpToolCall = {
+        toolName: command.toolName,
+        parameters: command.parameters,
+      };
+
+      const result = await this.mcpClientService.callTool(
+        integration,
+        toolCall,
+        userId,
       );
 
-      // Execute tool (errors are caught and returned, not thrown)
-      try {
-        const userId = this.contextService.get('userId');
-        const toolCall: McpToolCall = {
-          toolName: command.toolName,
-          parameters: command.parameters,
-        };
-
-        const result = await this.mcpClientService.callTool(
-          integration,
-          toolCall,
-          userId,
-        );
-
-        const duration = Date.now() - startTime;
-        this.logger.log(
-          `[MCP] operation=execute_tool integration=${command.integrationId} name="${integration.name}" tool="${command.toolName}" status=${result.isError ? 'tool_error' : 'success'} duration=${duration}ms`,
-        );
-
-        return {
-          isError: result.isError,
-          content: result.content,
-          ...(result.isError && { errorMessage: 'Tool execution failed' }),
-        };
-      } catch (toolError) {
-        const duration = Date.now() - startTime;
-        const errorMsg =
-          (toolError as Error).message || 'Tool execution failed';
-
-        this.logger.warn(
-          `[MCP] operation=execute_tool integration=${command.integrationId} name="${integration.name}" tool="${command.toolName}" status=error error="${errorMsg}" duration=${duration}ms`,
-        );
-
-        // Return error to LLM (don't throw)
-        return {
-          isError: true,
-          content: null,
-          errorMessage: errorMsg,
-        };
-      }
-    } catch (error) {
       const duration = Date.now() - startTime;
-
-      if (error instanceof ApplicationError) {
-        this.logger.warn(
-          `[MCP] operation=execute_tool integration=${command.integrationId} tool="${command.toolName}" status=error error="${error.message}" duration=${duration}ms`,
-        );
-        throw error;
-      }
-
-      this.logger.error(
-        `[MCP] operation=execute_tool integration=${command.integrationId} tool="${command.toolName}" status=unexpected_error error="${(error as Error).message}" duration=${duration}ms`,
-        { error: error as Error },
+      this.logger.log(
+        `[MCP] operation=execute_tool integration=${command.integrationId} name="${integration.name}" tool="${command.toolName}" status=${result.isError ? 'tool_error' : 'success'} duration=${duration}ms`,
       );
-      throw new UnexpectedMcpError(
-        'Unexpected error occurred during tool execution',
+
+      return {
+        isError: result.isError,
+        content: result.content,
+        ...(result.isError && { errorMessage: 'Tool execution failed' }),
+      };
+    } catch (toolError) {
+      const duration = Date.now() - startTime;
+      const errorMsg = (toolError as Error).message || 'Tool execution failed';
+
+      this.logger.warn(
+        `[MCP] operation=execute_tool integration=${command.integrationId} name="${integration.name}" tool="${command.toolName}" status=error error="${errorMsg}" duration=${duration}ms`,
       );
+
+      // Return error to LLM (don't throw)
+      return {
+        isError: true,
+        content: null,
+        errorMessage: errorMsg,
+      };
     }
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-integration/get-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-integration/get-mcp-integration.use-case.spec.ts
@@ -186,8 +186,8 @@ describe('GetMcpIntegrationUseCase', () => {
       // Act & Assert
       await expect(useCase.execute(query)).rejects.toThrow(UnexpectedMcpError);
       expect(loggerErrorSpy).toHaveBeenCalledWith(
-        'Unexpected error getting integration',
-        { error: unexpectedError },
+        'Unexpected use-case error',
+        expect.any(String),
       );
     });
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-integration/get-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-integration/get-mcp-integration.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetMcpIntegrationQuery } from './get-mcp-integration.query';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -8,7 +9,6 @@ import {
   McpIntegrationAccessDeniedError,
   UnexpectedMcpError,
 } from '../../mcp.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetMcpIntegrationUseCase {
@@ -19,37 +19,25 @@ export class GetMcpIntegrationUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(query: GetMcpIntegrationQuery): Promise<McpIntegration> {
     this.logger.log('getMcpIntegration', { id: query.integrationId });
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-
-      const integration = await this.repository.findById(query.integrationId);
-      if (!integration) {
-        throw new McpIntegrationNotFoundError(query.integrationId);
-      }
-
-      // Verify organization access
-      if (integration.orgId !== orgId) {
-        throw new McpIntegrationAccessDeniedError(query.integrationId);
-      }
-
-      return integration;
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-      this.logger.error('Unexpected error getting integration', {
-        error: error as Error,
-      });
-      throw new UnexpectedMcpError('Unexpected error occurred');
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
     }
+
+    const integration = await this.repository.findById(query.integrationId);
+    if (!integration) {
+      throw new McpIntegrationNotFoundError(query.integrationId);
+    }
+
+    // Verify organization access
+    if (integration.orgId !== orgId) {
+      throw new McpIntegrationAccessDeniedError(query.integrationId);
+    }
+
+    return integration;
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.use-case.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetMcpIntegrationsByIdsQuery } from './get-mcp-integrations-by-ids.query';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
 import { McpIntegration } from '../../../domain/mcp-integration.entity';
 import { UnexpectedMcpError } from '../../mcp.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 /**
  * Use case for fetching multiple MCP integrations by their IDs in a single query.
@@ -25,6 +25,7 @@ export class GetMcpIntegrationsByIdsUseCase {
    * @param query Query containing the integration IDs
    * @returns Array of McpIntegration entities (missing/unauthorized IDs omitted)
    */
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(
     query: GetMcpIntegrationsByIdsQuery,
   ): Promise<McpIntegration[]> {
@@ -32,33 +33,18 @@ export class GetMcpIntegrationsByIdsUseCase {
       count: query.integrationIds.length,
     });
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-
-      if (query.integrationIds.length === 0) {
-        return [];
-      }
-
-      const integrations = await this.repository.findByIds(
-        query.integrationIds,
-      );
-
-      // Filter to only return integrations belonging to user's organization
-      return integrations.filter((integration) => integration.orgId === orgId);
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-      this.logger.error('Unexpected error getting integrations by IDs', {
-        error: error as Error,
-      });
-      throw new UnexpectedMcpError('Unexpected error occurred');
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
     }
+
+    if (query.integrationIds.length === 0) {
+      return [];
+    }
+
+    const integrations = await this.repository.findByIds(query.integrationIds);
+
+    // Filter to only return integrations belonging to user's organization
+    return integrations.filter((integration) => integration.orgId === orgId);
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-prompt/get-mcp-prompt.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-prompt/get-mcp-prompt.use-case.spec.ts
@@ -407,8 +407,8 @@ describe('GetMcpPromptUseCase', () => {
       // Act & Assert
       await expect(useCase.execute(query)).rejects.toThrow(UnexpectedMcpError);
       expect(loggerErrorSpy).toHaveBeenCalledWith(
-        'Unexpected error getting prompt',
-        { error: unexpectedError },
+        'Unexpected use-case error',
+        expect.any(String),
       );
     });
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-prompt/get-mcp-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-prompt/get-mcp-prompt.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetMcpPromptQuery } from './get-mcp-prompt.query';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpClientService } from '../../services/mcp-client.service';
@@ -9,7 +10,6 @@ import {
   McpIntegrationDisabledError,
   UnexpectedMcpError,
 } from '../../mcp.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 export interface PromptMessage {
   role: string;
@@ -41,69 +41,57 @@ export class GetMcpPromptUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(query: GetMcpPromptQuery): Promise<PromptResult> {
     this.logger.log('getMcpPrompt', {
       id: query.integrationId,
       prompt: query.promptName,
     });
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-
-      const integration = await this.repository.findById(query.integrationId);
-      if (!integration) {
-        throw new McpIntegrationNotFoundError(query.integrationId);
-      }
-
-      if (integration.orgId !== orgId) {
-        throw new McpIntegrationAccessDeniedError(query.integrationId);
-      }
-
-      if (!integration.enabled) {
-        throw new McpIntegrationDisabledError(query.integrationId);
-      }
-
-      // Retrieve prompt from MCP server
-      const userId = this.contextService.get('userId');
-      const promptResponse = await this.mcpClientService.getPrompt(
-        integration,
-        query.promptName,
-        query.args || {},
-        userId,
-      );
-
-      this.logger.log('promptRetrieved', {
-        id: query.integrationId,
-        prompt: query.promptName,
-        messageCount: promptResponse.messages.length,
-      });
-
-      // Map to PromptResult
-      const response = promptResponse as McpPromptResponse;
-      return {
-        messages: response.messages.map((msg) => ({
-          role: msg.role,
-          content:
-            typeof msg.content === 'string'
-              ? msg.content
-              : (msg.content.text ?? JSON.stringify(msg.content)),
-        })),
-        description: response.description,
-      };
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-      this.logger.error('Unexpected error getting prompt', {
-        error: error as Error,
-      });
-      throw new UnexpectedMcpError('Unexpected error occurred');
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
     }
+
+    const integration = await this.repository.findById(query.integrationId);
+    if (!integration) {
+      throw new McpIntegrationNotFoundError(query.integrationId);
+    }
+
+    if (integration.orgId !== orgId) {
+      throw new McpIntegrationAccessDeniedError(query.integrationId);
+    }
+
+    if (!integration.enabled) {
+      throw new McpIntegrationDisabledError(query.integrationId);
+    }
+
+    // Retrieve prompt from MCP server
+    const userId = this.contextService.get('userId');
+    const promptResponse = await this.mcpClientService.getPrompt(
+      integration,
+      query.promptName,
+      query.args ?? {},
+      userId,
+    );
+
+    this.logger.log('promptRetrieved', {
+      id: query.integrationId,
+      prompt: query.promptName,
+      messageCount: promptResponse.messages.length,
+    });
+
+    // Map to PromptResult
+    const response = promptResponse as McpPromptResponse;
+    return {
+      messages: response.messages.map((msg) => ({
+        role: msg.role,
+        content:
+          typeof msg.content === 'string'
+            ? msg.content
+            : (msg.content.text ?? JSON.stringify(msg.content)),
+      })),
+      description: response.description,
+    };
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetUserMcpConfigQuery } from './get-user-mcp-config.query';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
@@ -7,6 +8,7 @@ import {
   McpIntegrationNotFoundError,
   McpIntegrationAccessDeniedError,
   McpNotMarketplaceIntegrationError,
+  UnexpectedMcpError,
 } from '../../mcp.errors';
 import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
 import { McpIntegration } from '../../../domain/mcp-integration.entity';
@@ -28,6 +30,7 @@ export class GetUserMcpConfigUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(query: GetUserMcpConfigQuery): Promise<UserMcpConfigResult> {
     this.logger.log('execute', { integrationId: query.integrationId });
 
@@ -79,7 +82,7 @@ export class GetUserMcpConfigUseCase {
   private getSecretKeys(integration: McpIntegration): Set<string> {
     if (integration instanceof MarketplaceMcpIntegration) {
       return new Set(
-        (integration.configSchema.userFields ?? [])
+        integration.configSchema.userFields
           .filter((f) => f.type === 'secret')
           .map((f) => f.key),
       );

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.ts
@@ -1,5 +1,7 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { InstallMarketplaceIntegrationCommand } from './install-marketplace-integration.command';
 import { GetMarketplaceIntegrationUseCase } from 'src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case';
 import { GetMarketplaceIntegrationQuery } from 'src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.query';
@@ -49,7 +51,6 @@ import {
   DuplicateMarketplaceMcpIntegrationError,
   UnexpectedMcpError,
 } from '../../mcp.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class InstallMarketplaceIntegrationUseCase {
@@ -68,6 +69,7 @@ export class InstallMarketplaceIntegrationUseCase {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(
     command: InstallMarketplaceIntegrationCommand,
   ): Promise<MarketplaceMcpIntegration> {
@@ -79,102 +81,109 @@ export class InstallMarketplaceIntegrationUseCase {
       throw new UnauthorizedException('User not authenticated');
     }
 
-    try {
-      const marketplaceIntegration =
-        await this.getMarketplaceIntegrationUseCase.execute(
-          new GetMarketplaceIntegrationQuery(command.identifier),
-        );
-
-      const existing =
-        await this.repository.findByOrgIdAndMarketplaceIdentifier(
-          orgId,
-          command.identifier,
-        );
-
-      if (existing) {
-        throw new DuplicateMarketplaceMcpIntegrationError(command.identifier);
-      }
-
-      const configSchema = this.parseConfigSchema(
-        marketplaceIntegration.configSchema,
+    const marketplaceIntegration =
+      await this.getMarketplaceIntegrationUseCase.execute(
+        new GetMarketplaceIntegrationQuery(command.identifier),
       );
 
-      if (configSchema.authType === (McpAuthMethod.OAUTH as string)) {
-        throw new McpOAuthNotSupportedError();
-      }
+    const existing = await this.repository.findByOrgIdAndMarketplaceIdentifier(
+      orgId,
+      command.identifier,
+    );
 
-      const mergedValues = this.marketplaceConfigService.mergeFixedValues(
-        command.orgConfigValues,
-        configSchema.orgFields,
-      );
+    if (existing) {
+      throw new DuplicateMarketplaceMcpIntegrationError(command.identifier);
+    }
 
-      this.marketplaceConfigService.validateRequiredFields(
+    const configSchema = this.parseConfigSchema(
+      marketplaceIntegration.configSchema,
+    );
+
+    if (configSchema.authType === (McpAuthMethod.OAUTH as string)) {
+      throw new McpOAuthNotSupportedError();
+    }
+
+    const integration = await this.buildIntegration(
+      command,
+      marketplaceIntegration,
+      configSchema,
+      orgId,
+    );
+
+    const saved = await this.repository.save(integration);
+
+    const validated =
+      await this.connectionValidationService.validateAndUpdateStatus(saved);
+
+    this.emitInstalledEvent(userId, orgId, marketplaceIntegration.identifier);
+
+    return validated as MarketplaceMcpIntegration;
+  }
+
+  private async buildIntegration(
+    command: InstallMarketplaceIntegrationCommand,
+    marketplaceIntegration: {
+      name: string;
+      serverUrl: string;
+      logoUrl?: string | null;
+    },
+    configSchema: IntegrationConfigSchema,
+    orgId: UUID,
+  ) {
+    const mergedValues = this.marketplaceConfigService.mergeFixedValues(
+      command.orgConfigValues,
+      configSchema.orgFields,
+    );
+
+    this.marketplaceConfigService.validateRequiredFields(
+      configSchema.orgFields,
+      mergedValues,
+    );
+
+    const encryptedValues =
+      await this.marketplaceConfigService.encryptSecretFields(
         configSchema.orgFields,
         mergedValues,
       );
 
-      const encryptedValues =
-        await this.marketplaceConfigService.encryptSecretFields(
-          configSchema.orgFields,
-          mergedValues,
-        );
+    const auth = this.authFactory.createAuth({
+      method: McpAuthMethod.NO_AUTH,
+    });
 
-      const auth = this.authFactory.createAuth({
-        method: McpAuthMethod.NO_AUTH,
-      });
+    return this.factory.createIntegration({
+      kind: McpIntegrationKind.MARKETPLACE,
+      orgId,
+      name: marketplaceIntegration.name,
+      serverUrl: marketplaceIntegration.serverUrl,
+      auth,
+      marketplaceIdentifier: command.identifier,
+      configSchema,
+      orgConfigValues: encryptedValues,
+      returnsPii: command.returnsPii,
+      logoUrl: marketplaceIntegration.logoUrl ?? null,
+    });
+  }
 
-      const integration = this.factory.createIntegration({
-        kind: McpIntegrationKind.MARKETPLACE,
-        orgId,
-        name: marketplaceIntegration.name,
-        serverUrl: marketplaceIntegration.serverUrl,
-        auth,
-        marketplaceIdentifier: command.identifier,
-        configSchema,
-        orgConfigValues: encryptedValues,
-        returnsPii: command.returnsPii,
-        logoUrl: marketplaceIntegration.logoUrl ?? null,
-      });
-
-      const saved = await this.repository.save(integration);
-
-      const validated =
-        await this.connectionValidationService.validateAndUpdateStatus(saved);
-
-      this.eventEmitter
-        .emitAsync(
-          MarketplaceIntegrationInstalledEvent.EVENT_NAME,
-          new MarketplaceIntegrationInstalledEvent(
-            userId,
+  private emitInstalledEvent(
+    userId: UUID,
+    orgId: UUID,
+    identifier: string,
+  ): void {
+    this.eventEmitter
+      .emitAsync(
+        MarketplaceIntegrationInstalledEvent.EVENT_NAME,
+        new MarketplaceIntegrationInstalledEvent(userId, orgId, identifier),
+      )
+      .catch((err: unknown) => {
+        this.logger.error(
+          'Failed to emit MarketplaceIntegrationInstalledEvent',
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            identifier,
             orgId,
-            marketplaceIntegration.identifier,
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error(
-            'Failed to emit MarketplaceIntegrationInstalledEvent',
-            {
-              error: err instanceof Error ? err.message : 'Unknown error',
-              identifier: marketplaceIntegration.identifier,
-              orgId,
-            },
-          );
-        });
-
-      return validated as MarketplaceMcpIntegration;
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-      this.logger.error('Unexpected error installing marketplace integration', {
-        identifier: command.identifier,
-        error: error instanceof Error ? error.message : 'Unknown error',
+          },
+        );
       });
-      throw new UnexpectedMcpError('Unexpected error occurred');
-    }
   }
 
   private parseConfigSchema(

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/list-available-mcp-integrations/list-available-mcp-integrations.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/list-available-mcp-integrations/list-available-mcp-integrations.use-case.ts
@@ -1,11 +1,11 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
 import { McpIntegration } from '../../../domain/mcp-integration.entity';
 import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedMcpError } from '../../mcp.errors';
 
 /**
@@ -40,44 +40,29 @@ export class ListAvailableMcpIntegrationsUseCase {
    * @throws UnauthorizedException if user is not authenticated
    * @throws UnexpectedMcpError if an unexpected error occurs
    */
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(): Promise<AvailableMcpIntegration[]> {
     this.logger.log('listAvailableMcpIntegrations');
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-
-      const integrations = await this.repository.findAll(orgId, {
-        enabled: true,
-      });
-
-      const userId = this.contextService.get('userId');
-      const userConfigValues = await this.loadUserConfigValues(
-        integrations,
-        userId,
-      );
-
-      return integrations.map((integration) => ({
-        integration,
-        userAuthorized: this.resolveUserAuthorized(
-          integration,
-          userConfigValues,
-        ),
-      }));
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-      this.logger.error('Unexpected error listing available integrations', {
-        error: error as Error,
-      });
-      throw new UnexpectedMcpError('Unexpected error occurred');
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
     }
+
+    const integrations = await this.repository.findAll(orgId, {
+      enabled: true,
+    });
+
+    const userId = this.contextService.get('userId');
+    const userConfigValues = await this.loadUserConfigValues(
+      integrations,
+      userId,
+    );
+
+    return integrations.map((integration) => ({
+      integration,
+      userAuthorized: this.resolveUserAuthorized(integration, userConfigValues),
+    }));
   }
 
   /**

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/list-org-mcp-integrations/list-org-mcp-integrations.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/list-org-mcp-integrations/list-org-mcp-integrations.use-case.spec.ts
@@ -161,8 +161,8 @@ describe('ListOrgMcpIntegrationsUseCase', () => {
       // Act & Assert
       await expect(useCase.execute()).rejects.toThrow(UnexpectedMcpError);
       expect(loggerErrorSpy).toHaveBeenCalledWith(
-        'Unexpected error listing integrations',
-        { error: unexpectedError },
+        'Unexpected use-case error',
+        expect.any(String),
       );
     });
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/list-org-mcp-integrations/list-org-mcp-integrations.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/list-org-mcp-integrations/list-org-mcp-integrations.use-case.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
 import { McpIntegration } from '../../../domain/mcp-integration.entity';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedMcpError } from '../../mcp.errors';
 
 /**
@@ -24,27 +24,15 @@ export class ListOrgMcpIntegrationsUseCase {
    * @throws UnauthorizedException if user is not authenticated
    * @throws UnexpectedMcpError if an unexpected error occurs
    */
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(): Promise<McpIntegration[]> {
     this.logger.log('listOrgMcpIntegrations');
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-
-      return await this.repository.findAll(orgId);
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-      this.logger.error('Unexpected error listing integrations', {
-        error: error as Error,
-      });
-      throw new UnexpectedMcpError('Unexpected error occurred');
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
     }
+
+    return await this.repository.findAll(orgId);
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/list-predefined-mcp-integration-configs/list-predefined-mcp-integration-configs.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/list-predefined-mcp-integration-configs/list-predefined-mcp-integration-configs.use-case.ts
@@ -33,7 +33,9 @@ export class ListPredefinedMcpIntegrationConfigsUseCase {
       this.logger.error('Unexpected error listing predefined configs', {
         error: error as Error,
       });
-      throw new UnexpectedMcpError('Unexpected error occurred');
+      throw new UnexpectedMcpError(
+        error instanceof Error ? error : new Error(String(error)),
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.use-case.spec.ts
@@ -222,11 +222,10 @@ describe('RetrieveMcpResourceUseCase', () => {
         ),
       ).rejects.toThrow(UnexpectedMcpError);
 
-      expect(loggerErrorSpy).toHaveBeenCalledWith('retrieveMcpResourceFailed', {
-        integrationId: mockIntegrationId,
-        resourceUri: mockResourceUri,
-        error: 'Network failure',
-      });
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'Unexpected use-case error',
+        expect.any(String),
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.use-case.ts
@@ -1,9 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { RetrieveMcpResourceCommand } from './retrieve-mcp-resource.command';
 import { McpClientService } from '../../services/mcp-client.service';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnexpectedMcpError } from '../../mcp.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
 
 @Injectable()
@@ -16,6 +16,7 @@ export class RetrieveMcpResourceUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(
     command: RetrieveMcpResourceCommand,
   ): Promise<{ content: unknown; mimeType: string }> {
@@ -24,34 +25,20 @@ export class RetrieveMcpResourceUseCase {
       resourceUri: command.resourceUri,
       parameters: command.parameters,
     });
-    try {
-      const integration = await this.validateIntegrationAccess.validate(
-        command.integrationId,
-      );
 
-      // Retrieve resource content with parameters (for URI template substitution)
-      const userId = this.contextService.get('userId');
-      const { content, mimeType } = await this.mcpClientService.readResource(
-        integration,
-        command.resourceUri,
-        command.parameters,
-        userId,
-      );
+    const integration = await this.validateIntegrationAccess.validate(
+      command.integrationId,
+    );
 
-      return { content, mimeType };
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
+    // Retrieve resource content with parameters (for URI template substitution)
+    const userId = this.contextService.get('userId');
+    const { content, mimeType } = await this.mcpClientService.readResource(
+      integration,
+      command.resourceUri,
+      command.parameters,
+      userId,
+    );
 
-      this.logger.error('retrieveMcpResourceFailed', {
-        integrationId: command.integrationId,
-        resourceUri: command.resourceUri,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedMcpError(
-        error instanceof Error ? error.message : 'Unknown error',
-      );
-    }
+    return { content, mimeType };
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SetUserMcpConfigCommand } from './set-user-mcp-config.command';
 import { UserMcpConfigResult } from '../get-user-mcp-config/get-user-mcp-config.use-case';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
@@ -16,6 +17,7 @@ import {
   McpNotMarketplaceIntegrationError,
   McpNoUserFieldsError,
   McpInvalidConfigKeysError,
+  UnexpectedMcpError,
 } from '../../mcp.errors';
 
 @Injectable()
@@ -29,20 +31,13 @@ export class SetUserMcpConfigUseCase {
     private readonly marketplaceConfigService: MarketplaceConfigService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(
     command: SetUserMcpConfigCommand,
   ): Promise<UserMcpConfigResult> {
     this.logger.log('execute', { integrationId: command.integrationId });
 
-    const userId = this.contextService.get('userId');
-    if (!userId) {
-      throw new UnauthorizedException('User not authenticated');
-    }
-
-    const orgId = this.contextService.get('orgId');
-    if (!orgId) {
-      throw new UnauthorizedException('User not authenticated');
-    }
+    const { userId, orgId } = this.getAuthContext();
 
     const integration = await this.integrationRepository.findById(
       command.integrationId,
@@ -63,7 +58,7 @@ export class SetUserMcpConfigUseCase {
     const marketplaceIntegration = integration as MarketplaceMcpIntegration;
     const { userFields } = marketplaceIntegration.configSchema;
 
-    if (!userFields || userFields.length === 0) {
+    if (userFields.length === 0) {
       throw new McpNoUserFieldsError(command.integrationId);
     }
 
@@ -95,6 +90,20 @@ export class SetUserMcpConfigUseCase {
     return this.maskResult(saved.configValues, userFields);
   }
 
+  private getAuthContext(): { userId: UUID; orgId: UUID } {
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedException('User not authenticated');
+    }
+
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
+    }
+
+    return { userId, orgId };
+  }
+
   private validateConfigKeys(
     userFields: ConfigField[],
     values: Record<string, string>,
@@ -124,18 +133,18 @@ export class SetUserMcpConfigUseCase {
       const provided = providedValues[field.key];
       const existing = existingValues[field.key];
 
-      if (provided === SECRET_MASK && existing !== undefined) {
+      if (provided === SECRET_MASK && field.key in existingValues) {
         merged[field.key] = existing;
       } else if (provided === SECRET_MASK) {
         // SECRET_MASK with no existing value — skip, don't store the mask literal
-      } else if (provided !== undefined) {
+      } else if (field.key in providedValues) {
         merged[field.key] =
           field.type === 'secret'
             ? await this.marketplaceConfigService
                 .encryptSecretFields([field], { [field.key]: provided })
                 .then((r) => r[field.key])
             : provided;
-      } else if (existing !== undefined) {
+      } else if (field.key in existingValues) {
         merged[field.key] = existing;
       }
     }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UpdateMcpIntegrationCommand } from './update-mcp-integration.command';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -9,7 +10,6 @@ import {
   McpNotMarketplaceIntegrationError,
   UnexpectedMcpError,
 } from '../../mcp.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { McpIntegration } from '../../../domain/mcp-integration.entity';
 import { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
 import { McpAuthMethod } from '../../../domain/value-objects/mcp-auth-method.enum';
@@ -32,70 +32,58 @@ export class UpdateMcpIntegrationUseCase {
     private readonly connectionValidationService: ConnectionValidationService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(command: UpdateMcpIntegrationCommand): Promise<McpIntegration> {
     this.logger.log('updateMcpIntegration', { id: command.integrationId });
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-
-      const integration = await this.repository.findById(
-        command.integrationId as UUID,
-      );
-      if (!integration) {
-        throw new McpIntegrationNotFoundError(command.integrationId);
-      }
-
-      if (integration.orgId !== orgId) {
-        throw new McpIntegrationAccessDeniedError(command.integrationId);
-      }
-
-      // Update fields (only if provided)
-      if (command.name !== undefined) {
-        integration.updateName(command.name);
-      }
-
-      if (command.returnsPii !== undefined) {
-        integration.updateReturnsPii(command.returnsPii);
-      }
-
-      if (
-        command.credentials !== undefined ||
-        command.authHeaderName !== undefined
-      ) {
-        await this.rotateCredentials(
-          integration,
-          command.credentials,
-          command.authHeaderName,
-        );
-      }
-
-      if (command.orgConfigValues !== undefined) {
-        await this.updateOrgConfigValues(integration, command.orgConfigValues);
-      }
-
-      let saved = await this.repository.save(integration);
-
-      if (command.orgConfigValues !== undefined) {
-        saved =
-          await this.connectionValidationService.validateAndUpdateStatus(saved);
-      }
-
-      return saved;
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-      this.logger.error('Unexpected error updating integration', {
-        error: error as Error,
-      });
-      throw new UnexpectedMcpError('Unexpected error occurred');
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
     }
+
+    const integration = await this.repository.findById(
+      command.integrationId as UUID,
+    );
+    if (!integration) {
+      throw new McpIntegrationNotFoundError(command.integrationId);
+    }
+
+    if (integration.orgId !== orgId) {
+      throw new McpIntegrationAccessDeniedError(command.integrationId);
+    }
+
+    // Update fields (only if provided)
+    if (command.name !== undefined) {
+      integration.updateName(command.name);
+    }
+
+    if (command.returnsPii !== undefined) {
+      integration.updateReturnsPii(command.returnsPii);
+    }
+
+    if (
+      command.credentials !== undefined ||
+      command.authHeaderName !== undefined
+    ) {
+      await this.rotateCredentials(
+        integration,
+        command.credentials,
+        command.authHeaderName,
+      );
+    }
+
+    if (command.orgConfigValues !== undefined) {
+      await this.updateOrgConfigValues(integration, command.orgConfigValues);
+    }
+
+    let saved = await this.repository.save(integration);
+
+    if (command.orgConfigValues !== undefined) {
+      saved =
+        await this.connectionValidationService.validateAndUpdateStatus(saved);
+    }
+
+    return saved;
   }
 
   private async updateOrgConfigValues(
@@ -120,74 +108,79 @@ export class UpdateMcpIntegrationUseCase {
     credentials?: string,
     authHeaderName?: string,
   ): Promise<void> {
-    const auth = integration.auth;
-    const authMethod = auth.getMethod();
+    const authMethod = integration.auth.getMethod();
 
     switch (authMethod) {
-      case McpAuthMethod.NO_AUTH: {
+      case McpAuthMethod.BEARER_TOKEN:
+        return this.rotateBearerToken(integration, credentials, authHeaderName);
+      case McpAuthMethod.CUSTOM_HEADER:
+        return this.rotateCustomHeader(
+          integration,
+          credentials,
+          authHeaderName,
+        );
+      case McpAuthMethod.NO_AUTH:
+      case McpAuthMethod.OAUTH:
         if (credentials !== undefined || authHeaderName !== undefined) {
           throw new McpValidationFailedError(
             integration.id,
             integration.name,
-            'This integration does not support authentication credentials.',
+            authMethod === McpAuthMethod.NO_AUTH
+              ? 'This integration does not support authentication credentials.'
+              : `Credential rotation is not supported for auth method ${authMethod}.`,
           );
         }
         return;
+    }
+  }
+
+  private async rotateBearerToken(
+    integration: McpIntegration,
+    credentials?: string,
+    authHeaderName?: string,
+  ): Promise<void> {
+    if (authHeaderName !== undefined) {
+      throw new McpValidationFailedError(
+        integration.id,
+        integration.name,
+        'Bearer token integrations always use the Authorization header.',
+      );
+    }
+
+    if (credentials === undefined) {
+      return;
+    }
+
+    const encryptedToken = await this.credentialEncryption.encrypt(credentials);
+    (integration.auth as BearerMcpIntegrationAuth).setToken(encryptedToken);
+  }
+
+  private async rotateCustomHeader(
+    integration: McpIntegration,
+    credentials?: string,
+    authHeaderName?: string,
+  ): Promise<void> {
+    const customAuth = integration.auth as CustomHeaderMcpIntegrationAuth;
+
+    if (credentials !== undefined) {
+      const encryptedSecret =
+        await this.credentialEncryption.encrypt(credentials);
+      const headerNameToUse = authHeaderName ?? customAuth.getAuthHeaderName();
+      customAuth.setSecret(encryptedSecret, headerNameToUse);
+      return;
+    }
+
+    if (authHeaderName !== undefined) {
+      const currentSecret = customAuth.secret;
+      if (!currentSecret) {
+        throw new McpValidationFailedError(
+          integration.id,
+          integration.name,
+          'Credentials must be configured before updating the header name.',
+        );
       }
-      case McpAuthMethod.BEARER_TOKEN: {
-        if (authHeaderName !== undefined) {
-          throw new McpValidationFailedError(
-            integration.id,
-            integration.name,
-            'Bearer token integrations always use the Authorization header.',
-          );
-        }
 
-        if (credentials === undefined) {
-          return;
-        }
-
-        const encryptedToken =
-          await this.credentialEncryption.encrypt(credentials);
-        (auth as BearerMcpIntegrationAuth).setToken(encryptedToken);
-        return;
-      }
-      case McpAuthMethod.CUSTOM_HEADER: {
-        const customAuth = auth as CustomHeaderMcpIntegrationAuth;
-
-        if (credentials !== undefined) {
-          const encryptedSecret =
-            await this.credentialEncryption.encrypt(credentials);
-          const headerNameToUse =
-            authHeaderName ?? customAuth.getAuthHeaderName();
-          customAuth.setSecret(encryptedSecret, headerNameToUse);
-          return;
-        }
-
-        if (authHeaderName !== undefined) {
-          const currentSecret = customAuth.secret;
-          if (!currentSecret) {
-            throw new McpValidationFailedError(
-              integration.id,
-              integration.name,
-              'Credentials must be configured before updating the header name.',
-            );
-          }
-
-          customAuth.setSecret(currentSecret, authHeaderName);
-        }
-        return;
-      }
-      case McpAuthMethod.OAUTH: {
-        if (credentials !== undefined || authHeaderName !== undefined) {
-          throw new McpValidationFailedError(
-            integration.id,
-            integration.name,
-            `Credential rotation is not supported for auth method ${authMethod}.`,
-          );
-        }
-        return;
-      }
+      customAuth.setSecret(currentSecret, authHeaderName);
     }
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/validate-mcp-integration/validate-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/validate-mcp-integration/validate-mcp-integration.use-case.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ValidateMcpIntegrationCommand } from './validate-mcp-integration.command';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpClientService } from '../../services/mcp-client.service';
@@ -9,7 +10,6 @@ import {
   McpIntegrationAccessDeniedError,
   UnexpectedMcpError,
 } from '../../mcp.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { McpIntegration } from '../../../domain/mcp-integration.entity';
 
 /**
@@ -33,6 +33,7 @@ export class ValidateMcpIntegrationUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(
     command: ValidateMcpIntegrationCommand,
   ): Promise<ValidationResult> {
@@ -40,78 +41,69 @@ export class ValidateMcpIntegrationUseCase {
       id: command.integrationId,
     });
 
-    try {
-      const orgId = this.getOrgIdOrThrow();
-      const integration = await this.getIntegrationOrThrow(
-        command.integrationId,
-      );
+    const orgId = this.getOrgIdOrThrow();
+    const integration = await this.getIntegrationOrThrow(command.integrationId);
 
-      this.ensureOrgAccess(integration, orgId);
+    this.ensureOrgAccess(integration, orgId);
 
-      // Validation is an org-level connectivity check. We deliberately do not
-      // pass a userId so it neither merges per-user credentials nor trips the
-      // per-user authorization guard — those are enforced at runtime per user.
-      const capabilityResult = await this.collectCapabilities(
-        integration,
-        command.integrationId,
-      );
+    // Validation is an org-level connectivity check. We deliberately do not
+    // pass a userId so it neither merges per-user credentials nor trips the
+    // per-user authorization guard — those are enforced at runtime per user.
+    const capabilityResult = await this.collectCapabilities(
+      integration,
+      command.integrationId,
+    );
 
-      if (capabilityResult.kind === 'failure') {
-        return {
-          isValid: false,
-          errorMessage: capabilityResult.error,
-        };
-      }
+    if (capabilityResult.kind === 'failure') {
+      return {
+        isValid: false,
+        errorMessage: capabilityResult.error,
+      };
+    }
 
-      const { tools, resources, resourceTemplates, prompts } = capabilityResult;
-      const toolCount = tools.length;
-      const resourceCount = resources.length + resourceTemplates.length;
-      const promptCount = prompts.length;
-      const totalCapabilities = toolCount + resourceCount + promptCount;
+    const { tools, resources, resourceTemplates, prompts } = capabilityResult;
 
-      if (totalCapabilities === 0) {
-        const errorMessage = 'No capabilities found on MCP server';
+    return this.buildValidationResult(command.integrationId, {
+      toolCount: tools.length,
+      resourceCount: resources.length + resourceTemplates.length,
+      promptCount: prompts.length,
+    });
+  }
 
-        this.logger.warn('validationFailed', {
-          id: command.integrationId,
-          error: errorMessage,
-        });
+  private buildValidationResult(
+    integrationId: UUID,
+    counts: { toolCount: number; resourceCount: number; promptCount: number },
+  ): ValidationResult {
+    const { toolCount, resourceCount, promptCount } = counts;
+    const totalCapabilities = toolCount + resourceCount + promptCount;
 
-        return {
-          isValid: false,
-          errorMessage,
-        };
-      }
+    if (totalCapabilities === 0) {
+      const errorMessage = 'No capabilities found on MCP server';
 
-      this.logger.log('validationSucceeded', {
-        id: command.integrationId,
-        toolCount,
-        resourceCount,
-        promptCount,
+      this.logger.warn('validationFailed', {
+        id: integrationId,
+        error: errorMessage,
       });
 
       return {
-        isValid: true,
-        toolCount,
-        resourceCount,
-        promptCount,
+        isValid: false,
+        errorMessage,
       };
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-
-      this.logger.error('unexpectedError', {
-        id: command.integrationId,
-        error: error as Error,
-      });
-      throw new UnexpectedMcpError(
-        'Unexpected error occurred during validation',
-      );
     }
+
+    this.logger.log('validationSucceeded', {
+      id: integrationId,
+      toolCount,
+      resourceCount,
+      promptCount,
+    });
+
+    return {
+      isValid: true,
+      toolCount,
+      resourceCount,
+      promptCount,
+    };
   }
 
   private getOrgIdOrThrow(): UUID {
@@ -173,32 +165,15 @@ export class ValidateMcpIntegrationUseCase {
     const [toolsResult, resourcesResult, templatesResult, promptsResult] =
       await Promise.allSettled(requests);
 
-    let criticalFailure: PromiseRejectedResult | undefined;
-
-    for (const result of [
+    const criticalFailure = this.findCriticalFailure([
       toolsResult,
       resourcesResult,
       templatesResult,
       promptsResult,
-    ]) {
-      if (this.isCriticalFailure(result)) {
-        criticalFailure = result;
-        break;
-      }
-    }
+    ]);
 
     if (criticalFailure) {
-      const errorMessage = this.extractErrorMessage(criticalFailure.reason);
-
-      this.logger.warn('validationFailed', {
-        id: integrationId,
-        error: errorMessage,
-      });
-
-      return {
-        kind: 'failure',
-        error: errorMessage,
-      };
+      return this.buildCapabilityFailure(integrationId, criticalFailure.reason);
     }
 
     return {
@@ -208,6 +183,31 @@ export class ValidateMcpIntegrationUseCase {
       resourceTemplates: this.extractArray(templatesResult),
       prompts: this.extractArray(promptsResult),
     };
+  }
+
+  private buildCapabilityFailure(
+    integrationId: UUID,
+    reason: unknown,
+  ): { kind: 'failure'; error: string } {
+    const errorMessage = this.extractErrorMessage(reason);
+
+    this.logger.warn('validationFailed', {
+      id: integrationId,
+      error: errorMessage,
+    });
+
+    return {
+      kind: 'failure',
+      error: errorMessage,
+    };
+  }
+
+  private findCriticalFailure(
+    results: PromiseSettledResult<unknown[]>[],
+  ): PromiseRejectedResult | undefined {
+    return results.find((result): result is PromiseRejectedResult =>
+      this.isCriticalFailure(result),
+    );
   }
 
   private isCriticalFailure(

--- a/ayunis-core-backend/src/domain/openai-compat/application/openai-compat.errors.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/openai-compat.errors.ts
@@ -25,8 +25,9 @@ export class OpenAIModelNotFoundError extends ApplicationError {
 }
 
 export class OpenAIUnexpectedError extends ApplicationError {
-  constructor(error: unknown) {
-    super('Unexpected error occurred', OpenAICompatErrorCode.UNEXPECTED, 500, {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, OpenAICompatErrorCode.UNEXPECTED, 500, {
+      ...metadata,
       error,
     });
   }

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.use-case.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { randomUUID } from 'crypto';
 import { Observable, finalize, map } from 'rxjs';
 import { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
@@ -15,7 +16,10 @@ import {
   OpenAIStreamMapper,
   OpenAIStreamSession,
 } from '../../mappers/openai-stream.mapper';
-import { OpenAIModelNotFoundError } from '../../openai-compat.errors';
+import {
+  OpenAIModelNotFoundError,
+  OpenAIUnexpectedError,
+} from '../../openai-compat.errors';
 import { ExecuteOpenAIChatCompletionCommand } from './execute-openai-chat-completion.command';
 import type { ChatCompletionResponse } from '../../types/openai-response.types';
 import type { ChatCompletionChunk } from '../../types/openai-chunk.types';
@@ -44,6 +48,7 @@ export class ExecuteOpenAIChatCompletionUseCase {
     private readonly streamMapper: OpenAIStreamMapper,
   ) {}
 
+  @HandleUnexpectedErrors(OpenAIUnexpectedError)
   async executeNonStreaming(
     command: ExecuteOpenAIChatCompletionCommand,
   ): Promise<ChatCompletionResponse> {
@@ -86,6 +91,7 @@ export class ExecuteOpenAIChatCompletionUseCase {
     });
   }
 
+  @HandleUnexpectedErrors(OpenAIUnexpectedError)
   async executeStreaming(
     command: ExecuteOpenAIChatCompletionCommand,
   ): Promise<Observable<ChatCompletionChunk>> {

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/get-openai-model/get-openai-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/get-openai-model/get-openai-model.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import {
   OpenAIModelNotFoundError,
   OpenAIUnexpectedError,
@@ -17,27 +17,20 @@ export class GetOpenAIModelUseCase {
     private readonly listOpenAIModelsUseCase: ListOpenAIModelsUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(OpenAIUnexpectedError)
   async execute(query: GetOpenAIModelQuery): Promise<OpenAIModelObject> {
     this.logger.log('Getting OpenAI-compatible model', {
       orgId: query.orgId,
       modelName: query.modelName,
     });
 
-    try {
-      const list = await this.listOpenAIModelsUseCase.execute(
-        new ListOpenAIModelsQuery(query.orgId),
-      );
-      const match = list.data.find((model) => model.id === query.modelName);
-      if (!match) {
-        throw new OpenAIModelNotFoundError(query.modelName);
-      }
-      return match;
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting OpenAI-compatible model', {
-        error: error as Error,
-      });
-      throw new OpenAIUnexpectedError(error);
+    const list = await this.listOpenAIModelsUseCase.execute(
+      new ListOpenAIModelsQuery(query.orgId),
+    );
+    const match = list.data.find((model) => model.id === query.modelName);
+    if (!match) {
+      throw new OpenAIModelNotFoundError(query.modelName);
     }
+    return match;
   }
 }

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/list-openai-models/list-openai-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/list-openai-models/list-openai-models.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetPermittedLanguageModelsUseCase } from 'src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.use-case';
 import { GetPermittedLanguageModelsQuery } from 'src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.query';
 import type { LanguageModel } from 'src/domain/models/domain/models/language.model';
@@ -17,33 +17,26 @@ export class ListOpenAIModelsUseCase {
     private readonly modelMapper: OpenAIModelMapper,
   ) {}
 
+  @HandleUnexpectedErrors(OpenAIUnexpectedError)
   async execute(
     query: ListOpenAIModelsQuery,
   ): Promise<OpenAIModelListResponse> {
     this.logger.log('Listing OpenAI-compatible models', { orgId: query.orgId });
 
-    try {
-      const permitted = await this.getPermittedLanguageModelsUseCase.execute(
-        new GetPermittedLanguageModelsQuery(query.orgId),
-      );
+    const permitted = await this.getPermittedLanguageModelsUseCase.execute(
+      new GetPermittedLanguageModelsQuery(query.orgId),
+    );
 
-      // Dedupe by name, first occurrence wins — chat/completions resolves the
-      // "model" field with `find()` over the same list, so this keeps the
-      // advertised ids exactly the set of names a completion request accepts.
-      const byName = new Map<string, LanguageModel>();
-      for (const { model } of permitted) {
-        if (!byName.has(model.name)) {
-          byName.set(model.name, model);
-        }
+    // Dedupe by name, first occurrence wins — chat/completions resolves the
+    // "model" field with `find()` over the same list, so this keeps the
+    // advertised ids exactly the set of names a completion request accepts.
+    const byName = new Map<string, LanguageModel>();
+    for (const { model } of permitted) {
+      if (!byName.has(model.name)) {
+        byName.set(model.name, model);
       }
-
-      return this.modelMapper.toListResponse([...byName.values()]);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error listing OpenAI-compatible models', {
-        error: error as Error,
-      });
-      throw new OpenAIUnexpectedError(error);
     }
+
+    return this.modelMapper.toListResponse([...byName.values()]);
   }
 }

--- a/ayunis-core-backend/src/domain/rag/embeddings/application/embeddings.errors.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/application/embeddings.errors.ts
@@ -8,6 +8,7 @@ export enum EmbeddingsErrorCode {
   PROCESSING_FAILED = 'PROCESSING_FAILED',
   INVALID_INPUT = 'INVALID_INPUT',
   NO_EMBEDDINGS_RETURNED = 'NO_EMBEDDINGS_RETURNED',
+  UNEXPECTED_EMBEDDINGS_ERROR = 'UNEXPECTED_EMBEDDINGS_ERROR',
 }
 
 export class EmbeddingsError extends ApplicationError {
@@ -50,6 +51,16 @@ export class EmbeddingsProcessingError extends EmbeddingsError {
   constructor(message: string, metadata?: ErrorMetadata) {
     super(message, EmbeddingsErrorCode.PROCESSING_FAILED, 500, metadata);
     this.name = 'EmbeddingsProcessingError';
+  }
+}
+
+export class UnexpectedEmbeddingsError extends EmbeddingsError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, EmbeddingsErrorCode.UNEXPECTED_EMBEDDINGS_ERROR, 500, {
+      ...metadata,
+      error,
+    });
+    this.name = 'UnexpectedEmbeddingsError';
   }
 }
 

--- a/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case.ts
@@ -1,9 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { EmbedTextCommand } from './embed-text.command';
 import { EmbeddingsHandlerRegistry } from '../../embeddings-handler.registry';
 import { EmbeddingsThrottleService } from '../../services/embeddings-throttle.service';
 import { Embedding } from '../../../domain/embedding.entity';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { UnexpectedEmbeddingsError } from '../../embeddings.errors';
 
 @Injectable()
 export class EmbedTextUseCase {
@@ -14,26 +15,17 @@ export class EmbedTextUseCase {
     private readonly throttle: EmbeddingsThrottleService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedEmbeddingsError)
   async execute(command: EmbedTextCommand): Promise<Embedding[]> {
     this.logger.log('execute', {
       model: command.model,
     });
-    try {
-      const handler = this.providerRegistry.getHandler(command.model.provider);
+    const handler = this.providerRegistry.getHandler(command.model.provider);
 
-      // Route through the global throttle so ingestion floods can never
-      // starve retrieval; retrieval embeds jump ahead of ingestion embeds.
-      return this.throttle.run(command.priority, () =>
-        handler.embed(command.texts, command.model),
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error embedding text', {
-        error: error as Error,
-      });
-      throw error;
-    }
+    // Route through the global throttle so ingestion floods can never
+    // starve retrieval; retrieval embeds jump ahead of ingestion embeds.
+    return this.throttle.run(command.priority, () =>
+      handler.embed(command.texts, command.model),
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/rag/indexers/application/indexer.errors.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/application/indexer.errors.ts
@@ -31,6 +31,9 @@ export class IndexNotFoundError extends IndexError {
 
 export class UnexpectedIndexError extends IndexError {
   constructor(error: Error, metadata?: ErrorMetadata) {
-    super(error.message, IndexErrorCode.UNEXPECTED_INDEX_ERROR, 500, metadata);
+    super(error.message, IndexErrorCode.UNEXPECTED_INDEX_ERROR, 500, {
+      ...metadata,
+      error,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/delete-content/delete-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/delete-content/delete-content.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { IndexRegistry } from '../../indexer.registry';
 import { DeleteContentCommand } from './delete-content.command';
 import { UnexpectedIndexError } from '../../indexer.errors';
@@ -8,19 +9,15 @@ export class DeleteContentUseCase {
   private readonly logger = new Logger(DeleteContentUseCase.name);
   constructor(private readonly indexRegistry: IndexRegistry) {}
 
+  @HandleUnexpectedErrors(UnexpectedIndexError)
   async execute(command: DeleteContentCommand): Promise<void> {
-    try {
-      if (command.type) {
-        const index = this.indexRegistry.get(command.type);
-        return index.delete(command.documentId);
-      }
-      const indices = this.indexRegistry.getAll();
-      for (const index of indices) {
-        await index.delete(command.documentId);
-      }
-    } catch (error) {
-      this.logger.error(error);
-      throw new UnexpectedIndexError(error as Error);
+    if (command.type) {
+      const index = this.indexRegistry.get(command.type);
+      return index.delete(command.documentId);
+    }
+    const indices = this.indexRegistry.getAll();
+    for (const index of indices) {
+      await index.delete(command.documentId);
     }
   }
 }

--- a/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.ts
@@ -1,34 +1,27 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { IndexRegistry } from '../../indexer.registry';
 import { IngestBulkContentCommand } from './ingest-bulk-content.command';
 import { IndexEntry } from 'src/domain/rag/indexers/domain/index-entry.entity';
 import { UnexpectedIndexError } from '../../indexer.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class IngestBulkContentUseCase {
   private readonly logger = new Logger(IngestBulkContentUseCase.name);
   constructor(private readonly indexRegistry: IndexRegistry) {}
 
+  @HandleUnexpectedErrors(UnexpectedIndexError)
   async execute(command: IngestBulkContentCommand): Promise<void> {
-    try {
-      const index = this.indexRegistry.get(command.type);
-      return await index.ingestBulk({
-        orgId: command.orgId,
-        entries: command.entries.map((entry) => ({
-          indexEntry: new IndexEntry({
-            relatedDocumentId: entry.documentId,
-            relatedChunkId: entry.chunkId,
-          }),
-          content: entry.content,
-        })),
-      });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error(error);
-      throw new UnexpectedIndexError(error as Error);
-    }
+    const index = this.indexRegistry.get(command.type);
+    return await index.ingestBulk({
+      orgId: command.orgId,
+      entries: command.entries.map((entry) => ({
+        indexEntry: new IndexEntry({
+          relatedDocumentId: entry.documentId,
+          relatedChunkId: entry.chunkId,
+        }),
+        content: entry.content,
+      })),
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/search-content/search-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/search-content/search-content.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { IndexRegistry } from '../../indexer.registry';
 import {
   SearchContentQuery,
@@ -6,46 +7,31 @@ import {
 } from './search-content.query';
 import type { IndexEntry } from '../../../domain/index-entry.entity';
 import { UnexpectedIndexError } from '../../indexer.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class SearchContentUseCase {
   private readonly logger = new Logger(SearchContentUseCase.name);
   constructor(private readonly indexRegistry: IndexRegistry) {}
 
+  @HandleUnexpectedErrors(UnexpectedIndexError)
   async execute(query: SearchContentQuery): Promise<IndexEntry[]> {
-    try {
-      const index = this.indexRegistry.get(query.type);
-      return await index.search({
-        orgId: query.orgId,
-        documentId: query.documentId,
-        query: query.query,
-        filter: { limit: query.limit ?? undefined },
-      });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error(error);
-      throw new UnexpectedIndexError(error as Error);
-    }
+    const index = this.indexRegistry.get(query.type);
+    return await index.search({
+      orgId: query.orgId,
+      documentId: query.documentId,
+      query: query.query,
+      filter: { limit: query.limit ?? undefined },
+    });
   }
 
+  @HandleUnexpectedErrors(UnexpectedIndexError)
   async executeMulti(query: SearchMultiContentQuery): Promise<IndexEntry[]> {
-    try {
-      const index = this.indexRegistry.get(query.type);
-      return await index.searchMulti({
-        orgId: query.orgId,
-        documentIds: query.documentIds,
-        query: query.query,
-        filter: { limit: query.limit ?? undefined },
-      });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error(error);
-      throw new UnexpectedIndexError(error as Error);
-    }
+    const index = this.indexRegistry.get(query.type);
+    return await index.searchMulti({
+      orgId: query.orgId,
+      documentIds: query.documentIds,
+      query: query.query,
+      filter: { limit: query.limit ?? undefined },
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/delete-content/delete-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/delete-content/delete-content.use-case.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { DeleteContentCommand } from './delete-content.command';
 import { ParentChildIndexerRepository } from '../../../parent-child-index.repository';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedIndexError } from 'src/domain/rag/indexers/application/indexer.errors';
 
 @Injectable()
@@ -11,15 +11,8 @@ export class DeleteContentUseCase {
     private readonly parentChildIndexerRepository: ParentChildIndexerRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedIndexError)
   async execute(command: DeleteContentCommand): Promise<void> {
-    try {
-      await this.parentChildIndexerRepository.delete(command.documentId);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error(error);
-      throw new UnexpectedIndexError(error as Error);
-    }
+    await this.parentChildIndexerRepository.delete(command.documentId);
   }
 }

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/delete-contents/delete-contents.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/delete-contents/delete-contents.use-case.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { DeleteContentsCommand } from './delete-contents.command';
 import { ParentChildIndexerRepository } from '../../../parent-child-index.repository';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedIndexError } from 'src/domain/rag/indexers/application/indexer.errors';
 
 @Injectable()
@@ -11,18 +11,11 @@ export class DeleteContentsUseCase {
     private readonly parentChildIndexerRepository: ParentChildIndexerRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedIndexError)
   async execute(command: DeleteContentsCommand): Promise<void> {
     if (command.documentIds.length === 0) {
       return;
     }
-    try {
-      await this.parentChildIndexerRepository.deleteMany(command.documentIds);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error(error);
-      throw new UnexpectedIndexError(error as Error);
-    }
+    await this.parentChildIndexerRepository.deleteMany(command.documentIds);
   }
 }

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.ts
@@ -1,4 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedIndexError } from 'src/domain/rag/indexers/application/indexer.errors';
 import { ParentChildIndexerRepositoryPort } from '../../ports/parent-child-indexer-repository.port';
 import { ParentChunk } from '../../../domain/parent-chunk.entity';
 import { SplitTextUseCase } from 'src/domain/rag/splitters/application/use-cases/split-text/split-text.use-case';
@@ -37,6 +39,7 @@ export class IngestBulkContentUseCase {
     private readonly getPermittedEmbeddingModelUseCase: GetPermittedEmbeddingModelUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedIndexError)
   async execute(command: IngestBulkContentCommand): Promise<void> {
     if (command.entries.length === 0) return;
 

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/search-content/search-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/search-content/search-content.use-case.ts
@@ -1,4 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedIndexError } from 'src/domain/rag/indexers/application/indexer.errors';
 import type {
   SearchInput,
   SearchMultiInput,
@@ -22,6 +24,7 @@ export class SearchContentUseCase {
     private readonly getPermittedEmbeddingModelUseCase: GetPermittedEmbeddingModelUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedIndexError)
   async execute(input: SearchInput): Promise<IndexEntry[]> {
     const queryVector = await this.embedQuery(input.orgId, input.query);
     const parentChunks = await this.parentChildIndexerRepository.find(
@@ -32,6 +35,7 @@ export class SearchContentUseCase {
     return this.toIndexEntries(parentChunks);
   }
 
+  @HandleUnexpectedErrors(UnexpectedIndexError)
   async executeMulti(input: SearchMultiInput): Promise<IndexEntry[]> {
     if (input.documentIds.length === 0) {
       return [];

--- a/ayunis-core-backend/src/domain/retention-policies/application/retention-policies.errors.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/application/retention-policies.errors.ts
@@ -20,12 +20,10 @@ export class InvalidRetentionPeriodError extends ApplicationError {
 }
 
 export class UnexpectedRetentionPolicyError extends ApplicationError {
-  constructor(operation: string, metadata?: ErrorMetadata) {
-    super(
-      `Unexpected retention policy error during ${operation}`,
-      RetentionPolicyErrorCode.UNEXPECTED_ERROR,
-      500,
-      { operation, ...metadata },
-    );
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, RetentionPolicyErrorCode.UNEXPECTED_ERROR, 500, {
+      ...metadata,
+      error,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/retention-policies/application/use-cases/enforce-retention/enforce-retention.use-case.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/application/use-cases/enforce-retention/enforce-retention.use-case.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import type { UUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { DeleteThreadUseCase } from 'src/domain/threads/application/use-cases/delete-thread/delete-thread.use-case';
 import { DeleteThreadCommand } from 'src/domain/threads/application/use-cases/delete-thread/delete-thread.command';
 import {
@@ -10,6 +11,7 @@ import {
 } from 'src/domain/threads/application/use-cases/find-expired-thread-refs-by-org/find-expired-thread-refs-by-org.use-case';
 import { FindExpiredThreadRefsByOrgQuery } from 'src/domain/threads/application/use-cases/find-expired-thread-refs-by-org/find-expired-thread-refs-by-org.query';
 import { RetentionPoliciesRepository } from '../../ports/retention-policies.repository';
+import { UnexpectedRetentionPolicyError } from '../../retention-policies.errors';
 import type { OrgRetentionPolicy } from '../../../domain/org-retention-policy.entity';
 import type {
   EnforceRetentionResult,
@@ -40,6 +42,7 @@ export class EnforceRetentionUseCase {
     private readonly configService: ConfigService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedRetentionPolicyError)
   async execute(): Promise<EnforceRetentionResult> {
     const dryRun = this.configService.get<boolean>('retention.dryRun') ?? false;
     const policies = await this.retentionPoliciesRepository.findAllEnabled();

--- a/ayunis-core-backend/src/domain/retention-policies/application/use-cases/get-org-retention-policy/get-org-retention-policy.use-case.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/application/use-cases/get-org-retention-policy/get-org-retention-policy.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { RetentionPoliciesRepository } from '../../ports/retention-policies.repository';
 import { UnexpectedRetentionPolicyError } from '../../retention-policies.errors';
 import type { OrgRetentionPolicy } from '../../../domain/org-retention-policy.entity';
@@ -12,25 +12,12 @@ export class GetOrgRetentionPolicyUseCase {
   constructor(private readonly repository: RetentionPoliciesRepository) {}
 
   /** Returns the org's policy, or null when retention has never been set. */
+  @HandleUnexpectedErrors(UnexpectedRetentionPolicyError)
   async execute(
     query: GetOrgRetentionPolicyQuery,
   ): Promise<OrgRetentionPolicy | null> {
     this.logger.debug('Getting retention policy', { orgId: query.orgId });
 
-    try {
-      return await this.repository.findByOrgId(query.orgId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-
-      this.logger.error('Failed to get retention policy', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: query.orgId,
-      });
-
-      throw new UnexpectedRetentionPolicyError('get', {
-        orgId: query.orgId,
-        ...(error instanceof Error && { originalError: error.message }),
-      });
-    }
+    return await this.repository.findByOrgId(query.orgId);
   }
 }

--- a/ayunis-core-backend/src/domain/retention-policies/application/use-cases/upsert-org-retention-policy/upsert-org-retention-policy.use-case.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/application/use-cases/upsert-org-retention-policy/upsert-org-retention-policy.use-case.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { RetentionPoliciesRepository } from '../../ports/retention-policies.repository';
 import {
   InvalidRetentionPeriodError,
@@ -15,6 +15,7 @@ export class UpsertOrgRetentionPolicyUseCase {
 
   constructor(private readonly repository: RetentionPoliciesRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedRetentionPolicyError)
   async execute(
     command: UpsertOrgRetentionPolicyCommand,
   ): Promise<OrgRetentionPolicy> {
@@ -29,28 +30,14 @@ export class UpsertOrgRetentionPolicyUseCase {
       });
     }
 
-    try {
-      const existing = await this.repository.findByOrgId(command.orgId);
-      const policy = new OrgRetentionPolicy({
-        id: existing?.id,
-        orgId: command.orgId,
-        retentionDays: command.retentionDays,
-        createdAt: existing?.createdAt,
-        updatedAt: new Date(),
-      });
-      return await this.repository.upsert(policy);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-
-      this.logger.error('Failed to upsert retention policy', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-      });
-
-      throw new UnexpectedRetentionPolicyError('upsert', {
-        orgId: command.orgId,
-        ...(error instanceof Error && { originalError: error.message }),
-      });
-    }
+    const existing = await this.repository.findByOrgId(command.orgId);
+    const policy = new OrgRetentionPolicy({
+      id: existing?.id,
+      orgId: command.orgId,
+      retentionDays: command.retentionDays,
+      createdAt: existing?.createdAt,
+      updatedAt: new Date(),
+    });
+    return await this.repository.upsert(policy);
   }
 }

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/preflight-check/preflight-check.use-case.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/preflight-check/preflight-check.use-case.ts
@@ -1,7 +1,11 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { PreflightCheckCommand } from './preflight-check.command';
-import { DocumentTooLargeForChatError } from '../../file-retriever.errors';
+import {
+  DocumentTooLargeForChatError,
+  FileRetrieverUnexpectedError,
+} from '../../file-retriever.errors';
 import { detectFileType } from 'src/common/util/file-type';
 import retrievalConfig from 'src/config/retrieval.config';
 import PdfParse from 'pdf-parse';
@@ -15,6 +19,7 @@ export class PreflightCheckUseCase {
     private readonly config: ConfigType<typeof retrievalConfig>,
   ) {}
 
+  @HandleUnexpectedErrors(FileRetrieverUnexpectedError)
   async execute(command: PreflightCheckCommand): Promise<void> {
     const fileType = detectFileType(command.fileType, command.fileName);
 

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.ts
@@ -23,7 +23,7 @@ import {
   MIME_TYPES,
 } from 'src/common/util/file-type';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { DocumentConverterPort } from '../../ports/document-converter.port';
 import retrievalConfig from 'src/config/retrieval.config';
 import { TranscribeUseCase } from 'src/domain/transcriptions/application/use-cases/transcribe/transcribe.use-case';
@@ -42,6 +42,7 @@ export class RetrieveFileContentUseCase {
     private readonly config: ConfigType<typeof retrievalConfig>,
   ) {}
 
+  @HandleUnexpectedErrors(FileRetrieverUnexpectedError)
   async execute(
     command: RetrieveFileContentCommand,
   ): Promise<FileRetrieverResult> {
@@ -50,48 +51,38 @@ export class RetrieveFileContentUseCase {
     if (!orgId) {
       throw new UnauthorizedException('User not authenticated');
     }
-    try {
-      const fileType = detectFileType(command.fileType, command.fileName);
+    const fileType = detectFileType(command.fileType, command.fileName);
 
-      if (fileType === 'txt') {
-        // TXT/MD: Read directly as UTF-8, no external service needed
-        const text = command.fileData.toString('utf8').replace(/^\uFEFF/, '');
-        return new FileRetrieverResult([new FileRetrieverPage(text, 1)]);
-      }
-
-      if (fileType === 'pdf') {
-        return await this.processPdf(
-          command.fileData,
-          command.fileName,
-          command.fileType,
-        );
-      }
-
-      if (fileType === 'docx' || fileType === 'pptx') {
-        return await this.processOfficeDocument(
-          command.fileData,
-          command.fileName,
-        );
-      }
-
-      if (isAudioFile(fileType)) {
-        return await this.processAudio(
-          command.fileData,
-          command.fileName,
-          command.fileType,
-        );
-      }
-
-      throw new InvalidFileTypeError(fileType);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Unexpected error while retrieving file content', {
-        error: error as Error,
-      });
-      throw new FileRetrieverUnexpectedError(error as Error);
+    if (fileType === 'txt') {
+      // TXT/MD: Read directly as UTF-8, no external service needed
+      const text = command.fileData.toString('utf8').replace(/^\uFEFF/, '');
+      return new FileRetrieverResult([new FileRetrieverPage(text, 1)]);
     }
+
+    if (fileType === 'pdf') {
+      return await this.processPdf(
+        command.fileData,
+        command.fileName,
+        command.fileType,
+      );
+    }
+
+    if (fileType === 'docx' || fileType === 'pptx') {
+      return await this.processOfficeDocument(
+        command.fileData,
+        command.fileName,
+      );
+    }
+
+    if (isAudioFile(fileType)) {
+      return await this.processAudio(
+        command.fileData,
+        command.fileName,
+        command.fileType,
+      );
+    }
+
+    throw new InvalidFileTypeError(fileType);
   }
 
   /**

--- a/ayunis-core-backend/src/domain/retrievers/internet-search-retrievers/application/use-cases/search-web/search-web.use-case.ts
+++ b/ayunis-core-backend/src/domain/retrievers/internet-search-retrievers/application/use-cases/search-web/search-web.use-case.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { InternetSearchHandler } from '../../ports/internet-search.handler';
 import { InternetSearchResult } from '../../../domain/internet-search-result.entity';
 import { SearchWebCommand } from './search-web.command';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedInternetSearchError } from '../../internet-search.errors';
 
 @Injectable()
@@ -11,20 +11,10 @@ export class SearchWebUseCase {
 
   constructor(private readonly internetSearchHandler: InternetSearchHandler) {}
 
+  @HandleUnexpectedErrors(UnexpectedInternetSearchError)
   async execute(command: SearchWebCommand): Promise<InternetSearchResult[]> {
-    try {
-      this.logger.debug(`Searching web for: ${command.query}`);
+    this.logger.debug(`Searching web for: ${command.query}`);
 
-      return this.internetSearchHandler.search(command.query);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error(
-        `Unexpected error searching web for: ${command.query}`,
-        error,
-      );
-      throw new UnexpectedInternetSearchError(error as Error);
-    }
+    return this.internetSearchHandler.search(command.query);
   }
 }

--- a/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/url-retriever.errors.ts
+++ b/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/url-retriever.errors.ts
@@ -20,6 +20,7 @@ export enum UrlRetrieverErrorCode {
   UNSUPPORTED_CONTENT_TYPE = 'UNSUPPORTED_CONTENT_TYPE',
   TOO_MANY_REDIRECTS = 'TOO_MANY_REDIRECTS',
   CONTENT_TOO_LARGE = 'CONTENT_TOO_LARGE',
+  UNEXPECTED_ERROR = 'UNEXPECTED_ERROR',
 }
 
 /**
@@ -71,6 +72,16 @@ export abstract class UrlRetrieverError extends ApplicationError {
           ...(this.metadata && { metadata: this.metadata }),
         });
     }
+  }
+}
+
+export class UnexpectedUrlRetrieverError extends UrlRetrieverError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, UrlRetrieverErrorCode.UNEXPECTED_ERROR, 500, {
+      ...metadata,
+      error,
+    });
+    this.name = 'UnexpectedUrlRetrieverError';
   }
 }
 

--- a/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/use-cases/crawl-url/crawl-url.use-case.ts
+++ b/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/use-cases/crawl-url/crawl-url.use-case.ts
@@ -10,6 +10,8 @@ import {
 import { UrlCrawlConstants } from '../../../domain/url-crawl.constants';
 import { CrawlUrlCommand } from './crawl-url.command';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedUrlRetrieverError } from '../../url-retriever.errors';
 
 /**
  * Crawls a root URL breadth-first, following same-site links up to a bounded
@@ -22,6 +24,7 @@ export class CrawlUrlUseCase {
 
   constructor(private readonly retrieveUrlUseCase: RetrieveUrlUseCase) {}
 
+  @HandleUnexpectedErrors(UnexpectedUrlRetrieverError)
   async execute(command: CrawlUrlCommand): Promise<UrlCrawlResult> {
     const maxDepth = this.clampDepth(command.maxDepth);
     this.logger.debug(`Crawling ${command.url} to depth ${maxDepth}`);

--- a/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/use-cases/retrieve-url/retrieve-url.use-case.ts
+++ b/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/use-cases/retrieve-url/retrieve-url.use-case.ts
@@ -6,11 +6,13 @@ import {
   UrlRetrieverHandler,
 } from '../../ports/url-retriever.handler';
 import {
+  UnexpectedUrlRetrieverError,
   UrlRetrieverProviderNotAvailableError,
   UrlRetrieverUnsupportedContentTypeError,
   UrlRetrieverParsingError,
 } from '../../url-retriever.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AssertCrawlDomainAccessUseCase } from 'src/domain/crawl-domain-grants/application/use-cases/assert-crawl-domain-access/assert-crawl-domain-access.use-case';
 import { AssertCrawlDomainAccessCommand } from 'src/domain/crawl-domain-grants/application/use-cases/assert-crawl-domain-access/assert-crawl-domain-access.command';
 import { RetrieveFileContentUseCase } from 'src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case';
@@ -28,6 +30,7 @@ export class RetrieveUrlUseCase {
     private readonly retrieveFileContentUseCase: RetrieveFileContentUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedUrlRetrieverError)
   async execute(command: RetrieveUrlCommand): Promise<UrlRetrieverResult> {
     this.logger.debug(`Retrieving URL: ${command.url}`);
 

--- a/ayunis-core-backend/src/domain/skill-templates/application/skill-templates.errors.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/skill-templates.errors.ts
@@ -41,12 +41,12 @@ export class DuplicateSkillTemplateNameError extends SkillTemplateError {
 }
 
 export class UnexpectedSkillTemplateError extends SkillTemplateError {
-  constructor(error: unknown) {
+  constructor(error: Error, metadata?: ErrorMetadata) {
     super(
-      'Unexpected error occurred',
+      error.message,
       SkillTemplateErrorCode.UNEXPECTED_SKILL_TEMPLATE_ERROR,
       500,
-      { error },
+      { ...metadata, error },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { CreateSkillTemplateCommand } from './create-skill-template.command';
 import { SkillTemplate } from '../../../domain/skill-template.entity';
@@ -9,8 +10,6 @@ import {
   DuplicateSkillTemplateNameError,
   UnexpectedSkillTemplateError,
 } from '../../skill-templates.errors';
-import { InvalidSkillTemplateNameError } from '../../../domain/skill-template.entity';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class CreateSkillTemplateUseCase {
@@ -20,43 +19,33 @@ export class CreateSkillTemplateUseCase {
     private readonly skillTemplateRepository: SkillTemplateRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillTemplateError)
   async execute(command: CreateSkillTemplateCommand): Promise<SkillTemplate> {
     this.logger.log('Creating skill template', { name: command.name });
-    try {
-      const existing = await this.skillTemplateRepository.findByName(
-        command.name,
-      );
-      if (existing) {
-        throw new DuplicateSkillTemplateNameError(command.name);
-      }
 
-      const baseParams = {
-        name: command.name,
-        shortDescription: command.shortDescription,
-        instructions: command.instructions,
-        isActive: command.isActive,
-      };
-
-      const skillTemplate: SkillTemplate =
-        command.distributionMode === DistributionMode.ALWAYS_ON
-          ? new AlwaysOnSkillTemplate(baseParams)
-          : new PreCreatedCopySkillTemplate({
-              ...baseParams,
-              defaultActive: command.defaultActive,
-              defaultPinned: command.defaultPinned,
-            });
-
-      return await this.skillTemplateRepository.create(skillTemplate);
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof InvalidSkillTemplateNameError
-      )
-        throw error;
-      this.logger.error('Error creating skill template', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillTemplateError(error);
+    const existing = await this.skillTemplateRepository.findByName(
+      command.name,
+    );
+    if (existing) {
+      throw new DuplicateSkillTemplateNameError(command.name);
     }
+
+    const baseParams = {
+      name: command.name,
+      shortDescription: command.shortDescription,
+      instructions: command.instructions,
+      isActive: command.isActive,
+    };
+
+    const skillTemplate: SkillTemplate =
+      command.distributionMode === DistributionMode.ALWAYS_ON
+        ? new AlwaysOnSkillTemplate(baseParams)
+        : new PreCreatedCopySkillTemplate({
+            ...baseParams,
+            defaultActive: command.defaultActive,
+            defaultPinned: command.defaultPinned,
+          });
+
+    return await this.skillTemplateRepository.create(skillTemplate);
   }
 }

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/delete-skill-template/delete-skill-template.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/delete-skill-template/delete-skill-template.use-case.ts
@@ -1,11 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { DeleteSkillTemplateCommand } from './delete-skill-template.command';
 import {
   SkillTemplateNotFoundError,
   UnexpectedSkillTemplateError,
 } from '../../skill-templates.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class DeleteSkillTemplateUseCase {
@@ -15,25 +15,19 @@ export class DeleteSkillTemplateUseCase {
     private readonly skillTemplateRepository: SkillTemplateRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillTemplateError)
   async execute(command: DeleteSkillTemplateCommand): Promise<void> {
     this.logger.log('Deleting skill template', {
       skillTemplateId: command.skillTemplateId,
     });
-    try {
-      const existing = await this.skillTemplateRepository.findOne(
-        command.skillTemplateId,
-      );
-      if (!existing) {
-        throw new SkillTemplateNotFoundError(command.skillTemplateId);
-      }
 
-      await this.skillTemplateRepository.delete(command.skillTemplateId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error deleting skill template', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillTemplateError(error);
+    const existing = await this.skillTemplateRepository.findOne(
+      command.skillTemplateId,
+    );
+    if (!existing) {
+      throw new SkillTemplateNotFoundError(command.skillTemplateId);
     }
+
+    await this.skillTemplateRepository.delete(command.skillTemplateId);
   }
 }

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case.spec.ts
@@ -4,6 +4,7 @@ import type { SkillTemplateRepository } from '../../ports/skill-template.reposit
 import type { SkillTemplate } from '../../../domain/skill-template.entity';
 import { AlwaysOnSkillTemplate } from '../../../domain/always-on-skill-template.entity';
 import { DistributionMode } from '../../../domain/distribution-mode.enum';
+import { UnexpectedSkillTemplateError } from '../../skill-templates.errors';
 import { randomUUID } from 'crypto';
 
 describe('FindActiveAlwaysOnTemplatesUseCase', () => {
@@ -65,6 +66,6 @@ describe('FindActiveAlwaysOnTemplatesUseCase', () => {
 
     await expect(
       useCase.execute(new FindActiveAlwaysOnTemplatesQuery()),
-    ).rejects.toThrow('Unexpected error occurred');
+    ).rejects.toThrow(UnexpectedSkillTemplateError);
   });
 });

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { SkillTemplate } from '../../../domain/skill-template.entity';
 import { DistributionMode } from '../../../domain/distribution-mode.enum';
 import { FindActiveAlwaysOnTemplatesQuery } from './find-active-always-on-templates.query';
 import { UnexpectedSkillTemplateError } from '../../skill-templates.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 const CACHE_TTL_MS = 60_000;
 
@@ -18,6 +18,7 @@ export class FindActiveAlwaysOnTemplatesUseCase {
     private readonly skillTemplateRepository: SkillTemplateRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillTemplateError)
   async execute(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _query: FindActiveAlwaysOnTemplatesQuery,
@@ -27,20 +28,12 @@ export class FindActiveAlwaysOnTemplatesUseCase {
       return this.cachedTemplates;
     }
 
-    try {
-      const templates = await this.skillTemplateRepository.findActiveByMode(
-        DistributionMode.ALWAYS_ON,
-      );
-      this.cachedTemplates = templates;
-      this.cacheExpiresAt = now + CACHE_TTL_MS;
-      return templates;
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding active always-on templates', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillTemplateError(error);
-    }
+    const templates = await this.skillTemplateRepository.findActiveByMode(
+      DistributionMode.ALWAYS_ON,
+    );
+    this.cachedTemplates = templates;
+    this.cacheExpiresAt = now + CACHE_TTL_MS;
+    return templates;
   }
 
   /** Clears the in-memory cache (useful for testing). */

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.spec.ts
@@ -4,6 +4,7 @@ import type { SkillTemplateRepository } from '../../ports/skill-template.reposit
 import type { SkillTemplate } from '../../../domain/skill-template.entity';
 import { PreCreatedCopySkillTemplate } from '../../../domain/pre-created-copy-skill-template.entity';
 import { DistributionMode } from '../../../domain/distribution-mode.enum';
+import { UnexpectedSkillTemplateError } from '../../skill-templates.errors';
 import { randomUUID } from 'crypto';
 
 describe('FindActivePreCreatedTemplatesUseCase', () => {
@@ -63,6 +64,6 @@ describe('FindActivePreCreatedTemplatesUseCase', () => {
 
     await expect(
       useCase.execute(new FindActivePreCreatedTemplatesQuery()),
-    ).rejects.toThrow('Unexpected error occurred');
+    ).rejects.toThrow(UnexpectedSkillTemplateError);
   });
 });

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { PreCreatedCopySkillTemplate } from '../../../domain/pre-created-copy-skill-template.entity';
 import { DistributionMode } from '../../../domain/distribution-mode.enum';
 import { FindActivePreCreatedTemplatesQuery } from './find-active-pre-created-templates.query';
 import { UnexpectedSkillTemplateError } from '../../skill-templates.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class FindActivePreCreatedTemplatesUseCase {
@@ -16,21 +16,15 @@ export class FindActivePreCreatedTemplatesUseCase {
     private readonly skillTemplateRepository: SkillTemplateRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillTemplateError)
   async execute(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _query: FindActivePreCreatedTemplatesQuery,
   ): Promise<PreCreatedCopySkillTemplate[]> {
     this.logger.log('Finding active pre-created copy templates');
-    try {
-      return await this.skillTemplateRepository.findActiveByMode<PreCreatedCopySkillTemplate>(
-        DistributionMode.PRE_CREATED_COPY,
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding active pre-created templates', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillTemplateError(error);
-    }
+
+    return await this.skillTemplateRepository.findActiveByMode<PreCreatedCopySkillTemplate>(
+      DistributionMode.PRE_CREATED_COPY,
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-all-skill-templates/find-all-skill-templates.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-all-skill-templates/find-all-skill-templates.use-case.ts
@@ -1,9 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { SkillTemplate } from '../../../domain/skill-template.entity';
 import { FindAllSkillTemplatesQuery } from './find-all-skill-templates.query';
 import { UnexpectedSkillTemplateError } from '../../skill-templates.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class FindAllSkillTemplatesUseCase {
@@ -13,17 +13,11 @@ export class FindAllSkillTemplatesUseCase {
     private readonly skillTemplateRepository: SkillTemplateRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillTemplateError)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async execute(_query: FindAllSkillTemplatesQuery): Promise<SkillTemplate[]> {
     this.logger.log('Finding all skill templates');
-    try {
-      return await this.skillTemplateRepository.findAll();
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding all skill templates', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillTemplateError(error);
-    }
+
+    return await this.skillTemplateRepository.findAll();
   }
 }

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-always-on-template-by-name/find-always-on-template-by-name.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-always-on-template-by-name/find-always-on-template-by-name.use-case.ts
@@ -1,8 +1,10 @@
 import { Injectable } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { FindActiveAlwaysOnTemplatesUseCase } from '../find-active-always-on-templates/find-active-always-on-templates.use-case';
 import { FindActiveAlwaysOnTemplatesQuery } from '../find-active-always-on-templates/find-active-always-on-templates.query';
 import { FindAlwaysOnTemplateByNameQuery } from './find-always-on-template-by-name.query';
 import { SkillTemplate } from '../../../domain/skill-template.entity';
+import { UnexpectedSkillTemplateError } from '../../skill-templates.errors';
 
 @Injectable()
 export class FindAlwaysOnTemplateByNameUseCase {
@@ -10,6 +12,7 @@ export class FindAlwaysOnTemplateByNameUseCase {
     private readonly findActiveAlwaysOnTemplatesUseCase: FindActiveAlwaysOnTemplatesUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillTemplateError)
   async execute(
     query: FindAlwaysOnTemplateByNameQuery,
   ): Promise<SkillTemplate | null> {

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-one-skill-template/find-one-skill-template.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-one-skill-template/find-one-skill-template.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { FindOneSkillTemplateQuery } from './find-one-skill-template.query';
 import { SkillTemplate } from '../../../domain/skill-template.entity';
@@ -6,7 +7,6 @@ import {
   SkillTemplateNotFoundError,
   UnexpectedSkillTemplateError,
 } from '../../skill-templates.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class FindOneSkillTemplateUseCase {
@@ -16,22 +16,14 @@ export class FindOneSkillTemplateUseCase {
     private readonly skillTemplateRepository: SkillTemplateRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillTemplateError)
   async execute(query: FindOneSkillTemplateQuery): Promise<SkillTemplate> {
     this.logger.log('Finding skill template', { id: query.id });
-    try {
-      const skillTemplate = await this.skillTemplateRepository.findOne(
-        query.id,
-      );
-      if (!skillTemplate) {
-        throw new SkillTemplateNotFoundError(query.id);
-      }
-      return skillTemplate;
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding skill template', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillTemplateError(error);
+
+    const skillTemplate = await this.skillTemplateRepository.findOne(query.id);
+    if (!skillTemplate) {
+      throw new SkillTemplateNotFoundError(query.id);
     }
+    return skillTemplate;
   }
 }

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { UpdateSkillTemplateCommand } from './update-skill-template.command';
 import { SkillTemplate } from '../../../domain/skill-template.entity';
@@ -10,8 +11,6 @@ import {
   SkillTemplateNotFoundError,
   UnexpectedSkillTemplateError,
 } from '../../skill-templates.errors';
-import { InvalidSkillTemplateNameError } from '../../../domain/skill-template.entity';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class UpdateSkillTemplateUseCase {
@@ -21,67 +20,64 @@ export class UpdateSkillTemplateUseCase {
     private readonly skillTemplateRepository: SkillTemplateRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillTemplateError)
   async execute(command: UpdateSkillTemplateCommand): Promise<SkillTemplate> {
     this.logger.log('Updating skill template', {
       skillTemplateId: command.skillTemplateId,
     });
-    try {
-      const existing = await this.skillTemplateRepository.findOne(
-        command.skillTemplateId,
-      );
-      if (!existing) {
-        throw new SkillTemplateNotFoundError(command.skillTemplateId);
-      }
 
-      const name = command.name ?? existing.name;
-
-      if (name !== existing.name) {
-        const duplicate = await this.skillTemplateRepository.findByName(name);
-        if (duplicate) {
-          throw new DuplicateSkillTemplateNameError(name);
-        }
-      }
-
-      const distributionMode =
-        command.distributionMode ?? existing.distributionMode;
-      const baseParams = {
-        id: existing.id,
-        name,
-        shortDescription: command.shortDescription ?? existing.shortDescription,
-        instructions: command.instructions ?? existing.instructions,
-        isActive: command.isActive ?? existing.isActive,
-        createdAt: existing.createdAt,
-        updatedAt: new Date(),
-      };
-
-      const updated: SkillTemplate =
-        distributionMode === DistributionMode.ALWAYS_ON
-          ? new AlwaysOnSkillTemplate(baseParams)
-          : new PreCreatedCopySkillTemplate({
-              ...baseParams,
-              defaultActive:
-                command.defaultActive ??
-                (existing instanceof PreCreatedCopySkillTemplate
-                  ? existing.defaultActive
-                  : false),
-              defaultPinned:
-                command.defaultPinned ??
-                (existing instanceof PreCreatedCopySkillTemplate
-                  ? existing.defaultPinned
-                  : false),
-            });
-
-      return await this.skillTemplateRepository.update(updated);
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof InvalidSkillTemplateNameError
-      )
-        throw error;
-      this.logger.error('Error updating skill template', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillTemplateError(error);
+    const existing = await this.skillTemplateRepository.findOne(
+      command.skillTemplateId,
+    );
+    if (!existing) {
+      throw new SkillTemplateNotFoundError(command.skillTemplateId);
     }
+
+    const name = command.name ?? existing.name;
+
+    if (name !== existing.name) {
+      const duplicate = await this.skillTemplateRepository.findByName(name);
+      if (duplicate) {
+        throw new DuplicateSkillTemplateNameError(name);
+      }
+    }
+
+    const updated = this.buildUpdatedTemplate(command, existing, name);
+
+    return await this.skillTemplateRepository.update(updated);
+  }
+
+  private buildUpdatedTemplate(
+    command: UpdateSkillTemplateCommand,
+    existing: SkillTemplate,
+    name: string,
+  ): SkillTemplate {
+    const distributionMode =
+      command.distributionMode ?? existing.distributionMode;
+    const baseParams = {
+      id: existing.id,
+      name,
+      shortDescription: command.shortDescription ?? existing.shortDescription,
+      instructions: command.instructions ?? existing.instructions,
+      isActive: command.isActive ?? existing.isActive,
+      createdAt: existing.createdAt,
+      updatedAt: new Date(),
+    };
+
+    return distributionMode === DistributionMode.ALWAYS_ON
+      ? new AlwaysOnSkillTemplate(baseParams)
+      : new PreCreatedCopySkillTemplate({
+          ...baseParams,
+          defaultActive:
+            command.defaultActive ??
+            (existing instanceof PreCreatedCopySkillTemplate
+              ? existing.defaultActive
+              : false),
+          defaultPinned:
+            command.defaultPinned ??
+            (existing instanceof PreCreatedCopySkillTemplate
+              ? existing.defaultPinned
+              : false),
+        });
   }
 }

--- a/ayunis-core-backend/src/domain/skill-templates/domain/skill-template.entity.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/domain/skill-template.entity.ts
@@ -1,5 +1,6 @@
 import type { UUID } from 'crypto';
 import { randomUUID } from 'crypto';
+import { ApplicationError } from '../../../common/errors/base.error';
 import type { DistributionMode } from './distribution-mode.enum';
 
 /**
@@ -10,14 +11,16 @@ import type { DistributionMode } from './distribution-mode.enum';
 const CONSECUTIVE_SPACES = / {2}/;
 const CONTROL_CHARS = /\p{Cc}/u;
 
-export class InvalidSkillTemplateNameError extends Error {
+export class InvalidSkillTemplateNameError extends ApplicationError {
   constructor(name: string) {
     super(
       `Invalid skill template name "${name}". Names must not be empty, ` +
         `must not start or end with whitespace, must not contain consecutive spaces, ` +
         `and must not contain control characters.`,
+      'INVALID_SKILL_TEMPLATE_NAME',
+      400,
+      { name },
     );
-    this.name = 'InvalidSkillTemplateNameError';
   }
 }
 

--- a/ayunis-core-backend/src/domain/skills/application/skills.errors.ts
+++ b/ayunis-core-backend/src/domain/skills/application/skills.errors.ts
@@ -249,12 +249,10 @@ export class SkillNameResolutionError extends SkillError {
 }
 
 export class UnexpectedSkillError extends SkillError {
-  constructor(error: unknown) {
-    super(
-      'Unexpected error occurred',
-      SkillErrorCode.UNEXPECTED_SKILL_ERROR,
-      500,
-      { error },
-    );
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, SkillErrorCode.UNEXPECTED_SKILL_ERROR, 500, {
+      ...metadata,
+      error,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/add-source-to-skill/add-source-to-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/add-source-to-skill/add-source-to-skill.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillRepository } from '../../ports/skill.repository';
 import { AddSourceToSkillCommand } from './add-source-to-skill.command';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -11,7 +12,6 @@ import {
 } from '../../skills.errors';
 import { Skill } from '../../../domain/skill.entity';
 import { SkillsConstants } from '../../../domain/skills.constants';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class AddSourceToSkillUseCase {
@@ -22,42 +22,35 @@ export class AddSourceToSkillUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(command: AddSourceToSkillCommand): Promise<Skill> {
     this.logger.log('Adding source to skill', {
       skillId: command.skillId,
       sourceId: command.sourceId,
     });
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      const skill = await this.skillRepository.findOne(command.skillId, userId);
-      if (!skill) {
-        throw new SkillNotFoundError(command.skillId);
-      }
-
-      if (skill.sourceIds.includes(command.sourceId)) {
-        throw new SkillSourceAlreadyAssignedError(command.sourceId);
-      }
-
-      if (skill.sourceIds.length >= SkillsConstants.MAX_SOURCES) {
-        throw new SkillSourceLimitExceededError(SkillsConstants.MAX_SOURCES);
-      }
-
-      const updatedSkill = new Skill({
-        ...skill,
-        sourceIds: [...skill.sourceIds, command.sourceId],
-      });
-
-      return await this.skillRepository.update(updatedSkill);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error adding source to skill', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillError(error);
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
     }
+
+    const skill = await this.skillRepository.findOne(command.skillId, userId);
+    if (!skill) {
+      throw new SkillNotFoundError(command.skillId);
+    }
+
+    if (skill.sourceIds.includes(command.sourceId)) {
+      throw new SkillSourceAlreadyAssignedError(command.sourceId);
+    }
+
+    if (skill.sourceIds.length >= SkillsConstants.MAX_SOURCES) {
+      throw new SkillSourceLimitExceededError(SkillsConstants.MAX_SOURCES);
+    }
+
+    const updatedSkill = new Skill({
+      ...skill,
+      sourceIds: [...skill.sourceIds, command.sourceId],
+    });
+
+    return this.skillRepository.update(updatedSkill);
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/assign-knowledge-base-to-skill/assign-knowledge-base-to-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/assign-knowledge-base-to-skill/assign-knowledge-base-to-skill.use-case.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AssignKnowledgeBaseToSkillCommand } from './assign-knowledge-base-to-skill.command';
 import { SkillRepository } from '../../ports/skill.repository';
 import { GetKnowledgeBasesByIdsUseCase } from 'src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.use-case';
@@ -12,7 +13,6 @@ import {
   SkillKnowledgeBaseAlreadyAssignedError,
   UnexpectedSkillError,
 } from '../../skills.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
@@ -27,49 +27,40 @@ export class AssignKnowledgeBaseToSkillUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(command: AssignKnowledgeBaseToSkillCommand): Promise<Skill> {
     this.logger.log('Assigning knowledge base to skill', {
       skillId: command.skillId,
       knowledgeBaseId: command.knowledgeBaseId,
     });
 
-    try {
-      const userId = this.contextService.get('userId');
-      const orgId = this.contextService.get('orgId');
-      if (!userId || !orgId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      const skill = await this.skillRepository.findOne(command.skillId, userId);
-      if (!skill) {
-        throw new SkillNotFoundError(command.skillId);
-      }
-
-      const knowledgeBases = await this.getKnowledgeBasesByIdsUseCase.execute(
-        new GetKnowledgeBasesByIdsQuery([command.knowledgeBaseId]),
-      );
-      if (knowledgeBases.length === 0) {
-        throw new SkillKnowledgeBaseNotFoundError(command.knowledgeBaseId);
-      }
-
-      if (skill.knowledgeBaseIds.includes(command.knowledgeBaseId)) {
-        throw new SkillKnowledgeBaseAlreadyAssignedError(
-          command.knowledgeBaseId,
-        );
-      }
-
-      const updatedSkill = new Skill({
-        ...skill,
-        knowledgeBaseIds: [...skill.knowledgeBaseIds, command.knowledgeBaseId],
-      });
-
-      return await this.skillRepository.update(updatedSkill);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Unexpected error assigning knowledge base', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillError(error);
+    const userId = this.contextService.get('userId');
+    const orgId = this.contextService.get('orgId');
+    if (!userId || !orgId) {
+      throw new UnauthorizedAccessError();
     }
+
+    const skill = await this.skillRepository.findOne(command.skillId, userId);
+    if (!skill) {
+      throw new SkillNotFoundError(command.skillId);
+    }
+
+    const knowledgeBases = await this.getKnowledgeBasesByIdsUseCase.execute(
+      new GetKnowledgeBasesByIdsQuery([command.knowledgeBaseId]),
+    );
+    if (knowledgeBases.length === 0) {
+      throw new SkillKnowledgeBaseNotFoundError(command.knowledgeBaseId);
+    }
+
+    if (skill.knowledgeBaseIds.includes(command.knowledgeBaseId)) {
+      throw new SkillKnowledgeBaseAlreadyAssignedError(command.knowledgeBaseId);
+    }
+
+    const updatedSkill = new Skill({
+      ...skill,
+      knowledgeBaseIds: [...skill.knowledgeBaseIds, command.knowledgeBaseId],
+    });
+
+    return this.skillRepository.update(updatedSkill);
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/assign-mcp-integration-to-skill/assign-mcp-integration-to-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/assign-mcp-integration-to-skill/assign-mcp-integration-to-skill.use-case.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AssignMcpIntegrationToSkillCommand } from './assign-mcp-integration-to-skill.command';
 import { SkillRepository } from '../../ports/skill.repository';
 import { McpIntegrationsRepositoryPort } from 'src/domain/mcp/application/ports/mcp-integrations.repository.port';
@@ -13,7 +14,6 @@ import {
   SkillMcpIntegrationWrongOrganizationError,
   UnexpectedSkillError,
 } from '../../skills.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
@@ -29,59 +29,50 @@ export class AssignMcpIntegrationToSkillUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(command: AssignMcpIntegrationToSkillCommand): Promise<Skill> {
     this.logger.log('Assigning MCP integration to skill', {
       skillId: command.skillId,
       integrationId: command.integrationId,
     });
 
-    try {
-      const userId = this.contextService.get('userId');
-      const orgId = this.contextService.get('orgId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
+    const userId = this.contextService.get('userId');
+    const orgId = this.contextService.get('orgId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
 
-      const skill = await this.skillRepository.findOne(command.skillId, userId);
-      if (!skill) {
-        throw new SkillNotFoundError(command.skillId);
-      }
+    const skill = await this.skillRepository.findOne(command.skillId, userId);
+    if (!skill) {
+      throw new SkillNotFoundError(command.skillId);
+    }
 
-      const integration = await this.mcpIntegrationsRepository.findById(
+    const integration = await this.mcpIntegrationsRepository.findById(
+      command.integrationId,
+    );
+    if (!integration) {
+      throw new SkillMcpIntegrationNotFoundError(command.integrationId);
+    }
+
+    if (!integration.enabled) {
+      throw new SkillMcpIntegrationDisabledError(command.integrationId);
+    }
+
+    if (integration.orgId !== orgId) {
+      throw new SkillMcpIntegrationWrongOrganizationError(
         command.integrationId,
       );
-      if (!integration) {
-        throw new SkillMcpIntegrationNotFoundError(command.integrationId);
-      }
-
-      if (!integration.enabled) {
-        throw new SkillMcpIntegrationDisabledError(command.integrationId);
-      }
-
-      if (integration.orgId !== orgId) {
-        throw new SkillMcpIntegrationWrongOrganizationError(
-          command.integrationId,
-        );
-      }
-
-      if (skill.mcpIntegrationIds.includes(command.integrationId)) {
-        throw new SkillMcpIntegrationAlreadyAssignedError(
-          command.integrationId,
-        );
-      }
-
-      const updatedSkill = new Skill({
-        ...skill,
-        mcpIntegrationIds: [...skill.mcpIntegrationIds, command.integrationId],
-      });
-
-      return await this.skillRepository.update(updatedSkill);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Unexpected error assigning MCP integration', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillError(error);
     }
+
+    if (skill.mcpIntegrationIds.includes(command.integrationId)) {
+      throw new SkillMcpIntegrationAlreadyAssignedError(command.integrationId);
+    }
+
+    const updatedSkill = new Skill({
+      ...skill,
+      mcpIntegrationIds: [...skill.mcpIntegrationIds, command.integrationId],
+    });
+
+    return this.skillRepository.update(updatedSkill);
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.ts
@@ -1,8 +1,12 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillRepository } from '../../ports/skill.repository';
 import { CreateSkillWithUniqueNameCommand } from './create-skill-with-unique-name.command';
 import { Skill } from '../../../domain/skill.entity';
-import { SkillNameResolutionError } from '../../skills.errors';
+import {
+  SkillNameResolutionError,
+  UnexpectedSkillError,
+} from '../../skills.errors';
 import type { UUID } from 'crypto';
 
 const MAX_NAME_RESOLUTION_ATTEMPTS = 100;
@@ -16,6 +20,7 @@ export class CreateSkillWithUniqueNameUseCase {
     private readonly skillRepository: SkillRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(command: CreateSkillWithUniqueNameCommand): Promise<Skill> {
     this.logger.log('Creating skill with unique name resolution', {
       baseName: command.name,

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill/create-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill/create-skill.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillRepository } from '../../ports/skill.repository';
 import { CreateSkillCommand } from './create-skill.command';
 import { Skill } from '../../../domain/skill.entity';
@@ -6,9 +7,9 @@ import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import {
   DuplicateSkillNameError,
+  SkillInvalidInputError,
   UnexpectedSkillError,
 } from '../../skills.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { InvalidSkillNameError } from '../../../domain/skill.entity';
 
 @Injectable()
@@ -20,6 +21,7 @@ export class CreateSkillUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(command: CreateSkillCommand): Promise<Skill> {
     this.logger.log('Creating skill', { name: command.name });
     try {
@@ -52,13 +54,12 @@ export class CreateSkillUseCase {
 
       return created;
     } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof InvalidSkillNameError
-      )
-        throw error;
-      this.logger.error('Error creating skill', { error: error as Error });
-      throw new UnexpectedSkillError(error);
+      // InvalidSkillNameError is a plain Error; translate it so the decorator
+      // does not wrap it into a 500.
+      if (error instanceof InvalidSkillNameError) {
+        throw new SkillInvalidInputError(error.message);
+      }
+      throw error;
     }
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/delete-skill/delete-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/delete-skill/delete-skill.use-case.ts
@@ -1,11 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillRepository } from '../../ports/skill.repository';
 import { DeleteSkillCommand } from './delete-skill.command';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { SkillNotFoundError, UnexpectedSkillError } from '../../skills.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class DeleteSkillUseCase {
@@ -17,24 +17,19 @@ export class DeleteSkillUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(command: DeleteSkillCommand): Promise<void> {
     this.logger.log('Deleting skill', { skillId: command.skillId });
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      const skill = await this.skillRepository.findOne(command.skillId, userId);
-      if (!skill) {
-        throw new SkillNotFoundError(command.skillId);
-      }
-
-      await this.skillRepository.delete(command.skillId, userId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error deleting skill', { error: error as Error });
-      throw new UnexpectedSkillError(error);
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
     }
+
+    const skill = await this.skillRepository.findOne(command.skillId, userId);
+    if (!skill) {
+      throw new SkillNotFoundError(command.skillId);
+    }
+
+    await this.skillRepository.delete(command.skillId, userId);
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/find-active-skills/find-active-skills.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/find-active-skills/find-active-skills.use-case.ts
@@ -1,11 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillRepository } from '../../ports/skill.repository';
 import { FindActiveSkillsQuery } from './find-active-skills.query';
 import { Skill } from '../../../domain/skill.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { UnexpectedSkillError } from '../../skills.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { FindSharesByScopeUseCase } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.use-case';
 import { FindSharesByScopeQuery } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.query';
 import { SharedEntityType } from 'src/domain/shares/domain/value-objects/shared-entity-type.enum';
@@ -22,63 +22,55 @@ export class FindActiveSkillsUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(query: FindActiveSkillsQuery): Promise<Skill[]> {
     this.logger.log('Finding active skills', query);
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      // 1. Fetch owned active skills
-      const ownedActiveSkills =
-        await this.skillRepository.findActiveByOwner(userId);
-      const ownedSkillIds = new Set(ownedActiveSkills.map((s) => s.id));
-
-      // 2. Get all active skill IDs for this user
-      const activeSkillIds =
-        await this.skillRepository.getActiveSkillIds(userId);
-
-      // 3. Find active skill IDs that are not owned (must be shared)
-      const potentialSharedActiveIds: UUID[] = [];
-      for (const activeId of activeSkillIds) {
-        if (!ownedSkillIds.has(activeId)) {
-          potentialSharedActiveIds.push(activeId);
-        }
-      }
-
-      if (potentialSharedActiveIds.length === 0) {
-        return ownedActiveSkills;
-      }
-
-      // 4. Verify these are actually shared with the user
-      const shares = await this.findSharesByScopeUseCase.execute(
-        new FindSharesByScopeQuery(SharedEntityType.SKILL),
-      );
-      const sharedSkillIds = new Set(
-        shares.map((s) => (s as SkillShare).skillId),
-      );
-
-      const confirmedSharedActiveIds = potentialSharedActiveIds.filter((id) =>
-        sharedSkillIds.has(id),
-      );
-
-      if (confirmedSharedActiveIds.length === 0) {
-        return ownedActiveSkills;
-      }
-
-      // 5. Fetch the shared active skills
-      const sharedActiveSkills = await this.skillRepository.findByIds(
-        confirmedSharedActiveIds,
-      );
-
-      return [...ownedActiveSkills, ...sharedActiveSkills];
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding active skills', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillError(error);
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
     }
+
+    // 1. Fetch owned active skills
+    const ownedActiveSkills =
+      await this.skillRepository.findActiveByOwner(userId);
+    const ownedSkillIds = new Set(ownedActiveSkills.map((s) => s.id));
+
+    // 2. Get all active skill IDs for this user
+    const activeSkillIds = await this.skillRepository.getActiveSkillIds(userId);
+
+    // 3. Find active skill IDs that are not owned (must be shared)
+    const potentialSharedActiveIds: UUID[] = [];
+    for (const activeId of activeSkillIds) {
+      if (!ownedSkillIds.has(activeId)) {
+        potentialSharedActiveIds.push(activeId);
+      }
+    }
+
+    if (potentialSharedActiveIds.length === 0) {
+      return ownedActiveSkills;
+    }
+
+    // 4. Verify these are actually shared with the user
+    const shares = await this.findSharesByScopeUseCase.execute(
+      new FindSharesByScopeQuery(SharedEntityType.SKILL),
+    );
+    const sharedSkillIds = new Set(
+      shares.map((s) => (s as SkillShare).skillId),
+    );
+
+    const confirmedSharedActiveIds = potentialSharedActiveIds.filter((id) =>
+      sharedSkillIds.has(id),
+    );
+
+    if (confirmedSharedActiveIds.length === 0) {
+      return ownedActiveSkills;
+    }
+
+    // 5. Fetch the shared active skills
+    const sharedActiveSkills = await this.skillRepository.findByIds(
+      confirmedSharedActiveIds,
+    );
+
+    return [...ownedActiveSkills, ...sharedActiveSkills];
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/find-all-skills/find-all-skills.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/find-all-skills/find-all-skills.use-case.ts
@@ -1,5 +1,7 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import type { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedSkillError } from '../../skills.errors';
 import { SkillRepository } from '../../ports/skill.repository';
 import { FindAllSkillsQuery } from './find-all-skills.query';
 import { Skill } from '../../../domain/skill.entity';
@@ -40,6 +42,7 @@ export class FindAllSkillsUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(query: FindAllSkillsQuery): Promise<FindAllSkillsResult> {
     this.logger.log('Finding all skills', query);
 

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/find-one-skill/find-one-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/find-one-skill/find-one-skill.use-case.ts
@@ -1,11 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillRepository } from '../../ports/skill.repository';
 import { FindOneSkillQuery } from './find-one-skill.query';
 import { Skill } from '../../../domain/skill.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { SkillNotFoundError, UnexpectedSkillError } from '../../skills.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { FindShareByEntityUseCase } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case';
 import { FindShareByEntityQuery } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.query';
 import { SharedEntityType } from 'src/domain/shares/domain/value-objects/shared-entity-type.enum';
@@ -27,50 +27,45 @@ export class FindOneSkillUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(query: FindOneSkillQuery): Promise<SkillWithUserContext> {
     this.logger.log('Finding skill', { id: query.id });
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
 
-      // Try owned skill first
-      const ownedSkill = await this.skillRepository.findOne(query.id, userId);
-      if (ownedSkill) {
+    // Try owned skill first
+    const ownedSkill = await this.skillRepository.findOne(query.id, userId);
+    if (ownedSkill) {
+      const [isActive, isPinned] = await Promise.all([
+        this.skillRepository.isSkillActive(query.id, userId),
+        this.skillRepository.isSkillPinned(query.id, userId),
+      ]);
+      return { skill: ownedSkill, isActive, isShared: false, isPinned };
+    }
+
+    // Check if skill is shared with user
+    const share = await this.findShareByEntityUseCase.execute(
+      new FindShareByEntityQuery(SharedEntityType.SKILL, query.id),
+    );
+
+    if (share) {
+      const sharedSkills = await this.skillRepository.findByIds([query.id]);
+      if (sharedSkills.length > 0) {
         const [isActive, isPinned] = await Promise.all([
           this.skillRepository.isSkillActive(query.id, userId),
           this.skillRepository.isSkillPinned(query.id, userId),
         ]);
-        return { skill: ownedSkill, isActive, isShared: false, isPinned };
+        return {
+          skill: sharedSkills[0],
+          isActive,
+          isShared: true,
+          isPinned,
+        };
       }
-
-      // Check if skill is shared with user
-      const share = await this.findShareByEntityUseCase.execute(
-        new FindShareByEntityQuery(SharedEntityType.SKILL, query.id),
-      );
-
-      if (share) {
-        const sharedSkills = await this.skillRepository.findByIds([query.id]);
-        if (sharedSkills.length > 0) {
-          const [isActive, isPinned] = await Promise.all([
-            this.skillRepository.isSkillActive(query.id, userId),
-            this.skillRepository.isSkillPinned(query.id, userId),
-          ]);
-          return {
-            skill: sharedSkills[0],
-            isActive,
-            isShared: true,
-            isPinned,
-          };
-        }
-      }
-
-      throw new SkillNotFoundError(query.id);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding skill', { error: error as Error });
-      throw new UnexpectedSkillError(error);
     }
+
+    throw new SkillNotFoundError(query.id);
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/find-skill-by-name/find-skill-by-name.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/find-skill-by-name/find-skill-by-name.use-case.ts
@@ -1,11 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillRepository } from '../../ports/skill.repository';
 import { FindSkillByNameQuery } from './find-skill-by-name.query';
 import { Skill } from '../../../domain/skill.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { SkillNotFoundError, UnexpectedSkillError } from '../../skills.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { FindSharesByScopeUseCase } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.use-case';
 import { FindSharesByScopeQuery } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.query';
 import { SharedEntityType } from 'src/domain/shares/domain/value-objects/shared-entity-type.enum';
@@ -21,47 +21,39 @@ export class FindSkillByNameUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(query: FindSkillByNameQuery): Promise<Skill> {
     this.logger.log('Finding skill by name', { name: query.name });
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      // Owned skills take priority
-      const ownedSkill = await this.skillRepository.findByNameAndOwner(
-        query.name,
-        userId,
-      );
-
-      if (ownedSkill) {
-        return ownedSkill;
-      }
-
-      // Check shared skills
-      const shares = await this.findSharesByScopeUseCase.execute(
-        new FindSharesByScopeQuery(SharedEntityType.SKILL),
-      );
-
-      if (shares.length > 0) {
-        const sharedSkillIds = shares.map((s) => (s as SkillShare).skillId);
-        const sharedSkills =
-          await this.skillRepository.findByIds(sharedSkillIds);
-        const matchingSkill = sharedSkills.find((s) => s.name === query.name);
-
-        if (matchingSkill) {
-          return matchingSkill;
-        }
-      }
-
-      throw new SkillNotFoundError(query.name);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding skill by name', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillError(error);
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
     }
+
+    // Owned skills take priority
+    const ownedSkill = await this.skillRepository.findByNameAndOwner(
+      query.name,
+      userId,
+    );
+
+    if (ownedSkill) {
+      return ownedSkill;
+    }
+
+    // Check shared skills
+    const shares = await this.findSharesByScopeUseCase.execute(
+      new FindSharesByScopeQuery(SharedEntityType.SKILL),
+    );
+
+    if (shares.length > 0) {
+      const sharedSkillIds = shares.map((s) => (s as SkillShare).skillId);
+      const sharedSkills = await this.skillRepository.findByIds(sharedSkillIds);
+      const matchingSkill = sharedSkills.find((s) => s.name === query.name);
+
+      if (matchingSkill) {
+        return matchingSkill;
+      }
+    }
+
+    throw new SkillNotFoundError(query.name);
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/install-skill-from-marketplace/install-skill-from-marketplace.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/install-skill-from-marketplace/install-skill-from-marketplace.use-case.ts
@@ -1,10 +1,14 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Skill } from '../../../domain/skill.entity';
 import { InstallSkillFromMarketplaceCommand } from './install-skill-from-marketplace.command';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ApplicationError } from 'src/common/errors/base.error';
-import { MarketplaceInstallFailedError } from '../../skills.errors';
+import {
+  MarketplaceInstallFailedError,
+  UnexpectedSkillError,
+} from '../../skills.errors';
 import { MarketplaceSkillInstallationService } from '../../services/marketplace-skill-installation.service';
 import { MarketplaceSkillInstalledEvent } from '../../events/marketplace-skill-installed.event';
 
@@ -18,6 +22,7 @@ export class InstallSkillFromMarketplaceUseCase {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(command: InstallSkillFromMarketplaceCommand): Promise<Skill> {
     this.logger.log('execute', { identifier: command.identifier });
 

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-knowledge-bases/list-skill-knowledge-bases.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-knowledge-bases/list-skill-knowledge-bases.use-case.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ListSkillKnowledgeBasesQuery } from './list-skill-knowledge-bases.query';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
 import { GetKnowledgeBasesByIdsUseCase } from 'src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.use-case';
 import { GetKnowledgeBasesByIdsQuery } from 'src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.query';
 import { UnexpectedSkillError } from '../../skills.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { SkillAccessService } from '../../services/skill-access.service';
 
 @Injectable()
@@ -16,31 +16,22 @@ export class ListSkillKnowledgeBasesUseCase {
     private readonly skillAccessService: SkillAccessService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(query: ListSkillKnowledgeBasesQuery): Promise<KnowledgeBase[]> {
     this.logger.log('Listing knowledge bases for skill', {
       skillId: query.skillId,
     });
 
-    try {
-      const skill = await this.skillAccessService.findAccessibleSkill(
-        query.skillId,
-      );
+    const skill = await this.skillAccessService.findAccessibleSkill(
+      query.skillId,
+    );
 
-      if (skill.knowledgeBaseIds.length === 0) {
-        return [];
-      }
-
-      return this.getKnowledgeBasesByIdsUseCase.execute(
-        new GetKnowledgeBasesByIdsQuery(skill.knowledgeBaseIds),
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Unexpected error listing skill knowledge bases', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillError(error);
+    if (skill.knowledgeBaseIds.length === 0) {
+      return [];
     }
+
+    return this.getKnowledgeBasesByIdsUseCase.execute(
+      new GetKnowledgeBasesByIdsQuery(skill.knowledgeBaseIds),
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-mcp-integrations/list-skill-mcp-integrations.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-mcp-integrations/list-skill-mcp-integrations.use-case.ts
@@ -5,12 +5,12 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ListSkillMcpIntegrationsQuery } from './list-skill-mcp-integrations.query';
 import { SkillRepository } from '../../ports/skill.repository';
 import { ContextService } from 'src/common/context/services/context.service';
 import { McpIntegration } from 'src/domain/mcp/domain/mcp-integration.entity';
 import { SkillNotFoundError, UnexpectedSkillError } from '../../skills.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { GetMcpIntegrationsByIdsUseCase } from 'src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.use-case';
 import { GetMcpIntegrationsByIdsQuery } from 'src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.query';
 import { FindShareByEntityUseCase } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case';
@@ -30,6 +30,7 @@ export class ListSkillMcpIntegrationsUseCase {
     private readonly findShareByEntityUseCase: FindShareByEntityUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(
     query: ListSkillMcpIntegrationsQuery,
   ): Promise<McpIntegration[]> {
@@ -37,36 +38,23 @@ export class ListSkillMcpIntegrationsUseCase {
       skillId: query.skillId,
     });
 
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-
-      const skill = await this.findSkillOwnedOrShared(query.skillId, userId);
-      if (!skill) {
-        throw new SkillNotFoundError(query.skillId);
-      }
-
-      if (skill.mcpIntegrationIds.length === 0) {
-        return [];
-      }
-
-      return this.getMcpIntegrationsByIdsUseCase.execute(
-        new GetMcpIntegrationsByIdsQuery(skill.mcpIntegrationIds),
-      );
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-      this.logger.error('Unexpected error listing skill MCP integrations', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillError(error);
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedException('User not authenticated');
     }
+
+    const skill = await this.findSkillOwnedOrShared(query.skillId, userId);
+    if (!skill) {
+      throw new SkillNotFoundError(query.skillId);
+    }
+
+    if (skill.mcpIntegrationIds.length === 0) {
+      return [];
+    }
+
+    return this.getMcpIntegrationsByIdsUseCase.execute(
+      new GetMcpIntegrationsByIdsQuery(skill.mcpIntegrationIds),
+    );
   }
 
   private async findSkillOwnedOrShared(

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-sources/list-skill-sources.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-sources/list-skill-sources.use-case.ts
@@ -5,6 +5,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ListSkillSourcesQuery } from './list-skill-sources.query';
 import { SkillRepository } from '../../ports/skill.repository';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -12,7 +13,6 @@ import { Source } from 'src/domain/sources/domain/source.entity';
 import { GetSourcesByIdsUseCase } from 'src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case';
 import { GetSourcesByIdsQuery } from 'src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.query';
 import { SkillNotFoundError, UnexpectedSkillError } from '../../skills.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { FindShareByEntityUseCase } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case';
 import { FindShareByEntityQuery } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.query';
 import { SharedEntityType } from 'src/domain/shares/domain/value-objects/shared-entity-type.enum';
@@ -30,39 +30,27 @@ export class ListSkillSourcesUseCase {
     private readonly findShareByEntityUseCase: FindShareByEntityUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(query: ListSkillSourcesQuery): Promise<Source[]> {
     this.logger.log('Listing sources for skill', { skillId: query.skillId });
 
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-
-      const skill = await this.findSkillOwnedOrShared(query.skillId, userId);
-      if (!skill) {
-        throw new SkillNotFoundError(query.skillId);
-      }
-
-      if (skill.sourceIds.length === 0) {
-        return [];
-      }
-
-      return this.getSourcesByIdsUseCase.execute(
-        new GetSourcesByIdsQuery(skill.sourceIds),
-      );
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-      this.logger.error('Unexpected error listing skill sources', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillError(error);
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedException('User not authenticated');
     }
+
+    const skill = await this.findSkillOwnedOrShared(query.skillId, userId);
+    if (!skill) {
+      throw new SkillNotFoundError(query.skillId);
+    }
+
+    if (skill.sourceIds.length === 0) {
+      return [];
+    }
+
+    return this.getSourcesByIdsUseCase.execute(
+      new GetSourcesByIdsQuery(skill.sourceIds),
+    );
   }
 
   private async findSkillOwnedOrShared(

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/remove-source-from-skill/remove-source-from-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/remove-source-from-skill/remove-source-from-skill.use-case.ts
@@ -1,11 +1,11 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillRepository } from '../../ports/skill.repository';
 import { RemoveSourceFromSkillCommand } from './remove-source-from-skill.command';
 import { ContextService } from 'src/common/context/services/context.service';
 import { SkillNotFoundError, UnexpectedSkillError } from '../../skills.errors';
 import { Skill } from '../../../domain/skill.entity';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { DeleteSourceUseCase } from 'src/domain/sources/application/use-cases/delete-source/delete-source.use-case';
 import { DeleteSourceCommand } from 'src/domain/sources/application/use-cases/delete-source/delete-source.command';
 
@@ -20,46 +20,34 @@ export class RemoveSourceFromSkillUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(command: RemoveSourceFromSkillCommand): Promise<void> {
     this.logger.log('Removing source from skill', {
       skillId: command.skillId,
       sourceId: command.sourceId,
     });
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-
-      const skill = await this.skillRepository.findOne(command.skillId, userId);
-      if (!skill) {
-        throw new SkillNotFoundError(command.skillId);
-      }
-
-      if (!skill.sourceIds.includes(command.sourceId)) {
-        return;
-      }
-
-      const updatedSkill = new Skill({
-        ...skill,
-        sourceIds: skill.sourceIds.filter((id) => id !== command.sourceId),
-      });
-
-      await this.deleteSourceUseCase.execute(
-        new DeleteSourceCommand(command.sourceId),
-      );
-      await this.skillRepository.update(updatedSkill);
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-      this.logger.error('Error removing source from skill', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillError(error);
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedException('User not authenticated');
     }
+
+    const skill = await this.skillRepository.findOne(command.skillId, userId);
+    if (!skill) {
+      throw new SkillNotFoundError(command.skillId);
+    }
+
+    if (!skill.sourceIds.includes(command.sourceId)) {
+      return;
+    }
+
+    const updatedSkill = new Skill({
+      ...skill,
+      sourceIds: skill.sourceIds.filter((id) => id !== command.sourceId),
+    });
+
+    await this.deleteSourceUseCase.execute(
+      new DeleteSourceCommand(command.sourceId),
+    );
+    await this.skillRepository.update(updatedSkill);
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/toggle-skill-active/toggle-skill-active.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/toggle-skill-active/toggle-skill-active.use-case.ts
@@ -1,11 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillRepository } from '../../ports/skill.repository';
 import { ToggleSkillActiveCommand } from './toggle-skill-active.command';
 import { Skill } from '../../../domain/skill.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnexpectedSkillError } from '../../skills.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { SkillAccessService } from '../../services/skill-access.service';
 
 @Injectable()
@@ -19,6 +19,7 @@ export class ToggleSkillActiveUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(command: ToggleSkillActiveCommand): Promise<{
     skill: Skill;
     isActive: boolean;
@@ -26,41 +27,33 @@ export class ToggleSkillActiveUseCase {
     isShared: boolean;
   }> {
     this.logger.log('Toggling skill active', { skillId: command.skillId });
-    try {
-      // findAccessibleSkill validates userId and throws UnauthorizedAccessError
-      const skill = await this.skillAccessService.findAccessibleSkill(
-        command.skillId,
-      );
-      const userId = this.contextService.get('userId')!;
+    // findAccessibleSkill validates userId and throws UnauthorizedAccessError
+    const skill = await this.skillAccessService.findAccessibleSkill(
+      command.skillId,
+    );
+    const userId = this.contextService.get('userId')!;
 
-      const currentlyActive = await this.skillRepository.isSkillActive(
-        command.skillId,
-        userId,
-      );
+    const currentlyActive = await this.skillRepository.isSkillActive(
+      command.skillId,
+      userId,
+    );
 
-      if (currentlyActive) {
-        await this.skillRepository.deactivateSkill(command.skillId, userId);
-      } else {
-        await this.skillRepository.activateSkill(command.skillId, userId);
-      }
-
-      const isActive = !currentlyActive;
-
-      // When deactivating, pinned state is implicitly cleared (activation row deleted)
-      const [isShared, isPinned] = await Promise.all([
-        this.skillAccessService.resolveIsShared(command.skillId, userId),
-        isActive
-          ? this.skillRepository.isSkillPinned(command.skillId, userId)
-          : Promise.resolve(false),
-      ]);
-
-      return { skill, isActive, isPinned, isShared };
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error toggling skill active', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillError(error);
+    if (currentlyActive) {
+      await this.skillRepository.deactivateSkill(command.skillId, userId);
+    } else {
+      await this.skillRepository.activateSkill(command.skillId, userId);
     }
+
+    const isActive = !currentlyActive;
+
+    // When deactivating, pinned state is implicitly cleared (activation row deleted)
+    const [isShared, isPinned] = await Promise.all([
+      this.skillAccessService.resolveIsShared(command.skillId, userId),
+      isActive
+        ? this.skillRepository.isSkillPinned(command.skillId, userId)
+        : Promise.resolve(false),
+    ]);
+
+    return { skill, isActive, isPinned, isShared };
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/toggle-skill-pinned/toggle-skill-pinned.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/toggle-skill-pinned/toggle-skill-pinned.use-case.ts
@@ -1,11 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillRepository } from '../../ports/skill.repository';
 import { ToggleSkillPinnedCommand } from './toggle-skill-pinned.command';
 import { Skill } from '../../../domain/skill.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { SkillNotActiveError, UnexpectedSkillError } from '../../skills.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { SkillAccessService } from '../../services/skill-access.service';
 
 @Injectable()
@@ -19,44 +19,37 @@ export class ToggleSkillPinnedUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(
     command: ToggleSkillPinnedCommand,
   ): Promise<{ skill: Skill; isPinned: boolean; isShared: boolean }> {
     this.logger.log('Toggling skill pinned', { skillId: command.skillId });
-    try {
-      // findAccessibleSkill validates userId and throws UnauthorizedAccessError
-      const skill = await this.skillAccessService.findAccessibleSkill(
-        command.skillId,
-      );
-      const userId = this.contextService.get('userId')!;
+    // findAccessibleSkill validates userId and throws UnauthorizedAccessError
+    const skill = await this.skillAccessService.findAccessibleSkill(
+      command.skillId,
+    );
+    const userId = this.contextService.get('userId')!;
 
-      // Skill must be active to toggle pinned
-      const isActive = await this.skillRepository.isSkillActive(
-        command.skillId,
-        userId,
-      );
+    // Skill must be active to toggle pinned
+    const isActive = await this.skillRepository.isSkillActive(
+      command.skillId,
+      userId,
+    );
 
-      if (!isActive) {
-        throw new SkillNotActiveError(command.skillId);
-      }
-
-      const isPinned = await this.skillRepository.toggleSkillPinned(
-        command.skillId,
-        userId,
-      );
-
-      const isShared = await this.skillAccessService.resolveIsShared(
-        command.skillId,
-        userId,
-      );
-
-      return { skill, isPinned, isShared };
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error toggling skill pinned', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillError(error);
+    if (!isActive) {
+      throw new SkillNotActiveError(command.skillId);
     }
+
+    const isPinned = await this.skillRepository.toggleSkillPinned(
+      command.skillId,
+      userId,
+    );
+
+    const isShared = await this.skillAccessService.resolveIsShared(
+      command.skillId,
+      userId,
+    );
+
+    return { skill, isPinned, isShared };
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/unassign-knowledge-base-from-skill/unassign-knowledge-base-from-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/unassign-knowledge-base-from-skill/unassign-knowledge-base-from-skill.use-case.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillRepository } from '../../ports/skill.repository';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnassignKnowledgeBaseFromSkillCommand } from './unassign-knowledge-base-from-skill.command';
@@ -9,7 +10,6 @@ import {
   SkillKnowledgeBaseNotAssignedError,
   UnexpectedSkillError,
 } from '../../skills.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
@@ -25,6 +25,7 @@ export class UnassignKnowledgeBaseFromSkillUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(
     command: UnassignKnowledgeBaseFromSkillCommand,
   ): Promise<Skill> {
@@ -33,37 +34,27 @@ export class UnassignKnowledgeBaseFromSkillUseCase {
       knowledgeBaseId: command.knowledgeBaseId,
     });
 
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      const skill = await this.skillRepository.findOne(command.skillId, userId);
-      if (!skill) {
-        throw new SkillNotFoundError(command.skillId);
-      }
-
-      if (!skill.knowledgeBaseIds.includes(command.knowledgeBaseId)) {
-        throw new SkillKnowledgeBaseNotAssignedError(command.knowledgeBaseId);
-      }
-
-      const updatedSkill = new Skill({
-        ...skill,
-        knowledgeBaseIds: skill.knowledgeBaseIds.filter(
-          (id) => id !== command.knowledgeBaseId,
-        ),
-      });
-
-      return await this.skillRepository.update(updatedSkill);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Unexpected error unassigning knowledge base', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillError(error);
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
     }
+
+    const skill = await this.skillRepository.findOne(command.skillId, userId);
+    if (!skill) {
+      throw new SkillNotFoundError(command.skillId);
+    }
+
+    if (!skill.knowledgeBaseIds.includes(command.knowledgeBaseId)) {
+      throw new SkillKnowledgeBaseNotAssignedError(command.knowledgeBaseId);
+    }
+
+    const updatedSkill = new Skill({
+      ...skill,
+      knowledgeBaseIds: skill.knowledgeBaseIds.filter(
+        (id) => id !== command.knowledgeBaseId,
+      ),
+    });
+
+    return this.skillRepository.update(updatedSkill);
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/unassign-mcp-integration-from-skill/unassign-mcp-integration-from-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/unassign-mcp-integration-from-skill/unassign-mcp-integration-from-skill.use-case.ts
@@ -5,6 +5,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillRepository } from '../../ports/skill.repository';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnassignMcpIntegrationFromSkillCommand } from './unassign-mcp-integration-from-skill.command';
@@ -14,7 +15,6 @@ import {
   SkillMcpIntegrationNotAssignedError,
   UnexpectedSkillError,
 } from '../../skills.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class UnassignMcpIntegrationFromSkillUseCase {
@@ -29,6 +29,7 @@ export class UnassignMcpIntegrationFromSkillUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(
     command: UnassignMcpIntegrationFromSkillCommand,
   ): Promise<Skill> {
@@ -37,40 +38,27 @@ export class UnassignMcpIntegrationFromSkillUseCase {
       integrationId: command.integrationId,
     });
 
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-
-      const skill = await this.skillRepository.findOne(command.skillId, userId);
-      if (!skill) {
-        throw new SkillNotFoundError(command.skillId);
-      }
-
-      if (!skill.mcpIntegrationIds.includes(command.integrationId)) {
-        throw new SkillMcpIntegrationNotAssignedError(command.integrationId);
-      }
-
-      const updatedSkill = new Skill({
-        ...skill,
-        mcpIntegrationIds: skill.mcpIntegrationIds.filter(
-          (id) => id !== command.integrationId,
-        ),
-      });
-
-      return await this.skillRepository.update(updatedSkill);
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-      this.logger.error('Unexpected error unassigning MCP integration', {
-        error: error as Error,
-      });
-      throw new UnexpectedSkillError(error);
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedException('User not authenticated');
     }
+
+    const skill = await this.skillRepository.findOne(command.skillId, userId);
+    if (!skill) {
+      throw new SkillNotFoundError(command.skillId);
+    }
+
+    if (!skill.mcpIntegrationIds.includes(command.integrationId)) {
+      throw new SkillMcpIntegrationNotAssignedError(command.integrationId);
+    }
+
+    const updatedSkill = new Skill({
+      ...skill,
+      mcpIntegrationIds: skill.mcpIntegrationIds.filter(
+        (id) => id !== command.integrationId,
+      ),
+    });
+
+    return this.skillRepository.update(updatedSkill);
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SkillRepository } from '../../ports/skill.repository';
 import { UpdateSkillCommand } from './update-skill.command';
 import { Skill } from '../../../domain/skill.entity';
@@ -7,10 +8,10 @@ import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import {
   DuplicateSkillNameError,
+  SkillInvalidInputError,
   SkillNotFoundError,
   UnexpectedSkillError,
 } from '../../skills.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { InvalidSkillNameError } from '../../../domain/skill.entity';
 
 @Injectable()
@@ -23,6 +24,7 @@ export class UpdateSkillUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(command: UpdateSkillCommand): Promise<Skill> {
     this.logger.log('Updating skill', { skillId: command.skillId });
     try {
@@ -63,15 +65,14 @@ export class UpdateSkillUseCase {
         updatedAt: new Date(),
       });
 
-      return this.skillRepository.update(updatedSkill);
+      return await this.skillRepository.update(updatedSkill);
     } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof InvalidSkillNameError
-      )
-        throw error;
-      this.logger.error('Error updating skill', { error: error as Error });
-      throw new UnexpectedSkillError(error);
+      // InvalidSkillNameError is a plain Error; translate it so the decorator
+      // does not wrap it into a 500.
+      if (error instanceof InvalidSkillNameError) {
+        throw new SkillInvalidInputError(error.message);
+      }
+      throw error;
     }
   }
 }

--- a/ayunis-core-backend/src/domain/storage/application/storage.errors.ts
+++ b/ayunis-core-backend/src/domain/storage/application/storage.errors.ts
@@ -9,6 +9,7 @@ export enum StorageErrorCode {
   BUCKET_NOT_FOUND = 'BUCKET_NOT_FOUND',
   INVALID_OBJECT_NAME = 'INVALID_OBJECT_NAME',
   PERMISSION_DENIED = 'PERMISSION_DENIED',
+  UNEXPECTED_STORAGE_ERROR = 'UNEXPECTED_STORAGE_ERROR',
 }
 
 export class StorageError extends ApplicationError {
@@ -20,6 +21,16 @@ export class StorageError extends ApplicationError {
   ) {
     super(message, code, statusCode, metadata);
     this.name = 'StorageError';
+  }
+}
+
+export class UnexpectedStorageError extends StorageError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(error.message, StorageErrorCode.UNEXPECTED_STORAGE_ERROR, 500, {
+      ...metadata,
+      error,
+    });
+    this.name = 'UnexpectedStorageError';
   }
 }
 

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/delete-object/delete-object.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/delete-object/delete-object.use-case.ts
@@ -1,9 +1,14 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ObjectStoragePort } from '../../ports/object-storage.port';
 import { DeleteObjectCommand } from './delete-object.command';
 import storageConfig from '../../../../../config/storage.config';
-import { DeleteFailedError, ObjectNotFoundError } from '../../storage.errors';
+import {
+  DeleteFailedError,
+  ObjectNotFoundError,
+  UnexpectedStorageError,
+} from '../../storage.errors';
 import { StorageUrl } from '../../../domain/storage-url.entity';
 
 @Injectable()
@@ -16,6 +21,7 @@ export class DeleteObjectUseCase {
     private readonly config: ConfigType<typeof storageConfig>,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedStorageError)
   async execute(command: DeleteObjectCommand): Promise<void> {
     this.logger.debug(`Deleting object: ${command.objectName}`, {
       bucket: command.bucket,

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/download-object/download-object.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/download-object/download-object.use-case.ts
@@ -1,9 +1,14 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ObjectStoragePort } from '../../ports/object-storage.port';
 import { DownloadObjectCommand } from './download-object.command';
 import storageConfig from '../../../../../config/storage.config';
-import { DownloadFailedError, ObjectNotFoundError } from '../../storage.errors';
+import {
+  DownloadFailedError,
+  ObjectNotFoundError,
+  UnexpectedStorageError,
+} from '../../storage.errors';
 import { StorageUrl } from '../../../domain/storage-url.entity';
 
 @Injectable()
@@ -16,6 +21,7 @@ export class DownloadObjectUseCase {
     private readonly config: ConfigType<typeof storageConfig>,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedStorageError)
   async execute(
     command: DownloadObjectCommand,
   ): Promise<NodeJS.ReadableStream> {

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/get-object-info/get-object-info.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/get-object-info/get-object-info.use-case.ts
@@ -1,10 +1,15 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ObjectStoragePort } from '../../ports/object-storage.port';
 import { StorageObject } from '../../../domain/storage-object.entity';
 import { GetObjectInfoCommand } from './get-object-info.command';
 import storageConfig from '../../../../../config/storage.config';
-import { DownloadFailedError, ObjectNotFoundError } from '../../storage.errors';
+import {
+  DownloadFailedError,
+  ObjectNotFoundError,
+  UnexpectedStorageError,
+} from '../../storage.errors';
 import { StorageUrl } from '../../../domain/storage-url.entity';
 
 @Injectable()
@@ -17,6 +22,7 @@ export class GetObjectInfoUseCase {
     private readonly config: ConfigType<typeof storageConfig>,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedStorageError)
   async execute(command: GetObjectInfoCommand): Promise<StorageObject> {
     this.logger.debug(`Getting info for object: ${command.objectName}`, {
       bucket: command.bucket,

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/get-presigned-url/get-presigned-url.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/get-presigned-url/get-presigned-url.use-case.ts
@@ -1,9 +1,14 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ObjectStoragePort } from '../../ports/object-storage.port';
 import { GetPresignedUrlCommand } from './get-presigned-url.command';
 import storageConfig from '../../../../../config/storage.config';
-import { DownloadFailedError, ObjectNotFoundError } from '../../storage.errors';
+import {
+  DownloadFailedError,
+  ObjectNotFoundError,
+  UnexpectedStorageError,
+} from '../../storage.errors';
 import { StorageUrl } from '../../../domain/storage-url.entity';
 import { PresignedUrl } from '../../../domain/presigned-url.entity';
 
@@ -17,6 +22,7 @@ export class GetPresignedUrlUseCase {
     private readonly config: ConfigType<typeof storageConfig>,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedStorageError)
   async execute(command: GetPresignedUrlCommand): Promise<PresignedUrl> {
     this.logger.debug(
       `Generating presigned URL for object: ${command.objectName}`,

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/list-objects/list-objects.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/list-objects/list-objects.use-case.ts
@@ -1,8 +1,10 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ObjectStoragePort } from '../../ports/object-storage.port';
 import { ListObjectsCommand } from './list-objects.command';
 import storageConfig from '../../../../../config/storage.config';
+import { UnexpectedStorageError } from '../../storage.errors';
 
 @Injectable()
 export class ListObjectsUseCase {
@@ -14,6 +16,7 @@ export class ListObjectsUseCase {
     private readonly config: ConfigType<typeof storageConfig>,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedStorageError)
   async execute(command: ListObjectsCommand): Promise<string[]> {
     this.logger.debug(`Listing objects with prefix: ${command.prefix}`);
     const bucket = command.bucket ?? this.config.minio.bucket;

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/upload-object/upload-object.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/upload-object/upload-object.use-case.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ObjectStoragePort } from '../../ports/object-storage.port';
 import { StorageObject } from '../../../domain/storage-object.entity';
 import { UploadObjectCommand } from './upload-object.command';
@@ -8,6 +9,7 @@ import {
   BucketNotFoundError,
   InvalidObjectNameError,
   StoragePermissionDeniedError,
+  UnexpectedStorageError,
   UploadFailedError,
 } from '../../storage.errors';
 import { StorageObjectUpload } from '../../../domain/storage-object-upload.entity';
@@ -22,25 +24,14 @@ export class UploadObjectUseCase {
     private readonly config: ConfigType<typeof storageConfig>,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedStorageError)
   async execute(command: UploadObjectCommand): Promise<StorageObject> {
     this.logger.debug(`Uploading object: ${command.objectName}`, {
       bucket: command.bucket,
     });
 
     try {
-      if (!this.isValidObjectName(command.objectName)) {
-        throw new InvalidObjectNameError({ objectName: command.objectName });
-      }
-
-      const bucketName = command.bucket || this.getDefaultBucket();
-
-      // Check if bucket exists before uploading
-      if (bucketName !== this.getDefaultBucket()) {
-        const bucketExists = this.bucketExists(bucketName);
-        if (!bucketExists) {
-          throw new BucketNotFoundError({ bucket: bucketName });
-        }
-      }
+      const bucketName = this.validateAndResolveBucket(command);
 
       const result = await this.objectStorage.upload(
         new StorageObjectUpload(
@@ -84,6 +75,24 @@ export class UploadObjectUseCase {
         metadata: { originalError: error as Error },
       });
     }
+  }
+
+  private validateAndResolveBucket(command: UploadObjectCommand): string {
+    if (!this.isValidObjectName(command.objectName)) {
+      throw new InvalidObjectNameError({ objectName: command.objectName });
+    }
+
+    const bucketName = command.bucket || this.getDefaultBucket();
+
+    // Check if bucket exists before uploading
+    if (bucketName !== this.getDefaultBucket()) {
+      const bucketExists = this.bucketExists(bucketName);
+      if (!bucketExists) {
+        throw new BucketNotFoundError({ bucket: bucketName });
+      }
+    }
+
+    return bucketName;
   }
 
   private getDefaultBucket(): string {

--- a/ayunis-core-backend/src/domain/tools/application/tools.errors.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tools.errors.ts
@@ -9,6 +9,7 @@ export enum ToolErrorCode {
   EXECUTION_FAILED = 'EXECUTION_FAILED',
   INVALID_INPUT = 'INVALID_INPUT',
   NOT_FOUND = 'NOT_FOUND',
+  UNEXPECTED_TOOL_ERROR = 'UNEXPECTED_TOOL_ERROR',
 }
 
 export class ToolError extends ApplicationError {
@@ -91,6 +92,17 @@ export class ToolExecutionFailedError extends ToolError {
     });
     this.name = 'ToolExecutionFailedError';
     this.exposeToLLM = params.exposeToLLM;
+  }
+}
+
+export class UnexpectedToolError extends ToolError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super({
+      message: error.message,
+      code: ToolErrorCode.UNEXPECTED_TOOL_ERROR,
+      metadata: { ...metadata, error },
+    });
+    this.name = 'UnexpectedToolError';
   }
 }
 

--- a/ayunis-core-backend/src/domain/tools/application/use-cases/assemble-tool/assemble-tool.use-case.ts
+++ b/ayunis-core-backend/src/domain/tools/application/use-cases/assemble-tool/assemble-tool.use-case.ts
@@ -1,10 +1,12 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AssembleToolCommand } from './assemble-tool.command';
 
 import { ToolFactory } from '../../tool.factory';
 import { Tool } from 'src/domain/tools/domain/tool.entity';
 import { ToolConfigRepository } from '../../ports/tool-config.repository';
 import { ContextService } from 'src/common/context/services/context.service';
+import { UnexpectedToolError } from '../../tools.errors';
 
 @Injectable()
 export class AssembleToolUseCase {
@@ -14,6 +16,7 @@ export class AssembleToolUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedToolError)
   async execute(command: AssembleToolCommand): Promise<Tool> {
     const userId = this.contextService.get('userId');
     if (!userId) {

--- a/ayunis-core-backend/src/domain/tools/application/use-cases/execute-tool/execute-tool.use-case.ts
+++ b/ayunis-core-backend/src/domain/tools/application/use-cases/execute-tool/execute-tool.use-case.ts
@@ -1,6 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ToolHandlerRegistry } from '../../tool-handler.registry';
-import { ToolExecutionFailedError } from '../../tools.errors';
+import {
+  ToolExecutionFailedError,
+  UnexpectedToolError,
+} from '../../tools.errors';
 import { ExecuteToolCommand } from './execute-tool.command';
 import { ApplicationError } from 'src/common/errors/base.error';
 
@@ -10,6 +14,7 @@ export class ExecuteToolUseCase {
 
   constructor(private readonly toolHandlerRegistry: ToolHandlerRegistry) {}
 
+  @HandleUnexpectedErrors(UnexpectedToolError)
   async execute(command: ExecuteToolCommand): Promise<string> {
     this.logger.log('execute', {
       toolName: command.tool.name,

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { randomUUID } from 'crypto';
+import { randomUUID, type UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { CollectUsageCommand } from './collect-usage.command';
 import { Usage } from '../../../domain/usage.entity';
 import { UsageRepository } from '../../ports/usage.repository';
@@ -10,7 +11,6 @@ import {
   UnexpectedUsageError,
 } from '../../usage.errors';
 import { UsageCollectedEvent } from '../../events/usage-collected.event';
-import { ApplicationError } from '../../../../../common/errors/base.error';
 import { ContextService } from '../../../../../common/context/services/context.service';
 import { GetCreditsPerEuroUseCase } from '../../../../../iam/platform-config/application/use-cases/get-credits-per-euro/get-credits-per-euro.use-case';
 import { PlatformConfigNotFoundError } from '../../../../../iam/platform-config/application/platform-config.errors';
@@ -26,15 +26,67 @@ export class CollectUsageUseCase {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedUsageError)
   async execute(command: CollectUsageCommand): Promise<void> {
+    const { userId, apiKeyId, organizationId } = this.resolvePrincipal(command);
+
+    this.logger.log('CollectUsageUseCase.execute called', {
+      userId,
+      apiKeyId,
+      organizationId,
+      modelId: command.modelId,
+      provider: command.provider,
+      totalTokens: command.totalTokens,
+    });
+
+    this.validateCommand(command);
+
+    const cost = this.calculateCost(command);
+    const creditsConsumed = await this.calculateCredits(cost);
+
+    const usage = new Usage({
+      userId: userId ?? null,
+      apiKeyId: apiKeyId ?? null,
+      organizationId,
+      modelId: command.modelId,
+      provider: command.provider,
+      inputTokens: command.inputTokens,
+      outputTokens: command.outputTokens,
+      totalTokens: command.totalTokens,
+      cost,
+      creditsConsumed,
+      requestId: command.requestId ?? randomUUID(),
+    });
+
+    await this.usageRepository.save(usage);
+
+    this.emitUsageCollectedEvent(usage, command.model.name);
+
+    this.logger.log('Usage collected successfully', {
+      userId,
+      apiKeyId,
+      organizationId,
+      modelId: command.modelId,
+      provider: command.provider,
+      totalTokens: command.totalTokens,
+      cost,
+      requestId: command.requestId,
+    });
+  }
+
+  // Enforce XOR on the principal: exactly one of userId or apiKeyId must
+  // be set. The DB `CHK_usage_principal_not_both` constraint rejects
+  // "both set" as a safety net; we reject both "neither" and "both" here
+  // so the failure is synchronous and the error type is meaningful.
+  private resolvePrincipal(command: CollectUsageCommand): {
+    userId: UUID | undefined;
+    apiKeyId: UUID | undefined;
+    organizationId: UUID;
+  } {
     const userId = this.contextService.get('userId');
     const apiKeyId = this.contextService.get('apiKeyId');
     const organizationId = this.contextService.get('orgId');
 
-    // Enforce XOR on the principal: exactly one of userId or apiKeyId must
-    // be set. The DB `CHK_usage_principal_not_both` constraint rejects
-    // "both set" as a safety net; we reject both "neither" and "both" here
-    // so the failure is synchronous and the error type is meaningful.
     const hasUserId = !!userId;
     const hasApiKeyId = !!apiKeyId;
     if (hasUserId === hasApiKeyId || !organizationId) {
@@ -49,80 +101,25 @@ export class CollectUsageUseCase {
       );
     }
 
-    this.logger.log('CollectUsageUseCase.execute called', {
-      userId,
-      apiKeyId,
-      organizationId,
-      modelId: command.modelId,
-      provider: command.provider,
-      totalTokens: command.totalTokens,
-    });
+    return { userId, apiKeyId, organizationId };
+  }
 
-    try {
-      this.validateCommand(command);
-
-      const cost = this.calculateCost(command);
-      const creditsConsumed = await this.calculateCredits(cost);
-
-      const usage = new Usage({
-        userId: userId ?? null,
-        apiKeyId: apiKeyId ?? null,
-        organizationId,
-        modelId: command.modelId,
-        provider: command.provider,
-        inputTokens: command.inputTokens,
-        outputTokens: command.outputTokens,
-        totalTokens: command.totalTokens,
-        cost,
-        creditsConsumed,
-        requestId: command.requestId ?? randomUUID(),
-      });
-
-      await this.usageRepository.save(usage);
-
-      // Fire-and-forget: notify downstream listeners (webhook dispatch,
-      // metrics, sync services) that a usage row has been persisted.
-      // We do this AFTER save() resolves so receivers never observe
-      // usage that did not actually make it to the database.
-      this.eventEmitter
-        .emitAsync(
-          UsageCollectedEvent.EVENT_NAME,
-          new UsageCollectedEvent(usage, command.model.name),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit UsageCollectedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            usageId: usage.id,
-          });
+  // Fire-and-forget: notify downstream listeners (webhook dispatch,
+  // metrics, sync services) that a usage row has been persisted.
+  // We do this AFTER save() resolves so receivers never observe
+  // usage that did not actually make it to the database.
+  private emitUsageCollectedEvent(usage: Usage, modelName: string): void {
+    this.eventEmitter
+      .emitAsync(
+        UsageCollectedEvent.EVENT_NAME,
+        new UsageCollectedEvent(usage, modelName),
+      )
+      .catch((err: unknown) => {
+        this.logger.error('Failed to emit UsageCollectedEvent', {
+          error: err instanceof Error ? err.message : 'Unknown error',
+          usageId: usage.id,
         });
-
-      this.logger.log('Usage collected successfully', {
-        userId,
-        apiKeyId,
-        organizationId,
-        modelId: command.modelId,
-        provider: command.provider,
-        totalTokens: command.totalTokens,
-        cost,
-        requestId: command.requestId,
       });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to collect usage', {
-        error: error as Error,
-        command,
-      });
-      throw new UnexpectedUsageError(
-        error instanceof Error ? error : new Error('Unknown error'),
-        {
-          userId,
-          organizationId,
-          modelId: command.modelId,
-        },
-      );
-    }
   }
 
   private validateCommand(command: CollectUsageCommand): void {

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-credit-usage/get-credit-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-credit-usage/get-credit-usage.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetCreditUsageQuery } from './get-credit-usage.query';
 import { GetMonthlyCreditUsageUseCase } from '../get-monthly-credit-usage/get-monthly-credit-usage.use-case';
 import { GetMonthlyCreditUsageQuery } from '../get-monthly-credit-usage/get-monthly-credit-usage.query';
@@ -6,7 +7,6 @@ import { GetMonthlyCreditLimitUseCase } from 'src/iam/subscriptions/application/
 import { GetMonthlyCreditLimitQuery } from 'src/iam/subscriptions/application/use-cases/get-monthly-credit-limit/get-monthly-credit-limit.query';
 import type { CreditUsage } from '../../../domain/credit-usage';
 import { UnexpectedUsageError } from '../../usage.errors';
-import { ApplicationError } from '../../../../../common/errors/base.error';
 
 @Injectable()
 export class GetCreditUsageUseCase {
@@ -17,31 +17,24 @@ export class GetCreditUsageUseCase {
     private readonly getMonthlyCreditUsageUseCase: GetMonthlyCreditUsageUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedUsageError)
   async execute(query: GetCreditUsageQuery): Promise<CreditUsage> {
     this.logger.log('Getting credit usage', { orgId: query.orgId });
 
-    try {
-      const { monthlyCredits, startsAt } =
-        await this.getMonthlyCreditLimitUseCase.execute(
-          new GetMonthlyCreditLimitQuery(query.orgId),
-        );
-
-      const { creditsUsed } = await this.getMonthlyCreditUsageUseCase.execute(
-        new GetMonthlyCreditUsageQuery(query.orgId, startsAt ?? undefined),
+    const { monthlyCredits, startsAt } =
+      await this.getMonthlyCreditLimitUseCase.execute(
+        new GetMonthlyCreditLimitQuery(query.orgId),
       );
 
-      const creditsRemaining =
-        monthlyCredits !== null
-          ? Math.max(0, monthlyCredits - creditsUsed)
-          : null;
+    const { creditsUsed } = await this.getMonthlyCreditUsageUseCase.execute(
+      new GetMonthlyCreditUsageQuery(query.orgId, startsAt ?? undefined),
+    );
 
-      return { monthlyCredits, creditsUsed, creditsRemaining };
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get credit usage', error);
-      throw new UnexpectedUsageError(error as Error, {
-        orgId: query.orgId,
-      });
-    }
+    const creditsRemaining =
+      monthlyCredits !== null
+        ? Math.max(0, monthlyCredits - creditsUsed)
+        : null;
+
+    return { monthlyCredits, creditsUsed, creditsRemaining };
   }
 }

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-model-distribution/get-model-distribution.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-model-distribution/get-model-distribution.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetModelDistributionQuery } from './get-model-distribution.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { ModelDistribution } from '../../../domain/model-distribution.entity';
@@ -10,7 +11,6 @@ import {
   validateOptionalDateRange,
   processModelDistribution,
 } from '../../usage.utils';
-import { ApplicationError } from '../../../../../common/errors/base.error';
 
 @Injectable()
 export class GetModelDistributionUseCase {
@@ -18,6 +18,7 @@ export class GetModelDistributionUseCase {
 
   constructor(private readonly usageRepository: UsageRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedUsageError)
   async execute(
     query: GetModelDistributionQuery,
   ): Promise<ModelDistribution[]> {
@@ -35,25 +36,14 @@ export class GetModelDistributionUseCase {
       endDate: query.endDate?.toISOString(),
     });
 
-    try {
-      const modelDistribution = await this.usageRepository.getModelDistribution(
-        {
-          organizationId: query.organizationId,
-          startDate: query.startDate,
-          endDate: query.endDate,
-          maxModels: query.maxModels,
-          modelId: query.modelId,
-        },
-      );
+    const modelDistribution = await this.usageRepository.getModelDistribution({
+      organizationId: query.organizationId,
+      startDate: query.startDate,
+      endDate: query.endDate,
+      maxModels: query.maxModels,
+      modelId: query.modelId,
+    });
 
-      return processModelDistribution(modelDistribution, query.maxModels);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get model distribution', error);
-      throw new UnexpectedUsageError(error as Error, {
-        organizationId: query.organizationId,
-        maxModels: query.maxModels,
-      });
-    }
+    return processModelDistribution(modelDistribution, query.maxModels);
   }
 }

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-team/get-monthly-credit-usage-for-team.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-team/get-monthly-credit-usage-for-team.use-case.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetMonthlyCreditUsageForTeamQuery } from './get-monthly-credit-usage-for-team.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { UnexpectedUsageError } from '../../usage.errors';
-import { ApplicationError } from '../../../../../common/errors/base.error';
 import { getEffectiveMonthStart } from '../../util/get-effective-month-start';
 import { FindAllUserIdsByTeamIdUseCase } from 'src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.use-case';
 import { FindAllUserIdsByTeamIdQuery } from 'src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.query';
@@ -19,6 +19,7 @@ export class GetMonthlyCreditUsageForTeamUseCase {
     private readonly findAllUserIdsByTeamIdUseCase: FindAllUserIdsByTeamIdUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedUsageError)
   async execute(
     query: GetMonthlyCreditUsageForTeamQuery,
   ): Promise<{ creditsUsed: number }> {
@@ -29,25 +30,17 @@ export class GetMonthlyCreditUsageForTeamUseCase {
       effectiveStart: effectiveStart.toISOString(),
     });
 
-    try {
-      const memberIds = await this.findAllUserIdsByTeamIdUseCase.execute(
-        new FindAllUserIdsByTeamIdQuery(query.teamId),
+    const memberIds = await this.findAllUserIdsByTeamIdUseCase.execute(
+      new FindAllUserIdsByTeamIdQuery(query.teamId),
+    );
+
+    const creditsUsed =
+      await this.usageRepository.getTotalMonthlyCreditUsageForUsers(
+        query.organizationId,
+        memberIds,
+        effectiveStart,
       );
 
-      const creditsUsed =
-        await this.usageRepository.getTotalMonthlyCreditUsageForUsers(
-          query.organizationId,
-          memberIds,
-          effectiveStart,
-        );
-
-      return { creditsUsed };
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get monthly credit usage for team', error);
-      throw new UnexpectedUsageError(error as Error, {
-        teamId: query.teamId,
-      });
-    }
+    return { creditsUsed };
   }
 }

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-user/get-monthly-credit-usage-for-user.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-user/get-monthly-credit-usage-for-user.use-case.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetMonthlyCreditUsageForUserQuery } from './get-monthly-credit-usage-for-user.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { UnexpectedUsageError } from '../../usage.errors';
-import { ApplicationError } from '../../../../../common/errors/base.error';
 import { getEffectiveMonthStart } from '../../util/get-effective-month-start';
 
 @Injectable()
@@ -13,6 +13,7 @@ export class GetMonthlyCreditUsageForUserUseCase {
 
   constructor(private readonly usageRepository: UsageRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedUsageError)
   async execute(
     query: GetMonthlyCreditUsageForUserQuery,
   ): Promise<{ creditsUsed: number }> {
@@ -23,21 +24,13 @@ export class GetMonthlyCreditUsageForUserUseCase {
       effectiveStart: effectiveStart.toISOString(),
     });
 
-    try {
-      const creditsUsed =
-        await this.usageRepository.getTotalMonthlyCreditUsageForUser(
-          query.organizationId,
-          query.userId,
-          effectiveStart,
-        );
+    const creditsUsed =
+      await this.usageRepository.getTotalMonthlyCreditUsageForUser(
+        query.organizationId,
+        query.userId,
+        effectiveStart,
+      );
 
-      return { creditsUsed };
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get monthly credit usage for user', error);
-      throw new UnexpectedUsageError(error as Error, {
-        userId: query.userId,
-      });
-    }
+    return { creditsUsed };
   }
 }

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-users/get-monthly-credit-usage-for-users.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-users/get-monthly-credit-usage-for-users.use-case.ts
@@ -1,9 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import type { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetMonthlyCreditUsageForUsersQuery } from './get-monthly-credit-usage-for-users.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { UnexpectedUsageError } from '../../usage.errors';
-import { ApplicationError } from '../../../../../common/errors/base.error';
 import { getEffectiveMonthStart } from '../../util/get-effective-month-start';
 
 @Injectable()
@@ -14,6 +14,7 @@ export class GetMonthlyCreditUsageForUsersUseCase {
 
   constructor(private readonly usageRepository: UsageRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedUsageError)
   async execute(
     query: GetMonthlyCreditUsageForUsersQuery,
   ): Promise<Map<UUID, number>> {
@@ -24,18 +25,10 @@ export class GetMonthlyCreditUsageForUsersUseCase {
       effectiveStart: effectiveStart.toISOString(),
     });
 
-    try {
-      return await this.usageRepository.getMonthlyCreditUsagePerUser(
-        query.organizationId,
-        query.userIds,
-        effectiveStart,
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get monthly credit usage for users', error);
-      throw new UnexpectedUsageError(error as Error, {
-        userCount: query.userIds.length,
-      });
-    }
+    return await this.usageRepository.getMonthlyCreditUsagePerUser(
+      query.organizationId,
+      query.userIds,
+      effectiveStart,
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage/get-monthly-credit-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage/get-monthly-credit-usage.use-case.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetMonthlyCreditUsageQuery } from './get-monthly-credit-usage.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { UnexpectedUsageError } from '../../usage.errors';
-import { ApplicationError } from '../../../../../common/errors/base.error';
 import { getEffectiveMonthStart } from '../../util/get-effective-month-start';
 
 @Injectable()
@@ -11,6 +11,7 @@ export class GetMonthlyCreditUsageUseCase {
 
   constructor(private readonly usageRepository: UsageRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedUsageError)
   async execute(
     query: GetMonthlyCreditUsageQuery,
   ): Promise<{ creditsUsed: number }> {
@@ -21,20 +22,11 @@ export class GetMonthlyCreditUsageUseCase {
       effectiveStart: effectiveStart.toISOString(),
     });
 
-    try {
-      const creditsUsed = await this.usageRepository.getMonthlyCreditUsage(
-        query.orgId,
-        effectiveStart,
-      );
+    const creditsUsed = await this.usageRepository.getMonthlyCreditUsage(
+      query.orgId,
+      effectiveStart,
+    );
 
-      return { creditsUsed };
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get monthly credit usage', error);
-      throw new UnexpectedUsageError(error as Error, {
-        orgId: query.orgId,
-        effectiveStart: effectiveStart.toISOString(),
-      });
-    }
+    return { creditsUsed };
   }
 }

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-provider-usage/get-provider-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-provider-usage/get-provider-usage.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetProviderUsageQuery } from './get-provider-usage.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { ProviderUsage } from '../../../domain/provider-usage.entity';
@@ -7,7 +8,6 @@ import {
   calculateProviderPercentages,
 } from '../../usage.utils';
 import { UnexpectedUsageError } from '../../usage.errors';
-import { ApplicationError } from '../../../../../common/errors/base.error';
 
 @Injectable()
 export class GetProviderUsageUseCase {
@@ -15,6 +15,7 @@ export class GetProviderUsageUseCase {
 
   constructor(private readonly usageRepository: UsageRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedUsageError)
   async execute(query: GetProviderUsageQuery): Promise<ProviderUsage[]> {
     validateOptionalDateRange(query.startDate, query.endDate);
 
@@ -24,15 +25,7 @@ export class GetProviderUsageUseCase {
       endDate: query.endDate?.toISOString(),
     });
 
-    try {
-      const providerUsage = await this.usageRepository.getProviderUsage(query);
-      return calculateProviderPercentages(providerUsage);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get provider usage', error);
-      throw new UnexpectedUsageError(error as Error, {
-        organizationId: query.organizationId,
-      });
-    }
+    const providerUsage = await this.usageRepository.getProviderUsage(query);
+    return calculateProviderPercentages(providerUsage);
   }
 }

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-usage-stats/get-usage-stats.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-usage-stats/get-usage-stats.use-case.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetUsageStatsQuery } from './get-usage-stats.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { UsageStats } from '../../../domain/usage-stats.entity';
 import { validateOptionalDateRange } from '../../usage.utils';
 import { UnexpectedUsageError } from '../../usage.errors';
-import { ApplicationError } from '../../../../../common/errors/base.error';
 
 @Injectable()
 export class GetUsageStatsUseCase {
@@ -12,6 +12,7 @@ export class GetUsageStatsUseCase {
 
   constructor(private readonly usageRepository: UsageRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedUsageError)
   async execute(query: GetUsageStatsQuery): Promise<UsageStats> {
     validateOptionalDateRange(query.startDate, query.endDate);
 
@@ -21,29 +22,21 @@ export class GetUsageStatsUseCase {
       endDate: query.endDate?.toISOString(),
     });
 
-    try {
-      const stats = await this.usageRepository.getUsageStats({
-        organizationId: query.organizationId,
-        startDate: query.startDate,
-        endDate: query.endDate,
-      });
+    const stats = await this.usageRepository.getUsageStats({
+      organizationId: query.organizationId,
+      startDate: query.startDate,
+      endDate: query.endDate,
+    });
 
-      return new UsageStats({
-        totalCredits: Math.max(0, stats.totalCredits),
-        totalRequests: Math.max(0, stats.totalRequests),
-        activeUsers: Math.min(
-          Math.max(0, stats.activeUsers),
-          Math.max(0, stats.totalUsers),
-        ),
-        totalUsers: Math.max(0, stats.totalUsers),
-        topModels: stats.topModels,
-      });
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get usage stats', error);
-      throw new UnexpectedUsageError(error as Error, {
-        organizationId: query.organizationId,
-      });
-    }
+    return new UsageStats({
+      totalCredits: Math.max(0, stats.totalCredits),
+      totalRequests: Math.max(0, stats.totalRequests),
+      activeUsers: Math.min(
+        Math.max(0, stats.activeUsers),
+        Math.max(0, stats.totalUsers),
+      ),
+      totalUsers: Math.max(0, stats.totalUsers),
+      topModels: stats.topModels,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetUserUsageQuery } from './get-user-usage.query';
 import {
   UsageRepository,
@@ -10,7 +11,6 @@ import {
 } from '../../usage.errors';
 import { validateOptionalDateRange } from '../../usage.utils';
 import { UsageConstants } from '../../../domain/value-objects/usage.constants';
-import { ApplicationError } from '../../../../../common/errors/base.error';
 
 @Injectable()
 export class GetUserUsageUseCase {
@@ -18,18 +18,15 @@ export class GetUserUsageUseCase {
 
   constructor(private readonly usageRepository: UsageRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedUsageError)
   async execute(query: GetUserUsageQuery): Promise<UserUsageResult> {
     this.validateQuery(query);
 
-    try {
-      return await this.usageRepository.getUserUsage(query);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get user usage', error);
-      throw new UnexpectedUsageError(error as Error, {
-        organizationId: query.organizationId,
-      });
-    }
+    this.logger.log('Getting user usage', {
+      organizationId: query.organizationId,
+    });
+
+    return await this.usageRepository.getUserUsage(query);
   }
 
   private validateQuery(query: GetUserUsageQuery): void {


### PR DESCRIPTION
- decorate every Promise-returning execute() in domain/skills, mcp,
  academy, knowledge-bases, rag, usage, skill-templates, storage,
  retrievers, crawl-domain-grants, tools, retention-policies,
  openai-compat, anonymization-settings, marketplace, common/emails,
  common/anonymization
- remove pure-boundary try/catch blocks now covered by the decorator
- normalize Unexpected*Error constructors to (error: Error, metadata?)
- translate InvalidSkillNameError to SkillInvalidInputError (400) in
  create/update-skill so the decorator does not surface it as a 500
- reinstate specific-error catch in send-email to preserve the
  EMAIL_SEND_FAILED contract (reviewer-confirmed)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide cross-cutting change to error mapping and logging across many bounded contexts; behavior should stay equivalent for `ApplicationError` paths but any missed edge case could change HTTP status or error codes clients see.
> 
> **Overview**
> This PR **standardizes how use cases surface failures** by applying `@HandleUnexpectedErrors` on `execute()` (and selected private delegates where overloads block decorating the public method). Repetitive `try/catch` blocks that re-threw `ApplicationError` and wrapped everything else in `Unexpected*Error` are removed in favor of the decorator’s shared **log + wrap** behavior (`Unexpected use-case error`).
> 
> **Unexpected error types** are aligned on `constructor(error: Error, metadata?)`, using the underlying message and attaching the original error in metadata. New codes/classes appear where needed (e.g. `UnexpectedAnonymizationError`, `UnexpectedEmailError`, marketplace `UnexpectedMarketplaceError` hierarchy).
> 
> **Domain-specific behavior is preserved where the generic wrapper would be wrong:** `SendEmailUseCase` keeps an inner `catch` so transport failures still become `EmailSendFailedError` while the decorator only handles truly unexpected cases. MCP create/update flows move the decorator onto `createPredefinedIntegration` / `createCustomIntegration` because overloaded `execute()` cannot be decorated.
> 
> Tests that asserted old per-use-case log messages are updated to expect the decorator’s uniform log line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6545769230b17771a917978e0420c70fba2e6a4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->