### PR TITLE
fix(threads): insert only the added source assignment (AYC-551)

### DIFF
--- a/ayunis-core-backend/src/domain/threads/application/ports/threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/application/ports/threads.repository.ts
@@ -66,10 +66,10 @@ export abstract class ThreadsRepository {
     threadId: UUID;
     lastActivityAt: Date;
   }): Promise<void>;
-  abstract updateSourceAssignments(params: {
+  abstract addSourceAssignment(params: {
     threadId: UUID;
     userId: UUID;
-    sourceAssignments: SourceAssignment[];
+    sourceAssignment: SourceAssignment;
   }): Promise<void>;
   abstract updateMcpIntegrations(params: {
     threadId: UUID;

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.spec.ts
@@ -43,7 +43,7 @@ describe('AddSourceToThreadUseCase', () => {
   beforeAll(async () => {
     const mockThreadsRepository = {
       findOne: jest.fn(),
-      updateSourceAssignments: jest.fn(),
+      addSourceAssignment: jest.fn(),
     };
 
     const mockContextService = {
@@ -91,22 +91,23 @@ describe('AddSourceToThreadUseCase', () => {
       thread.id,
       mockUserId,
     );
-    expect(threadsRepository.updateSourceAssignments).toHaveBeenCalledWith(
+    expect(threadsRepository.addSourceAssignment).toHaveBeenCalledWith(
       expect.objectContaining({
         threadId: thread.id,
         userId: mockUserId,
       }),
     );
 
-    const savedAssignments =
-      threadsRepository.updateSourceAssignments.mock.calls[0][0]
-        .sourceAssignments;
-    expect(savedAssignments).toHaveLength(1);
-    expect(savedAssignments[0].source.id).toBe(source.id);
-    expect(savedAssignments[0].originSkillId).toBeUndefined();
+    const written =
+      threadsRepository.addSourceAssignment.mock.calls[0][0].sourceAssignment;
+    expect(written.source.id).toBe(source.id);
+    expect(written.originSkillId).toBeUndefined();
   });
 
-  it('should pass survivors alongside the new assignment when the thread already has sources', async () => {
+  // Regression for AYC-551: writing the whole desired set re-inserted rows
+  // that a concurrent delete had removed between the two reads, colliding on
+  // their primary key. Only the added row may ever be written.
+  it('writes only the new assignment when the thread already has sources', async () => {
     const existingSource = new ConcreteSource({ name: 'Existing.pdf' });
     const existingAssignment = new SourceAssignment({ source: existingSource });
     const newSource = new ConcreteSource({ name: 'New.pdf' });
@@ -121,12 +122,11 @@ describe('AddSourceToThreadUseCase', () => {
 
     await useCase.execute(command);
 
-    const savedAssignments =
-      threadsRepository.updateSourceAssignments.mock.calls[0][0]
-        .sourceAssignments;
-    expect(savedAssignments).toHaveLength(2);
-    expect(savedAssignments[0]).toBe(existingAssignment);
-    expect(savedAssignments[1].source.id).toBe(newSource.id);
+    expect(threadsRepository.addSourceAssignment).toHaveBeenCalledTimes(1);
+    const written =
+      threadsRepository.addSourceAssignment.mock.calls[0][0].sourceAssignment;
+    expect(written.source.id).toBe(newSource.id);
+    expect(written.id).not.toBe(existingAssignment.id);
   });
 
   it('should propagate originSkillId to the created SourceAssignment', async () => {
@@ -145,13 +145,11 @@ describe('AddSourceToThreadUseCase', () => {
 
     await useCase.execute(command);
 
-    const savedAssignments =
-      threadsRepository.updateSourceAssignments.mock.calls[0][0]
-        .sourceAssignments;
-    expect(savedAssignments).toHaveLength(1);
-    expect(savedAssignments[0]).toBeInstanceOf(SourceAssignment);
-    expect(savedAssignments[0].source.id).toBe(source.id);
-    expect(savedAssignments[0].originSkillId).toBe(skillId);
+    const written =
+      threadsRepository.addSourceAssignment.mock.calls[0][0].sourceAssignment;
+    expect(written).toBeInstanceOf(SourceAssignment);
+    expect(written.source.id).toBe(source.id);
+    expect(written.originSkillId).toBe(skillId);
   });
 
   it('should throw SourceAlreadyAssignedError when source is already on the thread', async () => {
@@ -170,7 +168,7 @@ describe('AddSourceToThreadUseCase', () => {
     await expect(useCase.execute(command)).rejects.toThrow(
       SourceAlreadyAssignedError,
     );
-    expect(threadsRepository.updateSourceAssignments).not.toHaveBeenCalled();
+    expect(threadsRepository.addSourceAssignment).not.toHaveBeenCalled();
   });
 
   it('should map a unique-constraint violation from the database to SourceAlreadyAssignedError', async () => {
@@ -187,7 +185,7 @@ describe('AddSourceToThreadUseCase', () => {
       new Error('duplicate key value violates unique constraint'),
       { driverError: { code: '23505' } },
     );
-    threadsRepository.updateSourceAssignments.mockRejectedValue(dbError);
+    threadsRepository.addSourceAssignment.mockRejectedValue(dbError);
 
     await expect(useCase.execute(command)).rejects.toThrow(
       SourceAlreadyAssignedError,
@@ -204,7 +202,7 @@ describe('AddSourceToThreadUseCase', () => {
     const command = new AddSourceCommand(thread, source);
 
     threadsRepository.findOne.mockResolvedValue(thread);
-    threadsRepository.updateSourceAssignments.mockRejectedValue(
+    threadsRepository.addSourceAssignment.mockRejectedValue(
       new Error('Connection terminated'),
     );
 
@@ -236,6 +234,6 @@ describe('AddSourceToThreadUseCase', () => {
     await expect(useCase.execute(command)).rejects.toThrow(
       SourceAlreadyAssignedError,
     );
-    expect(threadsRepository.updateSourceAssignments).not.toHaveBeenCalled();
+    expect(threadsRepository.addSourceAssignment).not.toHaveBeenCalled();
   });
 });

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.ts
@@ -62,15 +62,13 @@ export class AddSourceToThreadUseCase {
       const currentAssignments = freshThread.sourceAssignments ?? [];
       this.assertSourceCanBeAdded(currentAssignments, command.source.id);
 
-      const sourceAssignment = new SourceAssignment({
-        source: command.source,
-        originSkillId: command.originSkillId,
-      });
-      const updatedAssignments = [...currentAssignments, sourceAssignment];
-      return await this.threadsRepository.updateSourceAssignments({
+      return await this.threadsRepository.addSourceAssignment({
         threadId: command.thread.id,
         userId,
-        sourceAssignments: updatedAssignments,
+        sourceAssignment: new SourceAssignment({
+          source: command.source,
+          originSkillId: command.originSkillId,
+        }),
       });
     } catch (error) {
       throw this.mapAddSourceError(error, command);

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-thread-assignments.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-thread-assignments.repository.spec.ts
@@ -33,9 +33,11 @@ function makeAssignmentRecord(
 
 describe('LocalThreadAssignmentsRepository', () => {
   let repository: LocalThreadAssignmentsRepository;
-  let threadRepo: jest.Mocked<Pick<Repository<ThreadRecord>, 'findOne'>>;
+  let threadRepo: jest.Mocked<
+    Pick<Repository<ThreadRecord>, 'findOne' | 'exists'>
+  >;
   let sourceAssignmentRepo: jest.Mocked<
-    Pick<Repository<ThreadSourceAssignmentRecord>, 'remove' | 'save'>
+    Pick<Repository<ThreadSourceAssignmentRecord>, 'save'>
   >;
   let kbAssignmentRepo: jest.Mocked<
     Repository<ThreadKnowledgeBaseAssignmentRecord>
@@ -49,13 +51,11 @@ describe('LocalThreadAssignmentsRepository', () => {
   beforeEach(() => {
     threadRepo = {
       findOne: jest.fn(),
+      exists: jest.fn(),
     };
     sourceAssignmentRepo = {
-      remove: jest.fn(),
       save: jest.fn(),
-    } as jest.Mocked<
-      Pick<Repository<ThreadSourceAssignmentRecord>, 'remove' | 'save'>
-    >;
+    };
     kbAssignmentRepo = {} as jest.Mocked<
       Repository<ThreadKnowledgeBaseAssignmentRecord>
     >;
@@ -85,155 +85,79 @@ describe('LocalThreadAssignmentsRepository', () => {
     );
   });
 
-  describe('updateSourceAssignments', () => {
-    it('inserts only the new assignment when adding to an existing list', async () => {
+  describe('addSourceAssignment', () => {
+    it('inserts exactly the new assignment', async () => {
+      const source = new ConcreteSource({ name: 'new.pdf' });
+      threadRepo.exists.mockResolvedValue(true);
+      const assignment = new SourceAssignment({ source });
+
+      await repository.addSourceAssignment({
+        threadId,
+        userId,
+        sourceAssignment: assignment,
+      });
+
+      expect(mapper.toRecord).toHaveBeenCalledTimes(1);
+      expect(mapper.toRecord).toHaveBeenCalledWith(assignment, threadId);
+      expect(sourceAssignmentRepo.save).toHaveBeenCalledTimes(1);
+      const inserted = sourceAssignmentRepo.save.mock
+        .calls[0][0] as ThreadSourceAssignmentRecord;
+      expect(inserted.sourceId).toBe(source.id);
+      expect(inserted.threadId).toBe(threadId);
+    });
+
+    // Regression for AYC-551: the previous full-set-replace write re-derived
+    // the diff from a second read, so a row deleted between the two reads was
+    // re-INSERTed with its original primary key and raised a 23505.
+    it('never writes assignments other than the one being added', async () => {
       const existingSource = new ConcreteSource({ name: 'existing.pdf' });
       const existingRecord = makeAssignmentRecord(threadId, existingSource.id);
-      const newSource = new ConcreteSource({ name: 'new.pdf' });
+      threadRepo.exists.mockResolvedValue(true);
 
-      threadRepo.findOne.mockResolvedValue({
-        id: threadId,
-        userId,
-        sourceAssignments: [existingRecord],
-      } as ThreadRecord);
-
-      await repository.updateSourceAssignments({
+      await repository.addSourceAssignment({
         threadId,
         userId,
-        sourceAssignments: [
-          new SourceAssignment({
-            id: existingRecord.id,
-            source: existingSource,
-            createdAt: existingRecord.createdAt,
-            updatedAt: existingRecord.updatedAt,
-          }),
-          new SourceAssignment({ source: newSource }),
-        ],
+        sourceAssignment: new SourceAssignment({
+          source: new ConcreteSource({ name: 'new.pdf' }),
+        }),
       });
 
-      expect(sourceAssignmentRepo.remove).not.toHaveBeenCalled();
-      expect(mapper.toRecord).toHaveBeenCalledTimes(1);
-      expect(mapper.toRecord).toHaveBeenCalledWith(
-        expect.objectContaining({ source: newSource }),
-        threadId,
-      );
+      const inserted = sourceAssignmentRepo.save.mock
+        .calls[0][0] as ThreadSourceAssignmentRecord;
+      expect(inserted.id).not.toBe(existingRecord.id);
       expect(sourceAssignmentRepo.save).toHaveBeenCalledTimes(1);
-      const savedRecords = sourceAssignmentRepo.save.mock
-        .calls[0][0] as ThreadSourceAssignmentRecord[];
-      expect(savedRecords).toHaveLength(1);
-      expect(savedRecords[0].sourceId).toBe(newSource.id);
-    });
-
-    it('removes stale assignments and does not re-insert survivors', async () => {
-      const keptSource = new ConcreteSource({ name: 'kept.pdf' });
-      const droppedSource = new ConcreteSource({ name: 'dropped.pdf' });
-      const keptRecord = makeAssignmentRecord(threadId, keptSource.id);
-      const droppedRecord = makeAssignmentRecord(threadId, droppedSource.id);
-
-      threadRepo.findOne.mockResolvedValue({
-        id: threadId,
-        userId,
-        sourceAssignments: [keptRecord, droppedRecord],
-      } as ThreadRecord);
-
-      await repository.updateSourceAssignments({
-        threadId,
-        userId,
-        sourceAssignments: [
-          new SourceAssignment({
-            id: keptRecord.id,
-            source: keptSource,
-            createdAt: keptRecord.createdAt,
-            updatedAt: keptRecord.updatedAt,
-          }),
-        ],
-      });
-
-      expect(sourceAssignmentRepo.remove).toHaveBeenCalledTimes(1);
-      expect(sourceAssignmentRepo.remove).toHaveBeenCalledWith([droppedRecord]);
-      expect(mapper.toRecord).not.toHaveBeenCalled();
-      expect(sourceAssignmentRepo.save).not.toHaveBeenCalled();
-    });
-
-    it('no-ops when target list matches the existing assignments', async () => {
-      const source = new ConcreteSource({ name: 'same.pdf' });
-      const record = makeAssignmentRecord(threadId, source.id);
-
-      threadRepo.findOne.mockResolvedValue({
-        id: threadId,
-        userId,
-        sourceAssignments: [record],
-      } as ThreadRecord);
-
-      await repository.updateSourceAssignments({
-        threadId,
-        userId,
-        sourceAssignments: [
-          new SourceAssignment({
-            id: record.id,
-            source,
-            createdAt: record.createdAt,
-            updatedAt: record.updatedAt,
-          }),
-        ],
-      });
-
-      expect(sourceAssignmentRepo.remove).not.toHaveBeenCalled();
-      expect(mapper.toRecord).not.toHaveBeenCalled();
-      expect(sourceAssignmentRepo.save).not.toHaveBeenCalled();
-    });
-
-    it('handles mixed add and remove in one call', async () => {
-      const keptSource = new ConcreteSource({ name: 'kept.pdf' });
-      const droppedSource = new ConcreteSource({ name: 'dropped.pdf' });
-      const addedSource = new ConcreteSource({ name: 'added.pdf' });
-      const keptRecord = makeAssignmentRecord(threadId, keptSource.id);
-      const droppedRecord = makeAssignmentRecord(threadId, droppedSource.id);
-
-      threadRepo.findOne.mockResolvedValue({
-        id: threadId,
-        userId,
-        sourceAssignments: [keptRecord, droppedRecord],
-      } as ThreadRecord);
-
-      await repository.updateSourceAssignments({
-        threadId,
-        userId,
-        sourceAssignments: [
-          new SourceAssignment({
-            id: keptRecord.id,
-            source: keptSource,
-            createdAt: keptRecord.createdAt,
-            updatedAt: keptRecord.updatedAt,
-          }),
-          new SourceAssignment({ source: addedSource }),
-        ],
-      });
-
-      expect(sourceAssignmentRepo.remove).toHaveBeenCalledWith([droppedRecord]);
-      expect(mapper.toRecord).toHaveBeenCalledTimes(1);
-      expect(mapper.toRecord).toHaveBeenCalledWith(
-        expect.objectContaining({ source: addedSource }),
-        threadId,
-      );
-      const savedRecords = sourceAssignmentRepo.save.mock
-        .calls[0][0] as ThreadSourceAssignmentRecord[];
-      expect(savedRecords).toHaveLength(1);
-      expect(savedRecords[0].sourceId).toBe(addedSource.id);
+      expect(threadRepo.findOne).not.toHaveBeenCalled();
     });
 
     it('throws ThreadNotFoundError when the thread does not exist', async () => {
-      threadRepo.findOne.mockResolvedValue(null);
+      threadRepo.exists.mockResolvedValue(false);
 
       await expect(
-        repository.updateSourceAssignments({
+        repository.addSourceAssignment({
           threadId,
           userId,
-          sourceAssignments: [],
+          sourceAssignment: new SourceAssignment({
+            source: new ConcreteSource({ name: 'new.pdf' }),
+          }),
         }),
       ).rejects.toBeInstanceOf(ThreadNotFoundError);
-      expect(sourceAssignmentRepo.remove).not.toHaveBeenCalled();
       expect(sourceAssignmentRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('scopes the ownership check to the requesting user', async () => {
+      threadRepo.exists.mockResolvedValue(true);
+
+      await repository.addSourceAssignment({
+        threadId,
+        userId,
+        sourceAssignment: new SourceAssignment({
+          source: new ConcreteSource({ name: 'new.pdf' }),
+        }),
+      });
+
+      expect(threadRepo.exists).toHaveBeenCalledWith({
+        where: { id: threadId, userId },
+      });
     });
   });
 });

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-thread-assignments.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-thread-assignments.repository.ts
@@ -24,53 +24,38 @@ export class LocalThreadAssignmentsRepository {
     private readonly sourceAssignmentMapper: ThreadSourceAssignmentMapper,
   ) {}
 
-  async updateSourceAssignments(params: {
+  /**
+   * Writes only the row being added. An earlier version took the caller's
+   * entire desired assignment set and re-derived the diff from a second,
+   * independently timed read — so a row deleted between the two reads (by a
+   * concurrent source removal or the stale-source cleanup task, both of which
+   * cascade) was re-INSERTed with its original primary key and raised a 23505
+   * (AYC-551).
+   */
+  async addSourceAssignment(params: {
     threadId: UUID;
     userId: UUID;
-    sourceAssignments: SourceAssignment[];
+    sourceAssignment: SourceAssignment;
   }): Promise<void> {
-    const threadEntity = await this.threadRepository.findOne({
-      where: { id: params.threadId, userId: params.userId },
-      relations: ['sourceAssignments'],
+    this.logger.log('addSourceAssignment', {
+      threadId: params.threadId,
+      userId: params.userId,
+      sourceId: params.sourceAssignment.source.id,
     });
 
-    if (!threadEntity) {
+    const threadExists = await this.threadRepository.exists({
+      where: { id: params.threadId, userId: params.userId },
+    });
+
+    if (!threadExists) {
       throw new ThreadNotFoundError(params.threadId, params.userId);
     }
 
-    // Diff against DB state so we only INSERT genuinely new rows and only
-    // DELETE dropped ones; touching unchanged rows would both waste writes
-    // and race with cascade deletes on the source FK.
-    const existing = threadEntity.sourceAssignments ?? [];
-    const targetSourceIds = new Set(
-      params.sourceAssignments.map((a) => a.source.id),
+    const record = this.sourceAssignmentMapper.toRecord(
+      params.sourceAssignment,
+      params.threadId,
     );
-    const existingSourceIds = new Set(existing.map((a) => a.sourceId));
-
-    const toDelete = existing.filter(
-      (assignment) => !targetSourceIds.has(assignment.sourceId),
-    );
-    const toInsert = params.sourceAssignments.filter(
-      (assignment) => !existingSourceIds.has(assignment.source.id),
-    );
-
-    this.logger.log('updateSourceAssignments', {
-      threadId: params.threadId,
-      userId: params.userId,
-      addCount: toInsert.length,
-      removeCount: toDelete.length,
-    });
-
-    if (toDelete.length > 0) {
-      await this.threadSourceAssignmentRepository.remove(toDelete);
-    }
-
-    if (toInsert.length > 0) {
-      const records = toInsert.map((assignment) =>
-        this.sourceAssignmentMapper.toRecord(assignment, params.threadId),
-      );
-      await this.threadSourceAssignmentRepository.save(records);
-    }
+    await this.threadSourceAssignmentRepository.save(record);
   }
 
   async updateMcpIntegrations(params: {

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
@@ -236,12 +236,12 @@ export class LocalThreadsRepository extends ThreadsRepository {
     );
   }
 
-  async updateSourceAssignments(params: {
+  async addSourceAssignment(params: {
     threadId: UUID;
     userId: UUID;
-    sourceAssignments: SourceAssignment[];
+    sourceAssignment: SourceAssignment;
   }): Promise<void> {
-    return this.assignments.updateSourceAssignments(params);
+    return this.assignments.addSourceAssignment(params);
   }
 
   async updateModel(params: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how thread source assignments are persisted on add; behavior is narrower and safer for concurrency, but touches core thread/source assignment writes.
> 
> **Overview**
> Fixes **AYC-551**, where adding a source to a thread could fail with a Postgres unique-constraint (`23505`) under concurrency.
> 
> The persistence path no longer uses **`updateSourceAssignments`** (full desired set + second read + diff insert/delete). **`addSourceAssignment`** now **inserts a single new row** after an ownership check via `threadRepository.exists`, so rows removed between reads (e.g. concurrent removal or stale-source cleanup) are not re-inserted with the same primary key.
> 
> **`AddSourceToThreadUseCase`** calls the new API with only the new `SourceAssignment`; duplicate and capacity checks still use a fresh `findOne`. Tests were updated with explicit regression coverage for the race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9b434ebe9779d40f95ce5845e1d3309662d1ccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->