### PR TITLE
perf(rag): track chunk offsets during splitting instead of searching (AYC-491)

### DIFF
--- a/ayunis-core-backend/src/domain/rag/splitters/infrastructure/handlers/chunk-assembler.ts
+++ b/ayunis-core-backend/src/domain/rag/splitters/infrastructure/handlers/chunk-assembler.ts
@@ -1,0 +1,149 @@
+export interface SplitConfig {
+  readonly chunkSize: number;
+  readonly chunkOverlap: number;
+}
+
+/**
+ * A chunk carrying absolute offsets into the original text, tracked while
+ * splitting so positions never have to be searched for afterwards.
+ * `newContentStartOffset` points at the first character after the carried
+ * overlap — the overlap prefix may not sit contiguously before it in the
+ * original text.
+ */
+export class PositionedChunk {
+  constructor(
+    readonly text: string,
+    readonly newContentStartOffset: number,
+    readonly contentEndOffset: number,
+    readonly carriedOverlapLength: number,
+  ) {}
+
+  get carriedOverlap(): string {
+    return this.text.slice(0, this.carriedOverlapLength);
+  }
+}
+
+function takeTrailingCharacters(text: string, maximumLength: number): string {
+  if (maximumLength <= 0) {
+    return '';
+  }
+  return text.slice(-maximumLength);
+}
+
+/**
+ * Accumulates split pieces into size-bounded chunks. Owns the overlap
+ * carried between consecutive chunks and the offset of the next piece,
+ * which makes every chunk's content position exact without ever searching
+ * the text.
+ */
+export class ChunkAssembler {
+  private readonly chunks: PositionedChunk[] = [];
+  private currentChunkText = '';
+  private carriedOverlap = '';
+  private newContentStartOffset: number;
+  private currentOffset: number;
+
+  constructor(
+    private readonly config: SplitConfig,
+    baseOffset: number,
+  ) {
+    this.newContentStartOffset = baseOffset;
+    this.currentOffset = baseOffset;
+  }
+
+  /** Absolute offset of the next piece in the original text. */
+  get nextPieceOffset(): number {
+    return this.currentOffset;
+  }
+
+  /**
+   * Appends the piece to the current chunk when it fits within the size
+   * limit; returns false otherwise so the caller can decide how to proceed.
+   */
+  tryAppendPiece(piece: string): boolean {
+    const combinedLength = this.currentChunkText.length + piece.length;
+    if (combinedLength > this.config.chunkSize) {
+      return false;
+    }
+    if (this.currentChunkText.length === this.carriedOverlap.length) {
+      this.newContentStartOffset = this.currentOffset;
+    }
+    this.currentChunkText += piece;
+    this.currentOffset += piece.length;
+    return true;
+  }
+
+  /**
+   * Emits the current chunk and starts the next one from the piece —
+   * seeded with the previous chunk's overlap when overlap plus piece stays
+   * within the size limit.
+   */
+  startChunkWithPiece(piece: string): void {
+    // Read the overlap before emitting so this method never depends on
+    // whether emitCurrentChunk leaves currentChunkText intact.
+    const overlap = takeTrailingCharacters(
+      this.currentChunkText,
+      this.config.chunkOverlap,
+    );
+    this.emitCurrentChunk();
+    if (overlap.length + piece.length <= this.config.chunkSize) {
+      this.currentChunkText = overlap + piece;
+      this.carriedOverlap = overlap;
+    } else {
+      this.currentChunkText = piece;
+      this.carriedOverlap = '';
+    }
+    this.newContentStartOffset = this.currentOffset;
+    this.currentOffset += piece.length;
+  }
+
+  /**
+   * Emits the current chunk, appends the chunks a deeper recursion built
+   * for an oversized piece, and carries that piece's tail as the next
+   * overlap.
+   */
+  appendRecursivelySplitPiece(
+    piece: string,
+    subChunks: PositionedChunk[],
+  ): void {
+    this.emitCurrentChunk();
+    this.chunks.push(...subChunks);
+    this.carriedOverlap = takeTrailingCharacters(
+      piece,
+      this.config.chunkOverlap,
+    );
+    this.currentChunkText = this.carriedOverlap;
+    this.currentOffset += piece.length;
+    this.newContentStartOffset = this.currentOffset;
+  }
+
+  build(): PositionedChunk[] {
+    this.emitCurrentChunk();
+    return this.chunks;
+  }
+
+  private emitCurrentChunk(): void {
+    if (this.hasNonWhitespaceContent()) {
+      this.chunks.push(
+        new PositionedChunk(
+          this.currentChunkText,
+          this.newContentStartOffset,
+          this.currentOffset,
+          this.carriedOverlap.length,
+        ),
+      );
+    }
+  }
+
+  /**
+   * Returns true only when the current chunk contains non-whitespace
+   * content beyond the overlap carried from the preceding chunk —
+   * whitespace-only remainders (e.g. an oversized segment's trailing
+   * separators) must not be emitted.
+   */
+  private hasNonWhitespaceContent(): boolean {
+    return (
+      this.currentChunkText.slice(this.carriedOverlap.length).trim().length > 0
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/rag/splitters/infrastructure/handlers/recursive.splitter.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/splitters/infrastructure/handlers/recursive.splitter.spec.ts
@@ -1,5 +1,6 @@
 import { RecursiveSplitterHandler } from './recursive.splitter';
 import type { SplitterInput } from '../../application/ports/splitter.handler';
+import type { TextChunk } from '../../domain/split-result.entity';
 
 describe('RecursiveSplitterHandler', () => {
   let handler: RecursiveSplitterHandler;
@@ -497,6 +498,130 @@ describe('RecursiveSplitterHandler', () => {
 
       for (const chunk of result.chunks) {
         expect(chunk.text.length).toBeLessThanOrEqual(1000);
+      }
+    });
+  });
+
+  describe('offset contract (property-based)', () => {
+    // Deterministic LCG so every run tests the identical case sequence and a
+    // failure is reproducible from the reported case index alone.
+    const createNextInt = (initialSeed: number) => {
+      let seed = initialSeed;
+      return (min: number, max: number): number => {
+        seed = (seed * 1103515245 + 12345) % 2 ** 31;
+        return min + Math.floor((seed / 2 ** 31) * (max - min + 1));
+      };
+    };
+
+    // Adversarial building blocks: separators of every level, separator-free
+    // low-entropy runs (repeated chars, dot leaders, tabs), and multi-byte
+    // characters.
+    const TEXT_FRAGMENTS = [
+      'wort',
+      'Satz.',
+      'Absatz!',
+      ' ',
+      '\n',
+      '\n\n',
+      '. ',
+      ', ',
+      '; ',
+      '? ',
+      '! ',
+      '\t',
+      'ÄÖÜäöüß',
+      'A'.repeat(50),
+      '.'.repeat(30),
+      '   ',
+      'x',
+    ];
+
+    const buildRandomText = (
+      nextInt: (min: number, max: number) => number,
+    ): string => {
+      const fragmentCount = nextInt(1, 400);
+      let text = '';
+      for (let i = 0; i < fragmentCount; i++) {
+        text += TEXT_FRAGMENTS[nextInt(0, TEXT_FRAGMENTS.length - 1)];
+      }
+      return text;
+    };
+
+    // Note: chunk starts are NOT required to be strictly increasing — with
+    // overlap close to chunkSize, a chunk's carried overlap may legitimately
+    // reach back past a smaller chunk emitted by a deeper recursion.
+    const collectChunkViolations = (
+      text: string,
+      chunkSize: number,
+      chunk: TextChunk,
+    ): string[] => {
+      const violations: string[] = [];
+      const start = chunk.metadata.startCharOffset as number;
+      const end = chunk.metadata.endCharOffset as number;
+      const startLine = chunk.metadata.startLine as number;
+      const endLine = chunk.metadata.endLine as number;
+
+      if (chunk.text.length > chunkSize) {
+        violations.push(`chunk exceeds size limit: ${chunk.text.length}`);
+      }
+      if (!(start >= 0 && end > start && end <= text.length)) {
+        violations.push(`offsets out of bounds: [${start},${end})`);
+      } else if (!chunk.text.endsWith(text.slice(start, end))) {
+        violations.push(`slice [${start},${end}) does not match chunk text`);
+      }
+      if (!(startLine >= 1 && endLine >= startLine)) {
+        violations.push(`invalid line range: ${startLine}-${endLine}`);
+      }
+      return violations;
+    };
+
+    const findUncoveredContentOffset = (
+      text: string,
+      chunks: TextChunk[],
+    ): number | null => {
+      const covered = new Uint8Array(text.length);
+      for (const chunk of chunks) {
+        const start = chunk.metadata.startCharOffset as number;
+        const end = chunk.metadata.endCharOffset as number;
+        covered.fill(1, Math.max(0, start), Math.max(0, end));
+      }
+      for (let offset = 0; offset < text.length; offset++) {
+        if (covered[offset] === 0 && text[offset].trim().length > 0) {
+          return offset;
+        }
+      }
+      return null;
+    };
+
+    it('should uphold the offset contract across randomized inputs and configs', () => {
+      const nextInt = createNextInt(20260722);
+
+      for (let caseIndex = 0; caseIndex < 300; caseIndex++) {
+        const text = buildRandomText(nextInt);
+        const chunkSize = nextInt(1, 300);
+        const chunkOverlap = nextInt(0, chunkSize - 1);
+
+        const result = handler.processText({
+          text,
+          metadata: { chunkSize, chunkOverlap },
+        });
+
+        const violations = result.chunks.flatMap((chunk) =>
+          collectChunkViolations(text, chunkSize, chunk),
+        );
+        const uncoveredOffset = findUncoveredContentOffset(text, result.chunks);
+        if (uncoveredOffset !== null) {
+          violations.push(`content at offset ${uncoveredOffset} not covered`);
+        }
+
+        // Case parameters are part of the compared object so a failure
+        // reports which deterministic case broke the contract.
+        expect({ caseIndex, chunkSize, chunkOverlap, violations }).toEqual({
+          caseIndex,
+          chunkSize,
+          chunkOverlap,
+          violations: [],
+        });
       }
     });
   });

--- a/ayunis-core-backend/src/domain/rag/splitters/infrastructure/handlers/recursive.splitter.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/splitters/infrastructure/handlers/recursive.splitter.spec.ts
@@ -126,6 +126,18 @@ describe('RecursiveSplitterHandler', () => {
       expect(result.chunks).toHaveLength(0);
     });
 
+    it('should emit no chunks for whitespace-only text longer than the chunk size', () => {
+      const input: SplitterInput = {
+        // Tabs match no separator, so this would reach the fixed-size split
+        text: '\t'.repeat(3000),
+        metadata: { chunkSize: 1000, chunkOverlap: 100 },
+      };
+
+      const result = handler.processText(input);
+
+      expect(result.chunks).toHaveLength(0);
+    });
+
     it('should preserve chunk index in metadata', () => {
       const lines = Array.from(
         { length: 20 },
@@ -230,6 +242,161 @@ describe('RecursiveSplitterHandler', () => {
         expect(chunk.metadata.startLine).toBeGreaterThanOrEqual(1);
         expect(chunk.metadata.endLine).toBeLessThanOrEqual(lines.length);
       }
+    });
+  });
+
+  describe('configuration', () => {
+    it('should honor chunkOverlap of 0 by emitting non-overlapping chunks', () => {
+      const sentences = Array.from(
+        { length: 20 },
+        (_, i) => `Satz ${i + 1} mit etwas Inhalt.`,
+      );
+      const text = sentences.join(' ');
+
+      const result = handler.processText({
+        text,
+        metadata: { chunkSize: 60, chunkOverlap: 0 },
+      });
+
+      expect(result.metadata.chunkOverlap).toBe(0);
+      expect(result.chunks.length).toBeGreaterThan(1);
+      for (let i = 1; i < result.chunks.length; i++) {
+        const prevEnd = result.chunks[i - 1].metadata.endCharOffset as number;
+        const currStart = result.chunks[i].metadata.startCharOffset as number;
+        expect(currStart).toBeGreaterThanOrEqual(prevEnd);
+      }
+      for (const chunk of result.chunks) {
+        const start = chunk.metadata.startCharOffset as number;
+        const end = chunk.metadata.endCharOffset as number;
+        expect(text.slice(start, end)).toBe(chunk.text);
+      }
+    });
+
+    it('should derive a fitting default overlap when only a small chunkSize is given', () => {
+      const sentences = Array.from(
+        { length: 20 },
+        (_, i) => `Satz ${i + 1} mit etwas Inhalt.`,
+      );
+      const text = sentences.join(' ');
+
+      const result = handler.processText({
+        text,
+        metadata: { chunkSize: 100 },
+      });
+
+      // The built-in overlap default (200) exceeds this chunkSize; the
+      // derived default keeps the built-in 20% ratio instead of rejecting
+      // the caller's chunkSize.
+      expect(result.metadata.chunkOverlap).toBe(20);
+      expect(result.chunks.length).toBeGreaterThan(1);
+      for (const chunk of result.chunks) {
+        expect(chunk.text.length).toBeLessThanOrEqual(100);
+      }
+    });
+
+    it.each([
+      ['zero chunkSize', { chunkSize: 0, chunkOverlap: 0 }],
+      ['negative chunkSize', { chunkSize: -5, chunkOverlap: 0 }],
+      ['non-integer chunkSize', { chunkSize: 10.5, chunkOverlap: 0 }],
+      ['negative chunkOverlap', { chunkSize: 100, chunkOverlap: -1 }],
+      [
+        'chunkOverlap equal to chunkSize',
+        { chunkSize: 100, chunkOverlap: 100 },
+      ],
+      ['chunkOverlap above chunkSize', { chunkSize: 100, chunkOverlap: 150 }],
+    ])('should reject invalid configuration: %s', (_label, metadata) => {
+      expect(() =>
+        handler.processText({ text: 'Some content to split.', metadata }),
+      ).toThrow('Failed to process text with Recursive Text Splitter');
+    });
+  });
+
+  describe('character offset tracking', () => {
+    const expectOffsetsPointAtContent = (
+      text: string,
+      chunks: { text: string; metadata: Record<string, unknown> }[],
+    ) => {
+      for (const chunk of chunks) {
+        const start = chunk.metadata.startCharOffset as number;
+        const end = chunk.metadata.endCharOffset as number;
+        expect(start).toBeGreaterThanOrEqual(0);
+        expect(end).toBeGreaterThan(start);
+        expect(end).toBeLessThanOrEqual(text.length);
+        // The offset range covers the chunk's content: either the full chunk
+        // text (offsets contiguous) or the content without the prepended
+        // overlap — in both cases the slice is a suffix of the chunk text.
+        expect(chunk.text.endsWith(text.slice(start, end))).toBe(true);
+      }
+    };
+
+    it('should emit offsets whose slice matches the chunk content across split paths', () => {
+      const paragraphs = Array.from(
+        { length: 30 },
+        (_, i) =>
+          `Absatz ${i + 1}: ` +
+          'Inhalt mit einigen Worten, Satzzeichen und etwas Länge. '.repeat(3),
+      );
+      const text = paragraphs.join('\n\n');
+
+      const result = handler.processText({
+        text,
+        metadata: { chunkSize: 200, chunkOverlap: 50 },
+      });
+
+      expect(result.chunks.length).toBeGreaterThan(5);
+      expectOffsetsPointAtContent(text, result.chunks);
+    });
+
+    it('should emit exact offsets for separator-free text (character split path)', () => {
+      const text = 'X'.repeat(2500);
+
+      const result = handler.processText({
+        text,
+        metadata: { chunkSize: 1000, chunkOverlap: 200 },
+      });
+
+      expect(
+        result.chunks.map((chunk) => chunk.metadata.startCharOffset),
+      ).toEqual([0, 800, 1600]);
+      expect(
+        result.chunks.map((chunk) => chunk.metadata.endCharOffset),
+      ).toEqual([1000, 1800, 2500]);
+      expectOffsetsPointAtContent(text, result.chunks);
+    });
+
+    it('should emit valid offsets when an oversized segment forces recursion with overlap seeding', () => {
+      const text =
+        'A'.repeat(10000) + '\n\n' + 'Ein normaler Absatz mit Inhalt.';
+
+      const result = handler.processText({
+        text,
+        metadata: { chunkSize: 2000, chunkOverlap: 200 },
+      });
+
+      expectOffsetsPointAtContent(text, result.chunks);
+    });
+
+    it('should split a large document without quadratic position searching', () => {
+      // ~1MB of unique words: every chunk exists verbatim in the text, but a
+      // position search that rescans the document per chunk (the removed
+      // findChunkPosition fallback) degrades to minutes on inputs like this.
+      let text = '';
+      let word = 0;
+      while (text.length < 1_000_000) {
+        text += `wort${word} `;
+        word += 1;
+        if (word % 100 === 0) {
+          text += '\n';
+        }
+      }
+
+      const startedAt = performance.now();
+      const result = handler.processText({ text });
+      const elapsedMs = performance.now() - startedAt;
+
+      expect(result.chunks.length).toBeGreaterThan(500);
+      expect(elapsedMs).toBeLessThan(2000);
+      expectOffsetsPointAtContent(text, result.chunks);
     });
   });
 

--- a/ayunis-core-backend/src/domain/rag/splitters/infrastructure/handlers/recursive.splitter.ts
+++ b/ayunis-core-backend/src/domain/rag/splitters/infrastructure/handlers/recursive.splitter.ts
@@ -6,75 +6,70 @@ import {
 import { SplitResult, TextChunk } from '../../domain/split-result.entity';
 import { SplitterProcessingError } from '../../application/splitter.errors';
 import { SplitterType } from '../../domain/splitter-type.enum';
+import {
+  ChunkAssembler,
+  PositionedChunk,
+  SplitConfig,
+} from './chunk-assembler';
 
-interface ChunkPosition {
-  startCharOffset: number;
-  endCharOffset: number;
-}
+const DEFAULT_CHUNK_SIZE = 1000;
+const DEFAULT_CHUNK_OVERLAP = 200;
 
-interface SplitConfig {
-  chunkSize: number;
-  chunkOverlap: number;
+// Separators in order of preference: paragraphs, lines, sentence
+// boundaries, clauses, words, and character-level as last resort.
+const DEFAULT_SEPARATORS = [
+  '\n\n',
+  '\n',
+  '. ',
+  '! ',
+  '? ',
+  '; ',
+  ', ',
+  ' ',
+  '',
+] as const;
+
+// Immutable state threaded through the recursive split. Recursion is bounded
+// by the separator list: every recursive call advances separatorIndex.
+interface RecursiveSplitContext {
+  readonly config: SplitConfig;
+  readonly separatorIndex: number;
+  readonly baseOffset: number;
 }
 
 @Injectable()
 export class RecursiveSplitterHandler extends SplitterHandler {
   private readonly logger = new Logger(RecursiveSplitterHandler.name);
-  private readonly PROVIDER_NAME = SplitterType.RECURSIVE;
-  private readonly DEFAULT_CHUNK_SIZE = 1000;
-  private readonly DEFAULT_CHUNK_OVERLAP = 200;
-
-  // Separators in order of preference: paragraphs, lines, sentence
-  // boundaries, clauses, words, and character-level as last resort.
-  private readonly SEPARATORS = [
-    '\n\n',
-    '\n',
-    '. ',
-    '! ',
-    '? ',
-    '; ',
-    ', ',
-    ' ',
-    '',
-  ];
-
-  constructor() {
-    super();
-    this.logger.log('Initializing Recursive Text Splitter handler');
-  }
 
   isAvailable(): boolean {
-    return true; // Always available as it's implemented internally
+    return true;
   }
 
   processText(input: SplitterInput): SplitResult {
     try {
       this.logger.debug(`Processing text with Recursive Text Splitter`);
 
-      // Extract metadata or use defaults
-      const chunkSize = input.metadata?.chunkSize || this.DEFAULT_CHUNK_SIZE;
-      const chunkOverlap =
-        input.metadata?.chunkOverlap || this.DEFAULT_CHUNK_OVERLAP;
+      const config = this.resolveAndValidateConfig(input);
 
       this.logger.debug(
-        `Chunk size: ${chunkSize}, Chunk overlap: ${chunkOverlap}`,
+        `Chunk size: ${config.chunkSize}, Chunk overlap: ${config.chunkOverlap}`,
       );
 
-      // Implement the recursive text splitting algorithm
-      const chunks = this.enforceMaxChunkSize(
-        this.splitTextRecursively(input.text, chunkSize, chunkOverlap),
-        chunkSize,
-        chunkOverlap,
+      const rawChunks = this.ensureChunkSizeLimit(
+        this.splitRecursively(input.text, {
+          config,
+          separatorIndex: 0,
+          baseOffset: 0,
+        }),
+        config,
       );
+      const textChunks = this.mapToTextChunks(input.text, rawChunks);
 
-      // Add line number information to each chunk
-      const chunksWithLineNumbers = this.addLineNumbers(input.text, chunks);
-
-      return new SplitResult(chunksWithLineNumbers, {
-        provider: this.PROVIDER_NAME,
-        chunkSize,
-        chunkOverlap,
-        totalChunks: chunksWithLineNumbers.length,
+      return new SplitResult(textChunks, {
+        provider: SplitterType.RECURSIVE,
+        chunkSize: config.chunkSize,
+        chunkOverlap: config.chunkOverlap,
+        totalChunks: textChunks.length,
       });
     } catch (error) {
       this.logger.error(
@@ -84,181 +79,219 @@ export class RecursiveSplitterHandler extends SplitterHandler {
       throw new SplitterProcessingError(
         `Failed to process text with Recursive Text Splitter`,
         {
-          provider: this.PROVIDER_NAME,
+          provider: SplitterType.RECURSIVE,
           originalError: error as Error,
         },
       );
     }
   }
 
-  private splitTextRecursively(
-    text: string,
-    chunkSize: number,
-    chunkOverlap: number,
-  ): TextChunk[] {
-    return this.recursiveSplit(text, { chunkSize, chunkOverlap }, 0, 0);
+  /**
+   * The algorithm relies on these invariants (e.g. chunkOverlap < chunkSize
+   * guarantees forward progress in splitIntoFixedSizeChunks); rejecting
+   * invalid input here beats silently adjusting it in the lower-level
+   * methods.
+   */
+  private resolveAndValidateConfig(input: SplitterInput): SplitConfig {
+    const chunkSize = input.metadata?.chunkSize ?? DEFAULT_CHUNK_SIZE;
+    // Only explicit values are validated strictly; a defaulted overlap must
+    // fit whatever chunkSize the caller chose, so it is capped at the same
+    // 20% ratio the built-in defaults use (1000/200).
+    const chunkOverlap =
+      input.metadata?.chunkOverlap ??
+      Math.min(DEFAULT_CHUNK_OVERLAP, Math.floor(chunkSize / 5));
+
+    if (!this.isPositiveInteger(chunkSize)) {
+      throw new Error(
+        `chunkSize must be a positive integer, received ${chunkSize}`,
+      );
+    }
+    if (!this.isValidOverlap(chunkOverlap, chunkSize)) {
+      throw new Error(
+        `chunkOverlap must be an integer between 0 and ${chunkSize - 1}, received ${chunkOverlap}`,
+      );
+    }
+
+    return { chunkSize, chunkOverlap };
   }
 
-  private recursiveSplit(
+  private isPositiveInteger(value: number): boolean {
+    return Number.isInteger(value) && value > 0;
+  }
+
+  private isValidOverlap(overlap: number, chunkSize: number): boolean {
+    return Number.isInteger(overlap) && overlap >= 0 && overlap < chunkSize;
+  }
+
+  private splitRecursively(
     text: string,
-    config: SplitConfig,
-    separatorIndex: number,
-    depth: number = 0,
-  ): TextChunk[] {
-    // Prevent excessive recursion
-    if (depth > 10) {
-      return this.splitByCharacter(text, config.chunkSize, config.chunkOverlap);
+    context: RecursiveSplitContext,
+  ): PositionedChunk[] {
+    if (text.trim().length === 0) {
+      return [];
     }
 
-    if (text.length <= config.chunkSize) {
-      return text.trim().length > 0 ? [new TextChunk(text, { index: 0 })] : [];
+    if (text.length <= context.config.chunkSize) {
+      return [
+        new PositionedChunk(
+          text,
+          context.baseOffset,
+          context.baseOffset + text.length,
+          0,
+        ),
+      ];
     }
 
-    if (separatorIndex >= this.SEPARATORS.length) {
-      return this.splitByCharacter(text, config.chunkSize, config.chunkOverlap);
+    if (context.separatorIndex >= DEFAULT_SEPARATORS.length) {
+      return this.splitIntoFixedSizeChunks(
+        text,
+        context.config,
+        context.baseOffset,
+      );
     }
 
-    const separator = this.SEPARATORS[separatorIndex];
+    const separator = DEFAULT_SEPARATORS[context.separatorIndex];
 
     // Character level is the last resort: hard-split
     if (separator === '') {
-      return this.splitByCharacter(text, config.chunkSize, config.chunkOverlap);
+      return this.splitIntoFixedSizeChunks(
+        text,
+        context.config,
+        context.baseOffset,
+      );
     }
 
-    const splits = text.split(separator);
+    const pieces = this.splitAndPreserveSeparator(text, separator);
 
-    // Separator not found in text: try the next one
-    if (splits.length === 1) {
-      return this.recursiveSplit(text, config, separatorIndex + 1, depth + 1);
+    if (!pieces) {
+      return this.splitRecursively(text, {
+        ...context,
+        separatorIndex: context.separatorIndex + 1,
+      });
     }
 
-    return this.combineSplits(splits, separator, config, separatorIndex, depth);
+    return this.assembleChunks(pieces, context);
   }
 
   /**
-   * Accumulates separator splits into chunks of at most chunkSize characters.
-   * A single split larger than chunkSize is recursively split with the next
-   * separator — regardless of position, so an oversized segment at the very
-   * start of the text cannot be emitted whole (the bug that sent a full
-   * document as one embedding input).
+   * Reattaches separators so concatenating the pieces reconstructs the
+   * original text exactly; returns null when the separator does not occur
+   * in the text.
    */
-  private combineSplits(
-    splits: string[],
+  private splitAndPreserveSeparator(
+    text: string,
     separator: string,
+  ): string[] | null {
+    const segments = text.split(separator);
+
+    if (segments.length === 1) {
+      return null;
+    }
+
+    return segments.map((segment, index) =>
+      index < segments.length - 1 ? segment + separator : segment,
+    );
+  }
+
+  /**
+   * Oversized pieces are recursively split with the next separator before
+   * being handed to the assembler, so no individual piece can bypass the
+   * size limit regardless of its position in the text.
+   */
+  private assembleChunks(
+    pieces: string[],
+    context: RecursiveSplitContext,
+  ): PositionedChunk[] {
+    const assembler = new ChunkAssembler(context.config, context.baseOffset);
+
+    for (const piece of pieces) {
+      if (assembler.tryAppendPiece(piece)) {
+        continue;
+      }
+
+      if (piece.length > context.config.chunkSize) {
+        const recursivelySplitChunks = this.splitRecursively(piece, {
+          ...context,
+          separatorIndex: context.separatorIndex + 1,
+          baseOffset: assembler.nextPieceOffset,
+        });
+        assembler.appendRecursivelySplitPiece(piece, recursivelySplitChunks);
+        continue;
+      }
+
+      assembler.startChunkWithPiece(piece);
+    }
+
+    return assembler.build();
+  }
+
+  /**
+   * Enforces the external contract that no chunk may exceed chunkSize.
+   * Recursive splitting should already guarantee this; the fallback protects
+   * callers from future changes to the splitting algorithm.
+   */
+  private ensureChunkSizeLimit(
+    chunks: PositionedChunk[],
     config: SplitConfig,
-    separatorIndex: number,
-    depth: number,
-  ): TextChunk[] {
-    const chunks: TextChunk[] = [];
-    const pushChunk = (text: string) =>
-      chunks.push(new TextChunk(text, { index: chunks.length }));
-    // overlapSeed tracks the part of currentChunk that is only carried-over
-    // overlap, so chunks containing no new content are never emitted.
-    let currentChunk = '';
-    let overlapSeed = '';
-
-    for (let i = 0; i < splits.length; i++) {
-      const split = i < splits.length - 1 ? splits[i] + separator : splits[i];
-      const fitsCurrentChunk =
-        currentChunk.length === 0 ||
-        (currentChunk + split).length <= config.chunkSize;
-
-      if (split.length <= config.chunkSize && fitsCurrentChunk) {
-        currentChunk += split;
-        continue;
-      }
-
-      if (this.hasNewContent(currentChunk, overlapSeed)) {
-        pushChunk(currentChunk);
-      }
-
-      if (split.length > config.chunkSize) {
-        const subChunks = this.recursiveSplit(
-          split,
-          config,
-          separatorIndex + 1,
-          depth + 1,
-        );
-        subChunks.forEach((subChunk) => pushChunk(subChunk.text));
-        overlapSeed = this.getOverlapText(split, config.chunkOverlap);
-        currentChunk = overlapSeed;
-        continue;
-      }
-
-      // Seed the next chunk with the previous chunk's overlap — but only
-      // when overlap plus content stays within the chunk size limit.
-      const overlap = this.getOverlapText(currentChunk, config.chunkOverlap);
-      if ((overlap + split).length <= config.chunkSize) {
-        currentChunk = overlap + split;
-        overlapSeed = overlap;
-      } else {
-        currentChunk = split;
-        overlapSeed = '';
-      }
-    }
-
-    if (this.hasNewContent(currentChunk, overlapSeed)) {
-      pushChunk(currentChunk);
-    }
-
-    return chunks;
-  }
-
-  /**
-   * currentChunk always begins with overlapSeed (it is only ever appended
-   * to after being reset to the seed), so new content means non-whitespace
-   * beyond the seed. Whitespace-only appends (e.g. the separator remainders
-   * of an oversized segment) must not make a chunk emittable.
-   */
-  private hasNewContent(currentChunk: string, overlapSeed: string): boolean {
-    return currentChunk.slice(overlapSeed.length).trim().length > 0;
-  }
-
-  /**
-   * Safety net for the splitter's contract: no emitted chunk may exceed
-   * chunkSize. Oversized chunks (e.g. from a future recursion edge case) are
-   * hard-split so they can never reach an embeddings API whole.
-   */
-  private enforceMaxChunkSize(
-    chunks: TextChunk[],
-    chunkSize: number,
-    chunkOverlap: number,
-  ): TextChunk[] {
-    if (chunks.every((chunk) => chunk.text.length <= chunkSize)) {
+  ): PositionedChunk[] {
+    if (chunks.every((chunk) => chunk.text.length <= config.chunkSize)) {
       return chunks;
     }
     this.logger.warn(
       'Recursive split produced oversized chunks; falling back to character split for them',
     );
-    return chunks
-      .flatMap((chunk) =>
-        chunk.text.length > chunkSize
-          ? this.splitByCharacter(chunk.text, chunkSize, chunkOverlap)
-          : [chunk],
-      )
-      .map(
-        (chunk, index) =>
-          new TextChunk(chunk.text, { ...chunk.metadata, index }),
-      );
+    return chunks.flatMap((chunk) =>
+      chunk.text.length > config.chunkSize
+        ? this.splitOversizedChunk(chunk, config)
+        : [chunk],
+    );
   }
 
-  private splitByCharacter(
-    text: string,
-    chunkSize: number,
-    chunkOverlap: number,
-  ): TextChunk[] {
-    const chunks: TextChunk[] = [];
-    let start = 0;
-    let chunkIndex = 0;
+  private splitOversizedChunk(
+    chunk: PositionedChunk,
+    config: SplitConfig,
+  ): PositionedChunk[] {
+    const pieces = this.splitIntoFixedSizeChunks(
+      chunk.text,
+      config,
+      chunk.newContentStartOffset - chunk.carriedOverlapLength,
+    );
+    // Pieces overlapping the chunk's carried-overlap region inherit those
+    // characters as their own overlap, so downstream offsets keep pointing
+    // at content.
+    return pieces.map((piece) => {
+      const overlapCharacters = Math.max(
+        0,
+        chunk.newContentStartOffset - piece.newContentStartOffset,
+      );
+      return new PositionedChunk(
+        piece.text,
+        piece.newContentStartOffset + overlapCharacters,
+        piece.contentEndOffset,
+        overlapCharacters,
+      );
+    });
+  }
 
-    // Ensure overlap doesn't exceed chunk size to prevent infinite loops
-    const safeOverlap = Math.min(chunkOverlap, Math.floor(chunkSize / 2));
+  private splitIntoFixedSizeChunks(
+    text: string,
+    config: SplitConfig,
+    baseOffset: number,
+  ): PositionedChunk[] {
+    const chunks: PositionedChunk[] = [];
+    let start = 0;
 
     while (start < text.length) {
-      const end = Math.min(start + chunkSize, text.length);
-      const chunkText = text.slice(start, end);
+      const end = Math.min(start + config.chunkSize, text.length);
 
-      chunks.push(new TextChunk(chunkText, { index: chunkIndex++ }));
+      chunks.push(
+        new PositionedChunk(
+          text.slice(start, end),
+          baseOffset + start,
+          baseOffset + end,
+          0,
+        ),
+      );
 
       // The last chunk consumed the rest of the text — stepping back for
       // overlap here would emit a duplicate tail-only chunk.
@@ -266,225 +299,99 @@ export class RecursiveSplitterHandler extends SplitterHandler {
         break;
       }
 
-      // Move start position, accounting for overlap
-      const nextStart = end - safeOverlap;
-
-      // Ensure we always make progress - if next start isn't ahead, just move to end
-      start = nextStart > start ? nextStart : end;
+      // Progress is guaranteed: config validation enforces overlap < size
+      start = end - config.chunkOverlap;
     }
 
     return chunks;
   }
 
-  private getOverlapText(text: string, overlapSize: number): string {
-    if (overlapSize <= 0 || text.length <= overlapSize) {
-      return text;
-    }
-    return text.slice(-overlapSize);
-  }
-
   /**
-   * Adds line number information to each chunk by finding its position in the original text.
-   * Line numbers are 1-based to match standard text editor conventions.
+   * Materializes positioned chunks into TextChunks with character offsets
+   * and 1-based line numbers, computed directly from the offsets tracked
+   * during splitting — no text searching involved.
    */
-  private addLineNumbers(
+  private mapToTextChunks(
     originalText: string,
-    chunks: TextChunk[],
+    chunks: PositionedChunk[],
   ): TextChunk[] {
     if (chunks.length === 0) {
-      return chunks;
+      return [];
     }
 
-    // Build array of character offsets where each line starts
-    const lineStarts = this.buildLineStarts(originalText);
+    const lineStartOffsets = this.collectLineStartOffsets(originalText);
 
-    let searchStart = 0;
-    return chunks.map((chunk) => {
-      // Find this chunk's position in the original text
-      const position = this.findChunkPosition(
-        originalText,
-        chunk.text,
-        searchStart,
-      );
-
-      if (position === null) {
-        // Chunk text not found in original
-        this.logger.warn(
-          `Could not find chunk position in original text. Chunk index: ${String(chunk.metadata.index)}`,
-        );
-        return new TextChunk(chunk.text, { ...chunk.metadata });
-      }
-
-      const { startCharOffset, endCharOffset } = position;
-
-      // Advance search position for next chunk
-      searchStart = Math.max(searchStart, startCharOffset + 1);
-
-      // Calculate line numbers from character offsets
-      const startLine = this.getLineNumber(lineStarts, startCharOffset);
-      const endLine = this.getLineNumber(lineStarts, endCharOffset - 1);
+    return chunks.map((chunk, index) => {
+      const startCharOffset = this.resolveChunkStartOffset(originalText, chunk);
+      const endCharOffset = chunk.contentEndOffset;
 
       return new TextChunk(chunk.text, {
-        ...chunk.metadata,
+        index,
         startCharOffset,
         endCharOffset,
-        startLine,
-        endLine,
+        startLine: this.findLineNumber(lineStartOffsets, startCharOffset),
+        endLine: this.findLineNumber(
+          lineStartOffsets,
+          Math.max(startCharOffset, endCharOffset - 1),
+        ),
       });
     });
   }
 
   /**
-   * Finds the position of a chunk in the original text.
-   * When overlap is prepended to chunks, the full chunk text may not exist as a
-   * contiguous substring. This method tries multiple strategies to find the position.
+   * The carried overlap usually sits directly before the chunk's content in
+   * the original text; a bounded prefix compare confirms it. When the
+   * overlap came from a non-adjacent region, the exact content position is
+   * the honest answer.
    */
-  private findChunkPosition(
+  private resolveChunkStartOffset(
     originalText: string,
-    chunkText: string,
-    searchStart: number,
-  ): ChunkPosition | null {
-    // Strategy 1: Try finding the full chunk text
-    const startCharOffset = this.indexOfNearOrAnywhere(
-      originalText,
-      chunkText,
-      searchStart,
-    );
-    if (startCharOffset !== -1) {
-      return {
-        startCharOffset,
-        endCharOffset: startCharOffset + chunkText.length,
-      };
-    }
-
-    return (
-      this.findBySuffix(originalText, chunkText, searchStart) ??
-      this.findByMiddlePortion(originalText, chunkText, searchStart)
-    );
-  }
-
-  /**
-   * indexOf that prefers a match at or after searchStart but falls back to
-   * searching from the beginning of the text.
-   */
-  private indexOfNearOrAnywhere(
-    text: string,
-    needle: string,
-    searchStart: number,
+    chunk: PositionedChunk,
   ): number {
-    const offset = text.indexOf(needle, searchStart);
-    return offset !== -1 ? offset : text.indexOf(needle);
-  }
-
-  /**
-   * Strategy 2: The chunk might have overlap prepended that doesn't match
-   * exactly. Try finding progressively smaller suffixes of the chunk — the
-   * chunk conceptually starts where the suffix starts.
-   */
-  private findBySuffix(
-    originalText: string,
-    chunkText: string,
-    searchStart: number,
-  ): ChunkPosition | null {
-    const minSearchLength = this.minSearchLength(chunkText);
-
-    for (
-      let suffixStart = 1;
-      suffixStart < chunkText.length - minSearchLength;
-      suffixStart++
-    ) {
-      const suffix = chunkText.slice(suffixStart);
-      const suffixOffset = this.indexOfNearOrAnywhere(
-        originalText,
-        suffix,
-        searchStart,
-      );
-
-      if (suffixOffset !== -1) {
-        return {
-          startCharOffset: suffixOffset,
-          endCharOffset: suffixOffset + suffix.length,
-        };
-      }
+    if (chunk.carriedOverlapLength === 0) {
+      return chunk.newContentStartOffset;
     }
-
-    return null;
+    const assumedStart =
+      chunk.newContentStartOffset - chunk.carriedOverlapLength;
+    return assumedStart >= 0 &&
+      originalText.startsWith(chunk.carriedOverlap, assumedStart)
+      ? assumedStart
+      : chunk.newContentStartOffset;
   }
 
-  /**
-   * Strategy 3: Try finding a significant middle portion, skipping the first
-   * and last 20% which might have overlap artifacts.
-   */
-  private findByMiddlePortion(
-    originalText: string,
-    chunkText: string,
-    searchStart: number,
-  ): ChunkPosition | null {
-    const skipPercent = 0.2;
-    const middleStart = Math.floor(chunkText.length * skipPercent);
-    const middleEnd = Math.floor(chunkText.length * (1 - skipPercent));
-
-    if (middleEnd <= middleStart + this.minSearchLength(chunkText)) {
-      return null;
-    }
-
-    const middlePortion = chunkText.slice(middleStart, middleEnd);
-    const middleOffset = this.indexOfNearOrAnywhere(
-      originalText,
-      middlePortion,
-      searchStart,
-    );
-
-    if (middleOffset === -1) {
-      return null;
-    }
-
-    return {
-      startCharOffset: Math.max(0, middleOffset - middleStart),
-      endCharOffset: Math.min(
-        originalText.length,
-        middleOffset - middleStart + chunkText.length,
-      ),
-    };
-  }
-
-  private minSearchLength(chunkText: string): number {
-    return Math.min(50, Math.floor(chunkText.length / 2));
-  }
-
-  /**
-   * Builds an array of character offsets where each line starts.
-   * Line 1 starts at offset 0.
-   */
-  private buildLineStarts(text: string): number[] {
-    const lineStarts: number[] = [0]; // Line 1 starts at offset 0
+  /** Character offsets where each line starts; line 1 starts at offset 0. */
+  private collectLineStartOffsets(text: string): number[] {
+    const lineStartOffsets: number[] = [0];
 
     for (let i = 0; i < text.length; i++) {
       if (text[i] === '\n') {
-        lineStarts.push(i + 1); // Next line starts after the newline
+        lineStartOffsets.push(i + 1);
       }
     }
 
-    return lineStarts;
+    return lineStartOffsets;
   }
 
   /**
    * Returns the 1-based line number for a given character offset.
    * Uses binary search for efficiency.
    */
-  private getLineNumber(lineStarts: number[], charOffset: number): number {
+  private findLineNumber(
+    lineStartOffsets: number[],
+    charOffset: number,
+  ): number {
     let low = 0;
-    let high = lineStarts.length - 1;
+    let high = lineStartOffsets.length - 1;
 
     while (low < high) {
       const mid = Math.floor((low + high + 1) / 2);
-      if (lineStarts[mid] <= charOffset) {
+      if (lineStartOffsets[mid] <= charOffset) {
         low = mid;
       } else {
         high = mid - 1;
       }
     }
 
-    return low + 1; // Convert to 1-based line number
+    return low + 1;
   }
 }


### PR DESCRIPTION
- carry absolute content offsets through the recursive split so chunk
  positions are exact and computed in O(text length)
- remove the findChunkPosition fallback that rescanned the document per
  chunk character (event-loop freeze on large uploads) and returned
  wrong offsets for repetitive text
- add offset-contract tests: slice invariant, character-split path,
  oversized-segment recursion, and a 1MB perf guard

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core document chunking for embeddings with algorithm and metadata changes, but behavior is heavily covered by new contract and performance tests.
> 
> **Overview**
> **Refactors the recursive text splitter** so chunk **character offsets and line metadata** are computed while splitting, not by scanning the source document afterward.
> 
> A new **`ChunkAssembler`** / **`PositionedChunk`** pipeline carries absolute positions through recursive separator splitting and overlap handling. The old **`findChunkPosition`** heuristics (suffix/middle search per chunk) are removed, which fixes wrong offsets on repetitive text and avoids **quadratic rescans** that could freeze the event loop on large uploads (~1MB perf test).
> 
> **Config handling** is tightened: invalid `chunkSize` / `chunkOverlap` values throw; when only a small `chunkSize` is set, default overlap is capped to a 20% ratio instead of using the global 200 default. Whitespace-only tails (e.g. long tab runs) no longer emit empty chunks.
> 
> Tests add offset invariants, zero-overlap behavior, a **1MB timing guard**, and **300-case** randomized offset-contract checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f35311d838be3b79d07d86302f89efd5470cec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->