### PR TITLE
fix(storage): retry transient object downloads instead of double round-tripping (AYC-568)

### DIFF
--- a/ayunis-core-backend/src/domain/storage/application/use-cases/download-object/download-object.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/download-object/download-object.use-case.spec.ts
@@ -8,6 +8,12 @@ import storageConfig from 'src/config/storage.config';
 import { DownloadFailedError, ObjectNotFoundError } from '../../storage.errors';
 import { Readable } from 'stream';
 
+function networkError(code: string): Error {
+  const error: NodeJS.ErrnoException = new Error(`${code} cdn-core.test`);
+  error.code = code;
+  return error;
+}
+
 describe('DownloadObjectUseCase', () => {
   let useCase: DownloadObjectUseCase;
   let mockObjectStorage: Partial<ObjectStoragePort>;
@@ -48,145 +54,136 @@ describe('DownloadObjectUseCase', () => {
 
   describe('execute', () => {
     it('should download object successfully', async () => {
-      // Arrange
-      const objectName = 'test-file.txt';
-      const command = new DownloadObjectCommand(objectName);
+      const command = new DownloadObjectCommand('test-file.txt');
       const mockStream = new Readable();
 
-      jest.spyOn(mockObjectStorage, 'exists').mockResolvedValue(true);
       jest.spyOn(mockObjectStorage, 'download').mockResolvedValue(mockStream);
 
-      // Act
       const result = await useCase.execute(command);
 
-      // Assert
-      expect(mockObjectStorage.exists).toHaveBeenCalled();
-      expect(mockObjectStorage.download).toHaveBeenCalled();
       expect(result).toBe(mockStream);
     });
 
-    it('should throw ObjectNotFoundError when object does not exist', async () => {
-      // Arrange
-      const objectName = 'non-existent-file.txt';
-      const command = new DownloadObjectCommand(objectName);
+    it('should not stat the object before downloading it', async () => {
+      const command = new DownloadObjectCommand('test-file.txt');
+      jest
+        .spyOn(mockObjectStorage, 'download')
+        .mockResolvedValue(new Readable());
 
-      jest.spyOn(mockObjectStorage, 'exists').mockResolvedValue(false);
+      await useCase.execute(command);
 
-      // Act & Assert
-      await expect(useCase.execute(command)).rejects.toThrow(
+      // The extra round-trip is what made a single DNS blip fatal.
+      expect(mockObjectStorage.exists).not.toHaveBeenCalled();
+      expect(mockObjectStorage.download).toHaveBeenCalledTimes(1);
+    });
+
+    it('should pass through ObjectNotFoundError from the storage adapter', async () => {
+      const command = new DownloadObjectCommand('missing.txt');
+      jest
+        .spyOn(mockObjectStorage, 'download')
+        .mockRejectedValue(
+          new ObjectNotFoundError({ objectName: 'missing.txt' }),
+        );
+
+      await expect(useCase.execute(command)).rejects.toBeInstanceOf(
         ObjectNotFoundError,
       );
-      expect(mockObjectStorage.exists).toHaveBeenCalled();
-      expect(mockObjectStorage.download).not.toHaveBeenCalled();
     });
 
     it('should use default bucket when no bucket specified', async () => {
-      // Arrange
-      const objectName = 'test-file.txt';
-      const command = new DownloadObjectCommand(objectName);
-      const mockStream = new Readable();
+      const command = new DownloadObjectCommand('test-file.txt');
+      jest
+        .spyOn(mockObjectStorage, 'download')
+        .mockResolvedValue(new Readable());
 
-      jest.spyOn(mockObjectStorage, 'exists').mockResolvedValue(true);
-      jest.spyOn(mockObjectStorage, 'download').mockResolvedValue(mockStream);
-
-      // Act
       await useCase.execute(command);
 
-      // Assert
-      expect(mockObjectStorage.exists).toHaveBeenCalledWith(
+      expect(mockObjectStorage.download).toHaveBeenCalledWith(
         expect.objectContaining({ bucket: 'test-bucket' }),
       );
     });
 
     it('should use custom bucket when specified', async () => {
-      // Arrange
-      const objectName = 'test-file.txt';
-      const customBucket = 'custom-bucket';
-      const command = new DownloadObjectCommand(objectName, customBucket);
-      const mockStream = new Readable();
+      const command = new DownloadObjectCommand('test-file.txt', 'custom');
+      jest
+        .spyOn(mockObjectStorage, 'download')
+        .mockResolvedValue(new Readable());
 
-      jest.spyOn(mockObjectStorage, 'exists').mockResolvedValue(true);
-      jest.spyOn(mockObjectStorage, 'download').mockResolvedValue(mockStream);
-
-      // Act
       await useCase.execute(command);
 
-      // Assert
-      expect(mockObjectStorage.exists).toHaveBeenCalledWith(
-        expect.objectContaining({ bucket: customBucket }),
+      expect(mockObjectStorage.download).toHaveBeenCalledWith(
+        expect.objectContaining({ bucket: 'custom' }),
       );
     });
 
-    it('should throw DownloadFailedError on storage error', async () => {
-      // Arrange
-      const objectName = 'test-file.txt';
-      const command = new DownloadObjectCommand(objectName);
+    it('should retry a transient DNS failure and succeed', async () => {
+      const command = new DownloadObjectCommand('test-file.txt');
+      const mockStream = new Readable();
 
-      jest.spyOn(mockObjectStorage, 'exists').mockResolvedValue(true);
       jest
         .spyOn(mockObjectStorage, 'download')
-        .mockRejectedValue(new Error('Storage error'));
+        .mockRejectedValueOnce(networkError('EAI_AGAIN'))
+        .mockResolvedValueOnce(mockStream);
 
-      // Act & Assert
-      await expect(useCase.execute(command)).rejects.toThrow(
+      await expect(useCase.execute(command)).resolves.toBe(mockStream);
+      expect(mockObjectStorage.download).toHaveBeenCalledTimes(2);
+    });
+
+    it('should give up after exhausting retries on a persistent network fault', async () => {
+      const command = new DownloadObjectCommand('test-file.txt');
+      jest
+        .spyOn(mockObjectStorage, 'download')
+        .mockRejectedValue(networkError('ECONNRESET'));
+
+      await expect(useCase.execute(command)).rejects.toBeInstanceOf(
         DownloadFailedError,
       );
+      expect(mockObjectStorage.download).toHaveBeenCalledTimes(3);
+    });
+
+    it('should not retry an error that a retry cannot fix', async () => {
+      const command = new DownloadObjectCommand('test-file.txt');
+      jest
+        .spyOn(mockObjectStorage, 'download')
+        .mockRejectedValue(new Error('Access Denied'));
+
+      await expect(useCase.execute(command)).rejects.toBeInstanceOf(
+        DownloadFailedError,
+      );
+      expect(mockObjectStorage.download).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not retry a missing object', async () => {
+      const command = new DownloadObjectCommand('missing.txt');
+      jest
+        .spyOn(mockObjectStorage, 'download')
+        .mockRejectedValue(
+          new ObjectNotFoundError({ objectName: 'missing.txt' }),
+        );
+
+      await expect(useCase.execute(command)).rejects.toBeInstanceOf(
+        ObjectNotFoundError,
+      );
+      expect(mockObjectStorage.download).toHaveBeenCalledTimes(1);
     });
 
     it('should not expose the object path or the upstream message', async () => {
-      // Arrange
       const objectName = 'org-id/thread-id/message-id/3.jpg';
       const command = new DownloadObjectCommand(objectName);
 
-      jest.spyOn(mockObjectStorage, 'exists').mockResolvedValue(true);
       jest
         .spyOn(mockObjectStorage, 'download')
         .mockRejectedValue(
           new Error('getaddrinfo EAI_AGAIN cdn-core.ayunis.com'),
         );
 
-      // Act
       const error = await useCase.execute(command).catch((e: unknown) => e);
 
-      // Assert — the serialised HTTP body is what reaches the client
       const body = JSON.stringify(
         (error as DownloadFailedError).toHttpException().getResponse(),
       );
       expect(body).not.toContain(objectName);
       expect(body).not.toContain('cdn-core.ayunis.com');
-    });
-
-    it('should pass through ObjectNotFoundError from download', async () => {
-      // Arrange
-      const objectName = 'test-file.txt';
-      const command = new DownloadObjectCommand(objectName);
-
-      jest.spyOn(mockObjectStorage, 'exists').mockResolvedValue(true);
-      const notFoundError = new ObjectNotFoundError({ objectName });
-      jest
-        .spyOn(mockObjectStorage, 'download')
-        .mockRejectedValue(notFoundError);
-
-      // Act & Assert
-      await expect(useCase.execute(command)).rejects.toThrow(
-        ObjectNotFoundError,
-      );
-    });
-
-    it('should handle exists check error gracefully', async () => {
-      // Arrange
-      const objectName = 'test-file.txt';
-      const command = new DownloadObjectCommand(objectName);
-
-      jest
-        .spyOn(mockObjectStorage, 'exists')
-        .mockRejectedValue(new Error('Exists check failed'));
-
-      // Act & Assert
-      await expect(useCase.execute(command)).rejects.toThrow(
-        DownloadFailedError,
-      );
-      expect(mockObjectStorage.download).not.toHaveBeenCalled();
     });
   });
 });

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/download-object/download-object.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/download-object/download-object.use-case.ts
@@ -5,6 +5,31 @@ import { DownloadObjectCommand } from './download-object.command';
 import storageConfig from 'src/config/storage.config';
 import { DownloadFailedError, ObjectNotFoundError } from '../../storage.errors';
 import { StorageUrl } from 'src/domain/storage/domain/storage-url.entity';
+import retryWithBackoff from 'src/common/util/retryWithBackoff';
+
+/**
+ * Transient network faults between the backend and object storage — a DNS
+ * blip, a reset keep-alive socket. Worth one more attempt; anything else
+ * (missing key, bad credentials, permanent DNS failure) is not.
+ */
+const TRANSIENT_NETWORK_CODES = new Set([
+  'EAI_AGAIN',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+]);
+
+/**
+ * Deliberately far below retryWithBackoff's 5s default: a browser is blocking
+ * on this response, so the whole retry budget has to stay imperceptible.
+ */
+const RETRY_DELAY_MS = 150;
+const MAX_RETRIES = 2;
+
+function isTransientNetworkError(error: Error): boolean {
+  const { code } = error as NodeJS.ErrnoException;
+  return code !== undefined && TRANSIENT_NETWORK_CODES.has(code);
+}
 
 @Injectable()
 export class DownloadObjectUseCase {
@@ -26,18 +51,19 @@ export class DownloadObjectUseCase {
     try {
       const bucketName = command.bucket || this.getDefaultBucket();
 
-      // Check if object exists before downloading
-      const exists = await this.objectExists(command.objectName, bucketName);
-      if (!exists) {
-        throw new ObjectNotFoundError({
-          objectName: command.objectName,
-          bucket: bucketName,
-        });
-      }
+      // No exists() pre-check: it doubled the DNS lookups and round-trips on
+      // the hot path for an answer the download itself already gives — the
+      // storage adapter maps a missing key to ObjectNotFoundError.
+      const stream = await retryWithBackoff({
+        fn: () =>
+          this.objectStorage.download(
+            new StorageUrl(command.objectName, bucketName),
+          ),
+        maxRetries: MAX_RETRIES,
+        delay: RETRY_DELAY_MS,
+        retryIfError: isTransientNetworkError,
+      });
 
-      const stream = await this.objectStorage.download(
-        new StorageUrl(command.objectName, bucketName),
-      );
       this.logger.debug(
         `Successfully started download for object: ${command.objectName}`,
       );
@@ -58,16 +84,5 @@ export class DownloadObjectUseCase {
 
   private getDefaultBucket(): string {
     return this.config.minio.bucket;
-  }
-
-  private async objectExists(
-    objectName: string,
-    bucket?: string,
-  ): Promise<boolean> {
-    // Rejections propagate to execute()'s handler on purpose: a stat that
-    // fails because storage is unreachable is a 500, not a 404 telling the
-    // caller their object is gone.
-    const bucketName = bucket || this.getDefaultBucket();
-    return this.objectStorage.exists(new StorageUrl(objectName, bucketName));
   }
 }

--- a/ayunis-core-backend/src/domain/storage/infrastructure/providers/minio-object-storage.provider.ts
+++ b/ayunis-core-backend/src/domain/storage/infrastructure/providers/minio-object-storage.provider.ts
@@ -12,6 +12,18 @@ import { StorageObject } from '../../domain/storage-object.entity';
 import { StorageUrl } from '../../domain/storage-url.entity';
 import { PresignedUrl } from '../../domain/presigned-url.entity';
 import { StorageBucket } from '../../domain/storage-bucket.entity';
+import { ObjectNotFoundError } from '../../application/storage.errors';
+
+/**
+ * S3 error codes minio raises for a key that is not there. `NotFound` comes
+ * back from HEAD-style calls, `NoSuchKey` from GETs.
+ */
+const MISSING_OBJECT_CODES = new Set(['NoSuchKey', 'NotFound']);
+
+function isMissingObjectError(error: unknown): boolean {
+  const code = (error as { code?: string } | null)?.code;
+  return code !== undefined && MISSING_OBJECT_CODES.has(code);
+}
 
 @Injectable()
 export class MinioObjectStorageProvider
@@ -117,7 +129,19 @@ export class MinioObjectStorageProvider
 
   async download(storageUrl: StorageUrl): Promise<NodeJS.ReadableStream> {
     const bucketName = storageUrl.bucket || this.defaultBucket;
-    return this.client.getObject(bucketName, storageUrl.objectName);
+    try {
+      return await this.client.getObject(bucketName, storageUrl.objectName);
+    } catch (error) {
+      // Without this translation a missing object is indistinguishable from
+      // storage being unreachable, and callers turn both into a 500.
+      if (isMissingObjectError(error)) {
+        throw new ObjectNotFoundError({
+          objectName: storageUrl.objectName,
+          bucket: bucketName,
+        });
+      }
+      throw error;
+    }
   }
 
   async getObjectInfo(storageUrl: StorageUrl): Promise<StorageObject> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the user-facing object download hot path and changes when 404 vs 500 is returned; behavior is narrowed with targeted retries and new adapter error mapping plus expanded tests.
> 
> **Overview**
> Object downloads no longer call **`exists`** before **`download`**, cutting an extra storage round-trip that made brief DNS failures more likely to fail the request.
> 
> **`DownloadObjectUseCase`** now wraps **`download`** in **`retryWithBackoff`** (2 retries, 150ms delay) only for transient network errno codes (`EAI_AGAIN`, `ECONNRESET`, `ETIMEDOUT`, `ECONNREFUSED`). Missing keys and non-retryable errors are not retried; **`ObjectNotFoundError`** still passes through, and other failures become **`DownloadFailedError`** without leaking paths or upstream messages.
> 
> The **MinIO** **`download`** adapter maps S3 **`NoSuchKey`** / **`NotFound`** from **`getObject`** to **`ObjectNotFoundError`**, so callers can rely on a single download call for “not found” instead of the old pre-check.
> 
> Specs were reshaped to assert no **`exists`** usage, retry behavior, and unchanged error-sanitization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6d98574aeefabc18dc3d0bdc09d07edbaa7a6e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->