### PR TITLE
chore(lint): exempt tanstack route files from react-refresh purity rule (AYC-000)

### DIFF
--- a/ayunis-core-frontend/eslint.config.mjs
+++ b/ayunis-core-frontend/eslint.config.mjs
@@ -149,4 +149,12 @@ export default tseslint.config(
       'no-console': 'off',
     },
   },
+  // TanStack Router file routes must export the Route constant alongside a
+  // local RouteComponent, so fast-refresh purity cannot hold in these files.
+  {
+    files: ['src/app/routes/**/*.tsx'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
+  },
 );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lint configuration only; no application or build behavior changes.
> 
> **Overview**
> Adds an ESLint override for `src/app/routes/**/*.tsx` that turns off **`react-refresh/only-export-components`**.
> 
> TanStack Router file routes must export the **`Route`** constant together with a local route component, which violates the fast-refresh “components only” rule. The override documents that limitation so route modules stop warning without changing runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdafb808f64fd02718041457b40dd5d8d9dc7c4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->