### PR TITLE
fix(app): bound db pool and statement time (AYC-491)

### DIFF
--- a/ayunis-core-backend/.env.example
+++ b/ayunis-core-backend/.env.example
@@ -118,6 +118,12 @@ POSTGRES_PORT=
 POSTGRES_USER=
 POSTGRES_PASSWORD=
 POSTGRES_DB=
+# Optional, connection pool size (default 20)
+POSTGRES_POOL_SIZE=
+# Optional, per-statement timeout in ms (default 60000); 0 disables it
+POSTGRES_STATEMENT_TIMEOUT_MS=
+# Optional, idle-in-transaction timeout in ms (default 60000); 0 disables it
+POSTGRES_IDLE_TX_TIMEOUT_MS=
 
 # Subscriptions
 # Not relevant for self hosters

--- a/ayunis-core-backend/src/config/typeorm.config.ts
+++ b/ayunis-core-backend/src/config/typeorm.config.ts
@@ -1,5 +1,9 @@
 import { registerAs } from '@nestjs/config';
 import type { DataSourceOptions } from 'typeorm';
+import {
+  parseNonNegativeIntWithDefault,
+  parsePositiveIntWithDefault,
+} from 'src/common/util/number.util';
 
 // Base configuration for TypeORM
 const baseConfig: DataSourceOptions = {
@@ -10,6 +14,17 @@ const baseConfig: DataSourceOptions = {
   password: process.env.POSTGRES_PASSWORD,
   database: process.env.POSTGRES_DB,
   synchronize: false,
+  poolSize: parsePositiveIntWithDefault(process.env.POSTGRES_POOL_SIZE, 20),
+  extra: {
+    statement_timeout: parseNonNegativeIntWithDefault(
+      process.env.POSTGRES_STATEMENT_TIMEOUT_MS,
+      60_000,
+    ),
+    idle_in_transaction_session_timeout: parseNonNegativeIntWithDefault(
+      process.env.POSTGRES_IDLE_TX_TIMEOUT_MS,
+      60_000,
+    ),
+  },
 };
 
 // Development-specific configuration
@@ -45,11 +60,16 @@ const testConfig: DataSourceOptions = {
 };
 
 // Determine which configuration to use based on NODE_ENV
-export const typeormConfigRaw: DataSourceOptions =
-  process.env.NODE_ENV === 'production'
-    ? productionConfig
-    : process.env.NODE_ENV === 'test'
-      ? testConfig
-      : developmentConfig;
+function resolveConfig(): DataSourceOptions {
+  if (process.env.NODE_ENV === 'production') {
+    return productionConfig;
+  }
+  if (process.env.NODE_ENV === 'test') {
+    return testConfig;
+  }
+  return developmentConfig;
+}
+
+export const typeormConfigRaw: DataSourceOptions = resolveConfig();
 
 export const typeormConfig = registerAs('typeorm', () => typeormConfigRaw);

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/parent-child-index.repository.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/parent-child-index.repository.ts
@@ -36,7 +36,9 @@ export class ParentChildIndexerRepository extends ParentChildIndexerRepositoryPo
     const records = parentChunks.map((chunk) =>
       this.parentChildIndexerMapper.toParentChunkRecord(chunk),
     );
-    await this.parentChunkRepository.save(records);
+    // Chunked insert: a large document's chunks in one statement can exceed
+    // Postgres's 65535-parameter limit.
+    await this.parentChunkRepository.save(records, { chunk: 500 });
   }
 
   async delete(relatedDocumentId: UUID) {


### PR DESCRIPTION
- typeorm: explicit pool size (default 20) plus statement_timeout and
  idle_in_transaction_session_timeout (default 60s, env-overridable) —
  a few stuck queries no longer hold the pool and hang every request
  while /health stays green
- parent-child indexer: chunk bulk insert (500 records) to stay under
  Postgres's 65535-parameter limit on huge documents

> The 25MB storage upload cap originally in this PR was dropped during restack: main removed the generic storage upload endpoint entirely (#1090).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global DB pool and session timeouts (can cancel long legitimate queries) and changes bulk indexing behavior for large documents; defaults are conservative but misconfigured env values could affect production stability.
> 
> **Overview**
> Adds **configurable Postgres connection limits** so a few long-running or stuck queries are less likely to exhaust the pool and stall the API while health checks still pass.
> 
> TypeORM now sets an explicit **`poolSize`** (default **20**, overridable via `POSTGRES_POOL_SIZE`) and passes **`statement_timeout`** and **`idle_in_transaction_session_timeout`** through driver `extra` (default **60s** each, env-overridable; **0** disables). `.env.example` documents the new variables. Config selection is refactored into a small **`resolveConfig()`** helper without changing dev/prod/test behavior.
> 
> The parent-child RAG indexer **`saveMany`** bulk insert is **chunked at 500 records** per statement to stay under Postgres’s **65535-parameter** limit on very large documents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ff4a6f6206d7a21ce68b616a5ce0db24a19ae09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

