### PR TITLE
feat(auth): add server-side sessions with refresh rotation and revocation (AYC-452)

### DIFF
--- a/ayunis-core-backend/src/common/context/services/context.service.ts
+++ b/ayunis-core-backend/src/common/context/services/context.service.ts
@@ -10,6 +10,7 @@ export interface MyClsStore extends ClsStore {
   orgId?: UUID;
   systemRole?: SystemRole;
   role?: UserRole;
+  refreshToken?: string;
 }
 
 export class ContextService extends ClsService<MyClsStore> {}

--- a/ayunis-core-backend/src/config/authentication.config.ts
+++ b/ayunis-core-backend/src/config/authentication.config.ts
@@ -110,6 +110,14 @@ export const authenticationConfig = registerAs('auth', () => {
         10,
       ),
     },
+    session: {
+      // Reuse of a just-rotated refresh token within this window is treated as
+      // a benign concurrent-request race rather than token theft.
+      refreshTokenGraceSeconds: parseInt(
+        process.env.SESSION_REFRESH_GRACE_SECONDS || '60',
+        10,
+      ),
+    },
     emailProviderBlacklist,
   };
 });

--- a/ayunis-core-backend/src/db/migrations/1784123206923-CreateRefreshTokensTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1784123206923-CreateRefreshTokensTable.ts
@@ -1,0 +1,39 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateRefreshTokensTable1784123206923 implements MigrationInterface {
+  name = 'CreateRefreshTokensTable1784123206923';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "refresh_tokens" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "userId" character varying NOT NULL, "familyId" character varying NOT NULL, "tokenHash" character varying NOT NULL, "expiresAt" TIMESTAMP WITH TIME ZONE NOT NULL, "usedAt" TIMESTAMP WITH TIME ZONE, "revokedAt" TIMESTAMP WITH TIME ZONE, "replacedByTokenId" character varying, CONSTRAINT "PK_7d8bee0204106019488c4c50ffa" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_610102b60fea1455310ccd299d" ON "refresh_tokens" ("userId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_40e9a8b923a1b3fb4429a5c624" ON "refresh_tokens" ("familyId") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_c25bc63d248ca90e8dcc1d92d0" ON "refresh_tokens" ("tokenHash") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "refresh_tokens" ADD CONSTRAINT "FK_610102b60fea1455310ccd299de" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "refresh_tokens" DROP CONSTRAINT "FK_610102b60fea1455310ccd299de"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_c25bc63d248ca90e8dcc1d92d0"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_40e9a8b923a1b3fb4429a5c624"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_610102b60fea1455310ccd299d"`,
+    );
+    await queryRunner.query(`DROP TABLE "refresh_tokens"`);
+  }
+}

--- a/ayunis-core-backend/src/db/migrations/1784275664960-AddReplacedByFkToRefreshTokens.ts
+++ b/ayunis-core-backend/src/db/migrations/1784275664960-AddReplacedByFkToRefreshTokens.ts
@@ -1,0 +1,17 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddReplacedByFkToRefreshTokens1784275664960 implements MigrationInterface {
+  name = 'AddReplacedByFkToRefreshTokens1784275664960';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "refresh_tokens" ADD CONSTRAINT "FK_6077443266dc1dde0ac43b6f727" FOREIGN KEY ("replacedByTokenId") REFERENCES "refresh_tokens"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "refresh_tokens" DROP CONSTRAINT "FK_6077443266dc1dde0ac43b6f727"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/iam/authentication/application/guards/jwt-auth.guard.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/guards/jwt-auth.guard.ts
@@ -6,7 +6,8 @@ import { Request, Response } from 'express';
 import { RefreshTokenUseCase } from '../use-cases/refresh-token/refresh-token.use-case';
 import { RefreshTokenCommand } from '../use-cases/refresh-token/refresh-token.command';
 import { ConfigService } from '@nestjs/config';
-import { setCookies } from 'src/common/util/cookie.util';
+import { setCookies, clearCookies } from 'src/common/util/cookie.util';
+import { RefreshTokenReuseError } from 'src/iam/sessions/application/sessions.errors';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
@@ -55,36 +56,40 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
       return false;
     }
 
+    return this.tryRefreshAndRetry(context, request, response, refreshToken);
+  }
+
+  private async tryRefreshAndRetry(
+    context: ExecutionContext,
+    request: Request,
+    response: Response,
+    refreshToken: string,
+  ): Promise<boolean> {
     try {
-      // Try to refresh the tokens
       const newTokens = await this.refreshTokenUseCase.execute(
         new RefreshTokenCommand(refreshToken),
       );
 
-      // Set new cookies with refreshed tokens
       setCookies(response, newTokens, this.configService, true);
 
-      // Manually set the new access token in the request for this request
+      // Inject the new access token so this request can re-validate.
       const accessTokenName = this.configService.get<string>(
         'auth.cookie.accessTokenName',
         'access_token',
       );
       request.cookies[accessTokenName] = newTokens.access_token;
 
-      // Try JWT validation again with the new token
-      const result = await super.canActivate(context);
-      if (result) {
-        return true;
-      }
+      return (await super.canActivate(context)) === true;
     } catch (error) {
+      if (error instanceof RefreshTokenReuseError) {
+        // Theft response: the family is already revoked; drop the cookies so the
+        // client stops presenting the compromised token.
+        clearCookies(response, this.configService);
+      }
       this.logger.debug('JwtAuthGuard canActivate: token refresh failed', {
         error: error instanceof Error ? error.message : String(error),
       });
+      return false;
     }
-
-    this.logger.debug(
-      'JwtAuthGuard canActivate: all authentication attempts failed',
-    );
-    return false;
   }
 }

--- a/ayunis-core-backend/src/iam/authentication/application/interceptors/user-context.interceptor.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/interceptors/user-context.interceptor.spec.ts
@@ -5,14 +5,23 @@ import { UserRole } from '../../../users/domain/value-objects/role.object';
 import { SystemRole } from '../../../users/domain/value-objects/system-role.enum';
 import { UserContextInterceptor } from './user-context.interceptor';
 import type { ContextService } from 'src/common/context/services/context.service';
+import type { ConfigService } from '@nestjs/config';
 import type { UUID } from 'crypto';
 
 describe('UserContextInterceptor', () => {
-  const createExecutionContext = (user?: unknown): ExecutionContext =>
+  const configService = {
+    get: jest.fn((_key: string, defaultValue?: unknown) => defaultValue),
+  } as unknown as ConfigService;
+
+  const createExecutionContext = (
+    user?: unknown,
+    cookies?: Record<string, string>,
+  ): ExecutionContext =>
     ({
       switchToHttp: () => ({
         getRequest: () => ({
           user,
+          cookies,
         }),
       }),
     }) as unknown as ExecutionContext;
@@ -24,7 +33,10 @@ describe('UserContextInterceptor', () => {
   it('sets user identifiers into the context store when an ActiveUser is present', async () => {
     const setMock = jest.fn();
     const contextService = { set: setMock } as unknown as ContextService;
-    const interceptor = new UserContextInterceptor(contextService);
+    const interceptor = new UserContextInterceptor(
+      contextService,
+      configService,
+    );
     const activeUser: ActiveUser = new ActiveUser({
       id: 'user-id' as UUID,
       email: 'super.admin@example.com',
@@ -37,13 +49,17 @@ describe('UserContextInterceptor', () => {
     const callHandler = createCallHandler();
 
     await lastValueFrom(
-      interceptor.intercept(createExecutionContext(activeUser), callHandler),
+      interceptor.intercept(
+        createExecutionContext(activeUser, { refresh_token: 'the-refresh' }),
+        callHandler,
+      ),
     );
 
     expect(setMock).toHaveBeenCalledWith('userId', activeUser.id);
     expect(setMock).toHaveBeenCalledWith('orgId', activeUser.orgId);
     expect(setMock).toHaveBeenCalledWith('role', activeUser.role);
     expect(setMock).toHaveBeenCalledWith('systemRole', activeUser.systemRole);
+    expect(setMock).toHaveBeenCalledWith('refreshToken', 'the-refresh');
     expect(setMock).not.toHaveBeenCalledWith('apiKeyId', expect.anything());
     expect(callHandler.handle).toHaveBeenCalled();
   });
@@ -51,7 +67,10 @@ describe('UserContextInterceptor', () => {
   it('sets apiKeyId and orgId only when the principal is an api-key shape', async () => {
     const setMock = jest.fn();
     const contextService = { set: setMock } as unknown as ContextService;
-    const interceptor = new UserContextInterceptor(contextService);
+    const interceptor = new UserContextInterceptor(
+      contextService,
+      configService,
+    );
     const apiKeyPrincipal = {
       apiKeyId: 'api-key-id' as UUID,
       orgId: 'org-id' as UUID,
@@ -76,7 +95,10 @@ describe('UserContextInterceptor', () => {
   it('skips setting context when user is undefined', async () => {
     const setMock = jest.fn();
     const contextService = { set: setMock } as unknown as ContextService;
-    const interceptor = new UserContextInterceptor(contextService);
+    const interceptor = new UserContextInterceptor(
+      contextService,
+      configService,
+    );
     const callHandler = createCallHandler();
 
     await lastValueFrom(

--- a/ayunis-core-backend/src/iam/authentication/application/interceptors/user-context.interceptor.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/interceptors/user-context.interceptor.ts
@@ -5,6 +5,7 @@ import {
   CallHandler,
 } from '@nestjs/common';
 import { Request } from 'express';
+import { ConfigService } from '@nestjs/config';
 import * as Sentry from '@sentry/nestjs';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ActiveUser } from '../../domain/active-user.entity';
@@ -14,7 +15,10 @@ type RequestPrincipal = ActiveUser | ApiKeyPrincipal;
 
 @Injectable()
 export class UserContextInterceptor implements NestInterceptor {
-  constructor(private readonly contextService: ContextService) {}
+  constructor(
+    private readonly contextService: ContextService,
+    private readonly configService: ConfigService,
+  ) {}
 
   intercept(context: ExecutionContext, next: CallHandler) {
     const req = context.switchToHttp().getRequest<Request>();
@@ -25,6 +29,7 @@ export class UserContextInterceptor implements NestInterceptor {
       this.contextService.set('orgId', principal.orgId);
       this.contextService.set('role', principal.role);
       this.contextService.set('systemRole', principal.systemRole);
+      this.contextService.set('refreshToken', this.extractRefreshToken(req));
 
       Sentry.getCurrentScope().setUser({
         id: principal.id,
@@ -37,5 +42,14 @@ export class UserContextInterceptor implements NestInterceptor {
     }
 
     return next.handle();
+  }
+
+  private extractRefreshToken(req: Request): string | undefined {
+    const refreshTokenName = this.configService.get<string>(
+      'auth.cookie.refreshTokenName',
+      'refresh_token',
+    );
+    const cookies = req.cookies as Record<string, string> | undefined;
+    return cookies?.[refreshTokenName];
   }
 }

--- a/ayunis-core-backend/src/iam/authentication/application/ports/authentication.repository.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/ports/authentication.repository.ts
@@ -1,6 +1,5 @@
 import type { ActiveUser } from 'src/iam/authentication/domain/active-user.entity';
-import type { AuthTokens } from 'src/iam/authentication/domain/auth-tokens.entity';
 
 export abstract class AuthenticationRepository {
-  abstract generateTokens(user: ActiveUser): Promise<AuthTokens>;
+  abstract generateAccessToken(user: ActiveUser): Promise<string>;
 }

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/login/login.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/login/login.use-case.spec.ts
@@ -5,27 +5,27 @@ import { LoginCommand } from './login.command';
 import type { AuthenticationRepository } from '../../ports/authentication.repository';
 import { AUTHENTICATION_REPOSITORY } from '../../tokens/authentication-repository.token';
 import { ActiveUser } from '../../../domain/active-user.entity';
-import { AuthTokens } from '../../../domain/auth-tokens.entity';
 import { UserRole } from '../../../../users/domain/value-objects/role.object';
 import { SystemRole } from '../../../../users/domain/value-objects/system-role.enum';
+import { CreateSessionUseCase } from 'src/iam/sessions/application/use-cases/create-session/create-session.use-case';
 import type { UUID } from 'crypto';
 
 describe('LoginUseCase', () => {
   let useCase: LoginUseCase;
   let mockAuthRepository: Partial<AuthenticationRepository>;
+  let mockCreateSessionUseCase: { execute: jest.Mock };
 
   beforeAll(async () => {
     mockAuthRepository = {
-      generateTokens: jest.fn(),
+      generateAccessToken: jest.fn(),
     };
+    mockCreateSessionUseCase = { execute: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         LoginUseCase,
-        {
-          provide: AUTHENTICATION_REPOSITORY,
-          useValue: mockAuthRepository,
-        },
+        { provide: AUTHENTICATION_REPOSITORY, useValue: mockAuthRepository },
+        { provide: CreateSessionUseCase, useValue: mockCreateSessionUseCase },
       ],
     }).compile();
 
@@ -39,7 +39,7 @@ describe('LoginUseCase', () => {
     expect(useCase).toBeDefined();
   });
 
-  it('should login user successfully', async () => {
+  it('should compose an access token and an opaque session refresh token', async () => {
     const activeUser = new ActiveUser({
       id: 'user-id' as UUID,
       email: 'test@example.com',
@@ -50,15 +50,22 @@ describe('LoginUseCase', () => {
       name: 'name',
     });
     const command = new LoginCommand(activeUser);
-    const expectedTokens = new AuthTokens('access-token', 'refresh-token');
 
     jest
-      .spyOn(mockAuthRepository, 'generateTokens')
-      .mockResolvedValue(expectedTokens);
+      .spyOn(mockAuthRepository, 'generateAccessToken')
+      .mockResolvedValue('access-token');
+    mockCreateSessionUseCase.execute.mockResolvedValue({
+      refreshToken: 'opaque-refresh-token',
+      expiresAt: new Date(),
+    });
 
     const result = await useCase.execute(command);
 
-    expect(result).toBe(expectedTokens);
-    expect(mockAuthRepository.generateTokens).toHaveBeenCalledWith(activeUser);
+    expect(result.access_token).toBe('access-token');
+    expect(result.refresh_token).toBe('opaque-refresh-token');
+    expect(mockAuthRepository.generateAccessToken).toHaveBeenCalledWith(
+      activeUser,
+    );
+    expect(mockCreateSessionUseCase.execute).toHaveBeenCalled();
   });
 });

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/login/login.use-case.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/login/login.use-case.ts
@@ -3,6 +3,10 @@ import { AuthenticationRepository } from '../../ports/authentication.repository'
 import { AUTHENTICATION_REPOSITORY } from '../../tokens/authentication-repository.token';
 import { LoginCommand } from './login.command';
 import { AuthTokens } from '../../../domain/auth-tokens.entity';
+import { UnexpectedAuthenticationError } from '../../authentication.errors';
+import { CreateSessionUseCase } from 'src/iam/sessions/application/use-cases/create-session/create-session.use-case';
+import { CreateSessionCommand } from 'src/iam/sessions/application/use-cases/create-session/create-session.command';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 
 @Injectable()
 export class LoginUseCase {
@@ -11,13 +15,23 @@ export class LoginUseCase {
   constructor(
     @Inject(AUTHENTICATION_REPOSITORY)
     private readonly authRepository: AuthenticationRepository,
+    private readonly createSessionUseCase: CreateSessionUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAuthenticationError)
   async execute(command: LoginCommand): Promise<AuthTokens> {
     this.logger.log('login', {
       userId: command.user.id,
       email: command.user.email,
     });
-    return this.authRepository.generateTokens(command.user);
+
+    const accessToken = await this.authRepository.generateAccessToken(
+      command.user,
+    );
+    const session = await this.createSessionUseCase.execute(
+      new CreateSessionCommand(command.user.id),
+    );
+
+    return new AuthTokens(accessToken, session.refreshToken);
   }
 }

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/refresh-token/refresh-token.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/refresh-token/refresh-token.use-case.spec.ts
@@ -8,141 +8,139 @@ import { JwtService } from '@nestjs/jwt';
 import { FindUserByIdUseCase } from '../../../../users/application/use-cases/find-user-by-id/find-user-by-id.use-case';
 import { User } from '../../../../users/domain/user.entity';
 import { UserRole } from '../../../../users/domain/value-objects/role.object';
-import { AuthTokens } from '../../../domain/auth-tokens.entity';
 import { InvalidTokenError } from '../../authentication.errors';
+import { RotateSessionUseCase } from 'src/iam/sessions/application/use-cases/rotate-session/rotate-session.use-case';
+import { CreateSessionUseCase } from 'src/iam/sessions/application/use-cases/create-session/create-session.use-case';
+import { RefreshTokenReuseError } from 'src/iam/sessions/application/sessions.errors';
 import type { UUID } from 'crypto';
 
 describe('RefreshTokenUseCase', () => {
   let useCase: RefreshTokenUseCase;
   let mockAuthRepository: Partial<AuthenticationRepository>;
-  let mockJwtService: Partial<JwtService>;
-  let mockFindUserByIdUseCase: Partial<FindUserByIdUseCase>;
+  let mockJwtService: { verify: jest.Mock };
+  let mockFindUserByIdUseCase: { execute: jest.Mock };
+  let mockRotateSessionUseCase: { execute: jest.Mock };
+  let mockCreateSessionUseCase: { execute: jest.Mock };
 
-  beforeAll(async () => {
-    mockAuthRepository = {
-      generateTokens: jest.fn(),
-    };
-    mockJwtService = {
-      verify: jest.fn(),
-    };
-    mockFindUserByIdUseCase = {
-      execute: jest.fn(),
-    };
+  const userId = 'user-id-123' as UUID;
+  const opaqueToken = 'opaque-refresh-token-no-dots';
+  const legacyJwt = 'header.payload.signature';
+
+  const buildUser = () =>
+    new User({
+      id: userId,
+      email: 'test@example.com',
+      emailVerified: false,
+      passwordHash: 'hash',
+      role: UserRole.USER,
+      orgId: 'org-id' as UUID,
+      name: 'name',
+      hasAcceptedMarketing: false,
+    });
+
+  beforeEach(async () => {
+    mockAuthRepository = { generateAccessToken: jest.fn() };
+    mockJwtService = { verify: jest.fn() };
+    mockFindUserByIdUseCase = { execute: jest.fn() };
+    mockRotateSessionUseCase = { execute: jest.fn() };
+    mockCreateSessionUseCase = { execute: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RefreshTokenUseCase,
-        {
-          provide: AUTHENTICATION_REPOSITORY,
-          useValue: mockAuthRepository,
-        },
+        { provide: AUTHENTICATION_REPOSITORY, useValue: mockAuthRepository },
         { provide: JwtService, useValue: mockJwtService },
         { provide: FindUserByIdUseCase, useValue: mockFindUserByIdUseCase },
+        { provide: RotateSessionUseCase, useValue: mockRotateSessionUseCase },
+        { provide: CreateSessionUseCase, useValue: mockCreateSessionUseCase },
       ],
     }).compile();
 
     useCase = module.get<RefreshTokenUseCase>(RefreshTokenUseCase);
-  });
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('should be defined', () => {
-    expect(useCase).toBeDefined();
-  });
-
-  it('should refresh token successfully', async () => {
-    const command = new RefreshTokenCommand('valid-refresh-token');
-    const mockUser = new User({
-      id: 'user-id-123' as UUID,
-      email: 'test@example.com',
-      emailVerified: false,
-      passwordHash: 'hash',
-      role: UserRole.USER,
-      orgId: 'org-id' as UUID,
-      name: 'name',
-      hasAcceptedMarketing: false,
-    });
-    const mockTokens = new AuthTokens('new-access-token', 'new-refresh-token');
 
     jest
-      .spyOn(mockJwtService, 'verify')
-      .mockReturnValue({ sub: 'user-id-123' });
-    jest.spyOn(mockFindUserByIdUseCase, 'execute').mockResolvedValue(mockUser);
-    jest
-      .spyOn(mockAuthRepository, 'generateTokens')
-      .mockResolvedValue(mockTokens);
-
-    const result = await useCase.execute(command);
-
-    expect(result).toBe(mockTokens);
-    expect(mockJwtService.verify).toHaveBeenCalledWith('valid-refresh-token');
-    expect(mockFindUserByIdUseCase.execute).toHaveBeenCalled();
-    expect(mockAuthRepository.generateTokens).toHaveBeenCalled();
+      .spyOn(mockAuthRepository, 'generateAccessToken')
+      .mockResolvedValue('new-access-token');
+    mockFindUserByIdUseCase.execute.mockResolvedValue(buildUser());
   });
 
-  it('should throw InvalidTokenError for invalid token', async () => {
-    const command = new RefreshTokenCommand('invalid-token');
+  afterEach(() => jest.clearAllMocks());
 
-    jest.spyOn(mockJwtService, 'verify').mockImplementation(() => {
-      throw new Error('Invalid token');
+  it('should rotate an opaque token and return a new token pair', async () => {
+    mockRotateSessionUseCase.execute.mockResolvedValue({
+      userId,
+      refreshToken: 'rotated-refresh-token',
     });
 
-    await expect(useCase.execute(command)).rejects.toThrow(InvalidTokenError);
+    const result = await useCase.execute(new RefreshTokenCommand(opaqueToken));
+
+    expect(result.access_token).toBe('new-access-token');
+    expect(result.refresh_token).toBe('rotated-refresh-token');
+    expect(mockRotateSessionUseCase.execute).toHaveBeenCalled();
+    expect(mockJwtService.verify).not.toHaveBeenCalled();
   });
 
-  it('should reject typed special-purpose tokens with a valid sub (laundering)', async () => {
-    const command = new RefreshTokenCommand('mfa-pending-token');
+  it('should propagate a reuse error un-flattened (theft response)', async () => {
+    mockRotateSessionUseCase.execute.mockRejectedValue(
+      new RefreshTokenReuseError(),
+    );
 
-    jest
-      .spyOn(mockJwtService, 'verify')
-      .mockReturnValue({ sub: 'user-id-123', type: 'mfa_pending' });
-
-    await expect(useCase.execute(command)).rejects.toThrow(InvalidTokenError);
-    expect(mockFindUserByIdUseCase.execute).not.toHaveBeenCalled();
-    expect(mockAuthRepository.generateTokens).not.toHaveBeenCalled();
+    await expect(
+      useCase.execute(new RefreshTokenCommand(opaqueToken)),
+    ).rejects.toThrow(RefreshTokenReuseError);
   });
 
-  it('should accept a token explicitly typed as refresh', async () => {
-    const command = new RefreshTokenCommand('new-refresh-token');
-    const mockUser = new User({
-      id: 'user-id-123' as UUID,
-      email: 'test@example.com',
-      emailVerified: false,
-      passwordHash: 'hash',
-      role: UserRole.USER,
-      orgId: 'org-id' as UUID,
-      name: 'name',
-      hasAcceptedMarketing: false,
-    });
-    const mockTokens = new AuthTokens('new-access-token', 'new-refresh-token');
-
-    jest
-      .spyOn(mockJwtService, 'verify')
-      .mockReturnValue({ sub: 'user-id-123', type: 'refresh' });
-    jest.spyOn(mockFindUserByIdUseCase, 'execute').mockResolvedValue(mockUser);
-    jest
-      .spyOn(mockAuthRepository, 'generateTokens')
-      .mockResolvedValue(mockTokens);
-
-    await expect(useCase.execute(command)).resolves.toBe(mockTokens);
-    expect(mockAuthRepository.generateTokens).toHaveBeenCalled();
-  });
-
-  // Regression for V2: an access token (untyped, but carrying `email`) must not
-  // be exchangeable for a fresh token pair.
-  it('should reject an access-shaped token presented as a refresh token', async () => {
-    const command = new RefreshTokenCommand('access-token');
-
-    jest.spyOn(mockJwtService, 'verify').mockReturnValue({
-      sub: 'user-id-123',
-      email: 'test@example.com',
-      role: UserRole.USER,
-      orgId: 'org-id',
+  it('should migrate a valid legacy JWT refresh token to an opaque session', async () => {
+    mockJwtService.verify.mockReturnValue({ sub: userId, type: 'refresh' });
+    mockCreateSessionUseCase.execute.mockResolvedValue({
+      refreshToken: 'migrated-refresh-token',
+      expiresAt: new Date(),
     });
 
-    await expect(useCase.execute(command)).rejects.toThrow(InvalidTokenError);
-    expect(mockFindUserByIdUseCase.execute).not.toHaveBeenCalled();
-    expect(mockAuthRepository.generateTokens).not.toHaveBeenCalled();
+    const result = await useCase.execute(new RefreshTokenCommand(legacyJwt));
+
+    expect(result.refresh_token).toBe('migrated-refresh-token');
+    expect(mockCreateSessionUseCase.execute).toHaveBeenCalled();
+    expect(mockRotateSessionUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('should migrate a bare {sub} legacy refresh token', async () => {
+    mockJwtService.verify.mockReturnValue({ sub: userId });
+    mockCreateSessionUseCase.execute.mockResolvedValue({
+      refreshToken: 'migrated',
+      expiresAt: new Date(),
+    });
+
+    await expect(
+      useCase.execute(new RefreshTokenCommand(legacyJwt)),
+    ).resolves.toBeDefined();
+    expect(mockCreateSessionUseCase.execute).toHaveBeenCalled();
+  });
+
+  it('should reject a legacy JWT that is access-shaped (carries email)', async () => {
+    mockJwtService.verify.mockReturnValue({ sub: userId, email: 'x@y.z' });
+
+    await expect(
+      useCase.execute(new RefreshTokenCommand(legacyJwt)),
+    ).rejects.toThrow(InvalidTokenError);
+    expect(mockCreateSessionUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('should reject a legacy JWT typed as a foreign token', async () => {
+    mockJwtService.verify.mockReturnValue({ sub: userId, type: 'mfa_pending' });
+
+    await expect(
+      useCase.execute(new RefreshTokenCommand(legacyJwt)),
+    ).rejects.toThrow(InvalidTokenError);
+  });
+
+  it('should wrap a malformed JWT verification failure as InvalidTokenError', async () => {
+    mockJwtService.verify.mockImplementation(() => {
+      throw new Error('jwt malformed');
+    });
+
+    await expect(
+      useCase.execute(new RefreshTokenCommand(legacyJwt)),
+    ).rejects.toThrow(InvalidTokenError);
   });
 });

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/refresh-token/refresh-token.use-case.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/refresh-token/refresh-token.use-case.ts
@@ -2,13 +2,22 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import { AuthenticationRepository } from '../../ports/authentication.repository';
 import { AUTHENTICATION_REPOSITORY } from '../../tokens/authentication-repository.token';
 import { JwtService } from '@nestjs/jwt';
+import type { UUID } from 'crypto';
 import { FindUserByIdUseCase } from '../../../../users/application/use-cases/find-user-by-id/find-user-by-id.use-case';
 import { FindUserByIdQuery } from '../../../../users/application/use-cases/find-user-by-id/find-user-by-id.query';
 import { RefreshTokenCommand } from './refresh-token.command';
 import { AuthTokens } from '../../../domain/auth-tokens.entity';
 import { ActiveUser } from '../../../domain/active-user.entity';
-import { InvalidTokenError } from '../../authentication.errors';
+import {
+  InvalidTokenError,
+  UnexpectedAuthenticationError,
+} from '../../authentication.errors';
 import { REFRESH_TOKEN_TYPE } from '../../../domain/token-type.constants';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { RotateSessionUseCase } from 'src/iam/sessions/application/use-cases/rotate-session/rotate-session.use-case';
+import { RotateSessionCommand } from 'src/iam/sessions/application/use-cases/rotate-session/rotate-session.command';
+import { CreateSessionUseCase } from 'src/iam/sessions/application/use-cases/create-session/create-session.use-case';
+import { CreateSessionCommand } from 'src/iam/sessions/application/use-cases/create-session/create-session.command';
 
 interface RefreshTokenPayload {
   sub?: string;
@@ -25,40 +34,62 @@ export class RefreshTokenUseCase {
     private readonly authRepository: AuthenticationRepository,
     private readonly jwtService: JwtService,
     private readonly findUserByIdUseCase: FindUserByIdUseCase,
+    private readonly rotateSessionUseCase: RotateSessionUseCase,
+    private readonly createSessionUseCase: CreateSessionUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedAuthenticationError)
   async execute(command: RefreshTokenCommand): Promise<AuthTokens> {
     this.logger.log('refreshToken');
+    const rotated = this.isJwt(command.refreshToken)
+      ? await this.migrateLegacyToken(command.refreshToken)
+      : await this.rotate(command.refreshToken);
+
+    const accessToken = await this.issueAccessToken(rotated.userId);
+    return new AuthTokens(accessToken, rotated.refreshToken);
+  }
+
+  private isJwt(token: string): boolean {
+    return token.split('.').length === 3;
+  }
+
+  private async rotate(
+    token: string,
+  ): Promise<{ userId: UUID; refreshToken: string }> {
+    const result = await this.rotateSessionUseCase.execute(
+      new RotateSessionCommand(token),
+    );
+    return { userId: result.userId, refreshToken: result.refreshToken };
+  }
+
+  /**
+   * Transitional path: a pre-deploy JWT refresh token is verified once and
+   * migrated to an opaque stored session (a new family).
+   *
+   * FUTURE(AYC-452): remove ~7 days after deploy, once legacy JWT refresh
+   * tokens have all expired.
+   */
+  private async migrateLegacyToken(
+    token: string,
+  ): Promise<{ userId: UUID; refreshToken: string }> {
+    const payload = this.verifyLegacyToken(token);
+    if (!this.isAcceptableRefreshPayload(payload)) {
+      throw new InvalidTokenError('Invalid token payload');
+    }
+    const userId = payload.sub as UUID;
+    const session = await this.createSessionUseCase.execute(
+      new CreateSessionCommand(userId),
+    );
+    return { userId, refreshToken: session.refreshToken };
+  }
+
+  // A tampered or expired legacy JWT is invalid credentials (401), not an
+  // unexpected failure — translate before the error boundary sees it.
+  private verifyLegacyToken(token: string): RefreshTokenPayload {
     try {
-      const payload = this.jwtService.verify<RefreshTokenPayload>(
-        command.refreshToken,
-      );
-
-      if (!this.isAcceptableRefreshPayload(payload)) {
-        throw new InvalidTokenError('Invalid token payload');
-      }
-
-      const userId =
-        payload.sub as `${string}-${string}-${string}-${string}-${string}`;
-      this.logger.debug('Token verified successfully', { userId });
-
-      const user = await this.findUserByIdUseCase.execute(
-        new FindUserByIdQuery(userId),
-      );
-
-      return this.authRepository.generateTokens(
-        new ActiveUser({
-          id: user.id,
-          email: user.email,
-          emailVerified: user.emailVerified,
-          role: user.role,
-          systemRole: user.systemRole,
-          orgId: user.orgId,
-          name: user.name,
-        }),
-      );
+      return this.jwtService.verify<RefreshTokenPayload>(token);
     } catch (error: unknown) {
-      this.logger.error('Token verification failed', { error });
+      this.logger.warn('Legacy refresh token verification failed', { error });
       throw new InvalidTokenError('Unable to verify refresh token');
     }
   }
@@ -70,12 +101,25 @@ export class RefreshTokenUseCase {
     if (payload.type === REFRESH_TOKEN_TYPE) {
       return true;
     }
-    // FUTURE(AYC-451): remove this legacy grace ~7 days after deploy. It accepts
-    // refresh tokens minted before the `type` claim existed. A legacy refresh
-    // token is a bare `{sub}` payload; access tokens always carry `email` and
-    // every special-purpose token carries a `type`, so this shape check accepts
-    // only genuine legacy refresh tokens and closes the access-as-refresh hole
-    // immediately without invalidating existing sessions.
+    // A legacy refresh token is a bare `{sub}` payload; access tokens always
+    // carry `email` and special-purpose tokens carry a `type`.
     return payload.type === undefined && payload.email === undefined;
+  }
+
+  private async issueAccessToken(userId: UUID): Promise<string> {
+    const user = await this.findUserByIdUseCase.execute(
+      new FindUserByIdQuery(userId),
+    );
+    return this.authRepository.generateAccessToken(
+      new ActiveUser({
+        id: user.id,
+        email: user.email,
+        emailVerified: user.emailVerified,
+        role: user.role,
+        systemRole: user.systemRole,
+        orgId: user.orgId,
+        name: user.name,
+      }),
+    );
   }
 }

--- a/ayunis-core-backend/src/iam/authentication/authentication.module.ts
+++ b/ayunis-core-backend/src/iam/authentication/authentication.module.ts
@@ -30,6 +30,7 @@ import { SubscriptionsModule } from '../subscriptions/subscriptions.module';
 import { TrialsModule } from '../trials/trials.module';
 import { ApiKeysModule } from '../api-keys/api-keys.module';
 import { MfaModule } from '../mfa/mfa.module';
+import { SessionsModule } from '../sessions/sessions.module';
 import { ClsModule } from 'nestjs-cls';
 import { UserContextInterceptor } from './application/interceptors/user-context.interceptor';
 import { MfaLoginController } from './presenters/http/mfa-login.controller';
@@ -50,6 +51,7 @@ const AUTHENTICATION_IMPORTS = [
   TrialsModule,
   ApiKeysModule,
   MfaModule,
+  SessionsModule,
   JwtConfigModule,
   ClsModule.forFeature(),
 ];

--- a/ayunis-core-backend/src/iam/authentication/infrastructure/repositories/local/local-authentication.repository.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/infrastructure/repositories/local/local-authentication.repository.spec.ts
@@ -43,38 +43,30 @@ describe('LocalAuthenticationRepository', () => {
 
   afterEach(() => jest.clearAllMocks());
 
-  it('should sign access and refresh tokens with their configured expiries', async () => {
+  it('should sign an access token with its configured expiry', async () => {
     configService.get.mockReturnValue({
       secret: 'super-secret',
       expiresIn: '1h',
       refreshTokenExpiresIn: '7d',
     });
-    jwtService.sign
-      .mockReturnValueOnce('signed-access-token')
-      .mockReturnValueOnce('signed-refresh-token');
+    jwtService.sign.mockReturnValueOnce('signed-access-token');
 
-    const tokens = await repository.generateTokens(user);
+    const accessToken = await repository.generateAccessToken(user);
 
-    expect(jwtService.sign).toHaveBeenNthCalledWith(
-      1,
+    // Access token stays untyped (JwtStrategy rejects typed tokens) and no
+    // refresh token is signed here — refresh is now an opaque stored session.
+    expect(jwtService.sign).toHaveBeenCalledTimes(1);
+    expect(jwtService.sign).toHaveBeenCalledWith(
       expect.objectContaining({ sub: user.id, email: user.email }),
       { expiresIn: '1h' },
     );
-    expect(jwtService.sign).toHaveBeenNthCalledWith(
-      2,
-      { sub: user.id, type: 'refresh' },
-      { expiresIn: '7d' },
-    );
-    expect(tokens).toEqual({
-      access_token: 'signed-access-token',
-      refresh_token: 'signed-refresh-token',
-    });
+    expect(accessToken).toBe('signed-access-token');
   });
 
-  it('should throw when the JWT configuration is missing', () => {
+  it('should throw when the JWT configuration is missing', async () => {
     configService.get.mockReturnValue(undefined);
 
-    expect(() => repository.generateTokens(user)).toThrow(
+    await expect(repository.generateAccessToken(user)).rejects.toThrow(
       'JWT configuration is missing',
     );
   });

--- a/ayunis-core-backend/src/iam/authentication/infrastructure/repositories/local/local-authentication.repository.ts
+++ b/ayunis-core-backend/src/iam/authentication/infrastructure/repositories/local/local-authentication.repository.ts
@@ -3,8 +3,6 @@ import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { AuthenticationRepository } from '../../../application/ports/authentication.repository';
 import { ActiveUser } from '../../../domain/active-user.entity';
-import { AuthTokens } from 'src/iam/authentication/domain/auth-tokens.entity';
-import { REFRESH_TOKEN_TYPE } from '../../../domain/token-type.constants';
 import type { StringValue } from 'ms';
 
 interface JwtConfig {
@@ -25,42 +23,40 @@ export class LocalAuthenticationRepository extends AuthenticationRepository {
     this.logger.log('constructor');
   }
 
-  generateTokens(user: ActiveUser): Promise<AuthTokens> {
-    this.logger.log('generateTokens', {
+  generateAccessToken(user: ActiveUser): Promise<string> {
+    this.logger.log('generateAccessToken', {
       userId: user.id,
       email: user.email,
       name: user.name,
     });
-    return Promise.resolve(this.createTokens(user));
+    try {
+      return Promise.resolve(this.signAccessToken(user));
+    } catch (error) {
+      return Promise.reject(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    }
   }
 
-  private createTokens(user: ActiveUser): AuthTokens {
+  private signAccessToken(user: ActiveUser): string {
     const jwtConfig = this.configService.get<JwtConfig>('auth.jwt');
     if (!jwtConfig) {
       throw new Error('JWT configuration is missing');
     }
 
-    return {
-      access_token: this.jwtService.sign(
-        {
-          email: user.email,
-          emailVerified: user.emailVerified,
-          sub: user.id,
-          orgId: user.orgId,
-          role: user.role,
-          systemRole: user.systemRole,
-          name: user.name,
-        },
-        {
-          expiresIn: jwtConfig.expiresIn,
-        },
-      ),
-      refresh_token: this.jwtService.sign(
-        { sub: user.id, type: REFRESH_TOKEN_TYPE },
-        {
-          expiresIn: jwtConfig.refreshTokenExpiresIn,
-        },
-      ),
-    };
+    return this.jwtService.sign(
+      {
+        email: user.email,
+        emailVerified: user.emailVerified,
+        sub: user.id,
+        orgId: user.orgId,
+        role: user.role,
+        systemRole: user.systemRole,
+        name: user.name,
+      },
+      {
+        expiresIn: jwtConfig.expiresIn,
+      },
+    );
   }
 }

--- a/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.spec.ts
@@ -19,6 +19,7 @@ import { RATE_LIMIT_KEY } from 'src/common/decorators/rate-limit.decorator';
 import type { RateLimitOptions } from 'src/common/decorators/rate-limit.decorator';
 import { CheckMfaLoginRequirementUseCase } from 'src/iam/mfa/application/use-cases/check-mfa-login-requirement/check-mfa-login-requirement.use-case';
 import { MfaPendingJwtService } from 'src/iam/mfa/application/services/mfa-pending-jwt.service';
+import { RevokeSessionFamilyUseCase } from 'src/iam/sessions/application/use-cases/revoke-session-family/revoke-session-family.use-case';
 
 describe('AuthenticationController', () => {
   let controller: AuthenticationController;
@@ -28,6 +29,7 @@ describe('AuthenticationController', () => {
   let mockGetCurrentUserUseCase: Partial<GetCurrentUserUseCase>;
   let mockCheckMfaLoginRequirementUseCase: { execute: jest.Mock };
   let mockMfaPendingJwtService: { generate: jest.Mock };
+  let mockRevokeSessionFamilyUseCase: { execute: jest.Mock };
   let mockConfigService: Partial<ConfigService>;
   let mockJwtService: Partial<JwtService>;
 
@@ -50,6 +52,9 @@ describe('AuthenticationController', () => {
     mockMfaPendingJwtService = {
       generate: jest.fn(),
     };
+    mockRevokeSessionFamilyUseCase = {
+      execute: jest.fn().mockResolvedValue(undefined),
+    };
     mockConfigService = {
       get: jest.fn(),
     };
@@ -71,6 +76,10 @@ describe('AuthenticationController', () => {
         {
           provide: MfaPendingJwtService,
           useValue: mockMfaPendingJwtService,
+        },
+        {
+          provide: RevokeSessionFamilyUseCase,
+          useValue: mockRevokeSessionFamilyUseCase,
         },
         { provide: ConfigService, useValue: mockConfigService },
         { provide: JwtService, useValue: mockJwtService },

--- a/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.ts
+++ b/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.ts
@@ -47,6 +47,8 @@ import { LoginUseCase } from '../../application/use-cases/login/login.use-case';
 import { RefreshTokenUseCase } from '../../application/use-cases/refresh-token/refresh-token.use-case';
 import { RegisterUserUseCase } from '../../application/use-cases/register-user/register-user.use-case';
 import { GetCurrentUserUseCase } from '../../application/use-cases/get-current-user/get-current-user.use-case';
+import { RevokeSessionFamilyUseCase } from 'src/iam/sessions/application/use-cases/revoke-session-family/revoke-session-family.use-case';
+import { RevokeSessionFamilyCommand } from 'src/iam/sessions/application/use-cases/revoke-session-family/revoke-session-family.command';
 import { LoginCommand } from '../../application/use-cases/login/login.command';
 import { RefreshTokenCommand } from '../../application/use-cases/refresh-token/refresh-token.command';
 import { RegisterUserCommand } from '../../application/use-cases/register-user/register-user.command';
@@ -63,6 +65,7 @@ export class AuthenticationController {
     private readonly refreshTokenUseCase: RefreshTokenUseCase,
     private readonly registerUserUseCase: RegisterUserUseCase,
     private readonly getCurrentUserUseCase: GetCurrentUserUseCase,
+    private readonly revokeSessionFamilyUseCase: RevokeSessionFamilyUseCase,
     private readonly checkMfaLoginRequirementUseCase: CheckMfaLoginRequirementUseCase,
     private readonly mfaPendingJwtService: MfaPendingJwtService,
     private readonly configService: ConfigService,
@@ -187,6 +190,11 @@ export class AuthenticationController {
 
   @Public()
   @Post('refresh')
+  // Every rotation writes a refresh-token row, so an uncapped endpoint lets a
+  // token holder grow the table without bound. The limit is per IP and refresh
+  // fires automatically for every active session, so it must stay generous
+  // enough for many municipal users sharing one NAT address.
+  @RateLimit({ limit: 300, windowMs: 15 * 60 * 1000 })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Refresh authentication tokens',
@@ -228,12 +236,29 @@ export class AuthenticationController {
       });
     }
 
-    const tokens = await this.refreshTokenUseCase.execute(
-      new RefreshTokenCommand(refreshToken),
-    );
-    setCookies(res, tokens, this.configService, true);
+    return this.performRefresh(res, refreshToken);
+  }
 
-    return res.json({ success: true });
+  private async performRefresh(
+    res: Response,
+    refreshToken: string,
+  ): Promise<Response> {
+    try {
+      const tokens = await this.refreshTokenUseCase.execute(
+        new RefreshTokenCommand(refreshToken),
+      );
+      setCookies(res, tokens, this.configService, true);
+      return res.json({ success: true });
+    } catch (error) {
+      // Any refresh failure (expired, reuse/theft, unknown) leaves the browser
+      // holding a useless refresh cookie — clear it so the client logs out
+      // cleanly instead of retrying a doomed token.
+      this.logger.warn('Refresh failed; clearing cookies', error);
+      clearCookies(res, this.configService);
+      return res
+        .status(HttpStatus.UNAUTHORIZED)
+        .json({ message: 'Invalid refresh token' });
+    }
   }
 
   @Get('me')
@@ -330,6 +355,8 @@ export class AuthenticationController {
       return res.json(this.meResponseDtoMapper.toDto(user));
     } catch (error) {
       this.logger.error('Token refresh failed during me request', error);
+      // Clear the now-useless refresh cookie so the client logs out cleanly.
+      clearCookies(res, this.configService);
       return res.status(HttpStatus.UNAUTHORIZED).json({
         success: false,
         message: 'Not authenticated',
@@ -349,7 +376,22 @@ export class AuthenticationController {
     description: 'Logout successful. Authentication cookies are cleared.',
     type: SuccessResponseDto,
   })
-  logout(@Res() res: Response) {
+  async logout(@Req() req: Request, @Res() res: Response) {
+    const refreshTokenName = this.configService.get<string>(
+      'auth.cookie.refreshTokenName',
+      'refresh_token',
+    );
+    const cookies = req.cookies as Record<string, string>;
+    const refreshToken = cookies[refreshTokenName];
+
+    if (refreshToken) {
+      // Revoke the whole family so the session cannot be resurrected via a
+      // still-live refresh token on another device sharing this login.
+      await this.revokeSessionFamilyUseCase.execute(
+        new RevokeSessionFamilyCommand(refreshToken),
+      );
+    }
+
     clearCookies(res, this.configService);
     return res.json({ success: true });
   }

--- a/ayunis-core-backend/src/iam/sessions/SUMMARY.md
+++ b/ayunis-core-backend/src/iam/sessions/SUMMARY.md
@@ -1,0 +1,14 @@
+Sessions
+Server-side refresh-token sessions with rotation, family-based reuse detection, and revocation.
+
+Owns the persistent state behind the refresh cookie: opaque refresh tokens grouped into families (one family per login/device). Rotation atomically consumes the presented token and issues a successor in the same family; presenting a revoked token — or replaying a rotated token after the grace window — revokes the entire family as a theft response. The module deliberately imports nothing from **users** or **authentication** (the record's `ManyToOne(UserRecord)` is a type-only import), so both can depend on it without a cycle.
+
+Domain entity: `RefreshToken` — `familyId` ties a rotation chain to its login, `tokenHash` is the SHA-256 of the opaque plaintext (which is never stored), `usedAt`/`revokedAt` gate rotation, and `replacedByTokenId` is an audit pointer to the successor (FK with `SET NULL` on delete). `isExpired()`/`isRevoked()` are the only domain checks.
+
+Application layer: `RefreshTokenFactory` builds tokens (32 random bytes base64url for the cookie, hash on the entity, TTL from `auth.jwt.refreshTokenExpiresIn`). The `RefreshTokensRepository` port's key operation is `markUsedAndInsertSuccessor` — a single transaction that marks the current token used, links it to the successor, and inserts the successor, so a partial failure can never consume a token without issuing its replacement; it returns `false` (writing nothing) when a concurrent request already won. `wasUsedWithinGrace` distinguishes a benign concurrent rotation (a sibling successor is issued) from a post-grace replay (family revoked). `sessions.errors.ts` defines `RefreshTokenNotFoundError`, `RefreshTokenExpiredError`, and `RefreshTokenReuseError` (all 401).
+
+Use cases: `CreateSessionUseCase` (new family on login), `RotateSessionUseCase` (validate → atomic rotate → grace-window race handling → reuse detection), `RevokeSessionFamilyUseCase` (logout), `RevokeAllSessionsForUserUseCase` (admin password reset), and `RevokeOtherSessionsForUserUseCase` (self-service password change — the actor's current family survives).
+
+Infrastructure: `LocalRefreshTokensRepository` implements the port with TypeORM; rotation-sensitive writes are conditional UPDATEs on DB time (`NOW()`), keeping the winner decision single-writer under concurrency and immune to app-clock skew. `SessionsCleanupTask` deletes rows strictly by expiry nightly at 5 AM — used and revoked rows survive until expiry so grace-window checks and "revoked family" replay responses keep working.
+
+It integrates with **authentication** (login mints a session, refresh rotates it, logout revokes the family) and **users** (password reset/change revoke sessions) via the exported use cases, and with **users** for the `userId` FK relationship.

--- a/ayunis-core-backend/src/iam/sessions/application/ports/refresh-tokens.repository.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/ports/refresh-tokens.repository.ts
@@ -1,0 +1,45 @@
+import type { UUID } from 'crypto';
+import type { RefreshToken } from '../../domain/refresh-token.entity';
+
+export abstract class RefreshTokensRepository {
+  abstract insert(token: RefreshToken): Promise<void>;
+
+  abstract findByTokenHash(tokenHash: string): Promise<RefreshToken | null>;
+
+  /**
+   * In one transaction, marks the current token used, links it to the
+   * successor, and inserts the successor — so a partial failure can never
+   * consume the presented token without issuing its replacement. Returns false
+   * (writing nothing) when the token was already used/revoked/expired, i.e. a
+   * concurrent request won the rotation. Uses DB time so app-clock skew is
+   * irrelevant.
+   */
+  abstract markUsedAndInsertSuccessor(
+    currentId: UUID,
+    successor: RefreshToken,
+  ): Promise<boolean>;
+
+  /**
+   * True when the token was marked used within the last `graceSeconds`
+   * (measured against DB time). Distinguishes a benign concurrent-request race
+   * from a genuine post-rotation replay.
+   */
+  abstract wasUsedWithinGrace(id: UUID, graceSeconds: number): Promise<boolean>;
+
+  /** Revokes every non-revoked token in the family (theft response / logout). */
+  abstract revokeFamily(familyId: UUID): Promise<void>;
+
+  abstract revokeAllForUser(userId: UUID): Promise<void>;
+
+  /**
+   * Revokes every non-revoked token for the user except the given family. Used
+   * on self-service password change so the actor's current device survives
+   * while all other sessions are killed.
+   */
+  abstract revokeAllForUserExceptFamily(
+    userId: UUID,
+    keepFamilyId: UUID,
+  ): Promise<void>;
+
+  abstract deleteExpired(now: Date): Promise<number>;
+}

--- a/ayunis-core-backend/src/iam/sessions/application/services/refresh-token.factory.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/services/refresh-token.factory.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomBytes, randomUUID, type UUID } from 'crypto';
+import { sha256Hex } from 'src/common/util/sha256.util';
+import { getMillisecondsFromJwtExpiry } from 'src/common/util/jwt.util';
+import { RefreshToken } from '../../domain/refresh-token.entity';
+
+/**
+ * Builds opaque refresh tokens. The plaintext (32 random bytes, base64url) is
+ * returned once for the cookie; only its SHA-256 hash is stored on the entity.
+ */
+@Injectable()
+export class RefreshTokenFactory {
+  constructor(private readonly configService: ConfigService) {}
+
+  create(params: { userId: UUID; familyId: UUID }): {
+    token: RefreshToken;
+    plaintext: string;
+  } {
+    const plaintext = randomBytes(32).toString('base64url');
+    const token = new RefreshToken({
+      userId: params.userId,
+      familyId: params.familyId,
+      tokenHash: sha256Hex(plaintext),
+      expiresAt: new Date(Date.now() + this.ttlMs()),
+    });
+    return { token, plaintext };
+  }
+
+  newFamilyId(): UUID {
+    return randomUUID();
+  }
+
+  private ttlMs(): number {
+    return getMillisecondsFromJwtExpiry(
+      this.configService.get<string>('auth.jwt.refreshTokenExpiresIn', '7d'),
+    );
+  }
+}

--- a/ayunis-core-backend/src/iam/sessions/application/sessions.errors.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/sessions.errors.ts
@@ -1,0 +1,73 @@
+import type { ErrorMetadata } from 'src/common/errors/base.error';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+export enum SessionsErrorCode {
+  REFRESH_TOKEN_NOT_FOUND = 'REFRESH_TOKEN_NOT_FOUND',
+  REFRESH_TOKEN_EXPIRED = 'REFRESH_TOKEN_EXPIRED',
+  REFRESH_TOKEN_REUSE = 'REFRESH_TOKEN_REUSE',
+  UNEXPECTED_SESSIONS_ERROR = 'UNEXPECTED_SESSIONS_ERROR',
+}
+
+export abstract class SessionsError extends ApplicationError {
+  constructor(
+    message: string,
+    code: SessionsErrorCode,
+    statusCode = 401,
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, code, statusCode, metadata);
+  }
+}
+
+/** The presented refresh token does not match any stored token. */
+export class RefreshTokenNotFoundError extends SessionsError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'Refresh token not found',
+      SessionsErrorCode.REFRESH_TOKEN_NOT_FOUND,
+      401,
+      metadata,
+    );
+  }
+}
+
+/** The presented refresh token exists but has expired. */
+export class RefreshTokenExpiredError extends SessionsError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'Refresh token expired',
+      SessionsErrorCode.REFRESH_TOKEN_EXPIRED,
+      401,
+      metadata,
+    );
+  }
+}
+
+/**
+ * A revoked token, or a rotated token replayed after the grace window, was
+ * presented. The whole token family is revoked as a theft response.
+ */
+export class RefreshTokenReuseError extends SessionsError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'Refresh token reuse detected',
+      SessionsErrorCode.REFRESH_TOKEN_REUSE,
+      401,
+      metadata,
+    );
+  }
+}
+
+export class UnexpectedSessionsError extends SessionsError {
+  constructor(error: unknown, metadata?: ErrorMetadata) {
+    super(
+      'An unexpected error occurred',
+      SessionsErrorCode.UNEXPECTED_SESSIONS_ERROR,
+      500,
+      {
+        error: error instanceof Error ? error.message : String(error),
+        ...metadata,
+      },
+    );
+  }
+}

--- a/ayunis-core-backend/src/iam/sessions/application/testing/refresh-token.fixtures.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/testing/refresh-token.fixtures.ts
@@ -1,0 +1,43 @@
+import type { UUID } from 'crypto';
+import { RefreshToken } from '../../domain/refresh-token.entity';
+import type { RefreshTokensRepository } from '../ports/refresh-tokens.repository';
+
+export const TEST_USER_ID = '22222222-2222-2222-2222-222222222222' as UUID;
+export const TEST_FAMILY_ID = '33333333-3333-3333-3333-333333333333' as UUID;
+export const TEST_TOKEN_ID = '44444444-4444-4444-4444-444444444444' as UUID;
+
+export function aRefreshToken(
+  overrides: Partial<{
+    id: UUID;
+    userId: UUID;
+    familyId: UUID;
+    tokenHash: string;
+    expiresAt: Date;
+    usedAt: Date | null;
+    revokedAt: Date | null;
+  }> = {},
+): RefreshToken {
+  return new RefreshToken({
+    id: overrides.id ?? TEST_TOKEN_ID,
+    userId: overrides.userId ?? TEST_USER_ID,
+    familyId: overrides.familyId ?? TEST_FAMILY_ID,
+    tokenHash: overrides.tokenHash ?? 'sha256-hash',
+    expiresAt:
+      overrides.expiresAt ?? new Date(Date.now() + 7 * 24 * 3600 * 1000),
+    usedAt: overrides.usedAt ?? null,
+    revokedAt: overrides.revokedAt ?? null,
+  });
+}
+
+export function createMockRefreshTokensRepository(): jest.Mocked<RefreshTokensRepository> {
+  return {
+    insert: jest.fn().mockResolvedValue(undefined),
+    findByTokenHash: jest.fn().mockResolvedValue(null),
+    markUsedAndInsertSuccessor: jest.fn().mockResolvedValue(true),
+    wasUsedWithinGrace: jest.fn().mockResolvedValue(false),
+    revokeFamily: jest.fn().mockResolvedValue(undefined),
+    revokeAllForUser: jest.fn().mockResolvedValue(undefined),
+    revokeAllForUserExceptFamily: jest.fn().mockResolvedValue(undefined),
+    deleteExpired: jest.fn().mockResolvedValue(0),
+  };
+}

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/create-session/create-session.command.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/create-session/create-session.command.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class CreateSessionCommand {
+  constructor(public readonly userId: UUID) {}
+}

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/create-session/create-session.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/create-session/create-session.use-case.spec.ts
@@ -1,0 +1,43 @@
+import { Logger } from '@nestjs/common';
+import { CreateSessionUseCase } from './create-session.use-case';
+import { CreateSessionCommand } from './create-session.command';
+import {
+  aRefreshToken,
+  createMockRefreshTokensRepository,
+  TEST_FAMILY_ID,
+  TEST_USER_ID,
+} from '../../testing/refresh-token.fixtures';
+
+describe('CreateSessionUseCase', () => {
+  let useCase: CreateSessionUseCase;
+  let repository: ReturnType<typeof createMockRefreshTokensRepository>;
+  let factory: { create: jest.Mock; newFamilyId: jest.Mock };
+
+  beforeEach(() => {
+    repository = createMockRefreshTokensRepository();
+    factory = {
+      create: jest.fn().mockReturnValue({
+        token: aRefreshToken(),
+        plaintext: 'plaintext',
+      }),
+      newFamilyId: jest.fn().mockReturnValue(TEST_FAMILY_ID),
+    };
+    useCase = new CreateSessionUseCase(repository, factory as never);
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should insert a token in a new family and return the plaintext', async () => {
+    const result = await useCase.execute(
+      new CreateSessionCommand(TEST_USER_ID),
+    );
+
+    expect(result.refreshToken).toBe('plaintext');
+    expect(factory.create).toHaveBeenCalledWith({
+      userId: TEST_USER_ID,
+      familyId: TEST_FAMILY_ID,
+    });
+    expect(repository.insert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/create-session/create-session.use-case.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/create-session/create-session.use-case.ts
@@ -1,0 +1,35 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { CreateSessionCommand } from './create-session.command';
+import { RefreshTokensRepository } from '../../ports/refresh-tokens.repository';
+import { RefreshTokenFactory } from '../../services/refresh-token.factory';
+import { UnexpectedSessionsError } from '../../sessions.errors';
+
+export interface CreateSessionResult {
+  refreshToken: string;
+  expiresAt: Date;
+}
+
+@Injectable()
+export class CreateSessionUseCase {
+  private readonly logger = new Logger(CreateSessionUseCase.name);
+
+  constructor(
+    private readonly refreshTokensRepository: RefreshTokensRepository,
+    private readonly refreshTokenFactory: RefreshTokenFactory,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedSessionsError)
+  async execute(command: CreateSessionCommand): Promise<CreateSessionResult> {
+    this.logger.log('createSession', { userId: command.userId });
+
+    const { token, plaintext } = this.refreshTokenFactory.create({
+      userId: command.userId,
+      familyId: this.refreshTokenFactory.newFamilyId(),
+    });
+
+    await this.refreshTokensRepository.insert(token);
+
+    return { refreshToken: plaintext, expiresAt: token.expiresAt };
+  }
+}

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-all-sessions-for-user/revoke-all-sessions-for-user.command.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-all-sessions-for-user/revoke-all-sessions-for-user.command.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class RevokeAllSessionsForUserCommand {
+  constructor(public readonly userId: UUID) {}
+}

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-all-sessions-for-user/revoke-all-sessions-for-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-all-sessions-for-user/revoke-all-sessions-for-user.use-case.spec.ts
@@ -1,0 +1,26 @@
+import { Logger } from '@nestjs/common';
+import { RevokeAllSessionsForUserUseCase } from './revoke-all-sessions-for-user.use-case';
+import { RevokeAllSessionsForUserCommand } from './revoke-all-sessions-for-user.command';
+import {
+  createMockRefreshTokensRepository,
+  TEST_USER_ID,
+} from '../../testing/refresh-token.fixtures';
+
+describe('RevokeAllSessionsForUserUseCase', () => {
+  let useCase: RevokeAllSessionsForUserUseCase;
+  let repository: ReturnType<typeof createMockRefreshTokensRepository>;
+
+  beforeEach(() => {
+    repository = createMockRefreshTokensRepository();
+    useCase = new RevokeAllSessionsForUserUseCase(repository);
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should revoke every session for the user', async () => {
+    await useCase.execute(new RevokeAllSessionsForUserCommand(TEST_USER_ID));
+
+    expect(repository.revokeAllForUser).toHaveBeenCalledWith(TEST_USER_ID);
+  });
+});

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-all-sessions-for-user/revoke-all-sessions-for-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-all-sessions-for-user/revoke-all-sessions-for-user.use-case.ts
@@ -1,0 +1,24 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { RevokeAllSessionsForUserCommand } from './revoke-all-sessions-for-user.command';
+import { RefreshTokensRepository } from '../../ports/refresh-tokens.repository';
+import { UnexpectedSessionsError } from '../../sessions.errors';
+
+/**
+ * Revokes every active session for a user. Called after a password change or
+ * reset so all other devices are logged out.
+ */
+@Injectable()
+export class RevokeAllSessionsForUserUseCase {
+  private readonly logger = new Logger(RevokeAllSessionsForUserUseCase.name);
+
+  constructor(
+    private readonly refreshTokensRepository: RefreshTokensRepository,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedSessionsError)
+  async execute(command: RevokeAllSessionsForUserCommand): Promise<void> {
+    this.logger.log('revokeAllSessionsForUser', { userId: command.userId });
+    await this.refreshTokensRepository.revokeAllForUser(command.userId);
+  }
+}

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-other-sessions-for-user/revoke-other-sessions-for-user.command.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-other-sessions-for-user/revoke-other-sessions-for-user.command.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class RevokeOtherSessionsForUserCommand {
+  constructor(
+    public readonly userId: UUID,
+    public readonly currentRefreshToken: string | undefined,
+  ) {}
+}

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-other-sessions-for-user/revoke-other-sessions-for-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-other-sessions-for-user/revoke-other-sessions-for-user.use-case.spec.ts
@@ -1,0 +1,56 @@
+import { Logger } from '@nestjs/common';
+import { RevokeOtherSessionsForUserUseCase } from './revoke-other-sessions-for-user.use-case';
+import { RevokeOtherSessionsForUserCommand } from './revoke-other-sessions-for-user.command';
+import {
+  aRefreshToken,
+  createMockRefreshTokensRepository,
+  TEST_FAMILY_ID,
+  TEST_USER_ID,
+} from '../../testing/refresh-token.fixtures';
+
+describe('RevokeOtherSessionsForUserUseCase', () => {
+  let useCase: RevokeOtherSessionsForUserUseCase;
+  let repository: ReturnType<typeof createMockRefreshTokensRepository>;
+
+  beforeEach(() => {
+    repository = createMockRefreshTokensRepository();
+    useCase = new RevokeOtherSessionsForUserUseCase(repository);
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should keep the current family and revoke the rest', async () => {
+    repository.findByTokenHash.mockResolvedValue(aRefreshToken());
+
+    await useCase.execute(
+      new RevokeOtherSessionsForUserCommand(TEST_USER_ID, 'current-token'),
+    );
+
+    expect(repository.revokeAllForUserExceptFamily).toHaveBeenCalledWith(
+      TEST_USER_ID,
+      TEST_FAMILY_ID,
+    );
+    expect(repository.revokeAllForUser).not.toHaveBeenCalled();
+  });
+
+  it('should revoke all sessions when the current token is unknown', async () => {
+    repository.findByTokenHash.mockResolvedValue(null);
+
+    await useCase.execute(
+      new RevokeOtherSessionsForUserCommand(TEST_USER_ID, 'stale'),
+    );
+
+    expect(repository.revokeAllForUser).toHaveBeenCalledWith(TEST_USER_ID);
+    expect(repository.revokeAllForUserExceptFamily).not.toHaveBeenCalled();
+  });
+
+  it('should revoke all sessions when no current token is supplied', async () => {
+    await useCase.execute(
+      new RevokeOtherSessionsForUserCommand(TEST_USER_ID, undefined),
+    );
+
+    expect(repository.revokeAllForUser).toHaveBeenCalledWith(TEST_USER_ID);
+    expect(repository.findByTokenHash).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-other-sessions-for-user/revoke-other-sessions-for-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-other-sessions-for-user/revoke-other-sessions-for-user.use-case.ts
@@ -1,0 +1,42 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { sha256Hex } from 'src/common/util/sha256.util';
+import { RevokeOtherSessionsForUserCommand } from './revoke-other-sessions-for-user.command';
+import { RefreshTokensRepository } from '../../ports/refresh-tokens.repository';
+import { UnexpectedSessionsError } from '../../sessions.errors';
+
+/**
+ * Revokes every session for a user except the one presented (the actor's
+ * current device). Used on self-service password change so the actor stays
+ * logged in while all other devices are logged out. Falls back to revoking all
+ * sessions when the current token cannot be resolved (e.g. a legacy JWT cookie).
+ */
+@Injectable()
+export class RevokeOtherSessionsForUserUseCase {
+  private readonly logger = new Logger(RevokeOtherSessionsForUserUseCase.name);
+
+  constructor(
+    private readonly refreshTokensRepository: RefreshTokensRepository,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedSessionsError)
+  async execute(command: RevokeOtherSessionsForUserCommand): Promise<void> {
+    this.logger.log('revokeOtherSessionsForUser', { userId: command.userId });
+
+    const current = command.currentRefreshToken
+      ? await this.refreshTokensRepository.findByTokenHash(
+          sha256Hex(command.currentRefreshToken),
+        )
+      : null;
+
+    if (current?.userId === command.userId) {
+      await this.refreshTokensRepository.revokeAllForUserExceptFamily(
+        command.userId,
+        current.familyId,
+      );
+      return;
+    }
+
+    await this.refreshTokensRepository.revokeAllForUser(command.userId);
+  }
+}

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-session-family/revoke-session-family.command.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-session-family/revoke-session-family.command.ts
@@ -1,0 +1,3 @@
+export class RevokeSessionFamilyCommand {
+  constructor(public readonly refreshToken: string) {}
+}

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-session-family/revoke-session-family.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-session-family/revoke-session-family.use-case.spec.ts
@@ -1,0 +1,39 @@
+import { Logger } from '@nestjs/common';
+import { RevokeSessionFamilyUseCase } from './revoke-session-family.use-case';
+import { RevokeSessionFamilyCommand } from './revoke-session-family.command';
+import {
+  aRefreshToken,
+  createMockRefreshTokensRepository,
+  TEST_FAMILY_ID,
+} from '../../testing/refresh-token.fixtures';
+
+describe('RevokeSessionFamilyUseCase', () => {
+  let useCase: RevokeSessionFamilyUseCase;
+  let repository: ReturnType<typeof createMockRefreshTokensRepository>;
+
+  beforeEach(() => {
+    repository = createMockRefreshTokensRepository();
+    useCase = new RevokeSessionFamilyUseCase(repository);
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should revoke the family of a known token', async () => {
+    repository.findByTokenHash.mockResolvedValue(aRefreshToken());
+
+    await useCase.execute(new RevokeSessionFamilyCommand('token'));
+
+    expect(repository.revokeFamily).toHaveBeenCalledWith(TEST_FAMILY_ID);
+  });
+
+  it('should no-op on an unknown token (idempotent logout)', async () => {
+    repository.findByTokenHash.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(new RevokeSessionFamilyCommand('unknown')),
+    ).resolves.toBeUndefined();
+    expect(repository.revokeFamily).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-session-family/revoke-session-family.use-case.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-session-family/revoke-session-family.use-case.ts
@@ -1,0 +1,32 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { sha256Hex } from 'src/common/util/sha256.util';
+import { RevokeSessionFamilyCommand } from './revoke-session-family.command';
+import { RefreshTokensRepository } from '../../ports/refresh-tokens.repository';
+import { UnexpectedSessionsError } from '../../sessions.errors';
+
+/**
+ * Revokes the token family of the presented refresh token (logout). Idempotent
+ * and tolerant of unknown/legacy tokens: an unrecognized token is a no-op, so
+ * logout never fails.
+ */
+@Injectable()
+export class RevokeSessionFamilyUseCase {
+  private readonly logger = new Logger(RevokeSessionFamilyUseCase.name);
+
+  constructor(
+    private readonly refreshTokensRepository: RefreshTokensRepository,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedSessionsError)
+  async execute(command: RevokeSessionFamilyCommand): Promise<void> {
+    const token = await this.refreshTokensRepository.findByTokenHash(
+      sha256Hex(command.refreshToken),
+    );
+    if (!token) {
+      this.logger.debug('No session found for token; nothing to revoke');
+      return;
+    }
+    await this.refreshTokensRepository.revokeFamily(token.familyId);
+  }
+}

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/rotate-session/rotate-session.command.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/rotate-session/rotate-session.command.ts
@@ -1,0 +1,3 @@
+export class RotateSessionCommand {
+  constructor(public readonly refreshToken: string) {}
+}

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/rotate-session/rotate-session.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/rotate-session/rotate-session.use-case.spec.ts
@@ -1,0 +1,116 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { RotateSessionUseCase } from './rotate-session.use-case';
+import { RotateSessionCommand } from './rotate-session.command';
+import { RefreshTokensRepository } from '../../ports/refresh-tokens.repository';
+import { RefreshTokenFactory } from '../../services/refresh-token.factory';
+import {
+  RefreshTokenExpiredError,
+  RefreshTokenNotFoundError,
+  RefreshTokenReuseError,
+} from '../../sessions.errors';
+import {
+  aRefreshToken,
+  createMockRefreshTokensRepository,
+  TEST_FAMILY_ID,
+} from '../../testing/refresh-token.fixtures';
+
+describe('RotateSessionUseCase', () => {
+  let useCase: RotateSessionUseCase;
+  let repository: jest.Mocked<RefreshTokensRepository>;
+  let factory: { create: jest.Mock };
+
+  beforeEach(async () => {
+    repository = createMockRefreshTokensRepository();
+    factory = {
+      create: jest.fn().mockReturnValue({
+        token: aRefreshToken({ id: 'successor-id' as never }),
+        plaintext: 'new-plaintext',
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RotateSessionUseCase,
+        { provide: RefreshTokensRepository, useValue: repository },
+        { provide: RefreshTokenFactory, useValue: factory },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue(60) },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(RotateSessionUseCase);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  const rotate = () => useCase.execute(new RotateSessionCommand('token'));
+
+  it('should rotate: atomically mark used and insert successor in the same family', async () => {
+    repository.findByTokenHash.mockResolvedValue(aRefreshToken());
+    repository.markUsedAndInsertSuccessor.mockResolvedValue(true);
+
+    const result = await rotate();
+
+    expect(result.refreshToken).toBe('new-plaintext');
+    expect(repository.markUsedAndInsertSuccessor).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'successor-id' }),
+    );
+    expect(repository.insert).not.toHaveBeenCalled();
+    expect(repository.revokeFamily).not.toHaveBeenCalled();
+  });
+
+  it('should throw NotFound for an unknown token and write nothing', async () => {
+    repository.findByTokenHash.mockResolvedValue(null);
+
+    await expect(rotate()).rejects.toThrow(RefreshTokenNotFoundError);
+    expect(repository.markUsedAndInsertSuccessor).not.toHaveBeenCalled();
+    expect(repository.insert).not.toHaveBeenCalled();
+  });
+
+  it('should revoke the family and throw Reuse for a revoked token', async () => {
+    repository.findByTokenHash.mockResolvedValue(
+      aRefreshToken({ revokedAt: new Date() }),
+    );
+
+    await expect(rotate()).rejects.toThrow(RefreshTokenReuseError);
+    expect(repository.revokeFamily).toHaveBeenCalledWith(TEST_FAMILY_ID);
+  });
+
+  it('should throw Expired for an expired token without rotating', async () => {
+    repository.findByTokenHash.mockResolvedValue(
+      aRefreshToken({ expiresAt: new Date(Date.now() - 1000) }),
+    );
+
+    await expect(rotate()).rejects.toThrow(RefreshTokenExpiredError);
+    expect(repository.markUsedAndInsertSuccessor).not.toHaveBeenCalled();
+  });
+
+  it('should issue a sibling on a benign race (lost rotation, within grace)', async () => {
+    repository.findByTokenHash.mockResolvedValue(aRefreshToken());
+    repository.markUsedAndInsertSuccessor.mockResolvedValue(false);
+    repository.wasUsedWithinGrace.mockResolvedValue(true);
+
+    const result = await rotate();
+
+    expect(result.refreshToken).toBe('new-plaintext');
+    expect(repository.insert).toHaveBeenCalledTimes(1);
+    expect(repository.revokeFamily).not.toHaveBeenCalled();
+  });
+
+  it('should revoke the family on a post-grace replay (lost rotation, past grace)', async () => {
+    repository.findByTokenHash.mockResolvedValue(aRefreshToken());
+    repository.markUsedAndInsertSuccessor.mockResolvedValue(false);
+    repository.wasUsedWithinGrace.mockResolvedValue(false);
+
+    await expect(rotate()).rejects.toThrow(RefreshTokenReuseError);
+    expect(repository.revokeFamily).toHaveBeenCalledWith(TEST_FAMILY_ID);
+    expect(repository.insert).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/rotate-session/rotate-session.use-case.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/rotate-session/rotate-session.use-case.ts
@@ -1,0 +1,97 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { sha256Hex } from 'src/common/util/sha256.util';
+import { RotateSessionCommand } from './rotate-session.command';
+import { RefreshTokensRepository } from '../../ports/refresh-tokens.repository';
+import { RefreshTokenFactory } from '../../services/refresh-token.factory';
+import { RefreshToken } from '../../../domain/refresh-token.entity';
+import {
+  RefreshTokenExpiredError,
+  RefreshTokenNotFoundError,
+  RefreshTokenReuseError,
+  UnexpectedSessionsError,
+} from '../../sessions.errors';
+
+export interface RotateSessionResult {
+  userId: UUID;
+  refreshToken: string;
+}
+
+@Injectable()
+export class RotateSessionUseCase {
+  private readonly logger = new Logger(RotateSessionUseCase.name);
+
+  constructor(
+    private readonly refreshTokensRepository: RefreshTokensRepository,
+    private readonly refreshTokenFactory: RefreshTokenFactory,
+    private readonly configService: ConfigService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedSessionsError)
+  async execute(command: RotateSessionCommand): Promise<RotateSessionResult> {
+    const current = await this.refreshTokensRepository.findByTokenHash(
+      sha256Hex(command.refreshToken),
+    );
+
+    if (!current) {
+      throw new RefreshTokenNotFoundError();
+    }
+    if (current.isRevoked()) {
+      // Presenting a revoked token means the family is compromised.
+      await this.refreshTokensRepository.revokeFamily(current.familyId);
+      this.logger.warn('Refresh token reuse detected (revoked token)', {
+        userId: current.userId,
+        familyId: current.familyId,
+      });
+      throw new RefreshTokenReuseError();
+    }
+    if (current.isExpired()) {
+      throw new RefreshTokenExpiredError();
+    }
+
+    return this.rotate(current);
+  }
+
+  private async rotate(current: RefreshToken): Promise<RotateSessionResult> {
+    const { token: successor, plaintext } = this.refreshTokenFactory.create({
+      userId: current.userId,
+      familyId: current.familyId,
+    });
+
+    const won = await this.refreshTokensRepository.markUsedAndInsertSuccessor(
+      current.id,
+      successor,
+    );
+    if (won) {
+      return { userId: current.userId, refreshToken: plaintext };
+    }
+
+    // Lost the atomic rotation: either a concurrent request already rotated
+    // this token (benign race, within grace) or it is a post-grace replay
+    // (theft).
+    const withinGrace = await this.refreshTokensRepository.wasUsedWithinGrace(
+      current.id,
+      this.graceSeconds(),
+    );
+    if (withinGrace) {
+      await this.refreshTokensRepository.insert(successor);
+      return { userId: current.userId, refreshToken: plaintext };
+    }
+
+    await this.refreshTokensRepository.revokeFamily(current.familyId);
+    this.logger.warn('Refresh token reuse detected (post-grace replay)', {
+      userId: current.userId,
+      familyId: current.familyId,
+    });
+    throw new RefreshTokenReuseError();
+  }
+
+  private graceSeconds(): number {
+    return this.configService.get<number>(
+      'auth.session.refreshTokenGraceSeconds',
+      60,
+    );
+  }
+}

--- a/ayunis-core-backend/src/iam/sessions/domain/refresh-token.entity.ts
+++ b/ayunis-core-backend/src/iam/sessions/domain/refresh-token.entity.ts
@@ -1,0 +1,55 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+
+export interface RefreshTokenParams {
+  id?: UUID;
+  userId: UUID;
+  familyId: UUID;
+  tokenHash: string;
+  expiresAt: Date;
+  usedAt?: Date | null;
+  revokedAt?: Date | null;
+  replacedByTokenId?: UUID | null;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+/**
+ * A single server-side refresh token. Rotation marks the presented token used
+ * and issues a successor in the same `familyId`; reuse of a revoked or
+ * past-grace token revokes the whole family (theft response). Only the SHA-256
+ * hash of the opaque token value is stored.
+ */
+export class RefreshToken {
+  id: UUID;
+  userId: UUID;
+  familyId: UUID;
+  tokenHash: string;
+  expiresAt: Date;
+  usedAt: Date | null;
+  revokedAt: Date | null;
+  replacedByTokenId: UUID | null;
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor(params: RefreshTokenParams) {
+    this.id = params.id ?? randomUUID();
+    this.userId = params.userId;
+    this.familyId = params.familyId;
+    this.tokenHash = params.tokenHash;
+    this.expiresAt = params.expiresAt;
+    this.usedAt = params.usedAt ?? null;
+    this.revokedAt = params.revokedAt ?? null;
+    this.replacedByTokenId = params.replacedByTokenId ?? null;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+
+  isExpired(now: Date = new Date()): boolean {
+    return this.expiresAt.getTime() <= now.getTime();
+  }
+
+  isRevoked(): boolean {
+    return this.revokedAt !== null;
+  }
+}

--- a/ayunis-core-backend/src/iam/sessions/infrastructure/repositories/local/local-refresh-tokens.repository.ts
+++ b/ayunis-core-backend/src/iam/sessions/infrastructure/repositories/local/local-refresh-tokens.repository.ts
@@ -1,0 +1,114 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThan, Repository } from 'typeorm';
+import type { UUID } from 'crypto';
+import { RefreshTokensRepository } from '../../../application/ports/refresh-tokens.repository';
+import { RefreshToken } from '../../../domain/refresh-token.entity';
+import { RefreshTokenRecord } from './schema/refresh-token.record';
+import { RefreshTokenMapper } from './mappers/refresh-token.mapper';
+
+/** Internal control flow: aborts the rotation transaction to roll it back. */
+class RotationLostError extends Error {}
+
+@Injectable()
+export class LocalRefreshTokensRepository extends RefreshTokensRepository {
+  constructor(
+    @InjectRepository(RefreshTokenRecord)
+    private readonly repository: Repository<RefreshTokenRecord>,
+  ) {
+    super();
+  }
+
+  async insert(token: RefreshToken): Promise<void> {
+    await this.repository.save(RefreshTokenMapper.toRecord(token));
+  }
+
+  async findByTokenHash(tokenHash: string): Promise<RefreshToken | null> {
+    const record = await this.repository.findOne({ where: { tokenHash } });
+    return record ? RefreshTokenMapper.toDomain(record) : null;
+  }
+
+  async markUsedAndInsertSuccessor(
+    currentId: UUID,
+    successor: RefreshToken,
+  ): Promise<boolean> {
+    try {
+      await this.repository.manager.transaction(async (manager) => {
+        // Successor goes in first so the FK behind replacedByTokenId holds;
+        // losing the conditional update rolls the insert back. The conditional
+        // update on DB time keeps rotation single-winner under concurrency and
+        // independent of app-clock skew.
+        await manager.save(RefreshTokenMapper.toRecord(successor));
+        const result = await manager
+          .createQueryBuilder()
+          .update(RefreshTokenRecord)
+          .set({ usedAt: () => 'NOW()', replacedByTokenId: successor.id })
+          .where('id = :id', { id: currentId })
+          .andWhere('usedAt IS NULL')
+          .andWhere('revokedAt IS NULL')
+          .andWhere('expiresAt > NOW()')
+          .execute();
+        if (result.affected !== 1) {
+          throw new RotationLostError();
+        }
+      });
+    } catch (error) {
+      if (error instanceof RotationLostError) {
+        return false;
+      }
+      throw error;
+    }
+    return true;
+  }
+
+  async wasUsedWithinGrace(id: UUID, graceSeconds: number): Promise<boolean> {
+    const count = await this.repository
+      .createQueryBuilder('t')
+      .where('t.id = :id', { id })
+      .andWhere('t.usedAt IS NOT NULL')
+      .andWhere('t.usedAt > NOW() - make_interval(secs => :graceSeconds)', {
+        graceSeconds,
+      })
+      .getCount();
+    return count > 0;
+  }
+
+  async revokeFamily(familyId: UUID): Promise<void> {
+    await this.repository
+      .createQueryBuilder()
+      .update(RefreshTokenRecord)
+      .set({ revokedAt: () => 'NOW()' })
+      .where('familyId = :familyId', { familyId })
+      .andWhere('revokedAt IS NULL')
+      .execute();
+  }
+
+  async revokeAllForUser(userId: UUID): Promise<void> {
+    await this.repository
+      .createQueryBuilder()
+      .update(RefreshTokenRecord)
+      .set({ revokedAt: () => 'NOW()' })
+      .where('userId = :userId', { userId })
+      .andWhere('revokedAt IS NULL')
+      .execute();
+  }
+
+  async revokeAllForUserExceptFamily(
+    userId: UUID,
+    keepFamilyId: UUID,
+  ): Promise<void> {
+    await this.repository
+      .createQueryBuilder()
+      .update(RefreshTokenRecord)
+      .set({ revokedAt: () => 'NOW()' })
+      .where('userId = :userId', { userId })
+      .andWhere('familyId != :keepFamilyId', { keepFamilyId })
+      .andWhere('revokedAt IS NULL')
+      .execute();
+  }
+
+  async deleteExpired(now: Date): Promise<number> {
+    const result = await this.repository.delete({ expiresAt: LessThan(now) });
+    return result.affected ?? 0;
+  }
+}

--- a/ayunis-core-backend/src/iam/sessions/infrastructure/repositories/local/mappers/refresh-token.mapper.ts
+++ b/ayunis-core-backend/src/iam/sessions/infrastructure/repositories/local/mappers/refresh-token.mapper.ts
@@ -1,0 +1,34 @@
+import { RefreshToken } from '../../../../domain/refresh-token.entity';
+import { RefreshTokenRecord } from '../schema/refresh-token.record';
+
+export class RefreshTokenMapper {
+  static toDomain(record: RefreshTokenRecord): RefreshToken {
+    return new RefreshToken({
+      id: record.id,
+      userId: record.userId,
+      familyId: record.familyId,
+      tokenHash: record.tokenHash,
+      expiresAt: record.expiresAt,
+      usedAt: record.usedAt,
+      revokedAt: record.revokedAt,
+      replacedByTokenId: record.replacedByTokenId,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  static toRecord(domain: RefreshToken): RefreshTokenRecord {
+    const record = new RefreshTokenRecord();
+    record.id = domain.id;
+    record.userId = domain.userId;
+    record.familyId = domain.familyId;
+    record.tokenHash = domain.tokenHash;
+    record.expiresAt = domain.expiresAt;
+    record.usedAt = domain.usedAt;
+    record.revokedAt = domain.revokedAt;
+    record.replacedByTokenId = domain.replacedByTokenId;
+    record.createdAt = domain.createdAt;
+    record.updatedAt = domain.updatedAt;
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/iam/sessions/infrastructure/repositories/local/schema/refresh-token.record.ts
+++ b/ayunis-core-backend/src/iam/sessions/infrastructure/repositories/local/schema/refresh-token.record.ts
@@ -1,0 +1,41 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import type { UUID } from 'crypto';
+import { BaseRecord } from '../../../../../../common/db/base-record';
+import { UserRecord } from '../../../../../users/infrastructure/repositories/local/schema/user.record';
+
+@Entity({ name: 'refresh_tokens' })
+export class RefreshTokenRecord extends BaseRecord {
+  @Index()
+  @Column()
+  userId: UUID;
+
+  @ManyToOne(() => UserRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: UserRecord;
+
+  @Index()
+  @Column()
+  familyId: UUID;
+
+  @Index({ unique: true })
+  @Column()
+  tokenHash: string;
+
+  @Column({ type: 'timestamptz' })
+  expiresAt: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  usedAt: Date | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  revokedAt: Date | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  replacedByTokenId: UUID | null;
+
+  // SET NULL (not CASCADE): the successor may be cleaned up before its
+  // predecessor without erasing the predecessor's audit trail row.
+  @ManyToOne(() => RefreshTokenRecord, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'replacedByTokenId' })
+  replacedByToken: RefreshTokenRecord | null;
+}

--- a/ayunis-core-backend/src/iam/sessions/infrastructure/tasks/sessions-cleanup.task.spec.ts
+++ b/ayunis-core-backend/src/iam/sessions/infrastructure/tasks/sessions-cleanup.task.spec.ts
@@ -1,0 +1,32 @@
+import { Logger } from '@nestjs/common';
+import { SessionsCleanupTask } from './sessions-cleanup.task';
+import { createMockRefreshTokensRepository } from '../../application/testing/refresh-token.fixtures';
+
+describe('SessionsCleanupTask', () => {
+  let task: SessionsCleanupTask;
+  let repository: ReturnType<typeof createMockRefreshTokensRepository>;
+
+  beforeEach(() => {
+    repository = createMockRefreshTokensRepository();
+    task = new SessionsCleanupTask(repository);
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should delete expired tokens', async () => {
+    repository.deleteExpired.mockResolvedValue(5);
+
+    await task.handleCleanup();
+
+    expect(repository.deleteExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it('should swallow repository errors', async () => {
+    repository.deleteExpired.mockRejectedValue(new Error('db down'));
+
+    await expect(task.handleCleanup()).resolves.toBeUndefined();
+  });
+});

--- a/ayunis-core-backend/src/iam/sessions/infrastructure/tasks/sessions-cleanup.task.ts
+++ b/ayunis-core-backend/src/iam/sessions/infrastructure/tasks/sessions-cleanup.task.ts
@@ -1,0 +1,47 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { RefreshTokensRepository } from '../../application/ports/refresh-tokens.repository';
+
+/**
+ * Nightly job that deletes expired refresh tokens. Runs at 5 AM. Deletes
+ * strictly by expiry: used/rotated rows keep their original future expiry (so
+ * nothing inside a grace window is ever swept), and revoked rows survive until
+ * expiry (so continued replay of a stolen token keeps mapping to "revoked
+ * family" rather than degrading to an anonymous "unknown token").
+ */
+@Injectable()
+export class SessionsCleanupTask {
+  private readonly logger = new Logger(SessionsCleanupTask.name);
+  private isRunning = false;
+
+  constructor(
+    private readonly refreshTokensRepository: RefreshTokensRepository,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_5AM)
+  async handleCleanup(): Promise<void> {
+    if (this.isRunning) {
+      this.logger.warn(
+        'Sessions cleanup already running, skipping this execution',
+      );
+      return;
+    }
+
+    this.isRunning = true;
+    this.logger.log('Starting scheduled sessions cleanup');
+
+    try {
+      const deleted = await this.refreshTokensRepository.deleteExpired(
+        new Date(),
+      );
+      this.logger.log('Scheduled sessions cleanup completed', { deleted });
+    } catch (error) {
+      this.logger.error(
+        'Scheduled sessions cleanup failed',
+        error instanceof Error ? error.stack : undefined,
+      );
+    } finally {
+      this.isRunning = false;
+    }
+  }
+}

--- a/ayunis-core-backend/src/iam/sessions/sessions.module.ts
+++ b/ayunis-core-backend/src/iam/sessions/sessions.module.ts
@@ -1,0 +1,43 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { RefreshTokenRecord } from './infrastructure/repositories/local/schema/refresh-token.record';
+import { LocalRefreshTokensRepository } from './infrastructure/repositories/local/local-refresh-tokens.repository';
+import { RefreshTokensRepository } from './application/ports/refresh-tokens.repository';
+import { RefreshTokenFactory } from './application/services/refresh-token.factory';
+import { CreateSessionUseCase } from './application/use-cases/create-session/create-session.use-case';
+import { RotateSessionUseCase } from './application/use-cases/rotate-session/rotate-session.use-case';
+import { RevokeSessionFamilyUseCase } from './application/use-cases/revoke-session-family/revoke-session-family.use-case';
+import { RevokeAllSessionsForUserUseCase } from './application/use-cases/revoke-all-sessions-for-user/revoke-all-sessions-for-user.use-case';
+import { RevokeOtherSessionsForUserUseCase } from './application/use-cases/revoke-other-sessions-for-user/revoke-other-sessions-for-user.use-case';
+import { SessionsCleanupTask } from './infrastructure/tasks/sessions-cleanup.task';
+
+/**
+ * Owns server-side refresh-token session state. Imports nothing from the users
+ * or authentication modules (the record's `ManyToOne(UserRecord)` is a
+ * type-only import), so both of those modules can depend on this one without a
+ * cycle.
+ */
+@Module({
+  imports: [TypeOrmModule.forFeature([RefreshTokenRecord])],
+  providers: [
+    {
+      provide: RefreshTokensRepository,
+      useClass: LocalRefreshTokensRepository,
+    },
+    RefreshTokenFactory,
+    CreateSessionUseCase,
+    RotateSessionUseCase,
+    RevokeSessionFamilyUseCase,
+    RevokeAllSessionsForUserUseCase,
+    RevokeOtherSessionsForUserUseCase,
+    SessionsCleanupTask,
+  ],
+  exports: [
+    CreateSessionUseCase,
+    RotateSessionUseCase,
+    RevokeSessionFamilyUseCase,
+    RevokeAllSessionsForUserUseCase,
+    RevokeOtherSessionsForUserUseCase,
+  ],
+})
+export class SessionsModule {}

--- a/ayunis-core-backend/src/iam/users/application/use-cases/reset-password/reset-password.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/reset-password/reset-password.use-case.spec.ts
@@ -9,6 +9,7 @@ import { PasswordSetTokenService } from '../../services/password-set-token.servi
 import { PasswordSetTokensRepository } from '../../ports/password-set-tokens.repository';
 import { HashTextUseCase } from 'src/iam/hashing/application/use-cases/hash-text/hash-text.use-case';
 import { IsValidPasswordUseCase } from '../is-valid-password/is-valid-password.use-case';
+import { RevokeAllSessionsForUserUseCase } from 'src/iam/sessions/application/use-cases/revoke-all-sessions-for-user/revoke-all-sessions-for-user.use-case';
 import {
   InvalidPasswordError,
   InvalidTokenError,
@@ -31,6 +32,7 @@ describe('ResetPasswordUseCase', () => {
   };
   let mockHashTextUseCase: { execute: jest.Mock };
   let mockIsValidPasswordUseCase: { execute: jest.Mock };
+  let mockRevokeAllSessionsForUserUseCase: { execute: jest.Mock };
 
   const orgId = '660e8400-e29b-41d4-a716-446655440000' as UUID;
 
@@ -52,6 +54,9 @@ describe('ResetPasswordUseCase', () => {
     mockUsersRepository = { findOneById: jest.fn(), update: jest.fn() };
     mockHashTextUseCase = { execute: jest.fn().mockResolvedValue('new-hash') };
     mockIsValidPasswordUseCase = { execute: jest.fn().mockResolvedValue(true) };
+    mockRevokeAllSessionsForUserUseCase = {
+      execute: jest.fn().mockResolvedValue(undefined),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -67,6 +72,10 @@ describe('ResetPasswordUseCase', () => {
           useValue: mockIsValidPasswordUseCase,
         },
         { provide: UsersRepository, useValue: mockUsersRepository },
+        {
+          provide: RevokeAllSessionsForUserUseCase,
+          useValue: mockRevokeAllSessionsForUserUseCase,
+        },
       ],
     }).compile();
 
@@ -93,6 +102,19 @@ describe('ResetPasswordUseCase', () => {
     expect(user.passwordHash).toBe('new-hash');
     expect(mockUsersRepository.update).toHaveBeenCalledWith(user);
     expect(mockTokensRepository.consume).toHaveBeenCalledTimes(1);
+    // A reset revokes every session (the user was logged out via an email link).
+    expect(mockRevokeAllSessionsForUserUseCase.execute).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it('should not revoke sessions when the reset fails', async () => {
+    mockTokenService.findValid.mockResolvedValue(aPasswordSetToken());
+    mockUsersRepository.findOneById.mockResolvedValue(buildUser());
+    mockTokensRepository.consume.mockResolvedValue(false);
+
+    await expect(useCase.execute(command())).rejects.toThrow(InvalidTokenError);
+    expect(mockRevokeAllSessionsForUserUseCase.execute).not.toHaveBeenCalled();
   });
 
   it('should reject and not write the password when the token is already consumed', async () => {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/reset-password/reset-password.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/reset-password/reset-password.use-case.ts
@@ -12,6 +12,8 @@ import { IsValidPasswordUseCase } from 'src/iam/users/application/use-cases/is-v
 import { IsValidPasswordQuery } from 'src/iam/users/application/use-cases/is-valid-password/is-valid-password.query';
 import { InvalidPasswordError } from '../../../../authentication/application/authentication.errors';
 import type { PasswordSetToken } from '../../../domain/password-set-token.entity';
+import { RevokeAllSessionsForUserUseCase } from 'src/iam/sessions/application/use-cases/revoke-all-sessions-for-user/revoke-all-sessions-for-user.use-case';
+import { RevokeAllSessionsForUserCommand } from 'src/iam/sessions/application/use-cases/revoke-all-sessions-for-user/revoke-all-sessions-for-user.command';
 
 @Injectable()
 export class ResetPasswordUseCase {
@@ -23,6 +25,7 @@ export class ResetPasswordUseCase {
     private readonly hashTextUseCase: HashTextUseCase,
     private readonly isValidPasswordUseCase: IsValidPasswordUseCase,
     private readonly usersRepository: UsersRepository,
+    private readonly revokeAllSessionsForUserUseCase: RevokeAllSessionsForUserUseCase,
   ) {}
 
   @HandleUnexpectedErrors(UserUnexpectedError)
@@ -56,6 +59,12 @@ export class ResetPasswordUseCase {
 
     user.passwordHash = newHashedPassword;
     await this.usersRepository.update(user);
+
+    // A reset happens while logged out (via an email link), so revoke every
+    // session — any that survive would be an attacker's.
+    await this.revokeAllSessionsForUserUseCase.execute(
+      new RevokeAllSessionsForUserCommand(user.id),
+    );
 
     this.logger.debug('Password reset successfully', { userId: user.id });
   }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-password/update-password.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-password/update-password.use-case.spec.ts
@@ -11,12 +11,17 @@ import { InvalidPasswordError } from 'src/iam/authentication/application/authent
 import { AuthenticationErrorCode } from 'src/iam/authentication/application/authentication.errors';
 import { User } from '../../../domain/user.entity';
 import { UserRole } from '../../../domain/value-objects/role.object';
+import { RevokeOtherSessionsForUserUseCase } from 'src/iam/sessions/application/use-cases/revoke-other-sessions-for-user/revoke-other-sessions-for-user.use-case';
+import { RevokeOtherSessionsForUserCommand } from 'src/iam/sessions/application/use-cases/revoke-other-sessions-for-user/revoke-other-sessions-for-user.command';
+import { ContextService } from 'src/common/context/services/context.service';
 
 describe('UpdatePasswordUseCase', () => {
   let useCase: UpdatePasswordUseCase;
   let mockUsersRepository: Partial<UsersRepository>;
   let mockHashTextUseCase: { execute: jest.Mock };
   let mockValidateUserUseCase: { execute: jest.Mock };
+  let mockRevokeOtherSessionsForUserUseCase: { execute: jest.Mock };
+  let mockContextService: { get: jest.Mock };
 
   const userId = 'user-id' as UUID;
   const buildUser = () =>
@@ -39,6 +44,12 @@ describe('UpdatePasswordUseCase', () => {
     };
     mockHashTextUseCase = { execute: jest.fn() };
     mockValidateUserUseCase = { execute: jest.fn() };
+    mockRevokeOtherSessionsForUserUseCase = {
+      execute: jest.fn().mockResolvedValue(undefined),
+    };
+    mockContextService = {
+      get: jest.fn().mockReturnValue('actor-refresh-token'),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -46,6 +57,11 @@ describe('UpdatePasswordUseCase', () => {
         { provide: UsersRepository, useValue: mockUsersRepository },
         { provide: HashTextUseCase, useValue: mockHashTextUseCase },
         { provide: ValidateUserUseCase, useValue: mockValidateUserUseCase },
+        {
+          provide: RevokeOtherSessionsForUserUseCase,
+          useValue: mockRevokeOtherSessionsForUserUseCase,
+        },
+        { provide: ContextService, useValue: mockContextService },
       ],
     }).compile();
 
@@ -83,6 +99,16 @@ describe('UpdatePasswordUseCase', () => {
     );
     expect(user.passwordHash).toBe('new-hash');
     expect(mockUsersRepository.update).toHaveBeenCalledWith(user);
+    // All other sessions are revoked; the actor's own device stays logged in.
+    // The actor's refresh token is resolved from request context and forwarded
+    // so its session family is preserved.
+    expect(mockContextService.get).toHaveBeenCalledWith('refreshToken');
+    expect(mockRevokeOtherSessionsForUserUseCase.execute).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(mockRevokeOtherSessionsForUserUseCase.execute).toHaveBeenCalledWith(
+      new RevokeOtherSessionsForUserCommand(userId, 'actor-refresh-token'),
+    );
   });
 
   it('throws INVALID_PASSWORD when the new password violates the policy', async () => {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-password/update-password.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-password/update-password.use-case.ts
@@ -1,14 +1,21 @@
 import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
 import { UsersRepository } from '../../ports/users.repository';
 import { UpdatePasswordCommand } from './update-password.command';
-import { UserInvalidInputError, UserNotFoundError } from '../../users.errors';
+import {
+  UserInvalidInputError,
+  UserNotFoundError,
+  UserUnexpectedError,
+} from '../../users.errors';
 import { HashTextCommand } from 'src/iam/hashing/application/use-cases/hash-text/hash-text.command';
 import { HashTextUseCase } from 'src/iam/hashing/application/use-cases/hash-text/hash-text.use-case';
-import { HashingError } from 'src/iam/hashing/application/hashing.errors';
 import { ValidateUserUseCase } from '../validate-user/validate-user.use-case';
 import { ValidateUserQuery } from '../validate-user/validate-user.query';
 import { InvalidPasswordError } from 'src/iam/authentication/application/authentication.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { RevokeOtherSessionsForUserUseCase } from 'src/iam/sessions/application/use-cases/revoke-other-sessions-for-user/revoke-other-sessions-for-user.use-case';
+import { RevokeOtherSessionsForUserCommand } from 'src/iam/sessions/application/use-cases/revoke-other-sessions-for-user/revoke-other-sessions-for-user.command';
+import { ContextService } from 'src/common/context/services/context.service';
 
 @Injectable()
 export class UpdatePasswordUseCase {
@@ -17,59 +24,57 @@ export class UpdatePasswordUseCase {
     private readonly validateUserUseCase: ValidateUserUseCase,
     private readonly usersRepository: UsersRepository,
     private readonly hashTextUseCase: HashTextUseCase,
+    private readonly revokeOtherSessionsForUserUseCase: RevokeOtherSessionsForUserUseCase,
+    private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: UpdatePasswordCommand): Promise<void> {
     this.logger.log('updatePassword', { userId: command.userId });
 
-    try {
-      if (command.newPassword !== command.newPasswordConfirmation) {
-        throw new UserInvalidInputError('Passwords do not match');
-      }
-
-      const user = await this.usersRepository.findOneById(command.userId);
-      if (!user) {
-        throw new UserNotFoundError(command.userId);
-      }
-
-      // Check if the current password is valid
-      await this.validateUserUseCase.execute(
-        new ValidateUserQuery(user.email, command.currentPassword),
-      );
-
-      const isValidPassword = await this.usersRepository.isValidPassword(
-        command.newPassword,
-      );
-
-      if (!isValidPassword) {
-        throw new InvalidPasswordError(
-          'Password does not meet security requirements',
-        );
-      }
-
-      const newHashedPassword = await this.hashTextUseCase
-        .execute(new HashTextCommand(command.newPassword))
-        .catch((error) => {
-          if (error instanceof HashingError) {
-            throw error;
-          }
-          this.logger.error('Password hashing failed', {
-            error: error instanceof Error ? error.message : 'Unknown error',
-          });
-          throw new UserInvalidInputError('Password hashing failed');
-        });
-
-      user.passwordHash = newHashedPassword;
-      await this.usersRepository.update(user);
-      return;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Password update failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UserInvalidInputError('Password update failed');
+    if (command.newPassword !== command.newPasswordConfirmation) {
+      throw new UserInvalidInputError('Passwords do not match');
     }
+
+    const user = await this.usersRepository.findOneById(command.userId);
+    if (!user) {
+      throw new UserNotFoundError(command.userId);
+    }
+
+    await this.validateUserUseCase.execute(
+      new ValidateUserQuery(user.email, command.currentPassword),
+    );
+
+    const isValidPassword = await this.usersRepository.isValidPassword(
+      command.newPassword,
+    );
+
+    if (!isValidPassword) {
+      throw new InvalidPasswordError(
+        'Password does not meet security requirements',
+      );
+    }
+
+    user.passwordHash = await this.hashTextUseCase.execute(
+      new HashTextCommand(command.newPassword),
+    );
+    await this.usersRepository.update(user);
+
+    await this.revokeOtherSessions(command.userId);
+  }
+
+  /**
+   * Logs out every other device; the actor's current session survives. The
+   * actor's refresh token is resolved from the request context (populated by
+   * UserContextInterceptor); when it is absent (e.g. a legacy cookie) every
+   * session is revoked instead.
+   */
+  private async revokeOtherSessions(userId: UUID): Promise<void> {
+    await this.revokeOtherSessionsForUserUseCase.execute(
+      new RevokeOtherSessionsForUserCommand(
+        userId,
+        this.contextService.get('refreshToken'),
+      ),
+    );
   }
 }

--- a/ayunis-core-backend/src/iam/users/users.module.ts
+++ b/ayunis-core-backend/src/iam/users/users.module.ts
@@ -52,6 +52,7 @@ import { AdminTriggerPasswordResetUseCase } from './application/use-cases/admin-
 import { SuperAdminTriggerPasswordResetUseCase } from './application/use-cases/super-admin-trigger-password-reset/super-admin-trigger-password-reset.use-case';
 import { InvitesModule } from '../invites/invites.module';
 import { OrgsModule } from '../orgs/orgs.module';
+import { SessionsModule } from '../sessions/sessions.module';
 import { SendSetInitialPasswordEmailUseCase } from './application/use-cases/send-set-initial-password-email/send-set-initial-password-email.use-case';
 import { TriggerSetInitialPasswordUseCase } from './application/use-cases/trigger-set-initial-password/trigger-set-initial-password.use-case';
 import { SuperAdminUsersController } from './presenters/http/super-admin-users.controller';
@@ -67,6 +68,7 @@ import { ExportAdminUsersUseCase } from './application/use-cases/export-admin-us
     TypeOrmModule.forFeature([UserRecord, PasswordSetTokenRecord]),
     InvitesModule,
     OrgsModule,
+    SessionsModule,
     HashingModule,
     EmailsModule,
     EmailTemplatesModule,


### PR DESCRIPTION
Replace stateless JWT refresh tokens with opaque, hashed, server-side
session records so sessions become revocable and refresh-token theft is
detectable (closes V6).

- New sessions module: refresh_tokens table storing SHA-256 hashes of
  256-bit opaque tokens, grouped into families (one family per login).
- Rotation uses an atomic conditional update plus an anchored grace
  window: concurrent callers presenting the same token within the grace
  window each receive a sibling successor, so parallel guard-driven
  refreshes never log a user out. Re-presentation after the grace window
  (or of a revoked token) revokes the whole family and raises
  RefreshTokenReuseError. All time checks use DB NOW() to avoid clock skew.
- Access tokens are still short-lived JWTs; login/refresh compose an
  access JWT with an opaque refresh token via CreateSession/RotateSession.
- Legacy JWT refresh cookies are transparently migrated to opaque
  sessions during a bounded grace window (they expire within 7 days).
- Logout revokes the presented token's family. Password reset revokes all
  sessions; self-service password change revokes every OTHER session while
  keeping the actor's own device logged in — the actor's refresh token is
  resolved from request context (UserContextInterceptor -> ContextService).
- Daily sweeper deletes only expired rows so grace windows and reuse
  detection are never undermined.

Refs: AYC-350, AYC-451

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large auth refactor touching login, refresh, logout, guards, and password flows; incorrect rotation/reuse/grace logic could lock users out or miss token theft.
> 
> **Overview**
> **Replaces stateless JWT refresh tokens** with opaque cookies backed by a new `refresh_tokens` table (SHA-256 hashes, per-login **families**). Access tokens stay short-lived JWTs; login and refresh now pair a JWT with a stored session via **CreateSession** / **RotateSession**.
> 
> The new **sessions** module handles atomic rotation (DB `NOW()`-based conditional updates), a configurable **grace window** for concurrent refreshes, and **family revocation** on reuse or logout. **RefreshTokenReuseError** clears cookies in `JwtAuthGuard` and refresh/`me` paths.
> 
> **Authentication** wiring changes: `AuthenticationRepository` only mints access JWTs; **logout** revokes the cookie’s family; **POST /auth/refresh** is rate-limited; failed refresh clears cookies. **Legacy JWT refresh cookies** are migrated once on refresh (transitional path). **UserContextInterceptor** puts the refresh cookie into CLS for password flows.
> 
> **Password reset** revokes all sessions; **self-service password change** revokes other sessions but keeps the current device (refresh token from context).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00b7d801dd05ccf07b4ff496d0e82b13c92ebd25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->