### PR TITLE
fix(retrievers): run mistral ocr by file id to avoid signed-url races (AYC-538)

### DIFF
--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.spec.ts
@@ -26,10 +26,26 @@ jest.mock('@mistralai/mistralai', () => ({
   })),
 }));
 
-// Mock retryWithBackoff to execute fn directly (no retries in tests)
+// Mock retryWithBackoff with single-retry semantics so tests can assert
+// which errors the call sites treat as retryable
 jest.mock('src/common/util/retryWithBackoff', () => ({
   __esModule: true,
-  default: ({ fn }: { fn: () => Promise<unknown> }) => fn(),
+  default: async ({
+    fn,
+    retryIfError,
+  }: {
+    fn: () => Promise<unknown>;
+    retryIfError?: (error: Error) => boolean;
+  }) => {
+    try {
+      return await fn();
+    } catch (error) {
+      if (retryIfError?.(error as Error)) {
+        return fn();
+      }
+      throw error;
+    }
+  },
 }));
 
 function createMistralError(statusCode: number, body: string): MistralError {
@@ -93,13 +109,63 @@ describe('MistralFileRetrieverHandler', () => {
     });
   });
 
+  describe('OCR flow', () => {
+    beforeEach(() => {
+      mockClient.files.upload.mockResolvedValue({ id: 'file-123' });
+      mockClient.files.delete.mockResolvedValue(undefined);
+    });
+
+    it('should run OCR by file id without requesting a signed URL', async () => {
+      mockClient.ocr.process.mockResolvedValue({
+        pages: [{ markdown: '# Content', index: 0 }],
+      });
+
+      const result = await handler.processFile(testFile);
+
+      expect(mockClient.ocr.process).toHaveBeenCalledWith(
+        expect.objectContaining({
+          document: { type: 'file', fileId: 'file-123' },
+        }),
+      );
+      expect(mockClient.files.getSignedUrl).not.toHaveBeenCalled();
+      expect(result.pages).toHaveLength(1);
+    });
+
+    it('should retry when OCR cannot see the just-uploaded file yet', async () => {
+      const notVisibleYet = createMistralError(
+        404,
+        '{"detail":"File not found"}',
+      );
+      mockClient.ocr.process
+        .mockRejectedValueOnce(notVisibleYet)
+        .mockResolvedValueOnce({
+          pages: [{ markdown: '# Content', index: 0 }],
+        });
+
+      const result = await handler.processFile(testFile);
+
+      expect(mockClient.ocr.process).toHaveBeenCalledTimes(2);
+      expect(result.pages).toHaveLength(1);
+    });
+
+    it('should not retry client errors like too many pages', async () => {
+      const tooManyPages = createMistralError(
+        400,
+        '{"type":"document_parser_too_many_pages"}',
+      );
+      mockClient.ocr.process.mockRejectedValue(tooManyPages);
+
+      await expect(handler.processFile(testFile)).rejects.toThrow(
+        TooManyPagesError,
+      );
+      expect(mockClient.ocr.process).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('transient upstream error handling', () => {
     beforeEach(() => {
-      // Setup upload and signedUrl to succeed — error on OCR process
+      // Setup upload to succeed — error on OCR process
       mockClient.files.upload.mockResolvedValue({ id: 'file-123' });
-      mockClient.files.getSignedUrl.mockResolvedValue({
-        url: 'https://signed.url',
-      });
       mockClient.files.delete.mockResolvedValue(undefined);
     });
 
@@ -175,12 +241,12 @@ describe('MistralFileRetrieverHandler', () => {
       );
     });
 
-    it('should throw FileRetrievalFailedError when Mistral cannot find the uploaded file', async () => {
+    it('should throw FileRetrievalFailedError when the file stays invisible to OCR after retries', async () => {
       const mistralError = createMistralError(
         404,
         '{"detail":"File not found"}',
       );
-      mockClient.files.getSignedUrl.mockRejectedValue(mistralError);
+      mockClient.ocr.process.mockRejectedValue(mistralError);
 
       await expect(handler.processFile(testFile)).rejects.toThrow(
         FileRetrievalFailedError,

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.ts
@@ -20,6 +20,16 @@ import { isTransientMistralError } from 'src/common/util/mistral-transient-error
 import { File } from '../../domain/file.entity';
 import { ConfigService } from '@nestjs/config';
 
+// A 404 from OCR right after a successful upload is files-API eventual
+// consistency, not a missing file — retry it alongside the shared transient
+// set. Other 4xx (e.g. too many pages) stay fatal.
+function isTransientOcrError(error: Error): boolean {
+  return (
+    isTransientMistralError(error) ||
+    (error instanceof MistralError && error.statusCode === 404)
+  );
+}
+
 @Injectable()
 export class MistralFileRetrieverHandler extends FileRetrieverHandler {
   private readonly logger = new Logger(MistralFileRetrieverHandler.name);
@@ -120,36 +130,21 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
     return uploaded.id;
   }
 
-  /** Fetches the signed URL and runs OCR; deletes the uploaded file on failure. */
+  /** Runs OCR on the uploaded file by id; deletes the uploaded file on failure. */
   private async runOcr(fileId: string): Promise<OCRResponse> {
-    const signedUrl = await retryWithBackoff({
-      fn: () => this.client.files.getSignedUrl({ fileId }),
-      maxRetries: 3,
-      delay: 1000,
-      retryIfError: isTransientMistralError,
-    }).catch(async (error) => {
-      this.logger.error(
-        `Mistral OCR signed URL retrieval failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        error instanceof Error ? error.stack : 'Unknown error',
-      );
-      await this.client.files.delete({ fileId }).catch(() => undefined);
-      throw error;
-    });
-
-    this.logger.debug('signed URL', { signedUrl });
     return retryWithBackoff({
       fn: () =>
         this.client.ocr.process({
           model: this.MODEL_NAME,
           document: {
-            type: 'document_url',
-            documentUrl: signedUrl.url,
+            type: 'file',
+            fileId,
           },
           includeImageBase64: true,
         }),
       maxRetries: 3,
       delay: 1000,
-      retryIfError: isTransientMistralError,
+      retryIfError: isTransientOcrError,
     }).catch(async (error) => {
       this.logger.error(
         `Mistral OCR processing failed: ${error instanceof Error ? error.message : 'Unknown error'}`,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the core Mistral OCR integration path and retry behavior for 404s; misclassification could mask real failures or add extra OCR attempts.
> 
> **Overview**
> **Mistral file retrieval** no longer fetches a signed URL before OCR. After upload, `ocr.process` is called with `document: { type: 'file', fileId }`, which removes an extra API hop and avoids races where OCR could not fetch the document from a freshly issued URL.
> 
> OCR retries now treat **404 "file not found"** as transient (via `isTransientOcrError`), on the assumption that the file may not be visible to OCR immediately after upload. Other client errors (e.g. too many pages) are still not retried. Failure cleanup still deletes the uploaded file when OCR exhausts retries.
> 
> Tests were updated: the `retryWithBackoff` mock can exercise `retryIfError`, plus new cases for file-id OCR, 404 retry, and non-retryable 400s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4447aba70aa74eb32b9289889583409514c1c6f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->