### PR TITLE
chore(agents): symlink claude setup for codex compatibility (AYC-000)

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,7 @@ node_modules
 # Auto-generated type-checking tsconfig files (tool-generated with hash names)
 tsconfig.?????????*.json
 .pi
-.agents/
 .pi/
-AGENTS.md
 .agentfiles
 .agentfiles.lock
 .claude/worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.claude/CLAUDE.md


### PR DESCRIPTION
- add root AGENTS.md symlink to .claude/CLAUDE.md (Codex reads
  project instructions from AGENTS.md at the repo root)
- add .agents/skills symlink to .claude/skills (Codex scans
  .agents/skills for repo-level skills and follows symlinks)
- unignore AGENTS.md and .agents/ so the symlinks are tracked

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and symlink wiring only; no runtime, auth, or application logic changes.
> 
> **Overview**
> Adds **Codex-compatible entry points** at the repo root without duplicating agent content: root `AGENTS.md` points at `.claude/CLAUDE.md`, and `.agents/skills` points at `.claude/skills`.
> 
> Updates **`.gitignore`** so those paths are no longer ignored (while still ignoring `.pi/` and related agent lock/worktree noise), so the symlinks can be committed and shared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e008eff9fef8953b0812872f3185d85aa1347580. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->