### PR TITLE
fix(skills): check the source cap before starting document processing (AYC-566)

### DIFF
--- a/ayunis-core-backend/src/domain/skills/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/skills/SUMMARY.md
@@ -42,6 +42,7 @@ skills/
 │       ├── toggle-skill-pinned/
 │       ├── find-active-skills/
 │       ├── add-source-to-skill/
+│       ├── add-file-source-to-skill/
 │       ├── remove-source-from-skill/
 │       ├── list-skill-sources/
 │       ├── assign-mcp-integration-to-skill/
@@ -72,6 +73,8 @@ skills/
 ## Design Decisions
 
 Both sources and MCP integrations use the same `@ManyToMany` + `@JoinTable` pattern. The domain entity stores `sourceIds: UUID[]` and `mcpIntegrationIds: UUID[]`. Full entity objects are fetched via dedicated list use cases (`ListSkillSourcesUseCase`, `ListSkillMcpIntegrationsUseCase`) that batch-fetch by IDs.
+
+File uploads go through `AddFileSourceToSkillUseCase`, which resolves the skill and asserts the `SkillsConstants.MAX_SOURCES` cap (via `assertSkillHasSourceCapacity` in `application/util/skill-source-capacity.ts`) *before* delegating to the sources module's `StartDocumentProcessingUseCase` — object-storage uploads and enqueued OCR jobs cannot be rolled back, so a skill that is already at the cap must be rejected before any of that work happens. `AddSourceToSkillUseCase` re-checks the same rule against a freshly loaded skill and remains authoritative for concurrent adds.
 
 Activation state is stored in a separate `skill_activations` table rather than a boolean on the skill entity. This allows tracking activation per user without modifying the skill record itself. The `SkillActivationRecord` has a unique constraint on `(skillId, userId)` to ensure each user can only have one activation per skill. The repository uses atomic upsert operations (`INSERT ... ON CONFLICT DO NOTHING`) to handle concurrent activation requests safely.
 

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/add-file-source-to-skill/add-file-source-to-skill.command.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/add-file-source-to-skill/add-file-source-to-skill.command.ts
@@ -1,0 +1,20 @@
+import type { UUID } from 'crypto';
+
+export class AddFileSourceToSkillCommand {
+  public readonly skillId: UUID;
+  public readonly fileData: Buffer;
+  public readonly fileName: string;
+  public readonly fileType: string;
+
+  constructor(params: {
+    skillId: UUID;
+    fileData: Buffer;
+    fileName: string;
+    fileType: string;
+  }) {
+    this.skillId = params.skillId;
+    this.fileData = params.fileData;
+    this.fileName = params.fileName;
+    this.fileType = params.fileType;
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/add-file-source-to-skill/add-file-source-to-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/add-file-source-to-skill/add-file-source-to-skill.use-case.spec.ts
@@ -1,0 +1,157 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+
+import { AddFileSourceToSkillUseCase } from './add-file-source-to-skill.use-case';
+import { AddFileSourceToSkillCommand } from './add-file-source-to-skill.command';
+import { AddSourceToSkillUseCase } from '../add-source-to-skill/add-source-to-skill.use-case';
+import { StartDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case';
+import { SkillRepository } from '../../ports/skill.repository';
+import { ContextService } from 'src/common/context/services/context.service';
+import { Skill } from 'src/domain/skills/domain/skill.entity';
+import { SkillsConstants } from 'src/domain/skills/domain/skills.constants';
+import {
+  SkillNotFoundError,
+  SkillSourceLimitExceededError,
+} from '../../skills.errors';
+import { SourceType } from 'src/domain/sources/domain/source-type.enum';
+import { Source } from 'src/domain/sources/domain/source.entity';
+import { EmptyFileDataError } from 'src/domain/sources/application/sources.errors';
+
+class ConcreteSource extends Source {
+  constructor(params: { id?: UUID; name: string }) {
+    super({
+      id: params.id,
+      type: SourceType.TEXT,
+      name: params.name,
+    });
+  }
+}
+
+describe('AddFileSourceToSkillUseCase', () => {
+  let useCase: AddFileSourceToSkillUseCase;
+  let skillRepository: jest.Mocked<SkillRepository>;
+  let startDocumentProcessingUseCase: jest.Mocked<StartDocumentProcessingUseCase>;
+  let addSourceToSkillUseCase: jest.Mocked<AddSourceToSkillUseCase>;
+
+  const mockUserId = randomUUID();
+  const mockSkillId = randomUUID();
+
+  const buildSkill = (sourceCount: number): Skill =>
+    new Skill({
+      id: mockSkillId,
+      userId: mockUserId,
+      name: 'Research',
+      shortDescription: 'Research helper',
+      instructions: 'Answer questions',
+      sourceIds: Array.from({ length: sourceCount }, () => randomUUID()),
+    });
+
+  const buildCommand = (): AddFileSourceToSkillCommand =>
+    new AddFileSourceToSkillCommand({
+      skillId: mockSkillId,
+      fileData: Buffer.from('file contents'),
+      fileName: 'report.pdf',
+      fileType: 'application/pdf',
+    });
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AddFileSourceToSkillUseCase,
+        { provide: SkillRepository, useValue: { findOne: jest.fn() } },
+        {
+          provide: StartDocumentProcessingUseCase,
+          useValue: { execute: jest.fn() },
+        },
+        { provide: AddSourceToSkillUseCase, useValue: { execute: jest.fn() } },
+        {
+          provide: ContextService,
+          useValue: {
+            get: jest.fn((key: string) =>
+              key === 'userId' ? mockUserId : undefined,
+            ),
+          },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get<AddFileSourceToSkillUseCase>(
+      AddFileSourceToSkillUseCase,
+    );
+    skillRepository = module.get(SkillRepository);
+    startDocumentProcessingUseCase = module.get(StartDocumentProcessingUseCase);
+    addSourceToSkillUseCase = module.get(AddSourceToSkillUseCase);
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should start processing and assign the source when the skill is below the cap', async () => {
+    const skill = buildSkill(SkillsConstants.MAX_SOURCES - 1);
+    const source = new ConcreteSource({ name: 'report.pdf' });
+    skillRepository.findOne.mockResolvedValue(skill);
+    startDocumentProcessingUseCase.execute.mockResolvedValue(
+      source as unknown as Awaited<
+        ReturnType<StartDocumentProcessingUseCase['execute']>
+      >,
+    );
+    const updatedSkill = buildSkill(SkillsConstants.MAX_SOURCES);
+    addSourceToSkillUseCase.execute.mockResolvedValue(updatedSkill);
+
+    const result = await useCase.execute(buildCommand());
+
+    expect(result).toBe(updatedSkill);
+    expect(startDocumentProcessingUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileName: 'report.pdf',
+        fileType: 'application/pdf',
+      }),
+    );
+    expect(addSourceToSkillUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ skillId: mockSkillId, sourceId: source.id }),
+    );
+  });
+
+  it('should reject before uploading or enqueueing when the skill is at the cap', async () => {
+    skillRepository.findOne.mockResolvedValue(
+      buildSkill(SkillsConstants.MAX_SOURCES),
+    );
+
+    await expect(useCase.execute(buildCommand())).rejects.toThrow(
+      SkillSourceLimitExceededError,
+    );
+
+    expect(startDocumentProcessingUseCase.execute).not.toHaveBeenCalled();
+    expect(addSourceToSkillUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('should reject before uploading when the skill does not belong to the user', async () => {
+    skillRepository.findOne.mockResolvedValue(null);
+
+    await expect(useCase.execute(buildCommand())).rejects.toThrow(
+      SkillNotFoundError,
+    );
+
+    expect(startDocumentProcessingUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('should propagate application errors from document processing unchanged', async () => {
+    skillRepository.findOne.mockResolvedValue(buildSkill(0));
+    startDocumentProcessingUseCase.execute.mockRejectedValue(
+      new EmptyFileDataError('report.pdf'),
+    );
+
+    await expect(useCase.execute(buildCommand())).rejects.toThrow(
+      EmptyFileDataError,
+    );
+
+    expect(addSourceToSkillUseCase.execute).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/add-file-source-to-skill/add-file-source-to-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/add-file-source-to-skill/add-file-source-to-skill.use-case.ts
@@ -1,0 +1,63 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { StartDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case';
+import { StartDocumentProcessingCommand } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.command';
+import { Skill } from 'src/domain/skills/domain/skill.entity';
+import { SkillRepository } from '../../ports/skill.repository';
+import { SkillNotFoundError, UnexpectedSkillError } from '../../skills.errors';
+import { assertSkillHasSourceCapacity } from '../../util/skill-source-capacity';
+import { AddSourceToSkillUseCase } from '../add-source-to-skill/add-source-to-skill.use-case';
+import { AddSourceToSkillCommand } from '../add-source-to-skill/add-source-to-skill.command';
+import { AddFileSourceToSkillCommand } from './add-file-source-to-skill.command';
+
+@Injectable()
+export class AddFileSourceToSkillUseCase {
+  private readonly logger = new Logger(AddFileSourceToSkillUseCase.name);
+
+  constructor(
+    private readonly skillRepository: SkillRepository,
+    private readonly startDocumentProcessingUseCase: StartDocumentProcessingUseCase,
+    private readonly addSourceToSkillUseCase: AddSourceToSkillUseCase,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedSkillError)
+  async execute(command: AddFileSourceToSkillCommand): Promise<Skill> {
+    this.logger.log('execute', {
+      skillId: command.skillId,
+      fileName: command.fileName,
+    });
+
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    // Document processing uploads to object storage and enqueues an OCR job,
+    // neither of which the assignment below can undo — so ownership and the
+    // cap are checked first. AddSourceToSkillUseCase re-checks both against a
+    // freshly loaded skill and stays authoritative for concurrent adds.
+    const skill = await this.skillRepository.findOne(command.skillId, userId);
+    if (!skill) {
+      throw new SkillNotFoundError(command.skillId);
+    }
+    assertSkillHasSourceCapacity(skill.sourceIds);
+
+    const source = await this.startDocumentProcessingUseCase.execute(
+      new StartDocumentProcessingCommand({
+        fileData: command.fileData,
+        fileName: command.fileName,
+        fileType: command.fileType,
+      }),
+    );
+
+    return this.addSourceToSkillUseCase.execute(
+      new AddSourceToSkillCommand({
+        skillId: command.skillId,
+        sourceId: source.id,
+      }),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/add-source-to-skill/add-source-to-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/add-source-to-skill/add-source-to-skill.use-case.ts
@@ -6,11 +6,10 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 import {
   SkillNotFoundError,
   SkillSourceAlreadyAssignedError,
-  SkillSourceLimitExceededError,
   UnexpectedSkillError,
 } from '../../skills.errors';
 import { Skill } from 'src/domain/skills/domain/skill.entity';
-import { SkillsConstants } from 'src/domain/skills/domain/skills.constants';
+import { assertSkillHasSourceCapacity } from '../../util/skill-source-capacity';
 import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
@@ -42,9 +41,7 @@ export class AddSourceToSkillUseCase {
         throw new SkillSourceAlreadyAssignedError(command.sourceId);
       }
 
-      if (skill.sourceIds.length >= SkillsConstants.MAX_SOURCES) {
-        throw new SkillSourceLimitExceededError(SkillsConstants.MAX_SOURCES);
-      }
+      assertSkillHasSourceCapacity(skill.sourceIds);
 
       const updatedSkill = new Skill({
         ...skill,

--- a/ayunis-core-backend/src/domain/skills/application/util/skill-source-capacity.ts
+++ b/ayunis-core-backend/src/domain/skills/application/util/skill-source-capacity.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+import { SkillsConstants } from 'src/domain/skills/domain/skills.constants';
+import { SkillSourceLimitExceededError } from '../skills.errors';
+
+export function assertSkillHasSourceCapacity(sourceIds: UUID[]): void {
+  if (sourceIds.length >= SkillsConstants.MAX_SOURCES) {
+    throw new SkillSourceLimitExceededError(SkillsConstants.MAX_SOURCES);
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/presenters/http/decorators/skill-sources.decorators.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/decorators/skill-sources.decorators.ts
@@ -1,0 +1,74 @@
+import { applyDecorators, UseInterceptors } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import {
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+} from '@nestjs/swagger';
+import { diskStorage } from 'multer';
+import { randomUUID } from 'crypto';
+import { extname } from 'path';
+import { SkillResponseDto } from '../dto/skill-response.dto';
+
+export function ApiSkillIdParam() {
+  return ApiParam({
+    name: 'id',
+    description: 'The UUID of the skill',
+    type: 'string',
+    format: 'uuid',
+  });
+}
+
+// Decorators are listed bottom-up: applyDecorators applies them in array order,
+// whereas a stacked decorator list applies bottom-to-top. Keeping that order
+// preserves the emitted OpenAPI (parameter order, response key order) exactly.
+export function ApiSkillFileSourceUpload() {
+  return applyDecorators(
+    /* eslint-disable sonarjs/content-length -- multer file size limit, not HTTP Content-Length */
+    UseInterceptors(
+      FileInterceptor('file', {
+        storage: diskStorage({
+          destination: './uploads',
+          filename: (req, file, cb) => {
+            const randomName = randomUUID();
+            cb(null, `${randomName}${extname(file.originalname)}`);
+          },
+        }),
+        limits: { fileSize: 25 * 1024 * 1024 }, // 25 MB
+      }),
+    ),
+    /* eslint-enable sonarjs/content-length */
+    ApiResponse({
+      status: 413,
+      description: 'File exceeds the 25 MB upload limit',
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Invalid or unsupported file type',
+    }),
+    ApiResponse({ status: 404, description: 'Skill not found' }),
+    ApiResponse({
+      status: 201,
+      description: 'The file source has been successfully added to the skill',
+      type: SkillResponseDto,
+    }),
+    ApiBody({
+      schema: {
+        type: 'object',
+        properties: {
+          file: {
+            type: 'string',
+            format: 'binary',
+            description: 'The file to upload (max 25 MB)',
+          },
+        },
+        required: ['file'],
+      },
+    }),
+    ApiConsumes('multipart/form-data'),
+    ApiSkillIdParam(),
+    ApiOperation({ summary: 'Add a file source to a skill' }),
+  );
+}

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
@@ -8,24 +8,18 @@ import {
   Logger,
   HttpCode,
   HttpStatus,
-  UseInterceptors,
   UploadedFile,
 } from '@nestjs/common';
 import { UUID } from 'crypto';
-import {
-  ApiTags,
-  ApiOperation,
-  ApiResponse,
-  ApiParam,
-  ApiBody,
-  ApiConsumes,
-} from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import {
   CurrentUser,
   UserProperty,
 } from 'src/iam/authentication/application/decorators/current-user.decorator';
 
 import { AddSourceToSkillUseCase } from '../../application/use-cases/add-source-to-skill/add-source-to-skill.use-case';
+import { AddFileSourceToSkillUseCase } from '../../application/use-cases/add-file-source-to-skill/add-file-source-to-skill.use-case';
+import { AddFileSourceToSkillCommand } from '../../application/use-cases/add-file-source-to-skill/add-file-source-to-skill.command';
 import { RemoveSourceFromSkillUseCase } from '../../application/use-cases/remove-source-from-skill/remove-source-from-skill.use-case';
 import { ListSkillSourcesUseCase } from '../../application/use-cases/list-skill-sources/list-skill-sources.use-case';
 
@@ -42,15 +36,10 @@ import {
 } from './dto/skill-response.dto';
 import { SkillDtoMapper } from './mappers/skill.mapper';
 
-import { FileInterceptor } from '@nestjs/platform-express';
-import { diskStorage } from 'multer';
-import { extname } from 'path';
-import { randomUUID } from 'crypto';
 import * as fs from 'fs';
 import { Transactional } from '@nestjs-cls/transactional';
-import { StartDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case';
-import { StartDocumentProcessingCommand } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.command';
 import { CreateDataSourceUseCase } from 'src/domain/sources/application/use-cases/create-data-source/create-data-source.use-case';
+import { ApiSkillFileSourceUpload } from './decorators/skill-sources.decorators';
 import { Source } from 'src/domain/sources/domain/source.entity';
 import { Skill } from '../../domain/skill.entity';
 import {
@@ -82,10 +71,10 @@ export class SkillSourcesController {
 
   constructor(
     private readonly addSourceToSkillUseCase: AddSourceToSkillUseCase,
+    private readonly addFileSourceToSkillUseCase: AddFileSourceToSkillUseCase,
     private readonly removeSourceFromSkillUseCase: RemoveSourceFromSkillUseCase,
     private readonly listSkillSourcesUseCase: ListSkillSourcesUseCase,
     private readonly skillDtoMapper: SkillDtoMapper,
-    private readonly startDocumentProcessingUseCase: StartDocumentProcessingUseCase,
     private readonly createDataSourceUseCase: CreateDataSourceUseCase,
     private readonly skillAccessService: SkillAccessService,
     private readonly skillCreatorNameService: SkillCreatorNameService,
@@ -119,55 +108,7 @@ export class SkillSourcesController {
   }
 
   @Post(':id/sources/file')
-  @ApiOperation({ summary: 'Add a file source to a skill' })
-  @ApiParam({
-    name: 'id',
-    description: 'The UUID of the skill',
-    type: 'string',
-    format: 'uuid',
-  })
-  @ApiConsumes('multipart/form-data')
-  @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        file: {
-          type: 'string',
-          format: 'binary',
-          description: 'The file to upload (max 25 MB)',
-        },
-      },
-      required: ['file'],
-    },
-  })
-  @ApiResponse({
-    status: 201,
-    description: 'The file source has been successfully added to the skill',
-    type: SkillResponseDto,
-  })
-  @ApiResponse({ status: 404, description: 'Skill not found' })
-  @ApiResponse({
-    status: 400,
-    description: 'Invalid or unsupported file type',
-  })
-  @ApiResponse({
-    status: 413,
-    description: 'File exceeds the 25 MB upload limit',
-  })
-  @UseInterceptors(
-    /* eslint-disable sonarjs/content-length -- multer file size limit, not HTTP Content-Length */
-    FileInterceptor('file', {
-      storage: diskStorage({
-        destination: './uploads',
-        filename: (req, file, cb) => {
-          const randomName = randomUUID();
-          cb(null, `${randomName}${extname(file.originalname)}`);
-        },
-      }),
-      limits: { fileSize: 25 * 1024 * 1024 }, // 25 MB
-    }),
-    /* eslint-enable sonarjs/content-length */
-  )
+  @ApiSkillFileSourceUpload()
   async addFileSource(
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Param('id', ParseUUIDPipe) skillId: UUID,
@@ -262,15 +203,13 @@ export class SkillSourcesController {
           `Unable to determine MIME type for detected file type: ${detectedType}`,
         );
       }
-      const source = await this.startDocumentProcessingUseCase.execute(
-        new StartDocumentProcessingCommand({
+      return this.addFileSourceToSkillUseCase.execute(
+        new AddFileSourceToSkillCommand({
+          skillId,
           fileData,
           fileName: file.originalname,
           fileType: canonicalMimeType,
         }),
-      );
-      return this.addSourceToSkillUseCase.execute(
-        new AddSourceToSkillCommand({ skillId, sourceId: source.id }),
       );
     } else if (isCSVFile(detectedType)) {
       return this.processCSVUpload(skillId, file);

--- a/ayunis-core-backend/src/domain/skills/skills.module.ts
+++ b/ayunis-core-backend/src/domain/skills/skills.module.ts
@@ -22,6 +22,7 @@ import { ToggleSkillActiveUseCase } from './application/use-cases/toggle-skill-a
 import { ToggleSkillPinnedUseCase } from './application/use-cases/toggle-skill-pinned/toggle-skill-pinned.use-case';
 import { FindActiveSkillsUseCase } from './application/use-cases/find-active-skills/find-active-skills.use-case';
 import { AddSourceToSkillUseCase } from './application/use-cases/add-source-to-skill/add-source-to-skill.use-case';
+import { AddFileSourceToSkillUseCase } from './application/use-cases/add-file-source-to-skill/add-file-source-to-skill.use-case';
 import { RemoveSourceFromSkillUseCase } from './application/use-cases/remove-source-from-skill/remove-source-from-skill.use-case';
 import { ListSkillSourcesUseCase } from './application/use-cases/list-skill-sources/list-skill-sources.use-case';
 import { AssignMcpIntegrationToSkillUseCase } from './application/use-cases/assign-mcp-integration-to-skill/assign-mcp-integration-to-skill.use-case';
@@ -101,6 +102,7 @@ import { KnowledgeBaseDtoMapper } from '../knowledge-bases/presenters/http/mappe
     ToggleSkillPinnedUseCase,
     FindActiveSkillsUseCase,
     AddSourceToSkillUseCase,
+    AddFileSourceToSkillUseCase,
     RemoveSourceFromSkillUseCase,
     ListSkillSourcesUseCase,
     AssignMcpIntegrationToSkillUseCase,


### PR DESCRIPTION
The skill file-upload path had the same ordering bug as the thread path:
StartDocumentProcessingUseCase uploaded the file and enqueued an OCR job
before AddSourceToSkillUseCase rejected the request on ownership or the
20-source cap, leaving an orphaned source row, an orphaned object and a
wasted OCR job behind every 409/404.

- Add AddFileSourceToSkillUseCase, which resolves the skill and asserts
  the cap before delegating to StartDocumentProcessingUseCase
- Extract assertSkillHasSourceCapacity so the rule has one definition;
  AddSourceToSkillUseCase keeps it as the authoritative check for
  concurrent adds
- Move the upload Swagger decorator stack into a composed decorator so
  the controller passes the complexity gate (emitted OpenAPI unchanged)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering on a user-facing upload path and touches irreversible side effects (storage/OCR), though behavior for successful uploads should match; CSV/spreadsheet skill uploads are unchanged.
> 
> **Overview**
> Fixes skill **file upload** rejecting ownership or the source cap only *after* `StartDocumentProcessingUseCase` had already uploaded to object storage and enqueued OCR, which left orphaned sources, blobs, and jobs on 404/409 responses.
> 
> **`AddFileSourceToSkillUseCase`** now loads the skill for the current user, runs **`assertSkillHasSourceCapacity`**, then starts document processing and delegates assignment to **`AddSourceToSkillUseCase`** (which still re-checks on a fresh load for concurrent adds). The HTTP layer routes document/audio/plain-text uploads through this use case instead of calling document processing directly from the controller.
> 
> Source-cap logic is centralized in **`assertSkillHasSourceCapacity`**; upload OpenAPI/multer setup moves into **`ApiSkillFileSourceUpload`** with unchanged emitted schema. Unit tests cover cap, not-found, and error propagation before assignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7185494ed2f83d5ad6032b74f94d247c77455763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->