### PR TITLE
feat(academy): download ki-fuehrerschein certificate after completing the academy (AYC-246)

### DIFF
--- a/ayunis-core-frontend/src/features/academy/index.ts
+++ b/ayunis-core-frontend/src/features/academy/index.ts
@@ -1,2 +1,3 @@
 export { useAcademyActive } from './useAcademyActive';
 export { isAcademyAddonActive } from './isAcademyAddonActive';
+export { useDownloadCertificate } from './useDownloadCertificate';

--- a/ayunis-core-frontend/src/features/academy/useDownloadCertificate.ts
+++ b/ayunis-core-frontend/src/features/academy/useDownloadCertificate.ts
@@ -1,0 +1,35 @@
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { academyCertificateControllerGetCertificate } from '@/shared/api';
+import { showError } from '@/shared/lib/toast';
+
+const CERTIFICATE_FILE_NAME = 'Ayunis-Core-KI-Fuehrerschein-Zertifikat.pdf';
+
+export function useDownloadCertificate() {
+  const { t } = useTranslation('academy');
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const downloadCertificate = useCallback(async () => {
+    setIsDownloading(true);
+    try {
+      const data = await academyCertificateControllerGetCertificate();
+
+      // The response is a file blob — trigger download
+      const blob = data instanceof Blob ? data : new Blob([data]);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = CERTIFICATE_FILE_NAME;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch {
+      showError(t('certificate.downloadError'));
+    } finally {
+      setIsDownloading(false);
+    }
+  }, [t]);
+
+  return { downloadCertificate, isDownloading };
+}

--- a/ayunis-core-frontend/src/pages/academy/ui/QuizResultCard.tsx
+++ b/ayunis-core-frontend/src/pages/academy/ui/QuizResultCard.tsx
@@ -1,5 +1,12 @@
 import { useTranslation } from 'react-i18next';
-import { CheckCircle2, RotateCcw, Trophy, XCircle } from 'lucide-react';
+import {
+  CheckCircle2,
+  Download,
+  RotateCcw,
+  Trophy,
+  XCircle,
+} from 'lucide-react';
+import { useDownloadCertificate } from '@/features/academy';
 import { Button } from '@/shared/ui/shadcn/button';
 import {
   Card,
@@ -22,6 +29,7 @@ export default function QuizResultCard({
   onBackToAcademy,
 }: Readonly<QuizResultCardProps>) {
   const { t } = useTranslation('academy');
+  const { downloadCertificate, isDownloading } = useDownloadCertificate();
 
   return (
     <Card className="mx-auto max-w-[600px]">
@@ -57,8 +65,22 @@ export default function QuizResultCard({
           </div>
         )}
         <div className="flex flex-wrap gap-3">
+          {result.academyCompleted && (
+            <Button
+              onClick={() => void downloadCertificate()}
+              disabled={isDownloading}
+            >
+              <Download className="h-4 w-4" />
+              {t('quiz.completed.downloadCertificate')}
+            </Button>
+          )}
           {result.passed ? (
-            <Button onClick={onBackToAcademy}>{t('quiz.backToAcademy')}</Button>
+            <Button
+              variant={result.academyCompleted ? 'outline' : 'default'}
+              onClick={onBackToAcademy}
+            >
+              {t('quiz.backToAcademy')}
+            </Button>
           ) : (
             <Button onClick={onRetry}>
               <RotateCcw className="h-4 w-4" />

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -17935,6 +17935,101 @@ export function useAcademyQuizControllerGetProgress<TData = Awaited<ReturnType<t
 
 
 /**
+ * Render the KI-Führerschein certificate PDF for the current user. Available once the whole academy has been completed.
+ * @summary Download the academy completion certificate
+ */
+export const academyCertificateControllerGetCertificate = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<Blob>(
+      {url: `/academy/certificate`, method: 'GET',
+        responseType: 'blob', signal
+    },
+      );
+    }
+  
+
+
+
+export const getAcademyCertificateControllerGetCertificateQueryKey = () => {
+    return [
+    `/academy/certificate`
+    ] as const;
+    }
+
+    
+export const getAcademyCertificateControllerGetCertificateQueryOptions = <TData = Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getAcademyCertificateControllerGetCertificateQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>> = ({ signal }) => academyCertificateControllerGetCertificate(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type AcademyCertificateControllerGetCertificateQueryResult = NonNullable<Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>>
+export type AcademyCertificateControllerGetCertificateQueryError = void
+
+
+export function useAcademyCertificateControllerGetCertificate<TData = Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>, TError = void>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>,
+          TError,
+          Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAcademyCertificateControllerGetCertificate<TData = Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>,
+          TError,
+          Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAcademyCertificateControllerGetCertificate<TData = Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Download the academy completion certificate
+ */
+
+export function useAcademyCertificateControllerGetCertificate<TData = Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyCertificateControllerGetCertificate>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getAcademyCertificateControllerGetCertificateQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
  * Retrieve all chapters with nested modules, ordered by position. Only accessible to super admins.
  * @summary Get all academy chapters with their modules
  */

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -8647,6 +8647,37 @@
         "tags": ["Academy"]
       }
     },
+    "/academy/certificate": {
+      "get": {
+        "description": "Render the KI-Führerschein certificate PDF for the current user. Available once the whole academy has been completed.",
+        "operationId": "AcademyCertificateController_getCertificate",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The certificate PDF",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated or academy add-on not active"
+          },
+          "404": {
+            "description": "The academy has not been completed"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Download the academy completion certificate",
+        "tags": ["Academy"]
+      }
+    },
     "/super-admin/academy/chapters": {
       "get": {
         "description": "Retrieve all chapters with nested modules, ordered by position. Only accessible to super admins.",

--- a/ayunis-core-frontend/src/shared/locales/de/academy.json
+++ b/ayunis-core-frontend/src/shared/locales/de/academy.json
@@ -37,7 +37,8 @@
     },
     "completed": {
       "title": "Academy abgeschlossen!",
-      "description": "Du hast jedes Kapitel bestanden. Glückwunsch!"
+      "description": "Du hast jedes Kapitel bestanden. Glückwunsch!",
+      "downloadCertificate": "Zertifikat herunterladen"
     },
     "errors": {
       "loadFailed": "Das Quiz konnte nicht geladen werden.",
@@ -54,5 +55,8 @@
       "title": "Academy abgeschlossen!",
       "description": "Du hast jedes Kapitel bestanden."
     }
+  },
+  "certificate": {
+    "downloadError": "Das Zertifikat konnte nicht heruntergeladen werden. Bitte versuche es erneut."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/academy.json
+++ b/ayunis-core-frontend/src/shared/locales/en/academy.json
@@ -37,7 +37,8 @@
     },
     "completed": {
       "title": "Academy complete!",
-      "description": "You've passed every chapter. Congratulations!"
+      "description": "You've passed every chapter. Congratulations!",
+      "downloadCertificate": "Download certificate"
     },
     "errors": {
       "loadFailed": "Couldn't load the quiz.",
@@ -54,5 +55,8 @@
       "title": "Academy complete!",
       "description": "You've passed every chapter."
     }
+  },
+  "certificate": {
+    "downloadError": "The certificate could not be downloaded. Please try again."
   }
 }


### PR DESCRIPTION
- regenerate API client with GET academy/certificate
- shared useDownloadCertificate hook in features/academy
- download button on the quiz result card when the academy is completed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive academy UX and API client usage; no auth or data-model changes on the frontend beyond calling an existing secured certificate endpoint.
> 
> **Overview**
> Users who finish the full academy can download their **KI-Führerschein** certificate PDF from the quiz result screen when `result.academyCompleted` is true.
> 
> The OpenAPI schema and generated client add **`GET /academy/certificate`** (blob response). A new **`useDownloadCertificate`** hook in `features/academy` calls that endpoint, saves the file as `Ayunis-Core-KI-Fuehrerschein-Zertifikat.pdf`, and surfaces a toast on failure. **`QuizResultCard`** wires a primary download button (with loading state) and demotes “Back to academy” to outline when the completion banner is shown. EN/DE copy covers the button label and download error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48b8b33dd0eb51303c857f9a1016e81d36d69daf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->