### PR TITLE
fix(threads): return 403 when thread creation uses an unpermitted model (AYC-546)

### DIFF
--- a/ayunis-core-backend/src/domain/threads/application/use-cases/create-thread/create-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/create-thread/create-thread.use-case.spec.ts
@@ -14,6 +14,7 @@ import {
   NoModelProvidedError,
   ThreadCreationError,
 } from '../../threads.errors';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import type { UUID } from 'crypto';
 
 describe('CreateThreadUseCase', () => {
@@ -147,6 +148,23 @@ describe('CreateThreadUseCase', () => {
         NoModelProvidedError,
       );
       expect(getPermittedLanguageModelUseCase.execute).not.toHaveBeenCalled();
+      expect(threadsRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('should propagate UnauthorizedAccessError when the model is not permitted', async () => {
+      // Arrange
+      const command = new CreateThreadCommand({
+        modelId: mockModelId,
+      });
+
+      getPermittedLanguageModelUseCase.execute.mockRejectedValue(
+        new UnauthorizedAccessError(),
+      );
+
+      // Act & Assert
+      await expect(useCase.execute(command)).rejects.toThrow(
+        UnauthorizedAccessError,
+      );
       expect(threadsRepository.create).not.toHaveBeenCalled();
     });
 

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/create-thread/create-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/create-thread/create-thread.use-case.ts
@@ -5,13 +5,13 @@ import { CreateThreadCommand } from './create-thread.command';
 import {
   NoModelProvidedError,
   ThreadCreationError,
-  ThreadError,
+  UnexpecteThreadError,
 } from '../../threads.errors';
 import { GetPermittedLanguageModelUseCase } from 'src/domain/models/application/use-cases/get-permitted-language-model/get-permitted-language-model.use-case';
-import { ModelError } from 'src/domain/models/application/models.errors';
 import { GetPermittedLanguageModelQuery } from 'src/domain/models/application/use-cases/get-permitted-language-model/get-permitted-language-model.query';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import { ContextService } from 'src/common/context/services/context.service';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 
 @Injectable()
 export class CreateThreadUseCase {
@@ -23,57 +23,48 @@ export class CreateThreadUseCase {
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpecteThreadError)
   async execute(command: CreateThreadCommand): Promise<Thread> {
     this.logger.log('execute');
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedException('User not authenticated');
+    }
+
+    const model = await this.resolveModel(command, userId);
+    const isAnonymous = model.anonymousOnly || (command.isAnonymous ?? false);
+
     try {
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-      let model: PermittedLanguageModel | undefined;
-
-      if (command.modelId) {
-        model = await this.getPermittedLanguageModelUseCase.execute(
-          new GetPermittedLanguageModelQuery({
-            id: command.modelId,
-          }),
-        );
-      }
-
-      if (!model) {
-        throw new NoModelProvidedError(userId);
-      }
-
-      const isAnonymous = model.anonymousOnly || (command.isAnonymous ?? false);
-
-      try {
-        const thread = new Thread({
-          userId,
-          model,
-          isAnonymous,
-          messages: [],
-        });
-        const createdThread = await this.threadsRepository.create(thread);
-        return new Thread({
-          ...createdThread,
-        });
-      } catch (error) {
-        this.logger.error('Failed to create thread', {
-          userId,
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
-        throw new ThreadCreationError(error as Error, userId);
-      }
+      const thread = new Thread({
+        userId,
+        model,
+        isAnonymous,
+        messages: [],
+      });
+      const createdThread = await this.threadsRepository.create(thread);
+      return new Thread({
+        ...createdThread,
+      });
     } catch (error) {
-      if (error instanceof ModelError || error instanceof ThreadError) {
-        throw error;
-      }
       this.logger.error('Failed to create thread', {
+        userId,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
-      throw error instanceof Error
-        ? new ThreadCreationError(error)
-        : new ThreadCreationError(new Error('Unknown error'));
+      throw new ThreadCreationError(error as Error, userId);
     }
+  }
+
+  private async resolveModel(
+    command: CreateThreadCommand,
+    userId: string,
+  ): Promise<PermittedLanguageModel> {
+    if (!command.modelId) {
+      throw new NoModelProvidedError(userId);
+    }
+    return this.getPermittedLanguageModelUseCase.execute(
+      new GetPermittedLanguageModelQuery({
+        id: command.modelId,
+      }),
+    );
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authorization on thread creation and changes error-handling paths, but the scope is a single use case with a new regression test.
> 
> **Overview**
> **Thread creation** now surfaces **403** when `GetPermittedLanguageModelUseCase` rejects an unpermitted model, instead of swallowing or mis-mapping that failure.
> 
> `CreateThreadUseCase` is refactored: model resolution moves to **`resolveModel`**, the outer manual `ModelError` / `ThreadError` catch is removed, and **`@HandleUnexpectedErrors(UnexpecteThreadError)`** handles unexpected failures while **`ApplicationError`** types (including **`UnauthorizedAccessError`**) pass through unchanged. Persistence errors are still wrapped in **`ThreadCreationError`** with **`userId`** in logs.
> 
> A spec asserts **`UnauthorizedAccessError`** propagates and **`threadsRepository.create`** is not called when the model is not permitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 182dc2632a98af59ce44c8b93b97ed183be4a526. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->