### PR TITLE
fix(chat): show a clear error when an image exceeds the provider size limit (AYC-473)

### DIFF
--- a/ayunis-core-backend/src/domain/models/application/models.errors.ts
+++ b/ayunis-core-backend/src/domain/models/application/models.errors.ts
@@ -13,6 +13,7 @@ export enum ModelErrorCode {
   MODEL_PROVIDER_NOT_SUPPORTED = 'MODEL_PROVIDER_NOT_SUPPORTED',
   INFERENCE_FAILED = 'INFERENCE_FAILED',
   INFERENCE_ABORTED = 'INFERENCE_ABORTED',
+  INFERENCE_IMAGE_TOO_LARGE = 'INFERENCE_IMAGE_TOO_LARGE',
   INFERENCE_INPUT_INVALID = 'INFERENCE_INPUT_INVALID',
   INFERENCE_TIMEOUT = 'INFERENCE_TIMEOUT',
   MODEL_RATE_LIMIT_EXCEEDED = 'MODEL_RATE_LIMIT_EXCEEDED',
@@ -208,6 +209,22 @@ export class InferenceAbortedError extends ModelError {
       'Inference aborted by client',
       ModelErrorCode.INFERENCE_ABORTED,
       499,
+      metadata,
+    );
+  }
+}
+
+/**
+ * Error thrown when a provider rejects an image for exceeding its size limit
+ * (Anthropic/Bedrock cap a single image at 5 MB base64). Distinct from the
+ * generic InferenceFailedError so the UI can tell the user to shrink the image.
+ */
+export class InferenceImageTooLargeError extends ModelError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'Image exceeds the provider size limit',
+      ModelErrorCode.INFERENCE_IMAGE_TOO_LARGE,
+      400,
       metadata,
     );
   }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/stream-inference/stream-inference.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/stream-inference/stream-inference.use-case.ts
@@ -10,6 +10,7 @@ import { Model } from 'src/domain/models/domain/model.entity';
 import {
   InferenceAbortedError,
   InferenceFailedError,
+  InferenceImageTooLargeError,
 } from '../../models.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { extractUpstreamStatus } from '../../helpers/extract-upstream-status.helper';
@@ -50,6 +51,7 @@ export class StreamInferenceUseCase {
       return new InferenceAbortedError();
     }
     const status = extractUpstreamStatus(error);
+    const message = error instanceof Error ? error.message : String(error);
     this.logger.error('Provider stream inference failed', {
       model: input.model.name,
       provider: input.model.provider,
@@ -59,6 +61,12 @@ export class StreamInferenceUseCase {
       errorName: error instanceof Error ? error.name : 'Unknown',
       status,
     });
+    // Anthropic/Bedrock reject oversized images with "image exceeds N MB
+    // maximum" — surface a distinct code so the UI can tell the user to shrink
+    // it instead of showing a generic failure.
+    if (/image exceeds .* maximum/i.test(message)) {
+      return new InferenceImageTooLargeError({ status });
+    }
     return new InferenceFailedError('Provider inference failed', { status });
   }
 

--- a/ayunis-core-frontend/src/pages/chat/hooks/useRunErrorHandler.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/useRunErrorHandler.ts
@@ -12,6 +12,9 @@ export function useRunErrorHandler(_threadId: string) {
         case 'EXECUTION_ERROR':
           showError(t('chat.errorExecutionError'));
           break;
+        case 'INFERENCE_IMAGE_TOO_LARGE':
+          showError(t('chat.errorImageTooLarge'));
+          break;
         case 'RUN_NO_MODEL_FOUND':
           showError(t('chat.errorNoModelFound'));
           break;

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -15,6 +15,7 @@
     "unknownMessageType": "Unbekannter Nachrichtentyp",
     "upgradeToProError": "Sie müssen ein Abonnement haben, um diese Funktion zu verwenden.",
     "errorExecutionError": "Fehler beim Abruf der Antwort",
+    "errorImageTooLarge": "Das Bild ist zu groß für das gewählte Modell. Bitte verkleinern Sie es (z. B. Auflösung reduzieren) und versuchen Sie es erneut.",
     "errorUnexpected": "Ein unerwarteter Fehler ist aufgetreten",
     "errorNoModelFound": "Kein Modell gefunden",
     "errorMaxIterationsReached": "Maximale Anzahl an Iterationen erreicht",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -15,6 +15,7 @@
     "unknownMessageType": "Unknown message type",
     "upgradeToProError": "You need to upgrade to a paid plan to use this feature.",
     "errorExecutionError": "Error fetching response",
+    "errorImageTooLarge": "The image is too large for the selected model. Please reduce its size (e.g. lower the resolution) and try again.",
     "errorUnexpected": "An unexpected error occurred",
     "errorNoModelFound": "No model found",
     "errorMaxIterationsReached": "Maximal number of iterations reached",


### PR DESCRIPTION
> Stacked on #1081 (AYC-473 preservation fix). Review/merge that first.

## Problem

Uploading a larger photo (e.g. a phone photo of handwritten notes, 4–8 MB) and asking for a summary fails on Claude via **Bedrock** with a generic "Ein unerwarteter Fehler ist aufgetreten" — the user has no idea the image is the cause. On **Anthropic-direct** the same image works, which is why it looks intermittent.

## Root cause

Anthropic/Bedrock cap a single image at **5 MB base64** (`5242880` bytes). A 4.3 MB JPEG becomes ~5.79 MB base64 and is rejected with a 400:

```
400 messages.0.content.1.image.source.base64: image exceeds 5 MB maximum: 6074384 bytes > 5242880 bytes
```

The stream-inference error handler collapsed every provider error into the generic `INFERENCE_FAILED`, so the UI showed the catch-all "unexpected error". (Anthropic-direct's limit is on the raw bytes, 4.3 MB < 5 MB, so it slips through — hence the model-dependent behaviour.)

## Fix

- Add `InferenceImageTooLargeError` (code `INFERENCE_IMAGE_TOO_LARGE`). Detect the provider's `image exceeds N MB maximum` message in `StreamInferenceUseCase.handleInferenceError` and throw it instead of the generic failure. The `code` field is a plain string end-to-end, so no OpenAPI/client regen is needed.
- Map the code to an actionable message in the chat UI (`useRunErrorHandler`), de + en. The message deliberately does **not** quote a MB number — the 5 MB limit is on the base64 size, not the file size the user sees, so quoting it would mislead.

This is the "clear error" half of AYC-473; combined with #1081 the failed image + prompt are also preserved for retry.

## Verification (running slot, real Bedrock failure)

- Oversized image → SSE `code: INFERENCE_IMAGE_TOO_LARGE` (was `INFERENCE_FAILED`); a downscaled copy still streams a summary (control).
- UI shows the specific toast below, with the image thumbnail + prompt preserved (via #1081).
- `tsc` (backend + frontend), ESLint, prettier, complexity, file-size checks pass.

![image too large — clear error](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-473/docs/pr-media/ayc-473/imgtoolarge.png)

> Media hosted on the `pr-media/ayc-473` branch (not part of this PR's diff); safe to delete after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to stream error mapping and chat error toasts; no auth, data, or API contract changes beyond a new error code string.
> 
> **Overview**
> When Bedrock/Anthropic reject an oversized image, chat no longer shows a generic unexpected error.
> 
> **Backend:** Adds `INFERENCE_IMAGE_TOO_LARGE` and `InferenceImageTooLargeError`. `StreamInferenceUseCase.handleInferenceError` matches provider messages like `image exceeds … maximum` and returns this error instead of `INFERENCE_FAILED`.
> 
> **Frontend:** `useRunErrorHandler` handles `INFERENCE_IMAGE_TOO_LARGE` with new **en** and **de** copy that tells users to shrink the image (no fixed MB limit in the message).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 908e8f7ac8d67598ac01c3897d84e1785c8d0476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->