### PR TITLE
chore(lint): apply prettier backlog fixes across backend (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/common/util/cookie.util.ts
+++ b/ayunis-core-backend/src/common/util/cookie.util.ts
@@ -25,9 +25,7 @@ function buildCookieOptions(configService: ConfigService): CookieOptions {
     httpOnly: configService.get<boolean>('auth.cookie.httpOnly', true),
     secure: configService.get<boolean>('auth.cookie.secure', false),
     sameSite: configService.get<string>('auth.cookie.sameSite', 'lax') as
-      | 'none'
-      | 'lax'
-      | 'strict',
+      'none' | 'lax' | 'strict',
     path: '/',
   };
 

--- a/ayunis-core-backend/src/config/features.config.ts
+++ b/ayunis-core-backend/src/config/features.config.ts
@@ -18,20 +18,17 @@ const parseBooleanWithDefault = (
   return value.trim() === 'true';
 };
 
-export const featuresConfig = registerAs(
-  'features',
-  (): FeaturesConfig => ({
-    knowledgeBasesEnabled: parseBooleanWithDefault(
-      process.env.FEATURE_KNOWLEDGE_BASES_ENABLED,
-      true,
-    ),
-    letterheadsEnabled: parseBooleanWithDefault(
-      process.env.FEATURE_LETTERHEADS_ENABLED,
-      false,
-    ),
-    skillsEnabled: parseBooleanWithDefault(
-      process.env.FEATURE_SKILLS_ENABLED,
-      false,
-    ),
-  }),
-);
+export const featuresConfig = registerAs('features', (): FeaturesConfig => ({
+  knowledgeBasesEnabled: parseBooleanWithDefault(
+    process.env.FEATURE_KNOWLEDGE_BASES_ENABLED,
+    true,
+  ),
+  letterheadsEnabled: parseBooleanWithDefault(
+    process.env.FEATURE_LETTERHEADS_ENABLED,
+    false,
+  ),
+  skillsEnabled: parseBooleanWithDefault(
+    process.env.FEATURE_SKILLS_ENABLED,
+    false,
+  ),
+}));

--- a/ayunis-core-backend/src/config/gotenberg.config.ts
+++ b/ayunis-core-backend/src/config/gotenberg.config.ts
@@ -4,9 +4,6 @@ export interface GotenbergConfig {
   url: string;
 }
 
-export const gotenbergConfig = registerAs(
-  'gotenberg',
-  (): GotenbergConfig => ({
-    url: process.env.GOTENBERG_URL || 'http://localhost:3000',
-  }),
-);
+export const gotenbergConfig = registerAs('gotenberg', (): GotenbergConfig => ({
+  url: process.env.GOTENBERG_URL || 'http://localhost:3000',
+}));

--- a/ayunis-core-backend/src/config/metrics.config.ts
+++ b/ayunis-core-backend/src/config/metrics.config.ts
@@ -5,10 +5,7 @@ export interface MetricsConfig {
   password: string | undefined;
 }
 
-export const metricsConfig = registerAs(
-  'metrics',
-  (): MetricsConfig => ({
-    user: process.env.AYUNIS_METRICS_USER,
-    password: process.env.AYUNIS_METRICS_PASSWORD,
-  }),
-);
+export const metricsConfig = registerAs('metrics', (): MetricsConfig => ({
+  user: process.env.AYUNIS_METRICS_USER,
+  password: process.env.AYUNIS_METRICS_PASSWORD,
+}));

--- a/ayunis-core-backend/src/config/retention.config.ts
+++ b/ayunis-core-backend/src/config/retention.config.ts
@@ -9,9 +9,6 @@ export interface RetentionConfig {
   dryRun: boolean;
 }
 
-export const retentionConfig = registerAs(
-  'retention',
-  (): RetentionConfig => ({
-    dryRun: process.env.RETENTION_DRY_RUN === 'true',
-  }),
-);
+export const retentionConfig = registerAs('retention', (): RetentionConfig => ({
+  dryRun: process.env.RETENTION_DRY_RUN === 'true',
+}));

--- a/ayunis-core-backend/src/config/retrieval.config.ts
+++ b/ayunis-core-backend/src/config/retrieval.config.ts
@@ -8,19 +8,16 @@ export interface RetrievalConfig {
   chatUploadMaxFileSizeMb: number;
 }
 
-export default registerAs(
-  'retrieval',
-  (): RetrievalConfig => ({
-    mistral: {
-      apiKey: process.env.MISTRAL_API_KEY,
-    },
-    chatUploadMaxPdfPages: parseInt(
-      process.env.CHAT_UPLOAD_MAX_PDF_PAGES || '50',
-      10,
-    ),
-    chatUploadMaxFileSizeMb: parseInt(
-      process.env.CHAT_UPLOAD_MAX_FILE_SIZE_MB || '5',
-      10,
-    ),
-  }),
-);
+export default registerAs('retrieval', (): RetrievalConfig => ({
+  mistral: {
+    apiKey: process.env.MISTRAL_API_KEY,
+  },
+  chatUploadMaxPdfPages: parseInt(
+    process.env.CHAT_UPLOAD_MAX_PDF_PAGES || '50',
+    10,
+  ),
+  chatUploadMaxFileSizeMb: parseInt(
+    process.env.CHAT_UPLOAD_MAX_FILE_SIZE_MB || '5',
+    10,
+  ),
+}));

--- a/ayunis-core-backend/src/config/tools.config.ts
+++ b/ayunis-core-backend/src/config/tools.config.ts
@@ -15,15 +15,9 @@ const parseIntWithDefault = (
   return Number.isNaN(parsed) ? defaultValue : parsed;
 };
 
-export default registerAs(
-  'tools',
-  (): ToolsConfig => ({
-    sourceGetText: {
-      maxLines: parseIntWithDefault(process.env.SOURCE_GET_TEXT_MAX_LINES, 200),
-      maxChars: parseIntWithDefault(
-        process.env.SOURCE_GET_TEXT_MAX_CHARS,
-        5000,
-      ),
-    },
-  }),
-);
+export default registerAs('tools', (): ToolsConfig => ({
+  sourceGetText: {
+    maxLines: parseIntWithDefault(process.env.SOURCE_GET_TEXT_MAX_LINES, 200),
+    maxChars: parseIntWithDefault(process.env.SOURCE_GET_TEXT_MAX_CHARS, 5000),
+  },
+}));

--- a/ayunis-core-backend/src/config/url.config.ts
+++ b/ayunis-core-backend/src/config/url.config.ts
@@ -20,16 +20,13 @@ const parsePositiveIntWithDefault = (
   return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
 };
 
-export const urlConfig = registerAs(
-  'url',
-  (): UrlConfig => ({
-    timeout: parsePositiveIntWithDefault(
-      process.env.URL_RETRIEVER_TIMEOUT_MS,
-      DEFAULT_TIMEOUT_MS,
-    ),
-    maxDownloadBytes: parsePositiveIntWithDefault(
-      process.env.URL_RETRIEVER_MAX_DOWNLOAD_BYTES,
-      DEFAULT_MAX_DOWNLOAD_BYTES,
-    ),
-  }),
-);
+export const urlConfig = registerAs('url', (): UrlConfig => ({
+  timeout: parsePositiveIntWithDefault(
+    process.env.URL_RETRIEVER_TIMEOUT_MS,
+    DEFAULT_TIMEOUT_MS,
+  ),
+  maxDownloadBytes: parsePositiveIntWithDefault(
+    process.env.URL_RETRIEVER_MAX_DOWNLOAD_BYTES,
+    DEFAULT_MAX_DOWNLOAD_BYTES,
+  ),
+}));

--- a/ayunis-core-backend/src/db/migrations/1781103662026-CreateAnonymizationWhitelistEntriesTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1781103662026-CreateAnonymizationWhitelistEntriesTable.ts
@@ -1,20 +1,33 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class CreateAnonymizationWhitelistEntriesTable1781103662026 implements MigrationInterface {
-    name = 'CreateAnonymizationWhitelistEntriesTable1781103662026'
+  name = 'CreateAnonymizationWhitelistEntriesTable1781103662026';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TYPE "public"."anonymization_whitelist_entries_category_enum" AS ENUM('person_name', 'organization', 'location', 'email_address', 'phone_number', 'url_or_ip', 'date_time', 'financial_account', 'government_id', 'nationality_religion_politics')`);
-        await queryRunner.query(`CREATE TABLE "anonymization_whitelist_entries" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "orgId" character varying NOT NULL, "category" "public"."anonymization_whitelist_entries_category_enum" NOT NULL, "pattern" text, CONSTRAINT "UQ_398e29bebe8413873fc849a16c4" UNIQUE ("orgId", "category"), CONSTRAINT "PK_87f703a36270e61894e2fba8163" PRIMARY KEY ("id"))`);
-        await queryRunner.query(`CREATE INDEX "IDX_afe776d2a9db9a54c762441699" ON "anonymization_whitelist_entries" ("orgId") `);
-        await queryRunner.query(`ALTER TABLE "anonymization_whitelist_entries" ADD CONSTRAINT "FK_afe776d2a9db9a54c762441699a" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."anonymization_whitelist_entries_category_enum" AS ENUM('person_name', 'organization', 'location', 'email_address', 'phone_number', 'url_or_ip', 'date_time', 'financial_account', 'government_id', 'nationality_religion_politics')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "anonymization_whitelist_entries" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "orgId" character varying NOT NULL, "category" "public"."anonymization_whitelist_entries_category_enum" NOT NULL, "pattern" text, CONSTRAINT "UQ_398e29bebe8413873fc849a16c4" UNIQUE ("orgId", "category"), CONSTRAINT "PK_87f703a36270e61894e2fba8163" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_afe776d2a9db9a54c762441699" ON "anonymization_whitelist_entries" ("orgId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "anonymization_whitelist_entries" ADD CONSTRAINT "FK_afe776d2a9db9a54c762441699a" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "anonymization_whitelist_entries" DROP CONSTRAINT "FK_afe776d2a9db9a54c762441699a"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_afe776d2a9db9a54c762441699"`);
-        await queryRunner.query(`DROP TABLE "anonymization_whitelist_entries"`);
-        await queryRunner.query(`DROP TYPE "public"."anonymization_whitelist_entries_category_enum"`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "anonymization_whitelist_entries" DROP CONSTRAINT "FK_afe776d2a9db9a54c762441699a"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_afe776d2a9db9a54c762441699"`,
+    );
+    await queryRunner.query(`DROP TABLE "anonymization_whitelist_entries"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."anonymization_whitelist_entries_category_enum"`,
+    );
+  }
 }

--- a/ayunis-core-backend/src/db/migrations/1781266620302-CreateOrgAddonsTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1781266620302-CreateOrgAddonsTable.ts
@@ -1,18 +1,27 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class CreateOrgAddonsTable1781266620302 implements MigrationInterface {
-    name = 'CreateOrgAddonsTable1781266620302'
+  name = 'CreateOrgAddonsTable1781266620302';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE "org_addons" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "type" character varying NOT NULL, "orgId" character varying NOT NULL, CONSTRAINT "UQ_a953cb4c09b15312670c9b231f3" UNIQUE ("orgId", "type"), CONSTRAINT "PK_5dbfcf5b94594de8a2784e7f02c" PRIMARY KEY ("id"))`);
-        await queryRunner.query(`CREATE INDEX "IDX_fb23061601e379b2b95aef9040" ON "org_addons" ("orgId") `);
-        await queryRunner.query(`ALTER TABLE "org_addons" ADD CONSTRAINT "FK_fb23061601e379b2b95aef90408" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "org_addons" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "type" character varying NOT NULL, "orgId" character varying NOT NULL, CONSTRAINT "UQ_a953cb4c09b15312670c9b231f3" UNIQUE ("orgId", "type"), CONSTRAINT "PK_5dbfcf5b94594de8a2784e7f02c" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_fb23061601e379b2b95aef9040" ON "org_addons" ("orgId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "org_addons" ADD CONSTRAINT "FK_fb23061601e379b2b95aef90408" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE "org_addons" DROP CONSTRAINT "FK_fb23061601e379b2b95aef90408"`);
-        await queryRunner.query(`DROP INDEX "public"."IDX_fb23061601e379b2b95aef9040"`);
-        await queryRunner.query(`DROP TABLE "org_addons"`);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "org_addons" DROP CONSTRAINT "FK_fb23061601e379b2b95aef90408"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_fb23061601e379b2b95aef9040"`,
+    );
+    await queryRunner.query(`DROP TABLE "org_addons"`);
+  }
 }

--- a/ayunis-core-backend/src/domain/anonymization-settings/domain/validate-pattern.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/domain/validate-pattern.ts
@@ -3,10 +3,7 @@ import safeRegex from 'safe-regex2';
 export const MAX_PATTERN_LENGTH = 200;
 
 export type PatternValidationError =
-  | 'empty'
-  | 'too_long'
-  | 'invalid_syntax'
-  | 'unsafe';
+  'empty' | 'too_long' | 'invalid_syntax' | 'unsafe';
 
 /**
  * Validates an admin-supplied whitelist regex at save time. Patterns are

--- a/ayunis-core-backend/src/domain/openai-compat/application/types/openai-request.types.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/types/openai-request.types.ts
@@ -53,11 +53,7 @@ export type OpenAIChatCompletionContentPart =
   | OpenAIChatCompletionInputAudioPart;
 
 export type OpenAIChatCompletionRole =
-  | 'system'
-  | 'developer'
-  | 'user'
-  | 'assistant'
-  | 'tool';
+  'system' | 'developer' | 'user' | 'assistant' | 'tool';
 
 export interface OpenAIChatCompletionMessage {
   role: OpenAIChatCompletionRole;

--- a/ayunis-core-backend/src/domain/openai-compat/application/types/openai-response.types.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/types/openai-response.types.ts
@@ -17,11 +17,7 @@ export interface ChatCompletionResponseMessage {
 }
 
 export type ChatCompletionFinishReason =
-  | 'stop'
-  | 'length'
-  | 'tool_calls'
-  | 'content_filter'
-  | null;
+  'stop' | 'length' | 'tool_calls' | 'content_filter' | null;
 
 export interface ChatCompletionResponseChoice {
   index: number;

--- a/ayunis-core-backend/src/domain/runs/application/helpers/resolve-integration.helper.ts
+++ b/ayunis-core-backend/src/domain/runs/application/helpers/resolve-integration.helper.ts
@@ -26,9 +26,7 @@ export function resolveIntegration(
 }
 
 type AssistantContent =
-  | TextMessageContent
-  | ToolUseMessageContent
-  | ThinkingMessageContent;
+  TextMessageContent | ToolUseMessageContent | ThinkingMessageContent;
 
 /**
  * Enriches assistant message content blocks with integration metadata.

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.query.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.query.ts
@@ -6,10 +6,7 @@ import { PaginatedQuery } from 'src/common/pagination';
 import { UsageConstants } from '../../../domain/value-objects/usage.constants';
 
 export type UserUsageSortBy =
-  | 'credits'
-  | 'requests'
-  | 'lastActivity'
-  | 'userName';
+  'credits' | 'requests' | 'lastActivity' | 'userName';
 export type SortOrder = 'asc' | 'desc';
 
 export class GetUserUsageQuery extends PaginatedQuery {

--- a/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.spec.ts
@@ -105,8 +105,7 @@ describe('AuthenticationController', () => {
 
     it('should rate limit the login endpoint to prevent credential brute-force', () => {
       const options = Reflect.getMetadata(RATE_LIMIT_KEY, controller.login) as
-        | RateLimitOptions
-        | undefined;
+        RateLimitOptions | undefined;
 
       expect(options).toBeDefined();
       expect(options?.limit).toBe(10);

--- a/ayunis-core-backend/src/iam/subscriptions/application/events/subscription-event-data.types.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/events/subscription-event-data.types.ts
@@ -26,8 +26,7 @@ export interface UsageBasedSubscriptionEventData extends SubscriptionEventDataBa
 }
 
 export type SubscriptionEventData =
-  | SeatBasedSubscriptionEventData
-  | UsageBasedSubscriptionEventData;
+  SeatBasedSubscriptionEventData | UsageBasedSubscriptionEventData;
 
 export interface BillingInfoEventData {
   companyName: string;

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case.ts
@@ -26,9 +26,9 @@ export class FindUsersByOrgIdUseCase {
     });
     const systemRole = this.contextService.get('systemRole');
     const orgRole = this.contextService.get('role');
-    if (
-      !(systemRole === SystemRole.SUPER_ADMIN || orgRole === UserRole.ADMIN)
-    ) {
+    if (!(
+      systemRole === SystemRole.SUPER_ADMIN || orgRole === UserRole.ADMIN
+    )) {
       throw new UnauthorizedAccessError({ orgId: query.orgId });
     }
     return this.usersRepository.findManyByOrgId(

--- a/ayunis-core-backend/src/integrations/webhooks/domain/subscription-webhook-payload.types.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/domain/subscription-webhook-payload.types.ts
@@ -24,8 +24,7 @@ export interface UsageBasedWebhookPayload extends SubscriptionWebhookPayloadBase
 }
 
 export type SubscriptionWebhookPayload =
-  | SeatBasedWebhookPayload
-  | UsageBasedWebhookPayload;
+  SeatBasedWebhookPayload | UsageBasedWebhookPayload;
 
 export interface BillingInfoPayload {
   companyName: string;


### PR DESCRIPTION
## Summary

Formatting-only. These 19 files (configs, generated migrations, misc types/utils) were committed before the repo-wide `eslint --fix` pass existed, so every full backend lint run dirtied them. This commits the canonical Prettier 3.9.4 formatting once so `pnpm lint` runs stay clean.

No behavior change — 115 insertions / 138 deletions, all whitespace, quoting, and wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qg4W2sfYR15Ai6iNNJUVi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formatting with no logic, config values, or migration SQL changes.
> 
> **Overview**
> **Formatting-only** cleanup across 19 backend files that were committed before the repo-wide Prettier/ESLint pass, so full `pnpm lint` runs no longer churn these paths.
> 
> Changes are **whitespace, quoting, and line wrapping** only: Nest `registerAs(...)` blocks are collapsed to single-line factory style in several config modules; union types move from multi-line to single-line in types, specs, and helpers; TypeORM migrations switch to single-quoted `import type`, 2-space indentation, and wrapped `queryRunner.query` calls; one auth guard `if` condition is re-wrapped.
> 
> **No runtime or behavioral change** — env parsing, SQL in migrations, and business logic are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc945a15ae8a820cf9603b6a6b79b27dd19cd518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->