### PR TITLE
docs(skills): document backend file & class naming conventions (AYC-000)

### DIFF
--- a/.claude/skills/nestjs-hexagonal-backend/SKILL.md
+++ b/.claude/skills/nestjs-hexagonal-backend/SKILL.md
@@ -88,7 +88,7 @@ Every domain module ships a `SUMMARY.md`. Read it first when editing an existing
 ├── domain/              # Pure entities, no decorators
 ├── application/
 │   ├── use-cases/       # Business operations
-│   ├── ports/           # Abstract interfaces
+│   ├── ports/           # Abstract classes (DI tokens, not interfaces)
 │   └── dtos/            # Validation decorators
 ├── infrastructure/
 │   └── persistence/postgres/
@@ -98,6 +98,20 @@ Every domain module ships a `SUMMARY.md`. Read it first when editing an existing
 ├── presenters/http/     # Controllers (thin)
 └── [module].module.ts   # NestJS wiring
 ```
+
+### File & class naming
+
+Suffixes carry structural meaning — the wrong one silently breaks the layer contract readers rely on and triggers review churn. **Before naming a new file, grep how the suffix is already used** (`find src -name "*.<suffix>.ts"`) and match that role.
+
+- **`*.service.ts`** — application-layer domain service (`application/services/`). In `infrastructure/`, only for adapters wrapping an *external* capability (encryption, export, transcription, queue) — never a persistence read helper.
+- **`*.repository.ts`** — port-backed persistence adapter. **Must `extends` an abstract port** (every `*Repository` does). No port → it is not a repository.
+- **`*.query.ts`** — query-input DTO in the application layer: the parameter object for a query use case (`GetXQuery`). Not a persistence read class.
+- **`*.command.ts`** — command-input DTO in the application layer: the parameter object for a write use case.
+- **`*.mapper.ts`** — object conversion, always in a `mappers/` dir. Two roles: domain ↔ record in `infrastructure/persistence/*/mappers/`, and domain → response DTO in `presenters/http/mappers/` (some modules also keep application-layer mappers in `application/mappers/`).
+
+**Ports are abstract classes, not interfaces** — NestJS DI needs a runtime token. Impls `extends` the port; the module wires `{ provide: Port, useClass: Impl }`; consumers inject the abstract class directly (no `@Inject('TOKEN')`).
+
+A **read-only collaborator of a repository** (a `findOne*`/`findMany*` helper with no port, often extracted to keep the repository under the file-size limit) is neither a repository nor a service — name it `*.finder.ts` / `*Finder`.
 
 ## Key Patterns
 
@@ -147,3 +161,4 @@ For schema changes, use the `typeorm-migrations` skill. Never write migrations b
 | Test implementation details (mock internals)          | Brittle tests that break on refactor | Test inputs → outputs and side effects |
 | Use vague test names (`should work`, `handles error`) | Tests are documentation              | Name the specific behavior being proven|
 | Throw HTTP exceptions from use cases                  | Couples domain to HTTP               | Throw domain errors                    |
+| Name a portless read helper `*.repository`            | Implies a port-backed adapter        | `*.finder.ts` / `*Finder`              |


### PR DESCRIPTION
Suffixes (.service/.repository/.query/.command) carry structural meaning
in this codebase; picking the wrong one breaks the layer contract and
causes review churn (recently: PermittedModelQueryService, a portless
read helper misnamed as a service). Add a File & class naming section to
the nestjs-hexagonal-backend skill with per-suffix rules, the
ports-are-abstract-classes note, the *.finder convention for read-only
repository collaborators, an anti-pattern row, and a 'grep the suffix
before naming' rule.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a Claude skill file; no runtime or application code is modified.
> 
> **Overview**
> Extends the **nestjs-hexagonal-backend** skill with a **File & class naming** section so suffixes match layer roles and avoid misnamed helpers (e.g. portless read classes labeled `*Service`).
> 
> The module tree now states that **`application/ports/`** holds **abstract classes** (DI tokens), not interfaces. New guidance covers **`*.service`**, **`*.repository`** (must extend a port), **`*.query`** / **`*.command`** (use-case input DTOs), **`*.mapper`**, and **`*.finder`** for portless read-only repository collaborators. It also adds a **grep-before-naming** rule and an anti-pattern row for portless read helpers named `*.repository`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a581cb06aa1222cd78be182d4295187e0010fe35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->