### PR TITLE
fix(observability): stop reporting handled crawler socket errors as incidents (AYC-538)

### DIFF
--- a/ayunis-core-backend/appsignal-hooks.cjs
+++ b/ayunis-core-backend/appsignal-hooks.cjs
@@ -1,0 +1,49 @@
+// Hooks for the AppSignal OpenTelemetry setup in appsignal.cjs. Kept
+// dependency-free (no dotenv, no @appsignal import) so tests can load this
+// file without booting the AppSignal client.
+
+// Must match the User-Agent the URL crawler sends
+// (cheerio.url-retriever.ts) — it is the key that scopes the undici
+// ignore hook to crawler traffic.
+const CRAWLER_USER_AGENT = 'Ayunis/1.0';
+
+/**
+ * Identifies outbound requests made by the URL crawler / website-content
+ * tool. Their failures against arbitrary user-supplied hosts (dead domains,
+ * unreachable intranet IPs, slow servers) are caught and surfaced as domain
+ * errors by the retriever, so the undici instrumentation must not record the
+ * raw socket errors as AppSignal incidents (AYC-538). Requests to model/OCR
+ * providers do not carry this User-Agent and stay fully instrumented.
+ */
+function isCrawlerRequest(request) {
+  return headerValue(request.headers, 'user-agent') === CRAWLER_USER_AGENT;
+}
+
+// Undici request headers are either a raw `name: value\r\n` string (undici
+// v5) or a flat [name, value, ...] array whose values may be string arrays
+// (undici v6).
+function headerValue(headers, name) {
+  if (typeof headers === 'string') {
+    for (const line of headers.split('\r\n')) {
+      const separatorIndex = line.indexOf(':');
+      if (
+        separatorIndex !== -1 &&
+        line.slice(0, separatorIndex).trim().toLowerCase() === name
+      ) {
+        return line.slice(separatorIndex + 1).trim();
+      }
+    }
+    return undefined;
+  }
+  if (Array.isArray(headers)) {
+    for (let i = 0; i + 1 < headers.length; i += 2) {
+      if (String(headers[i]).toLowerCase() === name) {
+        const value = headers[i + 1];
+        return String(Array.isArray(value) ? value[0] : value);
+      }
+    }
+  }
+  return undefined;
+}
+
+module.exports = { isCrawlerRequest, CRAWLER_USER_AGENT };

--- a/ayunis-core-backend/appsignal.cjs
+++ b/ayunis-core-backend/appsignal.cjs
@@ -3,8 +3,12 @@
 // patches http/express/pg before any application module is required.
 const { config } = require('dotenv');
 const { Appsignal } = require('@appsignal/nodejs');
+const {
+  UndiciInstrumentation,
+} = require('@opentelemetry/instrumentation-undici');
 const { readFileSync } = require('fs');
 const { join } = require('path');
+const { isCrawlerRequest } = require('./appsignal-hooks.cjs');
 
 // This file runs before main.ts imports src/config/env, so load the same
 // .env files here (dotenv never overwrites variables already set, so the
@@ -52,6 +56,25 @@ if (pushApiKey && environment !== 'development') {
     // spans and route-based action names.
     disableDefaultInstrumentations: [
       '@opentelemetry/instrumentation-nestjs-core',
+      // Replaced by the configured instance below.
+      '@opentelemetry/instrumentation-undici',
+    ],
+    // The undici instrumentation records raw socket errors (ENOTFOUND,
+    // EAI_AGAIN, connect/body timeouts, aborts) on outbound-request spans
+    // even when application code catches and handles them. Crawler fetches
+    // target arbitrary user-supplied URLs whose failures are expected and
+    // already surface as domain errors, so those requests are not
+    // instrumented at all. Requests to model/OCR providers don't carry the
+    // crawler User-Agent and stay fully instrumented — genuine inference
+    // errors must keep reporting.
+    additionalInstrumentations: [
+      new UndiciInstrumentation({
+        // AppSignal's default for its own undici instrumentation — without
+        // it, fire-and-forget fetches outside any request context create
+        // orphan root spans.
+        requireParentforSpans: true,
+        ignoreRequestHook: isCrawlerRequest,
+      }),
     ],
     // Queue consumers rename job failures that BullMQ will retry to this
     // error (see bullmq-job.helpers.ts), so only final failures — thrown

--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -73,6 +73,7 @@
     "@nestjs/serve-static": "^5.0.3",
     "@nestjs/swagger": "^11.4.5",
     "@nestjs/typeorm": "^11.0.3",
+    "@opentelemetry/instrumentation-undici": "^0.23.0",
     "@willsoto/nestjs-prometheus": "^6.0.2",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",

--- a/ayunis-core-backend/src/common/util/appsignal-hooks.spec.ts
+++ b/ayunis-core-backend/src/common/util/appsignal-hooks.spec.ts
@@ -1,0 +1,67 @@
+// appsignal-hooks.cjs is a plain CJS module loaded by appsignal.cjs before
+// the app boots; require() mirrors how it is consumed there.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const hooks = require('../../../appsignal-hooks.cjs') as {
+  isCrawlerRequest: (request: {
+    headers: string | (string | string[])[];
+  }) => boolean;
+  CRAWLER_USER_AGENT: string;
+};
+
+const { isCrawlerRequest, CRAWLER_USER_AGENT } = hooks;
+
+describe('isCrawlerRequest', () => {
+  describe('undici v6 array headers', () => {
+    it('matches a request carrying the crawler user agent', () => {
+      expect(
+        isCrawlerRequest({
+          headers: ['accept', 'text/html', 'User-Agent', CRAWLER_USER_AGENT],
+        }),
+      ).toBe(true);
+    });
+
+    it('matches case-insensitively on the header name', () => {
+      expect(
+        isCrawlerRequest({ headers: ['user-agent', CRAWLER_USER_AGENT] }),
+      ).toBe(true);
+    });
+
+    it('handles array-valued headers', () => {
+      expect(
+        isCrawlerRequest({ headers: ['user-agent', [CRAWLER_USER_AGENT]] }),
+      ).toBe(true);
+    });
+
+    it('does not match a different user agent', () => {
+      expect(
+        isCrawlerRequest({ headers: ['user-agent', 'node-fetch/3.0'] }),
+      ).toBe(false);
+    });
+
+    it('does not match when no user agent header is present', () => {
+      expect(isCrawlerRequest({ headers: ['accept', 'text/html'] })).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('undici v5 string headers', () => {
+    it('matches a request carrying the crawler user agent', () => {
+      expect(
+        isCrawlerRequest({
+          headers: `accept: text/html\r\nUser-Agent: ${CRAWLER_USER_AGENT}\r\n`,
+        }),
+      ).toBe(true);
+    });
+
+    it('does not match a different user agent', () => {
+      expect(
+        isCrawlerRequest({ headers: 'User-Agent: curl/8.0\r\n' }),
+      ).toBe(false);
+    });
+
+    it('does not match an empty header string', () => {
+      expect(isCrawlerRequest({ headers: '' })).toBe(false);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/retrievers/url-retrievers/infrastructure/cheerio.url-retriever.ts
+++ b/ayunis-core-backend/src/domain/retrievers/url-retrievers/infrastructure/cheerio.url-retriever.ts
@@ -153,6 +153,9 @@ export class CheerioUrlRetrieverHandler extends UrlRetrieverHandler {
     for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
       const response = await fetch(currentUrl, {
         signal,
+        // This User-Agent is also the key that excludes crawler requests
+        // from AppSignal's undici instrumentation — keep in sync with
+        // appsignal-hooks.cjs.
         headers: { 'User-Agent': 'Ayunis/1.0' },
         redirect: 'manual',
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@nestjs/typeorm':
         specifier: ^11.0.3
         version: 11.0.3(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.30(ioredis@5.11.1)(pg@8.22.0)(ts-node@10.9.2(@swc/core@1.15.43)(@types/node@24.12.4)(typescript@6.0.3)))
+      '@opentelemetry/instrumentation-undici':
+        specifier: ^0.23.0
+        version: 0.23.0(@opentelemetry/api@1.9.1)
       '@willsoto/nestjs-prometheus':
         specifier: ^6.0.2
         version: 6.1.0(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(prom-client@15.1.3)
@@ -470,7 +473,7 @@ importers:
         version: 1.167.0(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.14)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-plugin':
         specifier: ^1.168.19
-        version: 1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(lightningcss@1.32.0))
       '@tiptap/extension-link':
         specifier: ^3.27.1
         version: 3.27.3(@tiptap/core@3.27.3(@tiptap/pm@3.27.3))(@tiptap/pm@3.27.3)
@@ -17361,7 +17364,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@tanstack/router-plugin@1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/template': 7.29.7
@@ -17375,7 +17378,7 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-router': 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       vite: 6.4.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      webpack: 5.106.2(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.106.2(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -25483,16 +25486,15 @@ snapshots:
       '@swc/core': 1.15.43
       postcss: 8.5.15
 
-  terser-webpack-plugin@5.6.1(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.1(lightningcss@1.32.0)(webpack@5.106.2(lightningcss@1.32.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.106.2(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.106.2(lightningcss@1.32.0)
     optionalDependencies:
       lightningcss: 1.32.0
-      postcss: 8.5.15
     optional: true
 
   terser@5.48.0:
@@ -26296,7 +26298,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.15):
+  webpack@5.106.2(lightningcss@1.32.0):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -26319,7 +26321,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.1(lightningcss@1.32.0)(webpack@5.106.2(lightningcss@1.32.0))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes production observability bootstrap: mis-scoped `ignoreRequestHook` could hide real outbound failures, though the User-Agent gate limits impact to crawler traffic.
> 
> **Overview**
> **Stops AppSignal from opening incidents on expected URL-crawler fetch failures** (AYC-538) by replacing default undici instrumentation with a custom `UndiciInstrumentation` that skips outbound requests identified by the crawler `User-Agent` (`Ayunis/1.0`).
> 
> A new **`appsignal-hooks.cjs`** module exports `isCrawlerRequest`, which reads undici v5/v6 header shapes and powers `ignoreRequestHook`. Model/OCR and other outbound calls without that agent stay fully instrumented; `requireParentforSpans` is preserved to avoid orphan spans.
> 
> **`cheerio.url-retriever.ts`** gains a comment tying its existing `User-Agent` to the hook (must stay in sync). **`@opentelemetry/instrumentation-undici`** is added as a dependency, with unit tests for the hook logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 719fa9fbf984039e2b9ac99fa1dc2cf5c3e0f0bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->