### PR TITLE
fix(chat): keep new-chat gradient backdrop pinned to the bottom (AYC-459)

### DIFF
--- a/ayunis-core-frontend/src/pages/new-chat/ui/new-chat-backdrop.css
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/new-chat-backdrop.css
@@ -72,14 +72,15 @@
   animation-play-state: paused !important;
 }
 
+/* Fade-only entrance: the backdrop must stay pinned to the bottom, so it must
+   never translate vertically on appear (any Y movement reads as the gradient
+   "jumping up"). */
 @keyframes newChatBackdropAppear {
   from {
     opacity: 0;
-    transform: translate3d(0, 22%, 0);
   }
   to {
     opacity: 1;
-    transform: translate3d(0, 0, 0);
   }
 }
 
@@ -156,15 +157,18 @@
   animation-delay: var(--backdrop-blob-delay-3);
 }
 
+/* Blobs keep only horizontal drift + scale breathing. Vertical drift is
+   intentionally 0 so the glow stays anchored to the bottom edge and never
+   creeps upward. */
 @keyframes newChatBackdropBlobOne {
   0% {
     transform: translate3d(0%, 0%, 0) scale(1);
   }
   50% {
-    transform: translate3d(4%, -4%, 0) scale(1.06);
+    transform: translate3d(4%, 0%, 0) scale(1.06);
   }
   100% {
-    transform: translate3d(-3%, -7%, 0) scale(0.97);
+    transform: translate3d(-3%, 0%, 0) scale(0.97);
   }
 }
 
@@ -173,10 +177,10 @@
     transform: translate3d(0%, 0%, 0) scale(1);
   }
   50% {
-    transform: translate3d(5%, -5%, 0) scale(1.06);
+    transform: translate3d(5%, 0%, 0) scale(1.06);
   }
   100% {
-    transform: translate3d(-4%, -6%, 0) scale(1.01);
+    transform: translate3d(-4%, 0%, 0) scale(1.01);
   }
 }
 
@@ -185,10 +189,10 @@
     transform: translate3d(0%, 0%, 0) scale(1);
   }
   50% {
-    transform: translate3d(-14%, -5%, 0) scale(1.05, 1.02);
+    transform: translate3d(-14%, 0%, 0) scale(1.05, 1.02);
   }
   100% {
-    transform: translate3d(-8%, -6%, 0) scale(0.98, 1);
+    transform: translate3d(-8%, 0%, 0) scale(0.98, 1);
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The gradient backdrop on the new-chat page occasionally appeared to move "a little up" instead of staying anchored to the bottom. It was unclear when it happened (AYC-459).

## Root cause

Two vertical translations in `new-chat-backdrop.css` moved the glow upward:

1. **Entrance animation** — `newChatBackdropAppear` translated the whole canvas from `translate3d(0, 22%, 0)` up to `0`. Because a CSS animation replays whenever its element is (re)created, this upward rise showed up at unpredictable moments (page (re)mounts, personalization/loading state transitions), matching the "not clear when it moves up" report.
2. **Ambient blob motion** — the blob keyframes continuously drifted upward (up to `-7%` on `translateY`) via `infinite alternate`, letting the glow creep off the bottom edge.

## Fix

- Made the entrance a **pure opacity fade** (removed the vertical translate), so the backdrop never shifts position when it appears.
- Removed the vertical (`Y`) drift from all three blob keyframes while **keeping the horizontal drift and scale breathing**, so the blobs still feel alive but stay pinned to the bottom.
- The exit animation (a downward sink as a chat is sent) is intentionally left unchanged — it moves down, not up, and is part of the leaving transition.

Net effect: the gradient backdrop now stays anchored to the bottom at all times.

## Testing

CSS-only change. Verified Prettier formatting passes; pre-commit hooks pass on commit. Visual behavior is a straightforward removal of vertical transforms.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-459](https://linear.app/ayunis/issue/AYC-459/gradient-backdrop-fix)

<div><a href="https://cursor.com/agents/bc-3a28f4cf-b28d-41bd-90b7-92a5fd07bef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a28f4cf-b28d-41bd-90b7-92a5fd07bef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

