### PR TITLE
fix(minio): tie api to loopback (AYC-466)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,10 +48,12 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    # S3 API on loopback so a host-side proxy can front it for presigned URLs
+    # Both the S3 API and the admin console are bound to loopback so a
+    # host-side proxy can front them; the console must not be exposed on all
+    # interfaces to avoid unintentionally publishing the admin UI.
     ports:
       - "127.0.0.1:9000:9000"
-      - "9001:9001"
+      - "127.0.0.1:9001:9001"
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In `docker-compose.yml` war die **MinIO-Console** über `9001:9001` an **alle Host-Interfaces** gebunden, während die S3-API (`127.0.0.1:9000`) und Dozzle (`127.0.0.1:8888`) bewusst auf Loopback beschränkt sind. Diese Inkonsistenz führte zu einer unbeabsichtigten Exposition der Admin-Console.

## Änderung

- Port-Binding der MinIO-Console von `9001:9001` auf `127.0.0.1:9001:9001` beschränkt (Defense in depth, unabhängig von einer ggf. vorgelagerten Host-/Cloud-Firewall).
- Kommentar im Compose-File aktualisiert, damit klar ist, dass sowohl S3-API als auch Console absichtlich nur auf Loopback lauschen.

## Hinweis zum Zugriff

Der Zugriff auf die Console erfolgt weiterhin lokal (z. B. per SSH-Tunnel) oder über einen host-seitigen Proxy — genau wie bereits für die S3-API vorgesehen.

Closes AYC-466
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-466](https://linear.app/ayunis/issue/AYC-466/hartung-minio-console-port-9001-an-alle-interfaces-gebunden-statt)

<div><a href="https://cursor.com/agents/bc-c231de39-f397-4cc1-a9cc-03fe98db6818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c231de39-f397-4cc1-a9cc-03fe98db6818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

