### PR TITLE
fix(observability): stop reporting aborted mcp listening streams (AYC-555)

### DIFF
--- a/ayunis-core-backend/appsignal-hooks.cjs
+++ b/ayunis-core-backend/appsignal-hooks.cjs
@@ -19,6 +19,34 @@ function isCrawlerRequest(request) {
   return headerValue(request.headers, 'user-agent') === CRAWLER_USER_AGENT;
 }
 
+/**
+ * Identifies the listening stream the MCP SDK's StreamableHTTPClientTransport
+ * opens in the background on connect. The client adapter opens one connection
+ * per operation and always closes it, and close() unconditionally aborts that
+ * still-open stream — so undici reports an AbortError on a request the
+ * application deliberately cancelled and never consumed, after the operation
+ * already succeeded (AYC-555).
+ *
+ * The listening stream is the only outbound GET sending exactly
+ * `text/event-stream`; MCP JSON-RPC calls are POSTs sending
+ * `application/json, text/event-stream`, so genuine connectivity and auth
+ * failures stay fully instrumented.
+ */
+function isMcpEventStreamRequest(request) {
+  return (
+    request.method === 'GET' &&
+    headerValue(request.headers, 'accept') === 'text/event-stream'
+  );
+}
+
+/**
+ * The undici ignore hook wired in appsignal.cjs. Returning true skips span
+ * creation entirely, so no exception can be recorded for the request.
+ */
+function shouldIgnoreRequest(request) {
+  return isCrawlerRequest(request) || isMcpEventStreamRequest(request);
+}
+
 // Undici request headers are either a raw `name: value\r\n` string (undici
 // v5) or a flat [name, value, ...] array whose values may be string arrays
 // (undici v6).
@@ -46,4 +74,9 @@ function headerValue(headers, name) {
   return undefined;
 }
 
-module.exports = { isCrawlerRequest, CRAWLER_USER_AGENT };
+module.exports = {
+  isCrawlerRequest,
+  isMcpEventStreamRequest,
+  shouldIgnoreRequest,
+  CRAWLER_USER_AGENT,
+};

--- a/ayunis-core-backend/appsignal.cjs
+++ b/ayunis-core-backend/appsignal.cjs
@@ -8,7 +8,7 @@ const {
 } = require('@opentelemetry/instrumentation-undici');
 const { readFileSync } = require('fs');
 const { join } = require('path');
-const { isCrawlerRequest } = require('./appsignal-hooks.cjs');
+const { shouldIgnoreRequest } = require('./appsignal-hooks.cjs');
 
 // This file runs before main.ts imports src/config/env, so load the same
 // .env files here (dotenv never overwrites variables already set, so the
@@ -63,17 +63,18 @@ if (pushApiKey && environment !== 'development') {
     // EAI_AGAIN, connect/body timeouts, aborts) on outbound-request spans
     // even when application code catches and handles them. Crawler fetches
     // target arbitrary user-supplied URLs whose failures are expected and
-    // already surface as domain errors, so those requests are not
-    // instrumented at all. Requests to model/OCR providers don't carry the
-    // crawler User-Agent and stay fully instrumented — genuine inference
-    // errors must keep reporting.
+    // already surface as domain errors, and the MCP listening stream is
+    // aborted by design on every close — neither is instrumented (see
+    // appsignal-hooks.cjs). Requests to model/OCR providers and MCP
+    // JSON-RPC calls stay fully instrumented — genuine inference and
+    // connectivity errors must keep reporting.
     additionalInstrumentations: [
       new UndiciInstrumentation({
         // AppSignal's default for its own undici instrumentation — without
         // it, fire-and-forget fetches outside any request context create
         // orphan root spans.
         requireParentforSpans: true,
-        ignoreRequestHook: isCrawlerRequest,
+        ignoreRequestHook: shouldIgnoreRequest,
       }),
     ],
     // Queue consumers rename job failures that BullMQ will retry to this

--- a/ayunis-core-backend/src/common/util/appsignal-hooks.spec.ts
+++ b/ayunis-core-backend/src/common/util/appsignal-hooks.spec.ts
@@ -1,14 +1,25 @@
 // appsignal-hooks.cjs is a plain CJS module loaded by appsignal.cjs before
 // the app boots; require() mirrors how it is consumed there.
+
+type UndiciRequest = {
+  method?: string;
+  headers: string | (string | string[])[];
+};
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const hooks = require('../../../appsignal-hooks.cjs') as {
-  isCrawlerRequest: (request: {
-    headers: string | (string | string[])[];
-  }) => boolean;
+  isCrawlerRequest: (request: UndiciRequest) => boolean;
+  isMcpEventStreamRequest: (request: UndiciRequest) => boolean;
+  shouldIgnoreRequest: (request: UndiciRequest) => boolean;
   CRAWLER_USER_AGENT: string;
 };
 
-const { isCrawlerRequest, CRAWLER_USER_AGENT } = hooks;
+const {
+  isCrawlerRequest,
+  isMcpEventStreamRequest,
+  shouldIgnoreRequest,
+  CRAWLER_USER_AGENT,
+} = hooks;
 
 describe('isCrawlerRequest', () => {
   describe('undici v6 array headers', () => {
@@ -55,13 +66,94 @@ describe('isCrawlerRequest', () => {
     });
 
     it('does not match a different user agent', () => {
-      expect(
-        isCrawlerRequest({ headers: 'User-Agent: curl/8.0\r\n' }),
-      ).toBe(false);
+      expect(isCrawlerRequest({ headers: 'User-Agent: curl/8.0\r\n' })).toBe(
+        false,
+      );
     });
 
     it('does not match an empty header string', () => {
       expect(isCrawlerRequest({ headers: '' })).toBe(false);
     });
+  });
+});
+
+describe('isMcpEventStreamRequest', () => {
+  it('matches the MCP SDK listening stream', () => {
+    expect(
+      isMcpEventStreamRequest({
+        method: 'GET',
+        headers: ['accept', 'text/event-stream'],
+      }),
+    ).toBe(true);
+  });
+
+  it('matches undici v5 string headers', () => {
+    expect(
+      isMcpEventStreamRequest({
+        method: 'GET',
+        headers: 'Accept: text/event-stream\r\n',
+      }),
+    ).toBe(true);
+  });
+
+  // The JSON-RPC POST sends `application/json, text/event-stream` — genuine
+  // connectivity and auth failures surface there and must keep reporting.
+  it('does not match the MCP JSON-RPC POST', () => {
+    expect(
+      isMcpEventStreamRequest({
+        method: 'POST',
+        headers: ['accept', 'application/json, text/event-stream'],
+      }),
+    ).toBe(false);
+  });
+
+  it('does not match a GET that merely accepts event streams among others', () => {
+    expect(
+      isMcpEventStreamRequest({
+        method: 'GET',
+        headers: ['accept', 'application/json, text/event-stream'],
+      }),
+    ).toBe(false);
+  });
+
+  it('does not match a plain GET', () => {
+    expect(
+      isMcpEventStreamRequest({
+        method: 'GET',
+        headers: ['accept', 'application/json'],
+      }),
+    ).toBe(false);
+  });
+
+  it('does not match when the method is absent', () => {
+    expect(
+      isMcpEventStreamRequest({ headers: ['accept', 'text/event-stream'] }),
+    ).toBe(false);
+  });
+});
+
+describe('shouldIgnoreRequest', () => {
+  it('ignores crawler requests', () => {
+    expect(
+      shouldIgnoreRequest({ headers: ['user-agent', CRAWLER_USER_AGENT] }),
+    ).toBe(true);
+  });
+
+  it('ignores the MCP listening stream', () => {
+    expect(
+      shouldIgnoreRequest({
+        method: 'GET',
+        headers: ['accept', 'text/event-stream'],
+      }),
+    ).toBe(true);
+  });
+
+  it('instruments provider requests', () => {
+    expect(
+      shouldIgnoreRequest({
+        method: 'POST',
+        headers: ['user-agent', 'OpenAI/JS 4.104.0'],
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only change with narrow request fingerprinting; genuine MCP POST and provider errors stay reported per tests.
> 
> **Overview**
> Extends AppSignal **undici** request filtering so deliberate **MCP SDK** shutdown noise no longer becomes incidents, alongside the existing crawler ignore (AYC-538).
> 
> Adds **`isMcpEventStreamRequest`** (GET with `Accept: text/event-stream` only) and **`shouldIgnoreRequest`**, which combines crawler and MCP stream checks. **`appsignal.cjs`** wires **`ignoreRequestHook`** to **`shouldIgnoreRequest`** instead of **`isCrawlerRequest`**. MCP JSON-RPC POSTs and provider traffic remain instrumented.
> 
> Tests cover MCP stream matching, false positives (POST, mixed Accept), and **`shouldIgnoreRequest`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa744d82993eac2dc0a67f98d7be780e785c6d1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->