### PR TITLE
wip(auth): add MANAGER user role (AYC-347)

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1785142767428-AddManagerUserRole.ts
+++ b/ayunis-core-backend/src/db/migrations/1785142767428-AddManagerUserRole.ts
@@ -1,0 +1,51 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddManagerUserRole1785142767428 implements MigrationInterface {
+  name = 'AddManagerUserRole1785142767428';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."users_role_enum" RENAME TO "users_role_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."users_role_enum" AS ENUM('admin', 'manager', 'user')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ALTER COLUMN "role" TYPE "public"."users_role_enum" USING "role"::"text"::"public"."users_role_enum"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."users_role_enum_old"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."invites_role_enum" RENAME TO "invites_role_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."invites_role_enum" AS ENUM('admin', 'manager', 'user')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "invites" ALTER COLUMN "role" TYPE "public"."invites_role_enum" USING "role"::"text"::"public"."invites_role_enum"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."invites_role_enum_old"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."invites_role_enum_old" AS ENUM('admin', 'user')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "invites" ALTER COLUMN "role" TYPE "public"."invites_role_enum_old" USING "role"::"text"::"public"."invites_role_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."invites_role_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."invites_role_enum_old" RENAME TO "invites_role_enum"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."users_role_enum_old" AS ENUM('admin', 'user')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ALTER COLUMN "role" TYPE "public"."users_role_enum_old" USING "role"::"text"::"public"."users_role_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."users_role_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."users_role_enum_old" RENAME TO "users_role_enum"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/accept-invite/accept-invite.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/accept-invite/accept-invite.use-case.spec.ts
@@ -7,8 +7,7 @@ import {
   InviteJwtService,
   INVITE_TOKEN_TYPE,
 } from '../../services/invite-jwt.service';
-import { CreateRegularUserUseCase } from 'src/iam/users/application/use-cases/create-regular-user/create-regular-user.use-case';
-import { CreateAdminUserUseCase } from 'src/iam/users/application/use-cases/create-admin-user/create-admin-user.use-case';
+import { CreateUserUseCase } from 'src/iam/users/application/use-cases/create-user/create-user.use-case';
 import { IsValidPasswordUseCase } from 'src/iam/users/application/use-cases/is-valid-password/is-valid-password.use-case';
 import { FindUserByEmailUseCase } from 'src/iam/users/application/use-cases/find-user-by-email/find-user-by-email.use-case';
 import { Invite } from 'src/iam/invites/domain/invite.entity';
@@ -19,8 +18,7 @@ describe('AcceptInviteUseCase', () => {
   let useCase: AcceptInviteUseCase;
   let mockInvitesRepository: Partial<InvitesRepository>;
   let mockInviteJwtService: Partial<InviteJwtService>;
-  let mockCreateRegularUserUseCase: Partial<CreateRegularUserUseCase>;
-  let mockCreateAdminUserUseCase: Partial<CreateAdminUserUseCase>;
+  let mockCreateUserUseCase: Partial<CreateUserUseCase>;
   let mockIsValidPasswordUseCase: Partial<IsValidPasswordUseCase>;
   let mockFindUserByEmailUseCase: Partial<FindUserByEmailUseCase>;
 
@@ -35,8 +33,7 @@ describe('AcceptInviteUseCase', () => {
     mockInviteJwtService = {
       verifyInviteToken: jest.fn(),
     };
-    mockCreateRegularUserUseCase = { execute: jest.fn() };
-    mockCreateAdminUserUseCase = { execute: jest.fn() };
+    mockCreateUserUseCase = { execute: jest.fn() };
     mockIsValidPasswordUseCase = { execute: jest.fn() };
     mockFindUserByEmailUseCase = { execute: jest.fn() };
 
@@ -45,14 +42,7 @@ describe('AcceptInviteUseCase', () => {
         AcceptInviteUseCase,
         { provide: InvitesRepository, useValue: mockInvitesRepository },
         { provide: InviteJwtService, useValue: mockInviteJwtService },
-        {
-          provide: CreateRegularUserUseCase,
-          useValue: mockCreateRegularUserUseCase,
-        },
-        {
-          provide: CreateAdminUserUseCase,
-          useValue: mockCreateAdminUserUseCase,
-        },
+        { provide: CreateUserUseCase, useValue: mockCreateUserUseCase },
         {
           provide: IsValidPasswordUseCase,
           useValue: mockIsValidPasswordUseCase,
@@ -71,12 +61,12 @@ describe('AcceptInviteUseCase', () => {
     jest.clearAllMocks();
   });
 
-  it('should pass department to create-regular-user command', async () => {
+  const acceptInviteWithRole = async (role: UserRole, department?: string) => {
     const invite = new Invite({
       id: inviteId,
-      email: 'user@example.com',
+      email: `${role}@example.com`,
       orgId,
-      role: UserRole.USER,
+      role,
       expiresAt: new Date(Date.now() + 86_400_000),
     });
 
@@ -87,49 +77,33 @@ describe('AcceptInviteUseCase', () => {
     jest.spyOn(mockFindUserByEmailUseCase, 'execute').mockResolvedValue(null);
     jest.spyOn(mockIsValidPasswordUseCase, 'execute').mockResolvedValue(true);
 
-    const command = new AcceptInviteCommand({
-      inviteToken: 'valid-token',
-      userName: 'Jane Doe',
-      password: 'securePass123',
-      hasAcceptedMarketing: false,
-      department: 'jugendamt',
-    });
-
-    await useCase.execute(command);
-
-    expect(mockCreateRegularUserUseCase.execute).toHaveBeenCalledWith(
-      expect.objectContaining({ department: 'jugendamt' }),
+    await useCase.execute(
+      new AcceptInviteCommand({
+        inviteToken: 'valid-token',
+        userName: 'Jane Doe',
+        password: 'securePass123',
+        hasAcceptedMarketing: false,
+        department,
+      }),
     );
-  });
+  };
 
-  it('should pass department to create-admin-user command', async () => {
-    const invite = new Invite({
-      id: inviteId,
-      email: 'admin@example.com',
-      orgId,
-      role: UserRole.ADMIN,
-      expiresAt: new Date(Date.now() + 86_400_000),
-    });
+  it.each([UserRole.USER, UserRole.MANAGER, UserRole.ADMIN])(
+    'creates a user with the invite role %s',
+    async (role) => {
+      await acceptInviteWithRole(role);
 
-    jest
-      .spyOn(mockInviteJwtService, 'verifyInviteToken')
-      .mockReturnValue({ inviteId, type: INVITE_TOKEN_TYPE });
-    jest.spyOn(mockInvitesRepository, 'findOne').mockResolvedValue(invite);
-    jest.spyOn(mockFindUserByEmailUseCase, 'execute').mockResolvedValue(null);
-    jest.spyOn(mockIsValidPasswordUseCase, 'execute').mockResolvedValue(true);
+      expect(mockCreateUserUseCase.execute).toHaveBeenCalledWith(
+        expect.objectContaining({ role }),
+      );
+    },
+  );
 
-    const command = new AcceptInviteCommand({
-      inviteToken: 'valid-token',
-      userName: 'Admin User',
-      password: 'securePass123',
-      hasAcceptedMarketing: true,
-      department: 'other:Wasserwerk',
-    });
+  it('passes department through to user creation', async () => {
+    await acceptInviteWithRole(UserRole.USER, 'jugendamt');
 
-    await useCase.execute(command);
-
-    expect(mockCreateAdminUserUseCase.execute).toHaveBeenCalledWith(
-      expect.objectContaining({ department: 'other:Wasserwerk' }),
+    expect(mockCreateUserUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ department: 'jugendamt' }),
     );
   });
 });

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/accept-invite/accept-invite.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/accept-invite/accept-invite.use-case.ts
@@ -10,21 +10,18 @@ import {
   InviteExpiredError,
   InviteAlreadyAcceptedError,
   InvalidInviteTokenError,
-  InviteRoleError,
   InvalidPasswordError,
   UserAlreadyExistsError,
 } from '../../invites.errors';
-import { CreateRegularUserUseCase } from 'src/iam/users/application/use-cases/create-regular-user/create-regular-user.use-case';
-import { CreateAdminUserUseCase } from 'src/iam/users/application/use-cases/create-admin-user/create-admin-user.use-case';
-import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
-import { CreateAdminUserCommand } from 'src/iam/users/application/use-cases/create-admin-user/create-admin-user.command';
-import { CreateRegularUserCommand } from 'src/iam/users/application/use-cases/create-regular-user/create-regular-user.command';
+import { CreateUserUseCase } from 'src/iam/users/application/use-cases/create-user/create-user.use-case';
+import { CreateUserCommand } from 'src/iam/users/application/use-cases/create-user/create-user.command';
+import { Invite } from 'src/iam/invites/domain/invite.entity';
 import { IsValidPasswordUseCase } from 'src/iam/users/application/use-cases/is-valid-password/is-valid-password.use-case';
 import { IsValidPasswordQuery } from 'src/iam/users/application/use-cases/is-valid-password/is-valid-password.query';
 import { FindUserByEmailUseCase } from 'src/iam/users/application/use-cases/find-user-by-email/find-user-by-email.use-case';
 import { FindUserByEmailQuery } from 'src/iam/users/application/use-cases/find-user-by-email/find-user-by-email.query';
-import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedInviteError } from '../../invites.errors';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 
 @Injectable()
 export class AcceptInviteUseCase {
@@ -33,115 +30,96 @@ export class AcceptInviteUseCase {
   constructor(
     private readonly invitesRepository: InvitesRepository,
     private readonly inviteJwtService: InviteJwtService,
-    private readonly createRegularUserUseCase: CreateRegularUserUseCase,
-    private readonly createAdminUserUseCase: CreateAdminUserUseCase,
+    private readonly createUserUseCase: CreateUserUseCase,
     private readonly isValidPasswordUseCase: IsValidPasswordUseCase,
     private readonly findUserByEmailUseCase: FindUserByEmailUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedInviteError)
   async execute(
     command: AcceptInviteCommand,
   ): Promise<{ inviteId: string; email: string; orgId: string }> {
     this.logger.log('execute', { hasToken: !!command.inviteToken });
-    try {
-      // Verify and decode the JWT token
-      let payload: InviteJwtPayload;
-      try {
-        payload = this.inviteJwtService.verifyInviteToken(command.inviteToken);
-      } catch (error) {
-        this.logger.error('Invalid invite token', {
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
-        throw new InvalidInviteTokenError('Token verification failed');
-      }
 
-      // Find the invite in the database
-      const invite = await this.invitesRepository.findOne(payload.inviteId);
-      if (!invite) {
-        this.logger.error('Invite not found', { inviteId: payload.inviteId });
-        throw new InviteNotFoundError(payload.inviteId);
-      }
+    const invite = await this.resolveValidatedInvite(command);
 
-      const existingUser = await this.findUserByEmailUseCase.execute(
-        new FindUserByEmailQuery(invite.email),
-      );
-      if (existingUser) {
-        throw new UserAlreadyExistsError();
-      }
-
-      // Check if invite is already accepted
-      if (invite.acceptedAt) {
-        this.logger.error('Invite already accepted', { inviteId: invite.id });
-        throw new InviteAlreadyAcceptedError({ inviteId: invite.id });
-      }
-
-      // Check if invite has expired
-      if (invite.expiresAt < new Date()) {
-        this.logger.error('Invite expired', {
-          inviteId: invite.id,
-          expiresAt: invite.expiresAt,
-        });
-        throw new InviteExpiredError({
-          inviteId: invite.id,
-          expiresAt: invite.expiresAt,
-        });
-      }
-
-      if (
-        !(await this.isValidPasswordUseCase.execute(
-          new IsValidPasswordQuery(command.password),
-        ))
-      ) {
-        throw new InvalidPasswordError();
-      }
-
-      if (invite.role === UserRole.ADMIN) {
-        await this.createAdminUserUseCase.execute(
-          new CreateAdminUserCommand({
-            email: invite.email,
-            password: command.password,
-            orgId: invite.orgId,
-            name: command.userName,
-            emailVerified: true,
-            hasAcceptedMarketing: command.hasAcceptedMarketing,
-            department: command.department,
-          }),
-        );
-      } else if (invite.role === UserRole.USER) {
-        await this.createRegularUserUseCase.execute(
-          new CreateRegularUserCommand({
-            email: invite.email,
-            orgId: invite.orgId,
-            name: command.userName,
-            password: command.password,
-            emailVerified: true,
-            hasAcceptedMarketing: command.hasAcceptedMarketing,
-            department: command.department,
-          }),
-        );
-      } else {
-        throw new InviteRoleError(invite.role);
-      }
-
-      await this.invitesRepository.accept(invite.id);
-
-      this.logger.debug('Invite accepted successfully', {
-        inviteId: invite.id,
+    await this.createUserUseCase.execute(
+      new CreateUserCommand({
         email: invite.email,
-      });
-
-      return {
-        inviteId: invite.id,
-        email: invite.email,
+        password: command.password,
         orgId: invite.orgId,
-      };
+        name: command.userName,
+        role: invite.role,
+        emailVerified: true,
+        hasAcceptedMarketing: command.hasAcceptedMarketing,
+        department: command.department,
+      }),
+    );
+
+    await this.invitesRepository.accept(invite.id);
+
+    this.logger.debug('Invite accepted successfully', {
+      inviteId: invite.id,
+      email: invite.email,
+    });
+
+    return {
+      inviteId: invite.id,
+      email: invite.email,
+      orgId: invite.orgId,
+    };
+  }
+
+  private async resolveValidatedInvite(
+    command: AcceptInviteCommand,
+  ): Promise<Invite> {
+    let payload: InviteJwtPayload;
+    try {
+      payload = this.inviteJwtService.verifyInviteToken(command.inviteToken);
     } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      const err = error instanceof Error ? error : new Error('Unknown error');
-      this.logger.error('Accept invite failed', { error: err });
-      throw new UnexpectedInviteError(err);
+      this.logger.error('Invalid invite token', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      throw new InvalidInviteTokenError('Token verification failed');
     }
+
+    const invite = await this.invitesRepository.findOne(payload.inviteId);
+    if (!invite) {
+      this.logger.error('Invite not found', { inviteId: payload.inviteId });
+      throw new InviteNotFoundError(payload.inviteId);
+    }
+
+    const existingUser = await this.findUserByEmailUseCase.execute(
+      new FindUserByEmailQuery(invite.email),
+    );
+    if (existingUser) {
+      throw new UserAlreadyExistsError();
+    }
+
+    if (invite.acceptedAt) {
+      this.logger.error('Invite already accepted', { inviteId: invite.id });
+      throw new InviteAlreadyAcceptedError({ inviteId: invite.id });
+    }
+
+    if (invite.expiresAt < new Date()) {
+      this.logger.error('Invite expired', {
+        inviteId: invite.id,
+        expiresAt: invite.expiresAt,
+      });
+      throw new InviteExpiredError({
+        inviteId: invite.id,
+        expiresAt: invite.expiresAt,
+      });
+    }
+
+    if (
+      !(await this.isValidPasswordUseCase.execute(
+        new IsValidPasswordQuery(command.password),
+      ))
+    ) {
+      throw new InvalidPasswordError();
+    }
+
+    return invite;
   }
 }

--- a/ayunis-core-backend/src/iam/users/domain/value-objects/role.object.ts
+++ b/ayunis-core-backend/src/iam/users/domain/value-objects/role.object.ts
@@ -1,4 +1,5 @@
 export enum UserRole {
   ADMIN = 'admin',
+  MANAGER = 'manager',
   USER = 'user',
 }

--- a/ayunis-core-backend/src/iam/users/presenters/http/dtos/create-user.dto.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/dtos/create-user.dto.ts
@@ -32,7 +32,7 @@ export class CreateUserDto {
     example: UserRole.USER,
   })
   @IsEnum(UserRole, {
-    message: 'Role must be either admin or user',
+    message: 'Role must be a valid user role',
   })
   role: UserRole;
 

--- a/ayunis-core-backend/src/iam/users/presenters/http/dtos/update-user-role.dto.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/dtos/update-user-role.dto.ts
@@ -9,7 +9,7 @@ export class UpdateUserRoleDto {
     example: UserRole.ADMIN,
   })
   @IsEnum(UserRole, {
-    message: 'Role must be either admin or user',
+    message: 'Role must be a valid user role',
   })
   role: UserRole;
 }

--- a/ayunis-core-backend/src/iam/users/users.module.ts
+++ b/ayunis-core-backend/src/iam/users/users.module.ts
@@ -141,6 +141,7 @@ import { ExportUsersUseCase } from './application/use-cases/export-users/export-
     SuperAdminUserResponseDtoMapper,
   ],
   exports: [
+    CreateUserUseCase,
     CreateAdminUserUseCase,
     CreateRegularUserUseCase,
     SendConfirmationEmailUseCase,

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -32,6 +32,7 @@ export type UserResponseDtoRole = typeof UserResponseDtoRole[keyof typeof UserRe
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const UserResponseDtoRole = {
   admin: 'admin',
+  manager: 'manager',
   user: 'user',
 } as const;
 
@@ -80,6 +81,7 @@ export type UpdateUserRoleDtoRole = typeof UpdateUserRoleDtoRole[keyof typeof Up
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const UpdateUserRoleDtoRole = {
   admin: 'admin',
+  manager: 'manager',
   user: 'user',
 } as const;
 
@@ -170,6 +172,7 @@ export type CreateUserDtoRole = typeof CreateUserDtoRole[keyof typeof CreateUser
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const CreateUserDtoRole = {
   admin: 'admin',
+  manager: 'manager',
   user: 'user',
 } as const;
 
@@ -193,6 +196,7 @@ export type SuperAdminUserResponseDtoRole = typeof SuperAdminUserResponseDtoRole
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const SuperAdminUserResponseDtoRole = {
   admin: 'admin',
+  manager: 'manager',
   user: 'user',
 } as const;
 
@@ -244,6 +248,7 @@ export type CreateInviteDtoRole = typeof CreateInviteDtoRole[keyof typeof Create
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const CreateInviteDtoRole = {
   admin: 'admin',
+  manager: 'manager',
   user: 'user',
 } as const;
 
@@ -271,6 +276,7 @@ export type CreateBulkInviteItemDtoRole = typeof CreateBulkInviteItemDtoRole[key
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const CreateBulkInviteItemDtoRole = {
   admin: 'admin',
+  manager: 'manager',
   user: 'user',
 } as const;
 
@@ -299,6 +305,7 @@ export type BulkInviteResultDtoRole = typeof BulkInviteResultDtoRole[keyof typeo
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const BulkInviteResultDtoRole = {
   admin: 'admin',
+  manager: 'manager',
   user: 'user',
 } as const;
 
@@ -346,6 +353,7 @@ export type InviteResponseDtoRole = typeof InviteResponseDtoRole[keyof typeof In
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const InviteResponseDtoRole = {
   admin: 'admin',
+  manager: 'manager',
   user: 'user',
 } as const;
 
@@ -395,6 +403,7 @@ export type InviteDetailResponseDtoRole = typeof InviteDetailResponseDtoRole[key
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const InviteDetailResponseDtoRole = {
   admin: 'admin',
+  manager: 'manager',
   user: 'user',
 } as const;
 
@@ -1651,6 +1660,7 @@ export type TeamMemberResponseDtoUserRole = typeof TeamMemberResponseDtoUserRole
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const TeamMemberResponseDtoUserRole = {
   admin: 'admin',
+  manager: 'manager',
   user: 'user',
 } as const;
 
@@ -4656,6 +4666,7 @@ export type MeResponseDtoRole = typeof MeResponseDtoRole[keyof typeof MeResponse
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const MeResponseDtoRole = {
   admin: 'admin',
+  manager: 'manager',
   user: 'user',
 } as const;
 

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -10289,7 +10289,7 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": ["admin", "user"],
+            "enum": ["admin", "manager", "user"],
             "example": "user"
           },
           "orgId": {
@@ -10361,7 +10361,7 @@
           "role": {
             "type": "string",
             "description": "New role for the user",
-            "enum": ["admin", "user"],
+            "enum": ["admin", "manager", "user"],
             "example": "admin"
           }
         },
@@ -10509,7 +10509,7 @@
           "role": {
             "type": "string",
             "description": "Role for the user",
-            "enum": ["admin", "user"],
+            "enum": ["admin", "manager", "user"],
             "example": "user"
           },
           "sendActivationEmail": {
@@ -10542,7 +10542,7 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": ["admin", "user"],
+            "enum": ["admin", "manager", "user"],
             "example": "user"
           },
           "orgId": {
@@ -10602,7 +10602,7 @@
           "role": {
             "type": "string",
             "description": "Role to assign to the invited user",
-            "enum": ["admin", "user"],
+            "enum": ["admin", "manager", "user"],
             "example": "user"
           }
         },
@@ -10631,7 +10631,7 @@
           "role": {
             "type": "string",
             "description": "Role to assign to the invited user",
-            "enum": ["admin", "user"],
+            "enum": ["admin", "manager", "user"],
             "example": "user"
           }
         },
@@ -10663,7 +10663,7 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": ["admin", "manager", "user"],
             "example": "user"
           },
           "success": {
@@ -10744,7 +10744,7 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": ["admin", "manager", "user"],
             "example": "user"
           },
           "status": {
@@ -10812,7 +10812,7 @@
           "role": {
             "type": "string",
             "description": "Role assigned to the invited user",
-            "enum": ["admin", "user"],
+            "enum": ["admin", "manager", "user"],
             "example": "user"
           },
           "status": {
@@ -12618,7 +12618,7 @@
           "userRole": {
             "type": "string",
             "description": "The role of the team member in the organization",
-            "enum": ["admin", "user"],
+            "enum": ["admin", "manager", "user"],
             "example": "user"
           },
           "joinedAt": {
@@ -17443,7 +17443,7 @@
           "role": {
             "type": "string",
             "description": "User role",
-            "enum": ["admin", "user"],
+            "enum": ["admin", "manager", "user"],
             "example": "user"
           },
           "systemRole": {


### PR DESCRIPTION
<!-- stack-order -->
> ⚠️ **Stacked PR (AYC-347) — merge bottom-to-top, in order. Do not merge out of sequence; each depends on the ones below it.**
>
> 1. #1148 — add MANAGER role  👈 **this PR**
> 2. #1149 — per-org permissions foundation
> 3. #1150 — gate teams / skills / knowledge bases
> 4. #1151 — roles & permissions admin UI
> 5. #1152 — hide create controls by permission
> 6. #1153 — managers: permission-scoped settings access
> 7. #1154 — gate skill/KB edit·delete·share controls
> 8. #1155 — docs: RBAC approach
<!-- /stack-order -->




- Add MANAGER to UserRole enum + enum-alter migration (users.role,
  invites.role)
- Collapse accept-invite ADMIN/USER branch into a single CreateUserUseCase
  call driven by invite.role so all three roles are handled uniformly
- Export CreateUserUseCase from UsersModule
- Relax update-user-role validation message

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches IAM roles and the invite signup path plus a PostgreSQL enum migration; manager permissions are not defined in this PR, so behavior for existing admin-only guards is unchanged until follow-up stack PRs land.
> 
> **Overview**
> Introduces a **`manager`** org role alongside **`admin`** and **`user`**, as the first step in a stacked RBAC effort. The domain enum, Postgres enums on **`users.role`** and **`invites.role`**, API/OpenAPI role fields, and generated frontend types all gain **`manager`**.
> 
> **Invite acceptance** no longer branches on admin vs regular user: **`AcceptInviteUseCase`** validates the invite, then calls **`CreateUserUseCase`** once with **`invite.role`** (and department, marketing, etc.). Tests are parameterized for **user**, **manager**, and **admin**. Unexpected errors are handled via **`@HandleUnexpectedErrors`**, and **`CreateUserUseCase`** is exported from **`UsersModule`** for the invites module.
> 
> Create/update user role DTOs now use a generic “valid user role” validation message instead of “admin or user” only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dc75a003b93881ca03dd3d17284af9f1c2d272f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->