### PR TITLE
ci: add release compose overlay and ghcr cleanup workflow (AYC-588)

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,46 @@
+name: GHCR Cleanup
+
+# Every push to main publishes four sha-* images (build-images.yml), so the
+# packages accumulate fast. This deletes untagged versions and sha-* tags
+# older than the cut-off across the four Core packages. Versions tagged
+# vX.Y.Z or latest are safe even though release builds also carry a sha-*
+# tag: the action only deletes a version when ALL of its tags match the
+# image-tags filter (partial matches are kept and logged as warnings — see
+# filter_by_matchers in the action's select_package_versions.rs).
+#
+# GITHUB_TOKEN works because the packages are published from this repo with
+# GITHUB_TOKEN, which links them with admin access. If a run ever fails on
+# permissions, fall back to a fine-grained PAT org secret (read+delete
+# packages) per the snok/container-retention-policy docs.
+#
+# First run should be a manual dispatch with dry-run: true — verify the
+# candidate list contains only untagged/sha-* versions before trusting the
+# schedule.
+
+on:
+  schedule:
+    - cron: '17 4 * * 1' # Mondays 04:17 UTC
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Log what would be deleted without deleting
+        type: boolean
+        default: false
+
+permissions:
+  packages: write # deleting package versions requires write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete untagged and stale sha-* versions
+        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
+        with:
+          account: ayunis-core
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: 'ayunis-core-app ayunis-core-code-execution ayunis-core-anonymize ayunis-core-python-sandbox'
+          image-tags: 'sha-*'
+          tag-selection: both
+          cut-off: 4w
+          dry-run: ${{ inputs.dry-run || false }}

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -13,6 +13,15 @@ This guide covers deploying Ayunis Core to production and managing configuration
 
 ## Initial Deployment
 
+> **Published images:** every push to main and every release tag publishes the
+> four Core images (`app`, `code-execution`, `anonymize`, `python-sandbox`) to
+> `ghcr.io/ayunis-core/*` (`.github/workflows/build-images.yml`). To run a
+> release from the registry instead of building on the host, use the
+> `compose.release.yml` overlay:
+> `CORE_TAG=vX.Y.Z docker compose -f docker-compose.yml -f compose.release.yml up -d --no-build`.
+> The deploy workflows still build on the host; switching them to pulls is
+> tracked separately (AYC-589).
+
 ### Prerequisites
 
 - Node.js 24 or higher

--- a/compose.release.yml
+++ b/compose.release.yml
@@ -1,0 +1,27 @@
+# Release overlay — run published GHCR images instead of building on the host
+# (AYC-588). The base docker-compose.yml keeps its build: blocks for the
+# current build-on-host deploys; this overlay adds image: keys, which `up`
+# prefers (pass --no-build to be explicit). Wiring this into the deploy
+# workflows is AYC-589; retiring the split once prod moves to ayunis-infra
+# is AYC-592.
+#
+# Usage:
+#   CORE_TAG=v2.20.0 docker compose -f docker-compose.yml -f compose.release.yml up -d --no-build
+#
+# The python-sandbox image is not a compose service: code-execution pulls it
+# through the docker-socket-proxy when missing (the packages are public, so
+# no registry auth is needed).
+
+services:
+  app:
+    image: ghcr.io/ayunis-core/ayunis-core-app:${CORE_TAG:?Set CORE_TAG to a release tag, e.g. v2.20.0}
+
+  code-execution:
+    image: ghcr.io/ayunis-core/ayunis-core-code-execution:${CORE_TAG:?Set CORE_TAG to a release tag, e.g. v2.20.0}
+    environment:
+      # Overrides the base file's python-sandbox:latest (list-form env
+      # merges per key; the later file wins)
+      - DOCKER_IMAGE=ghcr.io/ayunis-core/ayunis-core-python-sandbox:${CORE_TAG:?Set CORE_TAG to a release tag, e.g. v2.20.0}
+
+  anonymize:
+    image: ghcr.io/ayunis-core/ayunis-core-anonymize:${CORE_TAG:?Set CORE_TAG to a release tag, e.g. v2.20.0}


### PR DESCRIPTION
- compose.release.yml runs published GHCR images via CORE_TAG (incl.
  the python-sandbox DOCKER_IMAGE override); base compose untouched —
  deploys keep building on the host until AYC-589
- weekly ghcr-cleanup.yml deletes untagged and 4w-old sha-* versions
  of the four packages; semver tags and latest are never touched;
  first run manual with dry-run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The cleanup workflow can permanently delete package versions if misconfigured; release compose changes only affect opt-in deploys, not existing workflows.
> 
> **Overview**
> Adds a way to **run Core from published GHCR images** without changing the default build-on-host `docker-compose.yml`. New **`compose.release.yml`** pins `app`, `code-execution`, and `anonymize` to `ghcr.io/ayunis-core/*` via required **`CORE_TAG`**, and overrides **`DOCKER_IMAGE`** on code-execution so the python-sandbox image matches the same release tag.
> 
> **`DEPLOYMENT.md`** now documents the four published images and the overlay command (`CORE_TAG=vX.Y.Z docker compose … compose.release.yml up -d --no-build`). Deploy workflows still build locally until AYC-589.
> 
> Introduces **`.github/workflows/ghcr-cleanup.yml`**: weekly (plus manual) cleanup with **`snok/container-retention-policy`**, deleting **untagged** and **`sha-*`** versions older than **4 weeks** across the four packages; **`vX.Y.Z`** / **`latest`** are preserved when they don’t fully match the delete filter. Supports **`dry-run`** for a safe first run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51764365dae4ec0c0ef80678cc442cb08b30df2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->