### PR TITLE
fix(marketplace): remove terms-of-use confirmation for first-party skills (AYC-465)

### DIFF
--- a/ayunis-core-frontend/src/pages/install/ui/InstallSkillCard.tsx
+++ b/ayunis-core-frontend/src/pages/install/ui/InstallSkillCard.tsx
@@ -1,4 +1,3 @@
-import { useForm } from 'react-hook-form';
 import { Button } from '@/shared/ui/shadcn/button';
 import {
   Card,
@@ -8,13 +7,10 @@ import {
   CardHeader,
   CardTitle,
 } from '@/shared/ui/shadcn/card';
-import { Form } from '@/shared/ui/shadcn/form';
 import { Bot } from 'lucide-react';
-import { useTranslation, Trans } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { Link } from '@tanstack/react-router';
-import { useMarketplaceConfig } from '@/features/marketplace';
 import type { MarketplaceSkillResponseDto } from '../api/useFetchMarketplaceSkill';
-import { AcceptanceCheckboxField } from './AcceptanceCheckboxField';
 
 interface InstallSkillCardProps {
   skill: MarketplaceSkillResponseDto;
@@ -28,81 +24,46 @@ export function InstallSkillCard({
   isInstalling,
 }: Readonly<InstallSkillCardProps>) {
   const { t } = useTranslation('install');
-  const marketplace = useMarketplaceConfig();
-  const form = useForm<{ termsAccepted: boolean }>({
-    defaultValues: { termsAccepted: false },
-  });
-
-  const termsOfServiceUrl = marketplace.url
-    ? `${marketplace.url.replace(/\/$/, '')}/nutzungsbedingungen`
-    : null;
 
   return (
-    <Form {...form}>
-      <form
-        onSubmit={(e) => {
-          void form.handleSubmit(() => onInstall())(e);
-        }}
-      >
-        <Card className="w-full max-w-lg">
-          <CardHeader className="text-center">
-            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
-              {skill.iconUrl ? (
-                <img
-                  src={skill.iconUrl}
-                  alt={skill.name}
-                  className="h-10 w-10 rounded-full object-cover"
-                />
-              ) : (
-                <Bot className="h-8 w-8 text-primary" />
-              )}
-            </div>
-            <CardTitle className="text-xl">{skill.name}</CardTitle>
-            <CardDescription>{skill.shortDescription}</CardDescription>
-          </CardHeader>
+    <Card className="w-full max-w-lg">
+      <CardHeader className="text-center">
+        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
+          {skill.iconUrl ? (
+            <img
+              src={skill.iconUrl}
+              alt={skill.name}
+              className="h-10 w-10 rounded-full object-cover"
+            />
+          ) : (
+            <Bot className="h-8 w-8 text-primary" />
+          )}
+        </div>
+        <CardTitle className="text-xl">{skill.name}</CardTitle>
+        <CardDescription>{skill.shortDescription}</CardDescription>
+      </CardHeader>
 
-          <CardContent className="space-y-4">
-            <div className="rounded-md bg-muted/50 p-4">
-              <p className="text-sm text-muted-foreground">
-                {t('detail.installNote')}
-              </p>
-            </div>
+      <CardContent className="space-y-4">
+        <div className="rounded-md bg-muted/50 p-4">
+          <p className="text-sm text-muted-foreground">
+            {t('detail.installNote')}
+          </p>
+        </div>
+      </CardContent>
 
-            <AcceptanceCheckboxField
-              form={form}
-              name="termsAccepted"
-              id="terms-accept"
-              disabled={isInstalling}
-            >
-              <Trans
-                ns="install"
-                i18nKey="detail.termsOfServiceText"
-                components={{
-                  termsLink: (
-                    <a
-                      href={termsOfServiceUrl ?? '#'}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="underline text-primary hover:text-primary/80"
-                    >
-                      placeholder
-                    </a>
-                  ),
-                }}
-              />
-            </AcceptanceCheckboxField>
-          </CardContent>
-
-          <CardFooter className="flex gap-3">
-            <Button variant="outline" className="flex-1" asChild>
-              <Link to="/skills">{t('action.cancel')}</Link>
-            </Button>
-            <Button type="submit" className="flex-1" disabled={isInstalling}>
-              {isInstalling ? t('action.installing') : t('action.install')}
-            </Button>
-          </CardFooter>
-        </Card>
-      </form>
-    </Form>
+      <CardFooter className="flex gap-3">
+        <Button variant="outline" className="flex-1" asChild>
+          <Link to="/skills">{t('action.cancel')}</Link>
+        </Button>
+        <Button
+          type="button"
+          className="flex-1"
+          disabled={isInstalling}
+          onClick={onInstall}
+        >
+          {isInstalling ? t('action.installing') : t('action.install')}
+        </Button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/ayunis-core-frontend/src/shared/locales/de/install.json
+++ b/ayunis-core-frontend/src/shared/locales/de/install.json
@@ -1,7 +1,6 @@
 {
   "detail": {
-    "installNote": "Diese Fähigkeit wird Ihrem Konto hinzugefügt. Sie können die Einstellungen der Fähigkeit nach der Installation anpassen.",
-    "termsOfServiceText": "Ich habe die <termsLink>Nutzungsbedingungen</termsLink> gelesen und akzeptiere diese."
+    "installNote": "Diese Fähigkeit wird Ihrem Konto hinzugefügt. Sie können die Einstellungen der Fähigkeit nach der Installation anpassen."
   },
   "action": {
     "install": "Fähigkeit installieren",

--- a/ayunis-core-frontend/src/shared/locales/en/install.json
+++ b/ayunis-core-frontend/src/shared/locales/en/install.json
@@ -1,7 +1,6 @@
 {
   "detail": {
-    "installNote": "This skill will be added to your account. You can customize the skill's settings after installation.",
-    "termsOfServiceText": "I have read and accept the <termsLink>terms of service</termsLink>."
+    "installNote": "This skill will be added to your account. You can customize the skill's settings after installation."
   },
   "action": {
     "install": "Install Skill",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Installing a skill from the Marketplace currently requires confirming terms of use, even though **all marketplace skills are first-party Ayunis-owned and free**. This created confusion and friction (especially for public-sector customers), because the dialog implied legal obligations or hidden costs. Per the Linear discussion, terms of use should only be shown for **third-party marketplace integrations** — not for skills or our own marketplace integrations.

Resolves **AYC-465**.

## Changes

- Remove the terms-of-service acceptance checkbox from `InstallSkillCard`. The install button now triggers installation directly (no `react-hook-form` / terms gating).
- Remove the now-unused `detail.termsOfServiceText` locale key from the skill `install` namespace (en + de).
- Terms-of-use confirmation for **third-party integrations** is untouched — `InstallIntegrationPage` still shows the checkbox and keeps its own `install-integration.termsOfServiceText` key.

## Testing

- `pnpm run build` — succeeds
- `pnpm run lint` — 0 errors (only pre-existing warnings in unrelated files)
- Pre-commit hooks (prettier, eslint, typecheck, dependency/duplication/file-size checks) all pass

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-465](https://linear.app/ayunis/issue/AYC-465/remove-terms-of-use-confirmation-for-first-party-skills-in-the)

<div><a href="https://cursor.com/agents/bc-1430b9f2-19a3-4e4c-af93-88c8b925ed8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1430b9f2-19a3-4e4c-af93-88c8b925ed8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

