### PR TITLE
wip(artifacts): add xlsx and csv spreadsheet export (AYC-153)

### DIFF
--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -87,6 +87,7 @@
     "cookie-parser": "^1.4.7",
     "docx": "^9.6.1",
     "dotenv": "^17.3.1",
+    "exceljs": "^4.4.0",
     "form-data": "^4.0.6",
     "helmet": "^8.1.0",
     "ioredis": "^5.11.1",

--- a/ayunis-core-backend/src/domain/artifacts/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/artifacts/SUMMARY.md
@@ -33,7 +33,8 @@ artifacts/
 │   │   └── sanitize-html-content.ts
 │   ├── ports/
 │   │   ├── artifacts-repository.port.ts
-│   │   └── document-export.port.ts
+│   │   ├── document-export.port.ts
+│   │   └── spreadsheet-export.port.ts
 │   └── use-cases/
 │       ├── apply-edits-to-artifact/
 │       ├── create-artifact/
@@ -53,7 +54,8 @@ artifacts/
 │       ├── html-document-export.service.ts
 │       ├── html-to-docx-converter.ts
 │       ├── docx-document-config.ts
-│       └── pdf-letterhead-compositor.ts
+│       ├── pdf-letterhead-compositor.ts
+│       └── xlsx-spreadsheet-export.service.ts
 ├── presenters/http/
 │   ├── artifacts.controller.ts
 │   ├── dtos/
@@ -71,6 +73,7 @@ artifacts/
 
 - **ArtifactsRepository** — CRUD for artifacts and versions
 - **DocumentExportPort** — Converts HTML content to DOCX/PDF buffers, optionally compositing PDF output onto stored letterhead backgrounds with configured margins
+- **SpreadsheetExportPort** — Converts validated spreadsheet content to XLSX or CSV buffers
 
 ## Key Behaviors
 
@@ -83,6 +86,7 @@ artifacts/
 - Deleting a thread cascade-deletes all its artifacts and versions
 - PDF export resolves the artifact's letterhead, downloads its PDFs from storage, and composites the rendered content onto the first-page / continuation-page backgrounds; if letterhead resolution fails, export falls back to a plain PDF
 - Export delegates to `DocumentExportPort` for format conversion
+- Spreadsheet export delegates to `SpreadsheetExportPort` for XLSX/CSV conversion, preserves original formula-cell provenance through PII de-anonymization, and neutralizes formula-like values in CSV output
 - Document HTML sanitization (XSS prevention) before storage and export
 - Spreadsheet content uses the versioned `spreadsheet-v1` JSON format with shape, size, and formula validation plus row canonicalization
 - Diagram content is stored without document HTML or spreadsheet normalization

--- a/ayunis-core-backend/src/domain/artifacts/application/helpers/spreadsheet-content-format.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/helpers/spreadsheet-content-format.ts
@@ -112,6 +112,19 @@ export function parseSpreadsheetContent(raw: string): SpreadsheetContentV1 {
   };
 }
 
+export function mapSpreadsheetStrings(
+  data: SpreadsheetContentV1,
+  map: (value: string) => string,
+): SpreadsheetContentV1 {
+  return {
+    format: data.format,
+    columns: data.columns.map(map),
+    rows: data.rows.map((row) =>
+      row.map((cell) => (typeof cell === 'string' ? map(cell) : cell)),
+    ),
+  };
+}
+
 function normalizeRow(
   row: SpreadsheetCell[],
   columnCount: number,

--- a/ayunis-core-backend/src/domain/artifacts/application/ports/spreadsheet-export.port.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/ports/spreadsheet-export.port.ts
@@ -1,0 +1,11 @@
+import type { SpreadsheetGrid } from '../helpers/spreadsheet-content-format';
+
+export interface SpreadsheetExportInput {
+  grid: SpreadsheetGrid;
+  formulaCells: boolean[][];
+}
+
+export abstract class SpreadsheetExportPort {
+  abstract exportToXlsx(data: SpreadsheetExportInput): Promise<Buffer>;
+  abstract exportToCsv(data: SpreadsheetExportInput): Promise<string>;
+}

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.command.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.command.ts
@@ -1,13 +1,19 @@
 import type { UUID } from 'crypto';
 
-export type ExportFormat = 'docx' | 'pdf';
+export type ExportFormat = 'docx' | 'pdf' | 'xlsx' | 'csv';
 
 export class ExportArtifactCommand {
   readonly artifactId: UUID;
   readonly format: ExportFormat;
+  readonly versionNumber?: number;
 
-  constructor(params: { artifactId: UUID; format: ExportFormat }) {
+  constructor(params: {
+    artifactId: UUID;
+    format: ExportFormat;
+    versionNumber?: number;
+  }) {
     this.artifactId = params.artifactId;
     this.format = params.format;
+    this.versionNumber = params.versionNumber;
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.spec.ts
@@ -8,8 +8,16 @@ import { ExportArtifactUseCase } from './export-artifact.use-case';
 import { ExportArtifactCommand } from './export-artifact.command';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { DocumentExportPort } from '../../ports/document-export.port';
-import { ArtifactNotFoundError } from '../../artifacts.errors';
-import { DocumentArtifact } from 'src/domain/artifacts/domain/artifact.entity';
+import { SpreadsheetExportPort } from '../../ports/spreadsheet-export.port';
+import {
+  ArtifactNotFoundError,
+  ArtifactNotExportableError,
+} from '../../artifacts.errors';
+import {
+  DocumentArtifact,
+  SpreadsheetArtifact,
+} from 'src/domain/artifacts/domain/artifact.entity';
+import { SPREADSHEET_CONTENT_FORMAT } from 'src/domain/artifacts/application/helpers/spreadsheet-content-format';
 import { ArtifactVersion } from 'src/domain/artifacts/domain/artifact-version.entity';
 import { AuthorType } from 'src/domain/artifacts/domain/value-objects/author-type.enum';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -33,6 +41,7 @@ describe('ExportArtifactUseCase', () => {
   let useCase: ExportArtifactUseCase;
   let artifactsRepository: jest.Mocked<ArtifactsRepository>;
   let documentExportPort: jest.Mocked<DocumentExportPort>;
+  let spreadsheetExportPort: jest.Mocked<SpreadsheetExportPort>;
   let findLetterheadUseCase: jest.Mocked<FindLetterheadUseCase>;
   let downloadObjectUseCase: jest.Mocked<DownloadObjectUseCase>;
   let getThreadPiiMasksUseCase: jest.Mocked<GetThreadPiiMasksUseCase>;
@@ -57,6 +66,11 @@ describe('ExportArtifactUseCase', () => {
     const mockExportPort = {
       exportToDocx: jest.fn(),
       exportToPdf: jest.fn(),
+    };
+
+    const mockSpreadsheetExportPort = {
+      exportToXlsx: jest.fn(),
+      exportToCsv: jest.fn(),
     };
 
     const mockContextService = {
@@ -84,6 +98,7 @@ describe('ExportArtifactUseCase', () => {
         ExportArtifactUseCase,
         { provide: ArtifactsRepository, useValue: mockRepository },
         { provide: DocumentExportPort, useValue: mockExportPort },
+        { provide: SpreadsheetExportPort, useValue: mockSpreadsheetExportPort },
         { provide: ContextService, useValue: mockContextService },
         { provide: FindLetterheadUseCase, useValue: mockFindLetterhead },
         { provide: DownloadObjectUseCase, useValue: mockDownloadObject },
@@ -94,6 +109,7 @@ describe('ExportArtifactUseCase', () => {
     useCase = module.get<ExportArtifactUseCase>(ExportArtifactUseCase);
     artifactsRepository = module.get(ArtifactsRepository);
     documentExportPort = module.get(DocumentExportPort);
+    spreadsheetExportPort = module.get(SpreadsheetExportPort);
     findLetterheadUseCase = module.get(FindLetterheadUseCase);
     downloadObjectUseCase = module.get(DownloadObjectUseCase);
     getThreadPiiMasksUseCase = module.get(GetThreadPiiMasksUseCase);
@@ -383,6 +399,7 @@ describe('ExportArtifactUseCase', () => {
         ExportArtifactUseCase,
         { provide: ArtifactsRepository, useValue: artifactsRepository },
         { provide: DocumentExportPort, useValue: documentExportPort },
+        { provide: SpreadsheetExportPort, useValue: spreadsheetExportPort },
         { provide: ContextService, useValue: mockContextService },
         { provide: FindLetterheadUseCase, useValue: findLetterheadUseCase },
         { provide: DownloadObjectUseCase, useValue: downloadObjectUseCase },
@@ -505,5 +522,252 @@ describe('ExportArtifactUseCase', () => {
         continuationPagePdf: undefined,
       }),
     );
+  });
+
+  describe('spreadsheet export', () => {
+    function createSpreadsheetArtifact(
+      content?: string,
+      currentVersionNumber = 1,
+      versions?: ArtifactVersion[],
+    ): SpreadsheetArtifact {
+      return new SpreadsheetArtifact({
+        id: mockArtifactId,
+        threadId: mockThreadId,
+        userId: mockUserId,
+        title: 'Budget 2026',
+        currentVersionNumber,
+        versions: versions ?? [
+          new ArtifactVersion({
+            artifactId: mockArtifactId,
+            versionNumber: 1,
+            content:
+              content ??
+              JSON.stringify({
+                format: SPREADSHEET_CONTENT_FORMAT,
+                columns: ['Item', 'Amount'],
+                rows: [['Rent', 1200]],
+              }),
+            authorType: AuthorType.ASSISTANT,
+          }),
+        ],
+      });
+    }
+
+    it('should export a spreadsheet as XLSX with parsed data and correct mime type', async () => {
+      artifactsRepository.findByIdWithVersions.mockResolvedValue(
+        createSpreadsheetArtifact(),
+      );
+      spreadsheetExportPort.exportToXlsx.mockResolvedValue(
+        Buffer.from('xlsx-content'),
+      );
+
+      const result = await useCase.execute(
+        new ExportArtifactCommand({
+          artifactId: mockArtifactId,
+          format: 'xlsx',
+        }),
+      );
+
+      expect(spreadsheetExportPort.exportToXlsx).toHaveBeenCalledWith(
+        expect.objectContaining({
+          grid: {
+            format: SPREADSHEET_CONTENT_FORMAT,
+            columns: ['Item', 'Amount'],
+            rows: [['Rent', 1200]],
+          },
+          formulaCells: [[false, false]],
+        }),
+      );
+      expect(result.fileName).toBe('Budget 2026.xlsx');
+      expect(result.mimeType).toBe(
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      );
+    });
+
+    it('should export a spreadsheet as CSV with correct mime type', async () => {
+      artifactsRepository.findByIdWithVersions.mockResolvedValue(
+        createSpreadsheetArtifact(),
+      );
+      spreadsheetExportPort.exportToCsv.mockResolvedValue(
+        'Item,Amount\nRent,1200',
+      );
+
+      const result = await useCase.execute(
+        new ExportArtifactCommand({
+          artifactId: mockArtifactId,
+          format: 'csv',
+        }),
+      );
+
+      expect(result.fileName).toBe('Budget 2026.csv');
+      expect(result.mimeType).toBe('text/csv');
+      expect(result.buffer.toString('utf8')).toBe('Item,Amount\nRent,1200');
+    });
+
+    it('should export a requested historical spreadsheet version', async () => {
+      const oldContent = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['Item', 'Amount'],
+        rows: [['Old rent', 1000]],
+      });
+      const currentContent = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['Item', 'Amount'],
+        rows: [['Current rent', 1200]],
+      });
+      const artifact = createSpreadsheetArtifact(undefined, 2, [
+        new ArtifactVersion({
+          artifactId: mockArtifactId,
+          versionNumber: 1,
+          content: oldContent,
+          authorType: AuthorType.ASSISTANT,
+        }),
+        new ArtifactVersion({
+          artifactId: mockArtifactId,
+          versionNumber: 2,
+          content: currentContent,
+          authorType: AuthorType.USER,
+          authorId: mockUserId,
+        }),
+      ]);
+      artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
+      spreadsheetExportPort.exportToXlsx.mockResolvedValue(Buffer.from('x'));
+
+      await useCase.execute(
+        new ExportArtifactCommand({
+          artifactId: mockArtifactId,
+          format: 'xlsx',
+          versionNumber: 1,
+        }),
+      );
+
+      expect(spreadsheetExportPort.exportToXlsx).toHaveBeenCalledWith({
+        grid: {
+          format: SPREADSHEET_CONTENT_FORMAT,
+          columns: ['Item', 'Amount'],
+          rows: [['Old rent', 1000]],
+        },
+        formulaCells: [[false, false]],
+      });
+    });
+
+    it('should reject xlsx export of a document artifact', async () => {
+      artifactsRepository.findByIdWithVersions.mockResolvedValue(
+        createArtifact(),
+      );
+
+      await expect(
+        useCase.execute(
+          new ExportArtifactCommand({
+            artifactId: mockArtifactId,
+            format: 'xlsx',
+          }),
+        ),
+      ).rejects.toThrow(ArtifactNotExportableError);
+      expect(spreadsheetExportPort.exportToXlsx).not.toHaveBeenCalled();
+    });
+
+    it('should reject pdf export of a spreadsheet artifact', async () => {
+      artifactsRepository.findByIdWithVersions.mockResolvedValue(
+        createSpreadsheetArtifact(),
+      );
+
+      await expect(
+        useCase.execute(
+          new ExportArtifactCommand({
+            artifactId: mockArtifactId,
+            format: 'pdf',
+          }),
+        ),
+      ).rejects.toThrow(ArtifactNotExportableError);
+      expect(documentExportPort.exportToPdf).not.toHaveBeenCalled();
+    });
+
+    it('should de-anonymize PII per cell, preserving numbers and JSON validity for quote-containing values', async () => {
+      const content = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['Kontakt {{pii:PERSON_NAME_1}}', 'Betrag'],
+        rows: [
+          ['{{pii:PERSON_NAME_1}}', 1200],
+          ['{{pii:EMAIL_ADDRESS_1}}', null],
+        ],
+      });
+      artifactsRepository.findByIdWithVersions.mockResolvedValue(
+        createSpreadsheetArtifact(content),
+      );
+      spreadsheetExportPort.exportToXlsx.mockResolvedValue(Buffer.from('x'));
+      getThreadPiiMasksUseCase.execute.mockResolvedValue([
+        new ThreadPiiMask({
+          threadId: mockThreadId,
+          category: PiiCategory.PERSON_NAME,
+          maskIndex: 1,
+          value: 'Mustermann, "Max"',
+        }),
+        new ThreadPiiMask({
+          threadId: mockThreadId,
+          category: PiiCategory.EMAIL_ADDRESS,
+          maskIndex: 1,
+          value: 'max@example.de',
+        }),
+      ]);
+
+      await useCase.execute(
+        new ExportArtifactCommand({
+          artifactId: mockArtifactId,
+          format: 'xlsx',
+        }),
+      );
+
+      expect(spreadsheetExportPort.exportToXlsx).toHaveBeenCalledWith({
+        grid: {
+          format: SPREADSHEET_CONTENT_FORMAT,
+          columns: ['Kontakt Mustermann, "Max"', 'Betrag'],
+          rows: [
+            ['Mustermann, "Max"', 1200],
+            ['max@example.de', null],
+          ],
+        },
+        formulaCells: [
+          [false, false],
+          [false, false],
+        ],
+      });
+    });
+
+    it('should preserve original formula provenance after de-anonymization', async () => {
+      const content = JSON.stringify({
+        format: SPREADSHEET_CONTENT_FORMAT,
+        columns: ['Note', 'Total'],
+        rows: [['{{pii:PERSON_NAME_1}}', '=SUM(1,2)']],
+      });
+      artifactsRepository.findByIdWithVersions.mockResolvedValue(
+        createSpreadsheetArtifact(content),
+      );
+      spreadsheetExportPort.exportToXlsx.mockResolvedValue(Buffer.from('x'));
+      getThreadPiiMasksUseCase.execute.mockResolvedValue([
+        new ThreadPiiMask({
+          threadId: mockThreadId,
+          category: PiiCategory.PERSON_NAME,
+          maskIndex: 1,
+          value: '=SUM(9,9)',
+        }),
+      ]);
+
+      await useCase.execute(
+        new ExportArtifactCommand({
+          artifactId: mockArtifactId,
+          format: 'xlsx',
+        }),
+      );
+
+      expect(spreadsheetExportPort.exportToXlsx).toHaveBeenCalledWith({
+        grid: {
+          format: SPREADSHEET_CONTENT_FORMAT,
+          columns: ['Note', 'Total'],
+          rows: [['=SUM(9,9)', '=SUM(1,2)']],
+        },
+        formulaCells: [[false, true]],
+      });
+    });
   });
 });

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
@@ -5,14 +5,31 @@ import {
   DocumentExportPort,
   LetterheadConfig,
 } from '../../ports/document-export.port';
-import { ExportArtifactCommand } from './export-artifact.command';
+import {
+  SpreadsheetExportPort,
+  type SpreadsheetExportInput,
+} from '../../ports/spreadsheet-export.port';
+import {
+  ExportArtifactCommand,
+  type ExportFormat,
+} from './export-artifact.command';
 import {
   ArtifactNotFoundError,
   ArtifactNotExportableError,
   ArtifactVersionNotFoundError,
   UnexpectedArtifactError,
 } from '../../artifacts.errors';
-import { DocumentArtifact } from 'src/domain/artifacts/domain/artifact.entity';
+import {
+  Artifact,
+  DocumentArtifact,
+  SpreadsheetArtifact,
+} from 'src/domain/artifacts/domain/artifact.entity';
+import {
+  isFormulaCell,
+  mapSpreadsheetStrings,
+  parseSpreadsheetContent,
+  type SpreadsheetContentV1,
+} from 'src/domain/artifacts/application/helpers/spreadsheet-content-format';
 import { ContextService } from 'src/common/context/services/context.service';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -38,6 +55,7 @@ export class ExportArtifactUseCase {
   constructor(
     private readonly artifactsRepository: ArtifactsRepository,
     private readonly documentExportPort: DocumentExportPort,
+    private readonly spreadsheetExportPort: SpreadsheetExportPort,
     private readonly contextService: ContextService,
     private readonly findLetterheadUseCase: FindLetterheadUseCase,
     private readonly downloadObjectUseCase: DownloadObjectUseCase,
@@ -59,12 +77,24 @@ export class ExportArtifactUseCase {
     const artifact = await this.loadExportableArtifact(
       command.artifactId,
       userId,
+      command.format,
     );
-    const currentVersion = this.requireCurrentVersion(artifact);
+    const version = this.requireVersion(artifact, command.versionNumber);
     const safeTitle = this.buildSafeTitle(artifact.title);
+
+    if (artifact instanceof SpreadsheetArtifact) {
+      const data = await this.prepareSpreadsheetExportData(
+        artifact.threadId,
+        version.content,
+      );
+      return command.format === 'xlsx'
+        ? await this.exportXlsx(data, safeTitle)
+        : await this.exportCsv(data, safeTitle);
+    }
+
     const content = await this.deanonymizeContent(
       artifact.threadId,
-      currentVersion.content,
+      version.content,
     );
 
     if (command.format === 'docx') {
@@ -77,7 +107,8 @@ export class ExportArtifactUseCase {
   private async loadExportableArtifact(
     artifactId: UUID,
     userId: UUID,
-  ): Promise<DocumentArtifact> {
+    format: ExportFormat,
+  ): Promise<DocumentArtifact | SpreadsheetArtifact> {
     const artifact = await this.artifactsRepository.findByIdWithVersions(
       artifactId,
       userId,
@@ -85,23 +116,34 @@ export class ExportArtifactUseCase {
     if (!artifact) {
       throw new ArtifactNotFoundError(artifactId);
     }
+
+    const isSpreadsheetFormat = format === 'xlsx' || format === 'csv';
+    if (isSpreadsheetFormat) {
+      if (!(artifact instanceof SpreadsheetArtifact)) {
+        throw new ArtifactNotExportableError(artifact.type, { format });
+      }
+      return artifact;
+    }
+
     if (!(artifact instanceof DocumentArtifact)) {
-      throw new ArtifactNotExportableError(artifact.type);
+      throw new ArtifactNotExportableError(artifact.type, { format });
     }
     return artifact;
   }
 
-  private requireCurrentVersion(artifact: DocumentArtifact) {
-    const currentVersion = artifact.versions.find(
-      (v) => v.versionNumber === artifact.currentVersionNumber,
+  private requireVersion(artifact: Artifact, versionNumber?: number) {
+    const requestedVersionNumber =
+      versionNumber ?? artifact.currentVersionNumber;
+    const version = artifact.versions.find(
+      (candidate) => candidate.versionNumber === requestedVersionNumber,
     );
-    if (!currentVersion) {
+    if (!version) {
       throw new ArtifactVersionNotFoundError(
         artifact.id,
-        artifact.currentVersionNumber,
+        requestedVersionNumber,
       );
     }
-    return currentVersion;
+    return version;
   }
 
   /**
@@ -113,14 +155,43 @@ export class ExportArtifactUseCase {
     threadId: UUID,
     content: string,
   ): Promise<string> {
+    const tokenToValue = await this.resolveTokenMap(threadId);
+    return tokenToValue ? deanonymizeText(content, tokenToValue) : content;
+  }
+
+  /**
+   * Spreadsheet content is JSON — token replacement must happen per header and
+   * per string cell after parsing, never on the raw JSON string, because PII
+   * values containing quotes or backslashes would corrupt it.
+   */
+  private async prepareSpreadsheetExportData(
+    threadId: UUID,
+    content: string,
+  ): Promise<SpreadsheetExportInput> {
+    const storedData = parseSpreadsheetContent(content);
+    const tokenToValue = await this.resolveTokenMap(threadId);
+    const grid: SpreadsheetContentV1 = tokenToValue
+      ? mapSpreadsheetStrings(storedData, (value) =>
+          deanonymizeText(value, tokenToValue),
+        )
+      : storedData;
+
+    return {
+      grid,
+      formulaCells: storedData.rows.map((row) => row.map(isFormulaCell)),
+    };
+  }
+
+  private async resolveTokenMap(
+    threadId: UUID,
+  ): Promise<Map<string, string> | null> {
     const masks = await this.getThreadPiiMasksUseCase.execute(
       new GetThreadPiiMasksQuery(threadId),
     );
     if (masks.length === 0) {
-      return content;
+      return null;
     }
-    const tokenToValue = new Map(masks.map((mask) => [mask.token, mask.value]));
-    return deanonymizeText(content, tokenToValue);
+    return new Map(masks.map((mask) => [mask.token, mask.value]));
   }
 
   private buildSafeTitle(title: string): string {
@@ -137,6 +208,31 @@ export class ExportArtifactUseCase {
       fileName: `${safeTitle}.docx`,
       mimeType:
         'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    };
+  }
+
+  private async exportXlsx(
+    data: SpreadsheetExportInput,
+    safeTitle: string,
+  ): Promise<ExportResult> {
+    const buffer = await this.spreadsheetExportPort.exportToXlsx(data);
+    return {
+      buffer,
+      fileName: `${safeTitle}.xlsx`,
+      mimeType:
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    };
+  }
+
+  private async exportCsv(
+    data: SpreadsheetExportInput,
+    safeTitle: string,
+  ): Promise<ExportResult> {
+    const csv = await this.spreadsheetExportPort.exportToCsv(data);
+    return {
+      buffer: Buffer.from(csv, 'utf8'),
+      fileName: `${safeTitle}.csv`,
+      mimeType: 'text/csv',
     };
   }
 

--- a/ayunis-core-backend/src/domain/artifacts/artifacts.module.ts
+++ b/ayunis-core-backend/src/domain/artifacts/artifacts.module.ts
@@ -2,9 +2,11 @@ import { forwardRef, Module } from '@nestjs/common';
 import { ArtifactsController } from './presenters/http/artifacts.controller';
 import { ArtifactsRepository } from './application/ports/artifacts-repository.port';
 import { DocumentExportPort } from './application/ports/document-export.port';
+import { SpreadsheetExportPort } from './application/ports/spreadsheet-export.port';
 import { LocalArtifactsRepositoryModule } from './infrastructure/persistence/local/local-artifacts-repository.module';
 import { LocalArtifactsRepository } from './infrastructure/persistence/local/local-artifacts.repository';
 import { HtmlDocumentExportService } from './infrastructure/export/html-document-export.service';
+import { XlsxSpreadsheetExportService } from './infrastructure/export/xlsx-spreadsheet-export.service';
 import { PdfLetterheadCompositor } from './infrastructure/export/pdf-letterhead-compositor';
 import { ArtifactDtoMapper } from './presenters/http/mappers/artifact-dto.mapper';
 import { ThreadsModule } from 'src/domain/threads/threads.module';
@@ -38,6 +40,10 @@ import { ApplyEditsToArtifactUseCase } from './application/use-cases/apply-edits
     {
       provide: DocumentExportPort,
       useClass: HtmlDocumentExportService,
+    },
+    {
+      provide: SpreadsheetExportPort,
+      useClass: XlsxSpreadsheetExportService,
     },
     // Use cases
     CreateArtifactUseCase,

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/xlsx-spreadsheet-export.service.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/xlsx-spreadsheet-export.service.spec.ts
@@ -1,0 +1,243 @@
+import * as XLSX from 'xlsx';
+import * as ExcelJS from 'exceljs';
+import type { SpreadsheetExportInput } from '../../application/ports/spreadsheet-export.port';
+import {
+  isFormulaCell,
+  type SpreadsheetGrid,
+} from '../../application/helpers/spreadsheet-content-format';
+import { XlsxSpreadsheetExportService } from './xlsx-spreadsheet-export.service';
+
+describe('XlsxSpreadsheetExportService', () => {
+  let service: XlsxSpreadsheetExportService;
+
+  beforeEach(() => {
+    service = new XlsxSpreadsheetExportService();
+  });
+
+  function createExportInput(
+    grid: SpreadsheetGrid,
+    formulaCells = grid.rows.map((row) => row.map(isFormulaCell)),
+  ): SpreadsheetExportInput {
+    return { grid, formulaCells };
+  }
+
+  function exportXlsx(
+    grid: SpreadsheetGrid,
+    formulaCells?: boolean[][],
+  ): Promise<Buffer> {
+    return service.exportToXlsx(createExportInput(grid, formulaCells));
+  }
+
+  function exportCsv(
+    grid: SpreadsheetGrid,
+    formulaCells?: boolean[][],
+  ): Promise<string> {
+    return service.exportToCsv(createExportInput(grid, formulaCells));
+  }
+
+  describe('exportToXlsx', () => {
+    it('should produce a readable workbook with headers and cells', async () => {
+      const buffer = await exportXlsx({
+        columns: ['Item', 'Amount'],
+        rows: [
+          ['Rent', 1200],
+          ['Food', 450.5],
+        ],
+      });
+
+      const workbook = XLSX.read(buffer, { type: 'buffer' });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+      const parsed = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet);
+
+      expect(parsed).toEqual([
+        { Item: 'Rent', Amount: 1200 },
+        { Item: 'Food', Amount: 450.5 },
+      ]);
+    });
+
+    it('should write numbers as numeric cells and strings as text cells', async () => {
+      const buffer = await exportXlsx({
+        columns: ['Label', 'Value'],
+        rows: [['Total', 42]],
+      });
+
+      const workbook = XLSX.read(buffer, { type: 'buffer' });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+
+      expect(sheet.A2.t).toBe('s');
+      expect(sheet.A2.v).toBe('Total');
+      expect(sheet.B2.t).toBe('n');
+      expect(sheet.B2.v).toBe(42);
+    });
+
+    it('should leave null cells empty', async () => {
+      const buffer = await exportXlsx({
+        columns: ['A', 'B'],
+        rows: [['x', null]],
+      });
+
+      const workbook = XLSX.read(buffer, { type: 'buffer' });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+
+      expect(sheet.B2).toBeUndefined();
+    });
+  });
+
+  describe('formula cells', () => {
+    async function readCellFormula(
+      buffer: Buffer,
+      address: string,
+    ): Promise<string | undefined> {
+      const workbook = new ExcelJS.Workbook();
+      // exceljs types its Buffer parameter as an ArrayBuffer subtype, which
+      // Node's generic Buffer no longer satisfies; runtime accepts both.
+      await workbook.xlsx.load(buffer as unknown as ArrayBuffer);
+      return workbook.getWorksheet(1)?.getCell(address).formula;
+    }
+
+    it('should write formula cells as real Excel formulas', async () => {
+      const buffer = await exportXlsx({
+        columns: ['Item', 'Amount'],
+        rows: [
+          ['Rent', 1200],
+          ['Food', 450.5],
+          ['Total', '=SUM(B2:B3)'],
+        ],
+      });
+
+      expect(await readCellFormula(buffer, 'B4')).toBe('SUM(B2:B3)');
+    });
+
+    it('should prefix post-2007 function names with _xlfn', async () => {
+      const buffer = await exportXlsx({
+        columns: ['A', 'B'],
+        rows: [['x', '=XLOOKUP(A2, A2:A5, B2:B5)']],
+      });
+
+      expect(await readCellFormula(buffer, 'B2')).toBe(
+        '_xlfn.XLOOKUP(A2, A2:A5, B2:B5)',
+      );
+    });
+
+    it.each([
+      [
+        'FILTER',
+        '=FILTER(A2:A10,B2:B10>0)',
+        '_xlfn._xlws.FILTER(A2:A10,B2:B10>0)',
+      ],
+      ['SORT', '=SORT(A2:A10)', '_xlfn._xlws.SORT(A2:A10)'],
+    ])(
+      'should use the _xlws prefix for %s dynamic array formulas',
+      async (_functionName, formula, expectedFormula) => {
+        const buffer = await exportXlsx({
+          columns: ['A'],
+          rows: [[formula]],
+        });
+
+        expect(await readCellFormula(buffer, 'A2')).toBe(expectedFormula);
+      },
+    );
+
+    it('should not rewrite function names inside string literals', async () => {
+      const buffer = await exportXlsx({
+        columns: ['A'],
+        rows: [['=CONCATENATE("use XLOOKUP(", "here")']],
+      });
+
+      expect(await readCellFormula(buffer, 'A2')).toBe(
+        'CONCATENATE("use XLOOKUP(", "here")',
+      );
+    });
+
+    it('should request a full recalculation on open', async () => {
+      const buffer = await exportXlsx({
+        columns: ['A'],
+        rows: [['=SUM(A2:A2)']],
+      });
+
+      // exceljs does not read calcPr back; SheetJS exposes it on Workbook,
+      // but its typings omit CalcPr, hence the structural cast.
+      const workbook = XLSX.read(buffer, { type: 'buffer' });
+      const wbProps = workbook.Workbook as
+        { CalcPr?: { fullCalcOnLoad?: string } } | undefined;
+      expect(wbProps?.CalcPr?.fullCalcOnLoad).toBe('1');
+    });
+
+    it('should keep an equals sign inside plain text as text', async () => {
+      const buffer = await exportXlsx({
+        columns: ['Note'],
+        rows: [['a = b']],
+      });
+
+      const workbook = XLSX.read(buffer, { type: 'buffer' });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+
+      expect(sheet.A2.f).toBeUndefined();
+      expect(sheet.A2.v).toBe('a = b');
+    });
+
+    it('should keep de-anonymized plain text that starts with equals as text', async () => {
+      const buffer = await exportXlsx(
+        {
+          columns: ['Note'],
+          rows: [['=SUM(9,9)']],
+        },
+        [[false]],
+      );
+
+      const workbook = XLSX.read(buffer, { type: 'buffer' });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+
+      expect(await readCellFormula(buffer, 'A2')).toBeUndefined();
+      expect(sheet.A2.v).toBe('=SUM(9,9)');
+    });
+  });
+
+  describe('exportToCsv', () => {
+    it('should render headers and rows as CSV', async () => {
+      const csv = await exportCsv({
+        columns: ['Item', 'Amount'],
+        rows: [['Rent', 1200]],
+      });
+
+      expect(csv.trim().split('\n')).toEqual(['Item,Amount', 'Rent,1200']);
+    });
+
+    it('should quote cells containing commas and double quotes', async () => {
+      const csv = await exportCsv({
+        columns: ['Name'],
+        rows: [['Mustermann, "Max"']],
+      });
+
+      const lines = csv.trim().split('\n');
+      expect(lines[1]).toBe('"Mustermann, ""Max"""');
+    });
+
+    it('should render null cells as empty fields', async () => {
+      const csv = await exportCsv({
+        columns: ['A', 'B', 'C'],
+        rows: [['x', null, 'z']],
+      });
+
+      expect(csv.trim().split('\n')[1]).toBe('x,,z');
+    });
+
+    it('should preserve typed negative numbers as numeric CSV fields', async () => {
+      const csv = await exportCsv({
+        columns: ['Expense', 'Balance'],
+        rows: [[-1200, -450.5]],
+      });
+
+      expect(csv.trim().split('\n')[1]).toBe('-1200,-450.5');
+    });
+
+    it('should neutralize formula-like cells in CSV output', async () => {
+      const csv = await exportCsv({
+        columns: ['Value'],
+        rows: [['=1+1']],
+      });
+
+      expect(csv.trim().split('\n')[1]).toBe("'=1+1");
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/xlsx-spreadsheet-export.service.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/xlsx-spreadsheet-export.service.ts
@@ -1,0 +1,117 @@
+import { Injectable } from '@nestjs/common';
+import * as ExcelJS from 'exceljs';
+import {
+  SpreadsheetExportPort,
+  type SpreadsheetExportInput,
+} from '../../application/ports/spreadsheet-export.port';
+import type { SpreadsheetCell } from '../../application/helpers/spreadsheet-content-format';
+import { isFormulaCell } from '../../application/helpers/spreadsheet-content-format';
+
+/**
+ * Functions introduced after Excel 2007 are stored in the file format with an
+ * internal `_xlfn.` prefix. Excel adds it itself; third-party writers must
+ * too, or the cell shows #NAME? on open.
+ *
+ * LET and LAMBDA are deliberately absent: OOXML additionally requires
+ * `_xlpm.` on their local parameter names, which needs real formula parsing,
+ * and the live grid's engine cannot evaluate them anyway.
+ */
+const MODERN_FUNCTIONS = [
+  'XLOOKUP',
+  'XMATCH',
+  'FILTER',
+  'SORT',
+  'SORTBY',
+  'UNIQUE',
+  'SEQUENCE',
+  'RANDARRAY',
+  'IFS',
+  'SWITCH',
+  'MAXIFS',
+  'MINIFS',
+  'CONCAT',
+  'TEXTJOIN',
+  'TEXTSPLIT',
+  'TEXTBEFORE',
+  'TEXTAFTER',
+  'IFNA',
+  'FORMULATEXT',
+];
+const FUNCTIONS_REQUIRING_XLWS_PREFIX = new Set(['FILTER', 'SORT']);
+
+const MODERN_FUNCTION_RE = new RegExp(
+  `\\b(${MODERN_FUNCTIONS.join('|')})\\s*\\(`,
+  'gi',
+);
+
+// Split on Excel string literals ("..." with "" escapes) so function names
+// inside quoted text are never rewritten.
+const STRING_LITERAL_SPLIT_RE = /("(?:[^"]|"")*")/;
+
+function prefixModernFunctions(formula: string): string {
+  return formula
+    .split(STRING_LITERAL_SPLIT_RE)
+    .map((segment, index) =>
+      index % 2 === 1
+        ? segment
+        : segment.replace(MODERN_FUNCTION_RE, (match, name: string) => {
+            const normalizedName = name.toUpperCase();
+            const prefix = FUNCTIONS_REQUIRING_XLWS_PREFIX.has(normalizedName)
+              ? '_xlfn._xlws.'
+              : '_xlfn.';
+
+            return `${prefix}${normalizedName}${match.slice(name.length)}`;
+          }),
+    )
+    .join('');
+}
+
+const toExcelValue = (
+  cell: SpreadsheetCell,
+  isOriginalFormula: boolean,
+): ExcelJS.CellValue =>
+  isOriginalFormula && isFormulaCell(cell)
+    ? { formula: prefixModernFunctions(cell.slice(1)) }
+    : cell;
+
+function toCsvField(cell: SpreadsheetCell): string {
+  if (cell === null) {
+    return '';
+  }
+  const rawText = String(cell);
+  const text =
+    typeof cell === 'string' && /^[=+\-@\t\r]/.test(cell)
+      ? `'${rawText}`
+      : rawText;
+  return /[",\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+@Injectable()
+export class XlsxSpreadsheetExportService extends SpreadsheetExportPort {
+  async exportToXlsx(data: SpreadsheetExportInput): Promise<Buffer> {
+    const workbook = new ExcelJS.Workbook();
+    workbook.calcProperties.fullCalcOnLoad = true;
+
+    const sheet = workbook.addWorksheet('Sheet1');
+    sheet.addRow(data.grid.columns);
+    for (const [rowIndex, row] of data.grid.rows.entries()) {
+      const formulaCells = data.formulaCells[rowIndex] ?? [];
+      sheet.addRow(
+        row.map((cell, columnIndex) =>
+          toExcelValue(cell, formulaCells[columnIndex] ?? false),
+        ),
+      );
+    }
+
+    const buffer = await workbook.xlsx.writeBuffer();
+    return Buffer.from(buffer);
+  }
+
+  async exportToCsv(data: SpreadsheetExportInput): Promise<string> {
+    return Promise.resolve(
+      [data.grid.columns, ...data.grid.rows]
+        .map((row) => row.map(toCsvField).join(','))
+        .join('\n'),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/artifacts/presenters/http/artifacts.controller.ts
+++ b/ayunis-core-backend/src/domain/artifacts/presenters/http/artifacts.controller.ts
@@ -200,7 +200,9 @@ export class ArtifactsController {
   }
 
   @Get(':id/export')
-  @ApiOperation({ summary: 'Export an artifact as DOCX or PDF' })
+  @ApiOperation({
+    summary: 'Export an artifact as DOCX, PDF, XLSX, or CSV',
+  })
   @ApiParam({
     name: 'id',
     description: 'The UUID of the artifact',
@@ -210,8 +212,9 @@ export class ArtifactsController {
   @ApiQuery({
     name: 'format',
     description: 'Export format',
-    enum: ['docx', 'pdf'],
+    enum: ['docx', 'pdf', 'xlsx', 'csv'],
   })
+  @ApiQuery({ name: 'versionNumber', required: false, type: Number })
   @ApiResponse({
     status: 200,
     description: 'The exported file',
@@ -229,9 +232,12 @@ export class ArtifactsController {
   ): Promise<StreamableFile> {
     this.logger.log('export', { artifactId: id, format: query.format });
     const result = await this.exportArtifactUseCase.execute(
-      new ExportArtifactCommand({ artifactId: id, format: query.format }),
+      new ExportArtifactCommand({
+        artifactId: id,
+        format: query.format,
+        versionNumber: query.versionNumber,
+      }),
     );
-
     res.set({
       'Content-Type': result.mimeType,
       'Content-Disposition': `attachment; filename="${result.fileName}"`,

--- a/ayunis-core-backend/src/domain/artifacts/presenters/http/dtos/export-artifact.dto.ts
+++ b/ayunis-core-backend/src/domain/artifacts/presenters/http/dtos/export-artifact.dto.ts
@@ -1,9 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, Min } from 'class-validator';
 
 export enum ExportFormatDto {
   DOCX = 'docx',
   PDF = 'pdf',
+  XLSX = 'xlsx',
+  CSV = 'csv',
 }
 
 export class ExportArtifactQueryDto {
@@ -14,4 +17,15 @@ export class ExportArtifactQueryDto {
   })
   @IsEnum(ExportFormatDto)
   format: ExportFormatDto;
+
+  @ApiProperty({
+    description: 'Version number to export; defaults to the current version',
+    example: 2,
+    required: false,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  versionNumber?: number;
 }

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -5126,6 +5126,10 @@ export type ArtifactsControllerExportParams = {
  * Export format
  */
 format: ArtifactsControllerExportFormat;
+/**
+ * Version number to export; defaults to the current version
+ */
+versionNumber?: number;
 };
 
 export type ArtifactsControllerExportFormat = typeof ArtifactsControllerExportFormat[keyof typeof ArtifactsControllerExportFormat];
@@ -5135,6 +5139,8 @@ export type ArtifactsControllerExportFormat = typeof ArtifactsControllerExportFo
 export const ArtifactsControllerExportFormat = {
   docx: 'docx',
   pdf: 'pdf',
+  xlsx: 'xlsx',
+  csv: 'csv',
 } as const;
 
 export type UsageControllerGetUserUsageParams = {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -13948,7 +13948,7 @@ export const useArtifactsControllerRevert = <TError = void,
     }
     
 /**
- * @summary Export an artifact as DOCX or PDF
+ * @summary Export an artifact as DOCX, PDF, XLSX, or CSV
  */
 export const artifactsControllerExport = (
     id: string,
@@ -14027,7 +14027,7 @@ export function useArtifactsControllerExport<TData = Awaited<ReturnType<typeof a
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
- * @summary Export an artifact as DOCX or PDF
+ * @summary Export an artifact as DOCX, PDF, XLSX, or CSV
  */
 
 export function useArtifactsControllerExport<TData = Awaited<ReturnType<typeof artifactsControllerExport>>, TError = void>(

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -6837,8 +6837,18 @@
             "in": "query",
             "description": "Export format",
             "schema": {
-              "enum": ["docx", "pdf"],
+              "enum": ["docx", "pdf", "xlsx", "csv"],
               "type": "string"
+            }
+          },
+          {
+            "name": "versionNumber",
+            "required": false,
+            "in": "query",
+            "description": "Version number to export; defaults to the current version",
+            "schema": {
+              "example": 2,
+              "type": "number"
             }
           }
         ],
@@ -6858,7 +6868,7 @@
             "description": "Artifact not found"
           }
         },
-        "summary": "Export an artifact as DOCX or PDF",
+        "summary": "Export an artifact as DOCX, PDF, XLSX, or CSV",
         "tags": ["artifacts"]
       }
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       dotenv:
         specifier: ^17.3.1
         version: 17.4.2
+      exceljs:
+        specifier: ^4.4.0
+        version: 4.4.0
       form-data:
         specifier: ^4.0.6
         version: 4.0.6
@@ -2139,6 +2142,12 @@ packages:
 
   '@exodus/schemasafe@1.3.0':
     resolution: {integrity: sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==}
+
+  '@fast-csv/format@4.3.5':
+    resolution: {integrity: sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==}
+
+  '@fast-csv/parse@4.3.6':
+    resolution: {integrity: sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==}
 
   '@fastify/deepmerge@3.2.1':
     resolution: {integrity: sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==}
@@ -5908,6 +5917,9 @@ packages:
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
+  '@types/node@14.18.63':
+    resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
+
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
@@ -6544,6 +6556,18 @@ packages:
   append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
 
+  archiver-utils@2.1.0:
+    resolution: {integrity: sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==}
+    engines: {node: '>= 6'}
+
+  archiver-utils@3.0.4:
+    resolution: {integrity: sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==}
+    engines: {node: '>= 10'}
+
+  archiver@5.3.2:
+    resolution: {integrity: sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==}
+    engines: {node: '>= 10'}
+
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
@@ -6734,6 +6758,10 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  big-integer@1.6.52:
+    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
+    engines: {node: '>=0.6'}
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
@@ -6749,6 +6777,9 @@ packages:
     resolution: {integrity: sha512-Iy//vPc3ANPNlIWd242Npqc8MK0a/i4kVcHDlDA6HNMv5zMxz4ulIFhOSYJVKw/8AbHdHy0CnGYEt1QqSXxPsw==}
     engines: {node: '>=18'}
 
+  binary@0.3.0:
+    resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
+
   bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
@@ -6757,6 +6788,9 @@ packages:
 
   block-stream2@2.1.0:
     resolution: {integrity: sha512-suhjmLI57Ewpmq00qaygS8UgEq2ly2PCItenIyhMqVjo4t4pGzqMvfgJuX8iWTeSDdfSSqS6j38fL4ToNL7Pfg==}
+
+  bluebird@3.4.7:
+    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -6810,11 +6844,19 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer-indexof-polyfill@1.0.2:
+    resolution: {integrity: sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==}
+    engines: {node: '>=0.10'}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  buffers@0.1.1:
+    resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
+    engines: {node: '>=0.2.0'}
 
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -6906,6 +6948,9 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  chainsaw@0.1.0:
+    resolution: {integrity: sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -7127,6 +7172,10 @@ packages:
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
+  compress-commons@4.1.2:
+    resolution: {integrity: sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==}
+    engines: {node: '>= 10'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -7211,6 +7260,10 @@ packages:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
     hasBin: true
+
+  crc32-stream@4.0.3:
+    resolution: {integrity: sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==}
+    engines: {node: '>= 10'}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -7674,6 +7727,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexer2@0.1.4:
+    resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -8006,6 +8062,10 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
+  exceljs@4.4.0:
+    resolution: {integrity: sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==}
+    engines: {node: '>=8.3.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -8062,6 +8122,10 @@ packages:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
     hasBin: true
+
+  fast-csv@4.3.6:
+    resolution: {integrity: sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==}
+    engines: {node: '>=10.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -8277,6 +8341,9 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
@@ -8299,6 +8366,11 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  fstream@1.0.12:
+    resolution: {integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==}
+    engines: {node: '>=0.6'}
+    deprecated: This package is no longer supported.
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -9308,6 +9380,10 @@ packages:
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -9409,6 +9485,9 @@ packages:
   linkifyjs@4.3.3:
     resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
 
+  listenercount@1.0.1:
+    resolution: {integrity: sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==}
+
   load-esm@1.0.3:
     resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
     engines: {node: '>=13.2.0'}
@@ -9438,6 +9517,18 @@ packages:
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
+  lodash.difference@4.5.0:
+    resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.flatten@4.4.0:
+    resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+
+  lodash.groupby@4.6.0:
+    resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
@@ -9450,8 +9541,18 @@ packages:
   lodash.isempty@4.4.0:
     resolution: {integrity: sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==}
 
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
+  lodash.isfunction@3.0.9:
+    resolution: {integrity: sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==}
+
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnil@4.0.0:
+    resolution: {integrity: sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==}
 
   lodash.isnumber@3.0.3:
     resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
@@ -9461,6 +9562,9 @@ packages:
 
   lodash.isstring@4.0.1:
     resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
+  lodash.isundefined@3.0.1:
+    resolution: {integrity: sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==}
 
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
@@ -9476,6 +9580,9 @@ packages:
 
   lodash.topath@4.5.2:
     resolution: {integrity: sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg==}
+
+  lodash.union@4.6.0:
+    resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}
 
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
@@ -9852,6 +9959,10 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -9995,6 +10106,10 @@ packages:
 
   mjml@4.18.0:
     resolution: {integrity: sha512-rQM4aqFRrNvV1k733e8hJSopBjZvoSdBpRYzNTMAN+As0jqJsO5eN0wTT2IFtfe4PREzzu5b06RkPiUQdd0IIg==}
+    hasBin: true
+
+  mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
 
   mlly@1.8.2:
@@ -11021,6 +11136,9 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -11184,6 +11302,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rimraf@2.7.1:
+    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
@@ -11274,6 +11397,10 @@ packages:
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
+
+  saxes@5.0.1:
+    resolution: {integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==}
+    engines: {node: '>=10'}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -11754,6 +11881,10 @@ packages:
   tar-fs@3.1.2:
     resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
 
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
@@ -11884,6 +12015,10 @@ packages:
     resolution: {integrity: sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==}
     hasBin: true
 
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
+    engines: {node: '>=14.14'}
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -11913,6 +12048,9 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  traverse@0.3.9:
+    resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -12274,6 +12412,9 @@ packages:
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
 
+  unzipper@0.10.14:
+    resolution: {integrity: sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -12358,6 +12499,11 @@ packages:
 
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -12810,6 +12956,10 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zip-stream@4.1.1:
+    resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
+    engines: {node: '>= 10'}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -13921,6 +14071,25 @@ snapshots:
   '@exodus/bytes@1.15.1': {}
 
   '@exodus/schemasafe@1.3.0': {}
+
+  '@fast-csv/format@4.3.5':
+    dependencies:
+      '@types/node': 14.18.63
+      lodash.escaperegexp: 4.1.2
+      lodash.isboolean: 3.0.3
+      lodash.isequal: 4.5.0
+      lodash.isfunction: 3.0.9
+      lodash.isnil: 4.0.0
+
+  '@fast-csv/parse@4.3.6':
+    dependencies:
+      '@types/node': 14.18.63
+      lodash.escaperegexp: 4.1.2
+      lodash.groupby: 4.6.0
+      lodash.isfunction: 3.0.9
+      lodash.isnil: 4.0.0
+      lodash.isundefined: 3.0.1
+      lodash.uniq: 4.5.0
 
   '@fastify/deepmerge@3.2.1': {}
 
@@ -17998,6 +18167,8 @@ snapshots:
       '@types/node': 24.13.2
       form-data: 4.0.6
 
+  '@types/node@14.18.63': {}
+
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
@@ -18751,6 +18922,42 @@ snapshots:
 
   append-field@1.0.0: {}
 
+  archiver-utils@2.1.0:
+    dependencies:
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      lazystream: 1.0.1
+      lodash.defaults: 4.2.0
+      lodash.difference: 4.5.0
+      lodash.flatten: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.union: 4.6.0
+      normalize-path: 3.0.0
+      readable-stream: 2.3.8
+
+  archiver-utils@3.0.4:
+    dependencies:
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      lazystream: 1.0.1
+      lodash.defaults: 4.2.0
+      lodash.difference: 4.5.0
+      lodash.flatten: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.union: 4.6.0
+      normalize-path: 3.0.0
+      readable-stream: 3.6.2
+
+  archiver@5.3.2:
+    dependencies:
+      archiver-utils: 2.1.0
+      async: 3.2.6
+      buffer-crc32: 0.2.13
+      readable-stream: 3.6.2
+      readdir-glob: 1.1.3
+      tar-stream: 2.2.0
+      zip-stream: 4.1.1
+
   arg@4.1.3: {}
 
   argparse@1.0.10:
@@ -18974,6 +19181,8 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  big-integer@1.6.52: {}
+
   bignumber.js@9.3.1: {}
 
   binary-extensions@2.3.0: {}
@@ -18989,6 +19198,11 @@ snapshots:
       execa: 8.0.1
       find-versions: 6.0.0
 
+  binary@0.3.0:
+    dependencies:
+      buffers: 0.1.1
+      chainsaw: 0.1.0
+
   bintrees@1.0.2: {}
 
   bl@4.1.0:
@@ -19000,6 +19214,8 @@ snapshots:
   block-stream2@2.1.0:
     dependencies:
       readable-stream: 3.6.2
+
+  bluebird@3.4.7: {}
 
   body-parser@2.2.2:
     dependencies:
@@ -19062,6 +19278,8 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  buffer-indexof-polyfill@1.0.2: {}
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
@@ -19071,6 +19289,8 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  buffers@0.1.1: {}
 
   builtin-modules@3.3.0: {}
 
@@ -19167,6 +19387,10 @@ snapshots:
       crc-32: 1.2.2
 
   chai@6.2.2: {}
+
+  chainsaw@0.1.0:
+    dependencies:
+      traverse: 0.3.9
 
   chalk@4.1.2:
     dependencies:
@@ -19372,6 +19596,13 @@ snapshots:
 
   compare-versions@6.1.1: {}
 
+  compress-commons@4.1.2:
+    dependencies:
+      buffer-crc32: 0.2.13
+      crc32-stream: 4.0.3
+      normalize-path: 3.0.0
+      readable-stream: 3.6.2
+
   concat-map@0.0.1: {}
 
   concat-stream@2.0.0:
@@ -19449,6 +19680,11 @@ snapshots:
       typescript: 6.0.3
 
   crc-32@1.2.2: {}
+
+  crc32-stream@4.0.3:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 3.6.2
 
   create-require@1.1.1: {}
 
@@ -19958,6 +20194,10 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexer2@0.1.4:
+    dependencies:
+      readable-stream: 2.3.8
+
   eastasianwidth@0.2.0: {}
 
   ecdsa-sig-formatter@1.0.11:
@@ -20459,6 +20699,18 @@ snapshots:
     dependencies:
       eventsource-parser: 3.1.0
 
+  exceljs@4.4.0:
+    dependencies:
+      archiver: 5.3.2
+      dayjs: 1.11.21
+      fast-csv: 4.3.6
+      jszip: 3.10.1
+      readable-stream: 3.6.2
+      saxes: 5.0.1
+      tmp: 0.2.7
+      unzipper: 0.10.14
+      uuid: 8.3.2
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -20574,6 +20826,11 @@ snapshots:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
+
+  fast-csv@4.3.6:
+    dependencies:
+      '@fast-csv/format': 4.3.5
+      '@fast-csv/parse': 4.3.6
 
   fast-deep-equal@3.1.3: {}
 
@@ -20811,6 +21068,8 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fs-constants@1.0.0: {}
+
   fs-extra@10.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -20833,6 +21092,13 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  fstream@1.0.12:
+    dependencies:
+      graceful-fs: 4.2.11
+      inherits: 2.0.4
+      mkdirp: 0.5.6
+      rimraf: 2.7.1
 
   function-bind@1.1.2: {}
 
@@ -22165,6 +22431,10 @@ snapshots:
 
   layout-base@2.0.1: {}
 
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
+
   leven@3.1.0: {}
 
   levn@0.4.1:
@@ -22237,6 +22507,8 @@ snapshots:
 
   linkifyjs@4.3.3: {}
 
+  listenercount@1.0.1: {}
+
   load-esm@1.0.3: {}
 
   load-tsconfig@0.2.5: {}
@@ -22257,6 +22529,14 @@ snapshots:
 
   lodash.defaults@4.2.0: {}
 
+  lodash.difference@4.5.0: {}
+
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.flatten@4.4.0: {}
+
+  lodash.groupby@4.6.0: {}
+
   lodash.includes@4.3.0: {}
 
   lodash.isarguments@3.1.0: {}
@@ -22265,13 +22545,21 @@ snapshots:
 
   lodash.isempty@4.4.0: {}
 
+  lodash.isequal@4.5.0: {}
+
+  lodash.isfunction@3.0.9: {}
+
   lodash.isinteger@4.0.4: {}
+
+  lodash.isnil@4.0.0: {}
 
   lodash.isnumber@3.0.3: {}
 
   lodash.isplainobject@4.0.6: {}
 
   lodash.isstring@4.0.1: {}
+
+  lodash.isundefined@3.0.1: {}
 
   lodash.memoize@4.1.2: {}
 
@@ -22282,6 +22570,8 @@ snapshots:
   lodash.once@4.1.1: {}
 
   lodash.topath@4.5.2: {}
+
+  lodash.union@4.6.0: {}
 
   lodash.uniq@4.5.0: {}
 
@@ -22945,6 +23235,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.15
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.1
@@ -23299,6 +23593,10 @@ snapshots:
       mjml-validator: 4.18.0
     transitivePeerDependencies:
       - encoding
+
+  mkdirp@0.5.6:
+    dependencies:
+      minimist: 1.2.8
 
   mlly@1.8.2:
     dependencies:
@@ -24580,6 +24878,10 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.9
+
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
@@ -24760,6 +25062,10 @@ snapshots:
   retry@0.13.1: {}
 
   reusify@1.1.0: {}
+
+  rimraf@2.7.1:
+    dependencies:
+      glob: 7.2.3
 
   robust-predicates@3.0.3: {}
 
@@ -24944,6 +25250,10 @@ snapshots:
       enhanced-resolve: 5.22.1
 
   sax@1.6.0: {}
+
+  saxes@5.0.1:
+    dependencies:
+      xmlchars: 2.2.0
 
   saxes@6.0.0:
     dependencies:
@@ -25471,6 +25781,14 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   tar-stream@3.1.7:
     dependencies:
       b4a: 1.8.1
@@ -25601,6 +25919,8 @@ snapshots:
     dependencies:
       tldts-core: 7.4.8
 
+  tmp@0.2.7: {}
+
   tmpl@1.0.5: {}
 
   to-buffer@1.2.2:
@@ -25630,6 +25950,8 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+
+  traverse@0.3.9: {}
 
   tree-kill@1.2.2: {}
 
@@ -25992,6 +26314,19 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.12.2
       '@unrs/resolver-binding-win32-x64-msvc': 1.12.2
 
+  unzipper@0.10.14:
+    dependencies:
+      big-integer: 1.6.52
+      binary: 0.3.0
+      bluebird: 3.4.7
+      buffer-indexof-polyfill: 1.0.2
+      duplexer2: 0.1.4
+      fstream: 1.0.12
+      graceful-fs: 4.2.11
+      listenercount: 1.0.1
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -26053,6 +26388,8 @@ snapshots:
   uuid@11.1.1: {}
 
   uuid@14.0.0: {}
+
+  uuid@8.3.2: {}
 
   v8-compile-cache-lib@3.0.1: {}
 
@@ -26602,6 +26939,12 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
+
+  zip-stream@4.1.1:
+    dependencies:
+      archiver-utils: 3.0.4
+      compress-commons: 4.1.2
+      readable-stream: 3.6.2
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
- New SpreadsheetExportPort with SheetJS adapter; typed numbers become
  numeric xlsx cells, nulls stay empty
- Export use case is format-aware: docx/pdf require a document artifact,
  xlsx/csv require a spreadsheet artifact, otherwise not-exportable
- PII de-anonymization for spreadsheets parses the JSON first and maps
  headers/string cells individually — never string-replacement on the
  raw JSON, which quote-containing PII values would corrupt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Export is a PII egress path: spreadsheet de-anonymization must stay cell-scoped to avoid corrupting JSON or misclassifying formulas. New download formats expand the attack surface, though CSV neutralization and broad tests mitigate this.
> 
> **Overview**
> Adds **XLSX and CSV export** for spreadsheet artifacts via a new `SpreadsheetExportPort` and ExcelJS-backed `XlsxSpreadsheetExportService`, plus the **exceljs** dependency.
> 
> The artifact export flow is now **format- and type-aware**: `docx`/`pdf` require documents, `xlsx`/`csv` require spreadsheets, with mismatches returning `ArtifactNotExportableError`. Export accepts an optional **`versionNumber`** query param (API, command, and OpenAPI/generated client).
> 
> Spreadsheet egress **parses JSON first** and de-anonymizes PII per header/string cell (`mapSpreadsheetStrings`), while **`formulaCells`** from stored content keeps real formulas vs. text that only looks like `=` after PII replacement. XLSX writes typed numbers, Excel formulas (with `_xlfn` / dynamic-array prefixes), and full recalc on open; CSV quotes fields and **prefixes formula-like strings** to reduce spreadsheet injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c68ea07c2054951af234c079056231d581e2fce4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->