### PR TITLE
ci: split schema drift check into DB and API jobs (AYC-173)

### DIFF
--- a/.github/workflows/db-schema-drift.yml
+++ b/.github/workflows/db-schema-drift.yml
@@ -1,14 +1,14 @@
-name: API Schema Drift
+name: Database Schema Drift
 
 on:
   pull_request:
     paths:
       - 'ayunis-core-backend/src/**'
-      - '.github/workflows/api-schema-drift.yml'
+      - '.github/workflows/db-schema-drift.yml'
 
 jobs:
   check:
-    name: Check API client is up to date
+    name: Check database schema is up to date
     runs-on: ubuntu-latest
 
     services:
@@ -31,17 +31,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-
-      - name: Start MinIO
-        run: |
-          docker run -d \
-            --name minio \
-            -p 9000:9000 \
-            -e MINIO_ROOT_USER=ayunis-ci \
-            -e MINIO_ROOT_PASSWORD=ayunis-ci-minio-secret \
-            quay.io/minio/minio:latest server /data
-          # Wait for MinIO to be ready
-          timeout 30 bash -c 'until curl -f http://localhost:9000/minio/health/live; do sleep 2; done'
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -95,40 +84,32 @@ jobs:
           STACKIT_API_KEY=test-dummy-key-for-ci
           EOF
 
-      - name: Build backend
-        working-directory: ayunis-core-backend
-        run: pnpm run build
-
       - name: Run migrations
         working-directory: ayunis-core-backend
         run: pnpm run migration:run:dev
         env:
           NODE_ENV: test
 
-      - name: Start backend
+      - name: Check for database schema drift
         working-directory: ayunis-core-backend
         run: |
-          node dist/src/main.js &
-          # Wait for backend to be ready
-          timeout 60 bash -c 'until curl -sf http://localhost:3000/api/docs-json > /dev/null 2>&1; do sleep 2; done'
-
-      - name: Create frontend environment file
-        working-directory: ayunis-core-frontend
-        run: |
-          cat > .env << 'EOF'
-          VITE_API_BASE_URL=http://localhost:3000/api
-          EOF
-
-      - name: Regenerate API client
-        working-directory: ayunis-core-frontend
-        run: pnpm run openapi:update
-
-      - name: Check for drift
-        run: |
-          if ! git diff --exit-code ayunis-core-frontend/src/shared/api/generated/; then
+          set -o pipefail
+          TYPEORM_EXIT=0
+          pnpm run migration:generate:dev src/db/migrations/__DriftCheck 2>&1 | tee /tmp/drift-output.txt || TYPEORM_EXIT=$?
+          if grep -q "has been generated successfully" /tmp/drift-output.txt; then
             echo ""
-            echo "❌ API client is out of date."
-            echo "Run 'pnpm run openapi:update' in ayunis-core-frontend and commit the changes."
+            echo "❌ Database schema drift detected."
+            echo "Entities and migrations are out of sync. Run:"
+            echo "  pnpm run migration:generate:dev src/db/migrations/DescriptiveName"
+            echo ""
+            echo "Generated drift:"
+            cat src/db/migrations/*__DriftCheck.ts
             exit 1
           fi
-          echo "✅ API client is up to date"
+          if [ "$TYPEORM_EXIT" -ne 0 ] && ! grep -q "No changes in database schema were found" /tmp/drift-output.txt; then
+            echo ""
+            echo "❌ migration:generate failed unexpectedly (exit code $TYPEORM_EXIT):"
+            cat /tmp/drift-output.txt
+            exit 1
+          fi
+          echo "✅ No database schema drift"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Splits the combined "Schema Drift" CI check into two independent checks so failures are attributable to the right layer and each job runs on its own.

Previously `api-schema-drift.yml` ran a single job that checked **both**:
1. Database schema drift (TypeORM entities vs. migrations)
2. Frontend API client drift (generated client vs. backend OpenAPI schema)

When it failed, it wasn't immediately clear which of the two concerns broke.

## Changes

- **`db-schema-drift.yml`** (new) — "Database Schema Drift". Runs migrations against Postgres and verifies no drift between entities and migrations. Leaner setup:
  - No MinIO container and no backend startup (not needed for a DB-only check)
  - No `pnpm run build` step, since the migration commands run via `ts-node`
- **`api-schema-drift.yml`** (renamed check to "API Schema Drift") — now only boots the backend, regenerates the frontend API client, and fails if the generated client is out of date.

## Notes

- Both workflows keep the same `pull_request` path triggers (`ayunis-core-backend/src/**` plus their own workflow file), so they fire on the same backend changes as before.
- YAML validated locally.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-173](https://linear.app/ayunis/issue/AYC-173/split-schema-drift-jobs-into-db-vs-api)

<div><a href="https://cursor.com/agents/bc-e1edce6e-8b1e-49fe-afef-fd45c740fbd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1edce6e-8b1e-49fe-afef-fd45c740fbd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

