### PR TITLE
fix(chat): preserve prompt and images when a run fails (AYC-473)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
@@ -208,7 +208,7 @@ export function useMessageSend(params: UseMessageSendParams) {
         }
       } catch (error) {
         console.error('Error in sendMessage', error);
-        
+
         if (error instanceof Error && error.name === 'AbortError') {
           wasAbortedRef.current = true;
           return;

--- a/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
@@ -60,8 +60,6 @@ export function useMessageSend(params: UseMessageSendParams) {
   const abortControllerRef = useRef<AbortController | null>(null);
   const isLoadingRef = useRef(false);
   const wasAbortedRef = useRef(false);
-  // Set by any failure path (SSE error event or HTTP/network error, incl. the
-  // 403/429 branches that don't call onError) so onComplete can restore.
   const hadErrorRef = useRef(false);
 
   const sendMessage = useCallback(
@@ -210,10 +208,7 @@ export function useMessageSend(params: UseMessageSendParams) {
         }
       } catch (error) {
         console.error('Error in sendMessage', error);
-
-        // An abort (superseded by a newer send, or user cancel) is not a
-        // failure: return before setting hadErrorRef so it can't pollute the
-        // shared flag of the send that superseded this one.
+        
         if (error instanceof Error && error.name === 'AbortError') {
           wasAbortedRef.current = true;
           return;

--- a/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
@@ -41,7 +41,7 @@ interface UseMessageSendParams {
   onMasksEvent?: (data: RunMasksResponseDto) => void;
   onErrorEvent?: (data: RunErrorResponseDto) => void;
   onError?: (error: Error) => void;
-  onComplete?: () => void;
+  onComplete?: (failed: boolean) => void;
 }
 
 interface SendMessagePayload {
@@ -60,6 +60,9 @@ export function useMessageSend(params: UseMessageSendParams) {
   const abortControllerRef = useRef<AbortController | null>(null);
   const isLoadingRef = useRef(false);
   const wasAbortedRef = useRef(false);
+  // Set by any failure path (SSE error event or HTTP/network error, incl. the
+  // 403/429 branches that don't call onError) so onComplete can restore.
+  const hadErrorRef = useRef(false);
 
   const sendMessage = useCallback(
     // eslint-disable-next-line sonarjs/cognitive-complexity
@@ -72,6 +75,7 @@ export function useMessageSend(params: UseMessageSendParams) {
 
         isLoadingRef.current = true;
         wasAbortedRef.current = false;
+        hadErrorRef.current = false;
         abortControllerRef.current = new AbortController();
         const signal = abortControllerRef.current.signal;
 
@@ -157,6 +161,7 @@ export function useMessageSend(params: UseMessageSendParams) {
                 params.onMasksEvent?.(data as RunMasksResponseDto);
                 break;
               case 'error':
+                hadErrorRef.current = true;
                 params.onErrorEvent?.(data as RunErrorResponseDto);
                 break;
               case undefined:
@@ -206,12 +211,17 @@ export function useMessageSend(params: UseMessageSendParams) {
       } catch (error) {
         console.error('Error in sendMessage', error);
 
-        if (error instanceof Error) {
-          if (error.name === 'AbortError') {
-            wasAbortedRef.current = true;
-            return; // Request was cancelled, don't show error
-          }
+        // An abort (superseded by a newer send, or user cancel) is not a
+        // failure: return before setting hadErrorRef so it can't pollute the
+        // shared flag of the send that superseded this one.
+        if (error instanceof Error && error.name === 'AbortError') {
+          wasAbortedRef.current = true;
+          return;
+        }
 
+        hadErrorRef.current = true;
+
+        if (error instanceof Error) {
           // Handle specific error status codes
           if (error.message.includes('429')) {
             // Try to extract retry time from error response
@@ -241,7 +251,7 @@ export function useMessageSend(params: UseMessageSendParams) {
         // When aborted, we keep the optimistic local state to avoid race conditions
         // with the backend's async save operation
         if (!wasAbortedRef.current) {
-          params.onComplete?.();
+          params.onComplete?.(hadErrorRef.current);
           // Cancel any in-flight thread refetch (e.g. an active refetchInterval
           // poll) so its older response can't land after ours and shorten the
           // displayed assistant text. Then await the refetch so the cache

--- a/ayunis-core-frontend/src/pages/chat/hooks/usePendingMessage.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/usePendingMessage.ts
@@ -11,7 +11,7 @@ interface UsePendingMessageParams {
     images?: PendingImage[];
     skillId?: string;
   }) => Promise<void>;
-  onSendStart?: (text: string) => void;
+  onSendStart?: (text: string, images?: PendingImage[]) => void;
 }
 
 /**
@@ -57,7 +57,7 @@ export function usePendingMessage({
 
     void (async () => {
       try {
-        onSendStart?.(text);
+        onSendStart?.(text, images);
         await sendTextMessage({ text, images, skillId });
       } catch (error) {
         if (error instanceof AxiosError && error.response?.status === 403) {

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -104,7 +104,6 @@ export default function ChatPage({
 
   const queryClient = useQueryClient();
   const chatInputRef = useRef<ChatInputRef>(null);
-  // In-flight submission, restored into the input if the run fails so the user can retry.
   const lastSubmissionRef = useRef<{ text: string; images?: File[] } | null>(
     null,
   );
@@ -256,9 +255,6 @@ export default function ChatPage({
       console.error('Error in useMessageSend:', error);
       showError(t('chat.errorSendMessage'));
     },
-    // Runs in the finally of every send (success or failure). Restore the
-    // prompt + images on any failure — incl. the 403/429 paths that never
-    // reach onError — then clear the stored submission.
     onComplete: (failed) => {
       if (failed) restoreFailedSubmission();
       lastSubmissionRef.current = null;

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -316,8 +316,6 @@ export default function ChatPage({
 
   function handleSendCancelled() {
     abort();
-    // Cancelling is intentional: discard the saved submission so it is neither
-    // restored now (abort skips onComplete) nor left stale for a later failure.
     lastSubmissionRef.current = null;
     setIsStreaming(false);
     setPendingSubmission(null);

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -28,7 +28,6 @@ import { useRunErrorHandler } from '../hooks/useRunErrorHandler';
 import { useLetterheadChange } from '../hooks/useLetterheadChange';
 import { usePendingMessage } from '../hooks/usePendingMessage';
 import AppLayout from '@/layouts/app-layout';
-import { AxiosError } from 'axios';
 import type { ChatInputRef } from '@/widgets/chat-input/ui/ChatInput';
 import { useCreateFileSource } from '@/pages/chat/api/useCreateFileSource';
 import { useDeleteFileSource } from '../api/useDeleteFileSource';
@@ -105,6 +104,10 @@ export default function ChatPage({
 
   const queryClient = useQueryClient();
   const chatInputRef = useRef<ChatInputRef>(null);
+  // In-flight submission, restored into the input if the run fails so the user can retry.
+  const lastSubmissionRef = useRef<{ text: string; images?: File[] } | null>(
+    null,
+  );
 
   const [threadTitle, setThreadTitle] = useState<string | undefined>(
     thread.title,
@@ -213,6 +216,12 @@ export default function ChatPage({
 
   const handleError = useRunErrorHandler(thread.id);
 
+  const restoreFailedSubmission = useCallback(() => {
+    const last = lastSubmissionRef.current;
+    if (!last) return;
+    chatInputRef.current?.restoreFailedSubmission(last.text, last.images ?? []);
+  }, []);
+
   const handleSession = useCallback((session: RunSessionResponseDto) => {
     if (config.env === 'development') {
       // eslint-disable-next-line no-console
@@ -247,9 +256,12 @@ export default function ChatPage({
       console.error('Error in useMessageSend:', error);
       showError(t('chat.errorSendMessage'));
     },
-    onComplete: () => {
-      // eslint-disable-next-line no-console
-      console.log('Message sending completed');
+    // Runs in the finally of every send (success or failure). Restore the
+    // prompt + images on any failure — incl. the 403/429 paths that never
+    // reach onError — then clear the stored submission.
+    onComplete: (failed) => {
+      if (failed) restoreFailedSubmission();
+      lastSubmissionRef.current = null;
       setIsStreaming(false);
       setPendingSubmission(null);
     },
@@ -261,7 +273,8 @@ export default function ChatPage({
 
   usePendingMessage({
     sendTextMessage,
-    onSendStart: (text) => {
+    onSendStart: (text, images) => {
+      lastSubmissionRef.current = { text, images: images?.map((i) => i.file) };
       setPendingSubmission(text);
       setIsStreaming(true);
     },
@@ -277,6 +290,10 @@ export default function ChatPage({
     imageFiles?: Array<{ file: File; altText?: string }>,
   ) {
     try {
+      lastSubmissionRef.current = {
+        text: message,
+        images: imageFiles?.map((img) => img.file),
+      };
       setPendingSubmission(message);
       setIsStreaming(true);
       chatInputRef.current?.setMessage('');
@@ -294,21 +311,18 @@ export default function ChatPage({
         text: message,
         images,
       });
-    } catch (error) {
-      chatInputRef.current?.setMessage(message);
-      setIsStreaming(false);
-      setPendingSubmission(null);
-      if (error instanceof AxiosError && error.response?.status === 403) {
-        showError(t('chat.upgradeToProError'));
-      } else {
-        showError(t('chat.errorSendMessage'));
-      }
-      throw error; // rethrow the error to preserve the message
+    } catch {
+      // Run errors arrive as SSE/HTTP events (handled in useMessageSend's
+      // onErrorEvent/onError); this only catches a rejected send promise.
+      restoreFailedSubmission();
     }
   }
 
   function handleSendCancelled() {
     abort();
+    // Cancelling is intentional: discard the saved submission so it is neither
+    // restored now (abort skips onComplete) nor left stale for a later failure.
+    lastSubmissionRef.current = null;
     setIsStreaming(false);
     setPendingSubmission(null);
 

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -16,7 +16,6 @@ import ChatHeader from './ChatHeader';
 import LongChatWarning from './LongChatWarning';
 import type { Thread, Message } from '../model/openapi';
 import { showError } from '@/shared/lib/toast';
-import config from '@/shared/config';
 
 import { useConfirmation } from '@/widgets/confirmation-modal';
 import { RenameThreadDialog } from '@/widgets/rename-thread-dialog';
@@ -233,24 +232,21 @@ export default function ChatPage({
   const restoreFailedSubmission = useCallback(() => {
     const last = lastSubmissionRef.current;
     if (!last) return;
-    chatInputRef.current?.restoreFailedSubmission(last.text, last.images ?? []);
-  }, []);
+    // false = a follow-up draft blocked restore; warn instead of dropping silently.
+    const restored = chatInputRef.current?.restoreFailedSubmission(
+      last.text,
+      last.images ?? [],
+    );
+    if (restored === false) showError(t('chat.errorRestoreFailedSubmission'));
+  }, [t]);
 
   const handleSession = useCallback((session: RunSessionResponseDto) => {
-    if (config.env === 'development') {
-      // eslint-disable-next-line no-console
-      console.log('session', session);
-    }
     if (session.streaming === true) setIsStreaming(true);
     if (session.streaming === false) setIsStreaming(false);
   }, []);
 
   const handleThread = useCallback(
     (thread: RunThreadResponseDto) => {
-      if (config.env === 'development') {
-        // eslint-disable-next-line no-console
-        console.log('Thread', thread);
-      }
       setThreadTitle(thread.title);
       void queryClient.invalidateQueries({
         queryKey: getThreadsControllerFindAllQueryKey(),

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -1,4 +1,12 @@
-import { useState, useRef, useCallback, useMemo, lazy, Suspense } from 'react';
+import {
+  useState,
+  useRef,
+  useCallback,
+  useMemo,
+  useEffect,
+  lazy,
+  Suspense,
+} from 'react';
 import ChatInterfaceLayout from '@/layouts/chat-interface-layout/ui/ChatInterfaceLayout';
 import { ChatThreadContent } from '@/pages/chat/ui/ChatThreadContent';
 import { groupMessagesIntoRuns } from '@/pages/chat/ui/agent-run-timeline';
@@ -127,6 +135,13 @@ export default function ChatPage({
     setThreadTitle(thread.title);
     setPiiMasks(thread.piiMasks);
   }
+
+  // ChatPage is reused across thread switches; drop any pending restore from
+  // the previous thread so a send that fails after navigation can't paste its
+  // prompt/images into the newly shown thread.
+  useEffect(() => {
+    lastSubmissionRef.current = null;
+  }, [thread.id]);
   const [pendingSubmission, setPendingSubmission] = useState<string | null>(
     null,
   );

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -21,6 +21,7 @@
     "errorToolNotFound": "Tool nicht gefunden",
     "errorAnonymizationUnavailable": "Die Anonymisierung ist derzeit nicht verfügbar. Ihre Nachricht wurde nicht gesendet, um Ihre Daten zu schützen.",
     "errorSendMessage": "Nachricht konnte nicht gesendet werden. Bitte aktualisieren Sie die Seite und versuchen Sie es erneut.",
+    "errorRestoreFailedSubmission": "Ihre vorherige Nachricht und Anhänge konnten nicht wiederhergestellt werden, da die Eingabe bereits einen Entwurf enthält.",
     "errorQuotaExceeded": "Sie haben das Nachrichtenlimit erreicht. Bitte versuchen Sie es später erneut.",
     "errorQuotaExceededWithTime": "Sie haben das Nachrichtenlimit erreicht. Bitte versuchen Sie es in {{minutes}} Minuten erneut.",
     "errorCreditBudgetExceeded": "Sie haben das Credits-Limit für diesen Monat erreicht. Bitte wenden Sie sich an Ihren Administrator.",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -21,6 +21,7 @@
     "errorToolNotFound": "Tool not found",
     "errorAnonymizationUnavailable": "Anonymization is currently unavailable. Your message was not sent to protect your data.",
     "errorSendMessage": "Message could not be sent. Please refresh the page and try again.",
+    "errorRestoreFailedSubmission": "Your previous message and attachments couldn't be restored because the input already contains a draft.",
     "errorQuotaExceeded": "You have reached the message limit. Please try again later.",
     "errorQuotaExceededWithTime": "You have reached the message limit. Please try again in {{minutes}} minutes.",
     "errorCreditBudgetExceeded": "You have reached the credit limit for this month. Please contact your administrator.",

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -111,7 +111,7 @@ interface ChatInputProps {
 export interface ChatInputRef {
   setMessage: (message: string) => void;
   sendMessage: (message: string) => void;
-  restoreFailedSubmission: (text: string, files: File[]) => void;
+  restoreFailedSubmission: (text: string, files: File[]) => boolean;
 }
 
 const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
@@ -219,14 +219,14 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
     useImperativeHandle(ref, () => ({
       setMessage,
       sendMessage: (text: string) => {
-        if (!text.trim() || !modelId) return;
-        onSend(text);
+        if (text.trim() && modelId) onSend(text);
       },
-      // Restore only into a pristine input, never onto a mid-run follow-up draft.
+      // Restore only into a pristine input; false when a draft blocks it.
       restoreFailedSubmission: (text: string, files: File[]) => {
-        if (message.trim() || pendingImages.length > 0) return;
+        if (message.trim() || pendingImages.length > 0) return false;
         setMessage(text);
         if (files.length > 0) addImages(files);
+        return true;
       },
     }));
 

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -111,6 +111,7 @@ interface ChatInputProps {
 export interface ChatInputRef {
   setMessage: (message: string) => void;
   sendMessage: (message: string) => void;
+  restoreFailedSubmission: (text: string, files: File[]) => void;
 }
 
 const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
@@ -180,7 +181,6 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
     const { pendingImages, addImages, removeImage, clearImages } =
       usePendingImages();
 
-    // Handle paste events for images
     const handleImagesPasted = (files: File[]) => {
       const result = addImages(files);
       if (result.limitExceeded) {
@@ -221,6 +221,12 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       sendMessage: (text: string) => {
         if (!text.trim() || !modelId) return;
         onSend(text);
+      },
+      // Restore only into a pristine input, never onto a mid-run follow-up draft.
+      restoreFailedSubmission: (text: string, files: File[]) => {
+        if (message.trim() || pendingImages.length > 0) return;
+        setMessage(text);
+        if (files.length > 0) addImages(files);
       },
     }));
 


### PR DESCRIPTION
## Problem

Uploading a JPEG into a chat and asking for a summary can fail mid-run with an error. After the error, the chat loses **both** the uploaded image and the typed prompt, so the user has nothing to retry with. (AYC-473)

## Root cause of the failure (why it happens — the message is fixed in the stacked #1089)

The run fails when the uploaded image's **base64 size exceeds the provider's 5 MB limit**. This is **model-dependent**, which is why it looked intermittent:

- **Bedrock** (e.g. Claude Sonnet 4 🇪🇺) enforces the limit on the base64 payload. A ~4.3 MB phone photo → ~5.8 MB base64 → `400 image exceeds 5 MB maximum`.
- **Anthropic-direct** (e.g. Claude Sonnet 4.5) applies its limit to the raw bytes (4.3 MB < 5 MB), so the **same** photo succeeds.

So larger images work on some models and fail on others. **This PR (the stack base) fixes the data-loss half** — regardless of *why* a run fails, the prompt and image are preserved for retry. The specific, actionable "image too large" message is handled in **#1089** (stacked on top).

## Fix

- Record the in-flight submission (prompt text + image `File` objects) on send — for **both** entry points: continuing an existing chat (`ChatPage.handleSend`) and the new-chat first message (`usePendingMessage` → `onSendStart`).
- Detect failure **centrally** in `useMessageSend`: a `hadError` flag is set by the SSE `error` event **and** by every HTTP/network error (including the 403/429 branches that only toast and never call `onError`), then passed to `onComplete(failed)`, which runs in the `finally` of every non-aborted send.
- On failure, restore via `ChatInput.restoreFailedSubmission`, which only fills **empty** fields — a follow-up drafted while the run was still streaming is never clobbered.
- Clear the stored submission once the send completes.

## Verification

- `tsc --noEmit`, ESLint, prettier, dependency + duplication + file-size checks pass.
- Behavioural QA in a running slot (headless Chrome) with a real 4284×5712 photo of handwritten notes:
  - Summarized successfully on a model within limits.
  - On a run-error (SSE `error` event) the prompt **and** image remain in the input — verified for **both** the new-chat first message and continuing an existing chat.
  - On an injected **403**, prompt + image are preserved (previously lost, since 403/429 never called `onError`).
  - A follow-up typed **during** streaming is **not** overwritten when the run then fails.
  - No horizontal overflow at 375/768/1280px.

### Screenshots / demo

**Happy path** — a JPEG of handwritten notes is summarized:

![summary](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-473/docs/pr-media/ayc-473/00-happy-summary.png)

**On failure the prompt + image are preserved** (new-chat first message; the image thumbnail and text stay in the input for retry):

![restored on error](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-473/docs/pr-media/ayc-473/02-after-error-restored.png)

![demo](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-473/docs/pr-media/ayc-473/demo.gif)

> Media hosted on the `pr-media/ayc-473` branch (not part of this PR's diff); safe to delete after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UX change in the chat send/restore path with guards against overwriting drafts and cross-thread leakage; no auth, persistence, or API contract changes.
> 
> **Overview**
> **Failed chat runs no longer wipe the user’s prompt and image attachments** — the input is repopulated so they can retry without retyping or re-uploading.
> 
> `useMessageSend` now reports whether a send failed via `onComplete(failed)`, setting a `hadError` flag on SSE `error` events and on HTTP/network failures (including 403/429 paths that only showed toasts before). `ChatPage` keeps the last submission (text + `File`s) for both normal send and the new-chat pending-message path, restores through `ChatInput.restoreFailedSubmission` when `failed` is true, and clears that stash on success, cancel, or thread change so a failure on another thread cannot leak content.
> 
> Restore only runs when the input is still empty (no draft typed during streaming); otherwise users get `errorRestoreFailedSubmission` in EN/DE. Ad-hoc restore logic in `handleSend`’s catch was removed in favor of this centralized completion path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a03357c3b649acdb3af37d6efe7c47f920f13b06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

