### PR TITLE
docs(architecture): document the RBAC / permissions approach (AYC-347)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,7 +55,8 @@ ayunis-core/
 | Module | Summary | Detail |
 | ------ | ------- | ------ |
 | [authentication](ayunis-core-backend/src/iam/authentication/SUMMARY.md) | User Auth | Login, registration, JWT tokens |
-| [authorization](ayunis-core-backend/src/iam/authorization/SUMMARY.md) | Access Control | Role-based guards |
+| [authorization](ayunis-core-backend/src/iam/authorization/SUMMARY.md) | Access Control | Role & permission guards |
+| [permissions](ayunis-core-backend/src/iam/permissions/SUMMARY.md) | RBAC | Per-org role/permission grants (MANAGER/USER configurable) |
 | [users](ayunis-core-backend/src/iam/users/SUMMARY.md) | Accounts | User profiles and credentials |
 | [orgs](ayunis-core-backend/src/iam/orgs/SUMMARY.md) | Tenants | Multi-tenant organization management |
 | [subscriptions](ayunis-core-backend/src/iam/subscriptions/SUMMARY.md) | Billing | Package and subscription management |
@@ -134,11 +135,54 @@ Routes  Composites  Logic    Primitives
 
 Import rules: layers only depend on layers to their right.
 
+### Authorization & RBAC
+
+Two independent axes gate every request, both bound globally as `APP_GUARD`s in
+[`iam.module.ts`](ayunis-core-backend/src/iam/iam.module.ts) (order is
+load-bearing):
+
+- **Role** — `UserRole` is `ADMIN | MANAGER | USER` (org-level, on the user).
+  `@Roles(...)` + `RolesGuard` do a plain OR-match. `SystemRole`
+  (`super_admin`) is a separate platform axis via `@SystemRoles` +
+  `SystemRolesGuard`.
+- **Permission** — fine-grained capabilities (`manage_teams`,
+  `assign_users_to_teams`, `manage_skills`, `share_skills`,
+  `manage_knowledge_bases`, `share_knowledge_bases`) that org admins grant
+  **per role, per org**. `@RequirePermission(Permission.X)` + `PermissionsGuard`
+  → `HasPermissionUseCase`. **ADMIN implicitly holds every permission**;
+  MANAGER/USER hold what the org's matrix grants (each must keep ≥1). Grants
+  live in the per-org `role_permissions` table; new orgs are seeded and existing
+  orgs backfilled to preserve pre-RBAC access. See
+  [permissions/SUMMARY.md](ayunis-core-backend/src/iam/permissions/SUMMARY.md).
+
+**Reads stay open** — only manage/share (write) endpoints are permission-gated;
+per-entity visibility (ownership + shares) is enforced separately inside the use
+cases, so a member without `manage_*` can still read what's shared with them.
+
+**Frontend enforcement mirrors, never replaces, the backend.** Any authenticated
+user reads their effective permissions from `GET /permissions/me`; the
+[`permissions` feature](ayunis-core-frontend/src/features/permissions) exposes
+`useMyPermissions()` and `<PermissionGate>` to hide controls a member can't use
+(create/edit/delete/share buttons, empty-state CTAs) and to permission-filter
+the admin-settings sidebar + route guard. The backend still 403s regardless.
+
+**Adding a new permission:**
+
+1. Add the value to the `Permission` enum
+   (`permissions/domain/value-objects/permission.enum.ts`). The API returns
+   grants only — labels, grouping and display order are a frontend concern
+   (`roles-settings/lib/catalog.ts` + the `admin-settings-roles` locales).
+2. Generate an enum-alter migration (the column is a Postgres enum) and, if the
+   default should change, update `DEFAULT_ROLE_PERMISSIONS` + the backfill.
+3. Gate the relevant endpoints with `@RequirePermission(Permission.X)`.
+4. (Optional) hide the matching UI controls with `<PermissionGate permission="x">`.
+5. Regenerate the API client so the enum reaches the frontend.
+
 ---
 
 ## Quick Navigation
 
 - **Adding a backend feature**: Start at the relevant domain module's SUMMARY.md
 - **Adding a frontend page**: See [pages/SUMMARY.md](ayunis-core-frontend/src/pages/SUMMARY.md)
-- **Understanding auth**: [authentication](ayunis-core-backend/src/iam/authentication/SUMMARY.md) + [authorization](ayunis-core-backend/src/iam/authorization/SUMMARY.md)
+- **Understanding auth**: [authentication](ayunis-core-backend/src/iam/authentication/SUMMARY.md) + [authorization](ayunis-core-backend/src/iam/authorization/SUMMARY.md) + [permissions](ayunis-core-backend/src/iam/permissions/SUMMARY.md) (RBAC — see "Authorization & RBAC" above)
 - **AI execution flow**: [threads](ayunis-core-backend/src/domain/threads/SUMMARY.md) → [runs](ayunis-core-backend/src/domain/runs/SUMMARY.md) → [messages](ayunis-core-backend/src/domain/messages/SUMMARY.md)

--- a/ayunis-core-frontend/src/pages/admin-settings/roles-settings/api/useUpdateRolePermissions.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/roles-settings/api/useUpdateRolePermissions.ts
@@ -3,6 +3,7 @@ import {
   getRolePermissionsControllerGetQueryKey,
 } from '@/shared/api';
 import { useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { showSuccess, showError } from '@/shared/lib/toast';
 import type { RolePermissionsDraft } from '../model/types';
@@ -24,6 +25,10 @@ export function useUpdateRolePermissions(
   const queryClient = useQueryClient();
   const { t } = useTranslation('admin-settings-roles');
   const mutation = useRolePermissionsControllerUpdate();
+  // Tracks the whole save (all roles + the awaited refetch), not a single
+  // request — mutation.isPending drops between roles and would re-enable the
+  // controls mid-save, allowing a double-submit.
+  const [isSaving, setIsSaving] = useState(false);
 
   const invalidate = () =>
     queryClient.invalidateQueries({
@@ -45,6 +50,7 @@ export function useUpdateRolePermissions(
       options?.onSaved?.();
       return;
     }
+    setIsSaving(true);
     try {
       for (const role of changed) {
         await mutation.mutateAsync({
@@ -63,8 +69,10 @@ export function useUpdateRolePermissions(
       // survive. On retry, changedRoles narrows to the roles that still differ.
       await invalidate();
       showError(t('saveError'));
+    } finally {
+      setIsSaving(false);
     }
   }
 
-  return { save, isSaving: mutation.isPending };
+  return { save, isSaving };
 }


### PR DESCRIPTION
<!-- stack-order -->
> ⚠️ **Stacked PR (AYC-347) — merge bottom-to-top, in order. Do not merge out of sequence; each depends on the ones below it.**
>
> 1. #1148 — add MANAGER role
> 2. #1149 — per-org permissions foundation
> 3. #1150 — gate teams / skills / knowledge bases
> 4. #1151 — roles & permissions admin UI
> 5. #1152 — hide create controls by permission
> 6. #1153 — managers: permission-scoped settings access
> 7. #1154 — gate skill/KB edit·delete·share controls
> 8. #1155 — docs: RBAC approach  👈 **this PR**
<!-- /stack-order -->

- New 'Authorization & RBAC' section: role vs permission axes, the guard chain,
  reads-stay-open, frontend enforcement (useMyPermissions/PermissionGate), and a
  'how to add a new permission' checklist.
- Register the permissions module in the IAM table; extend the auth nav pointer.
- Normalize table delimiter spacing to satisfy markdownlint MD060.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation plus a localized UI loading-state fix; no auth logic or API behavior changes.
> 
> **Overview**
> **Documents the org RBAC model** in `ARCHITECTURE.md`: role vs permission axes, global guard order, “reads stay open” vs write gating, frontend mirroring via `useMyPermissions` / `PermissionGate`, and a checklist for adding new permissions. The IAM module table now links **permissions**, and the auth quick-nav points there alongside authentication and authorization.
> 
> **Fixes double-submit on the roles matrix save:** `useUpdateRolePermissions` no longer exposes `mutation.isPending` as `isSaving`. A dedicated `isSaving` flag stays true for the full multi-role `mutateAsync` loop and the awaited cache refetch, so save controls stay disabled until the operation finishes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03e993a834e56f8411bd839684869262720f1b26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


### 🎥 Demo walkthrough (Loom)

Full feature walkthroughs recorded for the team:

- [Role Based Access With Managers](https://www.loom.com/share/86684e13118841c59618af4d6b60a956)
- [Role Based Access With Users](https://www.loom.com/share/ac25325b4061418585f61de1bc013312)
