### PR TITLE
refactor(models): rename PermittedModelQueryService to PermittedModelFinder (AYC-325)

### DIFF
--- a/ayunis-core-backend/src/domain/models/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/models/SUMMARY.md
@@ -70,7 +70,7 @@ The models module is the central registry for AI model configuration. The abstra
 
 ## Infrastructure Services
 
-- **PermittedModelQueryService** (`infrastructure/persistence/local-permitted-models/permitted-model-query.service.ts`): Centralizes permitted model queries with type-safe filtering by model type (language, embedding, image-generation) and scope (org, team). Handles both org-scoped and team-scoped lookups.
+- **PermittedModelFinder** (`infrastructure/persistence/local-permitted-models/permitted-model-finder.ts`): Read-only collaborator of `LocalPermittedModelsRepository` that centralizes permitted-model lookups with type-safe filtering by model type (language, embedding, image-generation) and scope (org, team). Handles both org-scoped and team-scoped reads.
 
 ## Image Generation
 

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models-repository.module.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models-repository.module.ts
@@ -5,7 +5,7 @@ import { PermittedModelMapper } from './mappers/permitted-model.mapper';
 import { LocalPermittedModelsRepository } from './local-permitted-models.repository';
 import { PermittedModelsRepository } from 'src/domain/models/application/ports/permitted-models.repository';
 import { LocalModelsRepositoryModule } from '../local-models/local-models-repository.module';
-import { PermittedModelQueryService } from './permitted-model-query.service';
+import { PermittedModelFinder } from './permitted-model-finder';
 
 @Module({
   imports: [
@@ -13,7 +13,7 @@ import { PermittedModelQueryService } from './permitted-model-query.service';
     LocalModelsRepositoryModule,
   ],
   providers: [
-    PermittedModelQueryService,
+    PermittedModelFinder,
     LocalPermittedModelsRepository,
     PermittedModelMapper,
     {

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models.repository.spec.ts
@@ -9,7 +9,7 @@ import {
 } from 'src/domain/models/domain/permitted-model.entity';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
 import { PermittedModelScope } from 'src/domain/models/domain/value-objects/permitted-model-scope.enum';
-import { PermittedModelQueryService } from './permitted-model-query.service';
+import { PermittedModelFinder } from './permitted-model-finder';
 import type { Repository } from 'typeorm';
 import type { UUID } from 'crypto';
 
@@ -17,7 +17,7 @@ describe('LocalPermittedModelsRepository', () => {
   let repository: LocalPermittedModelsRepository;
   let permittedModelRepository: jest.Mocked<Repository<PermittedModelRecord>>;
   let permittedModelMapper: jest.Mocked<PermittedModelMapper>;
-  let queryService: PermittedModelQueryService;
+  let finder: PermittedModelFinder;
 
   const orgId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
   const catalogModelId = '123e4567-e89b-12d3-a456-426614174001' as UUID;
@@ -39,7 +39,7 @@ describe('LocalPermittedModelsRepository', () => {
       toRecord: jest.fn(),
     } as unknown as jest.Mocked<PermittedModelMapper>;
 
-    queryService = new PermittedModelQueryService(
+    finder = new PermittedModelFinder(
       permittedModelRepository,
       permittedModelMapper,
     );
@@ -47,7 +47,7 @@ describe('LocalPermittedModelsRepository', () => {
     repository = new LocalPermittedModelsRepository(
       permittedModelRepository,
       permittedModelMapper,
-      queryService,
+      finder,
     );
   });
 

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models.repository.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models.repository.ts
@@ -23,7 +23,7 @@ import {
   NotALanguageModelError,
   PermittedModelNotFoundError,
 } from 'src/domain/models/application/models.errors';
-import { PermittedModelQueryService } from './permitted-model-query.service';
+import { PermittedModelFinder } from './permitted-model-finder';
 
 @Injectable()
 export class LocalPermittedModelsRepository extends PermittedModelsRepository {
@@ -32,7 +32,7 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
     @InjectRepository(PermittedModelRecord)
     private readonly permittedModelRepository: Repository<PermittedModelRecord>,
     private readonly permittedModelMapper: PermittedModelMapper,
-    private readonly queryService: PermittedModelQueryService,
+    private readonly finder: PermittedModelFinder,
   ) {
     super();
   }
@@ -178,31 +178,31 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
   }
 
   async findOneEmbedding(orgId: UUID): Promise<PermittedEmbeddingModel | null> {
-    return this.queryService.findOneEmbedding(orgId);
+    return this.finder.findOneEmbedding(orgId);
   }
 
   async findOneImageGeneration(
     orgId: UUID,
   ): Promise<PermittedImageGenerationModel | null> {
-    return this.queryService.findOneImageGeneration(orgId);
+    return this.finder.findOneImageGeneration(orgId);
   }
 
   async findManyLanguage(orgId: UUID): Promise<PermittedLanguageModel[]> {
-    return this.queryService.findManyLanguage(orgId);
+    return this.finder.findManyLanguage(orgId);
   }
 
   async findManyLanguageByTeam(
     teamId: UUID,
     orgId: UUID,
   ): Promise<PermittedLanguageModel[]> {
-    return this.queryService.findManyLanguageByTeam(teamId, orgId);
+    return this.finder.findManyLanguageByTeam(teamId, orgId);
   }
 
   async findManyImageGenerationByTeam(
     teamId: UUID,
     orgId: UUID,
   ): Promise<PermittedImageGenerationModel[]> {
-    return this.queryService.findManyImageGenerationByTeam(teamId, orgId);
+    return this.finder.findManyImageGenerationByTeam(teamId, orgId);
   }
 
   async findByTeamAndModelId(

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/permitted-model-finder.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/permitted-model-finder.ts
@@ -18,8 +18,8 @@ import { PermittedModelRecord } from './schema/permitted-model.record';
 import { PermittedModelMapper } from './mappers/permitted-model.mapper';
 
 @Injectable()
-export class PermittedModelQueryService {
-  private readonly logger = new Logger(PermittedModelQueryService.name);
+export class PermittedModelFinder {
+  private readonly logger = new Logger(PermittedModelFinder.name);
 
   constructor(
     @InjectRepository(PermittedModelRecord)


### PR DESCRIPTION
PermittedModelQueryService is a read-only collaborator of
LocalPermittedModelsRepository, not an application-layer service. The
.service suffix was misleading; .repository was also wrong (it is not a
port-backed adapter) and .query is reserved for query-input DTOs. Its
API is entirely findOne*/findMany*, so rename it to PermittedModelFinder
and the file to permitted-model-finder.ts. Pure rename, no behaviour
change.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure rename with no logic changes; only naming and wiring updates in the models persistence layer.
> 
> **Overview**
> Renames the read-only permitted-model lookup helper from **`PermittedModelQueryService`** (`permitted-model-query.service.ts`) to **`PermittedModelFinder`** (`permitted-model-finder.ts`) so naming matches its role as an infrastructure collaborator of `LocalPermittedModelsRepository`, not an application-layer service.
> 
> `LocalPermittedModelsRepository`, the Nest module, repository spec, and **`SUMMARY.md`** are updated to inject and delegate to `finder` instead of `queryService`. **No behavior change**—the same `findOne*` / `findMany*` read APIs are forwarded unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a255de9049fc1846472a360c2d39b3e6b069185b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->