### PR TITLE
fix(threads): map duplicate source assignment conflict to 409 (AYC-546)

### DIFF
--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.spec.ts
@@ -18,7 +18,10 @@ import { Thread } from 'src/domain/threads/domain/thread.entity';
 import { SourceAssignment } from 'src/domain/threads/domain/thread-source-assignment.entity';
 import { SourceType } from 'src/domain/sources/domain/source-type.enum';
 import { Source } from 'src/domain/sources/domain/source.entity';
-import { SourceAlreadyAssignedError } from '../../threads.errors';
+import {
+  SourceAdditionError,
+  SourceAlreadyAssignedError,
+} from '../../threads.errors';
 
 class ConcreteSource extends Source {
   constructor(params: { id?: UUID; name: string }) {
@@ -168,6 +171,44 @@ describe('AddSourceToThreadUseCase', () => {
       SourceAlreadyAssignedError,
     );
     expect(threadsRepository.updateSourceAssignments).not.toHaveBeenCalled();
+  });
+
+  it('should map a unique-constraint violation from the database to SourceAlreadyAssignedError', async () => {
+    const source = new ConcreteSource({ name: 'Raced.pdf' });
+    const thread = new Thread({
+      userId: mockUserId,
+      messages: [],
+      sourceAssignments: [],
+    });
+    const command = new AddSourceCommand(thread, source);
+
+    threadsRepository.findOne.mockResolvedValue(thread);
+    const dbError = Object.assign(
+      new Error('duplicate key value violates unique constraint'),
+      { driverError: { code: '23505' } },
+    );
+    threadsRepository.updateSourceAssignments.mockRejectedValue(dbError);
+
+    await expect(useCase.execute(command)).rejects.toThrow(
+      SourceAlreadyAssignedError,
+    );
+  });
+
+  it('should wrap other database errors in SourceAdditionError', async () => {
+    const source = new ConcreteSource({ name: 'Broken.pdf' });
+    const thread = new Thread({
+      userId: mockUserId,
+      messages: [],
+      sourceAssignments: [],
+    });
+    const command = new AddSourceCommand(thread, source);
+
+    threadsRepository.findOne.mockResolvedValue(thread);
+    threadsRepository.updateSourceAssignments.mockRejectedValue(
+      new Error('Connection terminated'),
+    );
+
+    await expect(useCase.execute(command)).rejects.toThrow(SourceAdditionError);
   });
 
   it('should detect duplicates from DB even when in-memory thread is stale', async () => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.ts
@@ -12,6 +12,23 @@ import {
 } from '../../threads.errors';
 import { ThreadsConstants } from 'src/domain/threads/domain/threads.constants';
 
+const PG_UNIQUE_VIOLATION = '23505';
+
+// The duplicate check below is check-then-insert and can race with a
+// concurrent add of the same source; the database unique violation is the
+// authoritative signal and must map to the same 409 as the app-level check.
+function isUniqueConstraintViolation(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const record = error as Record<string, unknown>;
+  const driverError = record.driverError as Record<string, unknown> | undefined;
+  return (
+    record.code === PG_UNIQUE_VIOLATION ||
+    driverError?.code === PG_UNIQUE_VIOLATION
+  );
+}
+
 @Injectable()
 export class AddSourceToThreadUseCase {
   private readonly logger = new Logger(AddSourceToThreadUseCase.name);
@@ -46,19 +63,7 @@ export class AddSourceToThreadUseCase {
       }
 
       const currentAssignments = freshThread.sourceAssignments ?? [];
-
-      // Check if source already exists in thread (against DB state)
-      const sourceExists = currentAssignments.some(
-        (assignment) => assignment.source.id === command.source.id,
-      );
-
-      if (sourceExists) {
-        throw new SourceAlreadyAssignedError(command.source.id);
-      }
-
-      if (currentAssignments.length >= ThreadsConstants.MAX_SOURCES) {
-        throw new ThreadSourceLimitExceededError(ThreadsConstants.MAX_SOURCES);
-      }
+      this.assertSourceCanBeAdded(currentAssignments, command.source.id);
 
       const sourceAssignment = new SourceAssignment({
         source: command.source,
@@ -71,11 +76,33 @@ export class AddSourceToThreadUseCase {
         sourceAssignments: updatedAssignments,
       });
     } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('addSource', error);
-      throw new SourceAdditionError(command.thread.id, error as Error);
+      throw this.mapAddSourceError(error, command);
     }
+  }
+
+  private assertSourceCanBeAdded(
+    assignments: SourceAssignment[],
+    sourceId: string,
+  ): void {
+    const sourceExists = assignments.some(
+      (assignment) => assignment.source.id === sourceId,
+    );
+    if (sourceExists) {
+      throw new SourceAlreadyAssignedError(sourceId);
+    }
+    if (assignments.length >= ThreadsConstants.MAX_SOURCES) {
+      throw new ThreadSourceLimitExceededError(ThreadsConstants.MAX_SOURCES);
+    }
+  }
+
+  private mapAddSourceError(error: unknown, command: AddSourceCommand): Error {
+    if (error instanceof ApplicationError) {
+      return error;
+    }
+    if (isUniqueConstraintViolation(error)) {
+      return new SourceAlreadyAssignedError(command.source.id);
+    }
+    this.logger.error('addSource', error);
+    return new SourceAdditionError(command.thread.id, error as Error);
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow change to error mapping and a small refactor in one use case; duplicate detection behavior is unchanged except for concurrent-insert races.
> 
> **Overview**
> **Add source to thread** now treats a PostgreSQL unique-constraint failure (`23505`) the same as an in-app duplicate: it surfaces **`SourceAlreadyAssignedError`** (409) instead of a generic **`SourceAdditionError`**. That closes the race where two concurrent adds pass the check-then-insert path and only the DB enforces uniqueness.
> 
> Validation is extracted into **`assertSourceCanBeAdded`**, and persistence failures go through **`mapAddSourceError`**, which rethrows domain errors, maps `23505` to **`SourceAlreadyAssignedError`**, and wraps everything else in **`SourceAdditionError`**. Specs cover the unique-violation path and non-duplicate DB failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 862f9a97d1ab0bee32723328ac2537eb0f202f19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->