### PR TITLE
fix(observability): copy appsignal-hooks.cjs into the production image (AYC-538)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ COPY --from=build /usr/src/app/ayunis-core-backend/dist ./dist
 COPY --from=build /usr/src/app/ayunis-core-backend/frontend ./dist/frontend
 # AppSignal bootstrap, loaded before the app via --require in CMD
 COPY --from=build /usr/src/app/ayunis-core-backend/appsignal.cjs ./appsignal.cjs
+COPY --from=build /usr/src/app/ayunis-core-backend/appsignal-hooks.cjs ./appsignal-hooks.cjs
 
 # Uploads dir (resolved relative to cwd = /app at runtime; matches the
 # app-uploads:/app/uploads compose mount)


### PR DESCRIPTION
- PR #1138 made appsignal.cjs require ./appsignal-hooks.cjs, but the
  production stage only copied appsignal.cjs, so the --require preload
  crashed the container at startup with MODULE_NOT_FOUND

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Dockerfile COPY for a file already required at runtime; no application logic changes.
> 
> **Overview**
> Fixes production container startup failures after `appsignal.cjs` began requiring `./appsignal-hooks.cjs` at preload time.
> 
> The production Docker stage now **copies `appsignal-hooks.cjs`** alongside `appsignal.cjs`, so `node --require ./appsignal.cjs` no longer exits with **MODULE_NOT_FOUND** before the app boots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adc48dff2347b5f32e9f3cc62fb6bc9b8aa5ba0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->