### PR TITLE
docs(skills): sync skill updates from agentfiles store (AYC-000)

### DIFF
--- a/.claude/skills/ayunis-core-frontend-dev/SKILL.md
+++ b/.claude/skills/ayunis-core-frontend-dev/SKILL.md
@@ -36,6 +36,19 @@ src/
 
 Layers only depend on layers to their right. Never import upward.
 
+### Check demonstrated conventions before deciding placement
+
+The FSD rules above are the theory; **this repo's actual conventions are the tie-breaker.** Before deciding where a slice or component lives — feature vs widget vs page, which page a route maps to, whether something is "shared enough" to promote a layer — grep how comparable cases are already structured and follow that, rather than reasoning from FSD principles alone.
+
+- The abstract heuristics ("used in ≥2 pages → widget", "used from more than one slice → promote") are necessary but not sufficient. They routinely disagree with how the codebase actually draws its boundaries when viewed across the whole repo instead of a single branch.
+- Concrete convention that has bitten before: **pages map one slice per route** — e.g. a list route and its detail route are separate page slices (`skills.index` vs `skill.$id`), not one page reused across two routes. Check the route files and `src/pages/` before assuming a shared placement.
+- When a colocated placement (feature/page) and a "promote to shared/widget" placement both look defensible, the existing convention wins. Look at the `Reference Pages` in the `new-page` skill and grep sibling slices before moving code.
+- Do not double down on a theory-driven placement after pushback — re-check the convention first. See "Confirm placement before mutating a stacked PR chain" below.
+
+### Confirm placement before mutating a stacked PR chain
+
+Do not execute structural moves and amend commits across a stacked-PR chain (e.g. `gt modify` a parent, then check out and amend the child) off a *preliminary* placement conclusion. Settle the placement against repo conventions first, then move — reverting a wrong move across stacked branches means restoring exact pre-session SHAs from the reflog.
+
 ## Shared shadcn UI — Never Modify
 
 **Never edit the shared shadcn components in `src/shared/ui/shadcn/` yourself.** These are managed via the shadcn registry (`components.json`) and are shared design-system primitives. Editing them by hand causes drift from the registry and breaks every consumer.
@@ -43,6 +56,13 @@ Layers only depend on layers to their right. Never import upward.
 - To add or update a shadcn component, use the shadcn CLI (`pnpm dlx shadcn@latest add <component>`) — do not hand-write or hand-patch files under `src/shared/ui/shadcn/`.
 - If a component's behavior or styling needs to change for a feature, **wrap or compose it** in your own component (in the relevant `ui/` directory or `src/shared/ui/` outside `shadcn/`) rather than modifying the primitive.
 - If you believe a shared shadcn primitive genuinely must change, **stop and ask the user** — do not make the change on your own.
+
+### Reach for existing primitives and tokens
+
+Compose the existing design system before hand-rolling layout, and use design tokens instead of raw Tailwind color scales:
+
+- **Look for a composite primitive first.** For an icon-plus-label row (banners, result cards, list rows) use the `Item` family — `Item` / `ItemMedia variant="icon"` / `ItemContent` — rather than assembling a bare `flex` container yourself. Check `src/shared/ui/` for an existing icon component before adding your own.
+- **Use semantic color tokens, never hardcoded palette classes.** `text-brand`, `text-muted-foreground`, etc. — not `text-amber-500`, `text-blue-600`, or other raw Tailwind color scales, which break theming and dark mode.
 
 ### Page module internals
 

--- a/.claude/skills/bugbot-triage/SKILL.md
+++ b/.claude/skills/bugbot-triage/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: bugbot-triage
+description: "Analyze Cursor Bugbot PR comments through a root-cause lens: is the finding valid, and is the suggested fix the real fix or a bandaid over a deeper problem? Use when the user asks to check, assess, or triage bugbot comments."
+---
+
+# Bugbot Triage
+
+Bugbot findings are usually *locally* correct but *shallowly* scoped: it sees the flagged lines, not why the surrounding construct exists. Your job is not to confirm the finding — it is to decide what the finding is a **symptom of**. Never jump straight to applying bugbot's suggested fix.
+
+## Fetching the Comments
+
+Bugbot posts as `cursor[bot]`. Findings live in **inline review comments**; the PR body only carries its summary.
+
+```bash
+gh pr view --json number --jq .number   # if no PR number given
+gh api repos/{owner}/{repo}/pulls/<number>/comments \
+  --jq '.[] | select(.user.login == "cursor[bot]") | {path, line, body}'
+```
+
+Strip the HTML boilerplate (Fix-in-Cursor buttons, `BUGBOT_BUG_ID`); the substance is the severity line, the description, and the `LOCATIONS` block.
+
+## The Triage Lens
+
+Classify every finding into exactly one verdict:
+
+1. **Invalid** — bugbot misread the code (wrong assumption about control flow, missed a guard, flagged intentional behavior). Requires evidence: cite the file:line that refutes it.
+2. **Valid & simple** — the finding is self-contained and the suggested fix *is* the root-cause fix (a real off-by-one, a missing await, a wrong error type). Fix as suggested.
+3. **Valid but symptom** — the finding is true, but it points at scaffolding whose *reason to exist* is gone or wrong. Applying the literal fix would polish code that should be deleted or redesigned. Propose the structural fix instead.
+
+The default temptation is verdict 2. Most low-severity "dead code / needless indirection / unused parameter" findings are actually verdict 3 — dead code is rarely lonely; it usually signals a dead *contract*.
+
+## Root-Cause Tracing (before settling on a verdict)
+
+Work through these steps; stop early only for verdict 1:
+
+1. **Read the whole flagged file**, not just the flagged lines. Understand what the construct's job is *now*, after the PR's changes.
+2. **Trace every consumer across all packages** (backend, frontend, other services — `grep -rn` the identifiers, response-body fields, config keys). An unconsumed output means the contract, not just the parameter, is dead.
+3. **Trace the stated purpose**: comments in the file, sibling files that reference it, module registrations, the PR description. Ask: *does the stated reason to exist still hold after this PR?* PRs that remove behavior routinely leave the scaffolding (helpers, flags, filters, rethrow branches, comments) standing.
+4. **Find all coupling points** that would be affected by removing the construct entirely (registrations, filters/guards ordering, comments in other modules referencing it, tests asserting its output).
+5. **Apply the structural test**: does deleting/redesigning the construct make the whole bug class *structurally impossible*, versus patching or testing around it? Prefer the fix where the vulnerable/dead code path no longer exists at all.
+
+## Reporting
+
+Report the assessment; do **not** implement a fix unless asked. Structure:
+
+- **Verdict** first: valid/invalid, and simple vs. symptom. If symptom: one sentence naming the actual disease ("the finding is the symptom, not the disease").
+- **Evidence** with `file:line` references for every claim — especially the consumer trace ("grepped both packages: only the filter and its spec reference these fields").
+- **Root-cause fix** as a concrete numbered change list (what to delete, what registrations/comments/tests to update, what stays and why).
+- **Caveats**: behavioral changes (e.g. response body shape), possible external consumers, test coverage that becomes moot.
+- **Scope recommendation**: does the root-cause fix belong in the PR under review, or in a small stacked follow-up PR (keep security/feature fixes independently revertible; respect large-PR warnings)? If deferring, suggest replying to bugbot that the construct is removed in the follow-up.
+
+If the honest answer is verdict 2, say so plainly and keep it short — not every finding hides a deeper problem, and inventing one is as wrong as missing one.

--- a/.claude/skills/use-case-reference/SKILL.md
+++ b/.claude/skills/use-case-reference/SKILL.md
@@ -13,7 +13,8 @@ The structural rules (error-boundary decorator, error wrapping, single `execute(
 
 ```typescript
 import { Injectable, Logger } from '@nestjs/common';
-import { HandleUnexpectedErrors } from 'src/common/use-case/handle-unexpected-errors.decorator';
+// Error-boundary decorator — exact import path varies by project
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 // Module-specific errors
 import { EntityNotFoundError, UnexpectedEntityError } from '../../entity.errors';
 // Repository class — the type doubles as the DI token (no @Inject() needed)
@@ -66,7 +67,7 @@ export class DoSomethingUseCase {
 async execute(command: DoSomethingCommand): Promise<Entity> {
 ```
 
-The decorator (from `src/common/use-case/handle-unexpected-errors.decorator.ts`) is the use case's error boundary:
+The decorator (from `src/common/decorators/handle-unexpected-errors.decorator.ts` — exact path varies by project) is the use case's error boundary:
 
 - **Re-throws `ApplicationError`** subclasses as-is — these are domain errors with proper status codes
 - **Logs unexpected errors** under the use-case class name — no extra context needed, the class name already describes the operation
@@ -192,4 +193,4 @@ When creating or modifying a use case, verify:
 - [ ] Preconditions checked before mutations (entity exists, permissions valid)
 - [ ] Repositories injected via DI token (interface), not concrete class
 - [ ] Module has an `Unexpected*Error` class in its errors file
-- [ ] Logger uses class name, logs entry point and errors
+- [ ] Logger uses class name, logs entry point (error logging is the decorator's job)


### PR DESCRIPTION
- use-case-reference: correct the @HandleUnexpectedErrors import path
  to src/common/decorators/ and note that the path varies by project
- ayunis-core-frontend-dev: prefer design-system primitives (Item
  family) and semantic color tokens; check demonstrated conventions
  before FSD placement
- add bugbot-triage skill: triage bugbot PR comments through a
  root-cause lens (valid & simple vs bandaid over a deeper problem)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015yCxMvN16JztBeAmKVM45s

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent guidance; no runtime, auth, or data paths affected.
> 
> **Overview**
> Syncs **Claude agent skills** under `.claude/skills/` with the agentfiles store—no application code changes.
> 
> **`use-case-reference`** fixes the `@HandleUnexpectedErrors` example to `src/common/decorators/handle-unexpected-errors.decorator` (matching the backend), notes that the path can vary by project, and clarifies that **unexpected-error logging is the decorator’s job**, not the use-case logger checklist item.
> 
> **`ayunis-core-frontend-dev`** adds guidance to **grep repo conventions before FSD placement** (e.g. one page slice per route like `skills.index` vs `skills.$id`), to **confirm placement before amending stacked PR chains**, and to prefer **`Item` primitives** and **semantic color tokens** over ad-hoc flex layouts and raw Tailwind palette classes.
> 
> **New `bugbot-triage` skill** defines how to fetch Cursor Bugbot inline comments and classify findings (invalid vs valid & simple vs valid-but-symptom), with root-cause tracing steps and a structured report format without auto-fixing unless asked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17025600fcd66b2b10da6c880300f5679f0ac434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->