### PR TITLE
refactor(frontend): inject env config at runtime instead of build time (AYC-588)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,17 +15,13 @@ ayunis-core-backend/frontend
 ayunis-core-backend/coverage
 **/.nyc_output
 
-# Secrets & local env
+# Secrets & local env — no .env enters the build context. The frontend's
+# environment-specific values are injected at runtime via GET /config.js
+# (the app container loads ayunis-core-frontend/.env as a compose env_file),
+# so the built image is host-agnostic.
 **/.env
 **/.env.*
 !**/.env.example
-# Exception: the frontend .env must enter the build context so Vite can inline its
-# VITE_* vars at build time. Being part of the context (vs a secret mount, whose
-# contents BuildKit excludes from the cache key) is what makes a changed value
-# correctly bust the frontend build layer. It only lands in the discarded build
-# stage — the production image copies the built dist, never the .env. The backend
-# .env stays excluded (the backend reads its env at runtime via compose env_file).
-!ayunis-core-frontend/.env
 
 # Python services (not part of the JS image; built by their own Dockerfiles)
 ayunis-core-code-execution

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,18 +29,10 @@ RUN pnpm install --frozen-lockfile
 # of dist/ (so nest's deleteOutDir doesn't wipe it), copied into dist/frontend in
 # the final stage. Then build the backend.
 #
-# The frontend .env enters the build context via a .dockerignore exception, so Vite
-# auto-loads it and inlines every VITE_* var at build time — no per-variable ARG/ENV
-# plumbing. Unlike a BuildKit secret mount (whose contents are excluded from the
-# layer cache key), the file is part of the context, so changing a value correctly
-# invalidates this layer instead of reusing a stale, previously-inlined bundle. It
-# lives only in this discarded build stage; the production image copies the built
-# dist, never the .env. The echo surfaces which VITE_* vars are present (names only)
-# so a missing one shows up in build logs rather than silently inlining as undefined.
-RUN echo "Frontend VITE_* vars present at build:" \
- && (grep -oE '^VITE_[A-Z0-9_]+=' ayunis-core-frontend/.env 2>/dev/null | sort \
-     || echo "  (none — VITE_* will be inlined as undefined)") \
- && pnpm --filter core-frontend-tanstack run build
+# No .env is consulted: environment-specific frontend values are injected at
+# runtime via the backend's GET /config.js, so the same image serves every
+# environment.
+RUN pnpm --filter core-frontend-tanstack run build
 RUN cp -r ayunis-core-frontend/dist ayunis-core-backend/frontend
 # Build the workspace packages the backend depends on (@ayunis/inference,
 # @ayunis/provider-anthropic, @ayunis/provider-openai) before the backend so

--- a/ayunis-core-backend/src/app/app.module.ts
+++ b/ayunis-core-backend/src/app/app.module.ts
@@ -44,6 +44,7 @@ import type { RedisConfig } from '../config/redis.config';
 import { BullModule } from '@nestjs/bullmq';
 import { IsCloudUseCase } from './application/use-cases/is-cloud/is-cloud.use-case';
 import { IsRegistrationDisabledUseCase } from './application/use-cases/is-registration-disabled/is-registration-disabled.use-case';
+import { GetFrontendRuntimeConfigUseCase } from './application/use-cases/get-frontend-runtime-config/get-frontend-runtime-config.use-case';
 import { ClsModule } from 'nestjs-cls';
 import { ContextModule } from 'src/common/context/context.module';
 import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
@@ -162,6 +163,7 @@ import { IntegrationsModule } from '../integrations/integrations.module';
     SecurityHeadersMiddleware,
     IsCloudUseCase,
     IsRegistrationDisabledUseCase,
+    GetFrontendRuntimeConfigUseCase,
   ],
 })
 export class AppModule implements NestModule {

--- a/ayunis-core-backend/src/app/application/use-cases/get-frontend-runtime-config/get-frontend-runtime-config.use-case.ts
+++ b/ayunis-core-backend/src/app/application/use-cases/get-frontend-runtime-config/get-frontend-runtime-config.use-case.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import {
+  frontendConfig,
+  FrontendRuntimeConfig,
+} from 'src/config/frontend.config';
+
+@Injectable()
+export class GetFrontendRuntimeConfigUseCase {
+  constructor(
+    @Inject(frontendConfig.KEY)
+    private readonly config: ConfigType<typeof frontendConfig>,
+  ) {}
+
+  execute(): FrontendRuntimeConfig {
+    return this.config;
+  }
+}

--- a/ayunis-core-backend/src/app/presenters/http/app.controller.ts
+++ b/ayunis-core-backend/src/app/presenters/http/app.controller.ts
@@ -1,7 +1,13 @@
-import { Controller, Get, Inject } from '@nestjs/common';
+import { Controller, Get, Header, Inject } from '@nestjs/common';
 import { IsCloudUseCase } from 'src/app/application/use-cases/is-cloud/is-cloud.use-case';
 import { IsRegistrationDisabledUseCase } from 'src/app/application/use-cases/is-registration-disabled/is-registration-disabled.use-case';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { GetFrontendRuntimeConfigUseCase } from 'src/app/application/use-cases/get-frontend-runtime-config/get-frontend-runtime-config.use-case';
+import {
+  ApiExcludeEndpoint,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { IsCloudResponseDto } from './dto/is-cloud-response.dto';
 import { FeatureTogglesResponseDto } from './dto/feature-toggles-response.dto';
 import { Public } from 'src/common/guards/public.guard';
@@ -16,7 +22,24 @@ export class AppController {
     private readonly isRegistrationDisabledUseCase: IsRegistrationDisabledUseCase,
     @Inject(featuresConfig.KEY)
     private readonly features: ConfigType<typeof featuresConfig>,
+    private readonly getFrontendRuntimeConfigUseCase: GetFrontendRuntimeConfigUseCase,
   ) {}
+
+  // Serves the SPA's runtime environment (see frontend.config.ts). Loaded by
+  // index.html before the app bundle; the route wins over the static
+  // dev-stub copy in dist/frontend because serve-static registers its
+  // handlers in onModuleInit, after controller routes. Excluded from the
+  // global /api prefix in main.ts and from the OpenAPI spec (not part of the
+  // public API, keeps the schema-drift check quiet).
+  @Public()
+  @ApiExcludeEndpoint()
+  @Get('config.js')
+  @Header('Content-Type', 'application/javascript; charset=utf-8')
+  @Header('Cache-Control', 'no-store')
+  frontendRuntimeConfig(): string {
+    const values = this.getFrontendRuntimeConfigUseCase.execute();
+    return `window.__RUNTIME_CONFIG__ = Object.freeze(${JSON.stringify(values)});`;
+  }
 
   @Public()
   @Get()

--- a/ayunis-core-backend/src/config/frontend.config.ts
+++ b/ayunis-core-backend/src/config/frontend.config.ts
@@ -1,0 +1,36 @@
+import { registerAs } from '@nestjs/config';
+
+/**
+ * Values the SPA reads at runtime via GET /config.js instead of Vite
+ * build-time inlining, so one published image serves every environment.
+ * Keys keep their VITE_ names because the frontend looks them up under the
+ * same name it would use for the import.meta.env fallback.
+ *
+ * VITE_API_BASE_URL is intentionally absent: production builds hardcode the
+ * relative /api base, and in dev the Vite dev server uses the build-time var.
+ */
+export type FrontendRuntimeConfig = Partial<
+  Record<(typeof FRONTEND_RUNTIME_KEYS)[number], string>
+>;
+
+export const FRONTEND_RUNTIME_KEYS = [
+  'VITE_APPSIGNAL_FRONTEND_KEY',
+  'VITE_ANNOUNCABLE_ORG_ID',
+  'VITE_PLAUSIBLE_DOMAIN',
+  'VITE_PLAUSIBLE_SRC',
+  'VITE_GTM_CONTAINER_ID',
+  'VITE_USERCENTRICS_SETTINGS_ID',
+] as const;
+
+export const frontendConfig = registerAs(
+  'frontend',
+  (): FrontendRuntimeConfig => {
+    // Empty/whitespace values count as unset — copying .env.example sets keys
+    // to "" via dotenv, which must behave like "not configured".
+    const entries = FRONTEND_RUNTIME_KEYS.flatMap((key) => {
+      const value = process.env[key]?.trim();
+      return value ? [[key, value] as const] : [];
+    });
+    return Object.fromEntries(entries);
+  },
+);

--- a/ayunis-core-backend/src/config/root-configs.ts
+++ b/ayunis-core-backend/src/config/root-configs.ts
@@ -13,6 +13,7 @@ import { mcpConfig } from './mcp.config';
 import { marketplaceConfig } from './marketplace.config';
 import toolsConfig from './tools.config';
 import { featuresConfig } from './features.config';
+import { frontendConfig } from './frontend.config';
 import { metricsConfig } from './metrics.config';
 import { redisConfig } from './redis.config';
 import { gotenbergConfig } from './gotenberg.config';
@@ -45,6 +46,7 @@ export const rootConfigs = [
   marketplaceConfig,
   toolsConfig,
   featuresConfig,
+  frontendConfig,
   metricsConfig,
   redisConfig,
   gotenbergConfig,

--- a/ayunis-core-backend/src/main.ts
+++ b/ayunis-core-backend/src/main.ts
@@ -76,7 +76,8 @@ class Bootstrap {
     this.setupSwagger(app);
     app.setGlobalPrefix('api', {
       // strip leading '/' — setGlobalPrefix exclude expects bare paths
-      exclude: [METRICS_PATH.slice(1)],
+      // config.js is the SPA's runtime environment and must live at the root
+      exclude: [METRICS_PATH.slice(1), 'config.js'],
     });
     app.useGlobalPipes(
       new ValidationPipe({

--- a/ayunis-core-frontend/.env.example
+++ b/ayunis-core-frontend/.env.example
@@ -7,6 +7,10 @@
 # Only relevant for development, leave blank in production
 VITE_API_BASE_URL=http://localhost:3000/api
 
+# The VITE_* values below are injected at RUNTIME: the app container loads
+# this file as a compose env_file and serves the values via GET /config.js.
+# They are no longer inlined at build time — the image is host-agnostic.
+
 # AppSignal front-end error tracking (optional, production only).
 # Uses the app's *front-end* API key, not the backend push API key.
 VITE_APPSIGNAL_FRONTEND_KEY=

--- a/ayunis-core-frontend/eslint.config.mjs
+++ b/ayunis-core-frontend/eslint.config.mjs
@@ -17,6 +17,9 @@ export default tseslint.config(
       '**/node_modules/**',
       '**/dist/**',
       '**/build/**',
+      // plain JS assets served as-is; outside the tsconfig project, so
+      // typed lint rules cannot load them
+      'public/**',
       'src/app/routeTree.gen.ts',
       'src/shared/api/generated/**',
       'src/shared/scripts/**',

--- a/ayunis-core-frontend/index.html
+++ b/ayunis-core-frontend/index.html
@@ -24,6 +24,9 @@
       crossorigin="use-credentials"
     />
     <title>Ayunis Core</title>
+    <!-- Runtime environment served by the backend (dev: stub from
+         public/config.js). Must load before the app bundle. -->
+    <script src="/config.js"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/ayunis-core-frontend/public/config.js
+++ b/ayunis-core-frontend/public/config.js
@@ -1,0 +1,5 @@
+// Dev-server stub. In the built app the backend serves /config.js
+// dynamically (its controller route registers before the static file
+// handler, so this copy is never served there). An empty object makes
+// runtimeEnv() fall back to Vite's build-time import.meta.env values.
+window.__RUNTIME_CONFIG__ = {};

--- a/ayunis-core-frontend/src/layouts/root-layout/ui/RootLayout.tsx
+++ b/ayunis-core-frontend/src/layouts/root-layout/ui/RootLayout.tsx
@@ -1,11 +1,12 @@
+import { runtimeEnv } from '@/shared/config/runtime-env';
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const plausibleDomain = import.meta.env.VITE_PLAUSIBLE_DOMAIN as
-    string | undefined;
-  const plausibleSrc = import.meta.env.VITE_PLAUSIBLE_SRC as string | undefined;
+  const plausibleDomain = runtimeEnv('VITE_PLAUSIBLE_DOMAIN');
+  const plausibleSrc = runtimeEnv('VITE_PLAUSIBLE_SRC');
 
   return (
     <>

--- a/ayunis-core-frontend/src/shared/config/index.ts
+++ b/ayunis-core-frontend/src/shared/config/index.ts
@@ -1,4 +1,8 @@
-// Simple configuration for Vite environment
+import { runtimeEnv } from './runtime-env';
+
+// Simple configuration for Vite environment. Environment-specific values come
+// from the backend at runtime via runtimeEnv (see runtime-env.ts) so the
+// built bundle stays host-agnostic.
 const config = {
   env: import.meta.env.MODE as 'development' | 'production' | 'test',
   api: {
@@ -13,13 +17,11 @@ const config = {
   },
   features: {
     devtools: import.meta.env.MODE !== 'production',
-    announcableOrgId: import.meta.env.VITE_ANNOUNCABLE_ORG_ID as
-      string | undefined,
+    announcableOrgId: runtimeEnv('VITE_ANNOUNCABLE_ORG_ID'),
   },
   analytics: {
-    gtmContainerId: import.meta.env.VITE_GTM_CONTAINER_ID as string | undefined,
-    usercentricsSettingsId: import.meta.env.VITE_USERCENTRICS_SETTINGS_ID as
-      string | undefined,
+    gtmContainerId: runtimeEnv('VITE_GTM_CONTAINER_ID'),
+    usercentricsSettingsId: runtimeEnv('VITE_USERCENTRICS_SETTINGS_ID'),
   },
 } as const;
 

--- a/ayunis-core-frontend/src/shared/config/runtime-env.ts
+++ b/ayunis-core-frontend/src/shared/config/runtime-env.ts
@@ -1,0 +1,21 @@
+/**
+ * Runtime-injected environment. The backend serves GET /config.js (loaded in
+ * index.html before the app bundle), which sets window.__RUNTIME_CONFIG__
+ * from its own process env — so one published image serves every environment
+ * without rebuilding. Falls back to Vite's build-time import.meta.env for
+ * `pnpm dev`, where the dev-server stub in public/config.js leaves the
+ * runtime object empty.
+ */
+declare global {
+  interface Window {
+    __RUNTIME_CONFIG__?: Readonly<Record<string, string | undefined>>;
+  }
+}
+
+export function runtimeEnv(key: string): string | undefined {
+  return (
+    window.__RUNTIME_CONFIG__?.[key] ??
+    (import.meta.env[key] as string | undefined) ??
+    undefined
+  );
+}

--- a/ayunis-core-frontend/src/shared/lib/appsignal.ts
+++ b/ayunis-core-frontend/src/shared/lib/appsignal.ts
@@ -1,10 +1,11 @@
 import Appsignal from '@appsignal/javascript';
 import { plugin as windowEventsPlugin } from '@appsignal/plugin-window-events';
+import { runtimeEnv } from '@/shared/config/runtime-env';
 
 let appsignal: Appsignal | undefined;
 
 export function initAppsignal() {
-  const key = import.meta.env.VITE_APPSIGNAL_FRONTEND_KEY as string | undefined;
+  const key = runtimeEnv('VITE_APPSIGNAL_FRONTEND_KEY');
 
   if (import.meta.env.PROD && key) {
     appsignal = new Appsignal({ key });
@@ -15,7 +16,7 @@ export function initAppsignal() {
 
 /**
  * Reports an error to AppSignal. No-ops when the client is not initialized
- * (development, or no frontend key configured at build time).
+ * (development, or no frontend key configured at runtime).
  */
 export function reportError(
   error: Error,


### PR DESCRIPTION
- Backend serves GET /config.js (excluded from the /api prefix and the
  OpenAPI spec) with the VITE_* values from its runtime env; the app
  container already loads ayunis-core-frontend/.env as a compose env_file
- Frontend prefers window.__RUNTIME_CONFIG__ over import.meta.env via
  runtimeEnv(); dev keeps build-time vars through the public/config.js stub
- Drop the frontend .env from the docker build context — the image no
  longer bakes environment-specific values and serves every environment

Part of the GHCR image publishing work: one host-agnostic app image.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production gets analytics/monitoring keys and touches SPA bootstrap order; misconfigured compose env could silently disable integrations, but the surface is limited to optional frontend config with a dev fallback.
> 
> **Overview**
> **Moves environment-specific frontend configuration from Vite build-time inlining to runtime injection**, so a single published Docker image can serve every deployment without rebuilding.
> 
> The backend adds a public root **`GET /config.js`** (outside the `/api` prefix, `Cache-Control: no-store`) that emits `window.__RUNTIME_CONFIG__` from selected `VITE_*` process env vars via new `frontend.config` and `GetFrontendRuntimeConfigUseCase`. **`index.html`** loads that script before the app bundle.
> 
> The frontend introduces **`runtimeEnv()`**, which prefers `window.__RUNTIME_CONFIG__` and falls back to `import.meta.env` for local dev (`public/config.js` stub). Analytics, AppSignal, Announcable, and related call sites switch to this helper. **`VITE_API_BASE_URL`** stays build/dev-only (production still uses `/api`).
> 
> Docker build no longer needs **`ayunis-core-frontend/.env`** in the context—the `.dockerignore` exception is removed and the Dockerfile drops the Vite env logging step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cea49b1161ff56040114fb53c010110c5785d71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->