### PR TITLE
wip(frontend): regenerate api client for spreadsheet type (AYC-153)

### DIFF
--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3422,6 +3422,7 @@ export type ArtifactResponseDtoType = typeof ArtifactResponseDtoType[keyof typeo
 export const ArtifactResponseDtoType = {
   document: 'document',
   diagram: 'diagram',
+  spreadsheet: 'spreadsheet',
 } as const;
 
 export interface ArtifactResponseDto {
@@ -4936,6 +4937,8 @@ export type ArtifactsControllerExportFormat = typeof ArtifactsControllerExportFo
 export const ArtifactsControllerExportFormat = {
   docx: 'docx',
   pdf: 'pdf',
+  xlsx: 'xlsx',
+  csv: 'csv',
 } as const;
 
 export type UsageControllerGetUserUsageParams = {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -13425,7 +13425,7 @@ export const useArtifactsControllerRevert = <TError = void,
     }
     
 /**
- * @summary Export an artifact as DOCX or PDF
+ * @summary Export an artifact as DOCX, PDF, XLSX, or CSV
  */
 export const artifactsControllerExport = (
     id: string,
@@ -13504,7 +13504,7 @@ export function useArtifactsControllerExport<TData = Awaited<ReturnType<typeof a
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
- * @summary Export an artifact as DOCX or PDF
+ * @summary Export an artifact as DOCX, PDF, XLSX, or CSV
  */
 
 export function useArtifactsControllerExport<TData = Awaited<ReturnType<typeof artifactsControllerExport>>, TError = void>(

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -6666,7 +6666,7 @@
             "in": "query",
             "description": "Export format",
             "schema": {
-              "enum": ["docx", "pdf"],
+              "enum": ["docx", "pdf", "xlsx", "csv"],
               "type": "string"
             }
           }
@@ -6687,7 +6687,7 @@
             "description": "Artifact not found"
           }
         },
-        "summary": "Export an artifact as DOCX or PDF",
+        "summary": "Export an artifact as DOCX, PDF, XLSX, or CSV",
         "tags": ["artifacts"]
       }
     },
@@ -15088,7 +15088,7 @@
           "type": {
             "type": "string",
             "description": "The kind of artifact — document (HTML) or diagram (mermaid)",
-            "enum": ["document", "diagram"],
+            "enum": ["document", "diagram", "spreadsheet"],
             "example": "document"
           },
           "threadId": {


### PR DESCRIPTION
Generated via openapi:update against the branch backend: artifact type
enum gains 'spreadsheet', export format enum gains 'xlsx' and 'csv'.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated-only sync with the backend OpenAPI spec; no runtime logic or auth changes in this diff.
> 
> **Overview**
> Regenerates the frontend API client from an updated OpenAPI spec so TypeScript matches the backend spreadsheet work.
> 
> **Artifact types** now include **`spreadsheet`** on `ArtifactResponseDtoType`, alongside `document` and `diagram`.
> 
> **Artifact export** accepts **`xlsx`** and **`csv`** in addition to `docx` and `pdf` via `ArtifactsControllerExportFormat` and the `GET /artifacts/{id}/export` `format` query param. Generated hooks (`artifactsControllerExport`, `useArtifactsControllerExport`) and schema docs reflect the wider format list.
> 
> Changes are limited to **`openapi-schema.json`** and Orval output (`ayunisCoreAPI.schemas.ts`, `ayunisCoreAPI.ts`); no feature UI in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeeda3e6c51cd1a4f2f92f43391b2c8f145cdb4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->