### PR TITLE
fix(observability): treat client stream aborts as expected cancellations (AYC-479)

### DIFF
--- a/ayunis-core-backend/src/domain/models/application/models.errors.ts
+++ b/ayunis-core-backend/src/domain/models/application/models.errors.ts
@@ -12,6 +12,7 @@ export enum ModelErrorCode {
   MODEL_INVALID = 'MODEL_INVALID',
   MODEL_PROVIDER_NOT_SUPPORTED = 'MODEL_PROVIDER_NOT_SUPPORTED',
   INFERENCE_FAILED = 'INFERENCE_FAILED',
+  INFERENCE_ABORTED = 'INFERENCE_ABORTED',
   INFERENCE_INPUT_INVALID = 'INFERENCE_INPUT_INVALID',
   INFERENCE_TIMEOUT = 'INFERENCE_TIMEOUT',
   MODEL_RATE_LIMIT_EXCEEDED = 'MODEL_RATE_LIMIT_EXCEEDED',
@@ -190,6 +191,23 @@ export class InferenceFailedError extends ModelError {
       `Inference failed: ${reason}`,
       ModelErrorCode.INFERENCE_FAILED,
       500,
+      metadata,
+    );
+  }
+}
+
+/**
+ * Client-side cancellation of a streaming inference (aborted fetch or
+ * disconnected SSE consumer). Expected behavior, not a provider failure —
+ * status 499 ("client closed request") keeps it below the error filter's
+ * 5xx reporting threshold so it never opens an AppSignal incident.
+ */
+export class InferenceAbortedError extends ModelError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'Inference aborted by client',
+      ModelErrorCode.INFERENCE_ABORTED,
+      499,
       metadata,
     );
   }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/stream-inference/stream-inference.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/stream-inference/stream-inference.use-case.spec.ts
@@ -1,0 +1,75 @@
+import { firstValueFrom, throwError } from 'rxjs';
+import { StreamInferenceUseCase } from './stream-inference.use-case';
+import { StreamInferenceInput } from '../../ports/stream-inference.handler';
+import {
+  InferenceAbortedError,
+  InferenceFailedError,
+  ModelRateLimitExceededError,
+} from '../../models.errors';
+import type { Model } from 'src/domain/models/domain/model.entity';
+
+const model = {
+  name: 'claude-sonnet-4',
+  provider: 'anthropic',
+} as unknown as Model;
+
+function makeInput(): StreamInferenceInput {
+  return new StreamInferenceInput({
+    model,
+    messages: [],
+    systemPrompt: 'You are a helpful municipal assistant.',
+    orgId: '123e4567-e89b-12d3-a456-426614174000',
+  });
+}
+
+function useCaseWithFailingHandler(error: unknown): StreamInferenceUseCase {
+  const registry = {
+    getHandler: () => ({ answer: () => throwError(() => error) }),
+  };
+  return new StreamInferenceUseCase(registry as never);
+}
+
+describe('StreamInferenceUseCase error mapping', () => {
+  it('maps client-abort DOMExceptions to InferenceAbortedError', async () => {
+    const abort = new DOMException('This operation was aborted', 'AbortError');
+
+    await expect(
+      firstValueFrom(useCaseWithFailingHandler(abort).execute(makeInput())),
+    ).rejects.toBeInstanceOf(InferenceAbortedError);
+  });
+
+  it('marks aborts with a sub-500 status so the error filter treats them as expected', async () => {
+    const abort = new DOMException('This operation was aborted', 'AbortError');
+
+    await expect(
+      firstValueFrom(useCaseWithFailingHandler(abort).execute(makeInput())),
+    ).rejects.toMatchObject({ code: 'INFERENCE_ABORTED', statusCode: 499 });
+  });
+
+  it('maps plain errors named AbortError (non-DOMException SDK aborts) to InferenceAbortedError', async () => {
+    const abort = new Error('Request was aborted.');
+    abort.name = 'AbortError';
+
+    await expect(
+      firstValueFrom(useCaseWithFailingHandler(abort).execute(makeInput())),
+    ).rejects.toBeInstanceOf(InferenceAbortedError);
+  });
+
+  it('still maps other provider failures to InferenceFailedError', async () => {
+    const providerError = new Error('fetch failed: ECONNRESET');
+
+    await expect(
+      firstValueFrom(
+        useCaseWithFailingHandler(providerError).execute(makeInput()),
+      ),
+    ).rejects.toBeInstanceOf(InferenceFailedError);
+  });
+
+  it('passes ApplicationErrors through unchanged', async () => {
+    const rateLimit = new ModelRateLimitExceededError('anthropic');
+
+    await expect(
+      firstValueFrom(useCaseWithFailingHandler(rateLimit).execute(makeInput())),
+    ).rejects.toBe(rateLimit);
+  });
+});

--- a/ayunis-core-backend/src/domain/models/application/use-cases/stream-inference/stream-inference.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/stream-inference/stream-inference.use-case.ts
@@ -7,7 +7,10 @@ import {
 } from '../../ports/stream-inference.handler';
 import { StreamInferenceResponseChunk } from '../../ports/stream-inference.handler';
 import { Model } from 'src/domain/models/domain/model.entity';
-import { InferenceFailedError } from '../../models.errors';
+import {
+  InferenceAbortedError,
+  InferenceFailedError,
+} from '../../models.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { extractUpstreamStatus } from '../../helpers/extract-upstream-status.helper';
 
@@ -39,6 +42,13 @@ export class StreamInferenceUseCase {
     input: StreamInferenceInput,
   ): Error {
     if (error instanceof ApplicationError) return error;
+    if (isAbortError(error)) {
+      this.logger.log('Streaming inference aborted by client', {
+        model: input.model.name,
+        provider: input.model.provider,
+      });
+      return new InferenceAbortedError();
+    }
     const status = extractUpstreamStatus(error);
     this.logger.error('Provider stream inference failed', {
       model: input.model.name,
@@ -55,4 +65,15 @@ export class StreamInferenceUseCase {
   private getHandler(model: Model): StreamInferenceHandler {
     return this.streamInferenceRegistry.getHandler(model.provider);
   }
+}
+
+// Undici fetch aborts surface as DOMException named AbortError; some provider
+// SDKs throw plain Errors with the same name. DOMException is checked
+// separately because it does not reliably pass `instanceof Error` across
+// realms (e.g. under Jest's sandboxed globals).
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof Error || error instanceof DOMException) &&
+    error.name === 'AbortError'
+  );
 }


### PR DESCRIPTION
Client aborts of streaming runs (disconnected SSE consumers, cancelled
fetches) surfaced as raw undici DOMExceptions and were reported to
AppSignal as unexpected errors (incident exceptionName '20' =
DOMException ABORT_ERR, since OTel recordException prefers error.code).

- map AbortError-named errors (DOMException and plain SDK errors) to a
  typed InferenceAbortedError in StreamInferenceUseCase, the single
  choke point all streaming provider errors flow through
- status 499 (client closed request) keeps it under the error filter's
  5xx reporting threshold, and the SSE error frame carries a clean
  INFERENCE_ABORTED code instead of a raw provider failure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to error classification in the stream inference use case; real provider errors unchanged and covered by tests.
> 
> **Overview**
> **Streaming inference** now treats client disconnects and aborted fetches as expected cancellations instead of provider failures.
> 
> `StreamInferenceUseCase` detects `AbortError` (undici `DOMException` and plain SDK errors) and maps them to a new `InferenceAbortedError` with code `INFERENCE_ABORTED` and HTTP **499**, so the global error filter does not report them as 5xx to AppSignal. Real upstream failures still become `InferenceFailedError`. Aborts are logged at info level; provider failures stay at error.
> 
> Unit tests cover abort mapping, status/code, non-abort failures, and passthrough of existing `ApplicationError`s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c816f70c0f742214968136667917653bb19b7fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->