### PR TITLE
refactor(code-execution): pull pinned sandbox image instead of building at startup (AYC-588)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -134,6 +134,19 @@ updates:
       - "python"
     open-pull-requests-limit: 5
 
+  # Python sandbox image (libraries available to user-submitted code)
+  - package-ecosystem: "pip"
+    directory: "/ayunis-core-code-execution/sandbox"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps-sandbox)"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 5
+
   # Docker base images
   - package-ecosystem: "docker"
     directory: "/"
@@ -171,6 +184,17 @@ updates:
 
   - package-ecosystem: "docker"
     directory: "/ayunis-core-code-execution"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps-docker)"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/ayunis-core-code-execution/sandbox"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/deploy-internal-manual.yml
+++ b/.github/workflows/deploy-internal-manual.yml
@@ -40,6 +40,10 @@ jobs:
             # Clean up old images and build cache before building new ones
             docker image prune -af
             docker builder prune -af
+            # Rebuild the sandbox image after the prune deleted it (not a
+            # compose service; code-execution fails hard without it — AYC-588.
+            # AYC-589 switches deploys to GHCR pulls.)
+            docker build -t python-sandbox:latest ayunis-core-code-execution/sandbox
             docker compose up -d --build
             sleep 60
             docker compose ps

--- a/.github/workflows/deploy-production-manual.yml
+++ b/.github/workflows/deploy-production-manual.yml
@@ -38,6 +38,9 @@ jobs:
             fi
             # Build with cache while old containers still serve traffic
             docker compose build
+            # Sandbox image: not a compose service, never built at runtime
+            # anymore (AYC-588); host-built until AYC-589 switches to GHCR pulls
+            docker build -t python-sandbox:latest ayunis-core-code-execution/sandbox
             # Quick swap — downtime is only the restart
             docker compose down
             docker compose up -d

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -34,6 +34,14 @@ jobs:
               echo "::error::docker compose build failed — keeping current containers, not deploying"
               exit 1
             fi
+            # The sandbox is not a compose service and is never built at
+            # runtime anymore (AYC-588) — build it here until AYC-589 switches
+            # deploys to GHCR pulls. Same guard: abort before touching
+            # running containers.
+            if ! docker build -t python-sandbox:latest ayunis-core-code-execution/sandbox; then
+              echo "::error::sandbox image build failed — keeping current containers, not deploying"
+              exit 1
+            fi
             # Quick swap — downtime is only the restart
             docker compose down
             docker compose up -d

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,6 +50,9 @@ jobs:
             git checkout -f "$RELEASE_TAG"
             # Build with cache while old containers still serve traffic
             docker compose build
+            # Sandbox image: not a compose service, never built at runtime
+            # anymore (AYC-588); host-built until AYC-589 switches to GHCR pulls
+            docker build -t python-sandbox:latest ayunis-core-code-execution/sandbox
             # Quick swap — downtime is only the restart
             docker compose down
             docker compose up -d
@@ -84,6 +87,9 @@ jobs:
             git checkout -f "$RELEASE_TAG"
             # Build with cache while old containers still serve traffic
             docker compose build
+            # Sandbox image: not a compose service, never built at runtime
+            # anymore (AYC-588); host-built until AYC-589 switches to GHCR pulls
+            docker build -t python-sandbox:latest ayunis-core-code-execution/sandbox
             # Quick swap — downtime is only the restart
             docker compose down
             docker compose up -d

--- a/ayunis-core-code-execution/README.md
+++ b/ayunis-core-code-execution/README.md
@@ -27,6 +27,7 @@ A secure Python code execution service that runs user code in isolated Docker co
    ```
 
 4. **Test the API**:
+
    ```bash
    curl -X POST http://localhost:8080/execute \
      -H "Content-Type: application/json" \
@@ -86,6 +87,12 @@ Configure the service using environment variables:
 - `PORT`: Server port (default: 8080)
 - `DOCKER_IMAGE`: Docker image for sandboxing (default: python-sandbox:latest)
 
+The sandbox image is defined in `sandbox/Dockerfile` and published to GHCR as
+`ghcr.io/ayunis-core/ayunis-core-python-sandbox`. The service pulls it when
+missing but never builds it; startup fails hard when the image is unavailable.
+For local development `./dev` builds `python-sandbox:latest` automatically
+(manually: `docker build -t python-sandbox:latest sandbox/`).
+
 ## Development
 
 1. **Install development dependencies**:
@@ -107,6 +114,7 @@ Configure the service using environment variables:
    ```
 
 4. **Run linting**:
+
    ```bash
    flake8 .
    ```

--- a/ayunis-core-code-execution/executor.py
+++ b/ayunis-core-code-execution/executor.py
@@ -24,40 +24,35 @@ class PythonExecutor:
         )
         self.docker_client = docker.from_env()
 
-        # Build the sandbox image on startup
-        self._build_sandbox_image()
+        # Ensure the sandbox image is available on startup
+        self._ensure_sandbox_image()
 
-    def _build_sandbox_image(self):
-        """Build the minimal sandbox image for code execution"""
-        dockerfile_content = """
-FROM python:3.12-slim
-RUN useradd -m -u 1000 sandbox
-WORKDIR /execution
-RUN pip install --no-cache-dir numpy pandas matplotlib
-RUN chown -R sandbox:sandbox /execution
-USER sandbox
-"""
-        # Use fileobj instead of temporary file to avoid permission issues
-        import io
+    def _ensure_sandbox_image(self) -> None:
+        """Ensure the sandbox image exists locally, pulling it if missing.
 
-        dockerfile_obj = io.BytesIO(dockerfile_content.encode("utf-8"))
+        The image is defined in sandbox/Dockerfile and published to GHCR; it
+        is never built here. Raises when unavailable — the service must not
+        come up healthy without a runnable sandbox (main.py exits on this).
+        """
+        image = self.config.docker_image
+        try:
+            self.docker_client.images.get(image)
+            print(f"Sandbox image present: {image}")
+            return
+        except docker.errors.ImageNotFound:
+            print(f"Sandbox image {image} not found locally, pulling...")
 
         try:
-            self.docker_client.images.build(
-                fileobj=dockerfile_obj, tag=self.config.docker_image, rm=True
-            )
+            self.docker_client.images.pull(image)
+            print(f"Pulled sandbox image: {image}")
         except Exception as e:
-            # If building fails, try to use existing image or continue
-            print(f"Warning: Could not build Docker image: {e}")
-            print(f"Will attempt to use existing image: {self.config.docker_image}")
-            # Check if image exists
-            try:
-                self.docker_client.images.get(self.config.docker_image)
-                print(f"✅ Found existing image: {self.config.docker_image}")
-            except:
-                print(
-                    f"❌ Image {self.config.docker_image} not found. Please build manually or use a different image."
-                )
+            raise RuntimeError(
+                f"Sandbox image '{image}' is not available locally and could "
+                f"not be pulled: {e}. "
+                f"Dev: run ./dev up (builds it) or `docker build -t "
+                f"python-sandbox:latest ayunis-core-code-execution/sandbox`. "
+                f"Prod: point DOCKER_IMAGE at a published GHCR sandbox tag."
+            ) from e
 
     async def execute(self, request: ExecutionRequest) -> ExecutionResponse:
         """

--- a/ayunis-core-code-execution/sandbox/Dockerfile
+++ b/ayunis-core-code-execution/sandbox/Dockerfile
@@ -1,0 +1,16 @@
+# Sandbox image for user code execution. Previously built inline at service
+# startup by executor.py (unpinned); now a committed Dockerfile so the image
+# is versioned, pinned, published to GHCR, and bumped by Dependabot.
+#
+# Dev: built as python-sandbox:latest by ./dev (or manually:
+#   docker build -t python-sandbox:latest ayunis-core-code-execution/sandbox).
+# Prod: published as ghcr.io/ayunis-core/ayunis-core-python-sandbox and
+# referenced via the code-execution service's DOCKER_IMAGE env var.
+FROM python:3.12-slim
+
+RUN useradd -m -u 1000 sandbox
+WORKDIR /execution
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
+RUN chown -R sandbox:sandbox /execution
+USER sandbox

--- a/ayunis-core-code-execution/sandbox/requirements.txt
+++ b/ayunis-core-code-execution/sandbox/requirements.txt
@@ -1,0 +1,6 @@
+# Runtime libraries available to user-submitted code inside the sandbox.
+# Exact pins keep released sandbox images reproducible; Dependabot
+# (pip, /ayunis-core-code-execution/sandbox) bumps them weekly.
+numpy==2.5.1
+pandas==3.0.5
+matplotlib==3.11.1

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -58,7 +58,6 @@ services:
       - PUT=1
       - POST=1
       - DELETE=1
-      - BUILD=1
       - IMAGES=1
       - VOLUMES=1
       - AUTH=0

--- a/dev
+++ b/dev
@@ -221,6 +221,13 @@ cmd_up() {
   export MINIO_ROOT_PASSWORD="$minio_password"
   export REDIS_PASSWORD="$redis_password"
 
+  # -- 0.5 Sandbox image ----------------------------------------------------
+  # code-execution fails hard at startup when the sandbox image is missing
+  # (it pulls but never builds), so build it before compose waits on health.
+  # The image is host-global and shared across dev slots.
+  info "Building python-sandbox image …"
+  docker build -t python-sandbox:latest "$REPO_DIR/ayunis-core-code-execution/sandbox" 2>&1 | tail -2
+
   # -- 1. Docker infrastructure -------------------------------------------
   info "Starting Docker infrastructure …"
   dc up -d --build --wait 2>&1 | tail -5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,10 +77,9 @@ services:
       - CONTAINERS=1 # Allow container operations
       - EXEC=1 # Allow exec operations inside containers
       - PUT=1 # Allow PUT requests (copy archive into containers)
-      - POST=1 # Allow POST requests (create containers)
+      - POST=1 # Allow POST requests (create containers, pull images)
       - DELETE=1 # Allow DELETE requests (remove containers)
-      - BUILD=1 # Allow image building
-      - IMAGES=1 # Allow image operations
+      - IMAGES=1 # Allow image operations (get/pull the sandbox image; BUILD stays off — the sandbox is a published image, never built at runtime)
       # Allow volume operations (needed for per-execution ephemeral volumes)
       - VOLUMES=1
       # Deny everything else for security


### PR DESCRIPTION
- Move the inline sandbox Dockerfile into sandbox/Dockerfile with exact
  numpy/pandas/matplotlib pins (Dependabot: new pip + docker entries)
- Replace the silent build-or-warn startup path with get, then pull,
  then raise; the service no longer reports healthy without a runnable
  sandbox image
- Drop BUILD=1 from the docker-socket-proxy allowlist (least privilege,
  ISM-8); IMAGES and POST cover the pull path
- ./dev builds python-sandbox:latest before compose waits on health

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the code-execution isolation path and deploy pipelines; a missing or failed sandbox build/pull will block healthy startup, though behavior is stricter rather than silently degraded.
> 
> **Overview**
> **User code execution** no longer builds the Python sandbox inline at service startup. The sandbox is now a committed `sandbox/Dockerfile` with pinned `numpy`/`pandas`/`matplotlib` in `requirements.txt`, intended for GHCR publish and Dependabot (new pip + docker entries under `ayunis-core-code-execution/sandbox`).
> 
> **Startup behavior** changes from build-or-warn to **get → pull → fail**: `executor.py` only ensures the configured `DOCKER_IMAGE` exists locally; if missing it pulls, and raises if unavailable so the service does not come up without a runnable sandbox.
> 
> **Docker socket proxy** drops `BUILD=1` in prod and dev compose (least privilege); `IMAGES`/`POST` remain for pull/create paths.
> 
> **Deploy and dev** explicitly build `python-sandbox:latest` on the host before bringing up code-execution (staging adds a fail-fast guard like compose build; internal rebuilds after aggressive image prune). `./dev up` builds the sandbox before compose health waits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6efae2cc39f71ebd9319f0343edb8a2e83631d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->