### PR TITLE
fix(skills): install marketplace ai description as skill trigger (AYC-456)

### DIFF
--- a/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.spec.ts
@@ -56,7 +56,7 @@ describe('MarketplaceSkillInstallationService', () => {
   it('should fetch marketplace skill and delegate creation to CreateSkillWithUniqueNameUseCase', async () => {
     const createdSkill = new Skill({
       name: 'Meeting Summarizer',
-      shortDescription: 'Summarize meetings and extract action items',
+      shortDescription: 'AI description for meeting summarizer',
       instructions:
         'You are a meeting summarization assistant. Analyze meeting notes.',
       marketplaceIdentifier: 'meeting-summarizer',
@@ -73,7 +73,7 @@ describe('MarketplaceSkillInstallationService', () => {
 
     expect(result.name).toBe('Meeting Summarizer');
     expect(result.shortDescription).toBe(
-      'Summarize meetings and extract action items',
+      'AI description for meeting summarizer',
     );
     expect(result.instructions).toBe(
       'You are a meeting summarization assistant. Analyze meeting notes.',
@@ -83,7 +83,9 @@ describe('MarketplaceSkillInstallationService', () => {
     expect(createSkillWithUniqueNameUseCase.execute).toHaveBeenCalledWith(
       new CreateSkillWithUniqueNameCommand({
         name: 'Meeting Summarizer',
-        shortDescription: 'Summarize meetings and extract action items',
+        // The installed skill's trigger must come from the marketplace
+        // aiDescription (shown to the LLM), not the marketing shortDescription
+        shortDescription: 'AI description for meeting summarizer',
         instructions:
           'You are a meeting summarization assistant. Analyze meeting notes.',
         marketplaceIdentifier: 'meeting-summarizer',

--- a/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.ts
@@ -75,7 +75,9 @@ export class MarketplaceSkillInstallationService {
     return this.createSkillWithUniqueNameUseCase.execute(
       new CreateSkillWithUniqueNameCommand({
         name: marketplaceSkill.name,
-        shortDescription: marketplaceSkill.shortDescription,
+        // aiDescription is the activation trigger shown to the LLM;
+        // shortDescription is marketing copy for marketplace cards
+        shortDescription: marketplaceSkill.aiDescription,
         instructions: marketplaceSkill.instructions,
         marketplaceIdentifier: marketplaceSkill.identifier,
         userId,


### PR DESCRIPTION
The marketplace install flow stored the marketing shortDescription as
the installed skill's trigger instead of the aiDescription that is
meant to be shown to the LLM for activation. Affects both user-triggered
installs and pre-installed skills at user creation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LLM-facing skill activation text for all marketplace installs (including pre-installed skills); behavior is intentional but affects core assistant routing logic.
> 
> **Overview**
> **Marketplace installs now copy `aiDescription` into the installed skill’s `shortDescription` (LLM activation trigger) instead of the marketplace card’s marketing `shortDescription`.**
> 
> `MarketplaceSkillInstallationService.installFromMarketplace` passes `marketplaceSkill.aiDescription` into `CreateSkillWithUniqueNameCommand.shortDescription`, with comments clarifying the field roles. Because pre-installed skills use the same path via `installAllPreInstalled`, both manual installs and onboarding pre-installs get the fix.
> 
> The unit test is updated so expectations and the mocked created skill use the AI description, and documents that the trigger must not come from marketing copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c6dbd63f96d47ef9439312a9caca3c2086db7b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->