### PR TITLE
fix(integrations): remove pre-selected Deutsche Gesetzestexte integration (AYC-484)

### DIFF
--- a/ayunis-core-backend/.env.example
+++ b/ayunis-core-backend/.env.example
@@ -238,8 +238,6 @@ AYUNIS_METRICS_PASSWORD=changeme
 ANONYMIZE_SERVICE_URL=
 # Code execution service (default http://localhost:8080)
 CODE_EXECUTION_SERVICE_URL=
-# Legal MCP server URL
-LEGAL_MCP_URL=
 # Locaboo 4 MCP server URL
 LOCABOO_4_MCP_URL=
 # Locaboo 3 base URL

--- a/ayunis-core-backend/src/config/mcp.config.ts
+++ b/ayunis-core-backend/src/config/mcp.config.ts
@@ -2,5 +2,4 @@ import { registerAs } from '@nestjs/config';
 
 export const mcpConfig = registerAs('mcp', () => ({
   locaboo4Url: process.env.LOCABOO_4_MCP_URL,
-  legalMcpUrl: process.env.LEGAL_MCP_URL,
 }));

--- a/ayunis-core-backend/src/domain/mcp/application/registries/predefined-mcp-integration-registry.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/registries/predefined-mcp-integration-registry.service.ts
@@ -31,19 +31,6 @@ export class PredefinedMcpIntegrationRegistry {
       });
     }
 
-    // Legal MCP Integration
-    const legalMcpUrl = this.configService.get<string>('mcp.legalMcpUrl');
-    if (legalMcpUrl) {
-      this.configs.set(PredefinedMcpIntegrationSlug.LEGAL_CODES, {
-        slug: PredefinedMcpIntegrationSlug.LEGAL_CODES,
-        displayName: 'Deutsche Gesetzestexte',
-        description:
-          'Ermöglicht KI-Agenten den Zugriff auf aktuelle deutsche Gesetzestexte.',
-        serverUrl: legalMcpUrl,
-        authType: McpAuthMethod.NO_AUTH,
-      });
-    }
-
     // Locaboo integration (Bearer token auth)
     const locabooUrl = this.configService.get<string>('mcp.locaboo4Url');
     if (locabooUrl) {

--- a/ayunis-core-backend/src/domain/mcp/domain/value-objects/predefined-mcp-integration-slug.enum.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/value-objects/predefined-mcp-integration-slug.enum.ts
@@ -1,5 +1,7 @@
 export enum PredefinedMcpIntegrationSlug {
   TEST = 'TEST',
   LOCABOO = 'LOCABOO',
+  // No longer offered as a predefined integration (installed via the Marketplace
+  // instead), but retained so existing installed records remain loadable.
   LEGAL_CODES = 'LEGAL_CODES',
 }

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/integrations-list.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/integrations-list.tsx
@@ -1,10 +1,12 @@
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent } from '@/shared/ui/shadcn/card';
-import { FileQuestion } from 'lucide-react';
+import { Button } from '@/shared/ui/shadcn/button';
+import { ExternalLink, FileQuestion, Store } from 'lucide-react';
 import type { McpIntegration } from '../model/types';
 import { IntegrationCard } from './integration-card';
 import { useToggleIntegration } from '../api/useToggleIntegration';
 import { useValidateIntegration } from '../api/useValidateIntegration';
+import { useMarketplaceConfig } from '@/features/marketplace';
 
 interface IntegrationsListProps {
   integrations: McpIntegration[];
@@ -20,8 +22,11 @@ export function IntegrationsList({
   const { t } = useTranslation('admin-settings-integrations');
   const { toggleIntegration, togglingIds } = useToggleIntegration();
   const { validateIntegration, validatingIds } = useValidateIntegration();
+  const marketplace = useMarketplaceConfig();
 
   if (integrations.length === 0) {
+    const hasMarketplace = marketplace.enabled && !!marketplace.url;
+
     return (
       <Card>
         <CardContent>
@@ -31,8 +36,23 @@ export function IntegrationsList({
               {t('integrations.list.noIntegrationsTitle')}
             </h3>
             <p className="text-sm text-muted-foreground">
-              {t('integrations.list.noIntegrationsMessage')}
+              {hasMarketplace
+                ? t('integrations.list.noIntegrationsMarketplaceMessage')
+                : t('integrations.list.noIntegrationsMessage')}
             </p>
+            {hasMarketplace && (
+              <Button variant="outline" size="sm" className="mt-4" asChild>
+                <a
+                  href={`${marketplace.url!.replace(/\/$/, '')}/integrations`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Store className="h-4 w-4" />
+                  {t('integrations.list.browseMarketplace')}
+                  <ExternalLink className="h-4 w-4" />
+                </a>
+              </Button>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-integrations.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-integrations.json
@@ -68,7 +68,9 @@
     },
     "list": {
       "noIntegrationsTitle": "Noch keine Integrationen",
-      "noIntegrationsMessage": "Erstellen Sie Ihre erste Integration, um loszulegen."
+      "noIntegrationsMessage": "Erstellen Sie Ihre erste Integration, um loszulegen.",
+      "noIntegrationsMarketplaceMessage": "Installieren Sie Integrationen über den Marktplatz, um loszulegen.",
+      "browseMarketplace": "Marktplatz durchsuchen"
     },
     "createCustomDialog": {
       "title": "Benutzerdefinierte Integration hinzufügen",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-integrations.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-integrations.json
@@ -68,7 +68,9 @@
     },
     "list": {
       "noIntegrationsTitle": "No integrations yet",
-      "noIntegrationsMessage": "Create your first integration to get started."
+      "noIntegrationsMessage": "Create your first integration to get started.",
+      "noIntegrationsMarketplaceMessage": "Install integrations from the Marketplace to get started.",
+      "browseMarketplace": "Browse Marketplace"
     },
     "createCustomDialog": {
       "title": "Add Custom Integration",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In Live, the integrations admin settings still offered a pre-selected integration named **"Deutsche Gesetzestexte"** that could be installed directly from the add-integration dialog. Integrations should only be installable via the Marketplace.

## Changes

**Backend**
- Removed the hard-coded `LEGAL_CODES` ("Deutsche Gesetzestexte") predefined integration from `PredefinedMcpIntegrationRegistry`, so it is no longer returned by the predefined-configs endpoint or offered in the add-integration dialog.
- Removed the now-unused `legalMcpUrl` config key and the `LEGAL_MCP_URL` entry from `.env.example`.
- Kept the `LEGAL_CODES` enum member (with an explanatory comment) so any existing installed records remain loadable — only the ability to create new ones via the predefined dialog is removed.

**Frontend**
- The admin integrations empty state now hints at the Marketplace: when the marketplace is enabled it shows a "Browse Marketplace" call-to-action and a message pointing admins to install integrations from the Marketplace.
- Added the corresponding `de`/`en` locale strings.

## Notes / scope

- Existing installed "Deutsche Gesetzestexte" integrations continue to work at runtime (they use their stored server URL/auth; the registry is only consulted at creation/listing time).
- The `Locaboo` predefined integration is intentionally left untouched — the ticket only concerns the hard-coded legal-codes entry.

## Testing

- `pnpm jest` for the MCP registry + list-predefined use case (28 passed).
- Frontend `pnpm run build` and `pnpm run lint` pass (0 errors).
- Pre-commit hooks (typecheck, eslint, prettier, complexity, dep/dup checks) pass for both commits.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-484](https://linear.app/ayunis/issue/AYC-484/remove-pre-selected-integration-deutsche-gesetzestexte)

<div><a href="https://cursor.com/agents/bc-edce29e5-71e8-4784-924b-e06b89512f45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-edce29e5-71e8-4784-924b-e06b89512f45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

