### PR TITLE
fix(observability): stop reporting expected 4xx errors as appsignal incidents (AYC-479)

### DIFF
--- a/ayunis-core-backend/appsignal.cjs
+++ b/ayunis-core-backend/appsignal.cjs
@@ -43,6 +43,16 @@ if (pushApiKey && environment !== 'development') {
     // processor. Debugging context comes from tags and structured logs.
     sendParams: false,
     sendSessionData: false,
+    // The NestJS instrumentation records EVERY exception thrown from guards
+    // and handlers on its span — before ApplicationErrorFilter runs — so
+    // expected 4xx errors (failed logins, expired sessions, domain
+    // validation) become AppSignal incidents despite the filter's guard.
+    // Disabling it makes the filter's setError() the single reporting path
+    // for HTTP errors; express/http instrumentation still provides request
+    // spans and route-based action names.
+    disableDefaultInstrumentations: [
+      '@opentelemetry/instrumentation-nestjs-core',
+    ],
   });
 
   console.warn(`✅ AppSignal initialized for environment: ${environment}`);


### PR DESCRIPTION
The @opentelemetry/instrumentation-nestjs-core auto-instrumentation
records every exception thrown from guards and handlers on its span
before ApplicationErrorFilter runs, so expected client errors (failed
logins, expired sessions, domain validation 4xx) flooded AppSignal as
incidents despite the filter's existing 4xx guard.

- disable the nestjs-core instrumentation via
  disableDefaultInstrumentations
- ApplicationErrorFilter.setError() becomes the single error-reporting
  path for HTTP: 5xx and unexpected errors only
- express/http instrumentation keeps request spans and route-based
  action names; bullmq instrumentation keeps background worker errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change in bootstrap config; HTTP tracing and intentional 5xx reporting via the filter remain.
> 
> **Overview**
> **Disables NestJS OpenTelemetry auto-instrumentation** in `appsignal.cjs` so expected HTTP 4xx responses no longer create AppSignal incidents before `ApplicationErrorFilter` runs.
> 
> The `@opentelemetry/instrumentation-nestjs-core` package was recording every guard/handler exception on its span, which duplicated reporting and bypassed the filter’s 4xx guard. Adding `disableDefaultInstrumentations: ['@opentelemetry/instrumentation-nestjs-core']` leaves **`ApplicationErrorFilter.setError()`** as the only HTTP error path to AppSignal (5xx and unexpected errors). Express/HTTP instrumentation is unchanged for request spans and route names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9764211add34d059a5fe97815f3a8f97eae4a330. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->