### PR TITLE
ci: publish core images to ghcr on main and release tags (AYC-588)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,125 @@
+name: Build & Publish Images
+
+# Publishes the four Core images to GHCR (AYC-588):
+#   ayunis-core-app             — frontend + backend (root Dockerfile)
+#   ayunis-core-code-execution  — sandbox orchestrator service
+#   ayunis-core-anonymize       — PII anonymization service
+#   ayunis-core-python-sandbox  — image user code executes in (DOCKER_IMAGE)
+#
+# Pushes to main produce sha-<commit> + latest tags (what staging pulls,
+# AYC-589); release tags produce vX.Y.Z. release-please dispatches this
+# workflow for its tags explicitly (GITHUB_TOKEN-created tags don't fire
+# push-tag workflows) — see release-please.yml.
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: build-images-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ayunis-core-app
+            context: .
+            dockerfile: Dockerfile
+            target: production
+          - image: ayunis-core-code-execution
+            context: ./ayunis-core-code-execution
+            dockerfile: ./ayunis-core-code-execution/Dockerfile
+            target: ''
+          - image: ayunis-core-anonymize
+            context: ./ayunis-core-anonymize
+            dockerfile: ./ayunis-core-anonymize/Dockerfile
+            target: ''
+          - image: ayunis-core-python-sandbox
+            context: ./ayunis-core-code-execution/sandbox
+            dockerfile: ./ayunis-core-code-execution/sandbox/Dockerfile
+            target: ''
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          # latest=false: the default latest=auto also tags :latest on semver
+          # builds, which would let a release (or a re-run of an old tag)
+          # overwrite the main-branch latest that staging pulls.
+          flavor: |
+            latest=false
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern=v{{version}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      # provenance: false keeps one manifest per tag — the default attestation
+      # manifests show up as untagged children in GHCR, which clutters the
+      # package view and makes the untagged-version cleanup workflow unsafe.
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target }}
+          push: true
+          provenance: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=build-${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=build-${{ matrix.image }}
+
+  # On a versioned release, ping ayunis-infra so Renovate opens a bump PR for
+  # the new image tags within a minute or two. Runs once per tag, not per
+  # matrix leg — the listener ignores the payload (pure wake-up), and one
+  # dispatch avoids four redundant app-token mints. The token is the shared
+  # Ayunis CI app, scoped to ayunis-infra; the app must be installed there
+  # and CI_APP_* org secrets shared with this repo.
+  notify-infra:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint ayunis-infra token
+        id: infra-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          owner: ayunis-core
+          repositories: ayunis-infra
+
+      - name: Trigger infra Renovate
+        env:
+          INFRA_TOKEN: ${{ steps.infra-token.outputs.token }}
+          IMAGE: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          curl -fsS -X POST \
+            -H "Authorization: Bearer ${INFRA_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/ayunis-core/ayunis-infra/dispatches \
+            -d "$(jq -nc --arg image "$IMAGE" --arg tag "$TAG" '{event_type:"image-published",client_payload:{image:$image,tag:$tag}}')"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write # dispatch build-images.yml for the release tag
 
 jobs:
   release-please:
@@ -24,6 +25,24 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # Tags created with GITHUB_TOKEN don't trigger push-tag workflows, so
+  # dispatch the image build for the release tag explicitly. Separate job:
+  # the deploys build on the host and don't consume these images, so a
+  # failed dispatch must not gate them (the dispatch is fire-and-forget
+  # anyway — it never waited for the build to succeed).
+  build-release-images:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch image build for release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run build-images.yml \
+            --ref "${{ needs.release-please.outputs.tag_name }}" \
+            --repo "${{ github.repository }}"
 
   deploy-internal:
     needs: release-please


### PR DESCRIPTION
- build-images.yml (modeled on ayunis-core-connect): buildx matrix over
  app, code-execution, anonymize, and python-sandbox; sha- + latest on
  main pushes, semver on v* tags; per-image gha cache scopes;
  provenance off so cleanup of untagged versions stays safe
- notify ayunis-infra via repository_dispatch image-published once per
  release tag so Renovate opens the image bump PR
- release-please dispatches build-images.yml for its tags (GITHUB_TOKEN
  tags don't fire push-tag workflows)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release and image-publish pipeline (GHCR tags, infra dispatch, CI app secrets); mis-tagged **latest** or failed builds could affect staging and downstream infra bumps, though tagging rules explicitly protect main-branch **latest**.
> 
> **Overview**
> Adds **`build-images.yml`** to build and push four Core images (app, code-execution, anonymize, python-sandbox) to GHCR on **main** and **`v*`** tags, with **sha-** + **latest** on main only, semver on releases, per-image GHA cache, and **provenance disabled** so GHCR cleanup stays safe.
> 
> On version tags, a **`notify-infra`** job sends **`image-published`** to **ayunis-infra** (GitHub App token) so Renovate can open image bump PRs.
> 
> **`release-please.yml`** gains **`actions: write`** and a **`build-release-images`** job that **`workflow_dispatch`**-es **`build-images.yml`** on the release ref, because tags from **`GITHUB_TOKEN`** do not trigger tag push workflows; that job is separate from deploy so a failed dispatch does not block internal/production deploys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed33842eb107d658dc0639023c1096d055ddfc52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->