### PR TITLE
wip(chat): add spreadsheet artifact chat integration (AYC-153)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/api/useExportArtifact.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useExportArtifact.ts
@@ -17,10 +17,13 @@ export function useExportArtifact({
   const [isExporting, setIsExporting] = useState(false);
 
   const exportArtifact = useCallback(
-    async (format: ArtifactsControllerExportFormat) => {
+    async (format: ArtifactsControllerExportFormat, versionNumber?: number) => {
       setIsExporting(true);
       try {
-        const data = await artifactsControllerExport(artifactId, { format });
+        const data = await artifactsControllerExport(artifactId, {
+          format,
+          versionNumber,
+        });
 
         // The response is a file blob — trigger download
         const blob = data instanceof Blob ? data : new Blob([data]);

--- a/ayunis-core-frontend/src/pages/chat/hooks/useArtifactActions.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/useArtifactActions.ts
@@ -4,6 +4,7 @@ import { useArtifact } from '../api/useArtifact';
 import { useUpdateArtifact } from '../api/useUpdateArtifact';
 import { useRevertArtifact } from '../api/useRevertArtifact';
 import { useExportArtifact } from '../api/useExportArtifact';
+import type { ArtifactsControllerExportFormat } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { UpdateArtifactDtoAuthorType } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { showSuccess } from '@/shared/lib/toast';
 
@@ -13,10 +14,7 @@ export function useArtifactActions(threadId: string) {
 
   const { artifact: openArtifact } = useArtifact(openArtifactId);
 
-  const {
-    updateArtifact: saveArtifact,
-    updateArtifactAsync: saveArtifactAsync,
-  } = useUpdateArtifact({
+  const { updateArtifactAsync: saveArtifactAsync } = useUpdateArtifact({
     artifactId: openArtifactId ?? '',
     threadId,
     onSuccess: () => showSuccess(t('chat.artifactSaved')),
@@ -37,10 +35,13 @@ export function useArtifactActions(threadId: string) {
   }, []);
 
   const handleSaveArtifact = useCallback(
-    (content: string) => {
-      saveArtifact({ content, authorType: UpdateArtifactDtoAuthorType.USER });
+    async (content: string) => {
+      await saveArtifactAsync({
+        content,
+        authorType: UpdateArtifactDtoAuthorType.USER,
+      });
     },
-    [saveArtifact],
+    [saveArtifactAsync],
   );
 
   const handleRevertArtifact = useCallback(
@@ -51,15 +52,19 @@ export function useArtifactActions(threadId: string) {
   );
 
   const handleExportArtifact = useCallback(
-    (format: 'docx' | 'pdf', unsavedContent?: string) => {
+    (
+      format: ArtifactsControllerExportFormat,
+      unsavedContent?: string,
+      versionNumber?: number,
+    ) => {
       const doExport = async () => {
-        if (unsavedContent) {
+        if (unsavedContent !== undefined) {
           await saveArtifactAsync({
             content: unsavedContent,
             authorType: UpdateArtifactDtoAuthorType.USER,
           });
         }
-        await exportArtifact(format);
+        await exportArtifact(format, versionNumber);
       };
       void doExport();
     },

--- a/ayunis-core-frontend/src/pages/chat/lib/find-latest-artifact-id.test.ts
+++ b/ayunis-core-frontend/src/pages/chat/lib/find-latest-artifact-id.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { findLatestArtifactId } from './find-latest-artifact-id';
+
+const artifacts = [
+  {
+    id: 'document-old',
+    title: 'Report',
+    type: 'document' as const,
+    createdAt: '2026-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'spreadsheet-new',
+    title: 'Report',
+    type: 'spreadsheet' as const,
+    createdAt: '2026-01-03T00:00:00.000Z',
+  },
+  {
+    id: 'spreadsheet-old',
+    title: 'Report',
+    type: 'spreadsheet' as const,
+    createdAt: '2026-01-02T00:00:00.000Z',
+  },
+];
+
+describe('findLatestArtifactId', () => {
+  it('returns the newest artifact matching title and type', () => {
+    expect(findLatestArtifactId(artifacts, 'Report', 'spreadsheet')).toBe(
+      'spreadsheet-new',
+    );
+  });
+
+  it('returns null when no artifact matches', () => {
+    expect(
+      findLatestArtifactId(artifacts, 'Missing', 'spreadsheet'),
+    ).toBeNull();
+  });
+});

--- a/ayunis-core-frontend/src/pages/chat/lib/find-latest-artifact-id.ts
+++ b/ayunis-core-frontend/src/pages/chat/lib/find-latest-artifact-id.ts
@@ -1,0 +1,30 @@
+import type { ArtifactResponseDto } from '@/shared/api';
+
+type ArtifactSummary = Pick<
+  ArtifactResponseDto,
+  'id' | 'title' | 'type' | 'createdAt'
+>;
+
+export function findLatestArtifactId(
+  artifacts: readonly ArtifactSummary[],
+  title: string | undefined,
+  type?: ArtifactResponseDto['type'],
+): string | null {
+  let latest: { id: string; createdAt: number } | undefined;
+
+  for (const artifact of artifacts) {
+    if (
+      artifact.title !== title ||
+      (type !== undefined && artifact.type !== type)
+    ) {
+      continue;
+    }
+
+    const createdAt = new Date(artifact.createdAt).getTime();
+    if (latest === undefined || createdAt > latest.createdAt) {
+      latest = { id: artifact.id, createdAt };
+    }
+  }
+
+  return latest?.id ?? null;
+}

--- a/ayunis-core-frontend/src/pages/chat/ui/ArtifactSidePanel.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ArtifactSidePanel.tsx
@@ -1,0 +1,90 @@
+import { lazy, Suspense } from 'react';
+import type { ArtifactResponseDto } from '@/shared/api';
+import type { ArtifactsControllerExportFormat } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+const LazyArtifactEditor = lazy(() =>
+  import('@/widgets/artifact-editor').then((m) => ({
+    default: m.ArtifactEditor,
+  })),
+);
+
+const LazyDiagramViewer = lazy(() =>
+  import('@/widgets/diagram-viewer').then((m) => ({
+    default: m.DiagramViewer,
+  })),
+);
+
+const LazySpreadsheetEditor = lazy(() =>
+  import('@/widgets/spreadsheet-editor').then((m) => ({
+    default: m.SpreadsheetEditor,
+  })),
+);
+
+interface ArtifactSidePanelProps {
+  readonly artifact: ArtifactResponseDto;
+  readonly onSave: (content: string) => void | Promise<void>;
+  readonly onRevert: (versionNumber: number) => void;
+  readonly onExport: (
+    format: ArtifactsControllerExportFormat,
+    unsavedContent?: string,
+    versionNumber?: number,
+  ) => void;
+  readonly onClose: () => void;
+  readonly onLetterheadChange: (letterheadId: string | null) => void;
+  readonly isExporting?: boolean;
+}
+
+export function ArtifactSidePanel({
+  artifact,
+  onSave,
+  onRevert,
+  onExport,
+  onClose,
+  onLetterheadChange,
+  isExporting,
+}: ArtifactSidePanelProps) {
+  // key={artifact.id} forces a remount when another artifact is opened: the
+  // editors keep local state (grid data, dirty flag, selected version) that
+  // must not leak from one artifact to the next.
+  const panel = () => {
+    switch (artifact.type) {
+      case 'diagram':
+        return (
+          <LazyDiagramViewer
+            key={artifact.id}
+            artifact={artifact}
+            onClose={onClose}
+          />
+        );
+      case 'spreadsheet':
+        return (
+          <LazySpreadsheetEditor
+            key={artifact.id}
+            artifact={artifact}
+            onSave={onSave}
+            onRevert={onRevert}
+            onExport={onExport}
+            onClose={onClose}
+            isExporting={isExporting}
+          />
+        );
+      case 'document':
+        return (
+          <LazyArtifactEditor
+            key={artifact.id}
+            artifact={artifact}
+            onSave={(content) => {
+              void onSave(content);
+            }}
+            onRevert={onRevert}
+            onExport={onExport}
+            onClose={onClose}
+            onLetterheadChange={onLetterheadChange}
+            isExporting={isExporting}
+          />
+        );
+    }
+  };
+
+  return <Suspense fallback={null}>{panel()}</Suspense>;
+}

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -1,12 +1,4 @@
-import {
-  useState,
-  useRef,
-  useCallback,
-  useMemo,
-  useEffect,
-  lazy,
-  Suspense,
-} from 'react';
+import { useState, useRef, useCallback, useMemo, useEffect } from 'react';
 import ChatInterfaceLayout from '@/layouts/chat-interface-layout/ui/ChatInterfaceLayout';
 import { ChatThreadContent } from '@/pages/chat/ui/ChatThreadContent';
 import { groupMessagesIntoRuns } from '@/pages/chat/ui/agent-run-timeline';
@@ -53,18 +45,7 @@ import { useMcpIntegrationAttachment } from '../api/useMcpIntegrationAttachment'
 import { useDownloadSource } from '../api/useDownloadSource';
 import type { PendingImage } from '../api/useMessageSend';
 import { reconcileMessages } from '../lib/reconcile-thread-messages';
-
-const LazyArtifactEditor = lazy(() =>
-  import('@/widgets/artifact-editor').then((m) => ({
-    default: m.ArtifactEditor,
-  })),
-);
-
-const LazyDiagramViewer = lazy(() =>
-  import('@/widgets/diagram-viewer').then((m) => ({
-    default: m.DiagramViewer,
-  })),
-);
+import { ArtifactSidePanel } from './ArtifactSidePanel';
 
 const PROCESSING_POLL_INTERVAL = 5000;
 
@@ -452,24 +433,15 @@ export default function ChatPage({
           resetKey={thread.id}
           sidePanel={
             openArtifact ? (
-              <Suspense fallback={null}>
-                {openArtifact.type === 'diagram' ? (
-                  <LazyDiagramViewer
-                    artifact={openArtifact}
-                    onClose={handleCloseArtifact}
-                  />
-                ) : (
-                  <LazyArtifactEditor
-                    artifact={openArtifact}
-                    onSave={handleSaveArtifact}
-                    onRevert={handleRevertArtifact}
-                    onExport={handleExportArtifact}
-                    onClose={handleCloseArtifact}
-                    onLetterheadChange={handleLetterheadChange}
-                    isExporting={isExporting}
-                  />
-                )}
-              </Suspense>
+              <ArtifactSidePanel
+                artifact={openArtifact}
+                onSave={handleSaveArtifact}
+                onRevert={handleRevertArtifact}
+                onExport={handleExportArtifact}
+                onClose={handleCloseArtifact}
+                onLetterheadChange={handleLetterheadChange}
+                isExporting={isExporting}
+              />
             ) : undefined
           }
         />

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/get-tool-action-label.ts
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/get-tool-action-label.ts
@@ -61,6 +61,16 @@ export function getToolActionLabel(
         verb: t('chat.timeline.actions.update_diagram'),
         target: asString(params.title),
       };
+    case 'create_spreadsheet':
+      return {
+        verb: t('chat.timeline.actions.create_spreadsheet'),
+        target: asString(params.title),
+      };
+    case 'update_spreadsheet':
+      return {
+        verb: t('chat.timeline.actions.update_spreadsheet'),
+        target: asString(params.title),
+      };
     case 'bar_chart':
     case 'line_chart':
     case 'pie_chart':

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/group-messages-into-runs.test.ts
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/group-messages-into-runs.test.ts
@@ -864,6 +864,72 @@ describe('groupMessagesIntoRuns', () => {
       expect(richTool.steps).toHaveLength(2);
     });
 
+    it('merges repeated update_spreadsheet calls on the same artifact', () => {
+      const messages = [
+        userMessage('add a column'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 's1',
+            name: 'update_spreadsheet',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('s1', 'ok'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 's2',
+            name: 'update_spreadsheet',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('s2', 'ok'),
+      ];
+
+      const units = groupMessagesIntoRuns(messages, { isStreaming: false });
+
+      const run = units[1];
+      if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+      expect(run.blocks.map((block) => block.kind)).toEqual(['rich-tool']);
+      const richTool = run.blocks[0];
+      if (richTool.kind !== 'rich-tool') throw new Error('expected rich tool');
+      expect(richTool.steps).toHaveLength(2);
+    });
+
+    it('splits update_spreadsheet calls that target different artifacts', () => {
+      const messages = [
+        userMessage('update both sheets'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 's1',
+            name: 'update_spreadsheet',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('s1', 'ok'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 's2',
+            name: 'update_spreadsheet',
+            params: { artifact_id: 'art-2' },
+          },
+        ]),
+        toolResultMessage('s2', 'ok'),
+      ];
+
+      const units = groupMessagesIntoRuns(messages, { isStreaming: false });
+
+      const run = units[1];
+      if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+      expect(run.blocks.map((block) => block.kind)).toEqual([
+        'rich-tool',
+        'rich-tool',
+      ]);
+    });
+
     it('merges a follow-up edit into the previous widget while its arguments still stream', () => {
       const messages = [
         userMessage('refine'),

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/tool-classification.ts
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/tool-classification.ts
@@ -6,6 +6,8 @@ const RICH_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
   'edit_document',
   'create_diagram',
   'update_diagram',
+  'create_spreadsheet',
+  'update_spreadsheet',
   'bar_chart',
   'line_chart',
   'pie_chart',
@@ -20,14 +22,14 @@ export function isRichTool(toolName: string): boolean {
   return RICH_TOOL_NAMES.has(toolName);
 }
 
-const ARTIFACT_MUTATION_TOOLS: ReadonlyMap<string, 'document' | 'diagram'> =
-  new Map([
-    ['edit_document', 'document'],
-    ['update_document', 'document'],
-    ['update_diagram', 'diagram'],
-  ]);
+const ARTIFACT_MUTATION_TOOLS: ReadonlyMap<string, ArtifactFamily> = new Map([
+  ['edit_document', 'document'],
+  ['update_document', 'document'],
+  ['update_diagram', 'diagram'],
+  ['update_spreadsheet', 'spreadsheet'],
+]);
 
-export type ArtifactFamily = 'document' | 'diagram';
+export type ArtifactFamily = 'document' | 'diagram' | 'spreadsheet';
 
 export interface ArtifactToolTarget {
   family: ArtifactFamily;

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateDiagramWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateDiagramWidget.tsx
@@ -4,6 +4,7 @@ import type { ToolUseMessageContent } from '../../model/openapi';
 import { useTranslation } from 'react-i18next';
 import { Check, Workflow } from 'lucide-react';
 import { useThreadArtifacts } from '../../api/useThreadArtifacts';
+import { findLatestArtifactId } from '../../lib/find-latest-artifact-id';
 import { DocumentWidgetCard } from './DocumentWidgetCard';
 
 // eslint-disable-next-line sonarjs/function-return-type -- intentional: returns JSX or string, both valid ReactNode
@@ -48,13 +49,7 @@ export default function CreateDiagramWidget({
   };
 
   const { artifacts } = useThreadArtifacts(threadId);
-  const artifactId =
-    artifacts
-      .filter((a) => a.title === params.title && a.type === 'diagram')
-      .sort(
-        (a, b) =>
-          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-      )[0]?.id ?? null;
+  const artifactId = findLatestArtifactId(artifacts, params.title, 'diagram');
 
   const handleOpen = () => {
     if (artifactId && onOpenArtifact) {

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateDocumentWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateDocumentWidget.tsx
@@ -4,6 +4,7 @@ import type { ToolUseMessageContent } from '../../model/openapi';
 import { useTranslation } from 'react-i18next';
 import { Check } from 'lucide-react';
 import { useThreadArtifacts } from '../../api/useThreadArtifacts';
+import { findLatestArtifactId } from '../../lib/find-latest-artifact-id';
 import { DocumentWidgetCard } from './DocumentWidgetCard';
 
 // eslint-disable-next-line sonarjs/function-return-type -- intentional: returns JSX or string, both valid ReactNode
@@ -51,13 +52,7 @@ export default function CreateDocumentWidget({
   // We look it up from the thread artifacts list by title.
   // When multiple artifacts share the same title, prefer the most recently created one.
   const { artifacts } = useThreadArtifacts(threadId);
-  const artifactId =
-    artifacts
-      .filter((a) => a.title === params.title)
-      .sort(
-        (a, b) =>
-          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-      )[0]?.id ?? null;
+  const artifactId = findLatestArtifactId(artifacts, params.title, 'document');
 
   const handleOpen = () => {
     if (artifactId && onOpenArtifact) {

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateSpreadsheetWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/CreateSpreadsheetWidget.tsx
@@ -1,0 +1,61 @@
+import type { ToolUseMessageContent } from '../../model/openapi';
+import { useTranslation } from 'react-i18next';
+import { Check, Table } from 'lucide-react';
+import { useThreadArtifacts } from '../../api/useThreadArtifacts';
+import { findLatestArtifactId } from '../../lib/find-latest-artifact-id';
+import { DocumentWidgetCard } from './DocumentWidgetCard';
+
+interface CreateSpreadsheetWidgetProps {
+  readonly content: ToolUseMessageContent;
+  readonly isStreaming?: boolean;
+  readonly threadId: string;
+  readonly onOpenArtifact?: (artifactId: string) => void;
+}
+
+export default function CreateSpreadsheetWidget({
+  content,
+  isStreaming = false,
+  threadId,
+  onOpenArtifact,
+}: CreateSpreadsheetWidgetProps) {
+  const { t } = useTranslation('chat');
+
+  // params may be undefined mid-stream even though the type says otherwise
+  const params = content.params as { title?: string } | undefined;
+  const title = params?.title;
+
+  const { artifacts } = useThreadArtifacts(threadId);
+  const artifactId = findLatestArtifactId(artifacts, title, 'spreadsheet');
+
+  const handleOpen = () => {
+    if (artifactId && onOpenArtifact) {
+      onOpenArtifact(artifactId);
+    }
+  };
+
+  const statusText = isStreaming
+    ? t('chat.tools.create_spreadsheet.generating')
+    : t('chat.tools.create_spreadsheet.title');
+  const statusLabel = artifactId ? (
+    <span className="flex items-center gap-1">
+      <Check className="size-3" />
+      {t('chat.tools.create_spreadsheet.created')}
+    </span>
+  ) : (
+    statusText
+  );
+
+  return (
+    <DocumentWidgetCard
+      contentKey={content.name}
+      contentId={content.id}
+      isStreaming={isStreaming}
+      title={title ? title : t('chat.tools.create_spreadsheet.title')}
+      statusLabel={statusLabel}
+      buttonLabel={t('chat.tools.create_spreadsheet.openInEditor')}
+      artifactId={artifactId}
+      onOpen={handleOpen}
+      icon={Table}
+    />
+  );
+}

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/UpdateSpreadsheetWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/UpdateSpreadsheetWidget.tsx
@@ -1,0 +1,50 @@
+import type { ToolUseMessageContent } from '../../model/openapi';
+import { useTranslation } from 'react-i18next';
+import { Check, Table } from 'lucide-react';
+import { DocumentWidgetCard } from './DocumentWidgetCard';
+import { useUpdateArtifactWidget } from './useUpdateArtifactWidget';
+
+interface UpdateSpreadsheetWidgetProps {
+  readonly content: ToolUseMessageContent;
+  readonly isStreaming?: boolean;
+  readonly onOpenArtifact?: (artifactId: string) => void;
+}
+
+export default function UpdateSpreadsheetWidget({
+  content,
+  isStreaming = false,
+  onOpenArtifact,
+}: UpdateSpreadsheetWidgetProps) {
+  const { t } = useTranslation('chat');
+  const { artifactId, handleOpen } = useUpdateArtifactWidget(
+    content,
+    onOpenArtifact,
+  );
+
+  const statusText = isStreaming
+    ? t('chat.tools.update_spreadsheet.generating')
+    : t('chat.tools.update_spreadsheet.title');
+  const statusLabel =
+    !isStreaming && artifactId ? (
+      <span className="flex items-center gap-1">
+        <Check className="size-3" />
+        {t('chat.tools.update_spreadsheet.updated')}
+      </span>
+    ) : (
+      statusText
+    );
+
+  return (
+    <DocumentWidgetCard
+      contentKey={content.name}
+      contentId={content.id}
+      isStreaming={isStreaming}
+      title={t('chat.tools.update_spreadsheet.title')}
+      statusLabel={statusLabel}
+      buttonLabel={t('chat.tools.update_spreadsheet.openInEditor')}
+      artifactId={artifactId || null}
+      onOpen={handleOpen}
+      icon={Table}
+    />
+  );
+}

--- a/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/renderArtifactToolWidget.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/chat-widgets/renderArtifactToolWidget.tsx
@@ -6,6 +6,8 @@ import UpdateDocumentWidget from './UpdateDocumentWidget';
 import EditDocumentWidget from './EditDocumentWidget';
 import CreateDiagramWidget from './CreateDiagramWidget';
 import UpdateDiagramWidget from './UpdateDiagramWidget';
+import CreateSpreadsheetWidget from './CreateSpreadsheetWidget';
+import UpdateSpreadsheetWidget from './UpdateSpreadsheetWidget';
 
 /**
  * Renders the chat widget for any document- or diagram-related tool call.
@@ -72,6 +74,25 @@ export function renderArtifactToolWidget(params: {
       return (
         <UpdateDiagramWidget
           key={`update-diagram-${keySuffix}`}
+          content={content}
+          isStreaming={isStreaming}
+          onOpenArtifact={onOpenArtifact}
+        />
+      );
+    case 'create_spreadsheet':
+      return (
+        <CreateSpreadsheetWidget
+          key={`create-spreadsheet-${keySuffix}`}
+          content={content}
+          isStreaming={isStreaming}
+          threadId={threadId}
+          onOpenArtifact={onOpenArtifact}
+        />
+      );
+    case 'update_spreadsheet':
+      return (
+        <UpdateSpreadsheetWidget
+          key={`update-spreadsheet-${keySuffix}`}
           content={content}
           isStreaming={isStreaming}
           onOpenArtifact={onOpenArtifact}

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -57,6 +57,8 @@
         "read_document": "Dokument gelesen",
         "create_diagram": "Diagramm erstellt",
         "update_diagram": "Diagramm aktualisiert",
+        "create_spreadsheet": "Tabelle erstellt",
+        "update_spreadsheet": "Tabelle aktualisiert",
         "chart": "Diagramm erstellt",
         "generate_image": "Bild generiert",
         "send_email": "E-Mail entworfen",
@@ -156,6 +158,20 @@
         "updating": "Diagramm wird aktualisiert…",
         "generating": "Aktualisierung wird generiert…",
         "openInEditor": "Diagramm öffnen"
+      },
+      "create_spreadsheet": {
+        "title": "Tabelle",
+        "created": "Tabelle erstellt",
+        "creating": "Tabelle wird erstellt…",
+        "generating": "Tabelle wird generiert…",
+        "openInEditor": "Tabelle öffnen"
+      },
+      "update_spreadsheet": {
+        "title": "Tabelle aktualisiert",
+        "updated": "Tabelle aktualisiert",
+        "updating": "Tabelle wird aktualisiert…",
+        "generating": "Aktualisierung wird generiert…",
+        "openInEditor": "Tabelle öffnen"
       },
       "create_calendar_event": {
         "title": "Titel",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -57,6 +57,8 @@
         "read_document": "Read document",
         "create_diagram": "Created diagram",
         "update_diagram": "Updated diagram",
+        "create_spreadsheet": "Created spreadsheet",
+        "update_spreadsheet": "Updated spreadsheet",
         "chart": "Created chart",
         "generate_image": "Generated image",
         "send_email": "Drafted email",
@@ -156,6 +158,20 @@
         "updating": "Updating diagram…",
         "generating": "Generating update…",
         "openInEditor": "Open diagram"
+      },
+      "create_spreadsheet": {
+        "title": "Spreadsheet",
+        "created": "Spreadsheet created",
+        "creating": "Creating spreadsheet…",
+        "generating": "Generating spreadsheet…",
+        "openInEditor": "Open spreadsheet"
+      },
+      "update_spreadsheet": {
+        "title": "Spreadsheet updated",
+        "updated": "Spreadsheet updated",
+        "updating": "Updating spreadsheet…",
+        "generating": "Generating update…",
+        "openInEditor": "Open spreadsheet"
       },
       "create_calendar_event": {
         "title": "Title",

--- a/ayunis-core-frontend/src/widgets/spreadsheet-editor/ui/SpreadsheetEditor.tsx
+++ b/ayunis-core-frontend/src/widgets/spreadsheet-editor/ui/SpreadsheetEditor.tsx
@@ -17,6 +17,7 @@ interface SpreadsheetEditorProps {
   readonly onExport: (
     format: SpreadsheetExportFormat,
     unsavedContent?: string,
+    versionNumber?: number,
   ) => void;
   readonly onClose: () => void;
   readonly isExporting?: boolean;
@@ -46,13 +47,16 @@ export function SpreadsheetEditor({
   };
 
   const handleExport = (format: SpreadsheetExportFormat) => {
-    // Export what is on screen: a browsed historical version or unsaved
-    // edits; undefined lets the backend export the saved current version.
+    // Historical exports use the immutable server version. Current unsaved
+    // edits are saved first so the downloaded file matches the editor.
+    const unsavedContent =
+      !editor.isViewingHistory && editor.isDirty
+        ? editor.getSerializedContent()
+        : undefined;
     onExport(
       format,
-      editor.isViewingHistory || editor.isDirty
-        ? editor.getDisplayedSerializedContent()
-        : undefined,
+      unsavedContent,
+      editor.isViewingHistory ? editor.displayedVersionNumber : undefined,
     );
   };
 


### PR DESCRIPTION
The assistant can now create and update Excel-like spreadsheets as
artifacts. Users edit them in a grid side panel (cells, rows, columns),
save versions, revert, and export to .xlsx or .csv. Assistant updates
are optimistic-locked against user edits via expected_version.

- Extract ArtifactSidePanel from ChatPage with a per-type switch
  (diagram viewer / spreadsheet editor / document editor)
- Add create/update spreadsheet chat widget cards (lucide Table icon)
- Register tools in the rich-widget renderer, timeline classification,
  and action labels; en/de i18n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches artifact open/save/export flows and timeline merging for a new tool family; behavior changes on spreadsheet export (save-before-export vs prior displayed-content export) could affect what users download.
> 
> **Overview**
> Adds end-to-end chat support for **spreadsheet** artifacts: create/update tool cards in the thread, timeline labels, rich-tool classification, and merged `update_spreadsheet` steps on the same artifact (with tests). **en/de** strings cover the new tools.
> 
> **Artifact side panel** is pulled out of `ChatPage` into `ArtifactSidePanel`, which lazy-loads the diagram viewer, document editor, or **spreadsheet editor** by `artifact.type` and remounts on `artifact.id` so editor state does not leak between artifacts.
> 
> Shared **`findLatestArtifactId`** replaces duplicated title/type sorting in create document and diagram widgets and powers the new create-spreadsheet widget; update-spreadsheet uses the existing update-artifact widget hook.
> 
> **Export/save wiring** now accepts an optional **`versionNumber`** on export (API → `useExportArtifact` → `useArtifactActions` → side panel). Spreadsheet export saves dirty current content first, or exports a specific historical version when browsing history. Saves from the panel go through async `saveArtifactAsync`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7ca8eb5a8be6363f2d6c36d70a144f9a0dfaad7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->