### PR TITLE
fix(app): accept larger json bodies and return 413 for oversized ones (AYC-553)

### DIFF
--- a/ayunis-core-backend/appsignal.cjs
+++ b/ayunis-core-backend/appsignal.cjs
@@ -80,7 +80,13 @@ if (pushApiKey && environment !== 'development') {
     // Queue consumers rename job failures that BullMQ will retry to this
     // error (see bullmq-job.helpers.ts), so only final failures — thrown
     // with their original name — become incidents.
-    ignoreErrors: ['JobRetryScheduledError'],
+    //
+    // PayloadTooLargeError is thrown by body-parser before routing, so the
+    // express instrumentation records it on the middleware span and neither
+    // ApplicationErrorFilter's 4xx guard nor any Nest filter can suppress it.
+    // A client sending an oversized body is a 413, not an app defect
+    // (AYC-553).
+    ignoreErrors: ['JobRetryScheduledError', 'PayloadTooLargeError'],
   });
 
   console.warn(`✅ AppSignal initialized for environment: ${environment}`);

--- a/ayunis-core-backend/src/bootstrap-body-limit.spec.ts
+++ b/ayunis-core-backend/src/bootstrap-body-limit.spec.ts
@@ -1,0 +1,75 @@
+import { Controller, Module, Post } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import type { NestExpressApplication } from '@nestjs/platform-express';
+
+// Guards the framework contract main.ts depends on: `NestFactory.create()`
+// does NOT register body parsers — `listen()` does, via `init()`, and it skips
+// any parser already applied by name. So `useBodyParser` called between the
+// two wins, and the configured limit is the one enforced.
+//
+// This replicates main.ts's ordering rather than importing it, because main.ts
+// calls `Bootstrap.start()` at module scope. If Nest ever moves parser
+// registration into `create()`, this fails and main.ts's limit is silently
+// back to the 100kb default (AYC-553).
+@Controller()
+class EchoController {
+  @Post('echo')
+  echo(): { ok: boolean } {
+    return { ok: true };
+  }
+}
+
+@Module({ controllers: [EchoController] })
+class EchoModule {}
+
+describe('body parser limit configured after NestFactory.create', () => {
+  let app: NestExpressApplication;
+  let url: string;
+
+  beforeAll(async () => {
+    app = await NestFactory.create<NestExpressApplication>(EchoModule, {
+      logger: false,
+    });
+    // Same order as main.ts: configure, then listen.
+    app.useBodyParser('json', { limit: '5mb' });
+    app.useBodyParser('urlencoded', { limit: '5mb', extended: true });
+    await app.listen(0);
+
+    const { port } = app.getHttpServer().address() as {
+      port: number;
+    };
+    url = `http://127.0.0.1:${port}/echo`;
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  async function postJsonOfBytes(bytes: number): Promise<number> {
+    const body = JSON.stringify({ payload: 'x'.repeat(bytes) });
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    });
+    return response.status;
+  }
+
+  it('accepts a 300kb body, which the 100kb Express default would reject', async () => {
+    expect(await postJsonOfBytes(300_000)).toBe(201);
+  });
+
+  it('still rejects a body beyond the configured limit', async () => {
+    expect(await postJsonOfBytes(6_000_000)).toBe(413);
+  });
+
+  it('registers exactly one json parser, not the default alongside ours', () => {
+    const instance = app.getHttpAdapter().getInstance() as {
+      router: { stack: { handle?: { name?: string } }[] };
+    };
+    const jsonParsers = instance.router.stack.filter(
+      (layer) => layer.handle?.name === 'jsonParser',
+    );
+    expect(jsonParsers).toHaveLength(1);
+  });
+});

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-error.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-error.mapper.spec.ts
@@ -106,5 +106,62 @@ describe('OpenAIErrorMapper', () => {
       // The public message must NOT echo the upstream payload.
       expect(result.body.error.message).toBe('Internal server error');
     });
+
+    it('maps an unknown 5xx-carrying error to server_error 500', () => {
+      const result = mapper.toEnvelope(
+        httpError(503, 'upstream unavailable', { expose: false }),
+      );
+      expect(result.status).toBe(500);
+      expect(result.body.error.type).toBe('server_error');
+      expect(result.body.error.message).toBe('Internal server error');
+    });
+  });
+
+  // body-parser rejects oversized bodies before routing, so the error never
+  // reaches a Nest filter and arrives here as a plain http-errors instance
+  // rather than an ApplicationError or HttpException (AYC-553).
+  describe('express middleware client errors', () => {
+    it('maps body-parser PayloadTooLargeError to 413, not 500', () => {
+      const result = mapper.toEnvelope(
+        httpError(413, 'request entity too large', {
+          name: 'PayloadTooLargeError',
+        }),
+      );
+      expect(result.status).toBe(413);
+      expect(result.body.error.type).toBe('invalid_request_error');
+      expect(result.body.error.message).toBe('request entity too large');
+    });
+
+    it('does not echo the message of a non-exposable client error', () => {
+      const result = mapper.toEnvelope(
+        httpError(400, 'internal detail: secret', { expose: false }),
+      );
+      expect(result.status).toBe(400);
+      expect(result.body.error.type).toBe('invalid_request_error');
+      expect(result.body.error.message).toBe('Bad request');
+    });
+
+    it('reads statusCode when status is absent', () => {
+      const error = Object.assign(new Error('request entity too large'), {
+        statusCode: 413,
+        expose: true,
+      });
+      expect(mapper.toEnvelope(error).status).toBe(413);
+    });
   });
 });
+
+/** Mirrors the shape the `http-errors` package produces. */
+function httpError(
+  status: number,
+  message: string,
+  options: { name?: string; expose?: boolean } = {},
+): Error {
+  const error = new Error(message);
+  error.name = options.name ?? 'HttpError';
+  return Object.assign(error, {
+    status,
+    statusCode: status,
+    expose: options.expose ?? status < 500,
+  });
+}

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-error.mapper.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-error.mapper.ts
@@ -42,11 +42,17 @@ export class OpenAIErrorMapper {
           : ((body as { message?: string }).message ?? error.message);
       return mappedError(status, message);
     }
+    const status = extractStatus(error);
+    // Express middleware (body-parser, CORS, Multer) rejects requests before
+    // routing, so its errors are plain `http-errors` instances rather than
+    // HttpExceptions. Without this branch a 413 would be reported as a 500
+    // and SDK clients would retry a permanently failing request (AYC-553).
+    if (status !== undefined && status >= 400 && status < 500) {
+      return mappedError(status, clientErrorMessage(error, status));
+    }
     // Log structurally — never include the raw error object, which can
     // echo prompt fragments from upstream SDKs (AYC-92 redaction sweep).
-    this.logger.error('Unhandled error in OpenAI-compat path', {
-      status: extractStatus(error),
-    });
+    this.logger.error('Unhandled error in OpenAI-compat path', { status });
     return {
       status: 500,
       body: envelope({
@@ -57,10 +63,25 @@ export class OpenAIErrorMapper {
   }
 }
 
+/**
+ * `http-errors` sets `expose` to true for client errors whose message is safe
+ * to return. Anything else falls back to the status' generic reason so an
+ * internal detail is never echoed to the caller.
+ */
+function clientErrorMessage(error: unknown, status: number): string {
+  const { expose, message } = error as { expose?: unknown; message?: unknown };
+  if (expose === true && typeof message === 'string' && message.length > 0) {
+    return message;
+  }
+  return status === 413 ? 'Request entity too large' : 'Bad request';
+}
+
 function extractStatus(error: unknown): number | undefined {
   if (typeof error !== 'object' || error === null) return undefined;
   const maybeStatus = (error as { status?: unknown }).status;
   if (typeof maybeStatus === 'number') return maybeStatus;
+  const maybeStatusCode = (error as { statusCode?: unknown }).statusCode;
+  if (typeof maybeStatusCode === 'number') return maybeStatusCode;
   const maybeResponse = (error as { response?: { status?: unknown } }).response;
   if (
     maybeResponse &&

--- a/ayunis-core-backend/src/main.ts
+++ b/ayunis-core-backend/src/main.ts
@@ -17,6 +17,7 @@ import { WinstonModule } from 'nest-winston';
 import { logger } from './common/logger/logger';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import type { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
+import type { NestExpressApplication } from '@nestjs/platform-express';
 
 import { AppModule } from './app/app.module';
 import { METRICS_PATH } from './integrations/metrics/metrics.constants';
@@ -24,9 +25,10 @@ import { parsePositiveIntWithDefault } from './common/util/number.util';
 
 class Bootstrap {
   private static readonly PORT = process.env.PORT ?? 3000;
+  private static readonly DEFAULT_BODY_LIMIT = '5mb';
 
   public static async start() {
-    const app = await NestFactory.create(AppModule, {
+    const app = await NestFactory.create<NestExpressApplication>(AppModule, {
       logger: WinstonModule.createLogger({ instance: logger }),
     });
 
@@ -55,9 +57,21 @@ class Bootstrap {
     server.headersTimeout = keepAliveTimeout + 1_000;
   }
 
-  private static configureApp(
-    app: Awaited<ReturnType<typeof NestFactory.create>>,
-  ) {
+  /**
+   * Express defaults to a 100kb body limit, which rejects legitimate
+   * OpenAI-compatible requests carrying long conversation histories and makes
+   * the 512k artifact content cap unreachable — body-parser fails before any
+   * validation runs (AYC-553). Must be called before listen(), which is when
+   * Nest registers its own parsers for any type not already applied.
+   */
+  private static configureBodyParser(app: NestExpressApplication) {
+    const limit = process.env.HTTP_BODY_LIMIT ?? this.DEFAULT_BODY_LIMIT;
+    app.useBodyParser('json', { limit });
+    app.useBodyParser('urlencoded', { limit, extended: true });
+  }
+
+  private static configureApp(app: NestExpressApplication) {
+    this.configureBodyParser(app);
     this.configureCors(app);
     this.setupSwagger(app);
     app.setGlobalPrefix('api', {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes global request body parsing for all routes and error handling on the OpenAI-compat surface; misconfiguration could affect availability or client retry behavior, but scope is bounded and covered by tests.
> 
> **Overview**
> Fixes **AYC-553** by replacing Express’s **100kb** default with a configurable limit (**`HTTP_BODY_LIMIT`**, default **`5mb`**) via `useBodyParser` on **`NestExpressApplication`** before `listen()`, so large OpenAI-compat chat payloads are accepted instead of failing in middleware.
> 
> **`OpenAIErrorMapper`** now treats plain **`http-errors`** 4xx (including **`PayloadTooLargeError`**) as client errors—**413** with **`invalid_request_error`**—rather than **500**, with safe messaging via **`expose`** and **`statusCode`** fallback. **`appsignal.cjs`** adds **`PayloadTooLargeError`** to **`ignoreErrors`**. New tests lock in bootstrap parser ordering/limit behavior and mapper coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cae4c4151fe4872a1ab8c260790313ba3fbf95e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->