### PR TITLE
wip(use-cases): apply HandleUnexpectedErrors to remaining IAM use cases (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/iam/addons/application/addons.errors.ts
+++ b/ayunis-core-backend/src/iam/addons/application/addons.errors.ts
@@ -6,12 +6,22 @@ export enum AddonErrorCode {
 }
 
 export class UnexpectedAddonError extends ApplicationError {
-  constructor(operation: string, metadata?: ErrorMetadata) {
+  constructor(error: Error, metadata?: ErrorMetadata);
+  constructor(operation: string, metadata?: ErrorMetadata);
+  constructor(errorOrOperation: Error | string, metadata?: ErrorMetadata) {
+    const isError = errorOrOperation instanceof Error;
     super(
-      `Unexpected addon error during ${operation}`,
+      isError
+        ? `Unexpected addon error: ${errorOrOperation.message}`
+        : `Unexpected addon error during ${errorOrOperation}`,
       AddonErrorCode.UNEXPECTED_ERROR,
       500,
-      { operation, ...metadata },
+      {
+        ...(isError
+          ? { error: errorOrOperation }
+          : { operation: errorOrOperation }),
+        ...metadata,
+      },
     );
   }
 }

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/activate-addon/activate-addon.use-case.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/activate-addon/activate-addon.use-case.ts
@@ -1,6 +1,6 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { OrgAddon } from '../../../domain/org-addon.entity';
 import { OrgAddonRepository } from '../../ports/org-addon.repository';
 import { AddonActivatedEvent } from '../../events/addon-activated.event';
@@ -16,48 +16,43 @@ export class ActivateAddonUseCase {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAddonError)
   async execute(command: ActivateAddonCommand): Promise<void> {
     this.logger.log('Activating addon', {
       orgId: command.orgId,
       type: command.type,
     });
 
-    try {
-      const existing = await this.orgAddonRepository.findByOrgAndType(
-        command.orgId,
-        command.type,
-      );
-      if (existing) {
-        // Already active — idempotent, no event.
-        return;
-      }
-
-      const addon = new OrgAddon({
-        orgId: command.orgId,
-        type: command.type,
-      });
-      await this.orgAddonRepository.create(addon);
-
-      this.eventEmitter
-        .emitAsync(
-          AddonActivatedEvent.EVENT_NAME,
-          new AddonActivatedEvent(
-            command.orgId,
-            command.type,
-            command.requestingUserId,
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit AddonActivatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            orgId: command.orgId,
-            type: command.type,
-          });
-        });
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error activating addon', { error: error as Error });
-      throw new UnexpectedAddonError('activate', { error: error as Error });
+    const existing = await this.orgAddonRepository.findByOrgAndType(
+      command.orgId,
+      command.type,
+    );
+    if (existing) {
+      // Already active — idempotent, no event.
+      return;
     }
+
+    const addon = new OrgAddon({
+      orgId: command.orgId,
+      type: command.type,
+    });
+    await this.orgAddonRepository.create(addon);
+
+    this.eventEmitter
+      .emitAsync(
+        AddonActivatedEvent.EVENT_NAME,
+        new AddonActivatedEvent(
+          command.orgId,
+          command.type,
+          command.requestingUserId,
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error('Failed to emit AddonActivatedEvent', {
+          error: err instanceof Error ? err.message : 'Unknown error',
+          orgId: command.orgId,
+          type: command.type,
+        });
+      });
   }
 }

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/deactivate-addon/deactivate-addon.use-case.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/deactivate-addon/deactivate-addon.use-case.ts
@@ -1,6 +1,6 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { OrgAddonRepository } from '../../ports/org-addon.repository';
 import { AddonDeactivatedEvent } from '../../events/addon-deactivated.event';
 import { UnexpectedAddonError } from '../../addons.errors';
@@ -15,44 +15,39 @@ export class DeactivateAddonUseCase {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAddonError)
   async execute(command: DeactivateAddonCommand): Promise<void> {
     this.logger.log('Deactivating addon', {
       orgId: command.orgId,
       type: command.type,
     });
 
-    try {
-      const existing = await this.orgAddonRepository.findByOrgAndType(
-        command.orgId,
-        command.type,
-      );
-      if (!existing) {
-        // Already inactive — idempotent, no event.
-        return;
-      }
-
-      await this.orgAddonRepository.delete(existing.id);
-
-      this.eventEmitter
-        .emitAsync(
-          AddonDeactivatedEvent.EVENT_NAME,
-          new AddonDeactivatedEvent(
-            command.orgId,
-            command.type,
-            command.requestingUserId,
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit AddonDeactivatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            orgId: command.orgId,
-            type: command.type,
-          });
-        });
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error deactivating addon', { error: error as Error });
-      throw new UnexpectedAddonError('deactivate', { error: error as Error });
+    const existing = await this.orgAddonRepository.findByOrgAndType(
+      command.orgId,
+      command.type,
+    );
+    if (!existing) {
+      // Already inactive — idempotent, no event.
+      return;
     }
+
+    await this.orgAddonRepository.delete(existing.id);
+
+    this.eventEmitter
+      .emitAsync(
+        AddonDeactivatedEvent.EVENT_NAME,
+        new AddonDeactivatedEvent(
+          command.orgId,
+          command.type,
+          command.requestingUserId,
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error('Failed to emit AddonDeactivatedEvent', {
+          error: err instanceof Error ? err.message : 'Unknown error',
+          orgId: command.orgId,
+          type: command.type,
+        });
+      });
   }
 }

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/is-addon-active/is-addon-active.use-case.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/is-addon-active/is-addon-active.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { OrgAddonRepository } from '../../ports/org-addon.repository';
 import { UnexpectedAddonError } from '../../addons.errors';
 import { IsAddonActiveQuery } from './is-addon-active.query';
@@ -10,24 +10,17 @@ export class IsAddonActiveUseCase {
 
   constructor(private readonly orgAddonRepository: OrgAddonRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedAddonError)
   async execute(query: IsAddonActiveQuery): Promise<boolean> {
     this.logger.log('Checking if addon is active', {
       orgId: query.orgId,
       type: query.type,
     });
 
-    try {
-      const addon = await this.orgAddonRepository.findByOrgAndType(
-        query.orgId,
-        query.type,
-      );
-      return addon !== null;
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error checking if addon is active', {
-        error: error as Error,
-      });
-      throw new UnexpectedAddonError('check', { error: error as Error });
-    }
+    const addon = await this.orgAddonRepository.findByOrgAndType(
+      query.orgId,
+      query.type,
+    );
+    return addon !== null;
   }
 }

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/list-org-addons/list-org-addons.use-case.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/list-org-addons/list-org-addons.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { AddonStatus } from '../../../domain/addon-status';
 import { AddonType } from '../../../domain/value-objects/addon-type.enum';
 import { OrgAddonRepository } from '../../ports/org-addon.repository';
@@ -12,26 +12,19 @@ export class ListOrgAddonsUseCase {
 
   constructor(private readonly orgAddonRepository: OrgAddonRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedAddonError)
   async execute(query: ListOrgAddonsQuery): Promise<AddonStatus[]> {
     this.logger.log('Listing org addons', { orgId: query.orgId });
 
-    try {
-      const activeAddons = await this.orgAddonRepository.findAllByOrgId(
-        query.orgId,
-      );
-      const activeTypes = new Set(activeAddons.map((addon) => addon.type));
+    const activeAddons = await this.orgAddonRepository.findAllByOrgId(
+      query.orgId,
+    );
+    const activeTypes = new Set(activeAddons.map((addon) => addon.type));
 
-      // Always return the full catalog so the caller sees inactive addons too.
-      return Object.values(AddonType).map((type) => ({
-        type,
-        active: activeTypes.has(type),
-      }));
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error listing org addons', {
-        error: error as Error,
-      });
-      throw new UnexpectedAddonError('list', { error: error as Error });
-    }
+    // Always return the full catalog so the caller sees inactive addons too.
+    return Object.values(AddonType).map((type) => ({
+      type,
+      active: activeTypes.has(type),
+    }));
   }
 }

--- a/ayunis-core-backend/src/iam/api-keys/application/api-keys.errors.ts
+++ b/ayunis-core-backend/src/iam/api-keys/application/api-keys.errors.ts
@@ -65,11 +65,14 @@ export class ApiKeyExpiredError extends ApiKeyError {
 }
 
 export class UnexpectedApiKeyError extends ApiKeyError {
-  constructor() {
+  constructor(error?: Error, metadata?: ErrorMetadata) {
     super(
-      'Unexpected error occurred',
+      error
+        ? `Unexpected API key error: ${error.message}`
+        : 'Unexpected error occurred',
       ApiKeyErrorCode.UNEXPECTED_API_KEY_ERROR,
       500,
+      { ...(error && { error }), ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/iam/api-keys/application/use-cases/create-api-key/create-api-key.use-case.ts
+++ b/ayunis-core-backend/src/iam/api-keys/application/use-cases/create-api-key/create-api-key.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { randomBytes } from 'crypto';
 import { QueryFailedError } from 'typeorm';
@@ -10,7 +11,6 @@ import {
   ApiKeyInvalidInputError,
   UnexpectedApiKeyError,
 } from '../../api-keys.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { HashTextUseCase } from 'src/iam/hashing/application/use-cases/hash-text/hash-text.use-case';
@@ -31,6 +31,7 @@ export class CreateApiKeyUseCase {
     private readonly hashTextUseCase: HashTextUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedApiKeyError)
   async execute(command: CreateApiKeyCommand): Promise<CreateApiKeyResult> {
     const orgId = this.contextService.get('orgId');
     const userId = this.contextService.get('userId');
@@ -51,20 +52,12 @@ export class CreateApiKeyUseCase {
       throw new ApiKeyExpirationInPastError();
     }
 
-    try {
-      return await this.persistWithCollisionRetry({
-        name: trimmedName,
-        expiresAt: command.expiresAt,
-        orgId,
-        userId,
-      });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to create API key', { error: error as Error });
-      throw new UnexpectedApiKeyError();
-    }
+    return await this.persistWithCollisionRetry({
+      name: trimmedName,
+      expiresAt: command.expiresAt,
+      orgId,
+      userId,
+    });
   }
 
   private async persistWithCollisionRetry(params: {

--- a/ayunis-core-backend/src/iam/api-keys/application/use-cases/list-api-keys-by-org/list-api-keys-by-org.use-case.ts
+++ b/ayunis-core-backend/src/iam/api-keys/application/use-cases/list-api-keys-by-org/list-api-keys-by-org.use-case.ts
@@ -1,8 +1,8 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { ApiKeysRepository } from '../../ports/api-keys.repository';
 import { ApiKey } from '../../../domain/api-key.entity';
 import { UnexpectedApiKeyError } from '../../api-keys.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
@@ -15,6 +15,7 @@ export class ListApiKeysByOrgUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedApiKeyError)
   async execute(): Promise<ApiKey[]> {
     const orgId = this.contextService.get('orgId');
 
@@ -24,14 +25,6 @@ export class ListApiKeysByOrgUseCase {
 
     this.logger.log('execute', { orgId });
 
-    try {
-      return await this.apiKeysRepository.findByOrgId(orgId);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to list API keys', { error: error as Error });
-      throw new UnexpectedApiKeyError();
-    }
+    return await this.apiKeysRepository.findByOrgId(orgId);
   }
 }

--- a/ayunis-core-backend/src/iam/api-keys/application/use-cases/revoke-api-key/revoke-api-key.use-case.ts
+++ b/ayunis-core-backend/src/iam/api-keys/application/use-cases/revoke-api-key/revoke-api-key.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { ApiKeysRepository } from '../../ports/api-keys.repository';
 import { RevokeApiKeyCommand } from './revoke-api-key.command';
@@ -5,7 +6,6 @@ import {
   ApiKeyNotFoundError,
   UnexpectedApiKeyError,
 } from '../../api-keys.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
@@ -18,6 +18,7 @@ export class RevokeApiKeyUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedApiKeyError)
   async execute(command: RevokeApiKeyCommand): Promise<void> {
     const orgId = this.contextService.get('orgId');
 
@@ -27,34 +28,26 @@ export class RevokeApiKeyUseCase {
 
     this.logger.log('execute', { apiKeyId: command.apiKeyId, orgId });
 
-    try {
-      const apiKey = await this.apiKeysRepository.findById(command.apiKeyId);
+    const apiKey = await this.apiKeysRepository.findById(command.apiKeyId);
 
-      // Surface "not found" for both the truly-missing case and the cross-org
-      // case so callers cannot enumerate API key IDs across organizations by
-      // observing 403 vs 404. Cross-org attempts are still logged.
-      if (!apiKey) {
-        throw new ApiKeyNotFoundError(command.apiKeyId);
-      }
-
-      if (apiKey.orgId !== orgId) {
-        this.logger.warn('Cross-org API key revoke attempt', {
-          apiKeyId: command.apiKeyId,
-          keyOrgId: apiKey.orgId,
-          callerOrgId: orgId,
-        });
-        throw new ApiKeyNotFoundError(command.apiKeyId);
-      }
-
-      await this.apiKeysRepository.revoke(command.apiKeyId);
-
-      this.logger.debug('API key revoked', { apiKeyId: command.apiKeyId });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to revoke API key', { error: error as Error });
-      throw new UnexpectedApiKeyError();
+    // Surface "not found" for both the truly-missing case and the cross-org
+    // case so callers cannot enumerate API key IDs across organizations by
+    // observing 403 vs 404. Cross-org attempts are still logged.
+    if (!apiKey) {
+      throw new ApiKeyNotFoundError(command.apiKeyId);
     }
+
+    if (apiKey.orgId !== orgId) {
+      this.logger.warn('Cross-org API key revoke attempt', {
+        apiKeyId: command.apiKeyId,
+        keyOrgId: apiKey.orgId,
+        callerOrgId: orgId,
+      });
+      throw new ApiKeyNotFoundError(command.apiKeyId);
+    }
+
+    await this.apiKeysRepository.revoke(command.apiKeyId);
+
+    this.logger.debug('API key revoked', { apiKeyId: command.apiKeyId });
   }
 }

--- a/ayunis-core-backend/src/iam/api-keys/application/use-cases/validate-api-key/validate-api-key.use-case.ts
+++ b/ayunis-core-backend/src/iam/api-keys/application/use-cases/validate-api-key/validate-api-key.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { CompareHashUseCase } from 'src/iam/hashing/application/use-cases/compare-hash/compare-hash.use-case';
 import { CompareHashCommand } from 'src/iam/hashing/application/use-cases/compare-hash/compare-hash.command';
 import { ApiKeysRepository } from '../../ports/api-keys.repository';
@@ -20,22 +20,13 @@ export class ValidateApiKeyUseCase {
     private readonly compareHashUseCase: CompareHashUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedApiKeyError)
   async execute(command: ValidateApiKeyCommand): Promise<ApiKey> {
     this.logger.log('execute');
 
-    try {
-      const apiKey = await this.lookupAndAuthenticate(command.token);
-      this.assertNotExpired(apiKey);
-      return apiKey;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to validate API key', {
-        error: error as Error,
-      });
-      throw new UnexpectedApiKeyError();
-    }
+    const apiKey = await this.lookupAndAuthenticate(command.token);
+    this.assertNotExpired(apiKey);
+    return apiKey;
   }
 
   // Unknown prefix, hash mismatch, and revoked keys collapse to a single

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/get-current-user/get-current-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/get-current-user/get-current-user.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedAuthenticationError } from 'src/iam/authentication/application/authentication.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { GetCurrentUserCommand } from './get-current-user.command';
@@ -29,6 +31,7 @@ export class GetCurrentUserUseCase {
     private readonly findUserByIdUseCase: FindUserByIdUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAuthenticationError)
   async execute(command: GetCurrentUserCommand): Promise<ActiveUser> {
     this.logger.log('getCurrentUser');
 

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/login/login.use-case.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/login/login.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedAuthenticationError } from 'src/iam/authentication/application/authentication.errors';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { AuthenticationRepository } from '../../ports/authentication.repository';
 import { AUTHENTICATION_REPOSITORY } from '../../tokens/authentication-repository.token';
@@ -13,6 +15,7 @@ export class LoginUseCase {
     private readonly authRepository: AuthenticationRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAuthenticationError)
   async execute(command: LoginCommand): Promise<AuthTokens> {
     this.logger.log('login', {
       userId: command.user.id,

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/refresh-token/refresh-token.use-case.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/refresh-token/refresh-token.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedAuthenticationError } from 'src/iam/authentication/application/authentication.errors';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { AuthenticationRepository } from '../../ports/authentication.repository';
 import { AUTHENTICATION_REPOSITORY } from '../../tokens/authentication-repository.token';
@@ -20,6 +22,7 @@ export class RefreshTokenUseCase {
     private readonly findUserByIdUseCase: FindUserByIdUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAuthenticationError)
   async execute(command: RefreshTokenCommand): Promise<AuthTokens> {
     this.logger.log('refreshToken');
     try {

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/register-user/register-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/register-user/register-user.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { CreateAdminUserUseCase } from '../../../../users/application/use-cases/create-admin-user/create-admin-user.use-case';
 import { CreateAdminUserCommand } from '../../../../users/application/use-cases/create-admin-user/create-admin-user.command';
@@ -12,7 +13,6 @@ import {
   RegistrationDisabledError,
   UnexpectedAuthenticationError,
 } from '../../authentication.errors';
-import { ApplicationError } from '../../../../../common/errors/base.error';
 import { CreateLegalAcceptanceUseCase } from 'src/iam/legal-acceptances/application/use-cases/create-legal-acceptance/create-legal-acceptance.use-case';
 import {
   CreatePrivacyPolicyAcceptanceCommand,
@@ -43,112 +43,107 @@ export class RegisterUserUseCase {
     private readonly configService: ConfigService,
   ) {}
 
+  // Registration coordinates validation, persistence, and session setup.
+  // eslint-disable-next-line max-lines-per-function
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedAuthenticationError)
   async execute(command: RegisterUserCommand): Promise<ActiveUser> {
     this.logger.log('register', {
       email: command.email,
       orgName: command.orgName,
     });
 
-    try {
-      const disableRegistration = this.configService.get<boolean>(
-        'app.disableRegistration',
+    const disableRegistration = this.configService.get<boolean>(
+      'app.disableRegistration',
+    );
+    if (disableRegistration) {
+      throw new RegistrationDisabledError();
+    }
+
+    const existingUser = await this.findUserByEmailUseCase.execute(
+      new FindUserByEmailQuery(command.email),
+    );
+    if (existingUser) {
+      throw new UserAlreadyExistsError(existingUser.id);
+    }
+
+    const isValidPassword = await this.isValidPasswordUseCase.execute(
+      new IsValidPasswordQuery(command.password),
+    );
+    if (!isValidPassword) {
+      this.logger.warn('Invalid password during registration', {
+        email: command.email,
+      });
+      throw new InvalidPasswordError(
+        'Password does not meet security requirements',
       );
-      if (disableRegistration) {
-        throw new RegistrationDisabledError();
-      }
+    }
 
-      const existingUser = await this.findUserByEmailUseCase.execute(
-        new FindUserByEmailQuery(command.email),
-      );
-      if (existingUser) {
-        throw new UserAlreadyExistsError(existingUser.id);
-      }
+    this.logger.debug('Creating organization');
+    const org = await this.createOrgUseCase.execute(
+      new CreateOrgCommand(command.orgName),
+    );
 
-      const isValidPassword = await this.isValidPasswordUseCase.execute(
-        new IsValidPasswordQuery(command.password),
-      );
-      if (!isValidPassword) {
-        this.logger.warn('Invalid password during registration', {
-          email: command.email,
-        });
-        throw new InvalidPasswordError(
-          'Password does not meet security requirements',
-        );
-      }
+    this.logger.debug('Creating trial for organization', { orgId: org.id });
+    const trialMaxMessages = this.configService.get<number>(
+      'subscriptions.trialMaxMessages',
+    )!;
+    await this.createTrialUseCase.execute(
+      new CreateTrialCommand(org.id, trialMaxMessages),
+    );
 
-      this.logger.debug('Creating organization');
-      const org = await this.createOrgUseCase.execute(
-        new CreateOrgCommand(command.orgName),
-      );
+    // Only send confirmation email if email config is available
+    const shouldConfirmEmail =
+      this.configService.get<boolean>('emails.hasConfig');
 
-      this.logger.debug('Creating trial for organization', { orgId: org.id });
-      const trialMaxMessages = this.configService.get<number>(
-        'subscriptions.trialMaxMessages',
-      )!;
-      await this.createTrialUseCase.execute(
-        new CreateTrialCommand(org.id, trialMaxMessages),
-      );
+    this.logger.debug('Creating admin user', { orgId: org.id });
+    const user = await this.createAdminUserUseCase.execute(
+      new CreateAdminUserCommand({
+        email: command.email,
+        password: command.password,
+        orgId: org.id,
+        name: command.userName,
+        emailVerified: shouldConfirmEmail ? false : true,
+        hasAcceptedMarketing: command.hasAcceptedMarketing,
+        department: command.department,
+      }),
+    );
 
-      // Only send confirmation email if email config is available
-      const shouldConfirmEmail =
-        this.configService.get<boolean>('emails.hasConfig');
-
-      this.logger.debug('Creating admin user', { orgId: org.id });
-      const user = await this.createAdminUserUseCase.execute(
-        new CreateAdminUserCommand({
-          email: command.email,
-          password: command.password,
-          orgId: org.id,
-          name: command.userName,
-          emailVerified: shouldConfirmEmail ? false : true,
-          hasAcceptedMarketing: command.hasAcceptedMarketing,
-          department: command.department,
-        }),
-      );
-
-      this.logger.debug('Creating legal acceptance', {
+    this.logger.debug('Creating legal acceptance', {
+      userId: user.id,
+      orgId: org.id,
+    });
+    await this.createLegalAcceptanceUseCase.execute(
+      new CreateTosAcceptanceCommand({
         userId: user.id,
         orgId: org.id,
-      });
-      await this.createLegalAcceptanceUseCase.execute(
-        new CreateTosAcceptanceCommand({
-          userId: user.id,
-          orgId: org.id,
-        }),
-      );
-      await this.createLegalAcceptanceUseCase.execute(
-        new CreatePrivacyPolicyAcceptanceCommand({
-          userId: user.id,
-          orgId: org.id,
-        }),
-      );
-
-      if (shouldConfirmEmail) {
-        await this.sendConfirmationEmailUseCase.execute(
-          new SendConfirmationEmailCommand(user),
-        );
-      }
-
-      this.logger.debug('Registration successful, logging in user', {
+      }),
+    );
+    await this.createLegalAcceptanceUseCase.execute(
+      new CreatePrivacyPolicyAcceptanceCommand({
         userId: user.id,
-      });
+        orgId: org.id,
+      }),
+    );
 
-      return new ActiveUser({
-        id: user.id,
-        email: user.email,
-        emailVerified: user.emailVerified,
-        role: user.role,
-        systemRole: user.systemRole,
-        orgId: user.orgId,
-        name: user.name,
-      });
-    } catch (error: unknown) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Unexpected authentication error', { error });
-      throw new UnexpectedAuthenticationError(error);
+    if (shouldConfirmEmail) {
+      await this.sendConfirmationEmailUseCase.execute(
+        new SendConfirmationEmailCommand(user),
+      );
     }
+
+    this.logger.debug('Registration successful, logging in user', {
+      userId: user.id,
+    });
+
+    return new ActiveUser({
+      id: user.id,
+      email: user.email,
+      emailVerified: user.emailVerified,
+      role: user.role,
+      systemRole: user.systemRole,
+      orgId: user.orgId,
+      name: user.name,
+    });
   }
 }

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/get-team-credit-limits-overview/get-team-credit-limits-overview.use-case.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/get-team-credit-limits-overview/get-team-credit-limits-overview.use-case.ts
@@ -1,7 +1,7 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import type { UUID } from 'crypto';
 import type { TeamCreditLimitOverviewItem } from './team-credit-limit.view';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { ListTeamsUseCase } from 'src/iam/teams/application/use-cases/list-teams/list-teams.use-case';
@@ -23,6 +23,7 @@ export class GetTeamCreditLimitsOverviewUseCase {
     private readonly getMonthlyCreditUsageForTeamUseCase: GetMonthlyCreditUsageForTeamUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedCreditLimitError)
   async execute(): Promise<TeamCreditLimitOverviewItem[]> {
     const orgId = this.contextService.get('orgId');
     if (!orgId) {
@@ -31,16 +32,8 @@ export class GetTeamCreditLimitsOverviewUseCase {
 
     this.logger.log('Listing team credit limits', { orgId });
 
-    try {
-      const limits = await this.creditLimitRepository.findTeamLimits(orgId);
-      return await this.enrich(orgId, limits);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to list team credit limits', {
-        error: error as Error,
-      });
-      throw new UnexpectedCreditLimitError(error);
-    }
+    const limits = await this.creditLimitRepository.findTeamLimits(orgId);
+    return await this.enrich(orgId, limits);
   }
 
   private async enrich(

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/get-user-credit-limits-overview/get-user-credit-limits-overview.use-case.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/get-user-credit-limits-overview/get-user-credit-limits-overview.use-case.ts
@@ -1,8 +1,8 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import type { UUID } from 'crypto';
 import type { User } from 'src/iam/users/domain/user.entity';
 import type { UserCreditLimitOverviewItem } from './user-credit-limit.view';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { FindUsersByIdsUseCase } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case';
@@ -25,6 +25,7 @@ export class GetUserCreditLimitsOverviewUseCase {
     private readonly getMonthlyCreditUsageForUsersUseCase: GetMonthlyCreditUsageForUsersUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedCreditLimitError)
   async execute(): Promise<UserCreditLimitOverviewItem[]> {
     const orgId = this.contextService.get('orgId');
     if (!orgId) {
@@ -33,16 +34,8 @@ export class GetUserCreditLimitsOverviewUseCase {
 
     this.logger.log('Listing user credit limits', { orgId });
 
-    try {
-      const limits = await this.creditLimitRepository.findUserLimits(orgId);
-      return await this.enrich(orgId, limits);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to list user credit limits', {
-        error: error as Error,
-      });
-      throw new UnexpectedCreditLimitError(error);
-    }
+    const limits = await this.creditLimitRepository.findUserLimits(orgId);
+    return await this.enrich(orgId, limits);
   }
 
   private async enrich(

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-org-credit-limits/remove-org-credit-limits.use-case.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-org-credit-limits/remove-org-credit-limits.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { CreditLimitRepository } from '../../ports/credit-limit.repository';
 import { UnexpectedCreditLimitError } from '../../credit-limits.errors';
 import { RemoveOrgCreditLimitsCommand } from './remove-org-credit-limits.command';
@@ -15,19 +15,12 @@ export class RemoveOrgCreditLimitsUseCase {
 
   constructor(private readonly creditLimitRepository: CreditLimitRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedCreditLimitError)
   async execute(command: RemoveOrgCreditLimitsCommand): Promise<void> {
     this.logger.log('Removing all credit limits for org', {
       orgId: command.orgId,
     });
 
-    try {
-      await this.creditLimitRepository.deleteByOrg(command.orgId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to remove org credit limits', {
-        error: error as Error,
-      });
-      throw new UnexpectedCreditLimitError(error);
-    }
+    await this.creditLimitRepository.deleteByOrg(command.orgId);
   }
 }

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-team-credit-limit/remove-team-credit-limit.use-case.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-team-credit-limit/remove-team-credit-limit.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { CreditLimitRepository } from '../../ports/credit-limit.repository';
@@ -15,6 +15,7 @@ export class RemoveTeamCreditLimitUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedCreditLimitError)
   async execute(command: RemoveTeamCreditLimitCommand): Promise<void> {
     const orgId = this.contextService.get('orgId');
     if (!orgId) {
@@ -26,14 +27,6 @@ export class RemoveTeamCreditLimitUseCase {
       teamId: command.teamId,
     });
 
-    try {
-      await this.creditLimitRepository.deleteByTeamId(orgId, command.teamId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to remove team credit limit', {
-        error: error as Error,
-      });
-      throw new UnexpectedCreditLimitError(error);
-    }
+    await this.creditLimitRepository.deleteByTeamId(orgId, command.teamId);
   }
 }

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-user-credit-limit/remove-user-credit-limit.use-case.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-user-credit-limit/remove-user-credit-limit.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { CreditLimitRepository } from '../../ports/credit-limit.repository';
@@ -15,6 +15,7 @@ export class RemoveUserCreditLimitUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedCreditLimitError)
   async execute(command: RemoveUserCreditLimitCommand): Promise<void> {
     const orgId = this.contextService.get('orgId');
     if (!orgId) {
@@ -26,14 +27,6 @@ export class RemoveUserCreditLimitUseCase {
       userId: command.userId,
     });
 
-    try {
-      await this.creditLimitRepository.deleteByUserId(orgId, command.userId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to remove user credit limit', {
-        error: error as Error,
-      });
-      throw new UnexpectedCreditLimitError(error);
-    }
+    await this.creditLimitRepository.deleteByUserId(orgId, command.userId);
   }
 }

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/resolve-credit-limits-for-user/resolve-credit-limits-for-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/resolve-credit-limits-for-user/resolve-credit-limits-for-user.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { FindTeamsByUserIdUseCase } from 'src/iam/teams/application/use-cases/find-teams-by-user-id/find-teams-by-user-id.use-case';
 import { FindTeamsByUserIdQuery } from 'src/iam/teams/application/use-cases/find-teams-by-user-id/find-teams-by-user-id.query';
 import { CreditLimitRepository } from '../../ports/credit-limit.repository';
@@ -17,6 +17,7 @@ export class ResolveCreditLimitsForUserUseCase {
     private readonly findTeamsByUserIdUseCase: FindTeamsByUserIdUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedCreditLimitError)
   async execute(
     query: ResolveCreditLimitsForUserQuery,
   ): Promise<CreditLimitsForUser> {
@@ -25,30 +26,22 @@ export class ResolveCreditLimitsForUserUseCase {
       userId: query.userId,
     });
 
-    try {
-      const userLimitEntity = await this.creditLimitRepository.findByUserId(
-        query.orgId,
-        query.userId,
-      );
+    const userLimitEntity = await this.creditLimitRepository.findByUserId(
+      query.orgId,
+      query.userId,
+    );
 
-      const teams = await this.findTeamsByUserIdUseCase.execute(
-        new FindTeamsByUserIdQuery(query.userId),
-      );
-      const teamLimits = await this.creditLimitRepository.findByTeamIds(
-        query.orgId,
-        teams.map((team) => team.id),
-      );
+    const teams = await this.findTeamsByUserIdUseCase.execute(
+      new FindTeamsByUserIdQuery(query.userId),
+    );
+    const teamLimits = await this.creditLimitRepository.findByTeamIds(
+      query.orgId,
+      teams.map((team) => team.id),
+    );
 
-      return {
-        personalCreditLimit: userLimitEntity?.monthlyCredits ?? null,
-        teamCreditLimits: selectTeamCreditLimits(teamLimits),
-      };
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to resolve credit limits for user', {
-        error: error as Error,
-      });
-      throw new UnexpectedCreditLimitError(error);
-    }
+    return {
+      personalCreditLimit: userLimitEntity?.monthlyCredits ?? null,
+      teamCreditLimits: selectTeamCreditLimits(teamLimits),
+    };
   }
 }

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/set-team-credit-limit/set-team-credit-limit.use-case.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/set-team-credit-limit/set-team-credit-limit.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { CreditLimitRepository } from '../../ports/credit-limit.repository';
@@ -23,6 +23,7 @@ export class SetTeamCreditLimitUseCase {
     private readonly getTeamUseCase: GetTeamUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedCreditLimitError)
   async execute(command: SetTeamCreditLimitCommand): Promise<TeamCreditLimit> {
     const orgId = this.contextService.get('orgId');
     if (!orgId) {
@@ -41,29 +42,21 @@ export class SetTeamCreditLimitUseCase {
       monthlyCredits: command.monthlyCredits,
     });
 
-    try {
-      await this.getTeamUseCase.execute(new GetTeamQuery(command.teamId));
+    await this.getTeamUseCase.execute(new GetTeamQuery(command.teamId));
 
-      const existing = await this.creditLimitRepository.findByTeamId(
-        orgId,
-        command.teamId,
-      );
+    const existing = await this.creditLimitRepository.findByTeamId(
+      orgId,
+      command.teamId,
+    );
 
-      const limit = new TeamCreditLimit({
-        id: existing?.id,
-        orgId,
-        teamId: command.teamId,
-        monthlyCredits: command.monthlyCredits,
-        createdAt: existing?.createdAt,
-      });
+    const limit = new TeamCreditLimit({
+      id: existing?.id,
+      orgId,
+      teamId: command.teamId,
+      monthlyCredits: command.monthlyCredits,
+      createdAt: existing?.createdAt,
+    });
 
-      return await this.creditLimitRepository.save(limit);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to set team credit limit', {
-        error: error as Error,
-      });
-      throw new UnexpectedCreditLimitError(error);
-    }
+    return await this.creditLimitRepository.save(limit);
   }
 }

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/set-user-credit-limit/set-user-credit-limit.use-case.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/set-user-credit-limit/set-user-credit-limit.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { CreditLimitRepository } from '../../ports/credit-limit.repository';
@@ -24,6 +24,7 @@ export class SetUserCreditLimitUseCase {
     private readonly findUsersByIdsUseCase: FindUsersByIdsUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedCreditLimitError)
   async execute(command: SetUserCreditLimitCommand): Promise<UserCreditLimit> {
     const orgId = this.contextService.get('orgId');
     if (!orgId) {
@@ -42,36 +43,28 @@ export class SetUserCreditLimitUseCase {
       monthlyCredits: command.monthlyCredits,
     });
 
-    try {
-      const members = await this.findUsersByIdsUseCase.execute(
-        new FindUsersByIdsQuery([command.userId]),
-      );
-      if (members.length === 0) {
-        throw new CreditLimitTargetNotFoundError({
-          userId: command.userId,
-        });
-      }
-
-      const existing = await this.creditLimitRepository.findByUserId(
-        orgId,
-        command.userId,
-      );
-
-      const limit = new UserCreditLimit({
-        id: existing?.id,
-        orgId,
+    const members = await this.findUsersByIdsUseCase.execute(
+      new FindUsersByIdsQuery([command.userId]),
+    );
+    if (members.length === 0) {
+      throw new CreditLimitTargetNotFoundError({
         userId: command.userId,
-        monthlyCredits: command.monthlyCredits,
-        createdAt: existing?.createdAt,
       });
-
-      return await this.creditLimitRepository.save(limit);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to set user credit limit', {
-        error: error as Error,
-      });
-      throw new UnexpectedCreditLimitError(error);
     }
+
+    const existing = await this.creditLimitRepository.findByUserId(
+      orgId,
+      command.userId,
+    );
+
+    const limit = new UserCreditLimit({
+      id: existing?.id,
+      orgId,
+      userId: command.userId,
+      monthlyCredits: command.monthlyCredits,
+      createdAt: existing?.createdAt,
+    });
+
+    return await this.creditLimitRepository.save(limit);
   }
 }

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/accept-invite/accept-invite.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/accept-invite/accept-invite.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { InvitesRepository } from '../../ports/invites.repository';
 import {
@@ -23,7 +24,6 @@ import { IsValidPasswordUseCase } from 'src/iam/users/application/use-cases/is-v
 import { IsValidPasswordQuery } from 'src/iam/users/application/use-cases/is-valid-password/is-valid-password.query';
 import { FindUserByEmailUseCase } from 'src/iam/users/application/use-cases/find-user-by-email/find-user-by-email.use-case';
 import { FindUserByEmailQuery } from 'src/iam/users/application/use-cases/find-user-by-email/find-user-by-email.query';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedInviteError } from '../../invites.errors';
 
 @Injectable()
@@ -39,109 +39,104 @@ export class AcceptInviteUseCase {
     private readonly findUserByEmailUseCase: FindUserByEmailUseCase,
   ) {}
 
+  // Invite acceptance coordinates token validation, membership, and cleanup.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UnexpectedInviteError)
   async execute(
     command: AcceptInviteCommand,
   ): Promise<{ inviteId: string; email: string; orgId: string }> {
     this.logger.log('execute', { hasToken: !!command.inviteToken });
+
+    // Verify and decode the JWT token
+    let payload: InviteJwtPayload;
     try {
-      // Verify and decode the JWT token
-      let payload: InviteJwtPayload;
-      try {
-        payload = this.inviteJwtService.verifyInviteToken(command.inviteToken);
-      } catch (error) {
-        this.logger.error('Invalid invite token', {
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
-        throw new InvalidInviteTokenError('Token verification failed');
-      }
-
-      // Find the invite in the database
-      const invite = await this.invitesRepository.findOne(payload.inviteId);
-      if (!invite) {
-        this.logger.error('Invite not found', { inviteId: payload.inviteId });
-        throw new InviteNotFoundError(payload.inviteId);
-      }
-
-      const existingUser = await this.findUserByEmailUseCase.execute(
-        new FindUserByEmailQuery(invite.email),
-      );
-      if (existingUser) {
-        throw new UserAlreadyExistsError();
-      }
-
-      // Check if invite is already accepted
-      if (invite.acceptedAt) {
-        this.logger.error('Invite already accepted', { inviteId: invite.id });
-        throw new InviteAlreadyAcceptedError({ inviteId: invite.id });
-      }
-
-      // Check if invite has expired
-      if (invite.expiresAt < new Date()) {
-        this.logger.error('Invite expired', {
-          inviteId: invite.id,
-          expiresAt: invite.expiresAt,
-        });
-        throw new InviteExpiredError({
-          inviteId: invite.id,
-          expiresAt: invite.expiresAt,
-        });
-      }
-
-      if (
-        !(await this.isValidPasswordUseCase.execute(
-          new IsValidPasswordQuery(command.password),
-        ))
-      ) {
-        throw new InvalidPasswordError();
-      }
-
-      if (invite.role === UserRole.ADMIN) {
-        await this.createAdminUserUseCase.execute(
-          new CreateAdminUserCommand({
-            email: invite.email,
-            password: command.password,
-            orgId: invite.orgId,
-            name: command.userName,
-            emailVerified: true,
-            hasAcceptedMarketing: command.hasAcceptedMarketing,
-            department: command.department,
-          }),
-        );
-      } else if (invite.role === UserRole.USER) {
-        await this.createRegularUserUseCase.execute(
-          new CreateRegularUserCommand({
-            email: invite.email,
-            orgId: invite.orgId,
-            name: command.userName,
-            password: command.password,
-            emailVerified: true,
-            hasAcceptedMarketing: command.hasAcceptedMarketing,
-            department: command.department,
-          }),
-        );
-      } else {
-        throw new InviteRoleError(invite.role);
-      }
-
-      await this.invitesRepository.accept(invite.id);
-
-      this.logger.debug('Invite accepted successfully', {
-        inviteId: invite.id,
-        email: invite.email,
-      });
-
-      return {
-        inviteId: invite.id,
-        email: invite.email,
-        orgId: invite.orgId,
-      };
+      payload = this.inviteJwtService.verifyInviteToken(command.inviteToken);
     } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      const err = error instanceof Error ? error : new Error('Unknown error');
-      this.logger.error('Accept invite failed', { error: err });
-      throw new UnexpectedInviteError(err);
+      this.logger.error('Invalid invite token', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw new InvalidInviteTokenError('Token verification failed');
     }
+
+    // Find the invite in the database
+    const invite = await this.invitesRepository.findOne(payload.inviteId);
+    if (!invite) {
+      this.logger.error('Invite not found', { inviteId: payload.inviteId });
+      throw new InviteNotFoundError(payload.inviteId);
+    }
+
+    const existingUser = await this.findUserByEmailUseCase.execute(
+      new FindUserByEmailQuery(invite.email),
+    );
+    if (existingUser) {
+      throw new UserAlreadyExistsError();
+    }
+
+    // Check if invite is already accepted
+    if (invite.acceptedAt) {
+      this.logger.error('Invite already accepted', { inviteId: invite.id });
+      throw new InviteAlreadyAcceptedError({ inviteId: invite.id });
+    }
+
+    // Check if invite has expired
+    if (invite.expiresAt < new Date()) {
+      this.logger.error('Invite expired', {
+        inviteId: invite.id,
+        expiresAt: invite.expiresAt,
+      });
+      throw new InviteExpiredError({
+        inviteId: invite.id,
+        expiresAt: invite.expiresAt,
+      });
+    }
+
+    if (
+      !(await this.isValidPasswordUseCase.execute(
+        new IsValidPasswordQuery(command.password),
+      ))
+    ) {
+      throw new InvalidPasswordError();
+    }
+
+    if (invite.role === UserRole.ADMIN) {
+      await this.createAdminUserUseCase.execute(
+        new CreateAdminUserCommand({
+          email: invite.email,
+          password: command.password,
+          orgId: invite.orgId,
+          name: command.userName,
+          emailVerified: true,
+          hasAcceptedMarketing: command.hasAcceptedMarketing,
+          department: command.department,
+        }),
+      );
+    } else if (invite.role === UserRole.USER) {
+      await this.createRegularUserUseCase.execute(
+        new CreateRegularUserCommand({
+          email: invite.email,
+          orgId: invite.orgId,
+          name: command.userName,
+          password: command.password,
+          emailVerified: true,
+          hasAcceptedMarketing: command.hasAcceptedMarketing,
+          department: command.department,
+        }),
+      );
+    } else {
+      throw new InviteRoleError(invite.role);
+    }
+
+    await this.invitesRepository.accept(invite.id);
+
+    this.logger.debug('Invite accepted successfully', {
+      inviteId: invite.id,
+      email: invite.email,
+    });
+
+    return {
+      inviteId: invite.id,
+      email: invite.email,
+      orgId: invite.orgId,
+    };
   }
 }

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/create-bulk-invites/create-bulk-invites.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/create-bulk-invites/create-bulk-invites.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InvitesRepository } from '../../ports/invites.repository';
@@ -59,6 +60,7 @@ export class CreateBulkInvitesUseCase {
     private readonly configService: ConfigService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedInviteError)
   async execute(
     command: CreateBulkInvitesCommand,
   ): Promise<CreateBulkInvitesResult> {
@@ -68,46 +70,38 @@ export class CreateBulkInvitesUseCase {
       userId: command.userId,
     });
 
-    try {
-      // Phase 1: Validation
-      const validationErrors = await this.validateAllInvites(command);
+    // Phase 1: Validation
+    const validationErrors = await this.validateAllInvites(command);
 
-      if (validationErrors.length > 0) {
-        throw new BulkInviteValidationFailedError(validationErrors);
-      }
-
-      // Phase 2: Check and update seats if needed (for cloud deployments)
-      await this.handleSeatsForBulkInvites(command);
-
-      // Phase 3: Process all invites
-      const results = await this.processInvites(command);
-
-      const successCount = results.filter((r) => r.success).length;
-      const failureCount = results.filter((r) => !r.success).length;
-
-      this.logger.log('Bulk invites completed', {
-        totalCount: command.invites.length,
-        successCount,
-        failureCount,
-      });
-
-      return {
-        totalCount: command.invites.length,
-        successCount,
-        failureCount,
-        results,
-      };
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error creating bulk invites', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedInviteError(error as Error);
+    if (validationErrors.length > 0) {
+      throw new BulkInviteValidationFailedError(validationErrors);
     }
+
+    // Phase 2: Check and update seats if needed (for cloud deployments)
+    await this.handleSeatsForBulkInvites(command);
+
+    // Phase 3: Process all invites
+    const results = await this.processInvites(command);
+
+    const successCount = results.filter((r) => r.success).length;
+    const failureCount = results.filter((r) => !r.success).length;
+
+    this.logger.log('Bulk invites completed', {
+      totalCount: command.invites.length,
+      successCount,
+      failureCount,
+    });
+
+    return {
+      totalCount: command.invites.length,
+      successCount,
+      failureCount,
+      results,
+    };
   }
 
+  // Validation intentionally keeps the complete bulk result classification together.
+  // eslint-disable-next-line max-lines-per-function
   private async validateAllInvites(
     command: CreateBulkInvitesCommand,
   ): Promise<ValidationError[]> {
@@ -211,6 +205,8 @@ export class CreateBulkInvitesUseCase {
     return errors;
   }
 
+  // Seat handling applies several subscription and quota rules as one transaction.
+  // eslint-disable-next-line max-lines-per-function
   private async handleSeatsForBulkInvites(
     command: CreateBulkInvitesCommand,
   ): Promise<void> {
@@ -278,6 +274,8 @@ export class CreateBulkInvitesUseCase {
     }
   }
 
+  // Processing preserves per-invite isolation and result reporting.
+  // eslint-disable-next-line max-lines-per-function, complexity
   private async processInvites(
     command: CreateBulkInvitesCommand,
   ): Promise<BulkInviteResult[]> {

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.spec.ts
@@ -501,9 +501,10 @@ describe('CreateInviteUseCase', () => {
       await expect(useCase.execute(command)).rejects.toThrow(
         UnexpectedInviteError,
       );
-      expect(errorSpy).toHaveBeenCalledWith('Error creating invite', {
-        error: 'Database connection failed',
-      });
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Unexpected use-case error',
+        expect.stringContaining('Database connection failed'),
+      );
     });
 
     it('should parse different time formats correctly', async () => {

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import type { UUID } from 'crypto';
 import { Injectable, Logger } from '@nestjs/common';
 import { InvitesRepository } from '../../ports/invites.repository';
@@ -17,7 +18,6 @@ import {
   UserAlreadyExistsError,
 } from '../../invites.errors';
 import { SendInvitationEmailUseCase } from '../send-invitation-email/send-invitation-email.use-case';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { FindUserByEmailUseCase } from 'src/iam/users/application/use-cases/find-user-by-email/find-user-by-email.use-case';
 import { FindUserByEmailQuery } from 'src/iam/users/application/use-cases/find-user-by-email/find-user-by-email.query';
 import { UserEmailProviderBlacklistedError } from 'src/iam/users/application/users.errors';
@@ -43,52 +43,44 @@ export class CreateInviteUseCase {
     private readonly configService: ConfigService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedInviteError)
   async execute(command: CreateInviteCommand): Promise<CreateInviteResult> {
     this.logger.log('execute', {
       email: command.email,
       orgId: command.orgId,
       userId: command.userId,
     });
-    try {
-      this.validateEmailProvider(command.email);
-      await this.ensureEmailAvailable(command.email, command.orgId);
-      await this.ensureCloudSeatsAvailable(command.orgId, command.userId);
 
-      const validDuration = this.configService.get<string>(
-        'auth.jwt.inviteExpiresIn',
-        '7d',
-      );
+    this.validateEmailProvider(command.email);
+    await this.ensureEmailAvailable(command.email, command.orgId);
+    await this.ensureCloudSeatsAvailable(command.orgId, command.userId);
 
-      const invite = new Invite({
-        email: command.email,
-        orgId: command.orgId,
-        role: command.role,
-        inviterId: command.userId,
-        expiresAt: getInviteExpiresAt(validDuration),
-      });
-      this.logger.debug('Invite to be created', { invite });
+    const validDuration = this.configService.get<string>(
+      'auth.jwt.inviteExpiresIn',
+      '7d',
+    );
 
-      await this.invitesRepository.create(invite);
+    const invite = new Invite({
+      email: command.email,
+      orgId: command.orgId,
+      role: command.role,
+      inviterId: command.userId,
+      expiresAt: getInviteExpiresAt(validDuration),
+    });
+    this.logger.debug('Invite to be created', { invite });
 
-      const inviteToken = this.inviteJwtService.generateInviteToken({
-        inviteId: invite.id,
-      });
+    await this.invitesRepository.create(invite);
 
-      this.logger.debug('Invite created successfully', {
-        inviteId: invite.id,
-        email: invite.email,
-      });
+    const inviteToken = this.inviteJwtService.generateInviteToken({
+      inviteId: invite.id,
+    });
 
-      return { token: inviteToken, invite };
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error creating invite', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedInviteError(error as Error);
-    }
+    this.logger.debug('Invite created successfully', {
+      inviteId: invite.id,
+      email: invite.email,
+    });
+
+    return { token: inviteToken, invite };
   }
 
   private validateEmailProvider(email: string): void {

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/delete-all-pending-invites/delete-all-pending-invites.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/delete-all-pending-invites/delete-all-pending-invites.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedInviteError } from 'src/iam/invites/application/invites.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { UUID } from 'crypto';
 import { InvitesRepository } from '../../ports/invites.repository';
@@ -9,6 +11,7 @@ export class DeleteAllPendingInvitesUseCase {
 
   constructor(private readonly invitesRepository: InvitesRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedInviteError)
   async execute(
     command: DeleteAllPendingInvitesCommand,
   ): Promise<{ deletedCount: number }> {

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/delete-invite-by-email/delete-invite-by-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/delete-invite-by-email/delete-invite-by-email.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedInviteError } from 'src/iam/invites/application/invites.errors';
 import { InvitesRepository } from '../../ports/invites.repository';
 import { DeleteInviteByEmailCommand } from './delete-invite-by-email.command';
 import { Injectable, Logger } from '@nestjs/common';
@@ -8,6 +10,7 @@ export class DeleteInviteByEmailUseCase {
   private readonly logger = new Logger(DeleteInviteByEmailUseCase.name);
   constructor(private readonly invitesRepository: InvitesRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedInviteError)
   async execute(command: DeleteInviteByEmailCommand): Promise<void> {
     this.logger.log('execute', {
       email: command.email,

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/delete-invite/delete-invite.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/delete-invite/delete-invite.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedInviteError } from 'src/iam/invites/application/invites.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { InvitesRepository } from '../../ports/invites.repository';
 import { DeleteInviteCommand } from './delete-invite.command';
@@ -9,6 +11,7 @@ export class DeleteInviteUseCase {
 
   constructor(private readonly invitesRepository: InvitesRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedInviteError)
   async execute(command: DeleteInviteCommand): Promise<void> {
     this.logger.log('execute', {
       inviteId: command.inviteId,

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/get-invite-by-token/get-invite-by-token.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/get-invite-by-token/get-invite-by-token.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedInviteError } from 'src/iam/invites/application/invites.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { InvitesRepository } from '../../ports/invites.repository';
 import { GetInviteByTokenQuery } from './get-invite-by-token.query';
@@ -36,6 +38,7 @@ export class GetInviteByTokenUseCase {
     private readonly inviteJwtService: InviteJwtService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedInviteError)
   async execute(query: GetInviteByTokenQuery): Promise<InviteWithOrgDetails> {
     this.logger.log('execute', { hasToken: !!query.token });
 

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.use-case.ts
@@ -1,9 +1,10 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedInviteError } from 'src/iam/invites/application/invites.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { InvitesRepository } from '../../ports/invites.repository';
 import { GetInvitesByOrgQuery } from './get-invites-by-org.query';
 import { Invite } from '../../../domain/invite.entity';
 import { UnauthorizedInviteAccessError } from '../../invites.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
@@ -18,47 +19,37 @@ export class GetInvitesByOrgUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedInviteError)
   async execute(query: GetInvitesByOrgQuery): Promise<Paginated<Invite>> {
-    try {
-      this.logger.log('execute', {
-        orgId: query.orgId,
-        requestingUserId: query.requestingUserId,
-        search: query.search,
-        limit: query.limit,
-        offset: query.offset,
-      });
+    this.logger.log('execute', {
+      orgId: query.orgId,
+      requestingUserId: query.requestingUserId,
+      search: query.search,
+      limit: query.limit,
+      offset: query.offset,
+    });
 
-      const orgId = this.contextService.get('orgId');
-      const orgRole = this.contextService.get('role');
-      const systemRole = this.contextService.get('systemRole');
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      const isOrgAdmin = orgRole === UserRole.ADMIN && orgId === query.orgId;
-      if (!isSuperAdmin && !isOrgAdmin) {
-        throw new UnauthorizedInviteAccessError();
-      }
-
-      const paginatedInvites =
-        await this.invitesRepository.findByOrgIdPaginated(
-          query.orgId,
-          { limit: query.limit, offset: query.offset },
-          { search: query.search, onlyPending: query.onlyOpen },
-        );
-
-      this.logger.debug('Found invites', {
-        orgId: query.orgId,
-        count: paginatedInvites.data.length,
-        total: paginatedInvites.total,
-      });
-
-      return paginatedInvites;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to get invites by organization', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw error;
+    const orgId = this.contextService.get('orgId');
+    const orgRole = this.contextService.get('role');
+    const systemRole = this.contextService.get('systemRole');
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+    const isOrgAdmin = orgRole === UserRole.ADMIN && orgId === query.orgId;
+    if (!isSuperAdmin && !isOrgAdmin) {
+      throw new UnauthorizedInviteAccessError();
     }
+
+    const paginatedInvites = await this.invitesRepository.findByOrgIdPaginated(
+      query.orgId,
+      { limit: query.limit, offset: query.offset },
+      { search: query.search, onlyPending: query.onlyOpen },
+    );
+
+    this.logger.debug('Found invites', {
+      orgId: query.orgId,
+      count: paginatedInvites.data.length,
+      total: paginatedInvites.total,
+    });
+
+    return paginatedInvites;
   }
 }

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/resend-expired-invite/resend-expired-invite.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/resend-expired-invite/resend-expired-invite.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { InvitesRepository } from '../../ports/invites.repository';
 import { Invite } from 'src/iam/invites/domain/invite.entity';
@@ -10,7 +11,6 @@ import {
   InviteAlreadyAcceptedError,
   UnexpectedInviteError,
 } from '../../invites.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { getInviteExpiresAt } from '../../services/invite-expiration.util';
 
 interface ResendExpiredInviteResult {
@@ -28,73 +28,64 @@ export class ResendExpiredInviteUseCase {
     private readonly configService: ConfigService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedInviteError)
   async execute(
     command: ResendExpiredInviteCommand,
   ): Promise<ResendExpiredInviteResult> {
     this.logger.log('execute', { inviteId: command.inviteId });
 
-    try {
-      // 1. Find the existing invite
-      const existingInvite = await this.invitesRepository.findOne(
-        command.inviteId,
-      );
-      if (!existingInvite) {
-        throw new InviteNotFoundError(command.inviteId);
-      }
-
-      // 2. Verify invite is not already accepted
-      if (existingInvite.acceptedAt) {
-        throw new InviteAlreadyAcceptedError();
-      }
-
-      // 3. Verify it is actually expired
-      if (existingInvite.expiresAt >= new Date()) {
-        throw new InviteNotExpiredError(command.inviteId);
-      }
-
-      // 4. Delete the expired invite
-      await this.invitesRepository.delete(command.inviteId);
-
-      // 5. Create a new invite with the same data
-      const validDuration = this.configService.get<string>(
-        'auth.jwt.inviteExpiresIn',
-        '7d',
-      );
-      const inviteExpiresAt = getInviteExpiresAt(validDuration);
-
-      const newInvite = new Invite({
-        email: existingInvite.email,
-        orgId: existingInvite.orgId,
-        role: existingInvite.role,
-        inviterId: existingInvite.inviterId,
-        expiresAt: inviteExpiresAt,
-      });
-
-      await this.invitesRepository.create(newInvite);
-
-      // 6. Generate JWT token for the new invite
-      const inviteToken = this.inviteJwtService.generateInviteToken({
-        inviteId: newInvite.id,
-      });
-
-      this.logger.debug('Expired invite resent successfully', {
-        oldInviteId: command.inviteId,
-        newInviteId: newInvite.id,
-        email: newInvite.email,
-      });
-
-      return {
-        token: inviteToken,
-        invite: newInvite,
-      };
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error resending expired invite', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedInviteError(error as Error);
+    // 1. Find the existing invite
+    const existingInvite = await this.invitesRepository.findOne(
+      command.inviteId,
+    );
+    if (!existingInvite) {
+      throw new InviteNotFoundError(command.inviteId);
     }
+
+    // 2. Verify invite is not already accepted
+    if (existingInvite.acceptedAt) {
+      throw new InviteAlreadyAcceptedError();
+    }
+
+    // 3. Verify it is actually expired
+    if (existingInvite.expiresAt >= new Date()) {
+      throw new InviteNotExpiredError(command.inviteId);
+    }
+
+    // 4. Delete the expired invite
+    await this.invitesRepository.delete(command.inviteId);
+
+    // 5. Create a new invite with the same data
+    const validDuration = this.configService.get<string>(
+      'auth.jwt.inviteExpiresIn',
+      '7d',
+    );
+    const inviteExpiresAt = getInviteExpiresAt(validDuration);
+
+    const newInvite = new Invite({
+      email: existingInvite.email,
+      orgId: existingInvite.orgId,
+      role: existingInvite.role,
+      inviterId: existingInvite.inviterId,
+      expiresAt: inviteExpiresAt,
+    });
+
+    await this.invitesRepository.create(newInvite);
+
+    // 6. Generate JWT token for the new invite
+    const inviteToken = this.inviteJwtService.generateInviteToken({
+      inviteId: newInvite.id,
+    });
+
+    this.logger.debug('Expired invite resent successfully', {
+      oldInviteId: command.inviteId,
+      newInviteId: newInvite.id,
+      email: newInvite.email,
+    });
+
+    return {
+      token: inviteToken,
+      invite: newInvite,
+    };
   }
 }

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/send-invitation-email/send-invitation-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/send-invitation-email/send-invitation-email.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedInviteError } from 'src/iam/invites/application/invites.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { SendInvitationEmailCommand } from './send-invitation-email.command';
 import { SendEmailCommand } from 'src/common/emails/application/use-cases/send-email/send-email.command';
@@ -25,6 +27,9 @@ export class SendInvitationEmailUseCase {
     private readonly findUserByIdUseCase: FindUserByIdUseCase,
   ) {}
 
+  // Email generation combines organization, template, and delivery context.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UnexpectedInviteError)
   async execute(command: SendInvitationEmailCommand): Promise<void> {
     try {
       this.logger.log('execute', {

--- a/ayunis-core-backend/src/iam/ip-allowlist/application/ip-allowlist.errors.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/application/ip-allowlist.errors.ts
@@ -37,12 +37,22 @@ export class InvalidCidrApplicationError extends ApplicationError {
 }
 
 export class UnexpectedIpAllowlistError extends ApplicationError {
-  constructor(operation: string, metadata?: ErrorMetadata) {
+  constructor(error: Error, metadata?: ErrorMetadata);
+  constructor(operation: string, metadata?: ErrorMetadata);
+  constructor(errorOrOperation: Error | string, metadata?: ErrorMetadata) {
+    const isError = errorOrOperation instanceof Error;
     super(
-      `Unexpected IP allowlist error during ${operation}`,
+      isError
+        ? `Unexpected IP allowlist error: ${errorOrOperation.message}`
+        : `Unexpected IP allowlist error during ${errorOrOperation}`,
       IpAllowlistErrorCode.UNEXPECTED_ERROR,
       500,
-      { operation, ...metadata },
+      {
+        ...(isError
+          ? { error: errorOrOperation }
+          : { operation: errorOrOperation }),
+        ...metadata,
+      },
     );
   }
 }

--- a/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/delete-ip-allowlist/delete-ip-allowlist.use-case.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/delete-ip-allowlist/delete-ip-allowlist.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { IpAllowlistRepository } from '../../ports/ip-allowlist.repository';
 import { IpAllowlistCachePort } from '../../ports/ip-allowlist-cache.port';
 import { UnexpectedIpAllowlistError } from '../../ip-allowlist.errors';
@@ -14,24 +14,11 @@ export class DeleteIpAllowlistUseCase {
     private readonly ipAllowlistCache: IpAllowlistCachePort,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedIpAllowlistError)
   async execute(command: DeleteIpAllowlistCommand): Promise<void> {
     this.logger.debug('Deleting IP allowlist', { orgId: command.orgId });
 
-    try {
-      await this.repository.deleteByOrgId(command.orgId);
-      this.ipAllowlistCache.invalidateCache(command.orgId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-
-      this.logger.error('Failed to delete IP allowlist', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-      });
-
-      throw new UnexpectedIpAllowlistError('delete', {
-        orgId: command.orgId,
-        ...(error instanceof Error && { originalError: error.message }),
-      });
-    }
+    await this.repository.deleteByOrgId(command.orgId);
+    this.ipAllowlistCache.invalidateCache(command.orgId);
   }
 }

--- a/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/get-ip-allowlist/get-ip-allowlist.use-case.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/get-ip-allowlist/get-ip-allowlist.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { IpAllowlistRepository } from '../../ports/ip-allowlist.repository';
 import { UnexpectedIpAllowlistError } from '../../ip-allowlist.errors';
 import type { GetIpAllowlistQuery } from './get-ip-allowlist.query';
@@ -11,23 +11,10 @@ export class GetIpAllowlistUseCase {
 
   constructor(private readonly repository: IpAllowlistRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedIpAllowlistError)
   async execute(query: GetIpAllowlistQuery): Promise<IpAllowlist | null> {
     this.logger.debug('Getting IP allowlist', { orgId: query.orgId });
 
-    try {
-      return await this.repository.findByOrgId(query.orgId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-
-      this.logger.error('Failed to get IP allowlist', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: query.orgId,
-      });
-
-      throw new UnexpectedIpAllowlistError('get', {
-        orgId: query.orgId,
-        ...(error instanceof Error && { originalError: error.message }),
-      });
-    }
+    return await this.repository.findByOrgId(query.orgId);
   }
 }

--- a/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/update-ip-allowlist/update-ip-allowlist.use-case.ts
+++ b/ayunis-core-backend/src/iam/ip-allowlist/application/use-cases/update-ip-allowlist/update-ip-allowlist.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { IpAllowlistRepository } from '../../ports/ip-allowlist.repository';
 import { IpAllowlistCachePort } from '../../ports/ip-allowlist-cache.port';
 import {
@@ -24,54 +24,41 @@ export class UpdateIpAllowlistUseCase {
     private readonly ipAllowlistCache: IpAllowlistCachePort,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedIpAllowlistError)
   async execute(command: UpdateIpAllowlistCommand): Promise<IpAllowlist> {
     this.logger.debug('Updating IP allowlist', {
       orgId: command.orgId,
       cidrCount: command.cidrs.length,
     });
 
+    // Validate CIDRs before lockout check so malformed input
+    // produces InvalidCidrError, not AdminLockoutError.
+    const existing = await this.repository.findByOrgId(command.orgId);
+    let entity: IpAllowlist;
     try {
-      // Validate CIDRs before lockout check so malformed input
-      // produces InvalidCidrError, not AdminLockoutError.
-      const existing = await this.repository.findByOrgId(command.orgId);
-      let entity: IpAllowlist;
-      try {
-        entity = new IpAllowlist({
-          id: existing?.id,
-          orgId: command.orgId,
-          cidrs: command.cidrs,
-          createdAt: existing?.createdAt,
-        });
-      } catch (error) {
-        if (
-          error instanceof InvalidCidrError ||
-          error instanceof EmptyCidrsError
-        ) {
-          throw new InvalidCidrApplicationError(error.message);
-        }
-        throw error;
-      }
-
-      if (!isIpInCidrs(command.clientIp, command.cidrs)) {
-        throw new AdminLockoutError({ clientIp: command.clientIp });
-      }
-
-      const result = await this.repository.upsert(entity);
-      this.ipAllowlistCache.invalidateCache(command.orgId);
-
-      return result;
+      entity = new IpAllowlist({
+        id: existing?.id,
+        orgId: command.orgId,
+        cidrs: command.cidrs,
+        createdAt: existing?.createdAt,
+      });
     } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-
-      this.logger.error('Failed to update IP allowlist', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-      });
-
-      throw new UnexpectedIpAllowlistError('update', {
-        orgId: command.orgId,
-        ...(error instanceof Error && { originalError: error.message }),
-      });
+      if (
+        error instanceof InvalidCidrError ||
+        error instanceof EmptyCidrsError
+      ) {
+        throw new InvalidCidrApplicationError(error.message);
+      }
+      throw error;
     }
+
+    if (!isIpInCidrs(command.clientIp, command.cidrs)) {
+      throw new AdminLockoutError({ clientIp: command.clientIp });
+    }
+
+    const result = await this.repository.upsert(entity);
+    this.ipAllowlistCache.invalidateCache(command.orgId);
+
+    return result;
   }
 }

--- a/ayunis-core-backend/src/iam/legal-acceptances/application/legal-acceptances.errors.ts
+++ b/ayunis-core-backend/src/iam/legal-acceptances/application/legal-acceptances.errors.ts
@@ -1,0 +1,28 @@
+import type { ErrorMetadata } from '../../../common/errors/base.error';
+import { ApplicationError } from '../../../common/errors/base.error';
+
+export enum LegalAcceptanceErrorCode {
+  UNEXPECTED_ERROR = 'LEGAL_ACCEPTANCE_UNEXPECTED_ERROR',
+}
+
+export abstract class LegalAcceptanceError extends ApplicationError {
+  constructor(
+    message: string,
+    code: LegalAcceptanceErrorCode,
+    statusCode: number = 400,
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, code, statusCode, metadata);
+  }
+}
+
+export class UnexpectedLegalAcceptanceError extends LegalAcceptanceError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(
+      'An unexpected legal acceptance error occurred',
+      LegalAcceptanceErrorCode.UNEXPECTED_ERROR,
+      500,
+      { ...metadata, error },
+    );
+  }
+}

--- a/ayunis-core-backend/src/iam/legal-acceptances/application/use-cases/create-legal-acceptance/create-legal-acceptance.use-case.ts
+++ b/ayunis-core-backend/src/iam/legal-acceptances/application/use-cases/create-legal-acceptance/create-legal-acceptance.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedLegalAcceptanceError } from 'src/iam/legal-acceptances/application/legal-acceptances.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import {
   CreateLegalAcceptanceCommand,
@@ -19,6 +21,7 @@ export class CreateLegalAcceptanceUseCase {
     private readonly configService: ConfigService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedLegalAcceptanceError)
   async execute(command: CreateLegalAcceptanceCommand): Promise<void> {
     const { userId, orgId, type } = command;
     this.logger.log(

--- a/ayunis-core-backend/src/iam/legal-acceptances/application/use-cases/has-accepted-latest-version/has-accepted-latest-version.use-case.ts
+++ b/ayunis-core-backend/src/iam/legal-acceptances/application/use-cases/has-accepted-latest-version/has-accepted-latest-version.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedLegalAcceptanceError } from 'src/iam/legal-acceptances/application/legal-acceptances.errors';
 import { Injectable } from '@nestjs/common';
 import { HasAcceptedLatestVersionQuery } from './has-accepted-latest-version.query';
 import { LegalAcceptancesRepository } from '../../ports/legal-acceptances.repository';
@@ -10,6 +12,7 @@ export class HasAcceptedLatestVersionUseCase {
     private readonly configService: ConfigService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedLegalAcceptanceError)
   async execute(query: HasAcceptedLatestVersionQuery): Promise<boolean> {
     const { orgId, type } = query;
     const legalAcceptance = await this.legalAcceptanceRepository.findOne(

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/check-mfa-login-requirement/check-mfa-login-requirement.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/check-mfa-login-requirement/check-mfa-login-requirement.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UserTotpsRepository } from '../../ports/user-totps.repository';
 import { OrgMfaRequirementsRepository } from '../../ports/org-mfa-requirements.repository';
 import { UnexpectedMfaError } from '../../mfa.errors';
@@ -23,27 +23,20 @@ export class CheckMfaLoginRequirementUseCase {
     private readonly orgMfaRequirementsRepository: OrgMfaRequirementsRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMfaError)
   async execute(
     query: CheckMfaLoginRequirementQuery,
   ): Promise<MfaLoginRequirement> {
     this.logger.log('checkMfaLoginRequirement', { userId: query.userId });
 
-    try {
-      const totp = await this.userTotpsRepository.findByUserId(query.userId);
-      if (totp?.isConfirmed()) {
-        return 'verify';
-      }
-
-      const requirement = await this.orgMfaRequirementsRepository.findByOrgId(
-        query.orgId,
-      );
-      return requirement?.required ? 'enroll' : 'none';
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error checking MFA login requirement', {
-        error: error as Error,
-      });
-      throw new UnexpectedMfaError(error);
+    const totp = await this.userTotpsRepository.findByUserId(query.userId);
+    if (totp?.isConfirmed()) {
+      return 'verify';
     }
+
+    const requirement = await this.orgMfaRequirementsRepository.findByOrgId(
+      query.orgId,
+    );
+    return requirement?.required ? 'enroll' : 'none';
   }
 }

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/confirm-totp/confirm-totp.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/confirm-totp/confirm-totp.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { HashTextUseCase } from 'src/iam/hashing/application/use-cases/hash-text/hash-text.use-case';
 import { HashTextCommand } from 'src/iam/hashing/application/use-cases/hash-text/hash-text.command';
 import { UserTotpsRepository } from '../../ports/user-totps.repository';
@@ -30,44 +30,39 @@ export class ConfirmTotpUseCase {
   ) {}
 
   /** Confirms a pending enrollment and returns the plaintext recovery codes. */
+  @HandleUnexpectedErrors(UnexpectedMfaError)
   async execute(command: ConfirmTotpCommand): Promise<string[]> {
     this.logger.log('confirmTotp', { userId: command.userId });
 
-    try {
-      const totp = await this.userTotpsRepository.findByUserId(command.userId);
-      if (!totp) {
-        throw new MfaNotEnabledError();
-      }
-      if (totp.isConfirmed()) {
-        throw new MfaAlreadyEnabledError();
-      }
-
-      const secret = await this.totpSecretEncryption.decrypt(
-        totp.encryptedSecret,
-      );
-      const counter = await this.totp.verifyCode(secret, command.code);
-      if (counter === null) {
-        throw new InvalidMfaCodeError();
-      }
-
-      // Codes are written before the totp is confirmed: codes without a
-      // confirmed totp are inert (verification requires confirmation), while
-      // a confirmed totp without codes would leave the user unable to ever
-      // retrieve recovery codes.
-      const codes = await this.issueRecoveryCodes(command.userId);
-
-      totp.confirmedAt = new Date();
-      totp.lastUsedCounter = counter;
-      totp.failedAttempts = 0;
-      totp.lockedUntil = null;
-      await this.userTotpsRepository.upsert(totp);
-
-      return codes;
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error confirming TOTP', { error: error as Error });
-      throw new UnexpectedMfaError(error);
+    const totp = await this.userTotpsRepository.findByUserId(command.userId);
+    if (!totp) {
+      throw new MfaNotEnabledError();
     }
+    if (totp.isConfirmed()) {
+      throw new MfaAlreadyEnabledError();
+    }
+
+    const secret = await this.totpSecretEncryption.decrypt(
+      totp.encryptedSecret,
+    );
+    const counter = await this.totp.verifyCode(secret, command.code);
+    if (counter === null) {
+      throw new InvalidMfaCodeError();
+    }
+
+    // Codes are written before the totp is confirmed: codes without a
+    // confirmed totp are inert (verification requires confirmation), while
+    // a confirmed totp without codes would leave the user unable to ever
+    // retrieve recovery codes.
+    const codes = await this.issueRecoveryCodes(command.userId);
+
+    totp.confirmedAt = new Date();
+    totp.lastUsedCounter = counter;
+    totp.failedAttempts = 0;
+    totp.lockedUntil = null;
+    await this.userTotpsRepository.upsert(totp);
+
+    return codes;
   }
 
   private async issueRecoveryCodes(

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/disable-mfa/disable-mfa.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/disable-mfa/disable-mfa.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UserTotpsRepository } from '../../ports/user-totps.repository';
 import { MfaRecoveryCodesRepository } from '../../ports/mfa-recovery-codes.repository';
 import { OrgMfaRequirementsRepository } from '../../ports/org-mfa-requirements.repository';
@@ -19,29 +19,24 @@ export class DisableMfaUseCase {
     private readonly verifyMfaCodeUseCase: VerifyMfaCodeUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMfaError)
   async execute(command: DisableMfaCommand): Promise<void> {
     this.logger.log('disableMfa', { userId: command.userId });
 
-    try {
-      // Checked before code verification so no recovery code is consumed on
-      // an attempt that is forbidden anyway.
-      const requirement = await this.orgMfaRequirementsRepository.findByOrgId(
-        command.orgId,
-      );
-      if (requirement?.required) {
-        throw new MfaRequiredByOrgError();
-      }
-
-      await this.verifyMfaCodeUseCase.execute(
-        new VerifyMfaCodeCommand(command.userId, command.code),
-      );
-
-      await this.recoveryCodesRepository.deleteByUserId(command.userId);
-      await this.userTotpsRepository.deleteByUserId(command.userId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error disabling MFA', { error: error as Error });
-      throw new UnexpectedMfaError(error);
+    // Checked before code verification so no recovery code is consumed on
+    // an attempt that is forbidden anyway.
+    const requirement = await this.orgMfaRequirementsRepository.findByOrgId(
+      command.orgId,
+    );
+    if (requirement?.required) {
+      throw new MfaRequiredByOrgError();
     }
+
+    await this.verifyMfaCodeUseCase.execute(
+      new VerifyMfaCodeCommand(command.userId, command.code),
+    );
+
+    await this.recoveryCodesRepository.deleteByUserId(command.userId);
+    await this.userTotpsRepository.deleteByUserId(command.userId);
   }
 }

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/get-mfa-status/get-mfa-status.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/get-mfa-status/get-mfa-status.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UserTotpsRepository } from '../../ports/user-totps.repository';
 import { MfaRecoveryCodesRepository } from '../../ports/mfa-recovery-codes.repository';
 import { UnexpectedMfaError } from '../../mfa.errors';
@@ -20,27 +20,22 @@ export class GetMfaStatusUseCase {
     private readonly recoveryCodesRepository: MfaRecoveryCodesRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMfaError)
   async execute(query: GetMfaStatusQuery): Promise<MfaStatus> {
     this.logger.log('getMfaStatus', { userId: query.userId });
 
-    try {
-      const totp = await this.userTotpsRepository.findByUserId(query.userId);
-      if (!totp?.isConfirmed()) {
-        return { enabled: false, confirmedAt: null, recoveryCodesRemaining: 0 };
-      }
-
-      const recoveryCodesRemaining =
-        await this.recoveryCodesRepository.countUnusedByUserId(query.userId);
-
-      return {
-        enabled: true,
-        confirmedAt: totp.confirmedAt,
-        recoveryCodesRemaining,
-      };
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting MFA status', { error: error as Error });
-      throw new UnexpectedMfaError(error);
+    const totp = await this.userTotpsRepository.findByUserId(query.userId);
+    if (!totp?.isConfirmed()) {
+      return { enabled: false, confirmedAt: null, recoveryCodesRemaining: 0 };
     }
+
+    const recoveryCodesRemaining =
+      await this.recoveryCodesRepository.countUnusedByUserId(query.userId);
+
+    return {
+      enabled: true,
+      confirmedAt: totp.confirmedAt,
+      recoveryCodesRemaining,
+    };
   }
 }

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/get-org-mfa-requirement/get-org-mfa-requirement.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/get-org-mfa-requirement/get-org-mfa-requirement.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { OrgMfaRequirementsRepository } from '../../ports/org-mfa-requirements.repository';
 import { OrgMfaRequirement } from '../../../domain/org-mfa-requirement.entity';
 import { UnexpectedMfaError } from '../../mfa.errors';
@@ -13,23 +13,16 @@ export class GetOrgMfaRequirementUseCase {
     private readonly orgMfaRequirementsRepository: OrgMfaRequirementsRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMfaError)
   async execute(query: GetOrgMfaRequirementQuery): Promise<OrgMfaRequirement> {
     this.logger.log('getOrgMfaRequirement', { orgId: query.orgId });
 
-    try {
-      const requirement = await this.orgMfaRequirementsRepository.findByOrgId(
-        query.orgId,
-      );
-      return (
-        requirement ??
-        new OrgMfaRequirement({ orgId: query.orgId, required: false })
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting org MFA requirement', {
-        error: error as Error,
-      });
-      throw new UnexpectedMfaError(error);
-    }
+    const requirement = await this.orgMfaRequirementsRepository.findByOrgId(
+      query.orgId,
+    );
+    return (
+      requirement ??
+      new OrgMfaRequirement({ orgId: query.orgId, required: false })
+    );
   }
 }

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/reset-user-mfa/reset-user-mfa.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/reset-user-mfa/reset-user-mfa.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { FindUserByIdUseCase } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case';
 import { FindUserByIdQuery } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.query';
@@ -30,6 +30,7 @@ export class ResetUserMfaUseCase {
     private readonly recoveryCodesRepository: MfaRecoveryCodesRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMfaError)
   async execute(command: ResetUserMfaCommand): Promise<void> {
     this.logger.log('resetUserMfa', { targetUserId: command.targetUserId });
 
@@ -39,26 +40,20 @@ export class ResetUserMfaUseCase {
       throw new UserUnauthorizedError('User not authenticated');
     }
 
-    try {
-      if (command.targetUserId === requesterId) {
-        throw new MfaSelfResetNotAllowedError();
-      }
-
-      const targetUser = await this.findUserByIdUseCase.execute(
-        new FindUserByIdQuery(command.targetUserId),
-      );
-
-      // Cross-org resets must look like a missing user, not a permission gap.
-      if (targetUser.orgId !== requesterOrgId) {
-        throw new UserNotFoundError(command.targetUserId);
-      }
-
-      await this.recoveryCodesRepository.deleteByUserId(command.targetUserId);
-      await this.userTotpsRepository.deleteByUserId(command.targetUserId);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error resetting user MFA', { error: error as Error });
-      throw new UnexpectedMfaError(error);
+    if (command.targetUserId === requesterId) {
+      throw new MfaSelfResetNotAllowedError();
     }
+
+    const targetUser = await this.findUserByIdUseCase.execute(
+      new FindUserByIdQuery(command.targetUserId),
+    );
+
+    // Cross-org resets must look like a missing user, not a permission gap.
+    if (targetUser.orgId !== requesterOrgId) {
+      throw new UserNotFoundError(command.targetUserId);
+    }
+
+    await this.recoveryCodesRepository.deleteByUserId(command.targetUserId);
+    await this.userTotpsRepository.deleteByUserId(command.targetUserId);
   }
 }

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/setup-totp/setup-totp.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/setup-totp/setup-totp.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UserTotpsRepository } from '../../ports/user-totps.repository';
 import { TotpSecretEncryptionPort } from '../../ports/totp-secret-encryption.port';
 import { TotpPort } from '../../ports/totp.port';
@@ -23,41 +23,36 @@ export class SetupTotpUseCase {
     private readonly totp: TotpPort,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMfaError)
   async execute(command: SetupTotpCommand): Promise<SetupTotpResult> {
     this.logger.log('setupTotp', { userId: command.userId });
 
-    try {
-      const existing = await this.userTotpsRepository.findByUserId(
-        command.userId,
-      );
-      if (existing?.isConfirmed()) {
-        throw new MfaAlreadyEnabledError();
-      }
-
-      const secret = this.totp.generateSecret();
-      const encryptedSecret = await this.totpSecretEncryption.encrypt(secret);
-
-      // An abandoned unconfirmed enrollment is simply overwritten.
-      await this.userTotpsRepository.upsert(
-        new UserTotp({
-          id: existing?.id,
-          userId: command.userId,
-          encryptedSecret,
-          createdAt: existing?.createdAt,
-        }),
-      );
-
-      const otpauthUri = this.totp.buildOtpauthUri({
-        label: command.email,
-        secret,
-      });
-      const qrCodeDataUri = await this.totp.generateQrDataUri(otpauthUri);
-
-      return { secret, otpauthUri, qrCodeDataUri };
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error setting up TOTP', { error: error as Error });
-      throw new UnexpectedMfaError(error);
+    const existing = await this.userTotpsRepository.findByUserId(
+      command.userId,
+    );
+    if (existing?.isConfirmed()) {
+      throw new MfaAlreadyEnabledError();
     }
+
+    const secret = this.totp.generateSecret();
+    const encryptedSecret = await this.totpSecretEncryption.encrypt(secret);
+
+    // An abandoned unconfirmed enrollment is simply overwritten.
+    await this.userTotpsRepository.upsert(
+      new UserTotp({
+        id: existing?.id,
+        userId: command.userId,
+        encryptedSecret,
+        createdAt: existing?.createdAt,
+      }),
+    );
+
+    const otpauthUri = this.totp.buildOtpauthUri({
+      label: command.email,
+      secret,
+    });
+    const qrCodeDataUri = await this.totp.generateQrDataUri(otpauthUri);
+
+    return { secret, otpauthUri, qrCodeDataUri };
   }
 }

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/upsert-org-mfa-requirement/upsert-org-mfa-requirement.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/upsert-org-mfa-requirement/upsert-org-mfa-requirement.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { OrgMfaRequirementsRepository } from '../../ports/org-mfa-requirements.repository';
 import { OrgMfaRequirement } from '../../../domain/org-mfa-requirement.entity';
 import { UnexpectedMfaError } from '../../mfa.errors';
@@ -13,6 +13,7 @@ export class UpsertOrgMfaRequirementUseCase {
     private readonly orgMfaRequirementsRepository: OrgMfaRequirementsRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMfaError)
   async execute(
     command: UpsertOrgMfaRequirementCommand,
   ): Promise<OrgMfaRequirement> {
@@ -21,25 +22,17 @@ export class UpsertOrgMfaRequirementUseCase {
       required: command.required,
     });
 
-    try {
-      const existing = await this.orgMfaRequirementsRepository.findByOrgId(
-        command.orgId,
-      );
+    const existing = await this.orgMfaRequirementsRepository.findByOrgId(
+      command.orgId,
+    );
 
-      return await this.orgMfaRequirementsRepository.upsert(
-        new OrgMfaRequirement({
-          id: existing?.id,
-          orgId: command.orgId,
-          required: command.required,
-          createdAt: existing?.createdAt,
-        }),
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error upserting org MFA requirement', {
-        error: error as Error,
-      });
-      throw new UnexpectedMfaError(error);
-    }
+    return await this.orgMfaRequirementsRepository.upsert(
+      new OrgMfaRequirement({
+        id: existing?.id,
+        orgId: command.orgId,
+        required: command.required,
+        createdAt: existing?.createdAt,
+      }),
+    );
   }
 }

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/verify-mfa-code/verify-mfa-code.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/verify-mfa-code/verify-mfa-code.use-case.ts
@@ -1,6 +1,6 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import type { UUID } from 'crypto';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { CompareHashUseCase } from 'src/iam/hashing/application/use-cases/compare-hash/compare-hash.use-case';
 import { CompareHashCommand } from 'src/iam/hashing/application/use-cases/compare-hash/compare-hash.command';
 import { UserTotpsRepository } from '../../ports/user-totps.repository';
@@ -40,31 +40,26 @@ export class VerifyMfaCodeUseCase {
     private readonly compareHashUseCase: CompareHashUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMfaError)
   async execute(command: VerifyMfaCodeCommand): Promise<void> {
     this.logger.log('verifyMfaCode', { userId: command.userId });
 
-    try {
-      const totp = await this.userTotpsRepository.findByUserId(command.userId);
-      if (!totp?.isConfirmed()) {
-        throw new MfaNotEnabledError();
-      }
+    const totp = await this.userTotpsRepository.findByUserId(command.userId);
+    if (!totp?.isConfirmed()) {
+      throw new MfaNotEnabledError();
+    }
 
-      const now = new Date();
-      if (totp.isLocked(now) && totp.lockedUntil) {
-        throw new MfaLockedError(totp.lockedUntil);
-      }
+    const now = new Date();
+    if (totp.isLocked(now) && totp.lockedUntil) {
+      throw new MfaLockedError(totp.lockedUntil);
+    }
 
-      const verified =
-        (await this.tryTotpCode(totp, command.code)) ||
-        (await this.tryRecoveryCode(command.userId, command.code, now));
+    const verified =
+      (await this.tryTotpCode(totp, command.code)) ||
+      (await this.tryRecoveryCode(command.userId, command.code, now));
 
-      if (!verified) {
-        await this.registerFailure(command.userId, now);
-      }
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error verifying MFA code', { error: error as Error });
-      throw new UnexpectedMfaError(error);
+    if (!verified) {
+      await this.registerFailure(command.userId, now);
     }
   }
 

--- a/ayunis-core-backend/src/iam/onboarding/application/use-cases/get-onboarding/get-onboarding.use-case.ts
+++ b/ayunis-core-backend/src/iam/onboarding/application/use-cases/get-onboarding/get-onboarding.use-case.ts
@@ -1,9 +1,9 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { OnboardingRepository } from '../../ports/onboarding.repository';
 import { GetOnboardingQuery } from './get-onboarding.query';
 import { Onboarding } from '../../../domain/onboarding.entity';
 import { OnboardingUnexpectedError } from '../../onboarding.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetOnboardingUseCase {
@@ -11,25 +11,15 @@ export class GetOnboardingUseCase {
 
   constructor(private readonly onboardingRepository: OnboardingRepository) {}
 
+  @HandleUnexpectedErrors(OnboardingUnexpectedError)
   async execute(query: GetOnboardingQuery): Promise<Onboarding> {
     this.logger.log('getOnboarding', { userId: query.userId });
 
-    try {
-      const onboarding = await this.onboardingRepository.findByUserId(
-        query.userId,
-      );
-      // No row yet means the user hasn't touched onboarding — return a
-      // transient default so the read endpoint never 404s.
-      return onboarding ?? new Onboarding({ userId: query.userId });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to get onboarding', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        userId: query.userId,
-      });
-      throw new OnboardingUnexpectedError(error as Error);
-    }
+    const onboarding = await this.onboardingRepository.findByUserId(
+      query.userId,
+    );
+    // No row yet means the user hasn't touched onboarding — return a
+    // transient default so the read endpoint never 404s.
+    return onboarding ?? new Onboarding({ userId: query.userId });
   }
 }

--- a/ayunis-core-backend/src/iam/onboarding/application/use-cases/update-onboarding/update-onboarding.use-case.ts
+++ b/ayunis-core-backend/src/iam/onboarding/application/use-cases/update-onboarding/update-onboarding.use-case.ts
@@ -1,10 +1,10 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import type { UUID } from 'crypto';
 import { OnboardingRepository } from '../../ports/onboarding.repository';
 import { UpdateOnboardingCommand } from './update-onboarding.command';
 import { Onboarding } from '../../../domain/onboarding.entity';
 import { OnboardingUnexpectedError } from '../../onboarding.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class UpdateOnboardingUseCase {
@@ -12,6 +12,7 @@ export class UpdateOnboardingUseCase {
 
   constructor(private readonly onboardingRepository: OnboardingRepository) {}
 
+  @HandleUnexpectedErrors(OnboardingUnexpectedError)
   async execute(command: UpdateOnboardingCommand): Promise<Onboarding> {
     this.logger.log('updateOnboarding', {
       userId: command.userId,
@@ -19,23 +20,12 @@ export class UpdateOnboardingUseCase {
       hidden: command.hidden,
     });
 
-    try {
-      const onboarding = await this.findOrCreateForUser(command.userId);
+    const onboarding = await this.findOrCreateForUser(command.userId);
 
-      onboarding.completedStepIds = command.completedStepIds;
-      onboarding.hidden = command.hidden;
+    onboarding.completedStepIds = command.completedStepIds;
+    onboarding.hidden = command.hidden;
 
-      return await this.onboardingRepository.save(onboarding);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to update onboarding', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        userId: command.userId,
-      });
-      throw new OnboardingUnexpectedError(error as Error);
-    }
+    return await this.onboardingRepository.save(onboarding);
   }
 
   private async findOrCreateForUser(userId: UUID): Promise<Onboarding> {

--- a/ayunis-core-backend/src/iam/orgs/application/orgs.errors.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/orgs.errors.ts
@@ -12,6 +12,7 @@ export enum OrgErrorCode {
   ORG_DELETION_FAILED = 'ORG_DELETION_FAILED',
   ORG_RETRIEVAL_FAILED = 'ORG_RETRIEVAL_FAILED',
   ORG_UNAUTHORIZED = 'ORG_UNAUTHORIZED',
+  ORG_UNEXPECTED_ERROR = 'ORG_UNEXPECTED_ERROR',
 }
 
 /**
@@ -25,6 +26,17 @@ export abstract class OrgError extends ApplicationError {
     metadata?: ErrorMetadata,
   ) {
     super(message, code, statusCode, metadata);
+  }
+}
+
+export class UnexpectedOrgError extends OrgError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(
+      'An unexpected organization error occurred',
+      OrgErrorCode.ORG_UNEXPECTED_ERROR,
+      500,
+      { ...metadata, error },
+    );
   }
 }
 

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/create-org/create-org.use-case.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/create-org/create-org.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedOrgError } from 'src/iam/orgs/application/orgs.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { OrgsRepository } from '../../ports/orgs.repository';
@@ -16,6 +18,7 @@ export class CreateOrgUseCase {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedOrgError)
   async execute(command: CreateOrgCommand): Promise<Org> {
     this.logger.log('create', { name: command.name });
 

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/delete-org/delete-org.use-case.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/delete-org/delete-org.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedOrgError } from 'src/iam/orgs/application/orgs.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { OrgsRepository } from '../../ports/orgs.repository';
 import { DeleteOrgCommand } from './delete-org.command';
@@ -9,6 +11,7 @@ export class DeleteOrgUseCase {
 
   constructor(private readonly orgsRepository: OrgsRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedOrgError)
   async execute(command: DeleteOrgCommand): Promise<void> {
     this.logger.log('delete', { id: command.id });
 

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/find-all-org-ids/find-all-org-ids.use-case.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/find-all-org-ids/find-all-org-ids.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedOrgError } from 'src/iam/orgs/application/orgs.errors';
 import { Injectable } from '@nestjs/common';
 import { OrgsRepository } from '../../ports/orgs.repository';
 import { UUID } from 'crypto';
@@ -6,6 +8,7 @@ import { UUID } from 'crypto';
 export class FindAllOrgIdsUseCase {
   constructor(private readonly orgsRepository: OrgsRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedOrgError)
   async execute(): Promise<UUID[]> {
     return this.orgsRepository.findAllIds();
   }

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/find-org-by-id/find-org-by-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/find-org-by-id/find-org-by-id.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedOrgError } from 'src/iam/orgs/application/orgs.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { OrgsRepository } from '../../ports/orgs.repository';
 import { FindOrgByIdQuery } from './find-org-by-id.query';
@@ -10,6 +12,7 @@ export class FindOrgByIdUseCase {
 
   constructor(private readonly orgsRepository: OrgsRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedOrgError)
   async execute(query: FindOrgByIdQuery): Promise<Org> {
     this.logger.log('findById', { id: query.id });
     try {

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.use-case.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedOrgError } from 'src/iam/orgs/application/orgs.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { Org } from 'src/iam/orgs/domain/org.entity';
 import { OrgsRepository } from '../../ports/orgs.repository';
@@ -16,6 +18,7 @@ export class SuperAdminGetAllOrgsUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedOrgError)
   async execute(query: SuperAdminGetAllOrgsQuery): Promise<Paginated<Org>> {
     this.logger.log('superAdminGetAllOrgs', {
       limit: query.limit,

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/update-org/update-org.use-case.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/update-org/update-org.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedOrgError } from 'src/iam/orgs/application/orgs.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { OrgsRepository } from '../../ports/orgs.repository';
 import { UpdateOrgCommand } from './update-org.command';
@@ -10,6 +12,7 @@ export class UpdateOrgUseCase {
 
   constructor(private readonly orgsRepository: OrgsRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedOrgError)
   async execute(command: UpdateOrgCommand): Promise<Org> {
     this.logger.log('update', { id: command.org.id, name: command.org.name });
 

--- a/ayunis-core-backend/src/iam/platform-config/application/platform-config.errors.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/platform-config.errors.ts
@@ -1,9 +1,22 @@
+import type { ErrorMetadata } from '../../../common/errors/base.error';
 import { ApplicationError } from '../../../common/errors/base.error';
 import type { PlatformConfigKey } from '../domain/platform-config-keys.enum';
 
 export enum PlatformConfigErrorCode {
   CONFIG_NOT_FOUND = 'PLATFORM_CONFIG_NOT_FOUND',
   INVALID_VALUE = 'PLATFORM_CONFIG_INVALID_VALUE',
+  UNEXPECTED_ERROR = 'PLATFORM_CONFIG_UNEXPECTED_ERROR',
+}
+
+export class UnexpectedPlatformConfigError extends ApplicationError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(
+      'An unexpected platform config error occurred',
+      PlatformConfigErrorCode.UNEXPECTED_ERROR,
+      500,
+      { ...metadata, error },
+    );
+  }
 }
 
 export class PlatformConfigNotFoundError extends ApplicationError {

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-app-alert/get-app-alert.use-case.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-app-alert/get-app-alert.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedPlatformConfigError } from 'src/iam/platform-config/application/platform-config.errors';
 import { Injectable } from '@nestjs/common';
 import { PlatformConfigRepositoryPort } from '../../ports/platform-config.repository';
 import { PlatformConfigKey } from '../../../domain/platform-config-keys.enum';
@@ -9,6 +11,7 @@ export class GetAppAlertUseCase {
     private readonly configRepository: PlatformConfigRepositoryPort,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedPlatformConfigError)
   async execute(): Promise<AppAlert> {
     const [enabledConfig, messageConfig] = await Promise.all([
       this.configRepository.get(PlatformConfigKey.APP_ALERT_ENABLED),

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-credits-per-euro/get-credits-per-euro.use-case.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-credits-per-euro/get-credits-per-euro.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedPlatformConfigError } from 'src/iam/platform-config/application/platform-config.errors';
 import { Injectable } from '@nestjs/common';
 import { PlatformConfigRepositoryPort } from '../../ports/platform-config.repository';
 import { PlatformConfigKey } from '../../../domain/platform-config-keys.enum';
@@ -12,6 +14,7 @@ export class GetCreditsPerEuroUseCase {
     private readonly configRepository: PlatformConfigRepositoryPort,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedPlatformConfigError)
   async execute(): Promise<number> {
     const config = await this.configRepository.get(
       PlatformConfigKey.CREDITS_PER_EURO,

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-fair-use-limits/get-fair-use-limits.use-case.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-fair-use-limits/get-fair-use-limits.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedPlatformConfigError } from 'src/iam/platform-config/application/platform-config.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { PlatformConfigRepositoryPort } from '../../ports/platform-config.repository';
 import { PlatformConfigKey } from '../../../domain/platform-config-keys.enum';
@@ -40,6 +42,9 @@ export class GetFairUseLimitsUseCase {
     private readonly configRepository: PlatformConfigRepositoryPort,
   ) {}
 
+  // This use case resolves the complete tiered configuration in one read model.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UnexpectedPlatformConfigError)
   async execute(): Promise<FairUseLimitsByTier> {
     const [
       zeroLimit,

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-app-alert/set-app-alert.use-case.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-app-alert/set-app-alert.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedPlatformConfigError } from 'src/iam/platform-config/application/platform-config.errors';
 import { Injectable } from '@nestjs/common';
 import { PlatformConfigRepositoryPort } from '../../ports/platform-config.repository';
 import { PlatformConfigKey } from '../../../domain/platform-config-keys.enum';
@@ -11,6 +13,7 @@ export class SetAppAlertUseCase {
     private readonly configRepository: PlatformConfigRepositoryPort,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedPlatformConfigError)
   async execute(command: SetAppAlertCommand): Promise<void> {
     if (command.message.length > APP_ALERT_MESSAGE_MAX_LENGTH) {
       throw new PlatformConfigInvalidValueError(

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-credits-per-euro/set-credits-per-euro.use-case.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-credits-per-euro/set-credits-per-euro.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedPlatformConfigError } from 'src/iam/platform-config/application/platform-config.errors';
 import { Injectable } from '@nestjs/common';
 import { PlatformConfigRepositoryPort } from '../../ports/platform-config.repository';
 import { PlatformConfigKey } from '../../../domain/platform-config-keys.enum';
@@ -10,6 +12,7 @@ export class SetCreditsPerEuroUseCase {
     private readonly configRepository: PlatformConfigRepositoryPort,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedPlatformConfigError)
   async execute(command: SetCreditsPerEuroCommand): Promise<void> {
     if (
       !Number.isFinite(command.creditsPerEuro) ||

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-fair-use-limit/set-fair-use-limit.use-case.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-fair-use-limit/set-fair-use-limit.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedPlatformConfigError } from 'src/iam/platform-config/application/platform-config.errors';
 import { Injectable } from '@nestjs/common';
 import { assertNever } from 'src/common/util/assert-never';
 import { ModelTier } from 'src/domain/models/domain/value-objects/model-tier.enum';
@@ -58,6 +60,7 @@ export class SetFairUseLimitUseCase {
     private readonly configRepository: PlatformConfigRepositoryPort,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedPlatformConfigError)
   async execute(command: SetFairUseLimitCommand): Promise<void> {
     // Validate the tier value is within the enum before doing anything else.
     // Non-HTTP callers (e.g., internal scripts) bypass DTO validation, so we

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-image-fair-use-limit/set-image-fair-use-limit.use-case.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/set-image-fair-use-limit/set-image-fair-use-limit.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedPlatformConfigError } from 'src/iam/platform-config/application/platform-config.errors';
 import { Injectable } from '@nestjs/common';
 import { PlatformConfigRepositoryPort } from '../../ports/platform-config.repository';
 import { PlatformConfigKey } from '../../../domain/platform-config-keys.enum';
@@ -10,6 +12,7 @@ export class SetImageFairUseLimitUseCase {
     private readonly configRepository: PlatformConfigRepositoryPort,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedPlatformConfigError)
   async execute(command: SetImageFairUseLimitCommand): Promise<void> {
     if (!Number.isInteger(command.limit) || command.limit <= 0) {
       throw new PlatformConfigInvalidValueError(

--- a/ayunis-core-backend/src/iam/quotas/application/quotas.errors.ts
+++ b/ayunis-core-backend/src/iam/quotas/application/quotas.errors.ts
@@ -4,6 +4,7 @@ import { HttpException, HttpStatus } from '@nestjs/common';
 
 export enum QuotaErrorCode {
   QUOTA_EXCEEDED = 'QUOTA_EXCEEDED',
+  QUOTA_UNEXPECTED_ERROR = 'QUOTA_UNEXPECTED_ERROR',
 }
 
 export abstract class QuotaError extends ApplicationError {
@@ -24,6 +25,17 @@ export abstract class QuotaError extends ApplicationError {
         ...(this.metadata && { metadata: this.metadata }),
       },
       this.statusCode,
+    );
+  }
+}
+
+export class UnexpectedQuotaError extends QuotaError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(
+      'An unexpected quota error occurred',
+      QuotaErrorCode.QUOTA_UNEXPECTED_ERROR,
+      500,
+      { ...metadata, error },
     );
   }
 }

--- a/ayunis-core-backend/src/iam/quotas/application/use-cases/check-quota/check-quota.use-case.ts
+++ b/ayunis-core-backend/src/iam/quotas/application/use-cases/check-quota/check-quota.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedQuotaError } from 'src/iam/quotas/application/quotas.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { UsageQuotaRepositoryPort } from '../../ports/usage-quota.repository.port';
 import { QuotaLimitResolverService } from '../../services/quota-limit-resolver.service';
@@ -16,6 +18,9 @@ export class CheckQuotaUseCase {
     private readonly isUsageBasedSubscriptionUseCase: IsUsageBasedSubscriptionUseCase,
   ) {}
 
+  // Quota checking intentionally performs all policy checks before returning.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UnexpectedQuotaError)
   async execute(query: CheckQuotaQuery): Promise<void> {
     // Fair-use is the protection of last resort for flat-fee plans.
     // Usage-based orgs already self-limit via their purchased credit budget

--- a/ayunis-core-backend/src/iam/subscriptions/application/subscription.errors.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/subscription.errors.ts
@@ -212,12 +212,17 @@ export class InvalidSubscriptionDataError extends SubscriptionError {
  * Error thrown when an unexpected error occurs
  */
 export class UnexpectedSubscriptionError extends SubscriptionError {
-  constructor(reason?: string, metadata?: ErrorMetadata) {
+  constructor(error: Error, metadata?: ErrorMetadata);
+  constructor(reason?: string, metadata?: ErrorMetadata);
+  constructor(errorOrReason?: Error | string, metadata?: ErrorMetadata) {
+    const isError = errorOrReason instanceof Error;
     super(
-      `Unexpected error: ${reason ? `: ${reason}` : ''}`,
+      isError
+        ? `Unexpected error: ${errorOrReason.message}`
+        : `Unexpected error: ${errorOrReason ? `: ${errorOrReason}` : ''}`,
       SubscriptionErrorCode.UNEXPECTED_ERROR,
       500,
-      metadata,
+      { ...(isError && { error: errorOrReason }), ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/cancel-subscription/cancel-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/cancel-subscription/cancel-subscription.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CancelSubscriptionCommand } from './cancel-subscription.command';
@@ -9,7 +10,6 @@ import {
 } from '../../subscription.errors';
 import { GetActiveSubscriptionUseCase } from '../get-active-subscription/get-active-subscription.use-case';
 import { GetActiveSubscriptionQuery } from '../get-active-subscription/get-active-subscription.query';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { SubscriptionCancelledEvent } from '../../events/subscription-cancelled.event';
 import { toSubscriptionEventData } from '../../mappers/to-subscription-event-data.mapper';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -26,77 +26,68 @@ export class CancelSubscriptionUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  // Cancellation coordinates access, state, billing, and audit updates.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UnexpectedSubscriptionError)
   async execute(command: CancelSubscriptionCommand): Promise<void> {
     this.logger.log('Cancelling subscription', {
       orgId: command.orgId,
       requestingUserId: command.requestingUserId,
     });
 
-    try {
-      validateSubscriptionAccess(
-        this.contextService,
-        command.requestingUserId,
-        command.orgId,
-      );
+    validateSubscriptionAccess(
+      this.contextService,
+      command.requestingUserId,
+      command.orgId,
+    );
 
-      this.logger.debug('Finding subscription');
-      const result = await this.getActiveSubscriptionUseCase.execute(
-        new GetActiveSubscriptionQuery({
-          orgId: command.orgId,
-          requestingUserId: command.requestingUserId,
-        }),
-      );
-      if (!result) {
-        this.logger.warn('Subscription not found', {
-          orgId: command.orgId,
-        });
-        throw new SubscriptionNotFoundError(command.orgId);
-      }
-      const subscription = result.subscription;
+    this.logger.debug('Finding subscription');
+    const result = await this.getActiveSubscriptionUseCase.execute(
+      new GetActiveSubscriptionQuery({
+        orgId: command.orgId,
+        requestingUserId: command.requestingUserId,
+      }),
+    );
+    if (!result) {
+      this.logger.warn('Subscription not found', {
+        orgId: command.orgId,
+      });
+      throw new SubscriptionNotFoundError(command.orgId);
+    }
+    const subscription = result.subscription;
 
-      this.logger.debug('Checking if subscription is already cancelled');
-      if (subscription.cancelledAt) {
-        this.logger.warn('Subscription already cancelled', {
-          orgId: command.orgId,
-          cancelledAt: subscription.cancelledAt,
-        });
-        throw new SubscriptionAlreadyCancelledError(command.orgId);
-      }
-
-      this.logger.debug('Updating subscription to cancelled');
-      subscription.cancelledAt = new Date();
-      await this.subscriptionRepository.update(subscription);
-
-      this.logger.debug('Subscription cancelled successfully', {
-        subscriptionId: subscription.id,
+    this.logger.debug('Checking if subscription is already cancelled');
+    if (subscription.cancelledAt) {
+      this.logger.warn('Subscription already cancelled', {
         orgId: command.orgId,
         cancelledAt: subscription.cancelledAt,
       });
-
-      this.eventEmitter
-        .emitAsync(
-          SubscriptionCancelledEvent.EVENT_NAME,
-          new SubscriptionCancelledEvent(
-            command.orgId,
-            toSubscriptionEventData(subscription),
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit SubscriptionCancelledEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            orgId: command.orgId,
-          });
-        });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Subscription cancellation failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-        requestingUserId: command.requestingUserId,
-      });
-      throw new UnexpectedSubscriptionError('Unexpected error');
+      throw new SubscriptionAlreadyCancelledError(command.orgId);
     }
+
+    this.logger.debug('Updating subscription to cancelled');
+    subscription.cancelledAt = new Date();
+    await this.subscriptionRepository.update(subscription);
+
+    this.logger.debug('Subscription cancelled successfully', {
+      subscriptionId: subscription.id,
+      orgId: command.orgId,
+      cancelledAt: subscription.cancelledAt,
+    });
+
+    this.eventEmitter
+      .emitAsync(
+        SubscriptionCancelledEvent.EVENT_NAME,
+        new SubscriptionCancelledEvent(
+          command.orgId,
+          toSubscriptionEventData(subscription),
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error('Failed to emit SubscriptionCancelledEvent', {
+          error: err instanceof Error ? err.message : 'Unknown error',
+          orgId: command.orgId,
+        });
+      });
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/change-subscription/change-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/change-subscription/change-subscription.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ChangeSubscriptionCommand } from './change-subscription.command';
@@ -8,7 +9,6 @@ import {
   SubscriptionNotFoundError,
   UnexpectedSubscriptionError,
 } from '../../subscription.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { SubscriptionCreatedEvent } from '../../events/subscription-created.event';
 import { SubscriptionCancelledEvent } from '../../events/subscription-cancelled.event';
 import { toSubscriptionEventData } from '../../mappers/to-subscription-event-data.mapper';
@@ -27,6 +27,7 @@ export class ChangeSubscriptionUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSubscriptionError)
   async execute(command: ChangeSubscriptionCommand): Promise<Subscription> {
     this.logger.log('Changing subscription', {
       orgId: command.orgId,
@@ -34,53 +35,38 @@ export class ChangeSubscriptionUseCase {
       disposition: command.disposition,
     });
 
-    try {
-      validateSubscriptionAccess(
-        this.contextService,
-        command.requestingUserId,
-        command.orgId,
-      );
+    validateSubscriptionAccess(
+      this.contextService,
+      command.requestingUserId,
+      command.orgId,
+    );
 
-      const current = await this.findReplaceableSubscription(command.orgId);
+    const current = await this.findReplaceableSubscription(command.orgId);
 
-      // Build and validate the new subscription BEFORE touching the old one,
-      // so a validation failure (e.g. too few seats) leaves the org untouched.
-      const newSubscription = await this.subscriptionFactory.build(command);
+    // Build and validate the new subscription BEFORE touching the old one,
+    // so a validation failure (e.g. too few seats) leaves the org untouched.
+    const newSubscription = await this.subscriptionFactory.build(command);
 
-      const createdSubscription = await this.subscriptionRepository.replace({
-        oldSubscriptionId: current.id,
-        disposition: command.disposition,
-        newSubscription,
-      });
+    const createdSubscription = await this.subscriptionRepository.replace({
+      oldSubscriptionId: current.id,
+      disposition: command.disposition,
+      newSubscription,
+    });
 
-      // Reflect the soft-cancellation on the in-memory entity so the emitted
-      // SubscriptionCancelledEvent carries a cancelledAt matching the persisted
-      // row (mirrors CancelSubscriptionUseCase). Preserve an existing timestamp
-      // when the subscription was already cancelled.
-      if (
-        command.disposition === OldSubscriptionDisposition.CANCEL &&
-        !current.cancelledAt
-      ) {
-        current.cancelledAt = new Date();
-      }
-
-      this.emitEvents(command, current, createdSubscription);
-
-      return createdSubscription;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Subscription change failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-        requestingUserId: command.requestingUserId,
-      });
-      throw new UnexpectedSubscriptionError(
-        'Unexpected error during subscription change',
-        { error: error as Error },
-      );
+    // Reflect the soft-cancellation on the in-memory entity so the emitted
+    // SubscriptionCancelledEvent carries a cancelledAt matching the persisted
+    // row (mirrors CancelSubscriptionUseCase). Preserve an existing timestamp
+    // when the subscription was already cancelled.
+    if (
+      command.disposition === OldSubscriptionDisposition.CANCEL &&
+      !current.cancelledAt
+    ) {
+      current.cancelledAt = new Date();
     }
+
+    this.emitEvents(command, current, createdSubscription);
+
+    return createdSubscription;
   }
 
   private async findReplaceableSubscription(

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CreateSubscriptionCommand } from './create-subscription.command';
@@ -8,7 +9,6 @@ import {
   UnexpectedSubscriptionError,
 } from '../../subscription.errors';
 
-import { ApplicationError } from 'src/common/errors/base.error';
 import { SubscriptionCreatedEvent } from '../../events/subscription-created.event';
 import { toSubscriptionEventData } from '../../mappers/to-subscription-event-data.mapper';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -26,57 +26,43 @@ export class CreateSubscriptionUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSubscriptionError)
   async execute(command: CreateSubscriptionCommand): Promise<Subscription> {
-    try {
-      validateSubscriptionAccess(
-        this.contextService,
-        command.requestingUserId,
-        command.orgId,
-      );
+    validateSubscriptionAccess(
+      this.contextService,
+      command.requestingUserId,
+      command.orgId,
+    );
 
-      await this.ensureNoExistingSubscription(command.orgId);
+    await this.ensureNoExistingSubscription(command.orgId);
 
-      const subscription = await this.subscriptionFactory.build(command);
+    const subscription = await this.subscriptionFactory.build(command);
 
-      const createdSubscription =
-        await this.subscriptionRepository.create(subscription);
+    const createdSubscription =
+      await this.subscriptionRepository.create(subscription);
 
-      this.logger.debug('Subscription created successfully', {
-        subscriptionId: createdSubscription.id,
-        orgId: command.orgId,
-        type: command.type,
-      });
+    this.logger.debug('Subscription created successfully', {
+      subscriptionId: createdSubscription.id,
+      orgId: command.orgId,
+      type: command.type,
+    });
 
-      this.eventEmitter
-        .emitAsync(
-          SubscriptionCreatedEvent.EVENT_NAME,
-          new SubscriptionCreatedEvent(
-            command.orgId,
-            toSubscriptionEventData(createdSubscription),
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit SubscriptionCreatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            orgId: command.orgId,
-          });
+    this.eventEmitter
+      .emitAsync(
+        SubscriptionCreatedEvent.EVENT_NAME,
+        new SubscriptionCreatedEvent(
+          command.orgId,
+          toSubscriptionEventData(createdSubscription),
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error('Failed to emit SubscriptionCreatedEvent', {
+          error: err instanceof Error ? err.message : 'Unknown error',
+          orgId: command.orgId,
         });
-
-      return createdSubscription;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Subscription creation failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-        requestingUserId: command.requestingUserId,
       });
-      throw new UnexpectedSubscriptionError(
-        'Unexpected error during subscription creation',
-        { error: error as Error },
-      );
-    }
+
+    return createdSubscription;
   }
 
   private async ensureNoExistingSubscription(

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-active-subscription/get-active-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-active-subscription/get-active-subscription.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedSubscriptionError } from 'src/iam/subscriptions/application/subscription.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { GetActiveSubscriptionQuery } from './get-active-subscription.query';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
@@ -8,7 +10,6 @@ import {
   MultipleActiveSubscriptionsError,
 } from '../../subscription.errors';
 import { isActive } from '../../util/is-active';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { FindUsersByOrgIdUseCase } from 'src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case';
 import { ContextService } from 'src/common/context/services/context.service';
 import { validateSubscriptionAccess } from '../../util/validate-subscription-access';
@@ -26,6 +27,7 @@ export class GetActiveSubscriptionUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSubscriptionError)
   async execute(query: GetActiveSubscriptionQuery): Promise<{
     subscription: Subscription;
     availableSeats: number | null;
@@ -36,52 +38,39 @@ export class GetActiveSubscriptionUseCase {
       requestingUserId: query.requestingUserId,
     });
 
-    try {
-      this.logger.debug('Checking if user is from organization');
-      validateSubscriptionAccess(
-        this.contextService,
-        query.requestingUserId,
-        query.orgId,
-      );
+    this.logger.debug('Checking if user is from organization');
+    validateSubscriptionAccess(
+      this.contextService,
+      query.requestingUserId,
+      query.orgId,
+    );
 
-      const subscriptions = (
-        await this.subscriptionRepository.findByOrgId(query.orgId)
-      ).filter(isActive);
-      if (subscriptions.length === 0) {
-        this.logger.warn('Subscription not found', {
-          orgId: query.orgId,
-        });
-        throw new SubscriptionNotFoundError(query.orgId);
-      }
-      if (subscriptions.length > 1) {
-        this.logger.warn('Multiple active subscriptions found', {
-          orgId: query.orgId,
-        });
-        throw new MultipleActiveSubscriptionsError(query.orgId);
-      }
-
-      const subscription = subscriptions[0];
-
-      const availableSeats = await computeAvailableSeats(
-        subscription,
-        query.orgId,
-        query.requestingUserId,
-        this.getInvitesByOrgUseCase,
-        this.findUsersByOrgIdUseCase,
-      );
-      const nextRenewalDate = getNextRenewalDate(subscription);
-      return { subscription, availableSeats, nextRenewalDate };
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        // Already logged and properly typed error, just rethrow
-        throw error;
-      }
-      this.logger.error('Getting subscription failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
+    const subscriptions = (
+      await this.subscriptionRepository.findByOrgId(query.orgId)
+    ).filter(isActive);
+    if (subscriptions.length === 0) {
+      this.logger.warn('Subscription not found', {
         orgId: query.orgId,
-        requestingUserId: query.requestingUserId,
       });
-      throw error;
+      throw new SubscriptionNotFoundError(query.orgId);
     }
+    if (subscriptions.length > 1) {
+      this.logger.warn('Multiple active subscriptions found', {
+        orgId: query.orgId,
+      });
+      throw new MultipleActiveSubscriptionsError(query.orgId);
+    }
+
+    const subscription = subscriptions[0];
+
+    const availableSeats = await computeAvailableSeats(
+      subscription,
+      query.orgId,
+      query.requestingUserId,
+      this.getInvitesByOrgUseCase,
+      this.findUsersByOrgIdUseCase,
+    );
+    const nextRenewalDate = getNextRenewalDate(subscription);
+    return { subscription, availableSeats, nextRenewalDate };
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-latest-subscription/get-latest-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-latest-subscription/get-latest-subscription.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { GetLatestSubscriptionQuery } from './get-latest-subscription.query';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
@@ -8,7 +9,6 @@ import {
   SubscriptionNotFoundError,
   UnexpectedSubscriptionError,
 } from '../../subscription.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { validateSubscriptionAccess } from '../../util/validate-subscription-access';
 import { computeAvailableSeats } from '../../util/compute-available-seats';
@@ -25,6 +25,7 @@ export class GetLatestSubscriptionUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSubscriptionError)
   async execute(query: GetLatestSubscriptionQuery): Promise<{
     subscription: Subscription;
     availableSeats: number | null;
@@ -35,39 +36,29 @@ export class GetLatestSubscriptionUseCase {
       requestingUserId: query.requestingUserId,
     });
 
-    try {
-      validateSubscriptionAccess(
-        this.contextService,
-        query.requestingUserId,
-        query.orgId,
-      );
+    validateSubscriptionAccess(
+      this.contextService,
+      query.requestingUserId,
+      query.orgId,
+    );
 
-      const subscription = await this.subscriptionRepository.findLatestByOrgId(
-        query.orgId,
-      );
+    const subscription = await this.subscriptionRepository.findLatestByOrgId(
+      query.orgId,
+    );
 
-      if (!subscription) {
-        throw new SubscriptionNotFoundError(query.orgId);
-      }
-
-      const availableSeats = await computeAvailableSeats(
-        subscription,
-        query.orgId,
-        query.requestingUserId,
-        this.getInvitesByOrgUseCase,
-        this.findUsersByOrgIdUseCase,
-      );
-      const nextRenewalDate = getNextRenewalDate(subscription);
-
-      return { subscription, availableSeats, nextRenewalDate };
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting latest subscription', {
-        error: error as Error,
-      });
-      throw new UnexpectedSubscriptionError(
-        'Failed to get latest subscription',
-      );
+    if (!subscription) {
+      throw new SubscriptionNotFoundError(query.orgId);
     }
+
+    const availableSeats = await computeAvailableSeats(
+      subscription,
+      query.orgId,
+      query.requestingUserId,
+      this.getInvitesByOrgUseCase,
+      this.findUsersByOrgIdUseCase,
+    );
+    const nextRenewalDate = getNextRenewalDate(subscription);
+
+    return { subscription, availableSeats, nextRenewalDate };
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-monthly-credit-limit/get-monthly-credit-limit.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-monthly-credit-limit/get-monthly-credit-limit.use-case.ts
@@ -1,9 +1,9 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { GetMonthlyCreditLimitQuery } from './get-monthly-credit-limit.query';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
 import { isActive } from '../../util/is-active';
 import { isUsageBased } from '../../../domain/subscription-type-guards';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedSubscriptionError } from '../../subscription.errors';
 
 /**
@@ -18,34 +18,25 @@ export class GetMonthlyCreditLimitUseCase {
     private readonly subscriptionRepository: SubscriptionRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSubscriptionError)
   async execute(
     query: GetMonthlyCreditLimitQuery,
   ): Promise<{ monthlyCredits: number | null; startsAt: Date | null }> {
-    try {
-      const subscriptions = await this.subscriptionRepository.findByOrgId(
-        query.orgId,
-      );
-      const usageSubscription = subscriptions
-        .filter(isActive)
-        .find(isUsageBased);
+    const subscriptions = await this.subscriptionRepository.findByOrgId(
+      query.orgId,
+    );
+    const usageSubscription = subscriptions.filter(isActive).find(isUsageBased);
 
-      if (!usageSubscription) {
-        this.logger.debug('No active usage-based subscription found', {
-          orgId: query.orgId,
-        });
-        return { monthlyCredits: null, startsAt: null };
-      }
-
-      return {
-        monthlyCredits: usageSubscription.monthlyCredits,
-        startsAt: usageSubscription.startsAt,
-      };
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get monthly credit limit', error);
-      throw new UnexpectedSubscriptionError((error as Error).message, {
+    if (!usageSubscription) {
+      this.logger.debug('No active usage-based subscription found', {
         orgId: query.orgId,
       });
+      return { monthlyCredits: null, startsAt: null };
     }
+
+    return {
+      monthlyCredits: usageSubscription.monthlyCredits,
+      startsAt: usageSubscription.startsAt,
+    };
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/has-active-subscription/has-active-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/has-active-subscription/has-active-subscription.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedSubscriptionError } from 'src/iam/subscriptions/application/subscription.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { HasActiveSubscriptionQuery } from './has-active-subscription.query';
 import { HasActiveSubscriptionResult } from './has-active-subscription.result';
@@ -15,6 +17,7 @@ export class HasActiveSubscriptionUseCase {
     private readonly configService: ConfigService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSubscriptionError)
   async execute(
     query: HasActiveSubscriptionQuery,
   ): Promise<HasActiveSubscriptionResult> {

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/is-usage-based-subscription/is-usage-based-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/is-usage-based-subscription/is-usage-based-subscription.use-case.ts
@@ -1,9 +1,9 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { IsUsageBasedSubscriptionQuery } from './is-usage-based-subscription.query';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
 import { isActive } from '../../util/is-active';
 import { isUsageBased } from '../../../domain/subscription-type-guards';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedSubscriptionError } from '../../subscription.errors';
 
 /**
@@ -19,18 +19,11 @@ export class IsUsageBasedSubscriptionUseCase {
     private readonly subscriptionRepository: SubscriptionRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSubscriptionError)
   async execute(query: IsUsageBasedSubscriptionQuery): Promise<boolean> {
-    try {
-      const subscriptions = await this.subscriptionRepository.findByOrgId(
-        query.orgId,
-      );
-      return subscriptions.filter(isActive).some(isUsageBased);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to determine subscription type', error);
-      throw new UnexpectedSubscriptionError((error as Error).message, {
-        orgId: query.orgId,
-      });
-    }
+    const subscriptions = await this.subscriptionRepository.findByOrgId(
+      query.orgId,
+    );
+    return subscriptions.filter(isActive).some(isUsageBased);
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/uncancel-subscription/uncancel-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/uncancel-subscription/uncancel-subscription.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UncancelSubscriptionCommand } from './uncancel-subscription.command';
@@ -8,7 +9,6 @@ import {
   SubscriptionExpiredError,
   UnexpectedSubscriptionError,
 } from '../../subscription.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { SubscriptionUncancelledEvent } from '../../events/subscription-uncancelled.event';
 import { toSubscriptionEventData } from '../../mappers/to-subscription-event-data.mapper';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -27,81 +27,72 @@ export class UncancelSubscriptionUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  // Uncancellation coordinates access, state, billing, and audit updates.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UnexpectedSubscriptionError)
   async execute(command: UncancelSubscriptionCommand): Promise<void> {
     this.logger.log('Uncancelling subscription', {
       orgId: command.orgId,
       requestingUserId: command.requestingUserId,
     });
 
-    try {
-      validateSubscriptionAccess(
-        this.contextService,
-        command.requestingUserId,
-        command.orgId,
-      );
+    validateSubscriptionAccess(
+      this.contextService,
+      command.requestingUserId,
+      command.orgId,
+    );
 
-      this.logger.debug('Finding subscription');
-      const subscription = await this.subscriptionRepository.findLatestByOrgId(
-        command.orgId,
-      );
-      if (!subscription) {
-        this.logger.warn('Subscription not found', {
-          orgId: command.orgId,
-        });
-        throw new SubscriptionNotFoundError(command.orgId);
-      }
-
-      this.logger.debug('Checking if subscription is cancelled');
-      if (!subscription.cancelledAt) {
-        this.logger.warn('Subscription is not cancelled', {
-          orgId: command.orgId,
-        });
-        throw new SubscriptionNotCancelledError(command.orgId);
-      }
-
-      this.logger.debug('Checking if subscription can still be uncancelled');
-      if (!this.canUncancel(subscription)) {
-        this.logger.warn('Subscription has expired and cannot be uncancelled', {
-          orgId: command.orgId,
-        });
-        throw new SubscriptionExpiredError(command.orgId);
-      }
-
-      subscription.cancelledAt = null;
-
-      this.logger.debug('Updating subscription to uncancelled');
-      await this.subscriptionRepository.update(subscription);
-
-      this.logger.debug('Subscription uncancelled successfully', {
-        subscriptionId: subscription.id,
+    this.logger.debug('Finding subscription');
+    const subscription = await this.subscriptionRepository.findLatestByOrgId(
+      command.orgId,
+    );
+    if (!subscription) {
+      this.logger.warn('Subscription not found', {
         orgId: command.orgId,
       });
-
-      this.eventEmitter
-        .emitAsync(
-          SubscriptionUncancelledEvent.EVENT_NAME,
-          new SubscriptionUncancelledEvent(
-            command.orgId,
-            toSubscriptionEventData(subscription),
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit SubscriptionUncancelledEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            orgId: command.orgId,
-          });
-        });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Subscription uncancellation failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-        requestingUserId: command.requestingUserId,
-      });
-      throw new UnexpectedSubscriptionError('Unexpected error');
+      throw new SubscriptionNotFoundError(command.orgId);
     }
+
+    this.logger.debug('Checking if subscription is cancelled');
+    if (!subscription.cancelledAt) {
+      this.logger.warn('Subscription is not cancelled', {
+        orgId: command.orgId,
+      });
+      throw new SubscriptionNotCancelledError(command.orgId);
+    }
+
+    this.logger.debug('Checking if subscription can still be uncancelled');
+    if (!this.canUncancel(subscription)) {
+      this.logger.warn('Subscription has expired and cannot be uncancelled', {
+        orgId: command.orgId,
+      });
+      throw new SubscriptionExpiredError(command.orgId);
+    }
+
+    subscription.cancelledAt = null;
+
+    this.logger.debug('Updating subscription to uncancelled');
+    await this.subscriptionRepository.update(subscription);
+
+    this.logger.debug('Subscription uncancelled successfully', {
+      subscriptionId: subscription.id,
+      orgId: command.orgId,
+    });
+
+    this.eventEmitter
+      .emitAsync(
+        SubscriptionUncancelledEvent.EVENT_NAME,
+        new SubscriptionUncancelledEvent(
+          command.orgId,
+          toSubscriptionEventData(subscription),
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error('Failed to emit SubscriptionUncancelledEvent', {
+          error: err instanceof Error ? err.message : 'Unknown error',
+          orgId: command.orgId,
+        });
+      });
   }
 
   /**

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-billing-info/update-billing-info.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-billing-info/update-billing-info.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { SubscriptionBillingInfo } from 'src/iam/subscriptions/domain/subscription-billing-info.entity';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
 import {
@@ -7,7 +8,6 @@ import {
 import { GetActiveSubscriptionQuery } from '../get-active-subscription/get-active-subscription.query';
 import { GetActiveSubscriptionUseCase } from '../get-active-subscription/get-active-subscription.use-case';
 import { UpdateBillingInfoCommand } from './update-billing-info.command';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { SubscriptionBillingInfoUpdatedEvent } from '../../events/subscription-billing-info-updated.event';
@@ -26,72 +26,67 @@ export class UpdateBillingInfoUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  // Billing updates coordinate access checks, persistence, and provider sync.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UnexpectedSubscriptionError)
   async execute(command: UpdateBillingInfoCommand): Promise<void> {
-    try {
-      validateSubscriptionAccess(
-        this.contextService,
-        command.requestingUserId,
-        command.orgId,
-      );
-      const subscription = await this.getActiveSubscriptionUseCase.execute(
-        new GetActiveSubscriptionQuery({
-          orgId: command.orgId,
-          requestingUserId: command.requestingUserId,
-        }),
-      );
-
-      if (!subscription) {
-        throw new SubscriptionNotFoundError(command.orgId);
-      }
-
-      const billingInfo = new SubscriptionBillingInfo({
-        ...subscription.subscription.billingInfo,
-        ...command.billingInfo,
-      });
-
-      await this.subscriptionRepository.updateBillingInfo(
-        subscription.subscription.id,
-        billingInfo,
-      );
-
-      subscription.subscription.billingInfo = billingInfo;
-
-      const billingInfoEventData: BillingInfoEventData = {
-        companyName: billingInfo.companyName,
-        street: billingInfo.street,
-        houseNumber: billingInfo.houseNumber,
-        postalCode: billingInfo.postalCode,
-        city: billingInfo.city,
-        country: billingInfo.country,
-        vatNumber: billingInfo.vatNumber,
-        subText: billingInfo.subText,
+    validateSubscriptionAccess(
+      this.contextService,
+      command.requestingUserId,
+      command.orgId,
+    );
+    const subscription = await this.getActiveSubscriptionUseCase.execute(
+      new GetActiveSubscriptionQuery({
         orgId: command.orgId,
-        subscriptionId: subscription.subscription.id,
-      };
+        requestingUserId: command.requestingUserId,
+      }),
+    );
 
-      this.eventEmitter
-        .emitAsync(
-          SubscriptionBillingInfoUpdatedEvent.EVENT_NAME,
-          new SubscriptionBillingInfoUpdatedEvent(
-            command.orgId,
-            billingInfoEventData,
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error(
-            'Failed to emit SubscriptionBillingInfoUpdatedEvent',
-            {
-              error: err instanceof Error ? err.message : 'Unknown error',
-              orgId: command.orgId,
-            },
-          );
-        });
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error(error);
-      throw new UnexpectedSubscriptionError((error as Error).message, {
-        error: error as Error,
-      });
+    if (!subscription) {
+      throw new SubscriptionNotFoundError(command.orgId);
     }
+
+    const billingInfo = new SubscriptionBillingInfo({
+      ...subscription.subscription.billingInfo,
+      ...command.billingInfo,
+    });
+
+    await this.subscriptionRepository.updateBillingInfo(
+      subscription.subscription.id,
+      billingInfo,
+    );
+
+    subscription.subscription.billingInfo = billingInfo;
+
+    const billingInfoEventData: BillingInfoEventData = {
+      companyName: billingInfo.companyName,
+      street: billingInfo.street,
+      houseNumber: billingInfo.houseNumber,
+      postalCode: billingInfo.postalCode,
+      city: billingInfo.city,
+      country: billingInfo.country,
+      vatNumber: billingInfo.vatNumber,
+      subText: billingInfo.subText,
+      orgId: command.orgId,
+      subscriptionId: subscription.subscription.id,
+    };
+
+    this.eventEmitter
+      .emitAsync(
+        SubscriptionBillingInfoUpdatedEvent.EVENT_NAME,
+        new SubscriptionBillingInfoUpdatedEvent(
+          command.orgId,
+          billingInfoEventData,
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error(
+          'Failed to emit SubscriptionBillingInfoUpdatedEvent',
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            orgId: command.orgId,
+          },
+        );
+      });
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-monthly-credits/update-monthly-credits.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-monthly-credits/update-monthly-credits.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UpdateMonthlyCreditsCommand } from './update-monthly-credits.command';
@@ -10,7 +11,6 @@ import {
 import { isUsageBased } from 'src/iam/subscriptions/domain/subscription-type-guards';
 import { GetActiveSubscriptionQuery } from '../get-active-subscription/get-active-subscription.query';
 import { GetActiveSubscriptionUseCase } from '../get-active-subscription/get-active-subscription.use-case';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { SubscriptionMonthlyCreditsUpdatedEvent } from '../../events/subscription-monthly-credits-updated.event';
 import { toSubscriptionEventData } from '../../mappers/to-subscription-event-data.mapper';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -27,6 +27,9 @@ export class UpdateMonthlyCreditsUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  // Credit updates coordinate access checks, persistence, and subscription rules.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UnexpectedSubscriptionError)
   async execute(command: UpdateMonthlyCreditsCommand): Promise<void> {
     this.logger.log('Updating monthly credits of subscription', {
       orgId: command.orgId,
@@ -34,79 +37,63 @@ export class UpdateMonthlyCreditsUseCase {
       monthlyCredits: command.monthlyCredits,
     });
 
-    try {
-      validateSubscriptionAccess(
-        this.contextService,
-        command.requestingUserId,
-        command.orgId,
-      );
+    validateSubscriptionAccess(
+      this.contextService,
+      command.requestingUserId,
+      command.orgId,
+    );
 
-      this.logger.debug('Validating monthly credits');
-      if (command.monthlyCredits < 0) {
-        this.logger.warn('Invalid monthly credits provided', {
-          monthlyCredits: command.monthlyCredits,
-        });
-        throw new InvalidSubscriptionDataError(
-          'Monthly credits must be 0 or greater',
-        );
-      }
-
-      this.logger.debug('Finding subscription');
-      const { subscription } = await this.getActiveSubscriptionUseCase.execute(
-        new GetActiveSubscriptionQuery({
-          orgId: command.orgId,
-          requestingUserId: command.requestingUserId,
-        }),
-      );
-
-      if (!isUsageBased(subscription)) {
-        throw new InvalidSubscriptionTypeError(
-          'Credit updates are only allowed for usage-based subscriptions',
-        );
-      }
-
-      const previousCredits = subscription.monthlyCredits;
-      subscription.monthlyCredits = command.monthlyCredits;
-      await this.subscriptionRepository.update(subscription);
-
-      this.logger.debug('Monthly credits updated successfully', {
-        subscriptionId: subscription.id,
-        orgId: command.orgId,
-        previousCredits,
-        newCredits: subscription.monthlyCredits,
-      });
-
-      this.eventEmitter
-        .emitAsync(
-          SubscriptionMonthlyCreditsUpdatedEvent.EVENT_NAME,
-          new SubscriptionMonthlyCreditsUpdatedEvent(
-            command.orgId,
-            toSubscriptionEventData(subscription),
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error(
-            'Failed to emit SubscriptionMonthlyCreditsUpdatedEvent',
-            {
-              error: err instanceof Error ? err.message : 'Unknown error',
-              orgId: command.orgId,
-            },
-          );
-        });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        // Already logged and properly typed error, just rethrow
-        throw error;
-      }
-      this.logger.error('Updating monthly credits failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-        requestingUserId: command.requestingUserId,
+    this.logger.debug('Validating monthly credits');
+    if (command.monthlyCredits < 0) {
+      this.logger.warn('Invalid monthly credits provided', {
         monthlyCredits: command.monthlyCredits,
       });
-      throw new UnexpectedSubscriptionError(
-        'Unexpected error during monthly credits update',
+      throw new InvalidSubscriptionDataError(
+        'Monthly credits must be 0 or greater',
       );
     }
+
+    this.logger.debug('Finding subscription');
+    const { subscription } = await this.getActiveSubscriptionUseCase.execute(
+      new GetActiveSubscriptionQuery({
+        orgId: command.orgId,
+        requestingUserId: command.requestingUserId,
+      }),
+    );
+
+    if (!isUsageBased(subscription)) {
+      throw new InvalidSubscriptionTypeError(
+        'Credit updates are only allowed for usage-based subscriptions',
+      );
+    }
+
+    const previousCredits = subscription.monthlyCredits;
+    subscription.monthlyCredits = command.monthlyCredits;
+    await this.subscriptionRepository.update(subscription);
+
+    this.logger.debug('Monthly credits updated successfully', {
+      subscriptionId: subscription.id,
+      orgId: command.orgId,
+      previousCredits,
+      newCredits: subscription.monthlyCredits,
+    });
+
+    this.eventEmitter
+      .emitAsync(
+        SubscriptionMonthlyCreditsUpdatedEvent.EVENT_NAME,
+        new SubscriptionMonthlyCreditsUpdatedEvent(
+          command.orgId,
+          toSubscriptionEventData(subscription),
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error(
+          'Failed to emit SubscriptionMonthlyCreditsUpdatedEvent',
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            orgId: command.orgId,
+          },
+        );
+      });
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-seats/update-seats.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-seats/update-seats.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UpdateSeatsCommand } from './update-seats.command';
@@ -16,7 +17,6 @@ import { FindUsersByOrgIdQuery } from 'src/iam/users/application/use-cases/find-
 import { GetInvitesByOrgQuery } from 'src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.query';
 import { GetActiveSubscriptionQuery } from '../get-active-subscription/get-active-subscription.query';
 import { GetActiveSubscriptionUseCase } from '../get-active-subscription/get-active-subscription.use-case';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { SubscriptionSeatsUpdatedEvent } from '../../events/subscription-seats-updated.event';
 import { toSubscriptionEventData } from '../../mappers/to-subscription-event-data.mapper';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -35,6 +35,9 @@ export class UpdateSeatsUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  // Seat updates coordinate access, limits, billing, and member effects.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UnexpectedSubscriptionError)
   async execute(command: UpdateSeatsCommand): Promise<void> {
     this.logger.log('Adding seats to subscription', {
       orgId: command.orgId,
@@ -42,116 +45,100 @@ export class UpdateSeatsUseCase {
       noOfSeats: command.noOfSeats,
     });
 
-    try {
-      validateSubscriptionAccess(
-        this.contextService,
-        command.requestingUserId,
-        command.orgId,
-      );
-      this.logger.debug('Validating seat count');
-      if (command.noOfSeats <= 0) {
-        this.logger.warn('Invalid number of seats provided', {
-          noOfSeats: command.noOfSeats,
-        });
-        throw new InvalidSubscriptionDataError(
-          'Number of seats must be greater than 0',
-        );
-      }
-
-      this.logger.debug('Finding subscription');
-      const result = await this.getActiveSubscriptionUseCase.execute(
-        new GetActiveSubscriptionQuery({
-          orgId: command.orgId,
-          requestingUserId: command.requestingUserId,
-        }),
-      );
-      if (!result) {
-        this.logger.warn('Subscription not found', {
-          orgId: command.orgId,
-        });
-        throw new SubscriptionNotFoundError(command.orgId);
-      }
-      const subscription = result.subscription;
-
-      if (!isSeatBased(subscription)) {
-        throw new InvalidSubscriptionTypeError(
-          'Seat updates are only allowed for seat-based subscriptions',
-        );
-      }
-
-      const usersResult = await this.findUsersByOrgIdUseCase.execute(
-        new FindUsersByOrgIdQuery({
-          orgId: command.orgId,
-          pagination: { limit: 1000, offset: 0 },
-        }),
-      );
-      const openInvitesResult = await this.getInvitesByOrgUseCase.execute(
-        new GetInvitesByOrgQuery({
-          orgId: command.orgId,
-          requestingUserId: command.requestingUserId,
-          onlyOpen: true,
-        }),
-      );
-      const openInvitesCount =
-        openInvitesResult.total ?? openInvitesResult.data.length;
-      if (
-        command.noOfSeats <
-        (usersResult.total ?? usersResult.data.length) + openInvitesCount
-      ) {
-        this.logger.warn('Too many used seats', {
-          orgId: command.orgId,
-          openInvites: openInvitesCount,
-        });
-        throw new TooManyUsedSeatsError({
-          orgId: command.orgId,
-          openInvites: openInvitesCount,
-        });
-      }
-
-      this.logger.debug('Updating seats of subscription', {
-        currentSeats: subscription.noOfSeats,
-        newSeats: command.noOfSeats,
-      });
-
-      const previousSeats = subscription.noOfSeats;
-      subscription.noOfSeats = command.noOfSeats;
-      await this.subscriptionRepository.update(subscription);
-
-      this.logger.debug('Seats updated successfully', {
-        subscriptionId: subscription.id,
-        orgId: command.orgId,
-        previousSeats,
-        newSeats: subscription.noOfSeats,
-      });
-
-      this.eventEmitter
-        .emitAsync(
-          SubscriptionSeatsUpdatedEvent.EVENT_NAME,
-          new SubscriptionSeatsUpdatedEvent(
-            command.orgId,
-            toSubscriptionEventData(subscription),
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit SubscriptionSeatsUpdatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            orgId: command.orgId,
-          });
-        });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        // Already logged and properly typed error, just rethrow
-        throw error;
-      }
-      this.logger.error('Adding seats failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-        requestingUserId: command.requestingUserId,
+    validateSubscriptionAccess(
+      this.contextService,
+      command.requestingUserId,
+      command.orgId,
+    );
+    this.logger.debug('Validating seat count');
+    if (command.noOfSeats <= 0) {
+      this.logger.warn('Invalid number of seats provided', {
         noOfSeats: command.noOfSeats,
       });
-      throw new UnexpectedSubscriptionError(
-        'Unexpected error during seat addition',
+      throw new InvalidSubscriptionDataError(
+        'Number of seats must be greater than 0',
       );
     }
+
+    this.logger.debug('Finding subscription');
+    const result = await this.getActiveSubscriptionUseCase.execute(
+      new GetActiveSubscriptionQuery({
+        orgId: command.orgId,
+        requestingUserId: command.requestingUserId,
+      }),
+    );
+    if (!result) {
+      this.logger.warn('Subscription not found', {
+        orgId: command.orgId,
+      });
+      throw new SubscriptionNotFoundError(command.orgId);
+    }
+    const subscription = result.subscription;
+
+    if (!isSeatBased(subscription)) {
+      throw new InvalidSubscriptionTypeError(
+        'Seat updates are only allowed for seat-based subscriptions',
+      );
+    }
+
+    const usersResult = await this.findUsersByOrgIdUseCase.execute(
+      new FindUsersByOrgIdQuery({
+        orgId: command.orgId,
+        pagination: { limit: 1000, offset: 0 },
+      }),
+    );
+    const openInvitesResult = await this.getInvitesByOrgUseCase.execute(
+      new GetInvitesByOrgQuery({
+        orgId: command.orgId,
+        requestingUserId: command.requestingUserId,
+        onlyOpen: true,
+      }),
+    );
+    const openInvitesCount =
+      openInvitesResult.total ?? openInvitesResult.data.length;
+    if (
+      command.noOfSeats <
+      (usersResult.total ?? usersResult.data.length) + openInvitesCount
+    ) {
+      this.logger.warn('Too many used seats', {
+        orgId: command.orgId,
+        openInvites: openInvitesCount,
+      });
+      throw new TooManyUsedSeatsError({
+        orgId: command.orgId,
+        openInvites: openInvitesCount,
+      });
+    }
+
+    this.logger.debug('Updating seats of subscription', {
+      currentSeats: subscription.noOfSeats,
+      newSeats: command.noOfSeats,
+    });
+
+    const previousSeats = subscription.noOfSeats;
+    subscription.noOfSeats = command.noOfSeats;
+    await this.subscriptionRepository.update(subscription);
+
+    this.logger.debug('Seats updated successfully', {
+      subscriptionId: subscription.id,
+      orgId: command.orgId,
+      previousSeats,
+      newSeats: subscription.noOfSeats,
+    });
+
+    this.eventEmitter
+      .emitAsync(
+        SubscriptionSeatsUpdatedEvent.EVENT_NAME,
+        new SubscriptionSeatsUpdatedEvent(
+          command.orgId,
+          toSubscriptionEventData(subscription),
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error('Failed to emit SubscriptionSeatsUpdatedEvent', {
+          error: err instanceof Error ? err.message : 'Unknown error',
+          orgId: command.orgId,
+        });
+      });
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-start-date/update-start-date.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-start-date/update-start-date.use-case.ts
@@ -1,5 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { isSeatBased } from 'src/iam/subscriptions/domain/subscription-type-guards';
 import type { Subscription } from 'src/iam/subscriptions/domain/subscription.entity';
@@ -21,6 +21,7 @@ export class UpdateStartDateUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedSubscriptionError)
   async execute(command: UpdateStartDateCommand): Promise<Subscription> {
     this.logger.log('Updating subscription start date', {
       orgId: command.orgId,
@@ -28,44 +29,29 @@ export class UpdateStartDateUseCase {
       startsAt: command.startsAt.toISOString(),
     });
 
-    try {
-      validateSubscriptionAccess(
-        this.contextService,
-        command.requestingUserId,
-        command.orgId,
-      );
+    validateSubscriptionAccess(
+      this.contextService,
+      command.requestingUserId,
+      command.orgId,
+    );
 
-      const subscription = await this.subscriptionRepository.findLatestByOrgId(
-        command.orgId,
-      );
-      if (!subscription) {
-        throw new SubscriptionNotFoundError(command.orgId);
-      }
-
-      if (subscription.cancelledAt) {
-        throw new SubscriptionAlreadyCancelledError(command.orgId);
-      }
-
-      return await this.subscriptionRepository.updateStartDate({
-        subscriptionId: subscription.id,
-        startsAt: command.startsAt,
-        renewalCycleAnchor: isSeatBased(subscription)
-          ? command.startsAt
-          : undefined,
-      });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-
-      this.logger.error('Error updating subscription start date', {
-        error: error as Error,
-        orgId: command.orgId,
-      });
-      throw new UnexpectedSubscriptionError(
-        'Unexpected error during subscription start date update',
-        { error },
-      );
+    const subscription = await this.subscriptionRepository.findLatestByOrgId(
+      command.orgId,
+    );
+    if (!subscription) {
+      throw new SubscriptionNotFoundError(command.orgId);
     }
+
+    if (subscription.cancelledAt) {
+      throw new SubscriptionAlreadyCancelledError(command.orgId);
+    }
+
+    return await this.subscriptionRepository.updateStartDate({
+      subscriptionId: subscription.id,
+      startsAt: command.startsAt,
+      renewalCycleAnchor: isSeatBased(subscription)
+        ? command.startsAt
+        : undefined,
+    });
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/add-team-member/add-team-member.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/add-team-member/add-team-member.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedTeamError } from 'src/iam/teams/application/teams.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { TeamMembersRepository } from '../../ports/team-members.repository';
@@ -5,14 +7,13 @@ import { FindUserByIdUseCase } from 'src/iam/users/application/use-cases/find-us
 import { FindUserByIdQuery } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.query';
 import { AddTeamMemberCommand } from './add-team-member.command';
 import { TeamMember } from '../../../domain/team-member.entity';
-import { TeamNotFoundError } from '../../teams.errors';
 import {
   UserAlreadyTeamMemberError,
   UserNotInSameOrgError,
 } from '../../team-members.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { findTeamInOrganization } from '../../utils/find-team-in-organization';
 
 @Injectable()
 export class AddTeamMemberUseCase {
@@ -25,6 +26,9 @@ export class AddTeamMemberUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  // Adding a member coordinates organization, user, and membership validation.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UnexpectedTeamError)
   async execute(command: AddTeamMemberCommand): Promise<TeamMember> {
     const orgId = this.contextService.get('orgId');
 
@@ -38,79 +42,57 @@ export class AddTeamMemberUseCase {
       orgId,
     });
 
-    try {
-      // Verify team exists and belongs to organization
-      const team = await this.teamsRepository.findById(command.teamId);
+    await findTeamInOrganization(
+      this.teamsRepository,
+      command.teamId,
+      orgId,
+      this.logger,
+    );
 
-      if (!team) {
-        this.logger.error('Team not found', { teamId: command.teamId });
-        throw new TeamNotFoundError(command.teamId);
-      }
+    // Verify user exists (throws UserNotFoundError if not found)
+    const user = await this.findUserByIdUseCase.execute(
+      new FindUserByIdQuery(command.userId),
+    );
 
-      if (team.orgId !== orgId) {
-        this.logger.error('Team does not belong to organization', {
-          teamId: command.teamId,
-          teamOrgId: team.orgId,
-          requestOrgId: orgId,
-        });
-        throw new TeamNotFoundError(command.teamId);
-      }
+    // Verify user belongs to same organization
+    if (user.orgId !== orgId) {
+      this.logger.error('User does not belong to organization', {
+        userId: command.userId,
+        userOrgId: user.orgId,
+        requestOrgId: orgId,
+      });
+      throw new UserNotInSameOrgError(command.userId);
+    }
 
-      // Verify user exists (throws UserNotFoundError if not found)
-      const user = await this.findUserByIdUseCase.execute(
-        new FindUserByIdQuery(command.userId),
+    // Check if user is already a member
+    const existingMember =
+      await this.teamMembersRepository.findByTeamIdAndUserId(
+        command.teamId,
+        command.userId,
       );
 
-      // Verify user belongs to same organization
-      if (user.orgId !== orgId) {
-        this.logger.error('User does not belong to organization', {
-          userId: command.userId,
-          userOrgId: user.orgId,
-          requestOrgId: orgId,
-        });
-        throw new UserNotInSameOrgError(command.userId);
-      }
-
-      // Check if user is already a member
-      const existingMember =
-        await this.teamMembersRepository.findByTeamIdAndUserId(
-          command.teamId,
-          command.userId,
-        );
-
-      if (existingMember) {
-        this.logger.error('User is already a team member', {
-          teamId: command.teamId,
-          userId: command.userId,
-        });
-        throw new UserAlreadyTeamMemberError(command.teamId, command.userId);
-      }
-
-      // Create team member
-      const teamMember = new TeamMember({
+    if (existingMember) {
+      this.logger.error('User is already a team member', {
         teamId: command.teamId,
         userId: command.userId,
       });
-
-      const createdMember = await this.teamMembersRepository.create(teamMember);
-
-      this.logger.debug('Team member added successfully', {
-        teamId: command.teamId,
-        userId: command.userId,
-        memberId: createdMember.id,
-      });
-
-      return createdMember;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to add team member', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        teamId: command.teamId,
-        userId: command.userId,
-      });
-      throw error;
+      throw new UserAlreadyTeamMemberError(command.teamId, command.userId);
     }
+
+    // Create team member
+    const teamMember = new TeamMember({
+      teamId: command.teamId,
+      userId: command.userId,
+    });
+
+    const createdMember = await this.teamMembersRepository.create(teamMember);
+
+    this.logger.debug('Team member added successfully', {
+      teamId: command.teamId,
+      userId: command.userId,
+      memberId: createdMember.id,
+    });
+
+    return createdMember;
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/bulk-add-team-members/bulk-add-team-members.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/bulk-add-team-members/bulk-add-team-members.use-case.spec.ts
@@ -4,7 +4,7 @@ import { BulkAddTeamMembersUseCase } from './bulk-add-team-members.use-case';
 import { BulkAddTeamMembersCommand } from './bulk-add-team-members.command';
 import { AddTeamMemberUseCase } from '../add-team-member/add-team-member.use-case';
 import { TeamMember } from '../../../domain/team-member.entity';
-import { TeamNotFoundError } from '../../teams.errors';
+import { UnexpectedTeamError, TeamNotFoundError } from '../../teams.errors';
 import { UserAlreadyTeamMemberError } from '../../team-members.errors';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import type { UUID } from 'crypto';
@@ -94,7 +94,7 @@ describe('BulkAddTeamMembersUseCase', () => {
     ).rejects.toBeInstanceOf(UnauthorizedAccessError);
   });
 
-  it('re-throws unexpected (non-ApplicationError) faults raw, without wrapping (no metadata leak)', async () => {
+  it('wraps unexpected (non-ApplicationError) faults', async () => {
     const fault = new Error('database is on fire');
     mockAddTeamMemberUseCase.execute.mockRejectedValueOnce(fault);
 
@@ -102,6 +102,6 @@ describe('BulkAddTeamMembersUseCase', () => {
       useCase.execute(
         new BulkAddTeamMembersCommand({ teamId, userIds: [userA] }),
       ),
-    ).rejects.toBe(fault);
+    ).rejects.toBeInstanceOf(UnexpectedTeamError);
   });
 });

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/bulk-add-team-members/bulk-add-team-members.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/bulk-add-team-members/bulk-add-team-members.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedTeamError } from 'src/iam/teams/application/teams.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { AddTeamMemberUseCase } from '../add-team-member/add-team-member.use-case';
 import { AddTeamMemberCommand } from '../add-team-member/add-team-member.command';
@@ -8,7 +10,6 @@ import {
   UserNotInSameOrgError,
 } from '../../team-members.errors';
 import { UserNotFoundError } from 'src/iam/users/application/users.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class BulkAddTeamMembersUseCase {
@@ -16,6 +17,7 @@ export class BulkAddTeamMembersUseCase {
 
   constructor(private readonly addTeamMemberUseCase: AddTeamMemberUseCase) {}
 
+  @HandleUnexpectedErrors(UnexpectedTeamError)
   async execute(command: BulkAddTeamMembersCommand): Promise<TeamMember[]> {
     const uniqueUserIds = [...new Set(command.userIds)];
 
@@ -24,48 +26,37 @@ export class BulkAddTeamMembersUseCase {
       count: uniqueUserIds.length,
     });
 
-    try {
-      const added: TeamMember[] = [];
-      for (const userId of uniqueUserIds) {
-        try {
-          added.push(
-            await this.addTeamMemberUseCase.execute(
-              new AddTeamMemberCommand({ teamId: command.teamId, userId }),
-            ),
-          );
-        } catch (error) {
-          if (
-            error instanceof UserAlreadyTeamMemberError ||
-            error instanceof UserNotInSameOrgError ||
-            error instanceof UserNotFoundError
-          ) {
-            this.logger.warn('Skipped user during bulk add', {
-              teamId: command.teamId,
-              userId,
-              reason: error.code,
-            });
-            continue;
-          }
-          throw error;
+    const added: TeamMember[] = [];
+    for (const userId of uniqueUserIds) {
+      try {
+        added.push(
+          await this.addTeamMemberUseCase.execute(
+            new AddTeamMemberCommand({ teamId: command.teamId, userId }),
+          ),
+        );
+      } catch (error) {
+        if (
+          error instanceof UserAlreadyTeamMemberError ||
+          error instanceof UserNotInSameOrgError ||
+          error instanceof UserNotFoundError
+        ) {
+          this.logger.warn('Skipped user during bulk add', {
+            teamId: command.teamId,
+            userId,
+            reason: error.code,
+          });
+          continue;
         }
-      }
-
-      this.logger.debug('Bulk add finished', {
-        teamId: command.teamId,
-        requested: uniqueUserIds.length,
-        added: added.length,
-      });
-
-      return added;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error bulk adding team members', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        teamId: command.teamId,
-      });
-      throw error;
     }
+
+    this.logger.debug('Bulk add finished', {
+      teamId: command.teamId,
+      requested: uniqueUserIds.length,
+      added: added.length,
+    });
+
+    return added;
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/check-user-team-membership/check-user-team-membership.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/check-user-team-membership/check-user-team-membership.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedTeamError } from 'src/iam/teams/application/teams.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { TeamMembersRepository } from '../../ports/team-members.repository';
 import { CheckUserTeamMembershipQuery } from './check-user-team-membership.query';
@@ -13,6 +15,7 @@ export class CheckUserTeamMembershipUseCase {
    * @param query - Query containing userId and teamId
    * @returns true if the user is a member of the team, false otherwise
    */
+  @HandleUnexpectedErrors(UnexpectedTeamError)
   async execute(query: CheckUserTeamMembershipQuery): Promise<boolean> {
     this.logger.log('checkUserTeamMembership', {
       userId: query.userId,

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/create-team/create-team.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/create-team/create-team.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { CreateTeamCommand } from './create-team.command';
 import { TeamsRepository } from '../../ports/teams.repository';
@@ -7,7 +8,6 @@ import {
   TeamNameAlreadyExistsError,
   UnexpectedTeamError,
 } from '../../teams.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
@@ -20,6 +20,7 @@ export class CreateTeamUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedTeamError)
   async execute(command: CreateTeamCommand): Promise<Team> {
     const orgId = this.contextService.get('orgId');
 
@@ -36,39 +37,27 @@ export class CreateTeamUseCase {
       throw new TeamInvalidInputError('Team name cannot be empty');
     }
 
-    try {
-      const existingTeam = await this.teamsRepository.findByNameAndOrgId(
-        trimmedName,
-        orgId,
-      );
+    const existingTeam = await this.teamsRepository.findByNameAndOrgId(
+      trimmedName,
+      orgId,
+    );
 
-      if (existingTeam) {
-        this.logger.warn('Team with this name already exists', {
-          name: trimmedName,
-          orgId,
-        });
-        throw new TeamNameAlreadyExistsError(trimmedName);
-      }
-
-      this.logger.debug('Creating new team', { name: trimmedName, orgId });
-      const team = new Team({ name: trimmedName, orgId });
-      const createdTeam = await this.teamsRepository.create(team);
-      this.logger.debug('Team created successfully', {
-        id: createdTeam.id,
-        name: createdTeam.name,
-      });
-
-      return createdTeam;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to create team', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        name: command.name,
+    if (existingTeam) {
+      this.logger.warn('Team with this name already exists', {
+        name: trimmedName,
         orgId,
       });
-      throw new UnexpectedTeamError(error);
+      throw new TeamNameAlreadyExistsError(trimmedName);
     }
+
+    this.logger.debug('Creating new team', { name: trimmedName, orgId });
+    const team = new Team({ name: trimmedName, orgId });
+    const createdTeam = await this.teamsRepository.create(team);
+    this.logger.debug('Team created successfully', {
+      id: createdTeam.id,
+      name: createdTeam.name,
+    });
+
+    return createdTeam;
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/delete-team/delete-team.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/delete-team/delete-team.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedTeamError } from 'src/iam/teams/application/teams.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { DeleteTeamCommand } from './delete-team.command';
@@ -16,6 +18,7 @@ export class DeleteTeamUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedTeamError)
   async execute(command: DeleteTeamCommand): Promise<void> {
     const orgId = this.contextService.get('orgId');
 

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedTeamError } from 'src/iam/teams/application/teams.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { UUID } from 'crypto';
 import { TeamMembersRepository } from '../../ports/team-members.repository';
@@ -13,6 +15,7 @@ export class FindAllUserIdsByTeamIdUseCase {
 
   constructor(private readonly teamMembersRepository: TeamMembersRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedTeamError)
   async execute(query: FindAllUserIdsByTeamIdQuery): Promise<UUID[]> {
     this.logger.log('execute', { teamId: query.teamId });
 

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/find-teams-by-user-id/find-teams-by-user-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/find-teams-by-user-id/find-teams-by-user-id.use-case.ts
@@ -1,9 +1,9 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { Team } from '../../../domain/team.entity';
 import { FindTeamsByUserIdQuery } from './find-teams-by-user-id.query';
 import { UnexpectedTeamError } from '../../teams.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class FindTeamsByUserIdUseCase {
@@ -11,20 +11,10 @@ export class FindTeamsByUserIdUseCase {
 
   constructor(private readonly teamsRepository: TeamsRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedTeamError)
   async execute(query: FindTeamsByUserIdQuery): Promise<Team[]> {
     this.logger.log('execute', { userId: query.userId });
 
-    try {
-      return await this.teamsRepository.findByUserId(query.userId);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to find teams by user ID', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        userId: query.userId,
-      });
-      throw new UnexpectedTeamError(error);
-    }
+    return await this.teamsRepository.findByUserId(query.userId);
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/get-team/get-team.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/get-team/get-team.use-case.ts
@@ -1,11 +1,12 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { GetTeamQuery } from './get-team.query';
 import { Team } from '../../../domain/team.entity';
-import { TeamNotFoundError, UnexpectedTeamError } from '../../teams.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { UnexpectedTeamError } from '../../teams.errors';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { findTeamInOrganization } from '../../utils/find-team-in-organization';
 
 @Injectable()
 export class GetTeamUseCase {
@@ -16,6 +17,7 @@ export class GetTeamUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedTeamError)
   async execute(query: GetTeamQuery): Promise<Team> {
     const orgId = this.contextService.get('orgId');
 
@@ -25,37 +27,17 @@ export class GetTeamUseCase {
 
     this.logger.log('execute', { teamId: query.teamId, orgId });
 
-    try {
-      const team = await this.teamsRepository.findById(query.teamId);
+    const team = await findTeamInOrganization(
+      this.teamsRepository,
+      query.teamId,
+      orgId,
+      this.logger,
+    );
 
-      if (!team) {
-        this.logger.error('Team not found', { teamId: query.teamId });
-        throw new TeamNotFoundError(query.teamId);
-      }
+    this.logger.debug('Team retrieved successfully', {
+      teamId: query.teamId,
+    });
 
-      if (team.orgId !== orgId) {
-        this.logger.error('Team does not belong to organization', {
-          teamId: query.teamId,
-          teamOrgId: team.orgId,
-          requestOrgId: orgId,
-        });
-        throw new TeamNotFoundError(query.teamId);
-      }
-
-      this.logger.debug('Team retrieved successfully', {
-        teamId: query.teamId,
-      });
-
-      return team;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to retrieve team', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        teamId: query.teamId,
-      });
-      throw new UnexpectedTeamError(error);
-    }
+    return team;
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/list-my-teams/list-my-teams.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/list-my-teams/list-my-teams.use-case.ts
@@ -1,8 +1,8 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { Team } from '../../../domain/team.entity';
 import { UnexpectedTeamError } from '../../teams.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
@@ -15,6 +15,7 @@ export class ListMyTeamsUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedTeamError)
   async execute(): Promise<Team[]> {
     const userId = this.contextService.get('userId');
 
@@ -24,23 +25,12 @@ export class ListMyTeamsUseCase {
 
     this.logger.log('listMyTeams', { userId });
 
-    try {
-      const teams = await this.teamsRepository.findByUserId(userId);
-      this.logger.debug('User teams retrieved successfully', {
-        userId,
-        count: teams.length,
-      });
+    const teams = await this.teamsRepository.findByUserId(userId);
+    this.logger.debug('User teams retrieved successfully', {
+      userId,
+      count: teams.length,
+    });
 
-      return teams;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to retrieve user teams', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        userId,
-      });
-      throw new UnexpectedTeamError(error);
-    }
+    return teams;
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/list-team-members/list-team-members.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/list-team-members/list-team-members.use-case.ts
@@ -1,13 +1,14 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { TeamMembersRepository } from '../../ports/team-members.repository';
 import { ListTeamMembersQuery } from './list-team-members.query';
 import { TeamMember } from '../../../domain/team-member.entity';
-import { TeamNotFoundError, UnexpectedTeamError } from '../../teams.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { UnexpectedTeamError } from '../../teams.errors';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { Paginated } from 'src/common/pagination';
+import { findTeamInOrganization } from '../../utils/find-team-in-organization';
 
 @Injectable()
 export class ListTeamMembersUseCase {
@@ -19,6 +20,7 @@ export class ListTeamMembersUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedTeamError)
   async execute(query: ListTeamMembersQuery): Promise<Paginated<TeamMember>> {
     const orgId = this.contextService.get('orgId');
 
@@ -28,44 +30,24 @@ export class ListTeamMembersUseCase {
 
     this.logger.log('execute', { teamId: query.teamId, orgId });
 
-    try {
-      const team = await this.teamsRepository.findById(query.teamId);
+    await findTeamInOrganization(
+      this.teamsRepository,
+      query.teamId,
+      orgId,
+      this.logger,
+    );
 
-      if (!team) {
-        this.logger.error('Team not found', { teamId: query.teamId });
-        throw new TeamNotFoundError(query.teamId);
-      }
+    const members = await this.teamMembersRepository.findByTeamId(
+      query.teamId,
+      { limit: query.limit, offset: query.offset },
+    );
 
-      if (team.orgId !== orgId) {
-        this.logger.error('Team does not belong to organization', {
-          teamId: query.teamId,
-          teamOrgId: team.orgId,
-          requestOrgId: orgId,
-        });
-        throw new TeamNotFoundError(query.teamId);
-      }
+    this.logger.debug('Team members retrieved successfully', {
+      teamId: query.teamId,
+      count: members.data.length,
+      total: members.total,
+    });
 
-      const members = await this.teamMembersRepository.findByTeamId(
-        query.teamId,
-        { limit: query.limit, offset: query.offset },
-      );
-
-      this.logger.debug('Team members retrieved successfully', {
-        teamId: query.teamId,
-        count: members.data.length,
-        total: members.total,
-      });
-
-      return members;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to retrieve team members', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        teamId: query.teamId,
-      });
-      throw new UnexpectedTeamError(error);
-    }
+    return members;
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/list-teams/list-teams.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/list-teams/list-teams.use-case.ts
@@ -1,8 +1,8 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { TeamMembersRepository } from '../../ports/team-members.repository';
 import { UnexpectedTeamError } from '../../teams.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { TeamWithMemberCount } from './team-with-member-count.view';
@@ -17,6 +17,7 @@ export class ListTeamsUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedTeamError)
   async execute(): Promise<TeamWithMemberCount[]> {
     const orgId = this.contextService.get('orgId');
 
@@ -26,30 +27,19 @@ export class ListTeamsUseCase {
 
     this.logger.log('listTeams', { orgId });
 
-    try {
-      const teams = await this.teamsRepository.findByOrgId(orgId);
-      const counts = await this.teamMembersRepository.countByTeamIds(
-        teams.map((team) => team.id),
-      );
+    const teams = await this.teamsRepository.findByOrgId(orgId);
+    const counts = await this.teamMembersRepository.countByTeamIds(
+      teams.map((team) => team.id),
+    );
 
-      this.logger.debug('Teams retrieved successfully', {
-        orgId,
-        count: teams.length,
-      });
+    this.logger.debug('Teams retrieved successfully', {
+      orgId,
+      count: teams.length,
+    });
 
-      return teams.map((team) => ({
-        team,
-        memberCount: counts.get(team.id) ?? 0,
-      }));
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to retrieve teams', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId,
-      });
-      throw new UnexpectedTeamError(error);
-    }
+    return teams.map((team) => ({
+      team,
+      memberCount: counts.get(team.id) ?? 0,
+    }));
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/remove-team-member/remove-team-member.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/remove-team-member/remove-team-member.use-case.ts
@@ -1,13 +1,14 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedTeamError } from 'src/iam/teams/application/teams.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { TeamMembersRepository } from '../../ports/team-members.repository';
 import { RemoveTeamMemberCommand } from './remove-team-member.command';
-import { TeamNotFoundError } from '../../teams.errors';
 import { TeamMemberNotFoundError } from '../../team-members.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { Transactional } from '@nestjs-cls/transactional';
+import { findTeamInOrganization } from '../../utils/find-team-in-organization';
 
 @Injectable()
 export class RemoveTeamMemberUseCase {
@@ -20,6 +21,7 @@ export class RemoveTeamMemberUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UnexpectedTeamError)
   async execute(command: RemoveTeamMemberCommand): Promise<void> {
     const orgId = this.contextService.get('orgId');
 
@@ -33,63 +35,41 @@ export class RemoveTeamMemberUseCase {
       orgId,
     });
 
-    try {
-      // Verify team exists and belongs to organization
-      const team = await this.teamsRepository.findById(command.teamId);
+    await findTeamInOrganization(
+      this.teamsRepository,
+      command.teamId,
+      orgId,
+      this.logger,
+    );
 
-      if (!team) {
-        this.logger.error('Team not found', { teamId: command.teamId });
-        throw new TeamNotFoundError(command.teamId);
-      }
-
-      if (team.orgId !== orgId) {
-        this.logger.error('Team does not belong to organization', {
-          teamId: command.teamId,
-          teamOrgId: team.orgId,
-          requestOrgId: orgId,
-        });
-        throw new TeamNotFoundError(command.teamId);
-      }
-
-      // Verify user is a member of the team
-      const existingMember =
-        await this.teamMembersRepository.findByTeamIdAndUserId(
-          command.teamId,
-          command.userId,
-        );
-
-      if (!existingMember) {
-        this.logger.error('User is not a team member', {
-          teamId: command.teamId,
-          userId: command.userId,
-        });
-        throw new TeamMemberNotFoundError(command.teamId, command.userId);
-      }
-
-      // Note: Threads that used shared agents from this team will show a
-      // "conversation no longer accessible" disclaimer when the removed user
-      // tries to continue the chat. The history is preserved.
-
-      // Remove team member
-      await this.teamMembersRepository.deleteByTeamIdAndUserId(
+    // Verify user is a member of the team
+    const existingMember =
+      await this.teamMembersRepository.findByTeamIdAndUserId(
         command.teamId,
         command.userId,
       );
 
-      this.logger.debug('Team member removed successfully', {
+    if (!existingMember) {
+      this.logger.error('User is not a team member', {
         teamId: command.teamId,
         userId: command.userId,
       });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to remove team member', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        teamId: command.teamId,
-        userId: command.userId,
-      });
-      throw error;
+      throw new TeamMemberNotFoundError(command.teamId, command.userId);
     }
+
+    // Note: Threads that used shared agents from this team will show a
+    // "conversation no longer accessible" disclaimer when the removed user
+    // tries to continue the chat. The history is preserved.
+
+    // Remove team member
+    await this.teamMembersRepository.deleteByTeamIdAndUserId(
+      command.teamId,
+      command.userId,
+    );
+
+    this.logger.debug('Team member removed successfully', {
+      teamId: command.teamId,
+      userId: command.userId,
+    });
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/update-team/update-team.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/update-team/update-team.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { UpdateTeamCommand } from './update-team.command';
 import { TeamsRepository } from '../../ports/teams.repository';
@@ -8,7 +9,6 @@ import {
   TeamNotFoundError,
   UnexpectedTeamError,
 } from '../../teams.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
@@ -21,6 +21,9 @@ export class UpdateTeamUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  // Team updates coordinate access, uniqueness, and persistence rules.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UnexpectedTeamError)
   async execute(command: UpdateTeamCommand): Promise<Team> {
     const orgId = this.contextService.get('orgId');
 
@@ -40,64 +43,51 @@ export class UpdateTeamUseCase {
       throw new TeamInvalidInputError('Team name cannot be empty');
     }
 
-    try {
-      const team = await this.teamsRepository.findById(command.teamId);
+    const team = await this.teamsRepository.findById(command.teamId);
 
-      if (team?.orgId !== orgId) {
-        this.logger.warn('Team not found or belongs to different org', {
-          teamId: command.teamId,
-          orgId,
-        });
-        throw new TeamNotFoundError(command.teamId);
-      }
-
-      // Only check for duplicates if the name is being changed
-      if (team.name !== trimmedName) {
-        const existingTeam = await this.teamsRepository.findByNameAndOrgId(
-          trimmedName,
-          orgId,
-        );
-
-        if (existingTeam && existingTeam.id !== command.teamId) {
-          this.logger.warn('Team with this name already exists', {
-            name: trimmedName,
-            orgId,
-          });
-          throw new TeamNameAlreadyExistsError(trimmedName);
-        }
-      }
-
-      this.logger.debug('Updating team', {
-        id: team.id,
-        oldName: team.name,
-        newName: trimmedName,
-      });
-
-      team.name = trimmedName;
-      if (command.modelOverrideEnabled !== undefined) {
-        team.modelOverrideEnabled = command.modelOverrideEnabled;
-      }
-      team.updatedAt = new Date();
-
-      const updatedTeam = await this.teamsRepository.update(team);
-
-      this.logger.debug('Team updated successfully', {
-        id: updatedTeam.id,
-        name: updatedTeam.name,
-      });
-
-      return updatedTeam;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to update team', {
-        error: error instanceof Error ? error.message : 'Unknown error',
+    if (team?.orgId !== orgId) {
+      this.logger.warn('Team not found or belongs to different org', {
         teamId: command.teamId,
-        name: command.name,
         orgId,
       });
-      throw new UnexpectedTeamError(error);
+      throw new TeamNotFoundError(command.teamId);
     }
+
+    // Only check for duplicates if the name is being changed
+    if (team.name !== trimmedName) {
+      const existingTeam = await this.teamsRepository.findByNameAndOrgId(
+        trimmedName,
+        orgId,
+      );
+
+      if (existingTeam && existingTeam.id !== command.teamId) {
+        this.logger.warn('Team with this name already exists', {
+          name: trimmedName,
+          orgId,
+        });
+        throw new TeamNameAlreadyExistsError(trimmedName);
+      }
+    }
+
+    this.logger.debug('Updating team', {
+      id: team.id,
+      oldName: team.name,
+      newName: trimmedName,
+    });
+
+    team.name = trimmedName;
+    if (command.modelOverrideEnabled !== undefined) {
+      team.modelOverrideEnabled = command.modelOverrideEnabled;
+    }
+    team.updatedAt = new Date();
+
+    const updatedTeam = await this.teamsRepository.update(team);
+
+    this.logger.debug('Team updated successfully', {
+      id: updatedTeam.id,
+      name: updatedTeam.name,
+    });
+
+    return updatedTeam;
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/utils/find-team-in-organization.ts
+++ b/ayunis-core-backend/src/iam/teams/application/utils/find-team-in-organization.ts
@@ -1,0 +1,30 @@
+import type { UUID } from 'crypto';
+import type { Logger } from '@nestjs/common';
+import type { TeamsRepository } from '../ports/teams.repository';
+import type { Team } from '../../domain/team.entity';
+import { TeamNotFoundError } from '../teams.errors';
+
+export async function findTeamInOrganization(
+  teamsRepository: TeamsRepository,
+  teamId: UUID,
+  orgId: UUID,
+  logger: Logger,
+): Promise<Team> {
+  const team = await teamsRepository.findById(teamId);
+
+  if (!team) {
+    logger.error('Team not found', { teamId });
+    throw new TeamNotFoundError(teamId);
+  }
+
+  if (team.orgId !== orgId) {
+    logger.error('Team does not belong to organization', {
+      teamId,
+      teamOrgId: team.orgId,
+      requestOrgId: orgId,
+    });
+    throw new TeamNotFoundError(teamId);
+  }
+
+  return team;
+}

--- a/ayunis-core-backend/src/iam/trials/application/trial.errors.ts
+++ b/ayunis-core-backend/src/iam/trials/application/trial.errors.ts
@@ -124,15 +124,38 @@ export class TrialUpdateFailedError extends TrialError {
  * Error thrown when an unexpected error occurs during trial operations
  */
 export class UnexpectedTrialError extends TrialError {
-  constructor(orgId: UUID, reason?: string, metadata?: ErrorMetadata) {
+  constructor(error: Error, metadata?: ErrorMetadata);
+  constructor(orgId: UUID, reason?: string, metadata?: ErrorMetadata);
+  // The overload preserves the legacy org/reason API while accepting Error causes.
+  // eslint-disable-next-line complexity
+  constructor(
+    errorOrOrgId: Error | UUID,
+    reasonOrMetadata?: string | ErrorMetadata,
+    metadata?: ErrorMetadata,
+  ) {
+    const isError = errorOrOrgId instanceof Error;
+    const orgId = isError ? undefined : errorOrOrgId;
+    const reason = isError
+      ? undefined
+      : typeof reasonOrMetadata === 'string'
+        ? reasonOrMetadata
+        : undefined;
+    const errorMetadata = isError
+      ? reasonOrMetadata && typeof reasonOrMetadata !== 'string'
+        ? reasonOrMetadata
+        : metadata
+      : metadata;
     super(
-      `Unexpected trial error for organization '${orgId}'${reason ? `: ${reason}` : ''}`,
+      isError
+        ? `Unexpected trial error: ${errorOrOrgId.message}`
+        : `Unexpected trial error for organization '${orgId}'${reason ? `: ${reason}` : ''}`,
       TrialErrorCode.UNEXPECTED_ERROR,
       500,
       {
-        orgId,
-        reason,
-        ...metadata,
+        ...(orgId && { orgId }),
+        ...(reason && { reason }),
+        ...(isError && { error: errorOrOrgId }),
+        ...errorMetadata,
       },
     );
   }

--- a/ayunis-core-backend/src/iam/trials/application/use-cases/create-trial/create-trial.use-case.ts
+++ b/ayunis-core-backend/src/iam/trials/application/use-cases/create-trial/create-trial.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { Trial } from 'src/iam/trials/domain/trial.entity';
 import { TrialRepository } from '../../ports/trial.repository';
@@ -7,7 +8,6 @@ import {
   TrialAlreadyExistsError,
   UnexpectedTrialError,
 } from '../../trial.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class CreateTrialUseCase {
@@ -15,72 +15,55 @@ export class CreateTrialUseCase {
 
   constructor(private readonly trialRepository: TrialRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedTrialError)
   async execute(command: CreateTrialCommand): Promise<Trial> {
     this.logger.log('Creating trial for organization', {
       orgId: command.orgId,
       maxMessages: command.maxMessages,
     });
 
-    try {
-      this.logger.debug('Checking if trial already exists');
-      const existingTrial = await this.trialRepository.findByOrgId(
-        command.orgId,
-      );
+    this.logger.debug('Checking if trial already exists');
+    const existingTrial = await this.trialRepository.findByOrgId(command.orgId);
 
-      if (existingTrial) {
-        this.logger.warn('Trial already exists for organization', {
-          orgId: command.orgId,
-          existingTrialId: existingTrial.id,
-        });
-
-        throw new TrialAlreadyExistsError(command.orgId, {
-          existingTrialId: existingTrial.id,
-        });
-      }
-
-      this.logger.debug('Creating trial entity');
-      const trial = new Trial({
+    if (existingTrial) {
+      this.logger.warn('Trial already exists for organization', {
         orgId: command.orgId,
-        maxMessages: command.maxMessages,
-        messagesSent: 0,
+        existingTrialId: existingTrial.id,
       });
 
-      this.logger.debug('Saving trial to repository');
-      const createdTrial = await this.trialRepository.create(trial);
-
-      if (!createdTrial) {
-        this.logger.error('Failed to create trial in repository', {
-          orgId: command.orgId,
-        });
-
-        throw new TrialCreationFailedError(
-          command.orgId,
-          'Repository operation failed',
-        );
-      }
-
-      this.logger.log('Trial created successfully', {
-        trialId: createdTrial.id,
-        orgId: createdTrial.orgId,
-        maxMessages: createdTrial.maxMessages,
-        messagesSent: createdTrial.messagesSent,
+      throw new TrialAlreadyExistsError(command.orgId, {
+        existingTrialId: existingTrial.id,
       });
+    }
 
-      return createdTrial;
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
+    this.logger.debug('Creating trial entity');
+    const trial = new Trial({
+      orgId: command.orgId,
+      maxMessages: command.maxMessages,
+      messagesSent: 0,
+    });
 
-      this.logger.error('Trial creation failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
+    this.logger.debug('Saving trial to repository');
+    const createdTrial = await this.trialRepository.create(trial);
+
+    if (!createdTrial) {
+      this.logger.error('Failed to create trial in repository', {
         orgId: command.orgId,
-        maxMessages: command.maxMessages,
       });
 
-      throw new UnexpectedTrialError(
+      throw new TrialCreationFailedError(
         command.orgId,
-        'Unexpected error during trial creation',
-        { ...(error instanceof Error && { originalError: error.message }) },
+        'Repository operation failed',
       );
     }
+
+    this.logger.log('Trial created successfully', {
+      trialId: createdTrial.id,
+      orgId: createdTrial.orgId,
+      maxMessages: createdTrial.maxMessages,
+      messagesSent: createdTrial.messagesSent,
+    });
+
+    return createdTrial;
   }
 }

--- a/ayunis-core-backend/src/iam/trials/application/use-cases/get-trial/get-trial.use-case.ts
+++ b/ayunis-core-backend/src/iam/trials/application/use-cases/get-trial/get-trial.use-case.ts
@@ -1,9 +1,9 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { Trial } from 'src/iam/trials/domain/trial.entity';
 import { TrialRepository } from '../../ports/trial.repository';
 import { GetTrialQuery } from './get-trial.query';
 import { TrialNotFoundError, UnexpectedTrialError } from '../../trial.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetTrialUseCase {
@@ -11,37 +11,19 @@ export class GetTrialUseCase {
 
   constructor(private readonly trialRepository: TrialRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedTrialError)
   async execute(query: GetTrialQuery): Promise<Trial> {
     this.logger.debug('Getting trial for organization', {
       orgId: query.orgId,
     });
 
-    try {
-      this.logger.debug('Finding trial in repository');
-      const trial = await this.trialRepository.findByOrgId(query.orgId);
+    this.logger.debug('Finding trial in repository');
+    const trial = await this.trialRepository.findByOrgId(query.orgId);
 
-      if (!trial) {
-        throw new TrialNotFoundError(query.orgId);
-      }
-
-      return trial;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        // Already logged and properly typed error, just rethrow
-        throw error;
-      }
-      this.logger.error('Failed to get trial', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: query.orgId,
-      });
-      throw new UnexpectedTrialError(
-        query.orgId,
-        'Unexpected error during trial retrieval',
-        {
-          operation: 'get-trial',
-          ...(error instanceof Error && { originalError: error.message }),
-        },
-      );
+    if (!trial) {
+      throw new TrialNotFoundError(query.orgId);
     }
+
+    return trial;
   }
 }

--- a/ayunis-core-backend/src/iam/trials/application/use-cases/increment-trial-messages/increment-trial-messages.use-case.ts
+++ b/ayunis-core-backend/src/iam/trials/application/use-cases/increment-trial-messages/increment-trial-messages.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { Trial } from 'src/iam/trials/domain/trial.entity';
 import { TrialRepository } from '../../ports/trial.repository';
@@ -8,7 +9,6 @@ import {
   TrialUpdateFailedError,
   UnexpectedTrialError,
 } from '../../trial.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class IncrementTrialMessagesUseCase {
@@ -16,82 +16,63 @@ export class IncrementTrialMessagesUseCase {
 
   constructor(private readonly trialRepository: TrialRepository) {}
 
+  @HandleUnexpectedErrors(UnexpectedTrialError)
   async execute(command: IncrementTrialMessagesCommand): Promise<Trial> {
     this.logger.debug('Incrementing trial messages', {
       orgId: command.orgId,
     });
 
-    try {
-      this.logger.debug('Finding trial for organization');
-      const currentTrial = await this.trialRepository.findByOrgId(
-        command.orgId,
-      );
+    this.logger.debug('Finding trial for organization');
+    const currentTrial = await this.trialRepository.findByOrgId(command.orgId);
 
-      if (!currentTrial) {
-        this.logger.warn('Trial not found for organization', {
-          orgId: command.orgId,
-        });
-
-        throw new TrialNotFoundError(command.orgId);
-      }
-
-      this.logger.debug('Checking trial capacity');
-      if (currentTrial.messagesSent >= currentTrial.maxMessages) {
-        this.logger.warn('Trial capacity exceeded, cannot increment', {
-          orgId: command.orgId,
-          messagesSent: currentTrial.messagesSent,
-          maxMessages: currentTrial.maxMessages,
-          remainingMessages:
-            currentTrial.maxMessages - currentTrial.messagesSent,
-        });
-
-        throw new TrialCapacityExceededError(
-          command.orgId,
-          currentTrial.messagesSent,
-          currentTrial.maxMessages,
-        );
-      }
-
-      this.logger.debug('Incrementing trial message count');
-      const updatedTrial = await this.trialRepository.incrementMessagesSent(
-        command.orgId,
-      );
-
-      if (!updatedTrial) {
-        this.logger.error('Failed to increment trial messages in repository', {
-          orgId: command.orgId,
-        });
-
-        throw new TrialUpdateFailedError(
-          command.orgId,
-          'Repository operation failed',
-          { operation: 'incrementMessagesSent' },
-        );
-      }
-
-      this.logger.log('Trial messages incremented successfully', {
-        orgId: command.orgId,
-        messagesSent: updatedTrial.messagesSent,
-        maxMessages: updatedTrial.maxMessages,
-        remainingMessages: updatedTrial.maxMessages - updatedTrial.messagesSent,
-      });
-
-      return updatedTrial;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-
-      this.logger.error('Failed to increment trial messages', {
-        error: error instanceof Error ? error.message : 'Unknown error',
+    if (!currentTrial) {
+      this.logger.warn('Trial not found for organization', {
         orgId: command.orgId,
       });
 
-      throw new UnexpectedTrialError(
+      throw new TrialNotFoundError(command.orgId);
+    }
+
+    this.logger.debug('Checking trial capacity');
+    if (currentTrial.messagesSent >= currentTrial.maxMessages) {
+      this.logger.warn('Trial capacity exceeded, cannot increment', {
+        orgId: command.orgId,
+        messagesSent: currentTrial.messagesSent,
+        maxMessages: currentTrial.maxMessages,
+        remainingMessages: currentTrial.maxMessages - currentTrial.messagesSent,
+      });
+
+      throw new TrialCapacityExceededError(
         command.orgId,
-        'Unexpected error during trial message increment',
-        { ...(error instanceof Error && { originalError: error.message }) },
+        currentTrial.messagesSent,
+        currentTrial.maxMessages,
       );
     }
+
+    this.logger.debug('Incrementing trial message count');
+    const updatedTrial = await this.trialRepository.incrementMessagesSent(
+      command.orgId,
+    );
+
+    if (!updatedTrial) {
+      this.logger.error('Failed to increment trial messages in repository', {
+        orgId: command.orgId,
+      });
+
+      throw new TrialUpdateFailedError(
+        command.orgId,
+        'Repository operation failed',
+        { operation: 'incrementMessagesSent' },
+      );
+    }
+
+    this.logger.log('Trial messages incremented successfully', {
+      orgId: command.orgId,
+      messagesSent: updatedTrial.messagesSent,
+      maxMessages: updatedTrial.maxMessages,
+      remainingMessages: updatedTrial.maxMessages - updatedTrial.messagesSent,
+    });
+
+    return updatedTrial;
   }
 }

--- a/ayunis-core-backend/src/iam/trials/application/use-cases/update-trial/update-trial.use-case.ts
+++ b/ayunis-core-backend/src/iam/trials/application/use-cases/update-trial/update-trial.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { Trial } from 'src/iam/trials/domain/trial.entity';
 import { TrialRepository } from '../../ports/trial.repository';
@@ -7,7 +8,6 @@ import {
   TrialUpdateFailedError,
   UnexpectedTrialError,
 } from '../../trial.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -21,87 +21,70 @@ export class UpdateTrialUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  // Trial updates coordinate access, validation, and persistence rules.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UnexpectedTrialError)
   async execute(command: UpdateTrialCommand): Promise<Trial> {
-    try {
-      this.logger.debug('Finding existing trial');
-      const systemRole = this.contextService.get<SystemRole>('systemRole');
-      if (systemRole !== SystemRole.SUPER_ADMIN) {
-        throw new UnauthorizedAccessError({
-          orgId: command.orgId,
-          systemRole: systemRole,
-        });
-      }
-      this.logger.log('Updating trial for organization', {
+    this.logger.debug('Finding existing trial');
+    const systemRole = this.contextService.get<SystemRole>('systemRole');
+    if (systemRole !== SystemRole.SUPER_ADMIN) {
+      throw new UnauthorizedAccessError({
         orgId: command.orgId,
-        maxMessages: command.maxMessages,
-        messagesSent: command.messagesSent,
+        systemRole: systemRole,
       });
-      const existingTrial = await this.trialRepository.findByOrgId(
-        command.orgId,
-      );
+    }
+    this.logger.log('Updating trial for organization', {
+      orgId: command.orgId,
+      maxMessages: command.maxMessages,
+      messagesSent: command.messagesSent,
+    });
+    const existingTrial = await this.trialRepository.findByOrgId(command.orgId);
 
-      if (!existingTrial) {
-        this.logger.warn('Trial not found for organization', {
-          orgId: command.orgId,
-        });
-
-        throw new TrialNotFoundError(command.orgId);
-      }
-
-      this.logger.debug('Updating trial entity');
-      const updatedTrial = new Trial({
-        id: existingTrial.id,
-        createdAt: existingTrial.createdAt,
-        updatedAt: new Date(),
-        orgId: existingTrial.orgId,
-        messagesSent:
-          command.messagesSent !== undefined
-            ? command.messagesSent
-            : existingTrial.messagesSent,
-        maxMessages:
-          command.maxMessages !== undefined
-            ? command.maxMessages
-            : existingTrial.maxMessages,
-      });
-
-      this.logger.debug('Saving updated trial to repository');
-      const savedTrial = await this.trialRepository.update(updatedTrial);
-
-      if (!savedTrial) {
-        this.logger.error('Failed to update trial in repository', {
-          orgId: command.orgId,
-        });
-
-        throw new TrialUpdateFailedError(
-          command.orgId,
-          'Repository operation failed',
-        );
-      }
-
-      this.logger.log('Trial updated successfully', {
-        trialId: savedTrial.id,
-        orgId: savedTrial.orgId,
-        maxMessages: savedTrial.maxMessages,
-        messagesSent: savedTrial.messagesSent,
-      });
-
-      return savedTrial;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        // Already logged and properly typed error, just rethrow
-        throw error;
-      }
-
-      this.logger.error('Trial update failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
+    if (!existingTrial) {
+      this.logger.warn('Trial not found for organization', {
         orgId: command.orgId,
       });
 
-      throw new UnexpectedTrialError(
+      throw new TrialNotFoundError(command.orgId);
+    }
+
+    this.logger.debug('Updating trial entity');
+    const updatedTrial = new Trial({
+      id: existingTrial.id,
+      createdAt: existingTrial.createdAt,
+      updatedAt: new Date(),
+      orgId: existingTrial.orgId,
+      messagesSent:
+        command.messagesSent !== undefined
+          ? command.messagesSent
+          : existingTrial.messagesSent,
+      maxMessages:
+        command.maxMessages !== undefined
+          ? command.maxMessages
+          : existingTrial.maxMessages,
+    });
+
+    this.logger.debug('Saving updated trial to repository');
+    const savedTrial = await this.trialRepository.update(updatedTrial);
+
+    if (!savedTrial) {
+      this.logger.error('Failed to update trial in repository', {
+        orgId: command.orgId,
+      });
+
+      throw new TrialUpdateFailedError(
         command.orgId,
-        'Unexpected error during trial update',
-        { ...(error instanceof Error && { originalError: error.message }) },
+        'Repository operation failed',
       );
     }
+
+    this.logger.log('Trial updated successfully', {
+      trialId: savedTrial.id,
+      orgId: savedTrial.orgId,
+      maxMessages: savedTrial.maxMessages,
+      messagesSent: savedTrial.messagesSent,
+    });
+
+    return savedTrial;
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/admin-trigger-password-reset/admin-trigger-password-reset.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/admin-trigger-password-reset/admin-trigger-password-reset.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UserUnexpectedError } from 'src/iam/users/application/users.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { AdminTriggerPasswordResetCommand } from './admin-trigger-password-reset.command';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -16,6 +18,7 @@ export class AdminTriggerPasswordResetUseCase {
     private readonly triggerPasswordResetUseCase: TriggerPasswordResetUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: AdminTriggerPasswordResetCommand): Promise<void> {
     this.logger.log('adminTriggerPasswordReset', { userId: command.userId });
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/admin-update-user/admin-update-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/admin-update-user/admin-update-user.use-case.ts
@@ -1,6 +1,6 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UsersRepository } from '../../ports/users.repository';
 import { AdminUpdateUserCommand } from './admin-update-user.command';
@@ -27,6 +27,7 @@ export class AdminUpdateUserUseCase {
     private readonly sendConfirmationEmailUseCase: SendConfirmationEmailUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: AdminUpdateUserCommand): Promise<User> {
     this.logger.log('adminUpdateUser', {
       userId: command.userId,
@@ -37,30 +38,19 @@ export class AdminUpdateUserUseCase {
     this.assertHasFieldsToUpdate(command);
     const requesterOrgId = this.readRequesterOrgId();
 
-    try {
-      const targetUser = await this.loadTargetUser(
-        command.userId,
-        requesterOrgId,
-      );
+    const targetUser = await this.loadTargetUser(
+      command.userId,
+      requesterOrgId,
+    );
 
-      const emailChanged = await this.applyChanges(targetUser, command);
+    const emailChanged = await this.applyChanges(targetUser, command);
 
-      const updatedUser = await this.usersRepository.update(targetUser);
-      this.emitUserUpdated(updatedUser);
-      if (emailChanged) {
-        await this.sendConfirmationEmail(updatedUser);
-      }
-      return updatedUser;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to update user', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        userId: command.userId,
-      });
-      throw new UserUnexpectedError(error as Error);
+    const updatedUser = await this.usersRepository.update(targetUser);
+    this.emitUserUpdated(updatedUser);
+    if (emailChanged) {
+      await this.sendConfirmationEmail(updatedUser);
     }
+    return updatedUser;
   }
 
   private assertHasFieldsToUpdate(command: AdminUpdateUserCommand): void {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/confirm-email/confirm-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/confirm-email/confirm-email.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ConfirmEmailCommand } from './confirm-email.command';
@@ -12,7 +13,6 @@ import {
   EmailConfirmationJwtService,
   EmailConfirmationJwtPayload,
 } from '../../services/email-confirmation-jwt.service';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UserUpdatedEvent } from '../../events/user-updated.event';
 
 @Injectable()
@@ -25,6 +25,7 @@ export class ConfirmEmailUseCase {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: ConfirmEmailCommand): Promise<void> {
     this.logger.log('execute', { hasToken: !!command.token });
 
@@ -41,52 +42,42 @@ export class ConfirmEmailUseCase {
       throw new InvalidEmailConfirmationTokenError('Token verification failed');
     }
 
-    try {
-      // Find the user in the database
-      const user = await this.usersRepository.findOneById(payload.userId);
-      if (!user) {
-        this.logger.error('User not found', { userId: payload.userId });
-        throw new UserNotFoundError(payload.userId);
-      }
-
-      // Verify the email matches
-      if (user.email !== payload.email) {
-        this.logger.error('Email mismatch', {
-          userId: payload.userId,
-          payloadEmail: payload.email,
-          userEmail: user.email,
-        });
-        throw new UserEmailMismatchError(payload.userId);
-      }
-
-      // Confirm the email
-      user.emailVerified = true;
-      await this.usersRepository.update(user);
-
-      this.logger.debug('Email confirmed successfully', {
-        userId: user.id,
-        email: user.email,
-      });
-
-      this.eventEmitter
-        .emitAsync(
-          UserUpdatedEvent.EVENT_NAME,
-          new UserUpdatedEvent(user.id, user.orgId, user),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit UserUpdatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            userId: user.id,
-          });
-        });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to confirm email', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UserUnexpectedError(error as Error);
+    // Find the user in the database
+    const user = await this.usersRepository.findOneById(payload.userId);
+    if (!user) {
+      this.logger.error('User not found', { userId: payload.userId });
+      throw new UserNotFoundError(payload.userId);
     }
+
+    // Verify the email matches
+    if (user.email !== payload.email) {
+      this.logger.error('Email mismatch', {
+        userId: payload.userId,
+        payloadEmail: payload.email,
+        userEmail: user.email,
+      });
+      throw new UserEmailMismatchError(payload.userId);
+    }
+
+    // Confirm the email
+    user.emailVerified = true;
+    await this.usersRepository.update(user);
+
+    this.logger.debug('Email confirmed successfully', {
+      userId: user.id,
+      email: user.email,
+    });
+
+    this.eventEmitter
+      .emitAsync(
+        UserUpdatedEvent.EVENT_NAME,
+        new UserUpdatedEvent(user.id, user.orgId, user),
+      )
+      .catch((err: unknown) => {
+        this.logger.error('Failed to emit UserUpdatedEvent', {
+          error: err instanceof Error ? err.message : 'Unknown error',
+          userId: user.id,
+        });
+      });
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-admin-user/create-admin-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-admin-user/create-admin-user.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UserUnexpectedError } from 'src/iam/users/application/users.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { CreateAdminUserCommand } from './create-admin-user.command';
 import { User } from '../../../domain/user.entity';
@@ -11,6 +13,7 @@ export class CreateAdminUserUseCase {
 
   constructor(private readonly createUserUseCase: CreateUserUseCase) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: CreateAdminUserCommand): Promise<User> {
     this.logger.log('createAdmin', {
       email: command.email,

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-regular-user/create-regular-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-regular-user/create-regular-user.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UserUnexpectedError } from 'src/iam/users/application/users.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { CreateRegularUserCommand } from './create-regular-user.command';
 import { User } from '../../../domain/user.entity';
@@ -11,6 +13,7 @@ export class CreateRegularUserUseCase {
 
   constructor(private readonly createUserUseCase: CreateUserUseCase) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: CreateRegularUserCommand): Promise<User> {
     this.logger.log('createUser', {
       email: command.email,

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UserUnexpectedError } from 'src/iam/users/application/users.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UsersRepository } from '../../ports/users.repository';
@@ -26,6 +28,9 @@ export class CreateUserUseCase {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
+  // User creation coordinates validation, hashing, persistence, and events.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: CreateUserCommand): Promise<User> {
     this.logger.log('createUser', {
       email: command.email,

--- a/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.spec.ts
@@ -19,7 +19,7 @@ import { DeleteInviteByEmailUseCase } from 'src/iam/invites/application/use-case
 import { ContextService } from 'src/common/context/services/context.service';
 import { User } from 'src/iam/users/domain/user.entity';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
-import { UserUnauthorizedError } from '../../users.errors';
+import { UserUnexpectedError, UserUnauthorizedError } from '../../users.errors';
 
 describe('DeleteUserUseCase', () => {
   let useCase: DeleteUserUseCase;
@@ -179,7 +179,7 @@ describe('DeleteUserUseCase', () => {
     jest.spyOn(mockUsersRepository, 'findOneById').mockResolvedValue(mockUser);
     jest.spyOn(mockUsersRepository, 'delete').mockRejectedValue(error);
 
-    await expect(useCase.execute(command)).rejects.toThrow('Repository error');
+    await expect(useCase.execute(command)).rejects.toThrow(UserUnexpectedError);
     expect(mockUsersRepository.findOneById).toHaveBeenCalledWith(
       command.userId,
     );

--- a/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UserUnexpectedError } from 'src/iam/users/application/users.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UsersRepository } from '../../ports/users.repository';
@@ -25,6 +27,7 @@ export class DeleteUserUseCase {
   ) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: DeleteUserCommand): Promise<void> {
     this.logger.log('deleteUser', { userId: command.userId });
     const requestingUserId = this.contextService.get('userId');

--- a/ayunis-core-backend/src/iam/users/application/use-cases/demote-from-super-admin/demote-from-super-admin.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/demote-from-super-admin/demote-from-super-admin.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
 import { UsersRepository } from '../../ports/users.repository';
@@ -10,7 +11,6 @@ import {
   UserSelfDemotionNotAllowedError,
   UserLastSuperAdminError,
 } from '../../users.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class DemoteFromSuperAdminUseCase {
@@ -19,43 +19,34 @@ export class DemoteFromSuperAdminUseCase {
   constructor(private readonly usersRepository: UsersRepository) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: DemoteFromSuperAdminCommand): Promise<void> {
     this.logger.log('execute', {
       userId: command.userId,
       requestingUserId: command.requestingUserId,
     });
 
-    try {
-      if (command.userId === command.requestingUserId) {
-        throw new UserSelfDemotionNotAllowedError();
-      }
-
-      const user = await this.usersRepository.findOneById(command.userId);
-      if (!user) {
-        throw new UserNotFoundError(command.userId);
-      }
-
-      if (user.systemRole !== SystemRole.SUPER_ADMIN) {
-        throw new UserNotSuperAdminError(command.userId);
-      }
-
-      const superAdmins = await this.usersRepository.findManyBySystemRole(
-        SystemRole.SUPER_ADMIN,
-      );
-      if (superAdmins.length <= 1) {
-        throw new UserLastSuperAdminError();
-      }
-
-      user.systemRole = SystemRole.CUSTOMER;
-      await this.usersRepository.update(user);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error demoting user from super admin', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UserUnexpectedError(error as Error);
+    if (command.userId === command.requestingUserId) {
+      throw new UserSelfDemotionNotAllowedError();
     }
+
+    const user = await this.usersRepository.findOneById(command.userId);
+    if (!user) {
+      throw new UserNotFoundError(command.userId);
+    }
+
+    if (user.systemRole !== SystemRole.SUPER_ADMIN) {
+      throw new UserNotSuperAdminError(command.userId);
+    }
+
+    const superAdmins = await this.usersRepository.findManyBySystemRole(
+      SystemRole.SUPER_ADMIN,
+    );
+    if (superAdmins.length <= 1) {
+      throw new UserLastSuperAdminError();
+    }
+
+    user.systemRole = SystemRole.CUSTOMER;
+    await this.usersRepository.update(user);
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/export-admin-users/export-admin-users.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/export-admin-users/export-admin-users.use-case.ts
@@ -1,10 +1,11 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { convertCSVToString } from 'src/common/util/csv';
 import {
   AdminUserExportRow,
   AdminUsersExportRepository,
 } from '../../ports/admin-users-export.repository';
-import { UserError, UserUnexpectedError } from '../../users.errors';
+import { UserUnexpectedError } from '../../users.errors';
 
 @Injectable()
 export class ExportAdminUsersUseCase {
@@ -14,36 +15,27 @@ export class ExportAdminUsersUseCase {
     private readonly adminUsersExportRepository: AdminUsersExportRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(): Promise<string> {
     this.logger.log('Exporting admin users for subscribed organizations');
 
-    try {
-      const rows =
-        await this.adminUsersExportRepository.findSubscribedOrgAdmins();
+    const rows =
+      await this.adminUsersExportRepository.findSubscribedOrgAdmins();
 
-      return convertCSVToString({
-        headers: [
-          'Eindeutige ID',
-          'Vorname',
-          'Nachname',
-          'E-Mail',
-          'Rolle',
-          'Organisation',
-          'Teams',
-          'Abonnement',
-          'Abonnement Startdatum',
-        ],
-        rows: rows.map((row) => this.toCsvRow(row)),
-      });
-    } catch (error) {
-      if (error instanceof UserError) {
-        throw error;
-      }
-      this.logger.error('Error exporting admin users', {
-        error: error as Error,
-      });
-      throw new UserUnexpectedError(error as Error);
-    }
+    return convertCSVToString({
+      headers: [
+        'Eindeutige ID',
+        'Vorname',
+        'Nachname',
+        'E-Mail',
+        'Rolle',
+        'Organisation',
+        'Teams',
+        'Abonnement',
+        'Abonnement Startdatum',
+      ],
+      rows: rows.map((row) => this.toCsvRow(row)),
+    });
   }
 
   private toCsvRow(row: AdminUserExportRow): string[] {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-all-user-ids-by-org-id/find-all-user-ids-by-org-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-all-user-ids-by-org-id/find-all-user-ids-by-org-id.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UserUnexpectedError } from 'src/iam/users/application/users.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { UUID } from 'crypto';
 import { UsersRepository } from '../../ports/users.repository';
@@ -13,6 +15,7 @@ export class FindAllUserIdsByOrgIdUseCase {
 
   constructor(private readonly usersRepository: UsersRepository) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(query: FindAllUserIdsByOrgIdQuery): Promise<UUID[]> {
     this.logger.log('execute', { orgId: query.orgId });
     return this.usersRepository.findAllIdsByOrgId(query.orgId);

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-super-admins/find-super-admins.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-super-admins/find-super-admins.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { UsersRepository } from '../../ports/users.repository';
 import { User } from '../../../domain/user.entity';
@@ -10,17 +11,12 @@ export class FindSuperAdminsUseCase {
 
   constructor(private readonly usersRepository: UsersRepository) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(): Promise<User[]> {
     this.logger.log('execute');
-    try {
-      return await this.usersRepository.findManyBySystemRole(
-        SystemRole.SUPER_ADMIN,
-      );
-    } catch (error) {
-      this.logger.error('Error finding super admins', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UserUnexpectedError(error as Error);
-    }
+
+    return await this.usersRepository.findManyBySystemRole(
+      SystemRole.SUPER_ADMIN,
+    );
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-user-by-email/find-user-by-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-user-by-email/find-user-by-email.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UserUnexpectedError } from 'src/iam/users/application/users.errors';
 import { Injectable } from '@nestjs/common';
 import { FindUserByEmailQuery } from './find-user-by-email.query';
 import { User } from 'src/iam/users/domain/user.entity';
@@ -7,6 +9,7 @@ import { UsersRepository } from '../../ports/users.repository';
 export class FindUserByEmailUseCase {
   constructor(private readonly usersRepository: UsersRepository) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(query: FindUserByEmailQuery): Promise<User | null> {
     return await this.usersRepository.findOneByEmail(query.email);
   }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case.ts
@@ -1,12 +1,9 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { UsersRepository } from '../../ports/users.repository';
 import { FindUserByIdQuery } from './find-user-by-id.query';
 import { User } from '../../../domain/user.entity';
-import {
-  UserError,
-  UserNotFoundError,
-  UserUnexpectedError,
-} from '../../users.errors';
+import { UserNotFoundError, UserUnexpectedError } from '../../users.errors';
 
 @Injectable()
 export class FindUserByIdUseCase {
@@ -14,19 +11,14 @@ export class FindUserByIdUseCase {
 
   constructor(private readonly usersRepository: UsersRepository) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(query: FindUserByIdQuery): Promise<User> {
     this.logger.log('findOneById', { id: query.id });
-    try {
-      const user = await this.usersRepository.findOneById(query.id);
-      if (!user) {
-        throw new UserNotFoundError(query.id);
-      }
-      return user;
-    } catch (error) {
-      if (error instanceof UserError) {
-        throw error;
-      }
-      throw new UserUnexpectedError(error as Error);
+
+    const user = await this.usersRepository.findOneById(query.id);
+    if (!user) {
+      throw new UserNotFoundError(query.id);
     }
+    return user;
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case.ts
@@ -1,8 +1,9 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { UsersRepository } from '../../ports/users.repository';
 import { FindUsersByIdsQuery } from './find-users-by-ids.query';
 import { User } from '../../../domain/user.entity';
-import { UserError, UserUnexpectedError } from '../../users.errors';
+import { UserUnexpectedError } from '../../users.errors';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
@@ -15,6 +16,7 @@ export class FindUsersByIdsUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(query: FindUsersByIdsQuery): Promise<User[]> {
     const orgId = this.contextService.get('orgId');
 
@@ -24,13 +26,6 @@ export class FindUsersByIdsUseCase {
 
     this.logger.log('execute', { idCount: query.ids.length, orgId });
 
-    try {
-      return await this.usersRepository.findManyByIdsAndOrgId(query.ids, orgId);
-    } catch (error) {
-      if (error instanceof UserError) {
-        throw error;
-      }
-      throw new UserUnexpectedError(error as Error);
-    }
+    return await this.usersRepository.findManyByIdsAndOrgId(query.ids, orgId);
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UserUnexpectedError } from 'src/iam/users/application/users.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { UsersRepository } from '../../ports/users.repository';
 import { FindUsersByOrgIdQuery } from './find-users-by-org-id.query';
@@ -17,6 +19,7 @@ export class FindUsersByOrgIdUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(query: FindUsersByOrgIdQuery): Promise<Paginated<User>> {
     this.logger.log('findManyByOrgId', {
       orgId: query.orgId,
@@ -26,9 +29,9 @@ export class FindUsersByOrgIdUseCase {
     });
     const systemRole = this.contextService.get('systemRole');
     const orgRole = this.contextService.get('role');
-    if (
-      !(systemRole === SystemRole.SUPER_ADMIN || orgRole === UserRole.ADMIN)
-    ) {
+    if (!(
+      systemRole === SystemRole.SUPER_ADMIN || orgRole === UserRole.ADMIN
+    )) {
       throw new UnauthorizedAccessError({ orgId: query.orgId });
     }
     return this.usersRepository.findManyByOrgId(

--- a/ayunis-core-backend/src/iam/users/application/use-cases/is-valid-password/is-valid-password.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/is-valid-password/is-valid-password.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UserUnexpectedError } from 'src/iam/users/application/users.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { UsersRepository } from '../../ports/users.repository';
 import { IsValidPasswordQuery } from './is-valid-password.query';
@@ -8,6 +10,7 @@ export class IsValidPasswordUseCase {
 
   constructor(private readonly usersRepository: UsersRepository) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(query: IsValidPasswordQuery): Promise<boolean> {
     return this.usersRepository.isValidPassword(query.password);
   }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/promote-to-super-admin/promote-to-super-admin.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/promote-to-super-admin/promote-to-super-admin.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
 import { UsersRepository } from '../../ports/users.repository';
@@ -5,7 +6,6 @@ import { PromoteToSuperAdminCommand } from './promote-to-super-admin.command';
 import { User } from '../../../domain/user.entity';
 import { SystemRole } from '../../../domain/value-objects/system-role.enum';
 import { UserNotFoundError, UserUnexpectedError } from '../../users.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class PromoteToSuperAdminUseCase {
@@ -14,30 +14,21 @@ export class PromoteToSuperAdminUseCase {
   constructor(private readonly usersRepository: UsersRepository) {}
 
   @Transactional()
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: PromoteToSuperAdminCommand): Promise<User> {
     this.logger.log('execute');
 
-    try {
-      const user = await this.usersRepository.findOneByEmail(command.email);
-      if (!user) {
-        throw new UserNotFoundError(command.email);
-      }
-
-      if (user.systemRole === SystemRole.SUPER_ADMIN) {
-        return user;
-      }
-
-      user.systemRole = SystemRole.SUPER_ADMIN;
-
-      return await this.usersRepository.update(user);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error promoting user to super admin', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UserUnexpectedError(error as Error);
+    const user = await this.usersRepository.findOneByEmail(command.email);
+    if (!user) {
+      throw new UserNotFoundError(command.email);
     }
+
+    if (user.systemRole === SystemRole.SUPER_ADMIN) {
+      return user;
+    }
+
+    user.systemRole = SystemRole.SUPER_ADMIN;
+
+    return await this.usersRepository.update(user);
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/resend-email-confirmation/resend-email-confirmation.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/resend-email-confirmation/resend-email-confirmation.use-case.ts
@@ -1,7 +1,7 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { ResendEmailConfirmationCommand } from './resend-email-confirmation.command';
 import { UsersRepository } from '../../ports/users.repository';
-import { ApplicationError } from 'src/common/errors/base.error';
 import {
   UserEmailAlreadyVerifiedError,
   UserUnexpectedError,
@@ -18,32 +18,25 @@ export class ResendEmailConfirmationUseCase {
     private readonly sendConfirmationEmailUseCase: SendConfirmationEmailUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: ResendEmailConfirmationCommand): Promise<void> {
-    try {
-      this.logger.log('execute', { email: command.email });
+    this.logger.log('execute', { email: command.email });
 
-      // Find the user by email
-      const user = await this.usersRepository.findOneByEmail(command.email);
-      if (!user) {
-        this.logger.error('User not found', { email: command.email });
-        return; // Silently return without error for security reasons
-      }
-
-      await this.sendConfirmationEmailUseCase
-        .execute(new SendConfirmationEmailCommand(user))
-        .catch((error) => {
-          if (error instanceof UserEmailAlreadyVerifiedError) return; // Silently return without error for security reasons
-          this.logger.error('Error resending email confirmation', {
-            error: error instanceof Error ? error.message : 'Unknown error',
-          });
-          throw new UserUnexpectedError(error as Error);
-        });
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error resending email confirmation', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UserUnexpectedError(error as Error);
+    // Find the user by email
+    const user = await this.usersRepository.findOneByEmail(command.email);
+    if (!user) {
+      this.logger.error('User not found', { email: command.email });
+      return; // Silently return without error for security reasons
     }
+
+    await this.sendConfirmationEmailUseCase
+      .execute(new SendConfirmationEmailCommand(user))
+      .catch((error) => {
+        if (error instanceof UserEmailAlreadyVerifiedError) return; // Silently return without error for security reasons
+        this.logger.error('Error resending email confirmation', {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
+        throw new UserUnexpectedError(error as Error);
+      });
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/reset-password/reset-password.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/reset-password/reset-password.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { UsersRepository } from 'src/iam/users/application/ports/users.repository';
 import { ResetPasswordCommand } from './reset-password.command';
@@ -9,7 +10,6 @@ import { HashTextCommand } from 'src/iam/hashing/application/use-cases/hash-text
 import { HashTextUseCase } from 'src/iam/hashing/application/use-cases/hash-text/hash-text.use-case';
 import { HashingError } from 'src/iam/hashing/application/hashing.errors';
 import { PasswordResetJwtService } from '../../services/password-reset-jwt.service';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { IsValidPasswordUseCase } from 'src/iam/users/application/use-cases/is-valid-password/is-valid-password.use-case';
 import { IsValidPasswordQuery } from 'src/iam/users/application/use-cases/is-valid-password/is-valid-password.query';
 import { InvalidPasswordError } from '../../../../authentication/application/authentication.errors';
@@ -25,91 +25,83 @@ export class ResetPasswordUseCase {
     private readonly usersRepository: UsersRepository,
   ) {}
 
+  // Password reset coordinates token validation, hashing, and persistence.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UnexpectedAuthenticationError)
   async execute(command: ResetPasswordCommand): Promise<void> {
     this.logger.log('resetPassword', { hasToken: !!command.resetToken });
 
-    try {
-      // Verify the reset token
-      this.logger.debug('Verifying password reset token');
-      const tokenPayload =
-        this.passwordResetJwtService.verifyPasswordResetToken(
-          command.resetToken,
-        );
+    // Verify the reset token
+    this.logger.debug('Verifying password reset token');
+    const tokenPayload = this.passwordResetJwtService.verifyPasswordResetToken(
+      command.resetToken,
+    );
 
-      // Check if passwords match
-      if (command.newPassword !== command.newPasswordConfirmation) {
-        this.logger.warn('Password confirmation mismatch', {
-          userId: tokenPayload.userId,
-        });
-        throw new InvalidPasswordError('Passwords do not match');
-      }
-
-      // Validate password strength
-      const isValidPassword = await this.isValidPasswordUseCase.execute(
-        new IsValidPasswordQuery(command.newPassword),
-      );
-
-      if (!isValidPassword) {
-        this.logger.warn('Password does not meet security requirements', {
-          userId: tokenPayload.userId,
-        });
-        throw new InvalidPasswordError(
-          'Password does not meet security requirements',
-        );
-      }
-
-      // Find the user
-      const user = await this.usersRepository.findOneById(tokenPayload.userId);
-      if (!user) {
-        this.logger.error('User not found during password reset', {
-          userId: tokenPayload.userId,
-          email: tokenPayload.email,
-        });
-        throw new InvalidTokenError('Invalid token - user not found');
-      }
-
-      // Verify the email matches the token
-      if (user.email !== tokenPayload.email) {
-        this.logger.error('Email mismatch during password reset', {
-          userId: tokenPayload.userId,
-          tokenEmail: tokenPayload.email,
-          userEmail: user.email,
-        });
-        throw new InvalidTokenError('Invalid token - email mismatch');
-      }
-
-      // Hash the new password
-      this.logger.debug('Hashing new password', {
-        userId: user.id,
+    // Check if passwords match
+    if (command.newPassword !== command.newPasswordConfirmation) {
+      this.logger.warn('Password confirmation mismatch', {
+        userId: tokenPayload.userId,
       });
-      const newHashedPassword = await this.hashTextUseCase
-        .execute(new HashTextCommand(command.newPassword))
-        .catch((error) => {
-          if (error instanceof HashingError) {
-            throw error;
-          }
-          this.logger.error('Password hashing failed', {
-            error: error instanceof Error ? error.message : 'Unknown error',
-            userId: user.id,
-          });
-          throw new InvalidPasswordError('Password hashing failed');
-        });
-
-      user.passwordHash = newHashedPassword;
-      await this.usersRepository.update(user);
-
-      this.logger.debug('Password reset successfully', {
-        userId: user.id,
-        email: user.email,
-      });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Password reset failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedAuthenticationError(error);
+      throw new InvalidPasswordError('Passwords do not match');
     }
+
+    // Validate password strength
+    const isValidPassword = await this.isValidPasswordUseCase.execute(
+      new IsValidPasswordQuery(command.newPassword),
+    );
+
+    if (!isValidPassword) {
+      this.logger.warn('Password does not meet security requirements', {
+        userId: tokenPayload.userId,
+      });
+      throw new InvalidPasswordError(
+        'Password does not meet security requirements',
+      );
+    }
+
+    // Find the user
+    const user = await this.usersRepository.findOneById(tokenPayload.userId);
+    if (!user) {
+      this.logger.error('User not found during password reset', {
+        userId: tokenPayload.userId,
+        email: tokenPayload.email,
+      });
+      throw new InvalidTokenError('Invalid token - user not found');
+    }
+
+    // Verify the email matches the token
+    if (user.email !== tokenPayload.email) {
+      this.logger.error('Email mismatch during password reset', {
+        userId: tokenPayload.userId,
+        tokenEmail: tokenPayload.email,
+        userEmail: user.email,
+      });
+      throw new InvalidTokenError('Invalid token - email mismatch');
+    }
+
+    // Hash the new password
+    this.logger.debug('Hashing new password', {
+      userId: user.id,
+    });
+    const newHashedPassword = await this.hashTextUseCase
+      .execute(new HashTextCommand(command.newPassword))
+      .catch((error) => {
+        if (error instanceof HashingError) {
+          throw error;
+        }
+        this.logger.error('Password hashing failed', {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          userId: user.id,
+        });
+        throw new InvalidPasswordError('Password hashing failed');
+      });
+
+    user.passwordHash = newHashedPassword;
+    await this.usersRepository.update(user);
+
+    this.logger.debug('Password reset successfully', {
+      userId: user.id,
+      email: user.email,
+    });
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/send-confirmation-email/send-confirmation-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/send-confirmation-email/send-confirmation-email.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { SendConfirmationEmailCommand } from './send-confirmation-email.command';
 import { SendEmailCommand } from 'src/common/emails/application/use-cases/send-email/send-email.command';
@@ -8,7 +9,6 @@ import {
   UserEmailAlreadyVerifiedError,
   UserUnexpectedError,
 } from '../../users.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { EmailConfirmationTemplate } from 'src/common/email-templates/domain/email-template.entity';
 import { RenderTemplateUseCase } from 'src/common/email-templates/application/use-cases/render-template/render-template.use-case';
 import { RenderTemplateCommand } from 'src/common/email-templates/application/use-cases/render-template/render-template.command';
@@ -24,73 +24,68 @@ export class SendConfirmationEmailUseCase {
     private readonly renderTemplateUseCase: RenderTemplateUseCase,
   ) {}
 
+  // Email generation combines user, template, and delivery context.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: SendConfirmationEmailCommand): Promise<void> {
-    try {
-      const user = command.user;
-      // Check if email is already verified
-      if (user.emailVerified) {
-        this.logger.debug('Email already verified, skipping resend', {
-          userId: user.id,
-          email: user.email,
-        });
-        throw new UserEmailAlreadyVerifiedError('Email already verified', {
-          userId: user.id,
-          email: user.email,
-        });
-      }
-
-      // Generate new confirmation token
-      this.logger.debug('Generating new email confirmation token', {
-        userId: user.id,
-      });
-      const confirmationToken =
-        this.emailConfirmationJwtService.generateEmailConfirmationToken({
-          userId: user.id,
-          email: user.email,
-        });
-
-      // Build confirmation link
-      const frontendBaseUrl = this.configService.get<string>(
-        'app.frontend.baseUrl',
-      );
-      const emailConfirmEndpoint = this.configService.get<string>(
-        'app.frontend.emailConfirmEndpoint',
-      );
-      const confirmationLink = `${frontendBaseUrl}${emailConfirmEndpoint}?token=${confirmationToken}`;
-
-      // Send email
-      this.logger.debug('Resending email confirmation email', {
+    const user = command.user;
+    // Check if email is already verified
+    if (user.emailVerified) {
+      this.logger.debug('Email already verified, skipping resend', {
         userId: user.id,
         email: user.email,
       });
-      const template = new EmailConfirmationTemplate({
-        confirmationUrl: confirmationLink,
-        userEmail: user.email,
-        currentYear: new Date().getFullYear().toString(),
-        companyName: 'Ayunis',
-      });
-      const emailContent = this.renderTemplateUseCase.execute(
-        new RenderTemplateCommand(template),
-      );
-      await this.sendEmailUseCase.execute(
-        new SendEmailCommand({
-          to: user.email,
-          subject: 'Ayunis Core – Bestätigen Sie Ihre E-Mail-Adresse',
-          html: emailContent.html,
-          text: emailContent.text,
-        }),
-      );
-
-      this.logger.debug('Email confirmation resent successfully', {
+      throw new UserEmailAlreadyVerifiedError('Email already verified', {
         userId: user.id,
         email: user.email,
       });
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error sending email confirmation', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UserUnexpectedError(error as Error);
     }
+
+    // Generate new confirmation token
+    this.logger.debug('Generating new email confirmation token', {
+      userId: user.id,
+    });
+    const confirmationToken =
+      this.emailConfirmationJwtService.generateEmailConfirmationToken({
+        userId: user.id,
+        email: user.email,
+      });
+
+    // Build confirmation link
+    const frontendBaseUrl = this.configService.get<string>(
+      'app.frontend.baseUrl',
+    );
+    const emailConfirmEndpoint = this.configService.get<string>(
+      'app.frontend.emailConfirmEndpoint',
+    );
+    const confirmationLink = `${frontendBaseUrl}${emailConfirmEndpoint}?token=${confirmationToken}`;
+
+    // Send email
+    this.logger.debug('Resending email confirmation email', {
+      userId: user.id,
+      email: user.email,
+    });
+    const template = new EmailConfirmationTemplate({
+      confirmationUrl: confirmationLink,
+      userEmail: user.email,
+      currentYear: new Date().getFullYear().toString(),
+      companyName: 'Ayunis',
+    });
+    const emailContent = this.renderTemplateUseCase.execute(
+      new RenderTemplateCommand(template),
+    );
+    await this.sendEmailUseCase.execute(
+      new SendEmailCommand({
+        to: user.email,
+        subject: 'Ayunis Core – Bestätigen Sie Ihre E-Mail-Adresse',
+        html: emailContent.html,
+        text: emailContent.text,
+      }),
+    );
+
+    this.logger.debug('Email confirmation resent successfully', {
+      userId: user.id,
+      email: user.email,
+    });
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/send-password-reset-email/send-password-reset-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/send-password-reset-email/send-password-reset-email.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UserUnexpectedError } from 'src/iam/users/application/users.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { SendPasswordResetEmailCommand } from './send-password-reset-email.command';
 import { SendEmailCommand } from 'src/common/emails/application/use-cases/send-email/send-email.command';
@@ -19,6 +21,9 @@ export class SendPasswordResetEmailUseCase {
     private readonly renderTemplateUseCase: RenderTemplateUseCase,
   ) {}
 
+  // Email generation combines user, template, and delivery context.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: SendPasswordResetEmailCommand): Promise<void> {
     try {
       this.logger.log('execute', {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/send-set-initial-password-email/send-set-initial-password-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/send-set-initial-password-email/send-set-initial-password-email.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UserUnexpectedError } from 'src/iam/users/application/users.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -22,6 +24,9 @@ export class SendSetInitialPasswordEmailUseCase {
     private readonly findOrgByIdUseCase: FindOrgByIdUseCase,
   ) {}
 
+  // Email generation combines organization, template, and delivery context.
+  // eslint-disable-next-line max-lines-per-function
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: SendSetInitialPasswordEmailCommand): Promise<void> {
     try {
       this.logger.log('execute', { email: command.userEmail });

--- a/ayunis-core-backend/src/iam/users/application/use-cases/super-admin-trigger-password-reset/super-admin-trigger-password-reset.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/super-admin-trigger-password-reset/super-admin-trigger-password-reset.use-case.ts
@@ -1,9 +1,9 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import type { UUID } from 'crypto';
 import { SuperAdminTriggerPasswordResetCommand } from './super-admin-trigger-password-reset.command';
 import { SuperAdminTriggerPasswordResetResult } from './super-admin-trigger-password-reset.result';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UsersRepository } from '../../ports/users.repository';
 import { PasswordResetJwtService } from '../../services/password-reset-jwt.service';
 import { SendPasswordResetEmailUseCase } from '../send-password-reset-email/send-password-reset-email.use-case';
@@ -23,6 +23,7 @@ export class SuperAdminTriggerPasswordResetUseCase {
     private readonly configService: ConfigService,
   ) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(
     command: SuperAdminTriggerPasswordResetCommand,
   ): Promise<SuperAdminTriggerPasswordResetResult> {
@@ -30,30 +31,19 @@ export class SuperAdminTriggerPasswordResetUseCase {
       userId: command.userId,
     });
 
-    try {
-      const user = await this.usersRepository.findOneById(command.userId);
-      if (!user) {
-        throw new UserNotFoundError(command.userId);
-      }
-
-      const resetUrl = await this.sendResetEmail(user);
-
-      this.logger.log('Email triggered for user', {
-        userId: command.userId,
-        email: user.email,
-      });
-
-      return new SuperAdminTriggerPasswordResetResult(resetUrl);
-    } catch (error) {
-      if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error triggering email as super admin', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UserUnexpectedError(
-        error instanceof Error ? error : new Error('Unknown error'),
-        'super admin trigger password reset email',
-      );
+    const user = await this.usersRepository.findOneById(command.userId);
+    if (!user) {
+      throw new UserNotFoundError(command.userId);
     }
+
+    const resetUrl = await this.sendResetEmail(user);
+
+    this.logger.log('Email triggered for user', {
+      userId: command.userId,
+      email: user.email,
+    });
+
+    return new SuperAdminTriggerPasswordResetResult(resetUrl);
   }
 
   private async sendResetEmail(user: {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/trigger-password-reset/trigger-password-reset.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/trigger-password-reset/trigger-password-reset.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { TriggerPasswordResetCommand } from './trigger-password-reset.command';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -19,6 +20,7 @@ export class TriggerPasswordResetUseCase {
     private readonly usersRepository: UsersRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAuthenticationError)
   async execute(command: TriggerPasswordResetCommand): Promise<void> {
     try {
       this.logger.log('execute', { email: command.email });

--- a/ayunis-core-backend/src/iam/users/application/use-cases/trigger-set-initial-password/trigger-set-initial-password.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/trigger-set-initial-password/trigger-set-initial-password.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { TriggerSetInitialPasswordCommand } from './trigger-set-initial-password.command';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -18,6 +19,7 @@ export class TriggerSetInitialPasswordUseCase {
     private readonly usersRepository: UsersRepository,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAuthenticationError)
   async execute(command: TriggerSetInitialPasswordCommand): Promise<void> {
     try {
       this.logger.log('execute', { email: command.email });

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-password/update-password.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-password/update-password.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UserUnexpectedError } from 'src/iam/users/application/users.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { UsersRepository } from '../../ports/users.repository';
 import { UpdatePasswordCommand } from './update-password.command';
@@ -19,6 +21,7 @@ export class UpdatePasswordUseCase {
     private readonly hashTextUseCase: HashTextUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: UpdatePasswordCommand): Promise<void> {
     this.logger.log('updatePassword', { userId: command.userId });
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-user-name/update-user-name.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-user-name/update-user-name.use-case.ts
@@ -1,10 +1,10 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UsersRepository } from '../../ports/users.repository';
 import { UpdateUserNameCommand } from './update-user-name.command';
 import { User } from '../../../domain/user.entity';
 import { UserNotFoundError, UserUnexpectedError } from '../../users.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UserUpdatedEvent } from '../../events/user-updated.event';
 
 @Injectable()
@@ -16,51 +16,40 @@ export class UpdateUserNameUseCase {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: UpdateUserNameCommand): Promise<User> {
     this.logger.log('updateUserName', {
       userId: command.userId,
       newName: command.newName,
     });
 
-    try {
-      const user = await this.usersRepository.findOneById(command.userId);
-      if (!user) {
-        throw new UserNotFoundError(command.userId);
-      }
-      this.logger.debug('user found', {
-        userId: user.id,
-        currentName: user.name,
-      });
-      user.name = command.newName;
-      const updatedUser = await this.usersRepository.update(user);
-      this.logger.log('user name updated successfully', {
-        userId: updatedUser.id,
-        newName: updatedUser.name,
-      });
-
-      this.eventEmitter
-        .emitAsync(
-          UserUpdatedEvent.EVENT_NAME,
-          new UserUpdatedEvent(updatedUser.id, updatedUser.orgId, updatedUser),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit UserUpdatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            userId: updatedUser.id,
-          });
-        });
-
-      return updatedUser;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to update user name', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        userId: command.userId,
-        newName: command.newName,
-      });
-      throw new UserUnexpectedError(error as Error);
+    const user = await this.usersRepository.findOneById(command.userId);
+    if (!user) {
+      throw new UserNotFoundError(command.userId);
     }
+    this.logger.debug('user found', {
+      userId: user.id,
+      currentName: user.name,
+    });
+    user.name = command.newName;
+    const updatedUser = await this.usersRepository.update(user);
+    this.logger.log('user name updated successfully', {
+      userId: updatedUser.id,
+      newName: updatedUser.name,
+    });
+
+    this.eventEmitter
+      .emitAsync(
+        UserUpdatedEvent.EVENT_NAME,
+        new UserUpdatedEvent(updatedUser.id, updatedUser.orgId, updatedUser),
+      )
+      .catch((err: unknown) => {
+        this.logger.error('Failed to emit UserUpdatedEvent', {
+          error: err instanceof Error ? err.message : 'Unknown error',
+          userId: updatedUser.id,
+        });
+      });
+
+    return updatedUser;
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.ts
@@ -1,3 +1,4 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UsersRepository } from '../../ports/users.repository';
@@ -8,7 +9,6 @@ import {
   UserUnauthorizedError,
   UserUnexpectedError,
 } from '../../users.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UserUpdatedEvent } from '../../events/user-updated.event';
 
@@ -22,6 +22,7 @@ export class UpdateUserRoleUseCase {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: UpdateUserRoleCommand): Promise<User> {
     this.logger.log('updateUserRole', {
       userId: command.userId,
@@ -33,48 +34,38 @@ export class UpdateUserRoleUseCase {
       throw new UserUnauthorizedError('User not authenticated');
     }
 
-    try {
-      // Find the user
-      const user = await this.usersRepository.findOneById(command.userId);
-      if (!user) {
-        throw new UserNotFoundError(command.userId);
-      }
-
-      // Prevent cross-org role changes: the target user must belong to the
-      // requesting admin's organization.
-      if (user.orgId !== requesterOrgId) {
-        throw new UserUnauthorizedError(
-          'You are not allowed to update this user',
-        );
-      }
-
-      // Update the role
-      user.role = command.newRole;
-
-      // Save the updated user
-      const updatedUser = await this.usersRepository.update(user);
-
-      this.eventEmitter
-        .emitAsync(
-          UserUpdatedEvent.EVENT_NAME,
-          new UserUpdatedEvent(updatedUser.id, updatedUser.orgId, updatedUser),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit UserUpdatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            userId: updatedUser.id,
-          });
-        });
-
-      return updatedUser;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error updating user role', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UserUnexpectedError(error as Error);
+    // Find the user
+    const user = await this.usersRepository.findOneById(command.userId);
+    if (!user) {
+      throw new UserNotFoundError(command.userId);
     }
+
+    // Prevent cross-org role changes: the target user must belong to the
+    // requesting admin's organization.
+    if (user.orgId !== requesterOrgId) {
+      throw new UserUnauthorizedError(
+        'You are not allowed to update this user',
+      );
+    }
+
+    // Update the role
+    user.role = command.newRole;
+
+    // Save the updated user
+    const updatedUser = await this.usersRepository.update(user);
+
+    this.eventEmitter
+      .emitAsync(
+        UserUpdatedEvent.EVENT_NAME,
+        new UserUpdatedEvent(updatedUser.id, updatedUser.orgId, updatedUser),
+      )
+      .catch((err: unknown) => {
+        this.logger.error('Failed to emit UserUpdatedEvent', {
+          error: err instanceof Error ? err.message : 'Unknown error',
+          userId: updatedUser.id,
+        });
+      });
+
+    return updatedUser;
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/validate-user/validate-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/validate-user/validate-user.use-case.ts
@@ -1,3 +1,5 @@
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UserUnexpectedError } from 'src/iam/users/application/users.errors';
 import { Injectable, Logger } from '@nestjs/common';
 import { UsersRepository } from '../../ports/users.repository';
 import { ValidateUserQuery } from './validate-user.query';
@@ -20,6 +22,7 @@ export class ValidateUserUseCase {
     private readonly compareHashUseCase: CompareHashUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(query: ValidateUserQuery): Promise<User> {
     this.logger.log('validateUser', { email: query.email });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Wide refactor across auth, MFA, subscriptions, and invites with behavior intended to stay the same, but any decorator edge case could change how unexpected failures are logged or surfaced.
> 
> **Overview**
> This PR **standardizes unexpected error handling** across remaining IAM use cases by applying `@HandleUnexpectedErrors(Unexpected*Error)` on `execute` methods and removing duplicated `try/catch` blocks that rethrew `ApplicationError` and manually logged/wrapped other failures.
> 
> **Unexpected error types** are extended so constructors can take an `Error` (and optional metadata), e.g. `UnexpectedAddonError`, `UnexpectedApiKeyError`, `UnexpectedIpAllowlistError`, plus new types for legal acceptances, orgs, platform config, and quotas. Domain-specific `ApplicationError` throws are unchanged; only non-domain failures are logged as `'Unexpected use-case error'` and wrapped.
> 
> Coverage spans addons, API keys, authentication, credit limits, invites, IP allowlist, legal acceptances, MFA, onboarding, orgs, platform config, quotas, and subscriptions. One invite spec now expects the decorator’s log message instead of use-case-specific text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14ba17f11be9d23112210be56b68ab5f7b84fb60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->