### PR TITLE
feat(dev): manage local dev config with infisical (AYC-505)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,22 @@ This creates **Demo Org** with `admin@demo.local` / `admin` (super admin) and pe
 
 ## 💻 Development
 
+### Local Development Environment
+
+Local development is driven by the `./dev` script (see
+`ayunis-core-backend/README.md` for details). Configuration comes from one of
+two sources:
+
+- **Team members:** install the Infisical CLI and log in once
+  (`brew install infisical/get-cli/infisical && infisical login`) — `./dev up`
+  injects the complete dev config from Infisical; no local env files needed.
+- **Contributors without Infisical access:** copy
+  `ayunis-core-backend/.env.example` to `ayunis-core-backend/.env` and fill in
+  your values; `./dev` falls back to `.env` automatically.
+
+The production setup above (copying `.env` files for `docker compose`) is
+unaffected.
+
 ### Git Hooks (Husky)
 
 This project uses [Husky](https://typicode.github.io/husky/) to manage Git hooks for code quality checks.

--- a/ayunis-core-backend/.env.example
+++ b/ayunis-core-backend/.env.example
@@ -1,4 +1,11 @@
 # See ./src/config/* for default values
+#
+# Team members: do NOT copy this file — the dev config (secrets + base
+# connection values) is injected from Infisical (`infisical login`, then
+# `./dev up`). This file is the template for contributors without Infisical
+# access and for production deployments. For local dev, keep connection
+# values at their base (slot-0) defaults: ports are derived from
+# DEV_PORT_OFFSET at boot (src/config/dev-port-offset.ts).
 # Application
 
 # The INTERNAL port of the app inside the container

--- a/ayunis-core-backend/README.md
+++ b/ayunis-core-backend/README.md
@@ -31,13 +31,24 @@ This is the core backend for the Ayunis platform, built with NestJS and followin
 ## Setup and Installation
 
 1. Clone the repository
-2. Copy the example environment file:
+2. Set up environment configuration — two paths:
+
+   **Team members (Infisical):** the complete dev config (secrets + base
+   connection config) is injected from Infisical at process start — no local
+   env files needed.
+
+   ```bash
+   brew install infisical/get-cli/infisical
+   infisical login   # pick the Ayunis instance domain, log in as yourself
+   ```
+
+   **Contributors without Infisical access:** copy the example file and fill
+   in your values; `./dev` detects the missing Infisical setup and falls back
+   to `.env` automatically.
 
    ```bash
    cp .env.example .env
    ```
-
-3. Update the `.env` file with your specific configuration values
 
 ### Development Environment
 
@@ -51,6 +62,21 @@ From the **repository root**:
 ```
 
 Use `./dev up --slot 1` to run a second instance in parallel (e.g. for another worktree).
+
+Environment precedence and the `DEV_PORT_OFFSET` slot derivation are
+documented in `src/config/SUMMARY.md`. Useful to know:
+
+- **Manual commands that need secrets** (Infisical path) must be prefixed,
+  because the DB config no longer lives in a local file:
+  `infisical run --env=dev --path=/backend -- pnpm seed` (same for
+  `pnpm run cli` and `pnpm run migration:*:dev`).
+- **Personal overrides:** to change a shared value just for yourself (a
+  feature flag, a temporary API key), set a *personal override* on the secret
+  in the Infisical UI — the CLI resolves it automatically. Offline
+  alternative: a gitignored `.env.local`, which beats every other source.
+- **Secrets are fetched at process start** — after changing a value in
+  Infisical, restart via `./dev down && ./dev up`.
+- `AYUNIS_NO_INFISICAL=1 ./dev up` forces the local `.env` fallback.
 
 ### Production Environment
 

--- a/ayunis-core-frontend/.env.example
+++ b/ayunis-core-frontend/.env.example
@@ -1,4 +1,9 @@
 # See ./src/shared/config/index.ts for all configured values and their defaults
+#
+# Team members: do NOT copy this file — dev values are injected from
+# Infisical by ./dev (env `dev`, folder /frontend). VITE_API_BASE_URL is the
+# exception: it is slot-specific, set by ./dev, and must stay out of
+# Infisical. This file is the template for contributors and production.
 # Only relevant for development, leave blank in production
 VITE_API_BASE_URL=http://localhost:3000/api
 

--- a/ayunis-core-frontend/README.md
+++ b/ayunis-core-frontend/README.md
@@ -1,4 +1,4 @@
-Welcome to your new TanStack app! 
+Welcome to your new TanStack app!
 
 # Getting Started
 
@@ -28,8 +28,6 @@ npm run test
 ## Styling
 
 This project uses [Tailwind CSS](https://tailwindcss.com/) for styling.
-
-
 
 ## Shadcn
 
@@ -62,11 +60,16 @@ To add components from the Ayunis registry:
 pnpx shadcn@latest add @ayunis/component-name
 ```
 
-**Note:** You need to set the `AYUNIS_REGISTRY_TOKEN` environment variable and have the registry server running on port 1998.
+**Note:** You need the `AYUNIS_REGISTRY_TOKEN` environment variable set and the registry server reachable. Team members get the token injected from Infisical:
 
+```bash
+infisical run --env=dev --path=/frontend -- pnpx shadcn@latest add @ayunis/component-name
+```
 
+(The `ui-library-update` GitHub workflow keeps its own Actions secret.)
 
 ## Routing
+
 This project uses [TanStack Router](https://tanstack.com/router). The initial setup is a file based router. Which means that the routes are managed as files in `src/routes`.
 
 ### Adding A Route
@@ -126,7 +129,6 @@ export const Route = createRootRoute({
 The `<TanStackRouterDevtools />` component is not required so you can remove it if you don't want it in your layout.
 
 More information on layouts can be found in the [Layouts documentation](https://tanstack.com/router/latest/docs/framework/react/guide/routing-concepts#layouts).
-
 
 ## Data Fetching
 


### PR DESCRIPTION
- Document the two setup paths: team members inject the full dev config via infisical login + ./dev up; contributors copy .env.example
- Document manual-command prefixes, personal overrides, the .env.local escape hatch and the restart-to-refresh behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to README and `.env.example` comments; no runtime, auth, or deployment behavior is modified in this diff.
> 
> **Overview**
> Documents how **local dev config** is managed now that team members use **Infisical** with `./dev`, while **contributors** still use copied `.env` files.
> 
> The **root README** adds a *Local Development Environment* section describing the two setup paths and clarifies that **production** `docker compose` env copying is unchanged. **Backend README** replaces a single “copy `.env`” step with Infisical vs contributor flows and adds operational notes: `infisical run` prefixes for seed/CLI/migrations, personal overrides / `.env.local`, restart after secret changes, and `AYUNIS_NO_INFISICAL=1` to force `.env`. **Backend and frontend `.env.example`** headers now tell team members not to copy the file for dev and explain slot/`DEV_PORT_OFFSET` (backend) and slot-specific `VITE_API_BASE_URL` (frontend). **Frontend README** updates Ayunis registry / shadcn usage to run via Infisical for the registry token, with minor whitespace cleanup elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcb9c96a08fd9645600ff64f35944de29b1ea04a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->