### PR TITLE
fix(shares): stop share-deleted listener failures crashing the process (AYC-491)

### DIFF
--- a/ayunis-core-backend/src/domain/shares/application/use-cases/delete-share/delete-share.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/shares/application/use-cases/delete-share/delete-share.use-case.spec.ts
@@ -52,7 +52,7 @@ describe('DeleteShareUseCase', () => {
         {
           provide: EventEmitter2,
           useValue: {
-            emit: jest.fn(),
+            emitAsync: jest.fn().mockResolvedValue([]),
           },
         },
       ],
@@ -90,7 +90,7 @@ describe('DeleteShareUseCase', () => {
       SharedEntityType.SKILL,
     );
 
-    const emittedEvent = (eventEmitter.emit as jest.Mock).mock.calls[0][1];
+    const emittedEvent = (eventEmitter.emitAsync as jest.Mock).mock.calls[0][1];
     expect(emittedEvent.entityType).toBe(SharedEntityType.SKILL);
     expect(emittedEvent.entityId).toBe(skillId);
     expect(emittedEvent.ownerId).toBe(mockUserId);
@@ -124,7 +124,7 @@ describe('DeleteShareUseCase', () => {
 
     await useCase.execute(share.id);
 
-    const emittedEvent = (eventEmitter.emit as jest.Mock).mock.calls[0][1];
+    const emittedEvent = (eventEmitter.emitAsync as jest.Mock).mock.calls[0][1];
     expect(emittedEvent.remainingScopes).toEqual([
       { scopeType: ShareScopeType.TEAM, scopeId: teamId },
     ]);
@@ -148,16 +148,37 @@ describe('DeleteShareUseCase', () => {
     await useCase.execute(share.id);
 
     expect(repository.delete).toHaveBeenCalledWith(share);
-    expect(eventEmitter.emit).toHaveBeenCalledWith(
+    expect(eventEmitter.emitAsync).toHaveBeenCalledWith(
       ShareDeletedEvent.EVENT_NAME,
       expect.any(ShareDeletedEvent),
     );
 
-    const emittedEvent = (eventEmitter.emit as jest.Mock).mock.calls[0][1];
+    const emittedEvent = (eventEmitter.emitAsync as jest.Mock).mock.calls[0][1];
     expect(emittedEvent.entityType).toBe(SharedEntityType.SKILL);
     expect(emittedEvent.entityId).toBe(skillId);
     expect(emittedEvent.ownerId).toBe(mockUserId);
     expect(emittedEvent.remainingScopes).toEqual([]);
+  });
+
+  it('should not fail the deletion when a share-deleted listener rejects', async () => {
+    const share = new SkillShare({
+      skillId: randomUUID(),
+      scope: new OrgShareScope({ orgId: mockOrgId }),
+      ownerId: mockUserId,
+    });
+
+    (contextService.get as jest.Mock).mockImplementation((key: string) =>
+      key === 'orgId' ? mockOrgId : mockUserId,
+    );
+    (repository.findById as jest.Mock).mockResolvedValue(share);
+    (repository.delete as jest.Mock).mockResolvedValue(undefined);
+    (repository.findByEntityIdAndType as jest.Mock).mockResolvedValue([]);
+    (eventEmitter.emitAsync as jest.Mock).mockRejectedValueOnce(
+      new Error('listener db write failed'),
+    );
+
+    await expect(useCase.execute(share.id)).resolves.toBeUndefined();
+    await new Promise(process.nextTick);
   });
 
   it('should throw UnauthorizedAccessError when user is not authenticated', async () => {
@@ -166,7 +187,7 @@ describe('DeleteShareUseCase', () => {
     await expect(useCase.execute(randomUUID())).rejects.toThrow(
       UnauthorizedAccessError,
     );
-    expect(eventEmitter.emit).not.toHaveBeenCalled();
+    expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
   });
 
   it('should throw when share does not exist', async () => {
@@ -174,7 +195,7 @@ describe('DeleteShareUseCase', () => {
     (repository.findById as jest.Mock).mockResolvedValue(null);
 
     await expect(useCase.execute(randomUUID())).rejects.toThrow();
-    expect(eventEmitter.emit).not.toHaveBeenCalled();
+    expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
   });
 
   it('should throw UnauthorizedAccessError when user does not own the share', async () => {
@@ -192,6 +213,6 @@ describe('DeleteShareUseCase', () => {
       UnauthorizedAccessError,
     );
     expect(repository.delete).not.toHaveBeenCalled();
-    expect(eventEmitter.emit).not.toHaveBeenCalled();
+    expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
   });
 });

--- a/ayunis-core-backend/src/domain/shares/application/use-cases/delete-share/delete-share.use-case.ts
+++ b/ayunis-core-backend/src/domain/shares/application/use-cases/delete-share/delete-share.use-case.ts
@@ -58,16 +58,22 @@ export class DeleteShareUseCase {
         throw new UnauthorizedAccessError();
       }
 
-      this.eventEmitter.emit(
-        ShareDeletedEvent.EVENT_NAME,
-        new ShareDeletedEvent(
-          share.entityType,
-          entityId,
-          share.ownerId,
-          orgId,
-          remainingScopes,
-        ),
-      );
+      this.eventEmitter
+        .emitAsync(
+          ShareDeletedEvent.EVENT_NAME,
+          new ShareDeletedEvent(
+            share.entityType,
+            entityId,
+            share.ownerId,
+            orgId,
+            remainingScopes,
+          ),
+        )
+        .catch((err: unknown) => {
+          this.logger.error(`Failed to emit ${ShareDeletedEvent.EVENT_NAME}`, {
+            error: err instanceof Error ? err.message : 'Unknown error',
+          });
+        });
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
       this.logger.error(error);


### PR DESCRIPTION
- the ShareDeletedEvent listeners perform DB writes; with a bare
  emit() a listener rejection had no catch anywhere and surfaced as
  an unhandled rejection
- switch to emitAsync().catch() so deletion stays non-blocking and a
  listener failure is logged instead of killing the process

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to event emission error handling after delete; improves resilience without altering authorization or delete persistence logic.
> 
> **Overview**
> **Delete share** no longer risks crashing the process when `ShareDeletedEvent` listeners fail (e.g. DB writes in downstream handlers).
> 
> `DeleteShareUseCase` switches from fire-and-forget `emit()` to `emitAsync()` with a `.catch()` that logs listener errors, so a successful repository delete still completes even if async listeners reject. Unit tests mock `emitAsync` instead of `emit` and add coverage that `execute` resolves when `emitAsync` rejects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daa670b72659741b6f9cc353403dba8e0ecbef96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->