### PR TITLE
fix(sources): stop reporting expected queue-job failures as incidents (AYC-564)

### DIFF
--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/bullmq-job.helpers.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/bullmq-job.helpers.spec.ts
@@ -1,12 +1,25 @@
 import type { Job } from 'bullmq';
 import {
   isFinalAttempt,
-  wrapIfRetryScheduled,
+  isExpectedFailure,
+  classifyJobFailure,
   JobRetryScheduledError,
 } from './bullmq-job.helpers';
+import { ApplicationError } from 'src/common/errors/base.error';
 
 function jobWith(attemptsMade: number, attempts?: number): Job {
   return { attemptsMade, opts: { attempts } } as Job;
+}
+
+class FakeRetrieverError extends ApplicationError {
+  constructor(statusCode: number) {
+    super(
+      `retrieval failed with ${statusCode}`,
+      'RETRIEVAL_FAILED',
+      statusCode,
+    );
+    this.name = 'FakeRetrieverError';
+  }
 }
 
 describe('isFinalAttempt', () => {
@@ -27,50 +40,117 @@ describe('isFinalAttempt', () => {
   });
 });
 
-describe('wrapIfRetryScheduled', () => {
+describe('isExpectedFailure', () => {
+  it('is true for an ApplicationError below 500', () => {
+    expect(isExpectedFailure(new FakeRetrieverError(422))).toBe(true);
+  });
+
+  it('is false for an ApplicationError at 500 and above', () => {
+    expect(isExpectedFailure(new FakeRetrieverError(503))).toBe(false);
+  });
+
+  it('is false for a plain Error, which carries no status', () => {
+    expect(isExpectedFailure(new Error('socket hang up'))).toBe(false);
+  });
+});
+
+describe('classifyJobFailure', () => {
   const providerError = new Error(
     'API error occurred: Status 400 - File could not be fetched from url',
   );
 
-  it('wraps the error in JobRetryScheduledError when a retry will follow', () => {
-    const result = wrapIfRetryScheduled(jobWith(0, 3), providerError);
+  describe('unexpected failures', () => {
+    it('wraps in JobRetryScheduledError when a retry will follow', () => {
+      const { final, rethrow } = classifyJobFailure(
+        jobWith(0, 3),
+        providerError,
+      );
 
-    expect(result).toBeInstanceOf(JobRetryScheduledError);
-    expect((result as Error).name).toBe('JobRetryScheduledError');
+      expect(final).toBe(false);
+      expect(rethrow).toBeInstanceOf(JobRetryScheduledError);
+      expect((rethrow as Error).name).toBe('JobRetryScheduledError');
+    });
+
+    it('preserves message, stack and cause so job.failedReason stays informative', () => {
+      const { rethrow } = classifyJobFailure(jobWith(0, 3), providerError);
+
+      expect((rethrow as Error).message).toBe(providerError.message);
+      expect((rethrow as Error).stack).toBe(providerError.stack);
+      expect((rethrow as Error).cause).toBe(providerError);
+    });
+
+    it('rethrows the original error on the final attempt, so it opens an incident', () => {
+      const { final, rethrow } = classifyJobFailure(
+        jobWith(2, 3),
+        providerError,
+      );
+
+      expect(final).toBe(true);
+      expect(rethrow).toBe(providerError);
+    });
+
+    it('treats UnrecoverableError as final even when attempts remain', () => {
+      const unrecoverable = new Error('source was deleted mid-processing');
+      unrecoverable.name = 'UnrecoverableError';
+
+      const { final, rethrow } = classifyJobFailure(
+        jobWith(0, 3),
+        unrecoverable,
+      );
+
+      expect(final).toBe(true);
+      expect(rethrow).toBe(unrecoverable);
+    });
+
+    it('wraps non-Error throwables with a stringified message', () => {
+      const { rethrow } = classifyJobFailure(jobWith(0, 3), 'redis timeout');
+
+      expect(rethrow).toBeInstanceOf(JobRetryScheduledError);
+      expect((rethrow as Error).message).toBe('redis timeout');
+    });
   });
 
-  it('preserves the original message so job.failedReason stays informative', () => {
-    const result = wrapIfRetryScheduled(jobWith(0, 3), providerError);
+  describe('expected failures', () => {
+    it('settles a permanent failure immediately, without an incident', () => {
+      const { final, rethrow } = classifyJobFailure(
+        jobWith(0, 3),
+        new FakeRetrieverError(422),
+      );
 
-    expect((result as Error).message).toBe(providerError.message);
-  });
+      expect(final).toBe(true);
+      expect(rethrow).toBeNull();
+    });
 
-  it('preserves the original stack and exposes the original as cause', () => {
-    const result = wrapIfRetryScheduled(jobWith(0, 3), providerError) as Error;
-
-    expect(result.stack).toBe(providerError.stack);
-    expect(result.cause).toBe(providerError);
-  });
-
-  it('returns the original error untouched on the final attempt', () => {
-    expect(wrapIfRetryScheduled(jobWith(2, 3), providerError)).toBe(
-      providerError,
+    it.each([413, 415, 404])(
+      'skips the remaining retries for status %i',
+      (status) => {
+        expect(
+          classifyJobFailure(jobWith(0, 3), new FakeRetrieverError(status)),
+        ).toEqual({ final: true, rethrow: null });
+      },
     );
-  });
 
-  it('returns UnrecoverableError untouched even when attempts remain, since BullMQ will not retry it', () => {
-    const unrecoverable = new Error('source was deleted mid-processing');
-    unrecoverable.name = 'UnrecoverableError';
+    it.each([408, 429])(
+      'keeps retrying status %i under the ignored name, since it may succeed later',
+      (status) => {
+        const { final, rethrow } = classifyJobFailure(
+          jobWith(0, 3),
+          new FakeRetrieverError(status),
+        );
 
-    expect(wrapIfRetryScheduled(jobWith(0, 3), unrecoverable)).toBe(
-      unrecoverable,
+        expect(final).toBe(false);
+        expect(rethrow).toBeInstanceOf(JobRetryScheduledError);
+      },
     );
-  });
 
-  it('wraps non-Error throwables with a stringified message', () => {
-    const result = wrapIfRetryScheduled(jobWith(0, 3), 'redis timeout');
+    it('settles a retryable failure quietly once its attempts run out', () => {
+      const { final, rethrow } = classifyJobFailure(
+        jobWith(2, 3),
+        new FakeRetrieverError(408),
+      );
 
-    expect(result).toBeInstanceOf(JobRetryScheduledError);
-    expect((result as Error).message).toBe('redis timeout');
+      expect(final).toBe(true);
+      expect(rethrow).toBeNull();
+    });
   });
 });

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/bullmq-job.helpers.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/bullmq-job.helpers.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@nestjs/common';
 import type { Job, JobsOptions, Queue } from 'bullmq';
 import type { UUID } from 'crypto';
+import { ApplicationError } from 'src/common/errors/base.error';
 
 /**
  * Standard retry/retention options shared by the source processing queues:
@@ -26,10 +27,11 @@ export function isFinalAttempt(job: Job): boolean {
 
 /**
  * Failure of a job attempt that BullMQ will retry. The AppSignal agent is
- * configured to drop errors with this name (`ignoreErrors` in appsignal.cjs)
- * so only final failures — thrown with their original name — become
- * incidents. Message and stack are preserved so job.failedReason and logs
- * stay as informative as the original error.
+ * configured to drop errors with this name (the `bullmq-retry-scheduled`
+ * suppression in appsignal-hooks.cjs) so only unexpected final failures —
+ * thrown with their original name — become incidents. Message and stack are
+ * preserved so job.failedReason and logs stay as informative as the original
+ * error.
  */
 export class JobRetryScheduledError extends Error {
   constructor(original: unknown) {
@@ -44,16 +46,62 @@ export class JobRetryScheduledError extends Error {
 }
 
 /**
- * BullMQ's UnrecoverableError aborts remaining retries by error name, so it
- * must never be renamed — and its failure is final regardless of attempts.
+ * Statuses where the same request may well succeed later: a timeout or a rate
+ * limit says nothing about whether the resource is fetchable. Every other
+ * expected status (404, 413, 415, 422, …) describes the input itself, so
+ * retrying only repeats the same failure against the same host.
  */
-export function wrapIfRetryScheduled(job: Job, error: unknown): unknown {
+const RETRYABLE_EXPECTED_STATUSES = new Set([408, 429]);
+
+/**
+ * A failure caused by the job's own input rather than by a defect of ours —
+ * the queue-side counterpart of ApplicationErrorFilter's `statusCode < 500`
+ * rule for HTTP. A user pasting a URL to a dead intranet host is not an
+ * incident.
+ */
+export function isExpectedFailure(error: unknown): boolean {
+  return error instanceof ApplicationError && error.statusCode < 500;
+}
+
+export interface JobFailureOutcome {
+  /** No further attempt will run, so the source must be settled as FAILED. */
+  final: boolean;
+  /**
+   * What to rethrow, or null to let the job complete. Returning null is what
+   * keeps an expected failure out of AppSignal: a job that completes opens no
+   * incident, while the source still shows FAILED with its message.
+   */
+  rethrow: Error | null;
+}
+
+/**
+ * Decides how a consumer should end a failed attempt. Expected failures never
+ * reach AppSignal — permanent ones settle immediately instead of burning two
+ * more attempts, while retryable ones (timeouts, rate limits) keep their
+ * retries under the ignored name and still settle quietly if those run out.
+ */
+export function classifyJobFailure(
+  job: Job,
+  error: unknown,
+): JobFailureOutcome {
+  const expected = isExpectedFailure(error);
+  const retryIsPointless =
+    expected &&
+    !RETRYABLE_EXPECTED_STATUSES.has((error as ApplicationError).statusCode);
   const isUnrecoverable =
     error instanceof Error && error.name === 'UnrecoverableError';
-  if (isFinalAttempt(job) || isUnrecoverable) {
-    return error;
+
+  if (!isFinalAttempt(job) && !isUnrecoverable && !retryIsPointless) {
+    return { final: false, rethrow: new JobRetryScheduledError(error) };
   }
-  return new JobRetryScheduledError(error);
+  if (expected) {
+    return { final: true, rethrow: null };
+  }
+  // AppSignal needs an Error to report; a bare throwable would be dropped.
+  return {
+    final: true,
+    rethrow: error instanceof Error ? error : new Error(String(error)),
+  };
 }
 
 /**

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.spec.ts
@@ -5,6 +5,7 @@ import { TextType } from 'src/domain/sources/domain/source-type.enum';
 import { FileType } from 'src/domain/sources/domain/source-type.enum';
 import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import type { DocumentProcessingJobData } from '../../application/ports/document-processing.port';
+import { FileTooLargeError } from 'src/domain/retrievers/file-retrievers/application/file-retriever.errors';
 import { DocumentProcessingConsumer } from './document-processing.consumer';
 
 /* ------------------------------------------------------------------ */
@@ -147,6 +148,19 @@ describe('DocumentProcessingConsumer', () => {
       message: 'MinIO object not found',
     });
     expect(helper.markFailed).toHaveBeenCalled();
+  });
+
+  it('completes without throwing when the file itself is the problem', async () => {
+    const source = makeSource(SourceStatus.PROCESSING);
+    sourceRepository.findById.mockResolvedValue(source);
+    retrieveFileContentUseCase.execute.mockRejectedValueOnce(
+      new FileTooLargeError(),
+    );
+
+    // Completing rather than throwing is what keeps it out of AppSignal.
+    await expect(consumer.process(makeJob())).resolves.toBeUndefined();
+    expect(helper.markFailed).toHaveBeenCalled();
+    expect(deleteObjectUseCase.execute).toHaveBeenCalled();
   });
 
   it('should skip saving and clean up when source is deleted mid-processing', async () => {

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.ts
@@ -19,7 +19,7 @@ import { SplitterType } from 'src/domain/rag/splitters/domain/splitter-type.enum
 import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import type { DocumentProcessingJobData } from '../../application/ports/document-processing.port';
 import { DOCUMENT_PROCESSING_QUEUE } from './document-processing.constants';
-import { isFinalAttempt, wrapIfRetryScheduled } from './bullmq-job.helpers';
+import { classifyJobFailure } from './bullmq-job.helpers';
 
 @Processor(DOCUMENT_PROCESSING_QUEUE, { concurrency: 2 })
 export class DocumentProcessingConsumer extends WorkerHost {
@@ -74,7 +74,8 @@ export class DocumentProcessingConsumer extends WorkerHost {
           error: error as Error,
         });
 
-        if (isFinalAttempt(job)) {
+        const { final, rethrow } = classifyJobFailure(job, error);
+        if (final) {
           await this.helper.markFailed(
             sourceId,
             error instanceof Error ? error.message : 'Unknown processing error',
@@ -82,9 +83,7 @@ export class DocumentProcessingConsumer extends WorkerHost {
           await this.helper.cleanupIndex(sourceId);
           await this.cleanupMinioFile(minioPath);
         }
-        // Re-throw so BullMQ handles retries; non-final attempts are renamed
-        // so AppSignal only opens incidents for final failures.
-        throw wrapIfRetryScheduled(job, error);
+        if (rethrow) throw rethrow;
       }
     });
   }

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.spec.ts
@@ -18,6 +18,10 @@ import {
   UrlCrawlPage,
   UrlCrawlResult,
 } from 'src/domain/retrievers/url-retrievers/domain/url-crawl-result.entity';
+import {
+  UrlRetrieverTimeoutError,
+  UrlRetrieverUnsupportedContentTypeError,
+} from 'src/domain/retrievers/url-retrievers/application/url-retriever.errors';
 import type { UrlCrawlJobData } from '../../application/ports/url-crawl-processing.port';
 import { UrlCrawlConsumer } from './url-crawl.consumer';
 
@@ -196,6 +200,49 @@ describe('UrlCrawlConsumer', () => {
     await expect(consumer.process(job)).rejects.toMatchObject({
       name: 'JobRetryScheduledError',
       message: 'root unreachable',
+    });
+    expect(indexer.markFailed).not.toHaveBeenCalled();
+  });
+
+  it('completes without throwing when the crawl fails for a user-caused reason', async () => {
+    const source = makeSource();
+    sourceRepository.findById.mockResolvedValue(source);
+    crawlUrlUseCase.execute.mockRejectedValueOnce(
+      new UrlRetrieverUnsupportedContentTypeError(
+        'https://acme.test/',
+        'application/zip',
+      ),
+    );
+
+    const job = {
+      data: makeJobData(),
+      id: 'job-1',
+      attemptsMade: 0,
+      opts: { attempts: 3 },
+    } as unknown as Job<UrlCrawlJobData>;
+
+    // Completing rather than throwing is what keeps it out of AppSignal.
+    await expect(consumer.process(job)).resolves.toBeUndefined();
+    expect(indexer.markFailed).toHaveBeenCalled();
+    expect(indexer.cleanupIndex).toHaveBeenCalled();
+  });
+
+  it('still retries a crawl timeout, which may succeed on a later attempt', async () => {
+    const source = makeSource();
+    sourceRepository.findById.mockResolvedValue(source);
+    crawlUrlUseCase.execute.mockRejectedValueOnce(
+      new UrlRetrieverTimeoutError('https://acme.test/', 5000),
+    );
+
+    const job = {
+      data: makeJobData(),
+      id: 'job-1',
+      attemptsMade: 0,
+      opts: { attempts: 3 },
+    } as unknown as Job<UrlCrawlJobData>;
+
+    await expect(consumer.process(job)).rejects.toMatchObject({
+      name: 'JobRetryScheduledError',
     });
     expect(indexer.markFailed).not.toHaveBeenCalled();
   });

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.ts
@@ -16,7 +16,7 @@ import { SplitterType } from 'src/domain/rag/splitters/domain/splitter-type.enum
 import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import type { UrlCrawlJobData } from '../../application/ports/url-crawl-processing.port';
 import { URL_CRAWL_QUEUE } from './url-crawl.constants';
-import { isFinalAttempt, wrapIfRetryScheduled } from './bullmq-job.helpers';
+import { classifyJobFailure } from './bullmq-job.helpers';
 
 @Processor(URL_CRAWL_QUEUE, { concurrency: 2 })
 export class UrlCrawlConsumer extends WorkerHost {
@@ -75,16 +75,15 @@ export class UrlCrawlConsumer extends WorkerHost {
           error: error as Error,
         });
 
-        if (isFinalAttempt(job)) {
+        const { final, rethrow } = classifyJobFailure(job, error);
+        if (final) {
           await this.helper.markFailed(
             sourceId,
             error instanceof Error ? error.message : 'Unknown crawl error',
           );
           await this.helper.cleanupIndex(sourceId);
         }
-        // Re-throw so BullMQ handles retries; non-final attempts are renamed
-        // so AppSignal only opens incidents for final failures.
-        throw wrapIfRetryScheduled(job, error);
+        if (rethrow) throw rethrow;
       }
     });
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes incident and retry behavior for all source queue failures; mis-tagged errors could hide real outages, but logic mirrors existing HTTP 4xx handling.
> 
> **Overview**
> Source processing queues now treat **user/input failures** like HTTP 4xx: they mark the source **FAILED** without opening AppSignal incidents or wasting BullMQ retries.
> 
> `wrapIfRetryScheduled` is replaced by **`classifyJobFailure`**, which returns `{ final, rethrow }`. **`ApplicationError` with `statusCode < 500`** is “expected”: the consumer settles the source and **does not rethrow** (job completes). Permanent cases such as **404, 413, 415, 422** stop retrying on the first attempt; **408 and 429** still retry under **`JobRetryScheduledError`** (suppressed in AppSignal), but if attempts are exhausted they also complete quietly. Unexpected errors keep the old behavior—retries wrapped as **`JobRetryScheduledError`**, final attempt rethrows the original error for incidents.
> 
> **Document** and **URL crawl** consumers use this helper in their catch blocks; specs cover oversized files, unsupported content types, and timeout retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 842d4bacf597e71f57cebbea62077f5eddfde178. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->