### PR TITLE
fix(chat): stop phantom image attachment on rich-text paste (AYC-453)

### DIFF
--- a/ayunis-core-frontend/src/widgets/chat-input/hooks/useImagePaste.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/hooks/useImagePaste.ts
@@ -24,6 +24,16 @@ export function useImagePaste({
         return;
       }
 
+      // Rich-text copies (Word/Excel/browsers/macOS) place a synthesized
+      // image/png snapshot on the clipboard alongside text/plain. That image
+      // is not an intentional attachment — only auto-attach clipboard images
+      // for image-only pastes, otherwise the text handler owns this paste.
+      // Mirror the textarea handler's `!pastedText` check (ChatInput.tsx) so an
+      // empty text/plain entry alongside an image still lets the image attach.
+      if (e.clipboardData.getData('text/plain')) {
+        return;
+      }
+
       const imageFiles: File[] = [];
       for (let i = 0; i < items.length; i++) {
         const item = items[i];


### PR DESCRIPTION
## AYC-453 — Unexpected error when pasting clipboard content

### Problem
Pasting content into the chat input silently added an unintended image/screenshot attachment. Sending then produced a brief "unexpected error" and the prompt was swallowed. Removing the image manually first avoided the error.

### Root cause
The chat input has two independent paste handlers:
- **Text** — React `onPaste` on the `<TextareaAutosize>` (inserts `text/plain`).
- **Images** — a native `paste` listener (`widgets/chat-input/hooks/useImagePaste.ts`).

`useImagePaste` treated **any** clipboard `image/*` item as an intentional attachment. But rich-text copies (Word/Excel/browsers/macOS) place a synthesized `image/png` snapshot on the clipboard **alongside** `text/plain`. So pasting text attached a phantom image, which the backend rejected on send → generic "unexpected error" toast.

### Fix
Only auto-attach clipboard images for **image-only** pastes. When `clipboardData.types` includes `text/plain`, bail out and let the text handler own the paste. Genuine image pastes (screenshots, copied image files — no `text/plain` present) still attach.

### Testing
- Lint + typecheck + pre-commit hooks pass.
- Manual: paste rich text → no phantom attachment, message sends without error; paste an image → still attaches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized paste-handling change in chat input with no auth or data-model impact.
> 
> **Overview**
> Fixes rich-text paste attaching an unintended screenshot alongside the pasted text, which could break send with a generic error.
> 
> **`useImagePaste`** now returns early when `clipboardData` includes **`text/plain`**, so only **image-only** pastes (no text) auto-attach files. That matches the textarea **`!pastedText`** guard in **`ChatInput.tsx`**: rich text goes to the text handler; real image pastes still attach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a775a037b2b16d3c62b94bb1000b98db345ff259. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->