### PR TITLE
fix(models): return conflict on duplicate model key and stop leaking raw errors (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/common/errors/base.error.spec.ts
+++ b/ayunis-core-backend/src/common/errors/base.error.spec.ts
@@ -1,0 +1,41 @@
+import { ApplicationError } from './base.error';
+
+class TestError extends ApplicationError {
+  constructor(statusCode: number, metadata?: Record<string, unknown>) {
+    super('Something went wrong', 'TEST_ERROR', statusCode, metadata);
+  }
+}
+
+describe('ApplicationError', () => {
+  describe('toHttpException', () => {
+    it('exposes code and message in the response body', () => {
+      const exception = new TestError(409).toHttpException();
+
+      expect(exception.getResponse()).toMatchObject({
+        code: 'TEST_ERROR',
+        message: 'Something went wrong',
+      });
+    });
+
+    it('does not serialize metadata into the response body', () => {
+      const driverError = {
+        query: 'UPDATE "models" SET ...',
+        parameters: ['secret'],
+      };
+      const exception = new TestError(500, {
+        error: driverError,
+      }).toHttpException();
+
+      const body = JSON.stringify(exception.getResponse());
+      expect(body).not.toContain('metadata');
+      expect(body).not.toContain('UPDATE');
+      expect(body).not.toContain('secret');
+    });
+
+    it('keeps metadata on the error instance for logging and Sentry', () => {
+      const error = new TestError(500, { orgId: 'org-1' });
+
+      expect(error.metadata).toEqual({ orgId: 'org-1' });
+    });
+  });
+});

--- a/ayunis-core-backend/src/common/errors/base.error.ts
+++ b/ayunis-core-backend/src/common/errors/base.error.ts
@@ -52,13 +52,14 @@ export abstract class ApplicationError extends Error {
   }
 
   /**
-   * Convert to a NestJS HTTP exception
+   * Convert to a NestJS HTTP exception. Metadata stays off the response
+   * body on purpose — it may carry internals (raw driver errors, queries)
+   * and is only meant for server-side logging and Sentry.
    */
   toHttpException() {
     const body = {
       code: this.code,
       message: this.message,
-      ...(this.metadata && { metadata: this.metadata }),
     };
 
     const factory = EXCEPTION_FACTORIES[this.statusCode];

--- a/ayunis-core-backend/src/common/filters/application-error.filter.ts
+++ b/ayunis-core-backend/src/common/filters/application-error.filter.ts
@@ -53,7 +53,6 @@ export class ApplicationErrorFilter extends BaseExceptionFilter {
       response.status(status).json({
         code: exception.code,
         message: exception.message,
-        ...(exception.metadata && { metadata: exception.metadata }),
         timestamp: new Date().toISOString(),
         path: request.url,
       });

--- a/ayunis-core-backend/src/domain/models/application/models.errors.ts
+++ b/ayunis-core-backend/src/domain/models/application/models.errors.ts
@@ -48,10 +48,17 @@ export abstract class ModelError extends ApplicationError {
 
 export class UnexpectedModelError extends ModelError {
   constructor(error: Error, metadata?: ErrorMetadata) {
-    super(error.message, ModelErrorCode.UNEXPECTED_MODEL_ERROR, 500, {
-      ...metadata,
-      error,
-    });
+    // Generic message on purpose: the underlying error may expose internals
+    // (SQL, driver details). It stays in metadata for logging and Sentry.
+    super(
+      'Unexpected error occurred',
+      ModelErrorCode.UNEXPECTED_MODEL_ERROR,
+      500,
+      {
+        ...metadata,
+        error,
+      },
+    );
   }
 }
 

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-embedding-model/update-embedding-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-embedding-model/update-embedding-model.use-case.ts
@@ -2,6 +2,7 @@ import { UpdateEmbeddingModelCommand } from './update-embedding-model.command';
 import { ModelsRepository } from '../../ports/models.repository';
 import { EmbeddingModel } from 'src/domain/models/domain/models/embedding.model';
 import {
+  ModelAlreadyExistsError,
   ModelNotFoundByIdError,
   UnexpectedModelError,
 } from '../../models.errors';
@@ -27,6 +28,14 @@ export class UpdateEmbeddingModelUseCase {
 
       if (!existingModel) {
         throw new ModelNotFoundByIdError(command.id);
+      }
+
+      const modelWithSameKey = await this.modelsRepository.findOne({
+        name: command.name,
+        provider: command.provider,
+      });
+      if (modelWithSameKey && modelWithSameKey.id !== command.id) {
+        throw new ModelAlreadyExistsError(command.name, command.provider);
       }
 
       // Check if model is being archived (isArchived: false -> true)

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-image-generation-model/update-image-generation-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-image-generation-model/update-image-generation-model.use-case.spec.ts
@@ -7,6 +7,7 @@ import { ImageGenerationModel } from 'src/domain/models/domain/models/image-gene
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
 import {
   ImageGenerationModelProviderNotSupportedError,
+  ModelAlreadyExistsError,
   ModelNotFoundByIdError,
 } from '../../models.errors';
 import { ModelPolicyService } from '../../services/model-policy.service';
@@ -88,6 +89,39 @@ describe('UpdateImageGenerationModelUseCase', () => {
       ImageGenerationModelProviderNotSupportedError,
     );
     expect(modelsRepository.findOne).not.toHaveBeenCalled();
+  });
+
+  it('throws when another model has the same name and provider', async () => {
+    const otherModelId = '123e4567-e89b-12d3-a456-426614174099' as UUID;
+    const existingModel = new ImageGenerationModel({
+      id: modelId,
+      name: 'gpt-image-1',
+      provider: ModelProvider.AZURE,
+      displayName: 'GPT Image 1',
+      isArchived: false,
+    });
+    const conflictingModel = new ImageGenerationModel({
+      id: otherModelId,
+      name: 'gpt-image-2',
+      provider: ModelProvider.AZURE,
+      displayName: 'GPT Image 2',
+      isArchived: false,
+    });
+    const command = new UpdateImageGenerationModelCommand({
+      id: modelId,
+      name: 'gpt-image-2',
+      provider: ModelProvider.AZURE,
+      displayName: 'GPT Image 1',
+      isArchived: false,
+    });
+
+    modelsRepository.findOneImageGeneration.mockResolvedValue(existingModel);
+    modelsRepository.findOne.mockResolvedValue(conflictingModel);
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      ModelAlreadyExistsError,
+    );
+    expect(modelsRepository.save).not.toHaveBeenCalled();
   });
 
   it('throws when the target model does not exist', async () => {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-image-generation-model/update-image-generation-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-image-generation-model/update-image-generation-model.use-case.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ImageGenerationModel } from 'src/domain/models/domain/models/image-generation.model';
 import {
+  ModelAlreadyExistsError,
   ModelNotFoundByIdError,
   UnexpectedModelError,
 } from '../../models.errors';
@@ -30,6 +31,14 @@ export class UpdateImageGenerationModelUseCase {
 
       if (!existingModel) {
         throw new ModelNotFoundByIdError(command.id);
+      }
+
+      const modelWithSameKey = await this.modelsRepository.findOne({
+        name: command.name,
+        provider: command.provider,
+      });
+      if (modelWithSameKey && modelWithSameKey.id !== command.id) {
+        throw new ModelAlreadyExistsError(command.name, command.provider);
       }
 
       const model = new ImageGenerationModel({

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.spec.ts
@@ -8,7 +8,10 @@ import { ClearDefaultsByCatalogModelIdUseCase } from '../clear-defaults-by-catal
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
 import { ModelTier } from 'src/domain/models/domain/value-objects/model-tier.enum';
-import { ModelNotFoundByIdError } from '../../models.errors';
+import {
+  ModelAlreadyExistsError,
+  ModelNotFoundByIdError,
+} from '../../models.errors';
 import type { UUID } from 'crypto';
 
 describe('UpdateLanguageModelUseCase', () => {
@@ -183,6 +186,39 @@ describe('UpdateLanguageModelUseCase', () => {
 
       // Assert
       expect(callOrder).toEqual(['save', 'clearDefaults']);
+    });
+
+    it('should throw ModelAlreadyExistsError when another model has the same name and provider', async () => {
+      // Arrange — a different catalog model already occupies (name, provider)
+      const otherModelId = '123e4567-e89b-12d3-a456-426614174099' as UUID;
+      const existingModel = createMockLanguageModel(mockModelId, false);
+      const conflictingModel = createMockLanguageModel(otherModelId, false);
+      const command = createUpdateCommand(mockModelId, false);
+
+      modelsRepository.findOne.mockImplementation((params) =>
+        Promise.resolve('id' in params ? existingModel : conflictingModel),
+      );
+
+      // Act & Assert
+      await expect(useCase.execute(command)).rejects.toThrow(
+        ModelAlreadyExistsError,
+      );
+      expect(modelsRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should not treat the model being updated as a duplicate of itself', async () => {
+      // Arrange — (name, provider) resolves to the same model that is updated
+      const existingModel = createMockLanguageModel(mockModelId, false);
+      const command = createUpdateCommand(mockModelId, false);
+
+      modelsRepository.findOne.mockResolvedValue(existingModel);
+      modelsRepository.save.mockResolvedValue();
+
+      // Act
+      await useCase.execute(command);
+
+      // Assert
+      expect(modelsRepository.save).toHaveBeenCalledTimes(1);
     });
 
     it('should throw ModelNotFoundByIdError when model does not exist', async () => {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.ts
@@ -2,6 +2,7 @@ import { UpdateLanguageModelCommand } from './update-language-model.command';
 import { ModelsRepository } from '../../ports/models.repository';
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import {
+  ModelAlreadyExistsError,
   ModelNotFoundByIdError,
   UnexpectedModelError,
 } from '../../models.errors';
@@ -27,6 +28,14 @@ export class UpdateLanguageModelUseCase {
 
       if (!existingModel) {
         throw new ModelNotFoundByIdError(command.id);
+      }
+
+      const modelWithSameKey = await this.modelsRepository.findOne({
+        name: command.name,
+        provider: command.provider,
+      });
+      if (modelWithSameKey && modelWithSameKey.id !== command.id) {
+        throw new ModelAlreadyExistsError(command.name, command.provider);
       }
 
       // Check if model is being archived (isArchived: false -> true)

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useUpdateEmbeddingModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useUpdateEmbeddingModel.ts
@@ -29,6 +29,8 @@ export function useUpdateEmbeddingModel(onSuccess?: () => void) {
             const { code } = extractErrorData(error);
             if (code === 'MODEL_NOT_FOUND') {
               showError(t('models.notFound'));
+            } else if (code === 'MODEL_ALREADY_EXISTS') {
+              showError(t('models.alreadyExists'));
             } else {
               showError(t('models.updateError'));
             }

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useUpdateImageGenerationModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useUpdateImageGenerationModel.ts
@@ -31,6 +31,8 @@ export function useUpdateImageGenerationModel(onSuccess?: () => void) {
               const { code } = extractErrorData(error);
               if (code === 'MODEL_NOT_FOUND') {
                 showError(t('models.notFound'));
+              } else if (code === 'MODEL_ALREADY_EXISTS') {
+                showError(t('models.alreadyExists'));
               } else {
                 showError(t('models.updateError'));
               }

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useUpdateLanguageModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useUpdateLanguageModel.ts
@@ -29,6 +29,8 @@ export function useUpdateLanguageModel(onSuccess?: () => void) {
             const { code } = extractErrorData(error);
             if (code === 'MODEL_NOT_FOUND') {
               showError(t('models.notFound'));
+            } else if (code === 'MODEL_ALREADY_EXISTS') {
+              showError(t('models.alreadyExists'));
             } else {
               showError(t('models.updateError'));
             }


### PR DESCRIPTION
- Catalog model updates now pre-check (name, provider) uniqueness and
  throw ModelAlreadyExistsError (409) instead of surfacing the raw
  Postgres unique-violation as UNEXPECTED_MODEL_ERROR
- Frontend update hooks map MODEL_ALREADY_EXISTS to the existing
  'A model with this identifier already exists' toast
- Error responses no longer serialize metadata (raw driver errors,
  SQL queries); it stays on the error instance for logging and Sentry
- UnexpectedModelError uses a generic message instead of echoing the
  underlying error message

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Global change to all ApplicationError HTTP bodies may affect any client that relied on metadata; model update paths gain new validation with behavior change from raw DB errors to 409.
> 
> **Overview**
> **Hardens API error responses** so clients only receive `code` and `message`. `ApplicationError` and the application error filter no longer put `metadata` on the wire (SQL, driver errors, etc. stay on the instance for logs/Sentry). `UnexpectedModelError` now returns a generic message instead of the underlying exception text.
> 
> **Catalog model updates** (language, embedding, image-generation) pre-check `(name, provider)` and return **409 `MODEL_ALREADY_EXISTS`** when another row would conflict, instead of failing with an unexpected/DB error. Super-admin update hooks show the existing “already exists” toast for that code.
> 
> Adds unit coverage for HTTP error shaping and duplicate-key behavior on update use cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ec13fcf0ce6f59123387778e60d98d0237c24f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->