### PR TITLE
fix(observability): report queue job failures only when retries are exhausted (AYC-479)

### DIFF
--- a/ayunis-core-backend/appsignal.cjs
+++ b/ayunis-core-backend/appsignal.cjs
@@ -53,6 +53,10 @@ if (pushApiKey && environment !== 'development') {
     disableDefaultInstrumentations: [
       '@opentelemetry/instrumentation-nestjs-core',
     ],
+    // Queue consumers rename job failures that BullMQ will retry to this
+    // error (see bullmq-job.helpers.ts), so only final failures — thrown
+    // with their original name — become incidents.
+    ignoreErrors: ['JobRetryScheduledError'],
   });
 
   console.warn(`✅ AppSignal initialized for environment: ${environment}`);

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/bullmq-job.helpers.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/bullmq-job.helpers.spec.ts
@@ -1,0 +1,76 @@
+import type { Job } from 'bullmq';
+import {
+  isFinalAttempt,
+  wrapIfRetryScheduled,
+  JobRetryScheduledError,
+} from './bullmq-job.helpers';
+
+function jobWith(attemptsMade: number, attempts?: number): Job {
+  return { attemptsMade, opts: { attempts } } as Job;
+}
+
+describe('isFinalAttempt', () => {
+  it('is false while retries remain (attempt 1 of 3)', () => {
+    expect(isFinalAttempt(jobWith(0, 3))).toBe(false);
+  });
+
+  it('is false on the middle attempt (attempt 2 of 3)', () => {
+    expect(isFinalAttempt(jobWith(1, 3))).toBe(false);
+  });
+
+  it('is true on the last configured attempt (attempt 3 of 3)', () => {
+    expect(isFinalAttempt(jobWith(2, 3))).toBe(true);
+  });
+
+  it('is true on the first attempt when opts.attempts is unset (BullMQ does not retry)', () => {
+    expect(isFinalAttempt(jobWith(0))).toBe(true);
+  });
+});
+
+describe('wrapIfRetryScheduled', () => {
+  const providerError = new Error(
+    'API error occurred: Status 400 - File could not be fetched from url',
+  );
+
+  it('wraps the error in JobRetryScheduledError when a retry will follow', () => {
+    const result = wrapIfRetryScheduled(jobWith(0, 3), providerError);
+
+    expect(result).toBeInstanceOf(JobRetryScheduledError);
+    expect((result as Error).name).toBe('JobRetryScheduledError');
+  });
+
+  it('preserves the original message so job.failedReason stays informative', () => {
+    const result = wrapIfRetryScheduled(jobWith(0, 3), providerError);
+
+    expect((result as Error).message).toBe(providerError.message);
+  });
+
+  it('preserves the original stack and exposes the original as cause', () => {
+    const result = wrapIfRetryScheduled(jobWith(0, 3), providerError) as Error;
+
+    expect(result.stack).toBe(providerError.stack);
+    expect(result.cause).toBe(providerError);
+  });
+
+  it('returns the original error untouched on the final attempt', () => {
+    expect(wrapIfRetryScheduled(jobWith(2, 3), providerError)).toBe(
+      providerError,
+    );
+  });
+
+  it('returns UnrecoverableError untouched even when attempts remain, since BullMQ will not retry it', () => {
+    const unrecoverable = new Error('source was deleted mid-processing');
+    unrecoverable.name = 'UnrecoverableError';
+
+    expect(wrapIfRetryScheduled(jobWith(0, 3), unrecoverable)).toBe(
+      unrecoverable,
+    );
+  });
+
+  it('wraps non-Error throwables with a stringified message', () => {
+    const result = wrapIfRetryScheduled(jobWith(0, 3), 'redis timeout');
+
+    expect(result).toBeInstanceOf(JobRetryScheduledError);
+    expect((result as Error).message).toBe('redis timeout');
+  });
+});

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/bullmq-job.helpers.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/bullmq-job.helpers.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '@nestjs/common';
-import type { JobsOptions, Queue } from 'bullmq';
+import type { Job, JobsOptions, Queue } from 'bullmq';
 import type { UUID } from 'crypto';
 
 /**
@@ -15,6 +15,46 @@ export const STANDARD_JOB_OPTIONS: JobsOptions = {
   removeOnComplete: 100,
   removeOnFail: 200,
 };
+
+/**
+ * True when no BullMQ retry will follow this attempt. When opts.attempts is
+ * unset, BullMQ runs the job exactly once, so the first attempt is final.
+ */
+export function isFinalAttempt(job: Job): boolean {
+  return job.attemptsMade + 1 >= (job.opts.attempts ?? 1);
+}
+
+/**
+ * Failure of a job attempt that BullMQ will retry. The AppSignal agent is
+ * configured to drop errors with this name (`ignoreErrors` in appsignal.cjs)
+ * so only final failures — thrown with their original name — become
+ * incidents. Message and stack are preserved so job.failedReason and logs
+ * stay as informative as the original error.
+ */
+export class JobRetryScheduledError extends Error {
+  constructor(original: unknown) {
+    const message =
+      original instanceof Error ? original.message : String(original);
+    super(message, { cause: original });
+    this.name = 'JobRetryScheduledError';
+    if (original instanceof Error && original.stack) {
+      this.stack = original.stack;
+    }
+  }
+}
+
+/**
+ * BullMQ's UnrecoverableError aborts remaining retries by error name, so it
+ * must never be renamed — and its failure is final regardless of attempts.
+ */
+export function wrapIfRetryScheduled(job: Job, error: unknown): unknown {
+  const isUnrecoverable =
+    error instanceof Error && error.name === 'UnrecoverableError';
+  if (isFinalAttempt(job) || isUnrecoverable) {
+    return error;
+  }
+  return new JobRetryScheduledError(error);
+}
 
 /**
  * Best-effort cancellation of a queued job keyed by its source id. Active jobs

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.spec.ts
@@ -119,6 +119,36 @@ describe('DocumentProcessingConsumer', () => {
     );
   });
 
+  it('rethrows as JobRetryScheduledError when retries remain, so AppSignal ignores the attempt', async () => {
+    const source = makeSource(SourceStatus.PROCESSING);
+    sourceRepository.findById.mockResolvedValue(source);
+    downloadObjectUseCase.execute.mockRejectedValueOnce(
+      new Error('MinIO object not found'),
+    );
+
+    await expect(consumer.process(makeJob())).rejects.toMatchObject({
+      name: 'JobRetryScheduledError',
+      message: 'MinIO object not found',
+    });
+    expect(helper.markFailed).not.toHaveBeenCalled();
+  });
+
+  it('rethrows the original error on the final attempt', async () => {
+    const source = makeSource(SourceStatus.PROCESSING);
+    sourceRepository.findById.mockResolvedValue(source);
+    downloadObjectUseCase.execute.mockRejectedValueOnce(
+      new Error('MinIO object not found'),
+    );
+
+    await expect(
+      consumer.process(makeJob({ attemptsMade: 2 } as never)),
+    ).rejects.toMatchObject({
+      name: 'Error',
+      message: 'MinIO object not found',
+    });
+    expect(helper.markFailed).toHaveBeenCalled();
+  });
+
   it('should skip saving and clean up when source is deleted mid-processing', async () => {
     const source = makeSource(SourceStatus.PROCESSING);
 

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.ts
@@ -19,6 +19,7 @@ import { SplitterType } from 'src/domain/rag/splitters/domain/splitter-type.enum
 import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import type { DocumentProcessingJobData } from '../../application/ports/document-processing.port';
 import { DOCUMENT_PROCESSING_QUEUE } from './document-processing.constants';
+import { isFinalAttempt, wrapIfRetryScheduled } from './bullmq-job.helpers';
 
 @Processor(DOCUMENT_PROCESSING_QUEUE, { concurrency: 2 })
 export class DocumentProcessingConsumer extends WorkerHost {
@@ -73,8 +74,7 @@ export class DocumentProcessingConsumer extends WorkerHost {
           error: error as Error,
         });
 
-        const isLastAttempt = job.attemptsMade >= (job.opts.attempts ?? 3) - 1;
-        if (isLastAttempt) {
+        if (isFinalAttempt(job)) {
           await this.helper.markFailed(
             sourceId,
             error instanceof Error ? error.message : 'Unknown processing error',
@@ -82,7 +82,9 @@ export class DocumentProcessingConsumer extends WorkerHost {
           await this.helper.cleanupIndex(sourceId);
           await this.cleanupMinioFile(minioPath);
         }
-        throw error; // Re-throw so BullMQ handles retries
+        // Re-throw so BullMQ handles retries; non-final attempts are renamed
+        // so AppSignal only opens incidents for final failures.
+        throw wrapIfRetryScheduled(job, error);
       }
     });
   }

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.spec.ts
@@ -1,5 +1,16 @@
 import type { UUID } from 'crypto';
 import type { Job } from 'bullmq';
+
+// p-limit is ESM-only — mock the dynamic import so Jest (CJS) doesn't choke.
+// (Pulled in transitively via UrlCrawlConsumer → CrawlUrlUseCase.)
+jest.mock('p-limit', () => ({
+  __esModule: true,
+  default:
+    () =>
+    <T>(fn: () => T) =>
+      fn(),
+}));
+
 import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
 import { TextType } from 'src/domain/sources/domain/source-type.enum';
 import { UrlSource } from 'src/domain/sources/domain/sources/text-source.entity';
@@ -166,5 +177,26 @@ describe('UrlCrawlConsumer', () => {
 
     await expect(consumer.process(job)).rejects.toThrow('root unreachable');
     expect(indexer.markFailed).toHaveBeenCalled();
+  });
+
+  it('rethrows as JobRetryScheduledError when retries remain, so AppSignal ignores the attempt', async () => {
+    const source = makeSource();
+    sourceRepository.findById.mockResolvedValue(source);
+    crawlUrlUseCase.execute.mockRejectedValueOnce(
+      new Error('root unreachable'),
+    );
+
+    const job = {
+      data: makeJobData(),
+      id: 'job-1',
+      attemptsMade: 0,
+      opts: { attempts: 3 },
+    } as unknown as Job<UrlCrawlJobData>;
+
+    await expect(consumer.process(job)).rejects.toMatchObject({
+      name: 'JobRetryScheduledError',
+      message: 'root unreachable',
+    });
+    expect(indexer.markFailed).not.toHaveBeenCalled();
   });
 });

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.ts
@@ -16,6 +16,7 @@ import { SplitterType } from 'src/domain/rag/splitters/domain/splitter-type.enum
 import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import type { UrlCrawlJobData } from '../../application/ports/url-crawl-processing.port';
 import { URL_CRAWL_QUEUE } from './url-crawl.constants';
+import { isFinalAttempt, wrapIfRetryScheduled } from './bullmq-job.helpers';
 
 @Processor(URL_CRAWL_QUEUE, { concurrency: 2 })
 export class UrlCrawlConsumer extends WorkerHost {
@@ -74,15 +75,16 @@ export class UrlCrawlConsumer extends WorkerHost {
           error: error as Error,
         });
 
-        const isLastAttempt = job.attemptsMade >= (job.opts.attempts ?? 3) - 1;
-        if (isLastAttempt) {
+        if (isFinalAttempt(job)) {
           await this.helper.markFailed(
             sourceId,
             error instanceof Error ? error.message : 'Unknown crawl error',
           );
           await this.helper.cleanupIndex(sourceId);
         }
-        throw error; // Re-throw so BullMQ handles retries
+        // Re-throw so BullMQ handles retries; non-final attempts are renamed
+        // so AppSignal only opens incidents for final failures.
+        throw wrapIfRetryScheduled(job, error);
       }
     });
   }


### PR DESCRIPTION
The BullMQ instrumentation records every failed attempt's exception on
its span, so transient failures that succeed on retry still opened
AppSignal incidents.

- rename errors of attempts that BullMQ will retry to
  JobRetryScheduledError (message/stack/cause preserved, so
  job.failedReason and logs are unchanged) and drop that single name
  agent-side via ignoreErrors
- final attempts rethrow the original error and keep being reported
- share the final-attempt detection in bullmq-job.helpers (replaces the
  duplicated inline expression; UnrecoverableError is never renamed
  since BullMQ matches it by name to abort retries)
- mock ESM-only p-limit in url-crawl.consumer.spec per existing
  convention so the suite runs under CJS jest locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to error naming and AppSignal filtering; BullMQ retry and mark-failed behavior on the last attempt are unchanged, with solid test coverage.
> 
> **Overview**
> Stops **transient BullMQ job failures** from opening AppSignal incidents when a retry is still scheduled. Non-final attempts are rethrown as **`JobRetryScheduledError`** (message, stack, and cause unchanged so logs and `failedReason` stay useful); the agent ignores that name via **`ignoreErrors`**. **Final** attempts still throw the original error so real failures are reported.
> 
> Shared helpers in **`bullmq-job.helpers`**: **`isFinalAttempt`** replaces duplicated inline checks (and treats missing `opts.attempts` as a single run), and **`wrapIfRetryScheduled`** skips renaming **`UnrecoverableError`**. Document and URL crawl consumers adopt both helpers in their catch blocks.
> 
> Adds unit tests for the helpers and consumer retry behavior; **`url-crawl.consumer.spec`** mocks ESM **`p-limit`** so Jest (CJS) can load the suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a7a908c05074fbb0fbfb9dada9819a3a546496c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->