### PR TITLE
fix(models): detect stalled provider streams in seconds, not minutes (AYC-565)

### DIFF
--- a/ayunis-core-backend/src/domain/models/application/models.errors.ts
+++ b/ayunis-core-backend/src/domain/models/application/models.errors.ts
@@ -244,15 +244,13 @@ export class InferenceInputInvalidError extends ModelError {
   }
 }
 
-/**
- * Error thrown when inference times out
- */
-export class InferenceTimeoutError extends ModelError {
-  constructor(timeoutMs: number, metadata?: ErrorMetadata) {
+/** A provider stream that went silent mid-response — see stream-idle-watchdog.ts. */
+export class InferenceStreamStalledError extends ModelError {
+  constructor(idleMs: number, metadata?: ErrorMetadata) {
     super(
-      `Inference timed out after ${timeoutMs}ms`,
+      `Provider stream produced no data for ${idleMs}ms`,
       ModelErrorCode.INFERENCE_TIMEOUT,
-      408,
+      504,
       metadata,
     );
   }

--- a/ayunis-core-backend/src/domain/models/infrastructure/runtime/runtime-stream-inference.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/runtime/runtime-stream-inference.handler.spec.ts
@@ -1,0 +1,143 @@
+import type { ModelProvider } from '@ayunis/inference';
+import type { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
+import type { StreamInferenceInput } from '../../application/ports/stream-inference.handler';
+import { InferenceStreamStalledError } from '../../application/models.errors';
+import { RuntimeStreamInferenceHandler } from './runtime-stream-inference.handler';
+import { STREAM_IDLE_TIMEOUT_MS } from './stream-idle-watchdog';
+
+/** Rejects the way a provider SDK does when its request signal aborts. */
+function whenAborted(signal: AbortSignal | undefined): Promise<never> {
+  return new Promise<never>((_resolve, reject) => {
+    const fail = () => {
+      const abortError = new Error('The operation was aborted');
+      abortError.name = 'AbortError';
+      reject(abortError);
+    };
+    if (!signal) return;
+    // An SDK checks the signal before waiting on it, so an abort that lands
+    // between the request and the wait is not lost.
+    if (signal.aborted) return fail();
+    signal.addEventListener('abort', fail);
+  });
+}
+
+/**
+ * A provider that yields one chunk and then hangs until aborted — the shape
+ * of a socket that dies mid-response.
+ */
+function stallingProvider(): {
+  provider: ModelProvider;
+  signal: () => AbortSignal | undefined;
+} {
+  let captured: AbortSignal | undefined;
+  const provider: ModelProvider = {
+    name: 'test:stalling',
+    async *stream(request) {
+      captured = request.signal;
+      yield { textDelta: 'first' };
+      await whenAborted(request.signal);
+    },
+  };
+  return { provider, signal: () => captured };
+}
+
+class TestHandler extends RuntimeStreamInferenceHandler {
+  constructor(private readonly provider: ModelProvider) {
+    super({} as ImageContentService);
+  }
+  protected createProvider(): ModelProvider {
+    return this.provider;
+  }
+}
+
+function makeInput(): StreamInferenceInput {
+  return {
+    model: { name: 'test-model', provider: 'test' },
+    messages: [],
+    systemPrompt: '',
+    tools: [],
+    orgId: 'org-1',
+  } as unknown as StreamInferenceInput;
+}
+
+/** Resolves once the handler has emitted its first chunk. */
+function firstChunkOf(handler: TestHandler): {
+  arrived: Promise<void>;
+  failure: Promise<unknown>;
+  unsubscribe: () => void;
+} {
+  let onArrival!: () => void;
+  const arrived = new Promise<void>((resolve) => (onArrival = resolve));
+  let onFailure!: (error: unknown) => void;
+  const failure = new Promise<unknown>((resolve) => (onFailure = resolve));
+
+  const subscription = handler.answer(makeInput()).subscribe({
+    next: () => onArrival(),
+    error: onFailure,
+  });
+
+  return { arrived, failure, unsubscribe: () => subscription.unsubscribe() };
+}
+
+describe('RuntimeStreamInferenceHandler', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('fails a stalled stream with InferenceStreamStalledError rather than a generic abort', async () => {
+    const { provider } = stallingProvider();
+    const { arrived, failure } = firstChunkOf(new TestHandler(provider));
+
+    await arrived;
+    jest.advanceTimersByTime(STREAM_IDLE_TIMEOUT_MS);
+
+    await expect(failure).resolves.toBeInstanceOf(InferenceStreamStalledError);
+  });
+
+  it('leaves a stream alone while it keeps producing just inside the budget', async () => {
+    const { provider } = stallingProvider();
+    const { arrived, failure } = firstChunkOf(new TestHandler(provider));
+
+    await arrived;
+    jest.advanceTimersByTime(STREAM_IDLE_TIMEOUT_MS - 1);
+
+    const settled = await Promise.race([
+      failure,
+      Promise.resolve('still streaming'),
+    ]);
+    expect(settled).toBe('still streaming');
+  });
+
+  it('aborts the provider call when the subscriber unsubscribes', async () => {
+    const { provider, signal } = stallingProvider();
+    const { arrived, unsubscribe } = firstChunkOf(new TestHandler(provider));
+
+    await arrived;
+    expect(signal()?.aborted).toBe(false);
+
+    unsubscribe();
+
+    expect(signal()?.aborted).toBe(true);
+  });
+
+  it('passes chunks through and completes when the provider streams normally', async () => {
+    const provider: ModelProvider = {
+      name: 'test:healthy',
+      async *stream() {
+        yield { textDelta: 'hello' };
+        yield { textDelta: ' world' };
+      },
+    };
+    const handler = new TestHandler(provider);
+
+    const deltas = await new Promise<(string | null)[]>((resolve, reject) => {
+      const seen: (string | null)[] = [];
+      handler.answer(makeInput()).subscribe({
+        next: (chunk) => seen.push(chunk.textContentDelta),
+        complete: () => resolve(seen),
+        error: reject,
+      });
+    });
+
+    expect(deltas).toEqual(['hello', ' world']);
+  });
+});

--- a/ayunis-core-backend/src/domain/models/infrastructure/runtime/runtime-stream-inference.handler.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/runtime/runtime-stream-inference.handler.ts
@@ -11,6 +11,11 @@ import type { Model } from '../../domain/model.entity';
 import { toProviderRequest } from './request.mapper';
 import { toStreamChunk } from './chunk.mapper';
 import type { ChunkTransform } from './chunk-transform';
+import {
+  StreamIdleWatchdog,
+  STREAM_IDLE_TIMEOUT_MS,
+} from './stream-idle-watchdog';
+import { InferenceStreamStalledError } from '../../application/models.errors';
 
 /**
  * Streaming inference handler backed by a `@ayunis` ModelProvider. Concrete
@@ -56,24 +61,45 @@ export abstract class RuntimeStreamInferenceHandler extends StreamInferenceHandl
     input: StreamInferenceInput,
   ): Observable<StreamInferenceResponseChunk> {
     return new Observable<StreamInferenceResponseChunk>((subscriber) => {
-      void this.streamResponse(input, subscriber);
+      const controller = new AbortController();
+      void this.streamResponse(input, subscriber, controller);
+      // Unsubscribing (client disconnect, downstream error) cancels the
+      // provider call. Without this the stream runs to completion unread and
+      // the tokens are billed for nobody.
+      return () => controller.abort();
     });
   }
 
   private async streamResponse(
     input: StreamInferenceInput,
     subscriber: Subscriber<StreamInferenceResponseChunk>,
+    controller: AbortController,
   ): Promise<void> {
+    const watchdog = new StreamIdleWatchdog(STREAM_IDLE_TIMEOUT_MS, () =>
+      controller.abort(new InferenceStreamStalledError(STREAM_IDLE_TIMEOUT_MS)),
+    );
     try {
       const request = await toProviderRequest(input, this.imageContentService);
       const provider = this.getProvider(input.model);
       const transform = this.createChunkTransform();
-      for await (const chunk of provider.stream(request)) {
+      for await (const chunk of provider.stream({
+        ...request,
+        signal: controller.signal,
+      })) {
+        watchdog.notifyChunk();
         subscriber.next(toStreamChunk(transform(chunk)));
       }
       subscriber.complete();
     } catch (error) {
-      subscriber.error(error);
+      // A stalled stream surfaces from the SDK as a generic AbortError, which
+      // the use case would otherwise read as a client cancellation. The abort
+      // reason carries what actually happened.
+      const reason: unknown = controller.signal.reason;
+      subscriber.error(
+        reason instanceof InferenceStreamStalledError ? reason : error,
+      );
+    } finally {
+      watchdog.stop();
     }
   }
 }

--- a/ayunis-core-backend/src/domain/models/infrastructure/runtime/stream-idle-watchdog.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/runtime/stream-idle-watchdog.spec.ts
@@ -1,0 +1,64 @@
+import { StreamIdleWatchdog } from './stream-idle-watchdog';
+
+describe('StreamIdleWatchdog', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('stays disarmed until the first chunk, leaving time-to-first-byte to the SDK', () => {
+    const onStall = jest.fn();
+    const watchdog = new StreamIdleWatchdog(1000, onStall);
+
+    jest.advanceTimersByTime(10_000);
+
+    expect(onStall).not.toHaveBeenCalled();
+    watchdog.stop();
+  });
+
+  it('fires once the gap after a chunk exceeds the idle budget', () => {
+    const onStall = jest.fn();
+    const watchdog = new StreamIdleWatchdog(1000, onStall);
+
+    watchdog.notifyChunk();
+    jest.advanceTimersByTime(1000);
+
+    expect(onStall).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire while chunks keep arriving inside the budget', () => {
+    const onStall = jest.fn();
+    const watchdog = new StreamIdleWatchdog(1000, onStall);
+
+    for (let i = 0; i < 10; i++) {
+      watchdog.notifyChunk();
+      jest.advanceTimersByTime(900);
+    }
+
+    expect(onStall).not.toHaveBeenCalled();
+  });
+
+  it('measures the gap since the last chunk, not since the stream started', () => {
+    const onStall = jest.fn();
+    const watchdog = new StreamIdleWatchdog(1000, onStall);
+
+    watchdog.notifyChunk();
+    jest.advanceTimersByTime(900);
+    watchdog.notifyChunk();
+    jest.advanceTimersByTime(900);
+
+    expect(onStall).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(100);
+    expect(onStall).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops firing once the stream ends', () => {
+    const onStall = jest.fn();
+    const watchdog = new StreamIdleWatchdog(1000, onStall);
+
+    watchdog.notifyChunk();
+    watchdog.stop();
+    jest.advanceTimersByTime(10_000);
+
+    expect(onStall).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/models/infrastructure/runtime/stream-idle-watchdog.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/runtime/stream-idle-watchdog.ts
@@ -1,0 +1,43 @@
+/**
+ * Milliseconds of silence between provider chunks before a stream counts as
+ * stalled. Healthy providers emit deltas continuously — many per second — so
+ * this only has to sit above the longest legitimate pause, not close to it.
+ */
+export const STREAM_IDLE_TIMEOUT_MS = 45_000;
+
+/**
+ * Detects a provider stream that stops producing chunks part-way through.
+ *
+ * The watchdog arms lazily, on the first chunk: time-to-first-byte is already
+ * bounded by the provider SDK's own request timeout, and duplicating that
+ * budget here would only make a slow prompt look like a stall. What is left
+ * unguarded is the gap *between* chunks, where a dropped socket otherwise
+ * goes unnoticed until the keep-alive agent times out minutes later.
+ *
+ * A stall raises InferenceStreamStalledError, a 504 rather than a 408: the
+ * fault is upstream, and keeping it above the error filter's 500 threshold
+ * leaves the rate of provider stalls visible instead of silently swallowed.
+ */
+export class StreamIdleWatchdog {
+  private timer: NodeJS.Timeout | null = null;
+
+  constructor(
+    private readonly idleMs: number,
+    private readonly onStall: () => void,
+  ) {}
+
+  /** Records a chunk, restarting the idle countdown. */
+  notifyChunk(): void {
+    this.stop();
+    this.timer = setTimeout(this.onStall, this.idleMs);
+    // A pending watchdog must never be the reason the process stays alive.
+    this.timer.unref();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/packages/provider-mistral/src/client-construction.spec.ts
+++ b/packages/provider-mistral/src/client-construction.spec.ts
@@ -31,3 +31,54 @@ describe('mistral client construction', () => {
     );
   });
 });
+
+describe('request deadline', () => {
+  const streamOptions = async (
+    request: Partial<Parameters<ReturnType<typeof mistral>['stream']>[0]>,
+  ) => {
+    const stream = vi.fn().mockResolvedValue([]);
+    // A regular function, not an arrow: the SDK client is built with `new`.
+    mistralCtor.mockImplementation(function () {
+      return { chat: { stream } };
+    });
+
+    const provider = mistral({
+      apiKey: 'mistral-key',
+      model: 'mistral-large-latest',
+      timeoutMs: 60_000,
+    });
+    // The generator body only runs once iteration starts.
+    await provider
+      .stream({ instructions: '', messages: [], tools: [], ...request })
+      [Symbol.asyncIterator]()
+      .next();
+
+    return stream.mock.calls[0][1] as { signal: AbortSignal };
+  };
+
+  it('arms the deadline even when the host supplies no signal', async () => {
+    const { signal } = await streamOptions({});
+
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal.aborted).toBe(false);
+  });
+
+  // The SDK drops its own timeout as soon as a signal is passed, so without
+  // composing them a cancellable request would have no deadline at all.
+  it('keeps the deadline when the host supplies a signal', async () => {
+    const hostController = new AbortController();
+    const { signal } = await streamOptions({ signal: hostController.signal });
+
+    expect(signal).not.toBe(hostController.signal);
+    expect(signal.aborted).toBe(false);
+  });
+
+  it('still aborts when the host cancels', async () => {
+    const hostController = new AbortController();
+    const { signal } = await streamOptions({ signal: hostController.signal });
+
+    hostController.abort();
+
+    expect(signal.aborted).toBe(true);
+  });
+});

--- a/packages/provider-mistral/src/mistral-provider.ts
+++ b/packages/provider-mistral/src/mistral-provider.ts
@@ -16,13 +16,11 @@ import {
   convertToolChoice,
 } from './convert-request';
 
-// Hard ceiling on the WHOLE request, stream consumption included: the Mistral
-// SDK arms AbortSignal.timeout(timeoutMs) as the fetch signal, which stays
-// active while the body streams. Generous on purpose — long healthy chat
-// streams must fit — while still bounding a stalled connection, which
-// previously hung forever (the SDK has no default timeout). Note: the SDK
-// skips this when a per-request signal is supplied, so a host-provided
-// AbortSignal takes over the deadline entirely.
+// Hard ceiling on the WHOLE request, stream consumption included. Generous on
+// purpose — long healthy chat streams must fit — while still bounding a
+// stalled connection, which hung forever before it existed (the SDK has no
+// default timeout). Applied via `boundedSignal`; see there for why this
+// provider arms the deadline itself rather than letting the SDK do it.
 export const DEFAULT_TIMEOUT_MS = 300_000;
 
 export interface MistralProviderOptions {
@@ -43,9 +41,10 @@ export interface MistralProviderOptions {
  * are out of scope for this provider.
  */
 export const mistral = (options: MistralProviderOptions): ModelProvider => {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const client = new Mistral({
     apiKey: options.apiKey,
-    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    timeoutMs,
     ...(options.baseUrl ? { serverURL: options.baseUrl } : {}),
     ...(options.maxRetries !== undefined
       ? { retryConfig: toRetryConfig(options.maxRetries) }
@@ -53,7 +52,7 @@ export const mistral = (options: MistralProviderOptions): ModelProvider => {
   });
   return {
     name: `mistral:${options.model}`,
-    stream: (request) => streamChat(client, options.model, request),
+    stream: (request) => streamChat(client, options.model, request, timeoutMs),
   };
 };
 
@@ -78,17 +77,33 @@ const toRetryConfig = (maxRetries: number): RetryConfig => {
   };
 };
 
+/**
+ * The SDK arms `AbortSignal.timeout(timeoutMs)` only when the caller supplies
+ * no signal of its own (`lib/sdks.js`: `if (!fetchOptions?.signal && ...)`), so
+ * a host-provided signal would silently delete the deadline. Composing the two
+ * keeps `timeoutMs` meaningful whether or not the host cancels. Note this makes
+ * the ceiling span the whole call rather than each retried attempt, which is
+ * what "whole request" was always meant to mean.
+ */
+function boundedSignal(
+  hostSignal: AbortSignal | undefined,
+  timeoutMs: number,
+): AbortSignal {
+  const deadline = AbortSignal.timeout(timeoutMs);
+  return hostSignal ? AbortSignal.any([hostSignal, deadline]) : deadline;
+}
+
 async function* streamChat(
   client: Mistral,
   model: string,
   request: ProviderRequest,
+  timeoutMs: number,
 ): AsyncIterable<ProviderChunk> {
   const codec = new ToolNameCodec(request.tools);
   const params = buildParams(model, request, codec);
-  const stream = await client.chat.stream(
-    params,
-    request.signal ? { signal: request.signal } : undefined,
-  );
+  const stream = await client.chat.stream(params, {
+    signal: boundedSignal(request.signal, timeoutMs),
+  });
   for await (const event of stream) {
     const converted = convertChunk(event, codec);
     if (converted) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core streaming inference cancellation and error classification for all providers; mis-tuned idle timeout could abort slow-but-valid streams, though 45s is conservative.
> 
> **Overview**
> Streaming inference now **fails fast when a provider stops sending chunks** instead of hanging until a low-level connection timeout. A new **45s inter-chunk idle watchdog** arms after the first token (time-to-first-byte stays on the SDK) and aborts the provider call with **`InferenceStreamStalledError`** (504, reusing `INFERENCE_TIMEOUT`) so upstream stalls are not mistaken for client **`InferenceAbortedError`**.
> 
> **`RuntimeStreamInferenceHandler`** wires an **`AbortController`** into every provider stream, resets the watchdog on each chunk, aborts on RxJS unsubscribe (client disconnect), and surfaces the abort **reason** when the stall watchdog fired. **`InferenceTimeoutError`** is removed in favor of the stalled-stream type.
> 
> The **Mistral provider** always passes a composed **`boundedSignal`** (`AbortSignal.any` of host cancel + whole-request deadline) because the SDK drops its built-in timeout whenever the host supplies a signal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a62b45448c01e3859914b942d60ae48130cbd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->