### PR TITLE
feat(auth): refuse to boot in production when COOKIE_SECURE is not true (AYC-467)

### DIFF
--- a/ayunis-core-backend/.env.example
+++ b/ayunis-core-backend/.env.example
@@ -73,7 +73,9 @@ COOKIE_DOMAIN=localhost
 # refuses to boot without it. There is no insecure default fallback.
 # Generate a secure value with: openssl rand -hex 32
 COOKIE_SECRET=
-# Optional, set to false when using over http (not https)
+# Controls the Secure attribute on session cookies. Set to false only for
+# local http (non-https) setups. REQUIRED to be true in production: the app
+# refuses to boot when NODE_ENV=production and COOKIE_SECURE is not "true".
 COOKIE_SECURE=true
 # Secret for signing logged in user's auth payload. REQUIRED in every
 # environment; the app refuses to boot without it. There is no insecure

--- a/ayunis-core-backend/src/config/authentication.config.spec.ts
+++ b/ayunis-core-backend/src/config/authentication.config.spec.ts
@@ -67,8 +67,48 @@ describe('authenticationConfig', () => {
       process.env.NODE_ENV = 'production';
       process.env.JWT_SECRET = 'jwt';
       process.env.COOKIE_SECRET = 'cookie';
+      process.env.COOKIE_SECURE = 'true';
 
       expect(() => authenticationConfig()).not.toThrow();
     });
+  });
+
+  describe('COOKIE_SECURE in production', () => {
+    beforeEach(() => {
+      process.env.JWT_SECRET = 'jwt';
+      process.env.COOKIE_SECRET = 'cookie';
+      delete process.env.COOKIE_SECURE;
+    });
+
+    it('throws in production when COOKIE_SECURE is not set', () => {
+      process.env.NODE_ENV = 'production';
+
+      expect(() => authenticationConfig()).toThrow(/COOKIE_SECURE/);
+    });
+
+    it('throws in production when COOKIE_SECURE is "false"', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.COOKIE_SECURE = 'false';
+
+      expect(() => authenticationConfig()).toThrow(/COOKIE_SECURE/);
+    });
+
+    it('does not throw in production when COOKIE_SECURE is "true"', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.COOKIE_SECURE = 'true';
+
+      expect(() => authenticationConfig()).not.toThrow();
+      expect(authenticationConfig().cookie.secure).toBe(true);
+    });
+
+    it.each(['development', 'test'])(
+      'does not throw outside production (%s) when COOKIE_SECURE is unset',
+      (nodeEnv) => {
+        process.env.NODE_ENV = nodeEnv;
+
+        expect(() => authenticationConfig()).not.toThrow();
+        expect(authenticationConfig().cookie.secure).toBe(false);
+      },
+    );
   });
 });

--- a/ayunis-core-backend/src/config/authentication.config.ts
+++ b/ayunis-core-backend/src/config/authentication.config.ts
@@ -36,6 +36,27 @@ function assertSecretsConfigured(secrets: {
   }
 }
 
+/**
+ * Fail fast at boot when session cookies would be sent over plain HTTP in
+ * production. The code default for COOKIE_SECURE is `false`, which is fine for
+ * local http setups but dangerous in production: without the `Secure`
+ * attribute the access/refresh token cookies are transmitted over unencrypted
+ * HTTP as well, exposing them to network interception. Requiring
+ * COOKIE_SECURE=true in production (and only there) keeps local/test setups
+ * simple while preventing an insecure production deployment.
+ */
+function assertCookieSecureInProduction(secure: boolean): void {
+  const isProduction = (process.env.NODE_ENV ?? '').trim() === 'production';
+  if (isProduction && !secure) {
+    throw new Error(
+      'COOKIE_SECURE must be set to "true" in production. Session cookies ' +
+        '(access/refresh tokens) would otherwise be sent over unencrypted ' +
+        'HTTP. Set COOKIE_SECURE=true (requires HTTPS) before starting the ' +
+        'application.',
+    );
+  }
+}
+
 function jwtConfig(secret: string) {
   return {
     secret,
@@ -95,11 +116,14 @@ export const authenticationConfig = registerAs('auth', () => {
 
   assertSecretsConfigured(secrets);
 
+  const cookie = cookieConfig(secrets.cookieSecret);
+  assertCookieSecureInProduction(cookie.secure);
+
   return {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- env var may be undefined at runtime despite type cast
     provider: (process.env.AUTH_PROVIDER as AuthProvider) || AuthProvider.LOCAL,
     jwt: jwtConfig(secrets.jwtSecret),
-    cookie: cookieConfig(secrets.cookieSecret),
+    cookie,
     cloud: {
       apiUrl: process.env.CLOUD_AUTH_API_URL,
       apiKey: process.env.CLOUD_AUTH_API_KEY,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The code default for `COOKIE_SECURE` is `false` (`authentication.config.ts`). In production it must be explicitly set to `true`, otherwise session cookies (access/refresh tokens) are transmitted over unencrypted HTTP as well, exposing them to network interception.

## Change

Adds a boot-time check that refuses to start the app when `NODE_ENV=production` and `COOKIE_SECURE` is not `true`, analogous to the existing secret boot checks (`assertSecretsConfigured`) and the production checks in `redis.config.ts` / `storage.config.ts`.

- `authentication.config.ts`: new `assertCookieSecureInProduction()` guard, invoked from the `auth` config factory. Only enforced in production so local/test http setups stay simple.
- `authentication.config.spec.ts`: added coverage — throws in production when `COOKIE_SECURE` is unset or `"false"`, does not throw when `"true"`, and does not throw outside production.
- `.env.example`: clarified the `COOKIE_SECURE` comment to document the production requirement.

## Testing

- `jest src/config/authentication.config.spec.ts` → 14 passed.
- ESLint clean on changed files.

## Context

Found while creating the Ayunis Core data security concept (ch. 7 Access Control, ch. 8 Cryptography).

Resolves AYC-467.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-467](https://linear.app/ayunis/issue/AYC-467/hardening-cookie-secure-default-is-false-verify-in-production-add-boot)

<div><a href="https://cursor.com/agents/bc-182da822-19c8-4903-90f0-82c31a1cb942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-182da822-19c8-4903-90f0-82c31a1cb942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

