### PR TITLE
fix(storage): stop leaking object paths and upstream errors to clients (AYC-568)

### DIFF
--- a/ayunis-core-backend/src/domain/storage/application/storage.errors.ts
+++ b/ayunis-core-backend/src/domain/storage/application/storage.errors.ts
@@ -41,49 +41,42 @@ export class ObjectNotFoundError extends StorageError {
   }
 }
 
+// The object name and the upstream driver message are deliberately kept out
+// of these messages: ApplicationError.message is serialised into the HTTP
+// response body, so embedding them exposes the bucket layout
+// ('<orgId>/<threadId>/<messageId>/3.jpg') and the CDN hostname to the
+// client. Every thrower logs both server-side before constructing these.
 export class UploadFailedError extends StorageError {
-  constructor(params: {
-    objectName: string;
-    message: string;
-    metadata?: ErrorMetadata;
-  }) {
+  constructor(params?: { metadata?: ErrorMetadata }) {
     super(
-      `Failed to upload object '${params.objectName}': ${params.message}`,
+      'Failed to upload object',
       StorageErrorCode.UPLOAD_FAILED,
       500,
-      params.metadata,
+      params?.metadata,
     );
     this.name = 'UploadFailedError';
   }
 }
 
 export class DownloadFailedError extends StorageError {
-  constructor(params: {
-    objectName: string;
-    message: string;
-    metadata?: ErrorMetadata;
-  }) {
+  constructor(params?: { metadata?: ErrorMetadata }) {
     super(
-      `Failed to download object '${params.objectName}': ${params.message}`,
+      'Failed to download object',
       StorageErrorCode.DOWNLOAD_FAILED,
       500,
-      params.metadata,
+      params?.metadata,
     );
     this.name = 'DownloadFailedError';
   }
 }
 
 export class DeleteFailedError extends StorageError {
-  constructor(params: {
-    objectName: string;
-    message: string;
-    metadata?: ErrorMetadata;
-  }) {
+  constructor(params?: { metadata?: ErrorMetadata }) {
     super(
-      `Failed to delete object '${params.objectName}': ${params.message}`,
+      'Failed to delete object',
       StorageErrorCode.DELETE_FAILED,
       500,
-      params.metadata,
+      params?.metadata,
     );
     this.name = 'DeleteFailedError';
   }

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/delete-object/delete-object.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/delete-object/delete-object.use-case.ts
@@ -46,11 +46,7 @@ export class DeleteObjectUseCase {
         `Failed to delete object: ${command.objectName}`,
         error,
       );
-      throw new DeleteFailedError({
-        objectName: command.objectName,
-        message: error instanceof Error ? error.message : 'Unknown error',
-        metadata: { originalError: error as Error },
-      });
+      throw new DeleteFailedError();
     }
   }
 
@@ -62,15 +58,10 @@ export class DeleteObjectUseCase {
     objectName: string,
     bucket?: string,
   ): Promise<boolean> {
-    try {
-      const bucketName = bucket || this.getDefaultBucket();
-      return this.objectStorage.exists(new StorageUrl(objectName, bucketName));
-    } catch (error) {
-      this.logger.error(
-        `Error checking if object exists: ${objectName}`,
-        error,
-      );
-      return false;
-    }
+    // Rejections propagate to execute()'s handler on purpose: a stat that
+    // fails because storage is unreachable is a 500, not a 404 telling the
+    // caller their object is gone.
+    const bucketName = bucket || this.getDefaultBucket();
+    return this.objectStorage.exists(new StorageUrl(objectName, bucketName));
   }
 }

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/download-object/download-object.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/download-object/download-object.use-case.spec.ts
@@ -133,6 +133,29 @@ describe('DownloadObjectUseCase', () => {
       );
     });
 
+    it('should not expose the object path or the upstream message', async () => {
+      // Arrange
+      const objectName = 'org-id/thread-id/message-id/3.jpg';
+      const command = new DownloadObjectCommand(objectName);
+
+      jest.spyOn(mockObjectStorage, 'exists').mockResolvedValue(true);
+      jest
+        .spyOn(mockObjectStorage, 'download')
+        .mockRejectedValue(
+          new Error('getaddrinfo EAI_AGAIN cdn-core.ayunis.com'),
+        );
+
+      // Act
+      const error = await useCase.execute(command).catch((e: unknown) => e);
+
+      // Assert — the serialised HTTP body is what reaches the client
+      const body = JSON.stringify(
+        (error as DownloadFailedError).toHttpException().getResponse(),
+      );
+      expect(body).not.toContain(objectName);
+      expect(body).not.toContain('cdn-core.ayunis.com');
+    });
+
     it('should pass through ObjectNotFoundError from download', async () => {
       // Arrange
       const objectName = 'test-file.txt';

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/download-object/download-object.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/download-object/download-object.use-case.ts
@@ -52,11 +52,7 @@ export class DownloadObjectUseCase {
         `Failed to download object: ${command.objectName}`,
         error,
       );
-      throw new DownloadFailedError({
-        objectName: command.objectName,
-        message: error instanceof Error ? error.message : 'Unknown error',
-        metadata: { originalError: error as Error },
-      });
+      throw new DownloadFailedError();
     }
   }
 
@@ -68,15 +64,10 @@ export class DownloadObjectUseCase {
     objectName: string,
     bucket?: string,
   ): Promise<boolean> {
-    try {
-      const bucketName = bucket || this.getDefaultBucket();
-      return this.objectStorage.exists(new StorageUrl(objectName, bucketName));
-    } catch (error) {
-      this.logger.error(
-        `Error checking if object exists: ${objectName}`,
-        error,
-      );
-      return false;
-    }
+    // Rejections propagate to execute()'s handler on purpose: a stat that
+    // fails because storage is unreachable is a 500, not a 404 telling the
+    // caller their object is gone.
+    const bucketName = bucket || this.getDefaultBucket();
+    return this.objectStorage.exists(new StorageUrl(objectName, bucketName));
   }
 }

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/get-object-info/get-object-info.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/get-object-info/get-object-info.use-case.ts
@@ -58,11 +58,7 @@ export class GetObjectInfoUseCase {
         `Failed to get object info: ${command.objectName}`,
         error,
       );
-      throw new DownloadFailedError({
-        objectName: command.objectName,
-        message: error instanceof Error ? error.message : 'Unknown error',
-        metadata: { originalError: error as Error },
-      });
+      throw new DownloadFailedError();
     }
   }
 

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/get-presigned-url/get-presigned-url.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/get-presigned-url/get-presigned-url.use-case.ts
@@ -65,11 +65,7 @@ export class GetPresignedUrlUseCase {
         `Failed to generate presigned URL for object: ${command.objectName}`,
         error,
       );
-      throw new DownloadFailedError({
-        objectName: command.objectName,
-        message: error instanceof Error ? error.message : 'Unknown error',
-        metadata: { originalError: error as Error },
-      });
+      throw new DownloadFailedError();
     }
   }
 
@@ -81,15 +77,10 @@ export class GetPresignedUrlUseCase {
     objectName: string,
     bucket?: string,
   ): Promise<boolean> {
-    try {
-      const bucketName = bucket ?? this.getDefaultBucket();
-      return this.objectStorage.exists(new StorageUrl(objectName, bucketName));
-    } catch (error) {
-      this.logger.error(
-        `Error checking if object exists: ${objectName}`,
-        error,
-      );
-      return false;
-    }
+    // Rejections propagate to execute()'s handler on purpose: a stat that
+    // fails because storage is unreachable is a 500, not a 404 telling the
+    // caller their object is gone.
+    const bucketName = bucket ?? this.getDefaultBucket();
+    return this.objectStorage.exists(new StorageUrl(objectName, bucketName));
   }
 }

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/upload-object/upload-object.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/upload-object/upload-object.use-case.ts
@@ -28,19 +28,7 @@ export class UploadObjectUseCase {
     });
 
     try {
-      if (!this.isValidObjectName(command.objectName)) {
-        throw new InvalidObjectNameError({ objectName: command.objectName });
-      }
-
-      const bucketName = command.bucket || this.getDefaultBucket();
-
-      // Check if bucket exists before uploading
-      if (bucketName !== this.getDefaultBucket()) {
-        const bucketExists = this.bucketExists(bucketName);
-        if (!bucketExists) {
-          throw new BucketNotFoundError({ bucket: bucketName });
-        }
-      }
+      const bucketName = this.resolveTargetBucket(command);
 
       const result = await this.objectStorage.upload(
         new StorageObjectUpload(
@@ -78,12 +66,23 @@ export class UploadObjectUseCase {
         `Failed to upload object: ${command.objectName}`,
         error,
       );
-      throw new UploadFailedError({
-        objectName: command.objectName,
-        message: error instanceof Error ? error.message : 'Unknown error',
-        metadata: { originalError: error as Error },
-      });
+      throw new UploadFailedError();
     }
+  }
+
+  private resolveTargetBucket(command: UploadObjectCommand): string {
+    if (!this.isValidObjectName(command.objectName)) {
+      throw new InvalidObjectNameError({ objectName: command.objectName });
+    }
+
+    const bucketName = command.bucket || this.getDefaultBucket();
+    if (
+      bucketName !== this.getDefaultBucket() &&
+      !this.bucketExists(bucketName)
+    ) {
+      throw new BucketNotFoundError({ bucket: bucketName });
+    }
+    return bucketName;
   }
 
   private getDefaultBucket(): string {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Security-sensitive error sanitisation plus a behaviour change: unreachable storage during `exists` now returns 500 rather than 404, which may affect clients that relied on the old semantics.
> 
> **Overview**
> **Stops storage failure responses from leaking internal details** by changing `UploadFailedError`, `DownloadFailedError`, and `DeleteFailedError` to use fixed client messages only. Object keys and upstream driver text (e.g. CDN hostnames) stay in server logs; callers no longer receive them in the serialised HTTP body.
> 
> Storage use cases now throw those errors without embedding `objectName` or `originalError` in the response. A download spec asserts the HTTP payload does not contain the object path or upstream hostname.
> 
> **`objectExists` no longer swallows errors** in download, delete, and presigned-URL flows: a failed `exists` call propagates and surfaces as a **500** instead of being treated as “missing” and returning **404** when storage is unreachable.
> 
> Upload validation/bucket resolution is moved into `resolveTargetBucket` (behavior preserved, structure only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a755f62cac08f2a3586c449ecf0b2ddc7df48cfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->