### PR TITLE
fix(sources): reject pdfs over the ocr page cap before processing (AYC-538)

### DIFF
--- a/ayunis-core-backend/.env.example
+++ b/ayunis-core-backend/.env.example
@@ -128,6 +128,10 @@ SUBSCRIPTIONS_PRICE_PER_SEAT_YEARLY=
 # Not relevant for self hosters
 TRIAL_MAX_MESSAGES=
 
+# Max PDF page count accepted for document processing.
+# Defaults to 1000 (the Mistral OCR hard limit).
+PROCESSING_MAX_PDF_PAGES=
+
 # Model Providers (at least one required!)
 
 ## Mistral API

--- a/ayunis-core-backend/src/config/retrieval.config.ts
+++ b/ayunis-core-backend/src/config/retrieval.config.ts
@@ -4,20 +4,17 @@ export interface RetrievalConfig {
   mistral: {
     apiKey: string | undefined;
   };
-  chatUploadMaxPdfPages: number;
-  chatUploadMaxFileSizeMb: number;
+  processingMaxPdfPages: number;
 }
 
 export default registerAs('retrieval', (): RetrievalConfig => ({
   mistral: {
     apiKey: process.env.MISTRAL_API_KEY,
   },
-  chatUploadMaxPdfPages: parseInt(
-    process.env.CHAT_UPLOAD_MAX_PDF_PAGES || '50',
-    10,
-  ),
-  chatUploadMaxFileSizeMb: parseInt(
-    process.env.CHAT_UPLOAD_MAX_FILE_SIZE_MB || '5',
+  // Mistral OCR rejects documents above 1000 pages — enforce the cap
+  // before upload so oversized documents fail fast with a clear error.
+  processingMaxPdfPages: parseInt(
+    process.env.PROCESSING_MAX_PDF_PAGES || '1000',
     10,
   ),
 }));

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/file-retriever.errors.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/file-retriever.errors.ts
@@ -21,7 +21,6 @@ export enum FileRetrieverErrorCode {
   INVALID_FILE_TYPE = 'INVALID_FILE_TYPE',
   FILE_TOO_LARGE = 'FILE_TOO_LARGE',
   TOO_MANY_PAGES = 'TOO_MANY_PAGES',
-  DOCUMENT_TOO_LARGE_FOR_CHAT = 'DOCUMENT_TOO_LARGE_FOR_CHAT',
   SERVICE_BUSY = 'SERVICE_BUSY',
   SERVICE_TIMEOUT = 'SERVICE_TIMEOUT',
   UNAUTHORIZED = 'UNAUTHORIZED',
@@ -122,9 +121,13 @@ export class FileTooLargeError extends FileRetrieverError {
 }
 
 export class TooManyPagesError extends FileRetrieverError {
-  constructor(metadata?: ErrorMetadata) {
+  constructor(
+    metadata?: ErrorMetadata & { pageCount?: number; maxPages?: number },
+  ) {
     super(
-      'Document rejected by preflight check (too many pages)',
+      metadata?.pageCount && metadata.maxPages
+        ? `This document has ${metadata.pageCount} pages; the maximum is ${metadata.maxPages}.`
+        : 'This document has too many pages to be processed.',
       FileRetrieverErrorCode.TOO_MANY_PAGES,
       422,
       metadata,
@@ -160,17 +163,6 @@ export class FileRetrieverUnauthorizedError extends FileRetrieverError {
       'Invalid or missing API key for document processing service',
       FileRetrieverErrorCode.UNAUTHORIZED,
       401,
-      metadata,
-    );
-  }
-}
-
-export class DocumentTooLargeForChatError extends FileRetrieverError {
-  constructor(metadata?: ErrorMetadata) {
-    super(
-      'This document is too large to process in a chat. Please add it to a knowledge base instead.',
-      FileRetrieverErrorCode.DOCUMENT_TOO_LARGE_FOR_CHAT,
-      422,
       metadata,
     );
   }

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/preflight-check/preflight-check.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/preflight-check/preflight-check.use-case.spec.ts
@@ -2,7 +2,7 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { PreflightCheckUseCase } from './preflight-check.use-case';
 import { PreflightCheckCommand } from './preflight-check.command';
-import { DocumentTooLargeForChatError } from '../../file-retriever.errors';
+import { TooManyPagesError } from '../../file-retriever.errors';
 import retrievalConfig from 'src/config/retrieval.config';
 
 // Mock pdf-parse to control page count without needing real PDFs
@@ -19,8 +19,7 @@ describe('PreflightCheckUseCase', () => {
 
   const defaultConfig = {
     mistral: { apiKey: undefined },
-    chatUploadMaxPdfPages: 50,
-    chatUploadMaxFileSizeMb: 5,
+    processingMaxPdfPages: 1000,
   };
 
   beforeAll(async () => {
@@ -41,11 +40,11 @@ describe('PreflightCheckUseCase', () => {
     jest.clearAllMocks();
   });
 
-  describe('PDF preflight', () => {
-    it('should allow a PDF with fewer pages than the limit', async () => {
+  describe('PDF page cap', () => {
+    it('should allow a PDF within the page cap', async () => {
       mockedPdfParse.mockResolvedValueOnce({
-        numpages: 10,
-        numrender: 10,
+        numpages: 999,
+        numrender: 999,
         info: {},
         metadata: null,
         version: 'default',
@@ -56,17 +55,17 @@ describe('PreflightCheckUseCase', () => {
         useCase.execute(
           new PreflightCheckCommand({
             fileData: Buffer.from('fake-pdf-data'),
-            fileName: 'small-document.pdf',
+            fileName: 'large-but-ok.pdf',
             fileType: 'application/pdf',
           }),
         ),
       ).resolves.toBeUndefined();
     });
 
-    it('should reject a PDF exceeding the page limit', async () => {
+    it('should reject a PDF exceeding the page cap with page counts in the error', async () => {
       mockedPdfParse.mockResolvedValueOnce({
-        numpages: 120,
-        numrender: 120,
+        numpages: 1486,
+        numrender: 1486,
         info: {},
         metadata: null,
         version: 'default',
@@ -81,7 +80,7 @@ describe('PreflightCheckUseCase', () => {
             fileType: 'application/pdf',
           }),
         ),
-      ).rejects.toThrow(DocumentTooLargeForChatError);
+      ).rejects.toThrow(TooManyPagesError);
     });
 
     it('should allow the PDF through if pdf-parse fails to read metadata', async () => {
@@ -99,54 +98,22 @@ describe('PreflightCheckUseCase', () => {
     });
   });
 
-  describe('DOCX/PPTX file size preflight', () => {
-    it('should allow a DOCX file under the size limit', async () => {
-      const smallFile = Buffer.alloc(1 * 1024 * 1024); // 1MB
-
+  describe('file types without preflight', () => {
+    it('should pass through DOCX files without any checks', async () => {
       await expect(
         useCase.execute(
           new PreflightCheckCommand({
-            fileData: smallFile,
-            fileName: 'report.docx',
-            fileType:
-              'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-          }),
-        ),
-      ).resolves.toBeUndefined();
-    });
-
-    it('should reject a DOCX file exceeding the size limit', async () => {
-      const largeFile = Buffer.alloc(10 * 1024 * 1024); // 10MB > 5MB limit
-
-      await expect(
-        useCase.execute(
-          new PreflightCheckCommand({
-            fileData: largeFile,
+            fileData: Buffer.alloc(10 * 1024 * 1024),
             fileName: 'huge-report.docx',
             fileType:
               'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
           }),
         ),
-      ).rejects.toThrow(DocumentTooLargeForChatError);
+      ).resolves.toBeUndefined();
+
+      expect(mockedPdfParse).not.toHaveBeenCalled();
     });
 
-    it('should reject a PPTX file exceeding the size limit', async () => {
-      const largeFile = Buffer.alloc(8 * 1024 * 1024); // 8MB > 5MB limit
-
-      await expect(
-        useCase.execute(
-          new PreflightCheckCommand({
-            fileData: largeFile,
-            fileName: 'large-presentation.pptx',
-            fileType:
-              'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-          }),
-        ),
-      ).rejects.toThrow(DocumentTooLargeForChatError);
-    });
-  });
-
-  describe('file types without preflight', () => {
     it('should pass through TXT files without any checks', async () => {
       await expect(
         useCase.execute(
@@ -159,18 +126,6 @@ describe('PreflightCheckUseCase', () => {
       ).resolves.toBeUndefined();
 
       expect(mockedPdfParse).not.toHaveBeenCalled();
-    });
-
-    it('should pass through CSV files without any checks', async () => {
-      await expect(
-        useCase.execute(
-          new PreflightCheckCommand({
-            fileData: Buffer.from('header1,header2\nval1,val2'),
-            fileName: 'data.csv',
-            fileType: 'text/csv',
-          }),
-        ),
-      ).resolves.toBeUndefined();
     });
   });
 });

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/preflight-check/preflight-check.use-case.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/preflight-check/preflight-check.use-case.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import { PreflightCheckCommand } from './preflight-check.command';
-import { DocumentTooLargeForChatError } from '../../file-retriever.errors';
+import { TooManyPagesError } from '../../file-retriever.errors';
 import { detectFileType } from 'src/common/util/file-type';
 import retrievalConfig from 'src/config/retrieval.config';
 import PdfParse from 'pdf-parse';
@@ -20,63 +20,40 @@ export class PreflightCheckUseCase {
 
     if (fileType === 'pdf') {
       await this.checkPdfPageCount(command.fileData, command.fileName);
-    } else if (fileType === 'docx' || fileType === 'pptx') {
-      this.checkFileSize(command.fileData, command.fileName);
     }
-
-    // TXT, MD, CSV, XLSX — always fast, no preflight needed
+    // Other types are either cheap to process or converted to PDF later —
+    // the OCR page cap on direct PDF uploads is the only provider-imposed
+    // hard limit we can check upfront.
   }
 
   private async checkPdfPageCount(
     fileData: Buffer,
     fileName: string,
   ): Promise<void> {
-    const maxPages = this.config.chatUploadMaxPdfPages;
+    const maxPages = this.config.processingMaxPdfPages;
 
+    let pageCount: number;
     try {
       // pdf-parse reads metadata including page count without full text extraction
       const pdf = await PdfParse(fileData, {
         // Only read first page to get metadata quickly
         max: 1,
       });
-      const pageCount = pdf.numpages;
-
-      if (pageCount > maxPages) {
-        this.logger.warn(
-          `PDF "${fileName}" has ${pageCount} pages (max: ${maxPages})`,
-        );
-        throw new DocumentTooLargeForChatError({
-          fileName,
-          pageCount,
-          maxPages,
-        });
-      }
+      pageCount = pdf.numpages;
     } catch (error) {
-      if (error instanceof DocumentTooLargeForChatError) {
-        throw error;
-      }
       // If pdf-parse fails to read metadata, let it through — the actual
       // processing step will handle or fail on the content itself
       this.logger.warn(
         `Could not read PDF metadata for preflight: ${(error as Error).message}`,
       );
+      return;
     }
-  }
 
-  private checkFileSize(fileData: Buffer, fileName: string): void {
-    const maxSizeMb = this.config.chatUploadMaxFileSizeMb;
-    const maxSizeBytes = maxSizeMb * 1024 * 1024;
-    const fileSize = Buffer.byteLength(fileData);
-
-    if (fileSize > maxSizeBytes) {
+    if (pageCount > maxPages) {
       this.logger.warn(
-        `File "${fileName}" is ${(fileSize / (1024 * 1024)).toFixed(1)}MB (max: ${maxSizeMb}MB)`,
+        `PDF "${fileName}" has ${pageCount} pages (max: ${maxPages})`,
       );
-      throw new DocumentTooLargeForChatError({
-        fileName,
-        fileSizeMb: Math.ceil(fileSize / (1024 * 1024)),
-        maxSizeMb,
-      });
+      throw new TooManyPagesError({ fileName, pageCount, maxPages });
     }
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case.spec.ts
@@ -10,6 +10,8 @@ import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/up
 import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
 import { GetPermittedEmbeddingModelUseCase } from 'src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case';
 import { PermittedEmbeddingModelNotFoundForOrgError } from 'src/domain/models/application/models.errors';
+import { PreflightCheckUseCase } from 'src/domain/retrievers/file-retrievers/application/use-cases/preflight-check/preflight-check.use-case';
+import { TooManyPagesError } from 'src/domain/retrievers/file-retrievers/application/file-retriever.errors';
 import { ContextService } from 'src/common/context/services/context.service';
 import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
 import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
@@ -23,6 +25,7 @@ describe('StartDocumentProcessingUseCase', () => {
   let mockDeleteObjectUseCase: jest.Mocked<DeleteObjectUseCase>;
   let mockEnqueueDocumentProcessingUseCase: jest.Mocked<EnqueueDocumentProcessingUseCase>;
   let mockGetPermittedEmbeddingModelUseCase: jest.Mocked<GetPermittedEmbeddingModelUseCase>;
+  let mockPreflightCheckUseCase: jest.Mocked<PreflightCheckUseCase>;
   let mockContextService: jest.Mocked<ContextService>;
 
   const userId = '11111111-1111-1111-1111-111111111111' as UUID;
@@ -65,6 +68,10 @@ describe('StartDocumentProcessingUseCase', () => {
       execute: jest.fn().mockResolvedValue({}),
     } as unknown as jest.Mocked<GetPermittedEmbeddingModelUseCase>;
 
+    mockPreflightCheckUseCase = {
+      execute: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<PreflightCheckUseCase>;
+
     mockContextService = {
       get: jest.fn().mockImplementation((key: string) => {
         if (key === 'orgId') return orgId;
@@ -97,6 +104,10 @@ describe('StartDocumentProcessingUseCase', () => {
         {
           provide: GetPermittedEmbeddingModelUseCase,
           useValue: mockGetPermittedEmbeddingModelUseCase,
+        },
+        {
+          provide: PreflightCheckUseCase,
+          useValue: mockPreflightCheckUseCase,
         },
         { provide: ContextService, useValue: mockContextService },
       ],
@@ -185,6 +196,24 @@ describe('StartDocumentProcessingUseCase', () => {
 
     // MinIO file should be cleaned up
     expect(mockDeleteObjectUseCase.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject before creating a source when the preflight check fails', async () => {
+    mockPreflightCheckUseCase.execute.mockRejectedValue(
+      new TooManyPagesError({ pageCount: 1486, maxPages: 1000 }),
+    );
+
+    const command = new StartDocumentProcessingCommand({
+      fileData: Buffer.from('fake pdf content'),
+      fileName: 'Haushaltsplan.pdf',
+      fileType: 'application/pdf',
+    });
+
+    await expect(useCase.execute(command)).rejects.toThrow(TooManyPagesError);
+
+    expect(mockCreateProcessingSourceUseCase.execute).not.toHaveBeenCalled();
+    expect(mockUploadObjectUseCase.execute).not.toHaveBeenCalled();
+    expect(mockEnqueueDocumentProcessingUseCase.execute).not.toHaveBeenCalled();
   });
 
   it('should reject before creating a source when the org has no permitted embedding model', async () => {

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case.ts
@@ -16,6 +16,8 @@ import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/de
 import { DeleteObjectCommand } from 'src/domain/storage/application/use-cases/delete-object/delete-object.command';
 import { GetPermittedEmbeddingModelUseCase } from 'src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case';
 import { GetPermittedEmbeddingModelQuery } from 'src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.query';
+import { PreflightCheckUseCase } from 'src/domain/retrievers/file-retrievers/application/use-cases/preflight-check/preflight-check.use-case';
+import { PreflightCheckCommand } from 'src/domain/retrievers/file-retrievers/application/use-cases/preflight-check/preflight-check.command';
 import { UnexpectedSourceError } from '../../sources.errors';
 import { StartDocumentProcessingCommand } from './start-document-processing.command';
 
@@ -30,6 +32,7 @@ export class StartDocumentProcessingUseCase {
     private readonly deleteObjectUseCase: DeleteObjectUseCase,
     private readonly enqueueDocumentProcessingUseCase: EnqueueDocumentProcessingUseCase,
     private readonly getPermittedEmbeddingModelUseCase: GetPermittedEmbeddingModelUseCase,
+    private readonly preflightCheckUseCase: PreflightCheckUseCase,
     private readonly contextService: ContextService,
   ) {}
 
@@ -53,6 +56,16 @@ export class StartDocumentProcessingUseCase {
       // fails fast with a clear error instead of a doomed processing job.
       await this.getPermittedEmbeddingModelUseCase.execute(
         new GetPermittedEmbeddingModelQuery({ orgId }),
+      );
+
+      // OCR would reject an oversized PDF only after the upload round trip —
+      // check the page cap here so it fails before any processing starts.
+      await this.preflightCheckUseCase.execute(
+        new PreflightCheckCommand({
+          fileData: command.fileData,
+          fileName: command.fileName,
+          fileType: command.fileType,
+        }),
       );
 
       const savedSource = await this.createProcessingSourceUseCase.execute(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes validation limits and error types on the document ingestion path; deployments using old env vars need `PROCESSING_MAX_PDF_PAGES`, and large Office uploads are no longer rejected at preflight.
> 
> **Overview**
> **Document processing** now enforces a single configurable PDF page limit (`PROCESSING_MAX_PDF_PAGES`, default **1000** to match Mistral OCR) instead of the old chat-oriented settings (50 pages / 5 MB for Office files). Chat-specific `DocumentTooLargeForChatError` is removed; oversize PDFs raise **`TooManyPagesError`** with explicit page count and max in the message.
> 
> **Preflight** is narrowed to PDF page metadata only—DOCX/PPTX size checks are dropped—and **`StartDocumentProcessingUseCase`** runs that preflight **before** creating a source, uploading to storage, or enqueueing work, so oversized PDFs fail immediately without side effects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05191de393efeacae4fc8e4651cc18526afa90c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->