### PR TITLE
refactor(backend): split oversized mcp-create and brave-search methods (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.ts
@@ -22,8 +22,11 @@ import { ApplicationError } from 'src/common/errors/base.error';
 import { UUID } from 'crypto';
 import { PredefinedMcpIntegration } from '../../../domain/integrations/predefined-mcp-integration.entity';
 import { CustomMcpIntegration } from '../../../domain/integrations/custom-mcp-integration.entity';
-import { CredentialFieldType } from 'src/domain/mcp/domain/predefined-mcp-integration-config';
-import { McpIntegrationAuth } from 'src/domain/mcp/domain';
+import {
+  CredentialFieldType,
+  PredefinedMcpIntegrationConfig,
+} from 'src/domain/mcp/domain/predefined-mcp-integration-config';
+import { McpIntegration, McpIntegrationAuth } from 'src/domain/mcp/domain';
 
 @Injectable()
 export class CreateMcpIntegrationUseCase {
@@ -50,8 +53,7 @@ export class CreateMcpIntegrationUseCase {
   // Implementation
   async execute(
     command:
-      | CreatePredefinedMcpIntegrationCommand
-      | CreateCustomMcpIntegrationCommand,
+      CreatePredefinedMcpIntegrationCommand | CreateCustomMcpIntegrationCommand,
   ): Promise<PredefinedMcpIntegration | CustomMcpIntegration> {
     // Get orgId from context first (common for both types)
     const orgId = this.contextService.get('orgId');
@@ -74,15 +76,11 @@ export class CreateMcpIntegrationUseCase {
     this.logger.log('createPredefinedIntegration', { slug: command.slug });
 
     try {
-      // Validate slug exists in registry
       if (!this.registryService.isValidSlug(command.slug)) {
         throw new InvalidPredefinedSlugError(command.slug);
       }
-
-      // Get configuration from registry
       const config = this.registryService.getConfig(command.slug);
 
-      // Check for duplicates
       const existing = await this.repository.findByOrgIdAndSlug(
         orgId,
         command.slug,
@@ -91,110 +89,92 @@ export class CreateMcpIntegrationUseCase {
         throw new DuplicateMcpIntegrationError(command.slug);
       }
 
-      let integrationAuth: McpIntegrationAuth;
-      switch (config.authType) {
-        case McpAuthMethod.NO_AUTH:
-          integrationAuth = this.authFactory.createAuth({
-            method: McpAuthMethod.NO_AUTH,
-          });
-          break;
-        case McpAuthMethod.BEARER_TOKEN: {
-          const tokenField = command.credentialFields.find(
-            (field) => field.name === CredentialFieldType.TOKEN,
-          );
-          const rawToken = tokenField?.value.trim();
-
-          if (!rawToken) {
-            throw new McpValidationFailedError(
-              '',
-              config.displayName,
-              'Bearer token credentials are required',
-              CredentialFieldType.TOKEN,
-            );
-          }
-
-          integrationAuth = this.authFactory.createAuth({
-            method: McpAuthMethod.BEARER_TOKEN,
-            authToken: await this.credentialEncryption.encrypt(rawToken),
-          });
-          break;
-        }
-        case McpAuthMethod.OAUTH:
-          integrationAuth = this.authFactory.createAuth({
-            method: McpAuthMethod.OAUTH,
-            clientId:
-              command.credentialFields.find(
-                (field) => field.name === CredentialFieldType.CLIENT_ID,
-              )?.value ?? '',
-            clientSecret:
-              command.credentialFields.find(
-                (field) => field.name === CredentialFieldType.CLIENT_SECRET,
-              )?.value ?? '',
-          });
-          break;
-        case McpAuthMethod.CUSTOM_HEADER: {
-          const secretField = command.credentialFields.find(
-            (field) => field.name === CredentialFieldType.TOKEN,
-          );
-          const rawSecret = secretField?.value.trim();
-
-          if (!rawSecret) {
-            throw new McpValidationFailedError(
-              '',
-              config.displayName,
-              'Custom header secret is required',
-              CredentialFieldType.TOKEN,
-            );
-          }
-
-          integrationAuth = this.authFactory.createAuth({
-            method: McpAuthMethod.CUSTOM_HEADER,
-            secret: await this.credentialEncryption.encrypt(rawSecret),
-            headerName: config.authHeaderName ?? 'X-API-Key',
-          });
-          break;
-        }
-        default: {
-          const exhaustiveCheck: never = config.authType;
-          throw new Error(`Unknown MCP auth type: ${String(exhaustiveCheck)}`);
-        }
-      }
-
       const integration = this.factory.createIntegration({
         kind: McpIntegrationKind.PREDEFINED,
         orgId,
         slug: config.slug,
         name: config.displayName,
         serverUrl: config.serverUrl,
-        auth: integrationAuth,
+        auth: await this.buildPredefinedAuth(command, config),
         returnsPii: command.returnsPii,
       });
 
-      // Save integration first to get ID
-      const savedIntegration = await this.repository.save(integration);
-
-      // Validate connection (don't throw on failure)
-      await this.connectionValidationService.validateAndUpdateStatus(
-        savedIntegration,
-      );
-
-      // Return the updated integration
-      return savedIntegration;
+      return await this.saveAndValidate(integration);
     } catch (error) {
-      // Re-throw application errors and auth errors
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-
-      // Log and wrap unexpected errors
-      this.logger.error('Unexpected error creating predefined integration', {
-        error: error as Error,
-      });
-      throw new UnexpectedMcpError('Unexpected error occurred');
+      return this.rethrowOrWrap(error, 'predefined');
     }
+  }
+
+  private async buildPredefinedAuth(
+    command: CreatePredefinedMcpIntegrationCommand,
+    config: PredefinedMcpIntegrationConfig,
+  ): Promise<McpIntegrationAuth> {
+    switch (config.authType) {
+      case McpAuthMethod.NO_AUTH:
+        return this.authFactory.createAuth({ method: McpAuthMethod.NO_AUTH });
+      case McpAuthMethod.BEARER_TOKEN:
+        return this.authFactory.createAuth({
+          method: McpAuthMethod.BEARER_TOKEN,
+          authToken: await this.encryptRequiredTokenField(
+            command,
+            config.displayName,
+            'Bearer token credentials are required',
+          ),
+        });
+      case McpAuthMethod.OAUTH:
+        return this.authFactory.createAuth({
+          method: McpAuthMethod.OAUTH,
+          clientId:
+            this.credentialFieldValue(command, CredentialFieldType.CLIENT_ID) ??
+            '',
+          clientSecret:
+            this.credentialFieldValue(
+              command,
+              CredentialFieldType.CLIENT_SECRET,
+            ) ?? '',
+        });
+      case McpAuthMethod.CUSTOM_HEADER:
+        return this.authFactory.createAuth({
+          method: McpAuthMethod.CUSTOM_HEADER,
+          secret: await this.encryptRequiredTokenField(
+            command,
+            config.displayName,
+            'Custom header secret is required',
+          ),
+          headerName: config.authHeaderName ?? 'X-API-Key',
+        });
+      default: {
+        const exhaustiveCheck: never = config.authType;
+        throw new Error(`Unknown MCP auth type: ${String(exhaustiveCheck)}`);
+      }
+    }
+  }
+
+  private credentialFieldValue(
+    command: CreatePredefinedMcpIntegrationCommand,
+    name: CredentialFieldType,
+  ): string | undefined {
+    return command.credentialFields.find((field) => field.name === name)?.value;
+  }
+
+  private async encryptRequiredTokenField(
+    command: CreatePredefinedMcpIntegrationCommand,
+    displayName: string,
+    message: string,
+  ): Promise<string> {
+    const raw = this.credentialFieldValue(
+      command,
+      CredentialFieldType.TOKEN,
+    )?.trim();
+    if (!raw) {
+      throw new McpValidationFailedError(
+        '',
+        displayName,
+        message,
+        CredentialFieldType.TOKEN,
+      );
+    }
+    return this.credentialEncryption.encrypt(raw);
   }
 
   private async createCustomIntegration(
@@ -206,116 +186,93 @@ export class CreateMcpIntegrationUseCase {
     });
 
     try {
-      // Validate URL format
       if (!this.isValidUrl(command.serverUrl)) {
         throw new InvalidServerUrlError(command.serverUrl);
       }
 
-      // Determine auth type (default to NO_AUTH if not provided)
+      // Default to NO_AUTH if not provided; OAUTH is not implemented yet
       const authType = command.authMethod ?? McpAuthMethod.NO_AUTH;
-
-      // Handle OAUTH - not implemented yet
       if (authType === McpAuthMethod.OAUTH) {
         throw new McpAuthNotImplementedError(McpAuthMethod.OAUTH);
       }
 
-      // Create integration using factory and handle credentials based on auth type
-      let integration: CustomMcpIntegration;
-
-      if (authType === McpAuthMethod.BEARER_TOKEN) {
-        if (!command.credentials) {
-          throw new McpValidationFailedError(
-            '',
-            command.name,
-            'Bearer token credentials are required',
-          );
-        }
-
-        const encryptedToken = await this.credentialEncryption.encrypt(
-          command.credentials,
-        );
-
-        const auth = this.authFactory.createAuth({
-          method: McpAuthMethod.BEARER_TOKEN,
-          authToken: encryptedToken,
-        });
-
-        integration = this.factory.createIntegration({
-          kind: McpIntegrationKind.CUSTOM,
-          orgId,
-          name: command.name,
-          serverUrl: command.serverUrl,
-          auth,
-          returnsPii: command.returnsPii,
-        });
-      } else if (authType === McpAuthMethod.CUSTOM_HEADER) {
-        if (!command.credentials) {
-          throw new McpValidationFailedError(
-            '',
-            command.name,
-            'Header credentials are required',
-          );
-        }
-
-        const encryptedKey = await this.credentialEncryption.encrypt(
-          command.credentials,
-        );
-
-        const headerName = command.authHeaderName ?? 'X-API-Key';
-        const auth = this.authFactory.createAuth({
-          method: McpAuthMethod.CUSTOM_HEADER,
-          secret: encryptedKey,
-          headerName,
-        });
-
-        integration = this.factory.createIntegration({
-          kind: McpIntegrationKind.CUSTOM,
-          orgId,
-          name: command.name,
-          serverUrl: command.serverUrl,
-          auth,
-          returnsPii: command.returnsPii,
-        });
-      } else {
-        // NO_AUTH doesn't need any credentials
-        const auth = this.authFactory.createAuth({
-          method: McpAuthMethod.NO_AUTH,
-        });
-        integration = this.factory.createIntegration({
-          kind: McpIntegrationKind.CUSTOM,
-          orgId,
-          name: command.name,
-          serverUrl: command.serverUrl,
-          auth,
-          returnsPii: command.returnsPii,
-        });
-      }
-
-      // Save integration first to get ID
-      const savedIntegration = await this.repository.save(integration);
-
-      // Validate connection (don't throw on failure)
-      await this.connectionValidationService.validateAndUpdateStatus(
-        savedIntegration,
-      );
-
-      // Return the updated integration
-      return savedIntegration;
-    } catch (error) {
-      // Re-throw application errors and auth errors
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-
-      // Log and wrap unexpected errors
-      this.logger.error('Unexpected error creating custom integration', {
-        error: error as Error,
+      const integration = this.factory.createIntegration({
+        kind: McpIntegrationKind.CUSTOM,
+        orgId,
+        name: command.name,
+        serverUrl: command.serverUrl,
+        auth: await this.buildCustomAuth(authType, command),
+        returnsPii: command.returnsPii,
       });
-      throw new UnexpectedMcpError('Unexpected error occurred');
+
+      return await this.saveAndValidate(integration);
+    } catch (error) {
+      return this.rethrowOrWrap(error, 'custom');
     }
+  }
+
+  private async buildCustomAuth(
+    authType: McpAuthMethod,
+    command: CreateCustomMcpIntegrationCommand,
+  ): Promise<McpIntegrationAuth> {
+    if (authType === McpAuthMethod.BEARER_TOKEN) {
+      return this.authFactory.createAuth({
+        method: McpAuthMethod.BEARER_TOKEN,
+        authToken: await this.encryptRequiredCredentials(
+          command,
+          'Bearer token credentials are required',
+        ),
+      });
+    }
+
+    if (authType === McpAuthMethod.CUSTOM_HEADER) {
+      return this.authFactory.createAuth({
+        method: McpAuthMethod.CUSTOM_HEADER,
+        secret: await this.encryptRequiredCredentials(
+          command,
+          'Header credentials are required',
+        ),
+        headerName: command.authHeaderName ?? 'X-API-Key',
+      });
+    }
+
+    // NO_AUTH doesn't need any credentials
+    return this.authFactory.createAuth({ method: McpAuthMethod.NO_AUTH });
+  }
+
+  private async encryptRequiredCredentials(
+    command: CreateCustomMcpIntegrationCommand,
+    message: string,
+  ): Promise<string> {
+    if (!command.credentials) {
+      throw new McpValidationFailedError('', command.name, message);
+    }
+    return this.credentialEncryption.encrypt(command.credentials);
+  }
+
+  /** Persist first (validation needs the ID), then probe the connection without failing creation. */
+  private async saveAndValidate<T extends McpIntegration>(
+    integration: T,
+  ): Promise<T> {
+    const savedIntegration = await this.repository.save(integration);
+    await this.connectionValidationService.validateAndUpdateStatus(
+      savedIntegration,
+    );
+    return savedIntegration;
+  }
+
+  private rethrowOrWrap(error: unknown, kind: 'predefined' | 'custom'): never {
+    if (
+      error instanceof ApplicationError ||
+      error instanceof UnauthorizedException
+    ) {
+      throw error;
+    }
+
+    this.logger.error(`Unexpected error creating ${kind} integration`, {
+      error: error as Error,
+    });
+    throw new UnexpectedMcpError('Unexpected error occurred');
   }
 
   private isValidUrl(url: string): boolean {

--- a/ayunis-core-backend/src/domain/retrievers/internet-search-retrievers/infrastructure/handlers/brave-internet-search.handler.ts
+++ b/ayunis-core-backend/src/domain/retrievers/internet-search-retrievers/infrastructure/handlers/brave-internet-search.handler.ts
@@ -40,61 +40,16 @@ export class BraveInternetSearchHandler implements InternetSearchHandler {
       query,
     });
     try {
-      const braveSearchUrl = this.configService.get<string>(
-        'internetSearch.brave.url',
-      );
-      const braveSearchApiKey = this.configService.get<string>(
-        'internetSearch.brave.apiKey',
-      );
-      if (!braveSearchUrl || !braveSearchApiKey) {
-        throw new Error('Brave search URL or API key is not configured');
-      }
-
-      const urlFriendlyQuery = encodeURI(query);
-      const url = `${braveSearchUrl}?q=${urlFriendlyQuery}`;
-      const headers = {
-        'x-subscription-token': braveSearchApiKey,
-        Accept: 'application/json',
-      };
-      const response = await fetch(url, { headers });
+      const response = await fetch(...this.buildRequest(query));
       const data = (await response.json()) as
-        | BraveSearchResult
-        | BraveSearchErrorResult;
+        BraveSearchResult | BraveSearchErrorResult;
       if ('error' in data) {
         this.logger.error('Brave search error', {
           error: data.error,
         });
         throw new Error(data.error.detail);
       }
-      const webResults =
-        data.web?.results.map((result) => {
-          if (result.title && result.url && result.description) {
-            return new InternetSearchResult({
-              type: InternetSearchResultType.WEB,
-              title: result.title,
-              url: result.url,
-              description: result.description,
-            });
-          }
-          return null;
-        }) ?? [];
-      const newsResults =
-        data.news?.results.map((result) => {
-          if (result.title && result.url && result.description) {
-            return new InternetSearchResult({
-              type: InternetSearchResultType.NEWS,
-              title: result.title,
-              url: result.url,
-              description: result.description,
-              pageAge: result.page_age,
-            });
-          }
-          return null;
-        }) ?? [];
-      const results = [
-        ...webResults.slice(0, 5),
-        ...newsResults.slice(0, 5),
-      ].filter((result) => result !== null);
+      const results = this.mapResults(data);
       this.logger.debug('Processed results', {
         results,
       });
@@ -105,5 +60,56 @@ export class BraveInternetSearchHandler implements InternetSearchHandler {
       });
       throw error;
     }
+  }
+
+  private buildRequest(query: string): [string, RequestInit] {
+    const braveSearchUrl = this.configService.get<string>(
+      'internetSearch.brave.url',
+    );
+    const braveSearchApiKey = this.configService.get<string>(
+      'internetSearch.brave.apiKey',
+    );
+    if (!braveSearchUrl || !braveSearchApiKey) {
+      throw new Error('Brave search URL or API key is not configured');
+    }
+
+    const urlFriendlyQuery = encodeURI(query);
+    const headers = {
+      'x-subscription-token': braveSearchApiKey,
+      Accept: 'application/json',
+    };
+    return [`${braveSearchUrl}?q=${urlFriendlyQuery}`, { headers }];
+  }
+
+  /** Top 5 web and top 5 news hits, skipping entries with missing fields. */
+  private mapResults(data: BraveSearchResult): InternetSearchResult[] {
+    const webResults =
+      data.web?.results.map((result) => {
+        if (result.title && result.url && result.description) {
+          return new InternetSearchResult({
+            type: InternetSearchResultType.WEB,
+            title: result.title,
+            url: result.url,
+            description: result.description,
+          });
+        }
+        return null;
+      }) ?? [];
+    const newsResults =
+      data.news?.results.map((result) => {
+        if (result.title && result.url && result.description) {
+          return new InternetSearchResult({
+            type: InternetSearchResultType.NEWS,
+            title: result.title,
+            url: result.url,
+            description: result.description,
+            pageAge: result.page_age,
+          });
+        }
+        return null;
+      }) ?? [];
+    return [...webResults.slice(0, 5), ...newsResults.slice(0, 5)].filter(
+      (result) => result !== null,
+    );
   }
 }


### PR DESCRIPTION
## Summary

Behavior-preserving refactor splitting three methods that exceeded the complexity gate (≤50 lines, cyclomatic ≤10):

- **CreateMcpIntegrationUseCase**: `createPredefinedIntegration` (108 lines, complexity 19) and `createCustomIntegration` (95 lines, complexity 12) — extracted `buildPredefinedAuth`/`buildCustomAuth`, credential-encryption helpers, a shared `saveAndValidate`, and a shared `rethrowOrWrap` error boundary
- **BraveInternetSearchHandler**: `search` (69 lines) — extracted `buildRequest` and `mapResults`

Unblocks the prettier backlog cleanup (stacked PR): the pre-commit complexity gate rejected these two files even for formatting-only changes.

Follow-up candidate: the use case still hand-rolls its error boundary and throws `UnauthorizedException`; converting to `@HandleUnexpectedErrors` requires changing `UnexpectedMcpError`'s constructor signature, so it was left out of scope.

Validation: full backend suite green (442 suites / 3000 tests), tsc clean, complexity gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qg4W2sfYR15Ai6iNNJUVi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with tests reported green; credential encryption and validation order are unchanged, only reorganized.
> 
> **Overview**
> **Behavior-preserving refactor** so oversized methods pass the pre-commit complexity gate (line/cyclomatic limits); no intended change to MCP integration creation or Brave search results.
> 
> In **`CreateMcpIntegrationUseCase`**, predefined and custom creation paths are slimmed by moving auth construction into **`buildPredefinedAuth`** / **`buildCustomAuth`**, credential handling into **`encryptRequiredTokenField`**, **`encryptRequiredCredentials`**, and **`credentialFieldValue`**, and shared post-create flow into **`saveAndValidate`** plus **`rethrowOrWrap`** for the duplicated error boundary.
> 
> In **`BraveInternetSearchHandler`**, **`search`** delegates HTTP setup to **`buildRequest`** and response shaping (top 5 web + top 5 news, skip incomplete rows) to **`mapResults`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acdb8056497850117f510766ba5647fcf0017525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->