### PR TITLE
fix(runs): unsubscribe buffered stream on early consumer exit (AYC-491)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/helpers/buffered-stream.helper.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/helpers/buffered-stream.helper.spec.ts
@@ -1,0 +1,82 @@
+import { Subject } from 'rxjs';
+import { observableToBufferedAsyncIterable } from './buffered-stream.helper';
+
+describe('observableToBufferedAsyncIterable', () => {
+  it('yields every emitted value and records it in the buffer', async () => {
+    const source$ = new Subject<number>();
+    const buffer: number[] = [];
+    const onComplete = jest.fn();
+    const iterable = observableToBufferedAsyncIterable(
+      source$,
+      buffer,
+      onComplete,
+    );
+
+    const consumed: number[] = [];
+    const consumer = (async () => {
+      for await (const value of iterable) {
+        consumed.push(value);
+      }
+    })();
+
+    source$.next(1);
+    source$.next(2);
+    source$.complete();
+    await consumer;
+
+    expect(consumed).toEqual([1, 2]);
+    expect(buffer).toEqual([1, 2]);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribes from the source when the consumer breaks out early', async () => {
+    const source$ = new Subject<number>();
+    const buffer: number[] = [];
+    const onComplete = jest.fn();
+    const iterable = observableToBufferedAsyncIterable(
+      source$,
+      buffer,
+      onComplete,
+    );
+
+    const consumer = (async () => {
+      for await (const value of iterable) {
+        if (value === 1) {
+          break;
+        }
+      }
+    })();
+
+    source$.next(1);
+    await consumer;
+
+    // A break must release the subscription — otherwise an aborted client
+    // keeps the provider stream buffering for the rest of the generation.
+    expect(source$.observed).toBe(false);
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('propagates source errors and unsubscribes', async () => {
+    const source$ = new Subject<number>();
+    const buffer: number[] = [];
+    const iterable = observableToBufferedAsyncIterable(
+      source$,
+      buffer,
+      jest.fn(),
+    );
+
+    const consumer = (async () => {
+      const values: number[] = [];
+      for await (const value of iterable) {
+        values.push(value);
+      }
+      return values;
+    })();
+
+    source$.next(1);
+    source$.error(new Error('provider failed'));
+
+    await expect(consumer).rejects.toThrow('provider failed');
+    expect(source$.observed).toBe(false);
+  });
+});

--- a/ayunis-core-backend/src/domain/runs/application/helpers/buffered-stream.helper.ts
+++ b/ayunis-core-backend/src/domain/runs/application/helpers/buffered-stream.helper.ts
@@ -1,4 +1,9 @@
-import type { Observable } from 'rxjs';
+import type { Observable, Subscription } from 'rxjs';
+
+interface BufferedStreamState {
+  completed: boolean;
+  error: Error | null;
+}
 
 /**
  * Bridges an RxJS Observable to an AsyncIterable while recording every
@@ -12,48 +17,71 @@ export function observableToBufferedAsyncIterable<T>(
   onComplete: () => void,
 ): AsyncIterable<T> {
   return {
-    [Symbol.asyncIterator]() {
-      let completed = false;
-      let error: Error | null = null;
-      let consumedIndex = 0;
+    [Symbol.asyncIterator]: () =>
+      createBufferedIterator(source$, buffer, onComplete),
+  };
+}
 
-      const subscription = source$.subscribe({
-        next: (value) => {
-          buffer.push(value);
-        },
-        error: (err) => {
-          error = err as Error;
-          completed = true;
-        },
-        complete: () => {
-          completed = true;
-        },
-      });
-
-      return {
-        async next() {
-          while (consumedIndex >= buffer.length && !completed) {
-            await new Promise((resolve) => setTimeout(resolve, 10));
-          }
-
-          if (error) {
-            subscription.unsubscribe();
-            throw error;
-          }
-
-          if (consumedIndex < buffer.length) {
-            const value = buffer[consumedIndex++];
-            return { value, done: false } as IteratorResult<T, void>;
-          } else {
-            subscription.unsubscribe();
-            onComplete();
-            return {
-              done: true,
-              value: undefined,
-            } as IteratorReturnResult<void>;
-          }
-        },
-      };
+function subscribeBuffering<T>(
+  source$: Observable<T>,
+  buffer: T[],
+  state: BufferedStreamState,
+): Subscription {
+  return source$.subscribe({
+    next: (value) => {
+      buffer.push(value);
     },
-  } as AsyncIterable<T>;
+    error: (err) => {
+      state.error = err as Error;
+      state.completed = true;
+    },
+    complete: () => {
+      state.completed = true;
+    },
+  });
+}
+
+function createBufferedIterator<T>(
+  source$: Observable<T>,
+  buffer: T[],
+  onComplete: () => void,
+): AsyncIterator<T, void> {
+  const state: BufferedStreamState = { completed: false, error: null };
+  let consumedIndex = 0;
+  const subscription = subscribeBuffering(source$, buffer, state);
+
+  return {
+    async next() {
+      while (consumedIndex >= buffer.length && !state.completed) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+
+      if (state.error) {
+        subscription.unsubscribe();
+        throw state.error;
+      }
+
+      if (consumedIndex < buffer.length) {
+        const value = buffer[consumedIndex++];
+        return { value, done: false };
+      }
+
+      subscription.unsubscribe();
+      onComplete();
+      return { done: true, value: undefined };
+    },
+    // Called when the consumer breaks out of for-await (e.g. client
+    // disconnect) — without it the provider stream stays subscribed and
+    // keeps buffering chunks for the rest of the generation.
+    return(): Promise<IteratorReturnResult<void>> {
+      subscription.unsubscribe();
+      return Promise.resolve({ done: true, value: undefined });
+    },
+    throw(err?: unknown): Promise<IteratorResult<T, void>> {
+      subscription.unsubscribe();
+      return Promise.reject(
+        err instanceof Error ? err : new Error(String(err)),
+      );
+    },
+  };
 }


### PR DESCRIPTION
- the hand-rolled AsyncIterator only implemented next(); breaking out
  of for-await (e.g. client disconnect) never released the provider
  subscription, which kept buffering chunks until the end of the
  generation
- implement return() and throw() so both early exit and consumer
  errors unsubscribe immediately, with specs covering both paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted fix in a runs streaming helper with tests; behavior change only affects abandoned consumers, not successful full streams.
> 
> **Overview**
> Fixes a **resource leak** in `observableToBufferedAsyncIterable`: when a consumer stops early (e.g. **client disconnect** via `break` out of `for await`), the RxJS subscription now tears down immediately instead of continuing to buffer until generation finishes.
> 
> The async iterator gains **`return()`** and **`throw()`** so early exit and consumer errors both **unsubscribe**; successful drain behavior and **`onComplete`** semantics are unchanged. Logic is split into **`subscribeBuffering`** / **`createBufferedIterator`** for clarity.
> 
> Adds **`buffered-stream.helper.spec.ts`** covering full consumption, early break (`source$.observed` false, no `onComplete`), and error propagation with unsubscribe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63acbdf591af1db28628d0994796a57caad4cc24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->