### PR TITLE
wip(auth): gate teams, skills and knowledge bases by permission (AYC-347)

### DIFF
--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
@@ -22,6 +22,8 @@ import {
   ApiParam,
   ApiBody,
   ApiConsumes,
+  ApiBodyOptions,
+  ApiParamOptions,
 } from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
@@ -75,6 +77,51 @@ import { KnowledgeBasesConstants } from '../../domain/knowledge-bases.constants'
 import { KnowledgeBaseDtoMapper } from './mappers/knowledge-base-dto.mapper';
 import { RequireFeature } from 'src/common/guards/feature.guard';
 import { FeatureFlag } from 'src/config/features.config';
+import { RequirePermission } from 'src/iam/authorization/application/decorators/permissions.decorator';
+import { Permission } from 'src/iam/permissions/domain/value-objects/permission.enum';
+
+interface UploadedDocument {
+  fieldname: string;
+  originalname: string;
+  encoding: string;
+  mimetype: string;
+  size: number;
+  buffer: Buffer;
+  path: string;
+}
+
+const KB_ID_PARAM: ApiParamOptions = {
+  name: 'id',
+  description: 'The UUID of the knowledge base',
+  type: 'string',
+  format: 'uuid',
+};
+
+const DOCUMENT_UPLOAD_API_BODY: ApiBodyOptions = {
+  schema: {
+    type: 'object',
+    properties: {
+      file: {
+        type: 'string',
+        format: 'binary',
+        description: 'The file to upload (PDF, DOCX, PPTX, TXT, max 25 MB)',
+      },
+    },
+    required: ['file'],
+  },
+};
+
+/* eslint-disable sonarjs/content-length -- multer file size limit, not HTTP Content-Length */
+const DocumentUploadInterceptor = FileInterceptor('file', {
+  storage: diskStorage({
+    destination: UPLOADS_DIR,
+    filename: (_req, file, cb) => {
+      cb(null, `${randomUUID()}${extname(file.originalname)}`);
+    },
+  }),
+  limits: { fileSize: KnowledgeBasesConstants.MAX_FILE_SIZE_BYTES },
+});
+/* eslint-enable sonarjs/content-length */
 
 @ApiTags('knowledge-bases')
 @RequireFeature(FeatureFlag.KnowledgeBases)
@@ -94,6 +141,7 @@ export class KnowledgeBasesController {
     private readonly knowledgeBaseDtoMapper: KnowledgeBaseDtoMapper,
   ) {}
 
+  @RequirePermission(Permission.MANAGE_KNOWLEDGE_BASES)
   @Post()
   @ApiOperation({ summary: 'Create a new knowledge base' })
   @ApiBody({ type: CreateKnowledgeBaseDto })
@@ -170,6 +218,7 @@ export class KnowledgeBasesController {
     return this.knowledgeBaseDtoMapper.toDto(knowledgeBase, isShared);
   }
 
+  @RequirePermission(Permission.MANAGE_KNOWLEDGE_BASES)
   @Patch(':id')
   @ApiOperation({ summary: 'Update a knowledge base' })
   @ApiParam({
@@ -205,6 +254,7 @@ export class KnowledgeBasesController {
     return this.knowledgeBaseDtoMapper.toDto(knowledgeBase);
   }
 
+  @RequirePermission(Permission.MANAGE_KNOWLEDGE_BASES)
   @Delete(':id')
   @ApiOperation({ summary: 'Delete a knowledge base' })
   @ApiParam({
@@ -265,28 +315,12 @@ export class KnowledgeBasesController {
     };
   }
 
+  @RequirePermission(Permission.MANAGE_KNOWLEDGE_BASES)
   @Post(':id/documents')
   @ApiOperation({ summary: 'Add a document to a knowledge base' })
-  @ApiParam({
-    name: 'id',
-    description: 'The UUID of the knowledge base',
-    type: 'string',
-    format: 'uuid',
-  })
+  @ApiParam(KB_ID_PARAM)
   @ApiConsumes('multipart/form-data')
-  @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        file: {
-          type: 'string',
-          format: 'binary',
-          description: 'The file to upload (PDF, DOCX, PPTX, TXT, max 25 MB)',
-        },
-      },
-      required: ['file'],
-    },
-  })
+  @ApiBody(DOCUMENT_UPLOAD_API_BODY)
   @HttpCode(HttpStatus.ACCEPTED)
   @ApiResponse({
     status: 202,
@@ -299,33 +333,11 @@ export class KnowledgeBasesController {
     status: 413,
     description: 'File exceeds the 25 MB upload limit',
   })
-  /* eslint-disable sonarjs/content-length -- multer file size limit, not HTTP Content-Length */
-  @UseInterceptors(
-    FileInterceptor('file', {
-      storage: diskStorage({
-        destination: UPLOADS_DIR,
-        filename: (_req, file, cb) => {
-          const randomName = randomUUID();
-          cb(null, `${randomName}${extname(file.originalname)}`);
-        },
-      }),
-      limits: { fileSize: KnowledgeBasesConstants.MAX_FILE_SIZE_BYTES },
-    }),
-  )
-  /* eslint-enable sonarjs/content-length */
+  @UseInterceptors(DocumentUploadInterceptor)
   async addDocument(
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Param('id', ParseUUIDPipe) id: UUID,
-    @UploadedFile()
-    file?: {
-      fieldname: string;
-      originalname: string;
-      encoding: string;
-      mimetype: string;
-      size: number;
-      buffer: Buffer;
-      path: string;
-    },
+    @UploadedFile() file?: UploadedDocument,
   ): Promise<KnowledgeBaseDocumentResponseDto> {
     if (!file) {
       throw new MissingFileError();
@@ -336,25 +348,7 @@ export class KnowledgeBasesController {
       fileName: file.originalname,
     });
 
-    const detectedType = detectFileType(file.mimetype, file.originalname);
-    if (
-      !isDocumentFile(detectedType) &&
-      !isPlainTextFile(detectedType) &&
-      !isAudioFile(detectedType)
-    ) {
-      await this.cleanupTempFile(file.path);
-      throw new BadRequestException(
-        `Unsupported file type: ${file.originalname}. Knowledge bases only support PDF, DOCX, PPTX, TXT, and audio files (MP3, M4A, WAV, WebM).`,
-      );
-    }
-
-    const canonicalMimeType = getCanonicalMimeType(detectedType);
-    if (!canonicalMimeType) {
-      await this.cleanupTempFile(file.path);
-      throw new BadRequestException(
-        `Unable to determine MIME type for detected file type: ${detectedType}`,
-      );
-    }
+    const canonicalMimeType = await this.resolveDocumentMimeType(file);
 
     try {
       const fileData = await fs.promises.readFile(file.path);
@@ -375,6 +369,33 @@ export class KnowledgeBasesController {
     }
   }
 
+  private async resolveDocumentMimeType(
+    file: UploadedDocument,
+  ): Promise<string> {
+    const detectedType = detectFileType(file.mimetype, file.originalname);
+    if (
+      !isDocumentFile(detectedType) &&
+      !isPlainTextFile(detectedType) &&
+      !isAudioFile(detectedType)
+    ) {
+      await this.cleanupTempFile(file.path);
+      throw new BadRequestException(
+        `Unsupported file type: ${file.originalname}. Knowledge bases only support PDF, DOCX, PPTX, TXT, and audio files (MP3, M4A, WAV, WebM).`,
+      );
+    }
+
+    const canonicalMimeType = getCanonicalMimeType(detectedType);
+    if (!canonicalMimeType) {
+      await this.cleanupTempFile(file.path);
+      throw new BadRequestException(
+        `Unable to determine MIME type for detected file type: ${detectedType}`,
+      );
+    }
+
+    return canonicalMimeType;
+  }
+
+  @RequirePermission(Permission.MANAGE_KNOWLEDGE_BASES)
   @Post(':id/urls')
   @ApiOperation({ summary: 'Add a URL source to a knowledge base' })
   @ApiParam({
@@ -415,6 +436,7 @@ export class KnowledgeBasesController {
     return this.knowledgeBaseDtoMapper.toDocumentDto(source);
   }
 
+  @RequirePermission(Permission.MANAGE_KNOWLEDGE_BASES)
   @Delete(':id/documents/:documentId')
   @ApiOperation({ summary: 'Remove a document from a knowledge base' })
   @ApiParam({

--- a/ayunis-core-backend/src/domain/shares/presenters/http/shares.controller.ts
+++ b/ayunis-core-backend/src/domain/shares/presenters/http/shares.controller.ts
@@ -45,6 +45,8 @@ import { ShareDtoMapper } from './mappers/share-dto.mapper';
 import { SharedEntityType } from '../../domain/value-objects/shared-entity-type.enum';
 import { ShareScopeType } from '../../domain/value-objects/share-scope-type.enum';
 import { TeamShareScope } from '../../domain/share-scope.entity';
+import { RequirePermission } from 'src/iam/authorization/application/decorators/permissions.decorator';
+import { Permission } from 'src/iam/permissions/domain/value-objects/permission.enum';
 
 @ApiTags('shares')
 @Controller('shares')
@@ -59,6 +61,7 @@ export class SharesController {
     private readonly getTeamUseCase: GetTeamUseCase,
   ) {}
 
+  @RequirePermission(Permission.SHARE_SKILLS)
   @Post('skills')
   @ApiOperation({ summary: 'Create a share for a skill' })
   @ApiBody({
@@ -101,6 +104,7 @@ export class SharesController {
     return this.shareDtoMapper.toDto(share);
   }
 
+  @RequirePermission(Permission.SHARE_KNOWLEDGE_BASES)
   @Post('knowledge-bases')
   @ApiOperation({ summary: 'Create a share for a knowledge base' })
   @ApiBody({

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skill-knowledge-bases.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skill-knowledge-bases.controller.ts
@@ -28,6 +28,8 @@ import { KnowledgeBaseResponseDto } from 'src/domain/knowledge-bases/presenters/
 import { KnowledgeBaseDtoMapper } from 'src/domain/knowledge-bases/presenters/http/mappers/knowledge-base-dto.mapper';
 import { RequireFeature } from 'src/common/guards/feature.guard';
 import { FeatureFlag } from 'src/config/features.config';
+import { RequirePermission } from 'src/iam/authorization/application/decorators/permissions.decorator';
+import { Permission } from 'src/iam/permissions/domain/value-objects/permission.enum';
 
 @ApiTags('skills')
 @RequireFeature(FeatureFlag.Skills)
@@ -46,6 +48,7 @@ export class SkillKnowledgeBasesController {
     private readonly skillCreatorNameService: SkillCreatorNameService,
   ) {}
 
+  @RequirePermission(Permission.MANAGE_SKILLS)
   @Post(':skillId/knowledge-bases/:knowledgeBaseId')
   @ApiOperation({ summary: 'Assign knowledge base to skill' })
   @ApiParam({
@@ -89,6 +92,7 @@ export class SkillKnowledgeBasesController {
     return this.skillDtoMapper.toDto(skill, context, creatorName);
   }
 
+  @RequirePermission(Permission.MANAGE_SKILLS)
   @Delete(':skillId/knowledge-bases/:knowledgeBaseId')
   @ApiOperation({ summary: 'Unassign knowledge base from skill' })
   @ApiParam({

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skill-mcp-integrations.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skill-mcp-integrations.controller.ts
@@ -33,6 +33,8 @@ import { McpIntegrationResponseDto } from 'src/domain/mcp/presenters/http/dto/mc
 import { McpIntegrationDtoMapper } from 'src/domain/mcp/presenters/http/mappers/mcp-integration-dto.mapper';
 import { RequireFeature } from 'src/common/guards/feature.guard';
 import { FeatureFlag } from 'src/config/features.config';
+import { RequirePermission } from 'src/iam/authorization/application/decorators/permissions.decorator';
+import { Permission } from 'src/iam/permissions/domain/value-objects/permission.enum';
 
 @ApiTags('skills')
 @RequireFeature(FeatureFlag.Skills)
@@ -50,6 +52,7 @@ export class SkillMcpIntegrationsController {
     private readonly skillCreatorNameService: SkillCreatorNameService,
   ) {}
 
+  @RequirePermission(Permission.MANAGE_SKILLS)
   @Post(':skillId/mcp-integrations/:integrationId')
   @ApiOperation({ summary: 'Assign MCP integration to skill' })
   @ApiParam({
@@ -91,6 +94,7 @@ export class SkillMcpIntegrationsController {
     return this.skillDtoMapper.toDto(skill, context, creatorName);
   }
 
+  @RequirePermission(Permission.MANAGE_SKILLS)
   @Delete(':skillId/mcp-integrations/:integrationId')
   @ApiOperation({ summary: 'Unassign MCP integration from skill' })
   @ApiParam({

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
@@ -43,6 +43,8 @@ import { AddFileSourceToSkillUseCase } from '../../application/use-cases/add-fil
 import { AddFileSourceToSkillCommand } from '../../application/use-cases/add-file-source-to-skill/add-file-source-to-skill.command';
 import { RequireFeature } from 'src/common/guards/feature.guard';
 import { FeatureFlag } from 'src/config/features.config';
+import { RequirePermission } from 'src/iam/authorization/application/decorators/permissions.decorator';
+import { Permission } from 'src/iam/permissions/domain/value-objects/permission.enum';
 
 @ApiTags('skills')
 @RequireFeature(FeatureFlag.Skills)
@@ -86,6 +88,7 @@ export class SkillSourcesController {
     return this.skillDtoMapper.sourcesToDtoArray(sources);
   }
 
+  @RequirePermission(Permission.MANAGE_SKILLS)
   @Post(':id/sources/file')
   @ApiSkillFileSourceUpload()
   async addFileSource(
@@ -127,6 +130,7 @@ export class SkillSourcesController {
     return this.skillDtoMapper.toDto(skill, context, creatorName);
   }
 
+  @RequirePermission(Permission.MANAGE_SKILLS)
   @Delete(':id/sources/:sourceId')
   @ApiOperation({ summary: 'Remove a source from a skill' })
   @ApiParam({

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skills.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skills.controller.ts
@@ -59,6 +59,8 @@ import { SkillDtoMapper } from './mappers/skill.mapper';
 import { InvalidSkillNameError } from '../../domain/skill.entity';
 import { RequireFeature } from 'src/common/guards/feature.guard';
 import { FeatureFlag } from 'src/config/features.config';
+import { RequirePermission } from 'src/iam/authorization/application/decorators/permissions.decorator';
+import { Permission } from 'src/iam/permissions/domain/value-objects/permission.enum';
 
 @ApiTags('skills')
 @RequireFeature(FeatureFlag.Skills)
@@ -80,6 +82,7 @@ export class SkillsController {
     private readonly skillCreatorNameService: SkillCreatorNameService,
   ) {}
 
+  @RequirePermission(Permission.MANAGE_SKILLS)
   @Post('install-from-marketplace')
   @ApiOperation({ summary: 'Install a skill from the marketplace' })
   @ApiBody({ type: InstallSkillFromMarketplaceDto })
@@ -113,6 +116,7 @@ export class SkillsController {
     });
   }
 
+  @RequirePermission(Permission.MANAGE_SKILLS)
   @Post()
   @ApiOperation({ summary: 'Create a new skill' })
   @ApiBody({ type: CreateSkillDto })
@@ -228,6 +232,7 @@ export class SkillsController {
     );
   }
 
+  @RequirePermission(Permission.MANAGE_SKILLS)
   @Put(':id')
   @ApiOperation({ summary: 'Update a skill' })
   @ApiParam({
@@ -280,6 +285,7 @@ export class SkillsController {
     }
   }
 
+  @RequirePermission(Permission.MANAGE_SKILLS)
   @Delete(':id')
   @ApiOperation({ summary: 'Delete a skill' })
   @ApiParam({

--- a/ayunis-core-backend/src/iam/teams/presenters/http/teams.controller.ts
+++ b/ayunis-core-backend/src/iam/teams/presenters/http/teams.controller.ts
@@ -50,8 +50,8 @@ import { BulkAddTeamMembersDto } from './dtos/bulk-add-team-members.dto';
 import { ListTeamMembersQueryDto } from './dtos/list-team-members-query.dto';
 import { TeamDtoMapper } from './mappers/team-dto.mapper';
 import { TeamMemberDtoMapper } from './mappers/team-member-dto.mapper';
-import { Roles } from 'src/iam/authorization/application/decorators/roles.decorator';
-import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import { RequirePermission } from 'src/iam/authorization/application/decorators/permissions.decorator';
+import { Permission } from 'src/iam/permissions/domain/value-objects/permission.enum';
 
 @ApiTags('teams')
 @Controller('teams')
@@ -82,7 +82,7 @@ export class TeamsController {
     private readonly teamMemberDtoMapper: TeamMemberDtoMapper,
   ) {}
 
-  @Roles(UserRole.ADMIN)
+  @RequirePermission(Permission.MANAGE_TEAMS)
   @Get()
   @ApiOperation({
     summary: 'List all teams for the current organization',
@@ -139,7 +139,7 @@ export class TeamsController {
     return this.teamDtoMapper.toDtoList(teams);
   }
 
-  @Roles(UserRole.ADMIN)
+  @RequirePermission(Permission.MANAGE_TEAMS)
   @Get(':id')
   @ApiOperation({
     summary: 'Get a team by ID',
@@ -179,7 +179,7 @@ export class TeamsController {
     return this.teamDtoMapper.toDto(response);
   }
 
-  @Roles(UserRole.ADMIN)
+  @RequirePermission(Permission.MANAGE_TEAMS)
   @Post()
   @ApiOperation({
     summary: 'Create a new team for the current organization',
@@ -223,7 +223,7 @@ export class TeamsController {
     return this.teamDtoMapper.toDto(team);
   }
 
-  @Roles(UserRole.ADMIN)
+  @RequirePermission(Permission.MANAGE_TEAMS)
   @Patch(':id')
   @ApiOperation({
     summary: 'Update a team in the current organization',
@@ -274,7 +274,7 @@ export class TeamsController {
     return this.teamDtoMapper.toDto(team);
   }
 
-  @Roles(UserRole.ADMIN)
+  @RequirePermission(Permission.MANAGE_TEAMS)
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({
@@ -309,7 +309,7 @@ export class TeamsController {
     this.logger.log(`Successfully deleted team with id: ${id}`);
   }
 
-  @Roles(UserRole.ADMIN)
+  @RequirePermission(Permission.MANAGE_TEAMS)
   @Get(':id/members')
   @ApiOperation({
     summary: 'List members of a team',
@@ -359,7 +359,7 @@ export class TeamsController {
     };
   }
 
-  @Roles(UserRole.ADMIN)
+  @RequirePermission(Permission.ASSIGN_USERS_TO_TEAMS)
   @Post(':id/members')
   @ApiOperation({
     summary: 'Add a user to a team',
@@ -409,7 +409,7 @@ export class TeamsController {
     return this.teamMemberDtoMapper.toDto(teamMember);
   }
 
-  @Roles(UserRole.ADMIN)
+  @RequirePermission(Permission.ASSIGN_USERS_TO_TEAMS)
   @Post(':id/members/bulk')
   @ApiOperation({
     summary: 'Add multiple users to a team at once',
@@ -445,7 +445,7 @@ export class TeamsController {
     return this.teamMemberDtoMapper.toDtoList(teamMembers);
   }
 
-  @Roles(UserRole.ADMIN)
+  @RequirePermission(Permission.ASSIGN_USERS_TO_TEAMS)
   @Delete(':id/members/:userId')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case.spec.ts
@@ -9,6 +9,7 @@ import type { UUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 import { Paginated } from 'src/common/pagination/paginated.entity';
+import { HasPermissionUseCase } from 'src/iam/permissions/application/use-cases/has-permission/has-permission.use-case';
 
 describe('FindUsersByOrgIdUseCase', () => {
   let useCase: FindUsersByOrgIdUseCase;
@@ -29,6 +30,10 @@ describe('FindUsersByOrgIdUseCase', () => {
         FindUsersByOrgIdUseCase,
         { provide: UsersRepository, useValue: mockUsersRepository },
         { provide: ContextService, useValue: mockContextService },
+        {
+          provide: HasPermissionUseCase,
+          useValue: { execute: jest.fn().mockResolvedValue(false) },
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case.ts
@@ -2,11 +2,13 @@ import { Injectable, Logger } from '@nestjs/common';
 import { UsersRepository } from '../../ports/users.repository';
 import { FindUsersByOrgIdQuery } from './find-users-by-org-id.query';
 import { User } from 'src/iam/users/domain/user.entity';
-import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { Paginated } from 'src/common/pagination/paginated.entity';
+import { HasPermissionUseCase } from 'src/iam/permissions/application/use-cases/has-permission/has-permission.use-case';
+import { HasPermissionQuery } from 'src/iam/permissions/application/use-cases/has-permission/has-permission.query';
+import { Permission } from 'src/iam/permissions/domain/value-objects/permission.enum';
 
 @Injectable()
 export class FindUsersByOrgIdUseCase {
@@ -15,6 +17,7 @@ export class FindUsersByOrgIdUseCase {
   constructor(
     private readonly usersRepository: UsersRepository,
     private readonly contextService: ContextService,
+    private readonly hasPermissionUseCase: HasPermissionUseCase,
   ) {}
 
   async execute(query: FindUsersByOrgIdQuery): Promise<Paginated<User>> {
@@ -26,9 +29,20 @@ export class FindUsersByOrgIdUseCase {
     });
     const systemRole = this.contextService.get('systemRole');
     const orgRole = this.contextService.get('role');
-    if (!(
-      systemRole === SystemRole.SUPER_ADMIN || orgRole === UserRole.ADMIN
-    )) {
+    // Listing org users is allowed for super-admins, org admins (admins hold
+    // every permission), and members who can assign users to teams — the
+    // add-team-member picker needs the list.
+    const canListUsers =
+      systemRole === SystemRole.SUPER_ADMIN ||
+      (orgRole !== undefined &&
+        (await this.hasPermissionUseCase.execute(
+          new HasPermissionQuery(
+            query.orgId,
+            orgRole,
+            Permission.ASSIGN_USERS_TO_TEAMS,
+          ),
+        )));
+    if (!canListUsers) {
       throw new UnauthorizedAccessError({ orgId: query.orgId });
     }
     return this.usersRepository.findManyByOrgId(

--- a/ayunis-core-backend/src/iam/users/users.module.ts
+++ b/ayunis-core-backend/src/iam/users/users.module.ts
@@ -53,6 +53,7 @@ import { SuperAdminTriggerPasswordResetUseCase } from './application/use-cases/s
 import { InvitesModule } from '../invites/invites.module';
 import { OrgsModule } from '../orgs/orgs.module';
 import { SessionsModule } from '../sessions/sessions.module';
+import { PermissionsModule } from '../permissions/permissions.module';
 import { SendSetInitialPasswordEmailUseCase } from './application/use-cases/send-set-initial-password-email/send-set-initial-password-email.use-case';
 import { TriggerSetInitialPasswordUseCase } from './application/use-cases/trigger-set-initial-password/trigger-set-initial-password.use-case';
 import { SuperAdminUsersController } from './presenters/http/super-admin-users.controller';
@@ -70,6 +71,7 @@ import { ExportUsersUseCase } from './application/use-cases/export-users/export-
     InvitesModule,
     OrgsModule,
     SessionsModule,
+    PermissionsModule,
     HashingModule,
     EmailsModule,
     EmailTemplatesModule,


### PR DESCRIPTION
<!-- stack-order -->
> ⚠️ **Stacked PR (AYC-347) — merge bottom-to-top, in order. Do not merge out of sequence; each depends on the ones below it.**
>
> 1. #1148 — add MANAGER role
> 2. #1149 — per-org permissions foundation
> 3. #1150 — gate teams / skills / knowledge bases  👈 **this PR**
> 4. #1151 — roles & permissions admin UI
> 5. #1152 — hide create controls by permission
> 6. #1153 — managers: permission-scoped settings access
> 7. #1154 — gate skill/KB edit·delete·share controls
> 8. #1155 — docs: RBAC approach
<!-- /stack-order -->




- Teams: replace @Roles(ADMIN) with @RequirePermission — team CRUD and member
  listing require MANAGE_TEAMS; member add/bulk/remove require
  ASSIGN_USERS_TO_TEAMS. GET /me stays open.
- Skills: gate create/install-from-marketplace/update/delete with MANAGE_SKILLS;
  reads and per-user activate/pin toggles stay open.
- Knowledge bases: gate create/update/delete and document/url mutations with
  MANAGE_KNOWLEDGE_BASES; reads stay open. Extract file validation, upload
  interceptor and Swagger metadata out of addDocument to satisfy length gate.
- Shares: gate POST /shares/skills with SHARE_SKILLS and
  POST /shares/knowledge-bases with SHARE_KNOWLEDGE_BASES.

Existing members keep skill/KB access via the migration backfill; teams stay
admin-only until an admin grants team permissions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Broad authorization changes across many HTTP endpoints can 403 users who previously relied on admin-only or implicit access until permissions are granted; org user listing logic also changed.
> 
> **Overview**
> **Replaces coarse admin-only `@Roles` checks with per-org `@RequirePermission` on mutating APIs** for teams, skills, knowledge bases, and shares. Read/list routes (and skill activate/pin toggles) stay unchanged; `GET /teams/me` remains open.
> 
> **Teams:** org team list/detail/CRUD and member listing require `MANAGE_TEAMS`; add/bulk/remove members require `ASSIGN_USERS_TO_TEAMS`.
> 
> **Skills:** create, marketplace install, update, delete, file sources, KB/MCP assignments require `MANAGE_SKILLS`.
> 
> **Knowledge bases:** create/update/delete and document/URL mutations require `MANAGE_KNOWLEDGE_BASES`. `addDocument` is refactored (shared Swagger/upload constants, `resolveDocumentMimeType` helper) without changing upload behavior.
> 
> **Shares:** `POST /shares/skills` and `POST /shares/knowledge-bases` require `SHARE_SKILLS` and `SHARE_KNOWLEDGE_BASES` respectively.
> 
> **Org user list:** `FindUsersByOrgIdUseCase` now allows super-admins and anyone with `ASSIGN_USERS_TO_TEAMS` (via `HasPermissionUseCase`), so managers can populate the add-team-member picker; `UsersModule` imports `PermissionsModule`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ab7154f7b60acff76c4d300664fb5ccfba602ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


### Screenshots / demo

**Managers can now populate the add-team-member picker.** The org-user list use case previously allowed only admins/super-admins and 403'd everyone else, so a manager's dropdown came back empty. It now also allows holders of `assign_users_to_teams` (admins still pass via the permission short-circuit):

![add-member dropdown populated](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-347/docs/pr-media/ayc-347/1150-addmember-dropdown.png)

![add-member demo](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-347/docs/pr-media/ayc-347/1150-addmember.gif)

> Media hosted on the `pr-media/ayc-347` branch (not part of this PR's diff); safe to delete after merge.
