### PR TITLE
feat(auth): gate skill & knowledge-base edit/delete/share controls by permission (AYC-347)

### DIFF
--- a/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBasePage.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBasePage.tsx
@@ -7,6 +7,7 @@ import type {
 import ContentAreaHeader from '@/widgets/content-area-header/ui/ContentAreaHeader';
 import ContentAreaLayout from '@/layouts/content-area-layout/ui/ContentAreaLayout';
 import { SharesTab } from '@/widgets/shares-tab';
+import { useMyPermissions } from '@/features/permissions';
 import { OnboardingTourTarget, TOUR_TARGET } from '@/widgets/onboarding';
 import {
   Tabs,
@@ -79,17 +80,19 @@ export function KnowledgeBasePage({
   }
 
   const isReadOnly = knowledgeBase.isShared;
+  const { can } = useMyPermissions();
+  const canManageKb = can('manage_knowledge_bases');
 
   const configContent = (
     <div className="grid gap-4">
       <KnowledgeBasePropertiesCard
         knowledgeBase={knowledgeBase}
-        disabled={isReadOnly}
+        disabled={isReadOnly || !canManageKb}
       />
       <OnboardingTourTarget name={TOUR_TARGET.addDocuments}>
         <KnowledgeBaseDocumentsCard
           knowledgeBaseId={knowledgeBase.id}
-          disabled={isReadOnly}
+          disabled={isReadOnly || !canManageKb}
         />
       </OnboardingTourTarget>
     </div>
@@ -110,7 +113,7 @@ export function KnowledgeBasePage({
               ) : undefined
             }
             action={
-              !isReadOnly ? (
+              !isReadOnly && canManageKb ? (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button

--- a/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBaseCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBaseCard.tsx
@@ -2,6 +2,7 @@ import { Button } from '@/shared/ui/shadcn/button';
 import { Badge } from '@/shared/ui/shadcn/badge';
 import { Trash2 } from 'lucide-react';
 import { useDeleteKnowledgeBase } from '../api/useDeleteKnowledgeBase';
+import { PermissionGate } from '@/features/permissions';
 import { useConfirmation } from '@/widgets/confirmation-modal';
 import { useTranslation } from 'react-i18next';
 import type { KnowledgeBase } from '../model/openapi';
@@ -67,21 +68,26 @@ export default function KnowledgeBaseCard({
           <ItemDescription>{knowledgeBase.description}</ItemDescription>
         )}
       </ItemContent>
+      {/* The gate wraps ItemActions rather than the button: delete is the only
+          action here, so gating inside would leave an empty flex sibling and a
+          trailing gap that shared cards don't have. */}
       {!isShared && (
-        <ItemActions>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="text-destructive hover:text-destructive"
-            onClick={(e) => {
-              e.stopPropagation();
-              handleDelete();
-            }}
-            disabled={deleteKnowledgeBase.isPending}
-          >
-            <Trash2 />
-          </Button>
-        </ItemActions>
+        <PermissionGate permission="manage_knowledge_bases">
+          <ItemActions>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-destructive hover:text-destructive"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleDelete();
+              }}
+              disabled={deleteKnowledgeBase.isPending}
+            >
+              <Trash2 />
+            </Button>
+          </ItemActions>
+        </PermissionGate>
       )}
     </Item>
   );

--- a/ayunis-core-frontend/src/pages/skill/ui/SkillPage.tsx
+++ b/ayunis-core-frontend/src/pages/skill/ui/SkillPage.tsx
@@ -11,6 +11,7 @@ import SkillKnowledgeBasesCard from './SkillKnowledgeBasesCard';
 import { KnowledgeBaseCard } from '@/widgets/knowledge-base-card';
 import SkillMcpIntegrationsCard from './SkillMcpIntegrationsCard';
 import { SharesTab } from '@/widgets/shares-tab';
+import { useMyPermissions } from '@/features/permissions';
 import {
   Tabs,
   TabsList,
@@ -90,6 +91,8 @@ export function SkillPage({
   }
 
   const isReadOnly = skill.isShared;
+  const { can } = useMyPermissions();
+  const canManageSkills = can('manage_skills');
 
   return (
     <AppLayout>
@@ -155,7 +158,7 @@ export function SkillPage({
                     </TooltipContent>
                   </Tooltip>
                 )}
-                {!isReadOnly && (
+                {!isReadOnly && canManageSkills && (
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button
@@ -206,12 +209,18 @@ export function SkillPage({
               </TabsList>
               <TabsContent value="config" className="mt-4">
                 <div className="grid gap-4">
-                  <SkillPropertiesCard skill={skill} />
-                  {isEmbeddingModelEnabled && <SkillKnowledgeBasesCard />}
-                  <SkillMcpIntegrationsCard />
+                  <SkillPropertiesCard
+                    skill={skill}
+                    disabled={!canManageSkills}
+                  />
+                  {isEmbeddingModelEnabled && (
+                    <SkillKnowledgeBasesCard disabled={!canManageSkills} />
+                  )}
+                  <SkillMcpIntegrationsCard disabled={!canManageSkills} />
                   <KnowledgeBaseCard
                     entity={skill}
                     isEnabled={isEmbeddingModelEnabled}
+                    disabled={!canManageSkills}
                     translationNamespace="skill"
                     sourcesHook={sourcesHook}
                   />

--- a/ayunis-core-frontend/src/pages/skills/ui/SkillCard.tsx
+++ b/ayunis-core-frontend/src/pages/skills/ui/SkillCard.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/shared/ui/shadcn/tooltip';
 import { Trash2, Pin } from 'lucide-react';
 import { useDeleteSkill } from '../api/useDeleteSkill';
+import { PermissionGate } from '@/features/permissions';
 import {
   useToggleSkillActive,
   useToggleSkillPinned,
@@ -134,24 +135,26 @@ export default function SkillCard({
             pinButton
           ))}
         {!skill.isShared && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="text-destructive hover:text-destructive"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleDelete();
-                }}
-                disabled={deleteSkill.isPending}
-                aria-label={t('card.deleteLabel')}
-              >
-                <Trash2 />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{t('card.deleteLabel')}</TooltipContent>
-          </Tooltip>
+          <PermissionGate permission="manage_skills">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-destructive hover:text-destructive"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDelete();
+                  }}
+                  disabled={deleteSkill.isPending}
+                  aria-label={t('card.deleteLabel')}
+                >
+                  <Trash2 />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t('card.deleteLabel')}</TooltipContent>
+            </Tooltip>
+          </PermissionGate>
         )}
       </ItemActions>
     </Item>

--- a/ayunis-core-frontend/src/widgets/shares-tab/ui/SharesTab.tsx
+++ b/ayunis-core-frontend/src/widgets/shares-tab/ui/SharesTab.tsx
@@ -8,6 +8,7 @@ import type {
 import { ShareResponseDtoScopeType } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { useCreateShare } from '../api/useCreateShare';
 import { useDeleteShare } from '../api/useDeleteShare';
+import { useMyPermissions } from '@/features/permissions';
 import {
   Item,
   ItemContent,
@@ -40,6 +41,12 @@ export default function SharesTab({
   const { confirm } = useConfirmation();
   const { createShare, isCreating } = useCreateShare(entityType, entityId);
   const { deleteShare, isDeleting } = useDeleteShare(entityType, entityId);
+  const { can } = useMyPermissions();
+  // Members without the entity's share permission cannot toggle shares (the
+  // backend 403s the create anyway); disable the switches so it's clear.
+  const canShare = can(
+    entityType === 'skill' ? 'share_skills' : 'share_knowledge_bases',
+  );
 
   // Check if organization share exists
   const organizationShare = shares.find(
@@ -125,7 +132,7 @@ export default function SharesTab({
           <Switch
             checked={!!organizationShare}
             onCheckedChange={handleOrgToggleChange}
-            disabled={isCreating || isDeleting}
+            disabled={isCreating || isDeleting || !canShare}
           />
         </ItemActions>
       </Item>
@@ -149,7 +156,7 @@ export default function SharesTab({
                     onCheckedChange={(checked) =>
                       handleTeamToggleChange(team.id, team.name, checked)
                     }
-                    disabled={isCreating || isDeleting}
+                    disabled={isCreating || isDeleting || !canShare}
                   />
                 </ItemActions>
               </Item>


### PR DESCRIPTION
<!-- stack-order -->
> ⚠️ **Stacked PR (AYC-347) — merge bottom-to-top, in order. Do not merge out of sequence; each depends on the ones below it.**
>
> 1. #1148 — add MANAGER role
> 2. #1149 — per-org permissions foundation
> 3. #1150 — gate teams / skills / knowledge bases
> 4. #1151 — roles & permissions admin UI
> 5. #1152 — hide create controls by permission
> 6. #1153 — managers: permission-scoped settings access
> 7. #1154 — gate skill/KB edit·delete·share controls  👈 **this PR**
> 8. #1155 — docs: RBAC approach
<!-- /stack-order -->


- Skills: hide the delete control (list card + detail) and disable the
  edit (properties/sources/MCP/KB) cards without manage_skills; disable the
  share switches without share_skills.
- Knowledge bases: same — delete + edit (properties/documents) gated on
  manage_knowledge_bases; share switches gated on share_knowledge_bases.
- Reuses the PermissionGate primitive and the entity cards' existing disabled
  prop; reading shared skills/KBs stays open. Backend already 403s these; this
  hides the controls so members don't hit dead ends.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only UX gating on top of existing backend enforcement; no auth or API behavior changes.
> 
> **Overview**
> Skill and knowledge-base **edit**, **delete**, and **share** UI now follow org RBAC instead of only hiding actions for shared (read-only) items.
> 
> **Manage permissions** (`manage_skills`, `manage_knowledge_bases`): list cards wrap delete in `PermissionGate` so the trash control is omitted without permission; detail pages hide delete and pass `disabled` into properties, documents/sources, MCP, and related config cards when the user cannot manage. Shared entities stay viewable; only mutating controls are affected.
> 
> **Share permissions** (`share_skills`, `share_knowledge_bases`): `SharesTab` disables org and team share switches when the user lacks the matching share permission, aligning the UI with backend 403s.
> 
> Skill **active** and **pin** toggles on list/detail are unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffa27a42e9c7c3897effd942cee685f73ca850a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Screenshots

Skill detail for its **owner**. With `manage_skills` + `share_skills` the edit fields, delete (trash), and share toggles are active; after an admin revokes them the delete disappears, the edit form is disabled, and the share switches are disabled (reading shared items stays open). Knowledge bases behave identically.

| With permissions | Permissions revoked |
| --- | --- |
| ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-347/docs/pr-media/ayc-347/before-skill-config.png) | ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-347/docs/pr-media/ayc-347/after-skill-config.png) |

Share tab, permissions revoked (org + team share toggles disabled; the per-user "Aktiv" toggle is not gated):

<img src="https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-347/docs/pr-media/ayc-347/after-skill-share.png" width="640" />

> Media hosted on the `pr-media/ayc-347` branch (not part of this PR's diff); safe to delete after merge.