### PR TITLE
wip(runs): anonymize runtime user input and PII tool output (AYC-148)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/backend-tool.adapter.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/backend-tool.adapter.spec.ts
@@ -1,9 +1,11 @@
-import { RunContext, type ToolExecutionContext } from '@ayunis/agent-runtime';
+import { RunContext } from '@ayunis/agent-runtime';
+import type { ToolExecutionContext } from '@ayunis/agent-runtime';
 import type { UUID } from 'crypto';
 import type { Tool as BackendTool } from 'src/domain/tools/domain/tool.entity';
 import type { ExecuteToolUseCase } from 'src/domain/tools/application/use-cases/execute-tool/execute-tool.use-case';
 import type { CheckToolCapabilitiesUseCase } from 'src/domain/tools/application/use-cases/check-tool-capabilities/check-tool-capabilities.use-case';
 import { ToolExecutionFailedError } from 'src/domain/tools/application/tools.errors';
+import type { AnonymizeTextForThreadUseCase } from 'src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case';
 import { BackendToolAdapter } from './backend-tool.adapter';
 
 const orgId = '323e4567-e89b-12d3-a456-426614174000' as UUID;
@@ -27,14 +29,17 @@ function toolCtx(): ToolExecutionContext {
 describe('BackendToolAdapter', () => {
   let execute: jest.Mock;
   let checkExecute: jest.Mock;
+  let anonymize: jest.Mock;
   let adapter: BackendToolAdapter;
 
   beforeEach(() => {
     execute = jest.fn();
     checkExecute = jest.fn();
+    anonymize = jest.fn();
     adapter = new BackendToolAdapter(
       { execute } as unknown as ExecuteToolUseCase,
       { execute: checkExecute } as unknown as CheckToolCapabilitiesUseCase,
+      { execute: anonymize } as unknown as AnonymizeTextForThreadUseCase,
     );
   });
 
@@ -101,6 +106,60 @@ describe('BackendToolAdapter', () => {
     expect(result).toEqual({
       result: expect.stringMatching(/too long to display/i),
       isError: false,
+    });
+  });
+
+  it('redacts PII tool output and emits masks in anonymous mode', async () => {
+    checkExecute.mockReturnValue({ isDisplayable: false, isExecutable: true });
+    execute.mockResolvedValue('call Jane at 555-1234');
+    anonymize.mockResolvedValue({
+      anonymizedText: 'call {{pii:PERSON_1}} at {{pii:PHONE_1}}',
+      masks: [{ token: '{{pii:PERSON_1}}' }],
+    });
+    const piiTool = {
+      name: 'lookup',
+      description: 'lookup',
+      parameters: { type: 'object' },
+      returnsPii: true,
+    } as unknown as BackendTool;
+    const emit = jest.fn();
+    const ctx = {
+      context: RunContext.create({ orgId, threadId, isAnonymous: true }),
+      toolCallId: 'c1',
+      emit,
+    } as unknown as ToolExecutionContext;
+
+    const [tool] = adapter.toRuntimeTools([piiTool]);
+    const result = await tool.execute!({}, ctx);
+
+    expect(result).toEqual({
+      result: 'call {{pii:PERSON_1}} at {{pii:PHONE_1}}',
+      isError: false,
+    });
+    expect(anonymize).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'thread_pii_masks' }),
+    );
+  });
+
+  it('stops the runtime when PII tool output cannot be anonymized', async () => {
+    checkExecute.mockReturnValue({ isDisplayable: false, isExecutable: true });
+    execute.mockResolvedValue('call Jane at 555-1234');
+    anonymize.mockRejectedValue(new Error('anonymizer unavailable'));
+    const piiTool = {
+      ...fakeTool('lookup'),
+      returnsPii: true,
+    } as unknown as BackendTool;
+    const ctx = {
+      context: RunContext.create({ orgId, threadId, isAnonymous: true }),
+      toolCallId: 'c1',
+      emit: jest.fn(),
+    } as unknown as ToolExecutionContext;
+
+    const [tool] = adapter.toRuntimeTools([piiTool]);
+
+    await expect(tool.execute!({}, ctx)).rejects.toMatchObject({
+      code: 'ANONYMIZATION_UNAVAILABLE',
     });
   });
 

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/backend-tool.adapter.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/backend-tool.adapter.ts
@@ -4,6 +4,7 @@ import type {
   ToolExecutionContext as RuntimeToolContext,
   ToolExecutionResult as RuntimeToolResult,
 } from '@ayunis/agent-runtime';
+import { AgentRuntimeError } from '@ayunis/agent-runtime';
 import { Injectable } from '@nestjs/common';
 import type { UUID } from 'crypto';
 import { Tool as BackendTool } from 'src/domain/tools/domain/tool.entity';
@@ -15,6 +16,9 @@ import {
 } from 'src/domain/tools/application/use-cases/check-tool-capabilities/check-tool-capabilities.use-case';
 import { CheckToolCapabilitiesQuery } from 'src/domain/tools/application/use-cases/check-tool-capabilities/check-tool-capabilities.query';
 import { ToolExecutionFailedError } from 'src/domain/tools/application/tools.errors';
+import { AnonymizeTextForThreadUseCase } from 'src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case';
+import { AnonymizeTextForThreadCommand } from 'src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.command';
+import { THREAD_PII_MASKS_EVENT } from './masks-event';
 
 const MAX_TOOL_RESULT_LENGTH = 20000;
 const DISPLAY_ACK = 'Tool has been displayed successfully';
@@ -35,13 +39,15 @@ interface ToolExecutionOutcome {
  *   surfaces the call — the client renders it and continues with a tool-result
  *   input (handled by the orchestrator).
  *
- * PII redaction of tool output is applied by the anonymization hook, not here.
+ * In anonymous threads, PII-returning tool output is redacted at production and
+ * the mask dictionary streamed via the run's `emit`, matching the legacy loop.
  */
 @Injectable()
 export class BackendToolAdapter {
   constructor(
     private readonly executeToolUseCase: ExecuteToolUseCase,
     private readonly checkToolCapabilitiesUseCase: CheckToolCapabilitiesUseCase,
+    private readonly anonymizeTextForThreadUseCase: AnonymizeTextForThreadUseCase,
   ) {}
 
   toRuntimeTools(tools: BackendTool[]): RuntimeTool[] {
@@ -78,15 +84,42 @@ export class BackendToolAdapter {
       isAnonymous: ctx.context.get<boolean>('isAnonymous') ?? false,
     };
     const outcome = await this.runTool(tool, input, context);
-    const result =
+    let result =
       outcome.result.length > MAX_TOOL_RESULT_LENGTH
         ? truncate(outcome.result)
         : outcome.result;
+    if (context.isAnonymous && tool.returnsPii) {
+      result = await this.redact(result, context, ctx);
+    }
     return {
       result:
         capabilities.isDisplayable && outcome.succeeded ? DISPLAY_ACK : result,
       isError: !outcome.succeeded,
     };
+  }
+
+  private async redact(
+    result: string,
+    context: { orgId: UUID; threadId: UUID },
+    ctx: RuntimeToolContext,
+  ): Promise<string> {
+    const anonymized = await this.anonymizeTextForThreadUseCase
+      .execute(
+        new AnonymizeTextForThreadCommand(
+          result,
+          context.orgId,
+          context.threadId,
+        ),
+      )
+      .catch((error: unknown) => {
+        throw new AgentRuntimeError(
+          'ANONYMIZATION_UNAVAILABLE',
+          'Anonymization is currently unavailable',
+          { cause: error },
+        );
+      });
+    ctx.emit({ name: THREAD_PII_MASKS_EVENT, data: anonymized.masks });
+    return anonymized.anonymizedText;
   }
 
   private async runTool(

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/run-event-stream.adapter.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/run-event-stream.adapter.spec.ts
@@ -9,6 +9,7 @@ import {
   type RunStreamItem,
 } from '../../domain/run-pii-masks-update.entity';
 import {
+  RunAnonymizationUnavailableError,
   RunExecutionFailedError,
   RunMaxIterationsReachedError,
 } from '../runs.errors';
@@ -290,5 +291,20 @@ describe('adaptRunEventsToStream', () => {
         ]),
       ),
     ).rejects.toBeInstanceOf(RunExecutionFailedError);
+  });
+
+  it('maps anonymization failures to the privacy-safe run error', async () => {
+    await expect(
+      collect(
+        eventsFrom([
+          {
+            type: 'error',
+            code: 'ANONYMIZATION_UNAVAILABLE',
+            message: 'Anonymization is unavailable',
+          },
+          { type: 'run_end', status: 'error', usage: {} },
+        ]),
+      ),
+    ).rejects.toBeInstanceOf(RunAnonymizationUnavailableError);
   });
 });

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/run-event-stream.adapter.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/run-event-stream.adapter.ts
@@ -12,6 +12,7 @@ import {
   type RunStreamItem,
 } from '../../domain/run-pii-masks-update.entity';
 import {
+  RunAnonymizationUnavailableError,
   RunExecutionFailedError,
   RunMaxIterationsReachedError,
 } from '../runs.errors';
@@ -223,6 +224,9 @@ function mapRunError(
     return new RunMaxIterationsReachedError(
       typeof max === 'number' ? max : DEFAULT_MAX_ITERATIONS,
     );
+  }
+  if (event.code === 'ANONYMIZATION_UNAVAILABLE') {
+    return new RunAnonymizationUnavailableError();
   }
   return new RunExecutionFailedError(event.message);
 }

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.spec.ts
@@ -13,6 +13,7 @@ import { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-
 import { ToolResultMessage } from 'src/domain/messages/domain/messages/tool-result-message.entity';
 import type { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
 import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
+import { ToolResultMessageContent } from 'src/domain/messages/domain/message-contents/tool-result.message-content.entity';
 import type { Tool as BackendTool } from 'src/domain/tools/domain/tool.entity';
 import { McpIntegrationTool } from 'src/domain/tools/domain/tools/mcp-integration-tool.entity';
 import { McpTool } from 'src/domain/mcp/domain/mcp-tool.entity';
@@ -23,6 +24,7 @@ import type { CreateUserMessageUseCase } from 'src/domain/messages/application/u
 import type { MapMessagesToInferenceUseCase } from 'src/domain/models/application/use-cases/map-messages-to-inference/map-messages-to-inference.use-case';
 import type { ResolveModelProviderUseCase } from 'src/domain/models/application/use-cases/resolve-model-provider/resolve-model-provider.use-case';
 import type { CreateToolResultMessageUseCase } from 'src/domain/messages/application/use-cases/create-tool-result-message/create-tool-result-message.use-case';
+import type { AnonymizeTextForThreadUseCase } from 'src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case';
 import type { InferenceUsageGuard } from '../../services/inference-usage-guard.service';
 import type { ToolAssemblyService } from '../../services/tool-assembly.service';
 import type { MessageCleanupService } from '../../services/message-cleanup.service';
@@ -33,7 +35,10 @@ import { UsageHookFactory } from '../../agent-runtime/hooks/usage-hook.factory';
 import { ToolUsageHookFactory } from '../../agent-runtime/hooks/tool-usage-hook.factory';
 import { ToolUsedEvent } from '../../events/tool-used.event';
 import { RunMaxIterationsReachedError } from '../../runs.errors';
-import type { RunStreamItem } from '../../../domain/run-pii-masks-update.entity';
+import {
+  RunPiiMasksUpdate,
+  type RunStreamItem,
+} from '../../../domain/run-pii-masks-update.entity';
 import {
   RunUserInput,
   RunToolResultInput,
@@ -55,6 +60,7 @@ interface Harness {
   createToolResult: jest.Mock;
   createSeedToolResult: jest.Mock;
   emitAsync: jest.Mock;
+  anonymize: jest.Mock;
 }
 
 interface HarnessOptions {
@@ -114,6 +120,13 @@ function buildHarness(overrides: HarnessOptions = {}): Harness {
   const backendToolAdapter = {
     toRuntimeTools: jest.fn().mockReturnValue(overrides.runtimeTools ?? []),
   } as unknown as BackendToolAdapter;
+  const anonymize = jest.fn().mockResolvedValue({
+    anonymizedText: 'Hi {{pii:PERSON_1}}',
+    masks: [{ token: '{{pii:PERSON_1}}' }],
+  });
+  const anonymizeTextForThreadUseCase = {
+    execute: anonymize,
+  } as unknown as AnonymizeTextForThreadUseCase;
   const createToolResult = jest.fn().mockImplementation((command) =>
     Promise.resolve(
       new ToolResultMessage({
@@ -188,6 +201,7 @@ function buildHarness(overrides: HarnessOptions = {}): Harness {
     inferenceUsageGuard,
     toolAssemblyService,
     backendToolAdapter,
+    anonymizeTextForThreadUseCase,
     createUserMessageUseCase,
     createToolResultMessageUseCase,
     addMessageToThreadUseCase,
@@ -210,6 +224,7 @@ function buildHarness(overrides: HarnessOptions = {}): Harness {
     createToolResult: flushToolResult,
     createSeedToolResult: createToolResult,
     emitAsync,
+    anonymize,
   };
 }
 
@@ -588,11 +603,61 @@ describe('ExecuteRunViaRuntimeUseCase', () => {
     );
   });
 
-  it('rejects anonymous threads (not yet supported on the runtime path)', async () => {
-    const { useCase } = buildHarness({ anonymous: true });
-    await expect(useCase.execute(userCommand())).rejects.toThrow(
-      /does not yet support anonymous/i,
+  it('anonymizes a display result and uses the pending tool name before persistence', async () => {
+    const lastMessage = {
+      content: [
+        new ToolUseMessageContent('chart-1', 'bar_chart', { title: 'Budget' }),
+      ],
+    } as unknown as Message;
+    const collectToolResults = jest.fn(
+      ({ input }: { input: RunToolResultInput }) => ({
+        contents: [
+          new ToolResultMessageContent(
+            input.toolId,
+            input.toolName,
+            input.result,
+          ),
+        ],
+        piiMasks: null,
+      }),
     );
+    const { useCase, createSeedToolResult } = buildHarness({
+      anonymous: true,
+      lastMessage,
+      toolResultCollector: { collectToolResults } as never,
+    });
+    const command = new ExecuteRunCommand({
+      threadId,
+      input: new RunToolResultInput(
+        'chart-1',
+        'forged_tool_name',
+        'Chart for Jane Doe',
+      ),
+    });
+
+    const items = await drain(await useCase.execute(command));
+
+    expect(collectToolResults.mock.calls[0][0].input).toMatchObject({
+      toolId: 'chart-1',
+      toolName: 'bar_chart',
+      result: 'Hi {{pii:PERSON_1}}',
+    });
+    expect(createSeedToolResult.mock.calls[0][0].content[0]).toMatchObject({
+      toolName: 'bar_chart',
+      result: 'Hi {{pii:PERSON_1}}',
+    });
+    expect(items[0]).toBeInstanceOf(RunPiiMasksUpdate);
+  });
+
+  it('anonymizes the user message and streams the mask dictionary first', async () => {
+    const { useCase, anonymize } = buildHarness({ anonymous: true });
+
+    const items = await drain(await useCase.execute(userCommand()));
+
+    expect(anonymize).toHaveBeenCalledTimes(1);
+    // masks are streamed before the (redacted) user message
+    expect(items[0]).toBeInstanceOf(RunPiiMasksUpdate);
+    expect(items[1]).toMatchObject({ id: 'user-msg' });
   });
 
   it('rejects skill activation (not yet supported on the runtime path)', async () => {

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.ts
@@ -14,8 +14,12 @@ import { ContextService } from 'src/common/context/services/context.service';
 import type { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import type { Thread } from 'src/domain/threads/domain/thread.entity';
 import type { Message } from 'src/domain/messages/domain/message.entity';
+import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
 import type { Tool as BackendTool } from 'src/domain/tools/domain/tool.entity';
 import { ToolType } from 'src/domain/tools/domain/value-objects/tool-type.enum';
+import { AnonymizeTextForThreadUseCase } from 'src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case';
+import { AnonymizeTextForThreadCommand } from 'src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.command';
+import type { ThreadPiiMask } from 'src/domain/thread-pii-masks/domain/thread-pii-mask.entity';
 import { FindThreadUseCase } from 'src/domain/threads/application/use-cases/find-thread/find-thread.use-case';
 import { FindThreadQuery } from 'src/domain/threads/application/use-cases/find-thread/find-thread.query';
 import { AddMessageToThreadUseCase } from 'src/domain/threads/application/use-cases/add-message-to-thread/add-message-to-thread.use-case';
@@ -33,8 +37,12 @@ import {
   RunToolResultInput,
 } from '../../../domain/run-input.entity';
 import type { RunInput } from '../../../domain/run-input.entity';
-import type { RunStreamItem } from '../../../domain/run-pii-masks-update.entity';
 import {
+  RunPiiMasksUpdate,
+  type RunStreamItem,
+} from '../../../domain/run-pii-masks-update.entity';
+import {
+  RunAnonymizationUnavailableError,
   RunExecutionFailedError,
   RunInvalidInputError,
   RunMaxIterationsReachedError,
@@ -71,12 +79,22 @@ interface PreparedRuntimeRun extends PreparedRuntimeTools {
   instructions: string;
 }
 
+interface SeededInput {
+  message: Message;
+  masks: ThreadPiiMask[] | null;
+}
+
+interface PreparedToolResultInput {
+  input: RunToolResultInput;
+  masks: ThreadPiiMask[] | null;
+}
+
 /**
  * Runs a thread through the extracted `@ayunis/agent-runtime` loop instead of
  * the legacy in-module loop. Gated behind the `agentRuntimeEnabled` toggle in
- * `ExecuteRunUseCase`. Covers plain chat and tool loops (executable, hybrid and
- * display-only tools); anonymization and skill activation are added in later
- * slices, so those paths fail fast rather than silently degrading.
+ * `ExecuteRunUseCase`. Covers plain chat, tool loops (executable, hybrid and
+ * display-only tools) and anonymized threads (user input + PII tool output).
+ * Skill activation is a later slice, so that path fails fast.
  */
 @Injectable()
 export class ExecuteRunViaRuntimeUseCase {
@@ -88,6 +106,7 @@ export class ExecuteRunViaRuntimeUseCase {
     private readonly inferenceUsageGuard: InferenceUsageGuard,
     private readonly toolAssemblyService: ToolAssemblyService,
     private readonly backendToolAdapter: BackendToolAdapter,
+    private readonly anonymizeTextForThreadUseCase: AnonymizeTextForThreadUseCase,
     private readonly createUserMessageUseCase: CreateUserMessageUseCase,
     private readonly createToolResultMessageUseCase: CreateToolResultMessageUseCase,
     private readonly addMessageToThreadUseCase: AddMessageToThreadUseCase,
@@ -107,7 +126,7 @@ export class ExecuteRunViaRuntimeUseCase {
   ): Promise<AsyncGenerator<RunStreamItem, void, void>> {
     this.logger.log('executeRunViaRuntime', { threadId: command.threadId });
     const prepared = await this.prepareRun(command);
-    this.requireSupported(command.input, prepared);
+    this.requireSupported(command.input);
     return this.streamRun(prepared, command.input);
   }
 
@@ -170,15 +189,7 @@ export class ExecuteRunViaRuntimeUseCase {
   }
 
   /** Fails fast on inputs this slice does not yet route through the runtime. */
-  private requireSupported(
-    input: RunInput,
-    prepared: PreparedRuntimeRun,
-  ): void {
-    if (prepared.isAnonymous) {
-      throw new RunInvalidInputError(
-        'The agent runtime path does not yet support anonymous threads',
-      );
-    }
+  private requireSupported(input: RunInput): void {
     if (input instanceof RunUserInput && input.skillId) {
       throw new RunInvalidInputError(
         'The agent runtime path does not yet support skill activation',
@@ -192,8 +203,12 @@ export class ExecuteRunViaRuntimeUseCase {
   ): AsyncGenerator<RunStreamItem, void, void> {
     let cleanupRequired = true;
     try {
-      const seedMessage = await this.seedInput(prepared, input);
-      yield seedMessage;
+      const seeded = await this.seedInput(prepared, input);
+      // Masks first, so the client can resolve {{pii:…}} tokens in the message.
+      if (seeded.masks) {
+        yield new RunPiiMasksUpdate(seeded.masks);
+      }
+      yield seeded.message;
       yield* adaptRunEventsToStream(
         await this.startRun(prepared),
         prepared.thread.id,
@@ -222,7 +237,7 @@ export class ExecuteRunViaRuntimeUseCase {
   private async seedInput(
     prepared: PreparedRuntimeRun,
     input: RunInput,
-  ): Promise<Message> {
+  ): Promise<SeededInput> {
     if (input instanceof RunUserInput) {
       return this.persistUserMessage(prepared, input);
     }
@@ -277,7 +292,7 @@ export class ExecuteRunViaRuntimeUseCase {
   private async persistUserMessage(
     prepared: PreparedRuntimeRun,
     input: RunUserInput,
-  ): Promise<Message> {
+  ): Promise<SeededInput> {
     const hasText = !!input.text && input.text.trim().length > 0;
     const hasImages = input.pendingImages.length > 0;
     if (!hasText && !hasImages) {
@@ -290,17 +305,44 @@ export class ExecuteRunViaRuntimeUseCase {
         'The selected model does not support image inputs',
       );
     }
+    let text = input.text;
+    let masks: ThreadPiiMask[] | null = null;
+    if (hasText && prepared.isAnonymous) {
+      const anonymized = await this.anonymizeUserText(prepared, input.text);
+      text = anonymized.anonymizedText;
+      masks = anonymized.masks;
+    }
     const message = await this.createUserMessageUseCase.execute(
       new CreateUserMessageCommand(
         prepared.thread.id,
-        input.text,
+        text,
         input.pendingImages,
       ),
     );
     this.addMessageToThreadUseCase.execute(
       new AddMessageCommand(prepared.thread, message),
     );
-    return message;
+    return { message, masks };
+  }
+
+  private async anonymizeUserText(
+    prepared: PreparedRuntimeRun,
+    text: string,
+  ): Promise<{ anonymizedText: string; masks: ThreadPiiMask[] }> {
+    try {
+      const result = await this.anonymizeTextForThreadUseCase.execute(
+        new AnonymizeTextForThreadCommand(
+          text,
+          prepared.orgId,
+          prepared.thread.id,
+        ),
+      );
+      return { anonymizedText: result.anonymizedText, masks: result.masks };
+    } catch (error) {
+      throw new RunAnonymizationUnavailableError({
+        originalError: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
   }
 
   /**
@@ -310,12 +352,13 @@ export class ExecuteRunViaRuntimeUseCase {
   private async persistToolResultSeed(
     prepared: PreparedRuntimeRun,
     input: RunToolResultInput,
-  ): Promise<Message> {
-    const { contents } =
+  ): Promise<SeededInput> {
+    const safeInput = await this.prepareToolResultInput(prepared, input);
+    const { contents, piiMasks } =
       await this.toolResultCollectorService.collectToolResults({
         thread: prepared.thread,
         tools: prepared.backendTools,
-        input,
+        input: safeInput.input,
         orgId: prepared.orgId,
         isAnonymous: prepared.isAnonymous,
       });
@@ -330,7 +373,40 @@ export class ExecuteRunViaRuntimeUseCase {
     this.addMessageToThreadUseCase.execute(
       new AddMessageCommand(prepared.thread, message),
     );
-    return message;
+    return { message, masks: piiMasks ?? safeInput.masks };
+  }
+
+  private async prepareToolResultInput(
+    prepared: PreparedRuntimeRun,
+    input: RunToolResultInput,
+  ): Promise<PreparedToolResultInput> {
+    const pending = prepared.thread
+      .getLastMessage()
+      ?.content.find(
+        (content): content is ToolUseMessageContent =>
+          content instanceof ToolUseMessageContent &&
+          content.id === input.toolId,
+      );
+    if (!pending) {
+      throw new RunInvalidInputError(
+        'No pending tool call to attach this result to',
+      );
+    }
+    if (!prepared.isAnonymous) {
+      return {
+        input: new RunToolResultInput(pending.id, pending.name, input.result),
+        masks: null,
+      };
+    }
+    const anonymized = await this.anonymizeUserText(prepared, input.result);
+    return {
+      input: new RunToolResultInput(
+        pending.id,
+        pending.name,
+        anonymized.anonymizedText,
+      ),
+      masks: anonymized.masks,
+    };
   }
 
   private emitRunExecuted(userId: UUID, orgId: UUID): void {

--- a/packages/agent-runtime/src/engine/loop.spec.ts
+++ b/packages/agent-runtime/src/engine/loop.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { RunEvent } from '../contracts/event';
+import { AgentRuntimeError } from '../contracts/errors';
 import {
   MockProvider,
   textTurn,
@@ -327,6 +328,88 @@ describe('the agent loop', () => {
     expect(finalCallFlags).toEqual([false, true]);
     expect(eventTypes(events)).not.toContain('tool_result_message');
     expect(events.at(-1)).toMatchObject({ type: 'run_end', status: 'error' });
+  });
+
+  it('stops the run when a tool throws a fatal runtime error', async () => {
+    const failing = echoTool({
+      name: 'pii_lookup',
+      execute: () => {
+        throw new AgentRuntimeError(
+          'ANONYMIZATION_UNAVAILABLE',
+          'Anonymization is unavailable',
+        );
+      },
+    });
+    const model = new MockProvider([
+      toolCallTurn({ id: 'call-1', name: 'pii_lookup', input: {} }),
+      textTurn('This turn must not run'),
+    ]);
+
+    const events = await collectEvents(baseInput(model, { tools: [failing] }));
+
+    expect(events.find((event) => event.type === 'error')).toMatchObject({
+      code: 'ANONYMIZATION_UNAVAILABLE',
+    });
+    expect(events.at(-1)).toMatchObject({ type: 'run_end', status: 'error' });
+    expect(model.requests).toHaveLength(1);
+  });
+
+  it('pairs every tool call before surfacing a fatal runtime error', async () => {
+    const firstExecute = vi.fn(() => 'first result');
+    const failingExecute = vi.fn(() => {
+      throw new AgentRuntimeError(
+        'ANONYMIZATION_UNAVAILABLE',
+        'Anonymization is unavailable',
+      );
+    });
+    const skippedExecute = vi.fn(() => 'must not run');
+    const model = new MockProvider([
+      [
+        {
+          toolCallDeltas: [
+            { index: 0, id: 'call-1', name: 'first', argumentsDelta: '{}' },
+            { index: 1, id: 'call-2', name: 'failing', argumentsDelta: '{}' },
+            { index: 2, id: 'call-3', name: 'skipped', argumentsDelta: '{}' },
+          ],
+        },
+        { finishReason: 'tool_calls' },
+      ],
+      textTurn('This turn must not run'),
+    ]);
+
+    const events = await collectEvents(
+      baseInput(model, {
+        tools: [
+          echoTool({ name: 'first', execute: firstExecute }),
+          echoTool({ name: 'failing', execute: failingExecute }),
+          echoTool({ name: 'skipped', execute: skippedExecute }),
+        ],
+      }),
+    );
+
+    const resultMessage = events.find(
+      (event) => event.type === 'tool_result_message',
+    );
+    expect(resultMessage).toMatchObject({
+      message: {
+        role: 'tool_result',
+        content: [
+          { toolCallId: 'call-1', isError: false },
+          { toolCallId: 'call-2', isError: true },
+          { toolCallId: 'call-3', isError: true },
+        ],
+      },
+    });
+    expect(firstExecute).toHaveBeenCalledOnce();
+    expect(failingExecute).toHaveBeenCalledOnce();
+    expect(skippedExecute).not.toHaveBeenCalled();
+    expect(events.find((event) => event.type === 'error')).toMatchObject({
+      code: 'ANONYMIZATION_UNAVAILABLE',
+    });
+    expect(eventTypes(events).indexOf('tool_result_message')).toBeLessThan(
+      eventTypes(events).indexOf('error'),
+    );
+    expect(model.requests).toHaveLength(1);
   });
 
   it('executes complete tool phases up to the iteration cap', async () => {

--- a/packages/agent-runtime/src/engine/loop.ts
+++ b/packages/agent-runtime/src/engine/loop.ts
@@ -94,13 +94,20 @@ async function* runToolPhase(
   iteration: number,
   toolCalls: readonly ToolUseContent[],
 ): AsyncGenerator<RunEventPayload> {
-  const results = yield* executeToolCalls(state, iteration, toolCalls);
+  const { results, fatalError } = yield* executeToolCalls(
+    state,
+    iteration,
+    toolCalls,
+  );
   const toolResultMessage: Message = {
     role: 'tool_result',
     content: results,
   };
   state.messages.push(toolResultMessage);
   yield { type: 'tool_result_message', message: toolResultMessage };
+  if (fatalError) {
+    throw fatalError;
+  }
 }
 
 const applyPendingMutations = (state: RunState): void => {

--- a/packages/agent-runtime/src/engine/tool-executor.ts
+++ b/packages/agent-runtime/src/engine/tool-executor.ts
@@ -1,4 +1,5 @@
 import type { RunEventPayload, ToolCallSummary } from '../contracts/event';
+import { AgentRuntimeError } from '../contracts/errors';
 import type { ToolResultContent, ToolUseContent } from '../contracts/message';
 import type {
   Tool,
@@ -14,6 +15,12 @@ export const MAX_TOOL_RESULT_LENGTH = 20_000;
 interface ToolOutcome {
   result: string;
   isError: boolean;
+  fatalError?: AgentRuntimeError;
+}
+
+interface ToolPhaseOutcome {
+  results: ToolResultContent[];
+  fatalError?: AgentRuntimeError;
 }
 
 /**
@@ -30,8 +37,9 @@ export async function* executeToolCalls(
   state: RunState,
   iteration: number,
   calls: readonly ToolUseContent[],
-): AsyncGenerator<RunEventPayload, ToolResultContent[]> {
+): AsyncGenerator<RunEventPayload, ToolPhaseOutcome> {
   const results: ToolResultContent[] = [];
+  let fatalError: AgentRuntimeError | undefined;
   for (const [callIndex, call] of calls.entries()) {
     const requested: ToolCallSummary = {
       id: call.id,
@@ -40,7 +48,7 @@ export async function* executeToolCalls(
     };
     let toolCall = requested;
     let outcome: ToolOutcome;
-    if (isAborted(state)) {
+    if (fatalError || isAborted(state)) {
       outcome = abortedOutcome();
     } else {
       toolCall = await state.hookRunner.beforeToolCall({
@@ -53,6 +61,7 @@ export async function* executeToolCalls(
         ? abortedOutcome()
         : await runTool(state, findTool(state, toolCall.name), toolCall);
     }
+    fatalError ??= outcome.fatalError;
     await state.hookRunner.afterToolCall({
       iteration,
       toolCall,
@@ -65,7 +74,7 @@ export async function* executeToolCalls(
     results.push(result);
     yield result;
   }
-  return results;
+  return { results, ...(fatalError ? { fatalError } : {}) };
 }
 
 const buildToolResult = (
@@ -112,9 +121,7 @@ const runTool = async (
     );
     return normalizeToolOutput(value);
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : 'Tool execution failed';
-    return { result: message, isError: true };
+    return failedOutcome(error);
   }
 };
 
@@ -123,6 +130,15 @@ const normalizeToolOutput = (output: ToolExecutionOutput): ToolOutcome => {
     return { result: clampResult(output), isError: false };
   }
   return { result: clampResult(output.result), isError: output.isError };
+};
+
+const failedOutcome = (error: unknown): ToolOutcome => {
+  if (error instanceof AgentRuntimeError) {
+    return { result: error.message, isError: true, fatalError: error };
+  }
+  const message =
+    error instanceof Error ? error.message : 'Tool execution failed';
+  return { result: message, isError: true };
 };
 
 const buildToolContext = (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes privacy-critical anonymization and PII streaming on the new runtime path, plus agent-loop semantics for fatal tool errors that can abort runs mid-batch.
> 
> **Overview**
> **Anonymous threads now work on the agent-runtime run path**, replacing the previous hard rejection. User text and client-submitted display tool results are anonymized before persistence; **PII mask dictionaries are streamed first** (`RunPiiMasksUpdate`) so clients can resolve `{{pii:…}}` tokens.
> 
> **In-loop PII tool output** is redacted in `BackendToolAdapter` when `returnsPii` and the thread is anonymous: output is passed through `AnonymizeTextForThreadUseCase`, masks are emitted via the runtime `emit` hook, and anonymizer failures surface as **`ANONYMIZATION_UNAVAILABLE`** (mapped to `RunAnonymizationUnavailableError` on the SSE stream). Display tool-result seeds also **trust the pending `tool_use` name** from the thread, not the client-supplied tool name.
> 
> **`@ayunis/agent-runtime`** treats `AgentRuntimeError` from tool execution as **fatal**: it still builds a full paired `tool_result_message` (including synthetic errors for skipped calls after the failure), then stops the run without another model turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 090ccd595a0485f75cbecfcb2ad89373c162fe23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->