### PR TITLE
wip(artifacts): add spreadsheet artifact domain type and persistence (AYC-153)

### DIFF
--- a/ayunis-core-backend/src/domain/artifacts/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/artifacts/SUMMARY.md
@@ -2,12 +2,16 @@
 
 ## Purpose
 
-Manages versioned documents (artifacts) attached to threads. Artifacts are created and updated by AI tools (`create_document`, `update_document`, `edit_document`) or by users via the WYSIWYG editor. Each modification creates a new version, enabling full version history with revert capability. Artifacts can also be linked to an optional organization letterhead that is applied during PDF export.
+Manages versioned artifacts (documents, diagrams, and spreadsheets) attached to threads. Artifacts are created and updated by AI tools (`create_document`, `update_document`, `edit_document`) or by users via the WYSIWYG editor. Each modification creates a new version, enabling full version history with revert capability. Document artifacts can also be linked to an optional organization letterhead that is applied during PDF export.
 
 ## Domain Concepts
 
-- **Artifact** — A named document belonging to a thread and user. Tracks the current version number and an optional `letterheadId` used for PDF export.
-- **ArtifactVersion** — An immutable snapshot of an artifact's content (HTML string) at a specific version number. Tracks who authored it (user or assistant).
+- **Artifact** — A named, typed artifact belonging to a thread and user. Tracks the current version number; only document artifacts can have an optional `letterheadId` used for PDF export.
+- **DocumentArtifact** — An artifact whose version content is sanitized HTML and may be exported to DOCX or PDF.
+- **DiagramArtifact** — An artifact whose version content is stored without document HTML sanitization or spreadsheet normalization.
+- **SpreadsheetArtifact** — An artifact whose version content is validated and canonicalized `spreadsheet-v1` JSON.
+- **ArtifactVersion** — An immutable snapshot of an artifact's serialized content at a specific version number. The content representation depends on the artifact type, and each version tracks who authored it (user or assistant).
+- **ArtifactType** — Enum distinguishing `DOCUMENT`, `DIAGRAM`, and `SPREADSHEET` artifacts.
 - **AuthorType** — Enum distinguishing whether a version was created by a `USER` or `ASSISTANT`.
 
 ## Architecture
@@ -18,11 +22,14 @@ artifacts/
 │   ├── artifact.entity.ts
 │   ├── artifact-version.entity.ts
 │   └── value-objects/
+│       ├── artifact-type.enum.ts
 │       └── author-type.enum.ts
 ├── application/
 │   ├── artifacts.errors.ts
 │   ├── helpers/
 │   │   ├── add-version-with-retry.ts
+│   │   ├── prepare-content-for-write.ts
+│   │   ├── spreadsheet-content-format.ts
 │   │   └── sanitize-html-content.ts
 │   ├── ports/
 │   │   ├── artifacts-repository.port.ts
@@ -76,7 +83,9 @@ artifacts/
 - Deleting a thread cascade-deletes all its artifacts and versions
 - PDF export resolves the artifact's letterhead, downloads its PDFs from storage, and composites the rendered content onto the first-page / continuation-page backgrounds; if letterhead resolution fails, export falls back to a plain PDF
 - Export delegates to `DocumentExportPort` for format conversion
-- HTML sanitization (XSS prevention) on all content before storage and export
+- Document HTML sanitization (XSS prevention) before storage and export
+- Spreadsheet content uses the versioned `spreadsheet-v1` JSON format with shape, size, and formula validation plus row canonicalization
+- Diagram content is stored without document HTML or spreadsheet normalization
 - Content size validation (max ~512K characters) on create and update
 - Thread ownership verification when creating artifacts
 - Retry-on-conflict logic for version number uniqueness (unique constraint + up to 3 retries)

--- a/ayunis-core-backend/src/domain/artifacts/application/artifacts.errors.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/artifacts.errors.spec.ts
@@ -1,0 +1,14 @@
+import { UnexpectedArtifactError } from './artifacts.errors';
+
+describe('UnexpectedArtifactError', () => {
+  it('does not expose the caught error in the HTTP response', () => {
+    const cause = new Error('database connection string leaked');
+    const error = new UnexpectedArtifactError(cause);
+
+    expect(error.cause).toBe(cause);
+    expect(error.toHttpException().getResponse()).toEqual({
+      code: 'ARTIFACT_UNEXPECTED',
+      message: 'Unexpected artifact error',
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/artifacts/application/artifacts.errors.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/artifacts.errors.ts
@@ -4,6 +4,10 @@ import { ApplicationError } from 'src/common/errors/base.error';
 /** Maximum allowed artifact content length in characters (~500 KB). */
 export const ARTIFACT_MAX_CONTENT_LENGTH = 512_000;
 
+export const MAX_SPREADSHEET_COLUMNS = 100;
+export const MAX_SPREADSHEET_ROWS = 5000;
+export const MAX_SPREADSHEET_FORMULA_LENGTH = 500;
+
 export enum ArtifactErrorCode {
   ARTIFACT_NOT_FOUND = 'ARTIFACT_NOT_FOUND',
   ARTIFACT_VERSION_NOT_FOUND = 'ARTIFACT_VERSION_NOT_FOUND',
@@ -14,6 +18,7 @@ export enum ArtifactErrorCode {
   ARTIFACT_EDIT_AMBIGUOUS = 'ARTIFACT_EDIT_AMBIGUOUS',
   ARTIFACT_LETTERHEAD_NOT_SUPPORTED = 'ARTIFACT_LETTERHEAD_NOT_SUPPORTED',
   ARTIFACT_NOT_EXPORTABLE = 'ARTIFACT_NOT_EXPORTABLE',
+  ARTIFACT_INVALID_SPREADSHEET_CONTENT = 'ARTIFACT_INVALID_SPREADSHEET_CONTENT',
   ARTIFACT_UNEXPECTED = 'ARTIFACT_UNEXPECTED',
 }
 
@@ -146,13 +151,25 @@ export class ArtifactNotExportableError extends ArtifactError {
   }
 }
 
-export class UnexpectedArtifactError extends ArtifactError {
-  constructor(message: string, metadata?: ErrorMetadata) {
+export class InvalidSpreadsheetContentError extends ArtifactError {
+  constructor(reason: string, metadata?: ErrorMetadata) {
     super(
-      `Unexpected artifact error: ${message}`,
+      `Invalid spreadsheet content: ${reason}`,
+      ArtifactErrorCode.ARTIFACT_INVALID_SPREADSHEET_CONTENT,
+      400,
+      metadata,
+    );
+  }
+}
+
+export class UnexpectedArtifactError extends ArtifactError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(
+      'Unexpected artifact error',
       ArtifactErrorCode.ARTIFACT_UNEXPECTED,
       500,
       metadata,
     );
+    this.cause = error;
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/helpers/prepare-content-for-write.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/helpers/prepare-content-for-write.spec.ts
@@ -1,0 +1,43 @@
+import { ArtifactType } from '../../domain/value-objects/artifact-type.enum';
+import { prepareContentForWrite } from './prepare-content-for-write';
+
+describe('prepareContentForWrite', () => {
+  it('sanitizes document HTML before returning it', () => {
+    const content = '<p>Quarterly report</p><script>alert("xss")</script>';
+
+    expect(prepareContentForWrite(ArtifactType.DOCUMENT, content)).toBe(
+      '<p>Quarterly report</p>',
+    );
+  });
+
+  it('normalizes spreadsheet content before returning it', () => {
+    const content = JSON.stringify({
+      format: 'spreadsheet-v1',
+      columns: ['Department', 'Headcount'],
+      rows: [['Finance'], ['Operations', 12, 'ignored extra cell']],
+    });
+
+    expect(
+      JSON.parse(prepareContentForWrite(ArtifactType.SPREADSHEET, content)),
+    ).toEqual({
+      format: 'spreadsheet-v1',
+      columns: ['Department', 'Headcount'],
+      rows: [
+        ['Finance', null],
+        ['Operations', 12],
+      ],
+    });
+  });
+
+  it('preserves diagram content', () => {
+    const content = 'graph TD; A[Start] --> B[Finish]';
+
+    expect(prepareContentForWrite(ArtifactType.DIAGRAM, content)).toBe(content);
+  });
+
+  it('rejects an unsupported artifact type at runtime', () => {
+    expect(() =>
+      prepareContentForWrite('audio' as ArtifactType, 'raw content'),
+    ).toThrow('Unsupported artifact type: audio');
+  });
+});

--- a/ayunis-core-backend/src/domain/artifacts/application/helpers/prepare-content-for-write.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/helpers/prepare-content-for-write.ts
@@ -1,0 +1,28 @@
+import { ArtifactType } from '../../domain/value-objects/artifact-type.enum';
+import { sanitizeHtmlContent } from './sanitize-html-content';
+import {
+  parseSpreadsheetContent,
+  serializeSpreadsheetContent,
+} from './spreadsheet-content-format';
+
+type ContentNormalizer = (content: string) => string;
+
+const identity: ContentNormalizer = (content) => content;
+
+const CONTENT_NORMALIZERS = {
+  [ArtifactType.DOCUMENT]: sanitizeHtmlContent,
+  [ArtifactType.SPREADSHEET]: (content: string) =>
+    serializeSpreadsheetContent(parseSpreadsheetContent(content)),
+  [ArtifactType.DIAGRAM]: identity,
+} satisfies Record<ArtifactType, ContentNormalizer>;
+
+export function prepareContentForWrite(
+  type: ArtifactType,
+  content: string,
+): string {
+  if (!Object.prototype.hasOwnProperty.call(CONTENT_NORMALIZERS, type)) {
+    throw new Error(`Unsupported artifact type: ${String(type)}`);
+  }
+
+  return CONTENT_NORMALIZERS[type](content);
+}

--- a/ayunis-core-backend/src/domain/artifacts/application/helpers/spreadsheet-content-format.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/helpers/spreadsheet-content-format.spec.ts
@@ -1,0 +1,317 @@
+import {
+  isFormulaCell,
+  parseSpreadsheetContent,
+  serializeSpreadsheetContent,
+  SPREADSHEET_CONTENT_FORMAT,
+} from './spreadsheet-content-format';
+import {
+  ArtifactContentTooLargeError,
+  InvalidSpreadsheetContentError,
+  MAX_SPREADSHEET_COLUMNS,
+  MAX_SPREADSHEET_FORMULA_LENGTH,
+  MAX_SPREADSHEET_ROWS,
+} from '../artifacts.errors';
+
+describe('spreadsheet-content-format', () => {
+  const validContent = JSON.stringify({
+    format: SPREADSHEET_CONTENT_FORMAT,
+    columns: ['Item', 'Amount'],
+    rows: [
+      ['Rent', 1200],
+      ['Food', 450.5],
+      ['Misc', null],
+    ],
+  });
+
+  describe('parseSpreadsheetContent', () => {
+    it('should parse valid spreadsheet content', () => {
+      const result = parseSpreadsheetContent(validContent);
+
+      expect(result.format).toBe(SPREADSHEET_CONTENT_FORMAT);
+      expect(result.columns).toEqual(['Item', 'Amount']);
+      expect(result.rows).toEqual([
+        ['Rent', 1200],
+        ['Food', 450.5],
+        ['Misc', null],
+      ]);
+    });
+
+    it('should reject content that is not valid JSON', () => {
+      expect(() => parseSpreadsheetContent('not json {')).toThrow(
+        InvalidSpreadsheetContentError,
+      );
+    });
+
+    it('should reject JSON that is not an object', () => {
+      expect(() => parseSpreadsheetContent('[1, 2, 3]')).toThrow(
+        InvalidSpreadsheetContentError,
+      );
+      expect(() => parseSpreadsheetContent('"text"')).toThrow(
+        InvalidSpreadsheetContentError,
+      );
+    });
+
+    it('should reject content with a wrong or missing format literal', () => {
+      const wrongFormat = JSON.stringify({
+        format: 'spreadsheet-v2',
+        columns: ['A'],
+        rows: [],
+      });
+      const missingFormat = JSON.stringify({ columns: ['A'], rows: [] });
+
+      expect(() => parseSpreadsheetContent(wrongFormat)).toThrow(
+        InvalidSpreadsheetContentError,
+      );
+      expect(() => parseSpreadsheetContent(missingFormat)).toThrow(
+        InvalidSpreadsheetContentError,
+      );
+    });
+
+    it('should reject empty or non-array columns', () => {
+      const emptyColumns = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: [],
+        rows: [],
+      });
+      const nonArrayColumns = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: 'Item',
+        rows: [],
+      });
+
+      expect(() => parseSpreadsheetContent(emptyColumns)).toThrow(
+        InvalidSpreadsheetContentError,
+      );
+      expect(() => parseSpreadsheetContent(nonArrayColumns)).toThrow(
+        InvalidSpreadsheetContentError,
+      );
+    });
+
+    it('should reject non-string column headers', () => {
+      const content = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['Item', 42],
+        rows: [],
+      });
+
+      expect(() => parseSpreadsheetContent(content)).toThrow(
+        InvalidSpreadsheetContentError,
+      );
+    });
+
+    it('should reject more columns than the maximum', () => {
+      const content = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: Array.from(
+          { length: MAX_SPREADSHEET_COLUMNS + 1 },
+          (_, i) => `Col ${i}`,
+        ),
+        rows: [],
+      });
+
+      expect(() => parseSpreadsheetContent(content)).toThrow(
+        InvalidSpreadsheetContentError,
+      );
+    });
+
+    it('should reject more rows than the maximum', () => {
+      const content = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['A'],
+        rows: Array.from({ length: MAX_SPREADSHEET_ROWS + 1 }, () => ['x']),
+      });
+
+      expect(() => parseSpreadsheetContent(content)).toThrow(
+        InvalidSpreadsheetContentError,
+      );
+    });
+
+    it('should reject rows that are not arrays', () => {
+      const content = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['A'],
+        rows: ['not-an-array'],
+      });
+
+      expect(() => parseSpreadsheetContent(content)).toThrow(
+        InvalidSpreadsheetContentError,
+      );
+    });
+
+    it('should reject cells that are not string, number, or null', () => {
+      const withObject = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['A'],
+        rows: [[{ nested: true }]],
+      });
+      const withBoolean = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['A'],
+        rows: [[true]],
+      });
+
+      expect(() => parseSpreadsheetContent(withObject)).toThrow(
+        InvalidSpreadsheetContentError,
+      );
+      expect(() => parseSpreadsheetContent(withBoolean)).toThrow(
+        InvalidSpreadsheetContentError,
+      );
+    });
+
+    it('should accept ragged rows (normalization happens on serialize)', () => {
+      const content = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['A', 'B'],
+        rows: [['only-one-cell']],
+      });
+
+      const result = parseSpreadsheetContent(content);
+
+      expect(result.rows).toEqual([['only-one-cell']]);
+    });
+  });
+
+  describe('serializeSpreadsheetContent', () => {
+    it('should serialize with the format literal and round-trip through parse', () => {
+      const serialized = serializeSpreadsheetContent({
+        columns: ['Item', 'Amount'],
+        rows: [['Rent', 1200]],
+      });
+
+      const parsed = parseSpreadsheetContent(serialized);
+      expect(parsed.format).toBe(SPREADSHEET_CONTENT_FORMAT);
+      expect(parsed.columns).toEqual(['Item', 'Amount']);
+      expect(parsed.rows).toEqual([['Rent', 1200]]);
+    });
+
+    it('should pad short rows with null to the column count', () => {
+      const serialized = serializeSpreadsheetContent({
+        columns: ['A', 'B', 'C'],
+        rows: [['x']],
+      });
+
+      expect(parseSpreadsheetContent(serialized).rows).toEqual([
+        ['x', null, null],
+      ]);
+    });
+
+    it('should truncate rows longer than the column count', () => {
+      const serialized = serializeSpreadsheetContent({
+        columns: ['A', 'B'],
+        rows: [['x', 'y', 'z']],
+      });
+
+      expect(parseSpreadsheetContent(serialized).rows).toEqual([['x', 'y']]);
+    });
+
+    it('should reject more columns than the maximum', () => {
+      expect(() =>
+        serializeSpreadsheetContent({
+          columns: Array.from(
+            { length: MAX_SPREADSHEET_COLUMNS + 1 },
+            (_, i) => `Col ${i}`,
+          ),
+          rows: [],
+        }),
+      ).toThrow(InvalidSpreadsheetContentError);
+    });
+
+    it('should reject more rows than the maximum', () => {
+      expect(() =>
+        serializeSpreadsheetContent({
+          columns: ['A'],
+          rows: Array.from({ length: MAX_SPREADSHEET_ROWS + 1 }, () => ['x']),
+        }),
+      ).toThrow(InvalidSpreadsheetContentError);
+    });
+
+    it('should reject non-finite numbers', () => {
+      expect(() =>
+        serializeSpreadsheetContent({
+          columns: ['A'],
+          rows: [[Number.NaN]],
+        }),
+      ).toThrow(InvalidSpreadsheetContentError);
+      expect(() =>
+        serializeSpreadsheetContent({
+          columns: ['A'],
+          rows: [[Number.POSITIVE_INFINITY]],
+        }),
+      ).toThrow(InvalidSpreadsheetContentError);
+    });
+
+    it('should reject serialized content exceeding the maximum length', () => {
+      expect(() =>
+        serializeSpreadsheetContent({
+          columns: ['A', 'B'],
+          rows: Array.from({ length: 300 }, () => ['x'.repeat(2000), null]),
+        }),
+      ).toThrow(ArtifactContentTooLargeError);
+    });
+
+    it('should be idempotent for already-canonical content', () => {
+      const first = serializeSpreadsheetContent({
+        columns: ['A', 'B'],
+        rows: [['x', 1]],
+      });
+      const second = serializeSpreadsheetContent(
+        parseSpreadsheetContent(first),
+      );
+
+      expect(second).toBe(first);
+    });
+  });
+
+  describe('formula cells', () => {
+    it('should identify formula cells by the leading equals sign', () => {
+      expect(isFormulaCell('=SUM(B2:B4)')).toBe(true);
+      expect(isFormulaCell('=A1')).toBe(true);
+      expect(isFormulaCell('plain text')).toBe(false);
+      expect(isFormulaCell('a = b')).toBe(false);
+      expect(isFormulaCell(42)).toBe(false);
+      expect(isFormulaCell(null)).toBe(false);
+    });
+
+    it('should accept formula cells through parse and serialize', () => {
+      const content = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['Item', 'Amount'],
+        rows: [
+          ['Rent', 1200],
+          ['Total', '=SUM(B2:B2)'],
+        ],
+      });
+
+      const parsed = parseSpreadsheetContent(content);
+      expect(parsed.rows[1][1]).toBe('=SUM(B2:B2)');
+
+      const roundTripped = parseSpreadsheetContent(
+        serializeSpreadsheetContent(parsed),
+      );
+      expect(roundTripped.rows[1][1]).toBe('=SUM(B2:B2)');
+    });
+
+    it('should reject formulas longer than the maximum length', () => {
+      const longFormula = `=SUM(${'A1,'.repeat(MAX_SPREADSHEET_FORMULA_LENGTH / 3)}A1)`;
+      const content = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['A'],
+        rows: [[longFormula]],
+      });
+
+      expect(() => parseSpreadsheetContent(content)).toThrow(
+        InvalidSpreadsheetContentError,
+      );
+    });
+
+    it('should not cap plain string cells at the formula length limit', () => {
+      const longText = 'x'.repeat(MAX_SPREADSHEET_FORMULA_LENGTH + 100);
+      const serialized = serializeSpreadsheetContent({
+        columns: ['A'],
+        rows: [[longText]],
+      });
+
+      expect(parseSpreadsheetContent(serialized).rows[0][0]).toBe(longText);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/artifacts/application/helpers/spreadsheet-content-format.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/helpers/spreadsheet-content-format.ts
@@ -1,0 +1,144 @@
+import {
+  ArtifactContentTooLargeError,
+  InvalidSpreadsheetContentError,
+  ARTIFACT_MAX_CONTENT_LENGTH,
+  MAX_SPREADSHEET_COLUMNS,
+  MAX_SPREADSHEET_FORMULA_LENGTH,
+  MAX_SPREADSHEET_ROWS,
+} from '../artifacts.errors';
+
+export const SPREADSHEET_CONTENT_FORMAT = 'spreadsheet-v1';
+
+export type SpreadsheetCell = string | number | null;
+
+export interface SpreadsheetGrid {
+  columns: string[];
+  rows: SpreadsheetCell[][];
+}
+
+export interface SpreadsheetContentV1 extends SpreadsheetGrid {
+  format: typeof SPREADSHEET_CONTENT_FORMAT;
+}
+
+function isSpreadsheetCell(value: unknown): value is SpreadsheetCell {
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    (typeof value === 'number' && Number.isFinite(value))
+  );
+}
+
+/**
+ * A string cell starting with '=' is an Excel formula (A1 notation against
+ * the exported layout: headers are row 1, data starts at row 2). Formulas are
+ * stored as plain text and evaluated only at display/export time.
+ */
+export function isFormulaCell(cell: SpreadsheetCell): cell is string {
+  return typeof cell === 'string' && cell.startsWith('=');
+}
+
+function validateColumns(columns: unknown): asserts columns is string[] {
+  if (!Array.isArray(columns) || columns.length === 0) {
+    throw new InvalidSpreadsheetContentError(
+      'columns must be a non-empty array',
+    );
+  }
+  if (columns.length > MAX_SPREADSHEET_COLUMNS) {
+    throw new InvalidSpreadsheetContentError(
+      `column count (${columns.length}) exceeds maximum (${MAX_SPREADSHEET_COLUMNS})`,
+    );
+  }
+  if (columns.some((column) => typeof column !== 'string')) {
+    throw new InvalidSpreadsheetContentError('column headers must be strings');
+  }
+}
+
+function validateRows(rows: unknown): asserts rows is SpreadsheetCell[][] {
+  if (!Array.isArray(rows)) {
+    throw new InvalidSpreadsheetContentError('rows must be an array');
+  }
+  if (rows.length > MAX_SPREADSHEET_ROWS) {
+    throw new InvalidSpreadsheetContentError(
+      `row count (${rows.length}) exceeds maximum (${MAX_SPREADSHEET_ROWS})`,
+    );
+  }
+  rows.forEach((row: unknown, index) => {
+    if (!Array.isArray(row)) {
+      throw new InvalidSpreadsheetContentError(`row ${index} must be an array`);
+    }
+    if (!row.every(isSpreadsheetCell)) {
+      throw new InvalidSpreadsheetContentError(
+        `row ${index} contains an invalid cell; cells must be strings, finite numbers, or null`,
+      );
+    }
+    if (
+      row.some(
+        (cell) =>
+          isFormulaCell(cell) && cell.length > MAX_SPREADSHEET_FORMULA_LENGTH,
+      )
+    ) {
+      throw new InvalidSpreadsheetContentError(
+        `row ${index} contains a formula longer than ${MAX_SPREADSHEET_FORMULA_LENGTH} characters`,
+      );
+    }
+  });
+}
+
+export function parseSpreadsheetContent(raw: string): SpreadsheetContentV1 {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new InvalidSpreadsheetContentError('content is not valid JSON');
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new InvalidSpreadsheetContentError('content must be a JSON object');
+  }
+
+  const candidate = parsed as Record<string, unknown>;
+  if (candidate.format !== SPREADSHEET_CONTENT_FORMAT) {
+    throw new InvalidSpreadsheetContentError(
+      `format must be '${SPREADSHEET_CONTENT_FORMAT}'`,
+    );
+  }
+  validateColumns(candidate.columns);
+  validateRows(candidate.rows);
+
+  return {
+    format: SPREADSHEET_CONTENT_FORMAT,
+    columns: candidate.columns,
+    rows: candidate.rows,
+  };
+}
+
+function normalizeRow(
+  row: SpreadsheetCell[],
+  columnCount: number,
+): SpreadsheetCell[] {
+  const normalized = row.slice(0, columnCount);
+  while (normalized.length < columnCount) {
+    normalized.push(null);
+  }
+  return normalized;
+}
+
+export function serializeSpreadsheetContent(data: SpreadsheetGrid): string {
+  validateColumns(data.columns);
+  validateRows(data.rows);
+
+  const content: SpreadsheetContentV1 = {
+    format: SPREADSHEET_CONTENT_FORMAT,
+    columns: data.columns,
+    rows: data.rows.map((row) => normalizeRow(row, data.columns.length)),
+  };
+
+  const serialized = JSON.stringify(content);
+  if (serialized.length > ARTIFACT_MAX_CONTENT_LENGTH) {
+    throw new ArtifactContentTooLargeError(
+      serialized.length,
+      ARTIFACT_MAX_CONTENT_LENGTH,
+    );
+  }
+  return serialized;
+}

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case.ts
@@ -15,7 +15,7 @@ import { ArtifactVersion } from '../../../domain/artifact-version.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UpdateArtifactUseCase } from '../update-artifact/update-artifact.use-case';
 import { UpdateArtifactCommand } from '../update-artifact/update-artifact.command';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
@@ -28,6 +28,7 @@ export class ApplyEditsToArtifactUseCase {
     private readonly updateArtifactUseCase: UpdateArtifactUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedArtifactError)
   async execute(
     command: ApplyEditsToArtifactCommand,
   ): Promise<ArtifactVersion> {
@@ -36,68 +37,54 @@ export class ApplyEditsToArtifactUseCase {
       editCount: command.edits.length,
     });
 
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
 
-      // Fetch artifact with versions to get current content
-      const artifact = await this.artifactsRepository.findByIdWithVersions(
+    // Fetch artifact with versions to get current content
+    const artifact = await this.artifactsRepository.findByIdWithVersions(
+      command.artifactId,
+      userId,
+    );
+    if (!artifact) {
+      throw new ArtifactNotFoundError(command.artifactId);
+    }
+
+    if (
+      command.expectedVersionNumber !== undefined &&
+      command.expectedVersionNumber !== artifact.currentVersionNumber
+    ) {
+      throw new ArtifactExpectedVersionMismatchError(
         command.artifactId,
-        userId,
-      );
-      if (!artifact) {
-        throw new ArtifactNotFoundError(command.artifactId);
-      }
-
-      if (
-        command.expectedVersionNumber !== undefined &&
-        command.expectedVersionNumber !== artifact.currentVersionNumber
-      ) {
-        throw new ArtifactExpectedVersionMismatchError(
-          command.artifactId,
-          command.expectedVersionNumber,
-          artifact.currentVersionNumber,
-        );
-      }
-
-      // Find current version content
-      const currentVersion = artifact.versions.find(
-        (v) => v.versionNumber === artifact.currentVersionNumber,
-      );
-      if (!currentVersion) {
-        throw new ArtifactVersionNotFoundError(
-          command.artifactId,
-          artifact.currentVersionNumber,
-        );
-      }
-
-      const content = this.applyEdits(currentVersion.content, command.edits);
-
-      // Sanitize and save using UpdateArtifactUseCase
-      const updateCommand = new UpdateArtifactCommand({
-        artifactId: command.artifactId,
-        content: content,
-        authorType: command.authorType,
-      });
-
-      const result = await this.updateArtifactUseCase.execute(updateCommand);
-      // Content is always provided here so result is always an ArtifactVersion
-      return result as ArtifactVersion;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-
-      this.logger.error('applyEditsToArtifactUnexpectedError', {
-        artifactId: command.artifactId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedArtifactError(
-        error instanceof Error ? error.message : 'Unknown error',
+        command.expectedVersionNumber,
+        artifact.currentVersionNumber,
       );
     }
+
+    // Find current version content
+    const currentVersion = artifact.versions.find(
+      (v) => v.versionNumber === artifact.currentVersionNumber,
+    );
+    if (!currentVersion) {
+      throw new ArtifactVersionNotFoundError(
+        command.artifactId,
+        artifact.currentVersionNumber,
+      );
+    }
+
+    const content = this.applyEdits(currentVersion.content, command.edits);
+
+    // Sanitize and save using UpdateArtifactUseCase
+    const updateCommand = new UpdateArtifactCommand({
+      artifactId: command.artifactId,
+      content: content,
+      authorType: command.authorType,
+    });
+
+    const result = await this.updateArtifactUseCase.execute(updateCommand);
+    // Content is always provided here so result is always an ArtifactVersion
+    return result as ArtifactVersion;
   }
 
   private applyEdits(

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.spec.ts
@@ -20,9 +20,16 @@ import { FindLetterheadUseCase } from 'src/domain/letterheads/application/use-ca
 import { LetterheadNotFoundError } from 'src/domain/letterheads/application/letterheads.errors';
 import {
   ArtifactContentTooLargeError,
+  InvalidSpreadsheetContentError,
   ARTIFACT_MAX_CONTENT_LENGTH,
 } from '../../artifacts.errors';
-import { DocumentArtifact } from 'src/domain/artifacts/domain/artifact.entity';
+import {
+  DiagramArtifact,
+  DocumentArtifact,
+  SpreadsheetArtifact,
+} from 'src/domain/artifacts/domain/artifact.entity';
+import { ArtifactType } from 'src/domain/artifacts/domain/value-objects/artifact-type.enum';
+import { SPREADSHEET_CONTENT_FORMAT } from 'src/domain/artifacts/application/helpers/spreadsheet-content-format';
 
 describe('CreateArtifactUseCase', () => {
   let useCase: CreateArtifactUseCase;
@@ -446,5 +453,113 @@ describe('CreateArtifactUseCase', () => {
     await useCase.execute(command);
 
     expect(callOrder).toEqual(['create', 'addVersion']);
+  });
+
+  describe('artifact type dispatch', () => {
+    beforeEach(() => {
+      artifactsRepository.create.mockImplementation(
+        async (artifact) => artifact,
+      );
+      artifactsRepository.addVersion.mockImplementation(
+        async (version) => version,
+      );
+    });
+
+    it('should create a DiagramArtifact with raw content for type DIAGRAM', async () => {
+      const mermaid = 'graph TD;\n  A-->B;';
+      const command = new CreateArtifactCommand({
+        threadId: mockThreadId,
+        type: ArtifactType.DIAGRAM,
+        title: 'Flow Chart',
+        content: mermaid,
+        authorType: AuthorType.ASSISTANT,
+      });
+
+      const result = await useCase.execute(command);
+
+      expect(result).toBeInstanceOf(DiagramArtifact);
+      expect(result.versions[0].content).toBe(mermaid);
+    });
+
+    it('should create a SpreadsheetArtifact, not a DiagramArtifact, for type SPREADSHEET', async () => {
+      const command = new CreateArtifactCommand({
+        threadId: mockThreadId,
+        type: ArtifactType.SPREADSHEET,
+        title: 'Budget Sheet',
+        content: JSON.stringify({
+          format: SPREADSHEET_CONTENT_FORMAT,
+          columns: ['Item', 'Amount'],
+          rows: [['Rent', 1200]],
+        }),
+        authorType: AuthorType.ASSISTANT,
+      });
+
+      const result = await useCase.execute(command);
+
+      expect(result).toBeInstanceOf(SpreadsheetArtifact);
+      expect(result).not.toBeInstanceOf(DiagramArtifact);
+      expect(result.type).toBe(ArtifactType.SPREADSHEET);
+    });
+
+    it('should canonicalize spreadsheet content by padding ragged rows', async () => {
+      const command = new CreateArtifactCommand({
+        threadId: mockThreadId,
+        type: ArtifactType.SPREADSHEET,
+        title: 'Ragged Sheet',
+        content: JSON.stringify({
+          format: SPREADSHEET_CONTENT_FORMAT,
+          columns: ['A', 'B', 'C'],
+          rows: [['only-one']],
+        }),
+        authorType: AuthorType.ASSISTANT,
+      });
+
+      const result = await useCase.execute(command);
+
+      expect(JSON.parse(result.versions[0].content)).toEqual({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['A', 'B', 'C'],
+        rows: [['only-one', null, null]],
+      });
+    });
+
+    it('should measure the canonical spreadsheet content for the size limit', async () => {
+      const compactContent = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['Value'],
+        rows: [['A'.repeat(ARTIFACT_MAX_CONTENT_LENGTH - 120)]],
+      });
+      const paddedContent = compactContent.replace(
+        '{',
+        `{${' '.repeat(ARTIFACT_MAX_CONTENT_LENGTH - compactContent.length + 1)}`,
+      );
+      const command = new CreateArtifactCommand({
+        threadId: mockThreadId,
+        type: ArtifactType.SPREADSHEET,
+        title: 'Large Formatted Sheet',
+        content: paddedContent,
+        authorType: AuthorType.ASSISTANT,
+      });
+
+      const result = await useCase.execute(command);
+
+      expect(result).toBeInstanceOf(SpreadsheetArtifact);
+      expect(result.versions[0].content).toBe(compactContent);
+    });
+
+    it('should reject invalid spreadsheet JSON without creating the artifact', async () => {
+      const command = new CreateArtifactCommand({
+        threadId: mockThreadId,
+        type: ArtifactType.SPREADSHEET,
+        title: 'Broken Sheet',
+        content: 'not valid json {',
+        authorType: AuthorType.ASSISTANT,
+      });
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        InvalidSpreadsheetContentError,
+      );
+      expect(artifactsRepository.create).not.toHaveBeenCalled();
+    });
   });
 });

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.ts
@@ -1,3 +1,4 @@
+import type { UUID } from 'crypto';
 import { Injectable, Logger } from '@nestjs/common';
 import { Transactional } from '@nestjs-cls/transactional';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
@@ -6,12 +7,14 @@ import {
   Artifact,
   DiagramArtifact,
   DocumentArtifact,
+  SpreadsheetArtifact,
 } from '../../../domain/artifact.entity';
 import { ArtifactVersion } from '../../../domain/artifact-version.entity';
 import { AuthorType } from '../../../domain/value-objects/author-type.enum';
 import { ArtifactType } from '../../../domain/value-objects/artifact-type.enum';
 import { ContextService } from 'src/common/context/services/context.service';
-import { sanitizeHtmlContent } from '../../helpers/sanitize-html-content';
+import { prepareContentForWrite } from '../../helpers/prepare-content-for-write';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { FindThreadUseCase } from 'src/domain/threads/application/use-cases/find-thread/find-thread.use-case';
 import { FindThreadQuery } from 'src/domain/threads/application/use-cases/find-thread/find-thread.query';
 import { FindLetterheadUseCase } from 'src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case';
@@ -21,7 +24,6 @@ import {
   UnexpectedArtifactError,
   ARTIFACT_MAX_CONTENT_LENGTH,
 } from '../../artifacts.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
@@ -35,6 +37,7 @@ export class CreateArtifactUseCase {
     private readonly findLetterheadUseCase: FindLetterheadUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedArtifactError)
   @Transactional()
   async execute(command: CreateArtifactCommand): Promise<Artifact> {
     this.logger.log('Creating artifact', {
@@ -42,97 +45,95 @@ export class CreateArtifactUseCase {
       type: command.type,
     });
 
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
+    const userId = this.resolveUserId();
+    const content = prepareContentForWrite(command.type, command.content);
+    this.validateContentLength(content);
 
-      if (command.content.length > ARTIFACT_MAX_CONTENT_LENGTH) {
-        throw new ArtifactContentTooLargeError(
-          command.content.length,
-          ARTIFACT_MAX_CONTENT_LENGTH,
-        );
-      }
+    await this.findThreadUseCase.execute(new FindThreadQuery(command.threadId));
 
-      await this.findThreadUseCase.execute(
-        new FindThreadQuery(command.threadId),
-      );
-
-      const isDocument = command.type === ArtifactType.DOCUMENT;
-
-      if (isDocument && command.letterheadId) {
-        await this.findLetterheadUseCase.execute(
-          new FindLetterheadQuery({ letterheadId: command.letterheadId }),
-        );
-      }
-
-      const artifact: Artifact = isDocument
-        ? new DocumentArtifact({
-            threadId: command.threadId,
-            userId,
-            title: command.title,
-            letterheadId: command.letterheadId ?? null,
-            currentVersionNumber: 1,
-          })
-        : new DiagramArtifact({
-            threadId: command.threadId,
-            userId,
-            title: command.title,
-            currentVersionNumber: 1,
-          });
-
-      const createdArtifact = await this.artifactsRepository.create(artifact);
-
-      const content = isDocument
-        ? sanitizeHtmlContent(command.content)
-        : command.content;
-
-      const version = new ArtifactVersion({
-        artifactId: createdArtifact.id,
-        versionNumber: 1,
-        content,
-        authorType: command.authorType,
-        authorId: command.authorType === AuthorType.USER ? userId : null,
-      });
-
-      await this.artifactsRepository.addVersion(version);
-
-      if (createdArtifact instanceof DocumentArtifact) {
-        return new DocumentArtifact({
-          id: createdArtifact.id,
-          threadId: createdArtifact.threadId,
-          userId: createdArtifact.userId,
-          title: createdArtifact.title,
-          letterheadId: createdArtifact.letterheadId,
-          currentVersionNumber: createdArtifact.currentVersionNumber,
-          versions: [version],
-          createdAt: createdArtifact.createdAt,
-          updatedAt: createdArtifact.updatedAt,
-        });
-      }
-      return new DiagramArtifact({
-        id: createdArtifact.id,
-        threadId: createdArtifact.threadId,
-        userId: createdArtifact.userId,
-        title: createdArtifact.title,
-        currentVersionNumber: createdArtifact.currentVersionNumber,
-        versions: [version],
-        createdAt: createdArtifact.createdAt,
-        updatedAt: createdArtifact.updatedAt,
-      });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-
-      this.logger.error('createArtifactUnexpectedError', {
-        title: command.title,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedArtifactError(
-        error instanceof Error ? error.message : 'Unknown error',
+    if (command.type === ArtifactType.DOCUMENT && command.letterheadId) {
+      await this.findLetterheadUseCase.execute(
+        new FindLetterheadQuery({ letterheadId: command.letterheadId }),
       );
     }
+
+    const createdArtifact = await this.artifactsRepository.create(
+      this.buildArtifact(command, userId),
+    );
+
+    const version = new ArtifactVersion({
+      artifactId: createdArtifact.id,
+      versionNumber: 1,
+      content,
+      authorType: command.authorType,
+      authorId: command.authorType === AuthorType.USER ? userId : null,
+    });
+
+    await this.artifactsRepository.addVersion(version);
+
+    return this.withVersion(createdArtifact, version);
+  }
+
+  private resolveUserId(): UUID {
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
+    return userId;
+  }
+
+  private validateContentLength(content: string): void {
+    if (content.length > ARTIFACT_MAX_CONTENT_LENGTH) {
+      throw new ArtifactContentTooLargeError(
+        content.length,
+        ARTIFACT_MAX_CONTENT_LENGTH,
+      );
+    }
+  }
+
+  private buildArtifact(
+    command: CreateArtifactCommand,
+    userId: UUID,
+  ): Artifact {
+    const base = {
+      threadId: command.threadId,
+      userId,
+      title: command.title,
+      currentVersionNumber: 1,
+    };
+    switch (command.type) {
+      case ArtifactType.DOCUMENT:
+        return new DocumentArtifact({
+          ...base,
+          letterheadId: command.letterheadId ?? null,
+        });
+      case ArtifactType.DIAGRAM:
+        return new DiagramArtifact(base);
+      case ArtifactType.SPREADSHEET:
+        return new SpreadsheetArtifact(base);
+    }
+  }
+
+  private withVersion(artifact: Artifact, version: ArtifactVersion): Artifact {
+    const base = {
+      id: artifact.id,
+      threadId: artifact.threadId,
+      userId: artifact.userId,
+      title: artifact.title,
+      currentVersionNumber: artifact.currentVersionNumber,
+      versions: [version],
+      createdAt: artifact.createdAt,
+      updatedAt: artifact.updatedAt,
+    };
+    if (artifact instanceof DocumentArtifact) {
+      return new DocumentArtifact({
+        ...base,
+        letterheadId: artifact.letterheadId,
+      });
+    }
+    if (artifact instanceof SpreadsheetArtifact) {
+      return new SpreadsheetArtifact(base);
+    }
+    return new DiagramArtifact(base);
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
@@ -14,7 +14,7 @@ import {
 } from '../../artifacts.errors';
 import { DocumentArtifact } from 'src/domain/artifacts/domain/artifact.entity';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { FindLetterheadUseCase } from 'src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case';
 import { FindLetterheadQuery } from 'src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.query';
@@ -44,47 +44,34 @@ export class ExportArtifactUseCase {
     private readonly getThreadPiiMasksUseCase: GetThreadPiiMasksUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedArtifactError)
   async execute(command: ExportArtifactCommand): Promise<ExportResult> {
     this.logger.log('Exporting artifact', {
       artifactId: command.artifactId,
       format: command.format,
     });
 
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      const artifact = await this.loadExportableArtifact(
-        command.artifactId,
-        userId,
-      );
-      const currentVersion = this.requireCurrentVersion(artifact);
-      const safeTitle = this.buildSafeTitle(artifact.title);
-      const content = await this.deanonymizeContent(
-        artifact.threadId,
-        currentVersion.content,
-      );
-
-      if (command.format === 'docx') {
-        return await this.exportDocx(content, safeTitle);
-      }
-
-      return await this.exportPdf(artifact, content, safeTitle);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-
-      this.logger.error('exportArtifactUnexpectedError', {
-        artifactId: command.artifactId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedArtifactError(
-        error instanceof Error ? error.message : 'Unknown error',
-      );
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
     }
+
+    const artifact = await this.loadExportableArtifact(
+      command.artifactId,
+      userId,
+    );
+    const currentVersion = this.requireCurrentVersion(artifact);
+    const safeTitle = this.buildSafeTitle(artifact.title);
+    const content = await this.deanonymizeContent(
+      artifact.threadId,
+      currentVersion.content,
+    );
+
+    if (command.format === 'docx') {
+      return await this.exportDocx(content, safeTitle);
+    }
+
+    return await this.exportPdf(artifact, content, safeTitle);
   }
 
   private async loadExportableArtifact(

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { FindArtifactWithVersionsQuery } from './find-artifact-with-versions.query';
 import {
@@ -7,45 +7,30 @@ import {
 } from '../../artifacts.errors';
 import { Artifact } from 'src/domain/artifacts/domain/artifact.entity';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
 export class FindArtifactWithVersionsUseCase {
-  private readonly logger = new Logger(FindArtifactWithVersionsUseCase.name);
-
   constructor(
     private readonly artifactsRepository: ArtifactsRepository,
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedArtifactError)
   async execute(query: FindArtifactWithVersionsQuery): Promise<Artifact> {
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      const artifact = await this.artifactsRepository.findByIdWithVersions(
-        query.artifactId,
-        userId,
-      );
-      if (!artifact) {
-        throw new ArtifactNotFoundError(query.artifactId);
-      }
-      return artifact;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-
-      this.logger.error('findArtifactWithVersionsUnexpectedError', {
-        artifactId: query.artifactId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedArtifactError(
-        error instanceof Error ? error.message : 'Unknown error',
-      );
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
     }
+
+    const artifact = await this.artifactsRepository.findByIdWithVersions(
+      query.artifactId,
+      userId,
+    );
+    if (!artifact) {
+      throw new ArtifactNotFoundError(query.artifactId);
+    }
+    return artifact;
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.use-case.ts
@@ -1,44 +1,29 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { FindArtifactsByThreadQuery } from './find-artifacts-by-thread.query';
 import { Artifact } from 'src/domain/artifacts/domain/artifact.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnexpectedArtifactError } from '../../artifacts.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 
 @Injectable()
 export class FindArtifactsByThreadUseCase {
-  private readonly logger = new Logger(FindArtifactsByThreadUseCase.name);
-
   constructor(
     private readonly artifactsRepository: ArtifactsRepository,
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedArtifactError)
   async execute(query: FindArtifactsByThreadQuery): Promise<Artifact[]> {
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      return await this.artifactsRepository.findByThreadId(
-        query.threadId,
-        userId,
-      );
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-
-      this.logger.error('findArtifactsByThreadUnexpectedError', {
-        threadId: query.threadId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedArtifactError(
-        error instanceof Error ? error.message : 'Unknown error',
-      );
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
     }
+
+    return await this.artifactsRepository.findByThreadId(
+      query.threadId,
+      userId,
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.spec.ts
@@ -10,6 +10,7 @@ import {
   ArtifactNotFoundError,
   ArtifactVersionConflictError,
   ArtifactVersionNotFoundError,
+  UnexpectedArtifactError,
 } from '../../artifacts.errors';
 import { DocumentArtifact } from 'src/domain/artifacts/domain/artifact.entity';
 import { ArtifactVersion } from 'src/domain/artifacts/domain/artifact-version.entity';
@@ -395,9 +396,15 @@ describe('RevertArtifactUseCase', () => {
         versionNumber: 1,
       });
 
-      await expect(useCase.execute(command)).rejects.toThrow(
-        'Connection refused',
+      const error = await useCase
+        .execute(command)
+        .catch((caughtError: unknown) => caughtError);
+
+      expect(error).toBeInstanceOf(UnexpectedArtifactError);
+      expect((error as UnexpectedArtifactError).message).toBe(
+        'Unexpected artifact error',
       );
+      expect((error as UnexpectedArtifactError).metadata).toBeUndefined();
 
       expect(artifactsRepository.findByIdWithVersions).toHaveBeenCalledTimes(1);
       expect(

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.ts
@@ -1,3 +1,4 @@
+import type { UUID } from 'crypto';
 import { Injectable, Logger } from '@nestjs/common';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { RevertArtifactCommand } from './revert-artifact.command';
@@ -8,10 +9,9 @@ import {
 } from '../../artifacts.errors';
 import { ArtifactVersion } from '../../../domain/artifact-version.entity';
 import { AuthorType } from '../../../domain/value-objects/author-type.enum';
-import { DocumentArtifact } from '../../../domain/artifact.entity';
-import { sanitizeHtmlContent } from '../../helpers/sanitize-html-content';
+import { prepareContentForWrite } from '../../helpers/prepare-content-for-write';
 import { ContextService } from 'src/common/context/services/context.service';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { addVersionWithRetry } from '../../helpers/add-version-with-retry';
 
@@ -24,70 +24,65 @@ export class RevertArtifactUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedArtifactError)
   async execute(command: RevertArtifactCommand): Promise<ArtifactVersion> {
     this.logger.log('Reverting artifact', {
       artifactId: command.artifactId,
       targetVersion: command.versionNumber,
     });
 
-    try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedAccessError();
-      }
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
 
-      return await addVersionWithRetry({
-        repository: this.artifactsRepository,
-        logger: this.logger,
-        artifactId: command.artifactId,
-        buildVersion: async () => {
-          const artifact = await this.artifactsRepository.findByIdWithVersions(
-            command.artifactId,
-            userId,
-          );
-          if (!artifact) {
-            throw new ArtifactNotFoundError(command.artifactId);
-          }
+    return await addVersionWithRetry({
+      repository: this.artifactsRepository,
+      logger: this.logger,
+      artifactId: command.artifactId,
+      buildVersion: () => this.buildRevertVersion(command, userId),
+    });
+  }
 
-          const targetVersion = artifact.versions.find(
-            (v) => v.versionNumber === command.versionNumber,
-          );
-          if (!targetVersion) {
-            throw new ArtifactVersionNotFoundError(
-              command.artifactId,
-              command.versionNumber,
-            );
-          }
+  private async buildRevertVersion(
+    command: RevertArtifactCommand,
+    userId: UUID,
+  ): Promise<{
+    expectedCurrentVersionNumber: number;
+    version: ArtifactVersion;
+  }> {
+    const artifact = await this.artifactsRepository.findByIdWithVersions(
+      command.artifactId,
+      userId,
+    );
+    if (!artifact) {
+      throw new ArtifactNotFoundError(command.artifactId);
+    }
 
-          const content =
-            artifact instanceof DocumentArtifact
-              ? sanitizeHtmlContent(targetVersion.content)
-              : targetVersion.content;
-
-          return {
-            expectedCurrentVersionNumber: artifact.currentVersionNumber,
-            version: new ArtifactVersion({
-              artifactId: artifact.id,
-              versionNumber: artifact.currentVersionNumber + 1,
-              content,
-              authorType: AuthorType.USER,
-              authorId: userId,
-            }),
-          };
-        },
-      });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-
-      this.logger.error('revertArtifactUnexpectedError', {
-        artifactId: command.artifactId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedArtifactError(
-        error instanceof Error ? error.message : 'Unknown error',
+    const targetVersion = artifact.versions.find(
+      (v) => v.versionNumber === command.versionNumber,
+    );
+    if (!targetVersion) {
+      throw new ArtifactVersionNotFoundError(
+        command.artifactId,
+        command.versionNumber,
       );
     }
+
+    const content = prepareContentForWrite(
+      artifact.type,
+      targetVersion.content,
+    );
+
+    return {
+      expectedCurrentVersionNumber: artifact.currentVersionNumber,
+      version: new ArtifactVersion({
+        artifactId: artifact.id,
+        versionNumber: artifact.currentVersionNumber + 1,
+        content,
+        authorType: AuthorType.USER,
+        authorId: userId,
+      }),
+    };
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.spec.ts
@@ -11,9 +11,15 @@ import {
   ArtifactExpectedVersionMismatchError,
   ArtifactNotFoundError,
   ArtifactVersionConflictError,
+  InvalidSpreadsheetContentError,
+  UnexpectedArtifactError,
   ARTIFACT_MAX_CONTENT_LENGTH,
 } from '../../artifacts.errors';
-import { DocumentArtifact } from 'src/domain/artifacts/domain/artifact.entity';
+import {
+  DocumentArtifact,
+  SpreadsheetArtifact,
+} from 'src/domain/artifacts/domain/artifact.entity';
+import { SPREADSHEET_CONTENT_FORMAT } from 'src/domain/artifacts/application/helpers/spreadsheet-content-format';
 import type { ArtifactVersion } from 'src/domain/artifacts/domain/artifact-version.entity';
 import { AuthorType } from 'src/domain/artifacts/domain/value-objects/author-type.enum';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -261,6 +267,15 @@ describe('UpdateArtifactUseCase', () => {
   it('should reject content exceeding the maximum allowed length', async () => {
     const oversizedContent =
       '<p>' + 'A'.repeat(ARTIFACT_MAX_CONTENT_LENGTH) + '</p>';
+    artifactsRepository.findById.mockResolvedValue(
+      new DocumentArtifact({
+        id: mockArtifactId,
+        threadId: mockThreadId,
+        userId: mockUserId,
+        title: 'Oversized Document',
+        currentVersionNumber: 1,
+      }),
+    );
 
     const command = new UpdateArtifactCommand({
       artifactId: mockArtifactId,
@@ -271,7 +286,9 @@ describe('UpdateArtifactUseCase', () => {
     await expect(useCase.execute(command)).rejects.toThrow(
       ArtifactContentTooLargeError,
     );
-    expect(artifactsRepository.findById).not.toHaveBeenCalled();
+    expect(
+      artifactsRepository.addVersionAndUpdateArtifact,
+    ).not.toHaveBeenCalled();
   });
 
   it('should accept content at exactly the maximum allowed length', async () => {
@@ -714,15 +731,116 @@ describe('UpdateArtifactUseCase', () => {
         authorType: AuthorType.USER,
       });
 
-      await expect(useCase.execute(command)).rejects.toThrow(
-        'Connection refused',
+      const error = await useCase
+        .execute(command)
+        .catch((caughtError: unknown) => caughtError);
+
+      expect(error).toBeInstanceOf(UnexpectedArtifactError);
+      expect((error as UnexpectedArtifactError).message).toBe(
+        'Unexpected artifact error',
       );
+      expect((error as UnexpectedArtifactError).metadata).toBeUndefined();
 
       // 1 ownership check + 1 buildVersion attempt
       expect(artifactsRepository.findById).toHaveBeenCalledTimes(2);
       expect(
         artifactsRepository.addVersionAndUpdateArtifact,
       ).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('spreadsheet artifacts', () => {
+    const spreadsheetArtifact = () =>
+      new SpreadsheetArtifact({
+        id: mockArtifactId,
+        threadId: mockThreadId,
+        userId: mockUserId,
+        title: 'Budget Sheet',
+        currentVersionNumber: 1,
+      });
+
+    beforeEach(() => {
+      artifactsRepository.findById.mockResolvedValue(spreadsheetArtifact());
+      artifactsRepository.addVersionAndUpdateArtifact.mockImplementation(
+        async ({ version }) => version,
+      );
+    });
+
+    it('should canonicalize spreadsheet content on user save', async () => {
+      const command = new UpdateArtifactCommand({
+        artifactId: mockArtifactId,
+        content: JSON.stringify({
+          format: SPREADSHEET_CONTENT_FORMAT,
+          columns: ['A', 'B'],
+          rows: [['x'], ['y', 1, 'extra']],
+        }),
+        authorType: AuthorType.USER,
+      });
+
+      const result = (await useCase.execute(command)) as ArtifactVersion;
+
+      expect(JSON.parse(result.content)).toEqual({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['A', 'B'],
+        rows: [
+          ['x', null],
+          ['y', 1],
+        ],
+      });
+    });
+
+    it('should measure the canonical spreadsheet content for the size limit', async () => {
+      const compactContent = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['Value'],
+        rows: [['A'.repeat(ARTIFACT_MAX_CONTENT_LENGTH - 120)]],
+      });
+      const paddedContent = compactContent.replace(
+        '{',
+        `{${' '.repeat(ARTIFACT_MAX_CONTENT_LENGTH - compactContent.length + 1)}`,
+      );
+      const command = new UpdateArtifactCommand({
+        artifactId: mockArtifactId,
+        content: paddedContent,
+        authorType: AuthorType.USER,
+      });
+
+      const result = (await useCase.execute(command)) as ArtifactVersion;
+
+      expect(result.content).toBe(compactContent);
+    });
+
+    it('should reject invalid spreadsheet content without saving a version', async () => {
+      const command = new UpdateArtifactCommand({
+        artifactId: mockArtifactId,
+        content: '{"format":"wrong-format","columns":["A"],"rows":[]}',
+        authorType: AuthorType.USER,
+      });
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        InvalidSpreadsheetContentError,
+      );
+      expect(
+        artifactsRepository.addVersionAndUpdateArtifact,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should not sanitize spreadsheet content as HTML', async () => {
+      const contentWithAngleBrackets = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['Comparison'],
+        rows: [['a < b > c']],
+      });
+
+      const command = new UpdateArtifactCommand({
+        artifactId: mockArtifactId,
+        content: contentWithAngleBrackets,
+        authorType: AuthorType.USER,
+      });
+
+      const result = (await useCase.execute(command)) as ArtifactVersion;
+
+      expect(JSON.parse(result.content).rows).toEqual([['a < b > c']]);
     });
   });
 });

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.ts
@@ -17,8 +17,8 @@ import {
   DocumentArtifact,
 } from 'src/domain/artifacts/domain/artifact.entity';
 import { ContextService } from 'src/common/context/services/context.service';
-import { sanitizeHtmlContent } from '../../helpers/sanitize-html-content';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { prepareContentForWrite } from '../../helpers/prepare-content-for-write';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { addVersionWithRetry } from '../../helpers/add-version-with-retry';
 import { FindLetterheadUseCase } from 'src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case';
@@ -34,50 +34,38 @@ export class UpdateArtifactUseCase {
     private readonly findLetterheadUseCase: FindLetterheadUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedArtifactError)
   async execute(
     command: UpdateArtifactCommand,
   ): Promise<ArtifactVersion | void> {
     this.logger.log('Updating artifact', { artifactId: command.artifactId });
 
-    try {
-      const userId = this.resolveUserId();
-      this.validateContentLength(command.content);
+    const userId = this.resolveUserId();
 
-      if (command.letterheadId) {
-        await this.findLetterheadUseCase.execute(
-          new FindLetterheadQuery({ letterheadId: command.letterheadId }),
-        );
-      }
-
-      const artifact = await this.artifactsRepository.findById(
-        command.artifactId,
-        userId,
-      );
-      if (!artifact) {
-        throw new ArtifactNotFoundError(command.artifactId);
-      }
-
-      const isDocument = artifact instanceof DocumentArtifact;
-      this.assertLetterheadAllowed(command, artifact, isDocument);
-
-      if (command.content === undefined) {
-        return await this.updateLetterheadOnly(command);
-      }
-
-      return await this.addContentVersion(command, userId, isDocument);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-
-      this.logger.error('updateArtifactUnexpectedError', {
-        artifactId: command.artifactId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedArtifactError(
-        error instanceof Error ? error.message : 'Unknown error',
+    if (command.letterheadId) {
+      await this.findLetterheadUseCase.execute(
+        new FindLetterheadQuery({ letterheadId: command.letterheadId }),
       );
     }
+
+    const artifact = await this.artifactsRepository.findById(
+      command.artifactId,
+      userId,
+    );
+    if (!artifact) {
+      throw new ArtifactNotFoundError(command.artifactId);
+    }
+
+    const isDocument = artifact instanceof DocumentArtifact;
+    this.assertLetterheadAllowed(command, artifact, isDocument);
+
+    if (command.content === undefined) {
+      return await this.updateLetterheadOnly(command);
+    }
+
+    const content = prepareContentForWrite(artifact.type, command.content);
+    this.validateContentLength(content);
+    return await this.addContentVersion(command, userId, content);
   }
 
   private resolveUserId(): UUID {
@@ -88,8 +76,8 @@ export class UpdateArtifactUseCase {
     return userId;
   }
 
-  private validateContentLength(content: string | undefined): void {
-    if (content !== undefined && content.length > ARTIFACT_MAX_CONTENT_LENGTH) {
+  private validateContentLength(content: string): void {
+    if (content.length > ARTIFACT_MAX_CONTENT_LENGTH) {
       throw new ArtifactContentTooLargeError(
         content.length,
         ARTIFACT_MAX_CONTENT_LENGTH,
@@ -121,11 +109,8 @@ export class UpdateArtifactUseCase {
   private async addContentVersion(
     command: UpdateArtifactCommand,
     userId: UUID,
-    isDocument: boolean,
+    content: string,
   ): Promise<ArtifactVersion> {
-    const content = isDocument
-      ? sanitizeHtmlContent(command.content!)
-      : command.content!;
     const authorType = command.authorType ?? AuthorType.USER;
 
     return addVersionWithRetry({

--- a/ayunis-core-backend/src/domain/artifacts/domain/artifact.entity.ts
+++ b/ayunis-core-backend/src/domain/artifacts/domain/artifact.entity.ts
@@ -70,3 +70,18 @@ export class DiagramArtifact extends Artifact {
     super({ ...params, type: ArtifactType.DIAGRAM });
   }
 }
+
+export class SpreadsheetArtifact extends Artifact {
+  constructor(params: {
+    id?: UUID;
+    threadId: UUID;
+    userId: UUID;
+    title: string;
+    currentVersionNumber?: number;
+    versions?: ArtifactVersion[];
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    super({ ...params, type: ArtifactType.SPREADSHEET });
+  }
+}

--- a/ayunis-core-backend/src/domain/artifacts/domain/value-objects/artifact-type.enum.ts
+++ b/ayunis-core-backend/src/domain/artifacts/domain/value-objects/artifact-type.enum.ts
@@ -1,4 +1,5 @@
 export enum ArtifactType {
   DOCUMENT = 'document',
   DIAGRAM = 'diagram',
+  SPREADSHEET = 'spreadsheet',
 }

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/local-artifacts-repository.module.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/local-artifacts-repository.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ArtifactRecord } from './schema/artifact.record';
 import { DocumentArtifactRecord } from './schema/document-artifact.record';
 import { DiagramArtifactRecord } from './schema/diagram-artifact.record';
+import { SpreadsheetArtifactRecord } from './schema/spreadsheet-artifact.record';
 import { ArtifactVersionRecord } from './schema/artifact-version.record';
 import { LocalArtifactsRepository } from './local-artifacts.repository';
 import { ArtifactMapper } from './mappers/artifact.mapper';
@@ -14,6 +15,7 @@ import { ArtifactVersionMapper } from './mappers/artifact-version.mapper';
       ArtifactRecord,
       DocumentArtifactRecord,
       DiagramArtifactRecord,
+      SpreadsheetArtifactRecord,
       ArtifactVersionRecord,
     ]),
   ],

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/mappers/artifact.mapper.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/mappers/artifact.mapper.ts
@@ -3,10 +3,12 @@ import {
   Artifact,
   DiagramArtifact,
   DocumentArtifact,
+  SpreadsheetArtifact,
 } from 'src/domain/artifacts/domain/artifact.entity';
 import { ArtifactRecord } from '../schema/artifact.record';
 import { DocumentArtifactRecord } from '../schema/document-artifact.record';
 import { DiagramArtifactRecord } from '../schema/diagram-artifact.record';
+import { SpreadsheetArtifactRecord } from '../schema/spreadsheet-artifact.record';
 import { ArtifactVersionMapper } from './artifact-version.mapper';
 
 @Injectable()
@@ -15,6 +17,7 @@ export class ArtifactMapper {
 
   toDomain(record: DocumentArtifactRecord): DocumentArtifact;
   toDomain(record: DiagramArtifactRecord): DiagramArtifact;
+  toDomain(record: SpreadsheetArtifactRecord): SpreadsheetArtifact;
   toDomain(record: ArtifactRecord): Artifact;
   toDomain(record: ArtifactRecord): Artifact {
     if (record instanceof DocumentArtifactRecord) {
@@ -42,11 +45,24 @@ export class ArtifactMapper {
         updatedAt: record.updatedAt,
       });
     }
+    if (record instanceof SpreadsheetArtifactRecord) {
+      return new SpreadsheetArtifact({
+        id: record.id,
+        threadId: record.threadId,
+        userId: record.userId,
+        title: record.title,
+        currentVersionNumber: record.currentVersionNumber,
+        versions: record.versions?.map((v) => this.versionMapper.toDomain(v)),
+        createdAt: record.createdAt,
+        updatedAt: record.updatedAt,
+      });
+    }
     throw new Error('Invalid artifact record type');
   }
 
   toRecord(domain: DocumentArtifact): DocumentArtifactRecord;
   toRecord(domain: DiagramArtifact): DiagramArtifactRecord;
+  toRecord(domain: SpreadsheetArtifact): SpreadsheetArtifactRecord;
   toRecord(domain: Artifact): ArtifactRecord;
   toRecord(domain: Artifact): ArtifactRecord {
     if (domain instanceof DocumentArtifact) {
@@ -64,6 +80,18 @@ export class ArtifactMapper {
     }
     if (domain instanceof DiagramArtifact) {
       const record = new DiagramArtifactRecord();
+      record.id = domain.id;
+      record.threadId = domain.threadId;
+      record.userId = domain.userId;
+      record.title = domain.title;
+      record.currentVersionNumber = domain.currentVersionNumber;
+      record.versions = domain.versions.map((v) =>
+        this.versionMapper.toRecord(v),
+      );
+      return record;
+    }
+    if (domain instanceof SpreadsheetArtifact) {
+      const record = new SpreadsheetArtifactRecord();
       record.id = domain.id;
       record.threadId = domain.threadId;
       record.userId = domain.userId;

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/schema/spreadsheet-artifact.record.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/schema/spreadsheet-artifact.record.ts
@@ -1,0 +1,6 @@
+import { ChildEntity } from 'typeorm';
+import { ArtifactRecord } from './artifact.record';
+import { ArtifactType } from '../../../../domain/value-objects/artifact-type.enum';
+
+@ChildEntity(ArtifactType.SPREADSHEET)
+export class SpreadsheetArtifactRecord extends ArtifactRecord {}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3595,6 +3595,7 @@ export type ArtifactResponseDtoType = typeof ArtifactResponseDtoType[keyof typeo
 export const ArtifactResponseDtoType = {
   document: 'document',
   diagram: 'diagram',
+  spreadsheet: 'spreadsheet',
 } as const;
 
 export interface ArtifactResponseDto {

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -15484,7 +15484,7 @@
           "type": {
             "type": "string",
             "description": "The kind of artifact — document (HTML) or diagram (mermaid)",
-            "enum": ["document", "diagram"],
+            "enum": ["document", "diagram", "spreadsheet"],
             "example": "document"
           },
           "threadId": {


### PR DESCRIPTION
- Add SPREADSHEET artifact type with STI record (no migration needed,
  discriminator column exists)
- Add spreadsheet-content helper: versioned spreadsheet-v1 JSON format,
  parse/serialize with canonicalization (row padding/truncation), limits
  (100 columns, 5000 rows), and string mapping for PII handling
- Route all content write paths (create, update, revert) through a shared
  prepareContentForWrite helper
- Fix create-artifact type dispatch: explicit switch instead of a
  document/diagram ternary that would silently persist new types as diagrams

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core artifact write paths and persistence for a new type; spreadsheet validation and canonicalization affect stored data shape, though document XSS behavior is unchanged.
> 
> **Overview**
> Introduces **spreadsheet** as a third artifact type alongside documents and diagrams, with domain entity, TypeORM STI child record, mapper wiring, and OpenAPI/frontend enum updates.
> 
> Spreadsheet version content uses a **`spreadsheet-v1`** JSON schema: parse/serialize helpers enforce column/row/formula limits, validate cell types, and **canonicalize** rows (pad/truncate to column width). Invalid payloads raise `InvalidSpreadsheetContentError` before persistence.
> 
> **Create**, **update**, and **revert** now call **`prepareContentForWrite`**, which sanitizes HTML for documents, normalizes spreadsheets, and leaves diagram text unchanged. Create uses an explicit **type switch** so new types are not misclassified as diagrams. Content size checks run on **canonical** serialized spreadsheet JSON.
> 
> Artifact use cases adopt **`@HandleUnexpectedErrors(UnexpectedArtifactError)`** instead of hand-rolled try/catch. **`UnexpectedArtifactError`** stores the cause internally but returns a generic message in HTTP responses (no leaked internals).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aaf0a64bba2124cceb1f0034b1ebbe480cd363d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->