### PR TITLE
fix(retrievers): map mistral ocr client errors to specific domain errors (AYC-538)

### DIFF
--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.spec.ts
@@ -3,9 +3,11 @@ import type { TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { MistralFileRetrieverHandler } from './mistral-file-retriever.handler';
 import {
+  FileRetrievalFailedError,
   FileRetrieverUnexpectedError,
   ServiceBusyError,
   ServiceTimeoutError,
+  TooManyPagesError,
 } from '../../application/file-retriever.errors';
 import { MistralError } from '@mistralai/mistralai/models/errors';
 import { File } from '../../domain/file.entity';
@@ -101,6 +103,18 @@ describe('MistralFileRetrieverHandler', () => {
       mockClient.files.delete.mockResolvedValue(undefined);
     });
 
+    it('should throw ServiceBusyError when Mistral rate limiting persists past retries', async () => {
+      const mistralError = createMistralError(
+        429,
+        '{"message":"Rate limit exceeded"}',
+      );
+      mockClient.ocr.process.mockRejectedValue(mistralError);
+
+      await expect(handler.processFile(testFile)).rejects.toThrow(
+        ServiceBusyError,
+      );
+    });
+
     it('should throw ServiceBusyError when Mistral returns 502', async () => {
       const mistralError = createMistralError(
         502,
@@ -137,12 +151,39 @@ describe('MistralFileRetrieverHandler', () => {
       );
     });
 
-    it('should throw FileRetrieverUnexpectedError for non-transient Mistral errors', async () => {
-      const mistralError = createMistralError(400, '{"message":"Bad request"}');
+    it('should throw TooManyPagesError when Mistral rejects the document for its page count', async () => {
+      const mistralError = createMistralError(
+        400,
+        '{"object":"error","message":"This document has 1486 pages, which is more than the maximum allowed of 1000.","type":"document_parser_too_many_pages","code":"3730"}',
+      );
       mockClient.ocr.process.mockRejectedValue(mistralError);
 
       await expect(handler.processFile(testFile)).rejects.toThrow(
-        FileRetrieverUnexpectedError,
+        TooManyPagesError,
+      );
+    });
+
+    it('should throw FileRetrievalFailedError for other Mistral 400 responses', async () => {
+      const mistralError = createMistralError(
+        400,
+        '{"object":"error","message":"File could not be fetched from url","type":"invalid_request_file","code":"3310"}',
+      );
+      mockClient.ocr.process.mockRejectedValue(mistralError);
+
+      await expect(handler.processFile(testFile)).rejects.toThrow(
+        FileRetrievalFailedError,
+      );
+    });
+
+    it('should throw FileRetrievalFailedError when Mistral cannot find the uploaded file', async () => {
+      const mistralError = createMistralError(
+        404,
+        '{"detail":"File not found"}',
+      );
+      mockClient.files.getSignedUrl.mockRejectedValue(mistralError);
+
+      await expect(handler.processFile(testFile)).rejects.toThrow(
+        FileRetrievalFailedError,
       );
     });
 

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.ts
@@ -6,9 +6,11 @@ import {
 } from '../../domain/file-retriever-result.entity';
 import {
   FileRetrievalFailedError,
+  FileRetrieverError,
   FileRetrieverUnexpectedError,
   ServiceBusyError,
   ServiceTimeoutError,
+  TooManyPagesError,
 } from '../../application/file-retriever.errors';
 import { MistralError } from '@mistralai/mistralai/models/errors';
 import { Mistral } from '@mistralai/mistralai';
@@ -62,16 +64,40 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
       const metadata = { model: this.MODEL_NAME };
 
       if (error instanceof MistralError) {
-        if (error.statusCode === 502 || error.statusCode === 503) {
-          throw new ServiceBusyError(metadata);
-        }
-        if (error.statusCode === 504) {
-          throw new ServiceTimeoutError(metadata);
-        }
+        throw this.mapMistralError(error, metadata);
       }
 
       throw new FileRetrieverUnexpectedError(error as Error, metadata);
     }
+  }
+
+  private mapMistralError(
+    error: MistralError,
+    metadata: { model: string },
+  ): FileRetrieverError {
+    // 429 lands here only after the transient-error retries are exhausted —
+    // persistent rate limiting is "busy, try again later", not a failed
+    // retrieval.
+    if (
+      error.statusCode === 429 ||
+      error.statusCode === 502 ||
+      error.statusCode === 503
+    ) {
+      return new ServiceBusyError(metadata);
+    }
+    if (error.statusCode === 504) {
+      return new ServiceTimeoutError(metadata);
+    }
+    if (
+      typeof error.body === 'string' &&
+      error.body.includes('document_parser_too_many_pages')
+    ) {
+      return new TooManyPagesError(metadata);
+    }
+    if (error.statusCode >= 400 && error.statusCode < 500) {
+      return new FileRetrievalFailedError(error.message, metadata);
+    }
+    return new FileRetrieverUnexpectedError(error, metadata);
   }
 
   private async uploadFile(fileBlob: Blob): Promise<string> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped to Mistral adapter error translation and tests; no auth, data, or API contract changes beyond clearer failure types for upstream OCR errors.
> 
> **Overview**
> **Mistral file retriever error mapping** is centralized in a new `mapMistralError` helper instead of inline status checks in `processFile`.
> 
> After retries are exhausted, **429** is treated like **502/503** as `ServiceBusyError`. Mistral’s **`document_parser_too_many_pages`** response maps to **`TooManyPagesError`**. Other **4xx** (e.g. invalid file, **404** on signed URL) map to **`FileRetrievalFailedError`** rather than a generic unexpected error; remaining Mistral errors still become **`FileRetrieverUnexpectedError`**.
> 
> Unit tests cover rate limiting, page-limit rejection, other 400s, and file-not-found on signed URL retrieval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bedd6d0aaa1e446f46eb47fe438dca0aeffaf94f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->