### PR TITLE
fix(openai-compat): strip strict-mode nulls from outbound tool calls (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/common/util/unicode-sanitizer.spec.ts
+++ b/ayunis-core-backend/src/common/util/unicode-sanitizer.spec.ts
@@ -1,0 +1,75 @@
+import { sanitizeObject, sanitizeUnicodeEscapes } from './unicode-sanitizer';
+
+describe('sanitizeUnicodeEscapes', () => {
+  it('removes completed null escapes and real NULL characters', () => {
+    expect(sanitizeUnicodeEscapes('a\\u0000b')).toBe('ab');
+    expect(sanitizeUnicodeEscapes(`a${String.fromCharCode(0)}b`)).toBe('ab');
+  });
+
+  it('fixes broken escape tails at end of string', () => {
+    expect(sanitizeUnicodeEscapes('abc\\u00')).toBe('abc');
+    expect(sanitizeUnicodeEscapes('abc\\u0')).toBe('abc');
+  });
+
+  it('preserves ordinary strings, paths, and valid escapes', () => {
+    expect(sanitizeUnicodeEscapes('C:\\Users\\name')).toBe('C:\\Users\\name');
+    expect(sanitizeUnicodeEscapes('emoji \\u1F600 ok')).toBe(
+      'emoji \\u1F600 ok',
+    );
+    expect(sanitizeUnicodeEscapes('plain text')).toBe('plain text');
+  });
+
+  // Message contents get re-sanitized whenever they are copied (e.g. replayed
+  // tool calls rebuilt via the ToolUseMessageContent constructor), so a second
+  // pass must never change the result of the first.
+  describe('idempotency', () => {
+    const adversarial = [
+      'A\\u00\\u00000', // removal creates a new broken tail
+      '\\u000\\u0000',
+      'x\\u0\\u00000y',
+      '\\u\\u0000',
+      'clean string',
+      'tail\\u000',
+    ];
+
+    it.each(adversarial)('sanitize(sanitize(%j)) === sanitize(%j)', (input) => {
+      const once = sanitizeUnicodeEscapes(input);
+      expect(sanitizeUnicodeEscapes(once)).toBe(once);
+    });
+  });
+});
+
+describe('sanitizeObject', () => {
+  // Tool params and other untrusted payloads arrive via JSON.parse, which
+  // yields `__proto__` as an own key; copying it with bracket assignment
+  // would replace the returned object's prototype, so reads of absent fields
+  // would resolve to attacker-controlled values.
+  it('keeps a __proto__ key as inert data instead of replacing the prototype', () => {
+    const parsed = JSON.parse(
+      '{"__proto__":{"injected":"yes"},"a":"b"}',
+    ) as Record<string, unknown>;
+
+    const result = sanitizeObject(parsed);
+
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect((result as { injected?: unknown }).injected).toBeUndefined();
+    expect(result.a).toBe('b');
+  });
+
+  it('leaves Object.prototype untouched', () => {
+    sanitizeObject(
+      JSON.parse('{"__proto__":{"polluted":"yes"}}') as Record<string, unknown>,
+    );
+
+    expect(({} as { polluted?: unknown }).polluted).toBeUndefined();
+  });
+
+  it('is idempotent over nested structures', () => {
+    const input = {
+      a: 'A\\u00\\u00000',
+      nested: { b: ['\\u000\\u0000', 42, null] },
+    };
+    const once = sanitizeObject(input);
+    expect(sanitizeObject(once)).toEqual(once);
+  });
+});

--- a/ayunis-core-backend/src/common/util/unicode-sanitizer.ts
+++ b/ayunis-core-backend/src/common/util/unicode-sanitizer.ts
@@ -14,6 +14,20 @@ export function sanitizeUnicodeEscapes(input: unknown): string {
     return String(input);
   }
 
+  // Dropping a completed null escape can leave a new broken tail behind, so
+  // one pass is not stable — and message contents are re-sanitized on every
+  // copy. Iterate to a fixpoint so a second pass never changes the result of
+  // the first. Terminates: every changing pass shortens the string.
+  let current = input;
+  let next = sanitizeUnicodeEscapesOnce(current);
+  while (next !== current) {
+    current = next;
+    next = sanitizeUnicodeEscapesOnce(current);
+  }
+  return next;
+}
+
+function sanitizeUnicodeEscapesOnce(input: string): string {
   return (
     input
       // Only remove \u sequences that are clearly broken Unicode escapes
@@ -70,7 +84,7 @@ export function safeJsonParse<T>(
  */
 export function sanitizeObject<T>(obj: T): T {
   // Handle primitives
-  if (obj === null || obj === undefined) {
+  if (obj === null || typeof obj === 'undefined') {
     return obj;
   }
 
@@ -89,10 +103,13 @@ export function sanitizeObject<T>(obj: T): T {
   }
 
   // Handle objects
-  const sanitized = {} as Record<string, unknown>;
-  for (const [key, value] of Object.entries(obj)) {
-    sanitized[key] = sanitizeObject(value);
-  }
+  // fromEntries defines own properties, so a `__proto__` key in untrusted
+  // JSON stays inert data instead of replacing the returned object's
+  // prototype (which bracket assignment would do, letting reads of absent
+  // fields resolve to attacker-controlled values).
+  const sanitizedEntries = Object.entries(obj).map(
+    ([key, value]): [string, unknown] => [key, sanitizeObject(value)],
+  );
 
-  return sanitized as T;
+  return Object.fromEntries(sanitizedEntries) as T;
 }

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-response.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-response.mapper.spec.ts
@@ -1,0 +1,80 @@
+import { OpenAIResponseMapper } from './openai-response.mapper';
+import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
+import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
+import type { InferenceResponse } from 'src/domain/models/application/ports/inference.handler';
+import type { ToolSchema } from 'src/domain/models/domain/value-objects/tool-schema';
+
+const searchTool: ToolSchema = {
+  name: 'search_customers',
+  description: 'Search customers',
+  parameters: {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      churnDate: { type: 'string', format: 'date' },
+    },
+  },
+};
+
+function responseWithToolCall(
+  params: Record<string, unknown>,
+): InferenceResponse {
+  return {
+    content: [new ToolUseMessageContent('call-1', 'search_customers', params)],
+    meta: {},
+  };
+}
+
+describe('OpenAIResponseMapper', () => {
+  const mapper = new OpenAIResponseMapper();
+
+  // The gateway's strict-mode normalization invites the model to emit nulls
+  // for optional params; the external consumer executing the tool never
+  // opted into that convention, so the nulls must not leave the gateway.
+  it('strips schema-disallowed nulls from outbound tool-call arguments', () => {
+    const result = mapper.toResponse({
+      id: 'cmpl-1',
+      modelName: 'gpt-4o',
+      response: responseWithToolCall({
+        name: 'Stadt Ladenburg',
+        churnDate: null,
+      }),
+      tools: [searchTool],
+    });
+
+    const toolCall = result.choices[0].message.tool_calls?.[0];
+    expect(JSON.parse(toolCall?.function.arguments ?? '{}')).toEqual({
+      name: 'Stadt Ladenburg',
+    });
+  });
+
+  it('passes tool-call arguments through when no matching tool schema exists', () => {
+    const result = mapper.toResponse({
+      id: 'cmpl-1',
+      modelName: 'gpt-4o',
+      response: responseWithToolCall({ name: 'x', churnDate: null }),
+      tools: [],
+    });
+
+    const toolCall = result.choices[0].message.tool_calls?.[0];
+    expect(JSON.parse(toolCall?.function.arguments ?? '{}')).toEqual({
+      name: 'x',
+      churnDate: null,
+    });
+  });
+
+  it('maps text content and finish reason', () => {
+    const result = mapper.toResponse({
+      id: 'cmpl-1',
+      modelName: 'gpt-4o',
+      response: {
+        content: [new TextMessageContent('hello')],
+        meta: {},
+      },
+      tools: [],
+    });
+
+    expect(result.choices[0].message.content).toBe('hello');
+    expect(result.choices[0].finish_reason).toBe('stop');
+  });
+});

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-response.mapper.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-response.mapper.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
 import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
 import type { InferenceResponse } from 'src/domain/models/application/ports/inference.handler';
+import type { ToolSchema } from 'src/domain/models/domain/value-objects/tool-schema';
+import { stripDisallowedNulls } from 'src/common/util/strip-disallowed-nulls';
 import type {
   ChatCompletionResponse,
   ChatCompletionResponseChoice,
@@ -15,8 +17,9 @@ export class OpenAIResponseMapper {
     id: string;
     modelName: string;
     response: InferenceResponse;
+    tools: readonly ToolSchema[];
   }): ChatCompletionResponse {
-    const message = this.buildAssistantMessage(params.response);
+    const message = this.buildAssistantMessage(params.response, params.tools);
     const finishReason: ChatCompletionResponseChoice['finish_reason'] =
       message.tool_calls && message.tool_calls.length > 0
         ? 'tool_calls'
@@ -45,6 +48,7 @@ export class OpenAIResponseMapper {
 
   private buildAssistantMessage(
     response: InferenceResponse,
+    tools: readonly ToolSchema[],
   ): ChatCompletionResponseMessage {
     let textContent = '';
     const toolCalls: ChatCompletionToolCallResponse[] = [];
@@ -53,12 +57,21 @@ export class OpenAIResponseMapper {
       if (block instanceof TextMessageContent) {
         textContent += block.text;
       } else if (block instanceof ToolUseMessageContent) {
+        // The consumer executes this tool call against their own schema —
+        // remove the nulls our strict-mode normalization invited, which the
+        // consumer's tools never opted into. Only possible here: the
+        // streaming path emits arguments as raw text deltas and cannot strip
+        // without buffering whole tool calls.
+        const schema = tools.find((tool) => tool.name === block.name);
+        const args = schema
+          ? stripDisallowedNulls(block.params, schema.parameters)
+          : block.params;
         toolCalls.push({
           id: block.id,
           type: 'function',
           function: {
             name: block.name,
-            arguments: JSON.stringify(block.params),
+            arguments: JSON.stringify(args),
           },
         });
       }

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.use-case.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.use-case.ts
@@ -54,12 +54,13 @@ export class ExecuteOpenAIChatCompletionUseCase {
     );
 
     const requestId = this.requestMapper.newRequestId();
+    const tools = this.requestMapper.toToolSchemas(command.request);
 
     const response = await this.getInferenceUseCase.execute(
       new GetInferenceCommand({
         model,
         messages,
-        tools: this.requestMapper.toToolSchemas(command.request),
+        tools,
         toolChoice: this.requestMapper.toModelToolChoice(command.request),
         instructions: systemPrompt || undefined,
       }),
@@ -83,6 +84,7 @@ export class ExecuteOpenAIChatCompletionUseCase {
       id: this.completionId(),
       modelName: command.request.model,
       response,
+      tools,
     });
   }
 


### PR DESCRIPTION
- strip schema-disallowed nulls from non-streaming tool-call arguments
  against the consumer-provided tool schema before they leave the
  gateway — strict-mode normalization invited those nulls, and the
  consumer's own tools never opted into that convention (streaming
  deltas documented as out of reach without buffering whole calls)
- make sanitizeUnicodeEscapes idempotent (iterate to a fixpoint) so
  re-sanitizing copied message contents can never mangle strings
  further; adversarial regression spec included

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound API tool-call payloads and untrusted JSON sanitization paths; fixes are scoped but affect security-sensitive parsing and external consumers.
> 
> **Overview**
> Non-streaming OpenAI-compat chat completions now **strip null tool arguments** that the consumer’s tool schema does not allow, using `stripDisallowedNulls` in `OpenAIResponseMapper` with the request’s tool schemas (streaming is unchanged—arguments are still raw deltas). The execute use case passes those schemas through to the mapper.
> 
> **Unicode sanitization** is tightened: `sanitizeUnicodeEscapes` loops to a fixpoint so re-sanitizing copied message content cannot change strings again, and `sanitizeObject` builds results with `Object.fromEntries` so a `__proto__` key from parsed JSON cannot pollute prototypes. New specs cover idempotency, `__proto__` handling, and mapper behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af68b220eaf3480b22be49a652832393dc28a3d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->