### PR TITLE
fix(retrievers): recover when a deduplicated mistral upload is deleted mid-flight (AYC-556)

### DIFF
--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.spec.ts
@@ -19,6 +19,7 @@ jest.mock('@mistralai/mistralai', () => ({
       upload: jest.fn(),
       getSignedUrl: jest.fn(),
       delete: jest.fn(),
+      retrieve: jest.fn(),
     },
     ocr: {
       process: jest.fn(),
@@ -70,6 +71,7 @@ describe('MistralFileRetrieverHandler', () => {
       upload: jest.Mock;
       getSignedUrl: jest.Mock;
       delete: jest.Mock;
+      retrieve: jest.Mock;
     };
     ocr: { process: jest.Mock };
   };
@@ -229,16 +231,22 @@ describe('MistralFileRetrieverHandler', () => {
       );
     });
 
+    // Uses a still-reachable 3310 message: "could not be fetched from url"
+    // belongs to the pre-#1136 signed-URL era and can no longer occur now that
+    // OCR is always addressed by file id.
     it('should throw FileRetrievalFailedError for other Mistral 400 responses', async () => {
       const mistralError = createMistralError(
         400,
-        '{"object":"error","message":"File could not be fetched from url","type":"invalid_request_file","code":"3310"}',
+        '{"object":"error","message":"File is corrupted and cannot be parsed.","type":"invalid_request_file","code":"3310"}',
       );
       mockClient.ocr.process.mockRejectedValue(mistralError);
+      // The file is still there, so this is not the vanished-file case.
+      mockClient.files.retrieve.mockResolvedValue({ id: 'file-123' });
 
       await expect(handler.processFile(testFile)).rejects.toThrow(
         FileRetrievalFailedError,
       );
+      expect(mockClient.files.upload).toHaveBeenCalledTimes(1);
     });
 
     it('should throw FileRetrievalFailedError when the file stays invisible to OCR after retries', async () => {
@@ -270,6 +278,138 @@ describe('MistralFileRetrieverHandler', () => {
       await expect(handler.processFile(testFile)).rejects.toThrow(
         ServiceBusyError,
       );
+    });
+  });
+
+  // Mistral deduplicates uploads by content signature, so a job processing
+  // bytes identical to another job's is handed the same file id and can have
+  // it deleted mid-flight. Recovery is decided by asking the files API whether
+  // the file still exists — not by matching the OCR error text (AYC-556).
+  describe('recovery when the uploaded file is deleted mid-flight', () => {
+    const missingFileBody = JSON.stringify({
+      object: 'error',
+      message: "File 'file-123' could not be found or may have expired.",
+      type: 'invalid_request_file',
+      code: '3310',
+    });
+
+    function fileGone(): void {
+      mockClient.files.retrieve.mockRejectedValue(
+        createMistralError(
+          404,
+          '{"detail":"No file matches the given query."}',
+        ),
+      );
+    }
+
+    beforeEach(() => {
+      mockClient.files.delete.mockResolvedValue(undefined);
+      mockClient.files.upload
+        .mockResolvedValueOnce({ id: 'file-123' })
+        .mockResolvedValueOnce({ id: 'file-456' });
+    });
+
+    it('re-uploads and succeeds when the file is gone', async () => {
+      mockClient.ocr.process
+        .mockRejectedValueOnce(createMistralError(400, missingFileBody))
+        .mockResolvedValueOnce({
+          pages: [{ markdown: '# Recovered', index: 0 }],
+        });
+      fileGone();
+
+      const result = await handler.processFile(testFile);
+
+      expect(mockClient.files.upload).toHaveBeenCalledTimes(2);
+      expect(mockClient.ocr.process).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          document: { type: 'file', fileId: 'file-456' },
+        }),
+      );
+      expect(result.pages[0].text).toBe('# Recovered');
+    });
+
+    // The probe must run before any cleanup, or our own delete would make
+    // every failure look like the vanished-file case.
+    it('probes the files API before deleting the failed upload', async () => {
+      mockClient.ocr.process
+        .mockRejectedValueOnce(createMistralError(400, missingFileBody))
+        .mockResolvedValueOnce({ pages: [{ markdown: '#', index: 0 }] });
+      fileGone();
+
+      await handler.processFile(testFile);
+
+      expect(mockClient.files.retrieve).toHaveBeenCalledWith({
+        fileId: 'file-123',
+      });
+      expect(mockClient.files.delete).not.toHaveBeenCalledWith({
+        fileId: 'file-123',
+      });
+      expect(mockClient.files.delete).toHaveBeenCalledWith({
+        fileId: 'file-456',
+      });
+    });
+
+    // Recovery is keyed on file existence, so an error whose text looks like
+    // the vanished-file case must NOT trigger a re-upload while the file lives.
+    it('does not re-upload when the file still exists', async () => {
+      mockClient.ocr.process.mockRejectedValue(
+        createMistralError(400, missingFileBody),
+      );
+      mockClient.files.retrieve.mockResolvedValue({ id: 'file-123' });
+
+      await expect(handler.processFile(testFile)).rejects.toThrow(
+        FileRetrievalFailedError,
+      );
+      expect(mockClient.files.upload).toHaveBeenCalledTimes(1);
+      expect(mockClient.files.delete).toHaveBeenCalledWith({
+        fileId: 'file-123',
+      });
+    });
+
+    // Conversely, the trigger is the file being gone — whatever OCR reported.
+    it('recovers a non-3310 failure when the file turns out to be gone', async () => {
+      mockClient.ocr.process
+        .mockRejectedValueOnce(
+          createMistralError(400, '{"message":"bad request"}'),
+        )
+        .mockResolvedValueOnce({
+          pages: [{ markdown: '# Recovered', index: 0 }],
+        });
+      fileGone();
+
+      const result = await handler.processFile(testFile);
+
+      expect(mockClient.files.upload).toHaveBeenCalledTimes(2);
+      expect(result.pages[0].text).toBe('# Recovered');
+    });
+
+    it('treats an inconclusive probe as "still there" and does not re-upload', async () => {
+      mockClient.ocr.process.mockRejectedValue(
+        createMistralError(400, missingFileBody),
+      );
+      mockClient.files.retrieve.mockRejectedValue(
+        createMistralError(503, '{"message":"Service unavailable"}'),
+      );
+
+      await expect(handler.processFile(testFile)).rejects.toThrow(
+        FileRetrievalFailedError,
+      );
+      expect(mockClient.files.upload).toHaveBeenCalledTimes(1);
+    });
+
+    it('surfaces the failure when the retry also fails', async () => {
+      mockClient.ocr.process.mockRejectedValue(
+        createMistralError(400, missingFileBody),
+      );
+      fileGone();
+
+      await expect(handler.processFile(testFile)).rejects.toThrow(
+        FileRetrievalFailedError,
+      );
+      expect(mockClient.files.upload).toHaveBeenCalledTimes(2);
+      expect(mockClient.files.delete).toHaveBeenCalledWith({
+        fileId: 'file-456',
+      });
     });
   });
 });

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.ts
@@ -30,6 +30,10 @@ function isTransientOcrError(error: Error): boolean {
   );
 }
 
+function isFileNotFound(error: unknown): boolean {
+  return error instanceof MistralError && error.statusCode === 404;
+}
+
 @Injectable()
 export class MistralFileRetrieverHandler extends FileRetrieverHandler {
   private readonly logger = new Logger(MistralFileRetrieverHandler.name);
@@ -60,9 +64,7 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
       const blobPart: BlobPart = file.fileData as unknown as BlobPart;
       const fileBlob = new Blob([blobPart], { type: file.fileType });
 
-      const uploadedFileId = await this.uploadFile(fileBlob);
-      const ocrResponse = await this.runOcr(uploadedFileId);
-      await this.deleteFileBestEffort(uploadedFileId);
+      const ocrResponse = await this.ocrWithReuploadRecovery(fileBlob);
 
       return this.parseResponse(ocrResponse);
     } catch (error) {
@@ -130,7 +132,67 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
     return uploaded.id;
   }
 
-  /** Runs OCR on the uploaded file by id; deletes the uploaded file on failure. */
+  /**
+   * Uploads, runs OCR, and cleans up.
+   *
+   * Mistral deduplicates uploads by content signature, so two jobs processing
+   * byte-identical documents are handed the same file id; whichever finishes
+   * first deletes it, and the other's OCR call fails even though its own
+   * upload succeeded (AYC-556). Re-uploading recovers, because once the id is
+   * gone an upload of the same bytes yields a fresh, live one.
+   *
+   * The recoverable case is decided by asking the files API whether the file
+   * still exists, not by matching the OCR error's text: `invalid_request_file`
+   * / code 3310 also covers unrelated failures that re-uploading cannot fix,
+   * and error wording is not a stable contract.
+   */
+  private async ocrWithReuploadRecovery(fileBlob: Blob): Promise<OCRResponse> {
+    const fileId = await this.uploadFile(fileBlob);
+    try {
+      const response = await this.runOcr(fileId);
+      await this.deleteFileBestEffort(fileId);
+      return response;
+    } catch (error) {
+      // Probe before any cleanup — deleting first would make every failure
+      // look like the vanished-file case.
+      if (!(await this.uploadedFileIsGone(fileId))) {
+        await this.deleteFileBestEffort(fileId);
+        throw error;
+      }
+      this.logger.warn(
+        'Uploaded file was removed before OCR ran; re-uploading once',
+        { fileId },
+      );
+    }
+
+    const freshFileId = await this.uploadFile(fileBlob);
+    try {
+      return await this.runOcr(freshFileId);
+    } finally {
+      await this.deleteFileBestEffort(freshFileId);
+    }
+  }
+
+  /**
+   * Distinguishes "the file we uploaded is gone" from any other OCR failure.
+   * A retrieve of a deleted or never-existing id returns 404; a live one
+   * returns 200. Treats an inconclusive answer as "still there" so an
+   * unrelated failure is never retried as if the file had vanished.
+   */
+  private async uploadedFileIsGone(fileId: string): Promise<boolean> {
+    try {
+      await this.client.files.retrieve({ fileId });
+      return false;
+    } catch (error) {
+      return isFileNotFound(error);
+    }
+  }
+
+  /**
+   * Runs OCR on the uploaded file by id. Cleanup is the caller's job — it must
+   * not delete before `ocrWithReuploadRecovery` has probed whether the file
+   * still exists.
+   */
   private async runOcr(fileId: string): Promise<OCRResponse> {
     return retryWithBackoff({
       fn: () =>
@@ -145,12 +207,11 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
       maxRetries: 3,
       delay: 1000,
       retryIfError: isTransientOcrError,
-    }).catch(async (error) => {
+    }).catch((error) => {
       this.logger.error(
         `Mistral OCR processing failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
         error instanceof Error ? error.stack : 'Unknown error',
       );
-      await this.client.files.delete({ fileId }).catch(() => undefined);
       throw error;
     });
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core document OCR retry/cleanup ordering in production; behavior is narrower (existence-based) but adds an extra API call on every OCR failure path.
> 
> **Overview**
> Fixes flaky Mistral OCR when **deduplicated uploads share a file id** and another job deletes that id before OCR runs (AYC-556).
> 
> `processFile` now goes through **`ocrWithReuploadRecovery`**: on OCR failure it calls **`files.retrieve`** to see if the upload is really gone (404 only). If so, it **re-uploads once** and retries OCR; if the file still exists or the probe is inconclusive (e.g. 503), it keeps the old behavior—cleanup and surface **`FileRetrievalFailedError`** without a pointless second upload. **`runOcr`** no longer deletes on failure so the probe runs before cleanup.
> 
> Tests add a full recovery suite (probe ordering, no re-upload when file lives, recovery on non-3310 errors when file is gone, inconclusive probe, double failure) and adjust the generic 400 case to use a current 3310 message plus **`retrieve`** mocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac6761c1550ec5026636277143a9ba533a7fcf2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->