### PR TITLE
refactor(users): remove dead validateUser() method [AYC-468]

### DIFF
--- a/ayunis-core-backend/src/iam/users/application/ports/users.repository.ts
+++ b/ayunis-core-backend/src/iam/users/application/ports/users.repository.ts
@@ -27,6 +27,5 @@ export abstract class UsersRepository {
   abstract create(user: User): Promise<User>;
   abstract update(user: User): Promise<User>;
   abstract delete(id: UUID): Promise<void>;
-  abstract validateUser(email: string, password: string): Promise<User>;
   abstract isValidPassword(password: string): Promise<boolean>;
 }

--- a/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/local-users.repository.ts
+++ b/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/local-users.repository.ts
@@ -14,7 +14,6 @@ import { UserMapper } from './mappers/user.mapper';
 import {
   UserNotFoundError,
   UserAlreadyExistsError,
-  UserAuthenticationFailedError,
 } from 'src/iam/users/application/users.errors';
 import { Paginated } from 'src/common/pagination/paginated.entity';
 
@@ -208,25 +207,6 @@ export class LocalUsersRepository extends UsersRepository {
 
     await this.userRepository.delete(id);
     this.logger.debug('User deleted successfully', { userId: id });
-  }
-
-  async validateUser(email: string, password: string): Promise<User> {
-    this.logger.log('validateUser', { email });
-
-    const user = await this.findOneByEmail(email);
-    if (!user) {
-      this.logger.warn('User not found during validation', { email });
-      throw new UserNotFoundError(email);
-    }
-
-    // In a real implementation, this would validate the password hash
-    if (password !== 'admin') {
-      // This is a placeholder validation
-      this.logger.warn('Invalid password during validation', { email });
-      throw new UserAuthenticationFailedError('Invalid password');
-    }
-
-    return user;
   }
 
   async isValidPassword(password: string): Promise<boolean> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`LocalUsersRepository.validateUser()` contained a placeholder password check (`password !== 'admin'`) and was never used in the production login path. The real login flow runs through `ValidateUserUseCase`, which performs a proper bcrypt comparison via `CompareHashUseCase`.

Dead code of this kind is a classic audit finding and a latent risk if the method were ever wired up by accident (found while creating the Ayunis Core data security concept, ch. 7 Access Control).

## Changes

- Removed the dead `validateUser()` method from `local-users.repository.ts`.
- Removed the corresponding `abstract validateUser(...)` declaration from the `UsersRepository` port.
- Removed the now-unused `UserAuthenticationFailedError` import in the local repository.

## Verification

- Confirmed the method had no callers (only the abstract declaration and its single implementation referenced it; `ValidateUserUseCase` does not use it).
- `tsc --noEmit` passes.
- ESLint passes on the affected files, and all pre-commit checks passed.

Closes AYC-468
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-468](https://linear.app/ayunis/issue/AYC-468/cleanup-remove-dead-validateuser-method-with-password-admin-check)

<div><a href="https://cursor.com/agents/bc-aaeb2e6e-77bf-4e38-8028-2e6b4f00ea3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aaeb2e6e-77bf-4e38-8028-2e6b4f00ea3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

