### PR TITLE
ci: switch staging deploys to ghcr image pulls (AYC-589)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,8 +1,13 @@
 name: Deploy to Staging
 
+# Staging runs published GHCR images instead of building on the host (AYC-589).
+# Chained after build-images.yml rather than triggered by the push itself: the
+# image for a commit does not exist until that build finishes (~7 min).
+
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: ["Build & Publish Images"]
+    types: [completed]
   workflow_dispatch:
 
 concurrency:
@@ -11,42 +16,79 @@ concurrency:
 
 jobs:
   deploy:
+    # Tag builds have head_branch == the tag, so only main-branch builds deploy.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
     environment: staging
 
     steps:
       - name: Deploy to Staging
         uses: appleboy/ssh-action@v1.2.5
+        env:
+          # The commit whose images were just built. Empty on manual dispatch,
+          # where the script falls back to origin/main.
+          DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
         with:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USER }}
           key: ${{ secrets.STAGING_SSH_KEY }}
+          envs: DEPLOY_SHA
           script_stop: true
           script: |
             cd /home/ayunis/apps/ayunis-core
+            # The checkout still supplies the compose files, the .env files and
+            # postgres/init.sql — only the build is gone. Reset to the exact
+            # built commit so the compose files and the image tag cannot drift
+            # apart if another push lands mid-deploy.
             git fetch origin main
-            git reset --hard origin/main
-            # Build with cache while old containers still serve traffic. If the
-            # build fails, abort BEFORE touching running containers — otherwise a
-            # broken build would tear down the app and restart the stale image
-            # while the deploy still reports success (see AYC: corepack outage).
-            if ! docker compose build; then
-              echo "::error::docker compose build failed — keeping current containers, not deploying"
+            git reset --hard "${DEPLOY_SHA:-origin/main}"
+            export COMPOSE_FILE=docker-compose.yml:compose.release.yml
+            # Plain truncation, not `git rev-parse --short=7`: --short is a
+            # *minimum* and git lengthens it when the prefix is ambiguous,
+            # while metadata-action's type=sha is an unconditional
+            # sha.substring(0, 7). A longer abbreviation would name a tag that
+            # was never published.
+            export CORE_TAG="sha-$(git rev-parse HEAD | cut -c1-7)"
+            echo "Deploying $CORE_TAG"
+            # Pull while the old containers still serve traffic. If a pull
+            # fails, abort BEFORE touching them — otherwise a missing image
+            # would tear down the app and leave it down while the deploy still
+            # reports success (see AYC: corepack outage).
+            # Scoped to the Core services on purpose: a bare `compose pull`
+            # would also refresh minio/dozzle/redis/gotenberg, which are
+            # deliberately only pulled when first started.
+            if ! docker compose pull app code-execution anonymize; then
+              echo "::error::image pull failed — keeping current containers, not deploying"
               exit 1
             fi
-            # The sandbox is not a compose service and is never built at
-            # runtime anymore (AYC-588) — build it here until AYC-589 switches
-            # deploys to GHCR pulls. Same guard: abort before touching
-            # running containers.
-            if ! docker build -t python-sandbox:latest ayunis-core-code-execution/sandbox; then
-              echo "::error::sandbox image build failed — keeping current containers, not deploying"
+            # The sandbox is not a compose service; code-execution pulls it
+            # through the docker-socket-proxy on first use. Pulling it here
+            # keeps that first execution fast and proves the tag exists before
+            # the swap.
+            if ! docker pull "ghcr.io/ayunis-core/ayunis-core-python-sandbox:$CORE_TAG"; then
+              echo "::error::sandbox image pull failed — keeping current containers, not deploying"
               exit 1
             fi
             # Quick swap — downtime is only the restart
             docker compose down
-            docker compose up -d
+            docker compose up -d --no-build
             # Wait for app to be healthy (up to 120s)
             timeout 120 bash -c 'until docker compose ps app --format json | grep -q "(healthy)"; do sleep 5; done'
             docker compose ps
-            # Clean up dangling images to reclaim disk space
+            # Reclaim superseded Core images — pulled images are tagged, not
+            # dangling, so `prune -f` alone would never touch them and every
+            # main push would add four. `prune -a` is the wrong tool here: the
+            # sandbox image is referenced only by ephemeral per-execution
+            # containers, so it always looks unused, and no `until=` cut-off
+            # saves it either — a cache-hit rebuild keeps the original Created
+            # date, so a freshly pulled sandbox tag can already read as weeks
+            # old. Deleting exactly the Core tags that aren't the one just
+            # deployed cannot touch what this deploy pulled. Superseded tags
+            # stay in GHCR, so a rollback re-pulls them.
+            docker images --filter "reference=ghcr.io/ayunis-core/*" --format '{{.Repository}}:{{.Tag}}' \
+              | grep -v ":${CORE_TAG}$" \
+              | xargs -r docker rmi || true
             docker image prune -f

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -19,8 +19,11 @@ This guide covers deploying Ayunis Core to production and managing configuration
 > release from the registry instead of building on the host, use the
 > `compose.release.yml` overlay:
 > `CORE_TAG=vX.Y.Z docker compose -f docker-compose.yml -f compose.release.yml up -d --no-build`.
-> The deploy workflows still build on the host; switching them to pulls is
-> tracked separately (AYC-589).
+> The packages are public, so no registry login is needed to pull them.
+>
+> Staging deploys this way already — it pulls `sha-<short-commit>` after
+> `build-images.yml` finishes for that commit. Internal and production still
+> build on the host; switching them is the second half of AYC-589.
 
 ### Prerequisites
 


### PR DESCRIPTION
Stage 1 of AYC-589: staging stops building on the host and runs the published GHCR images. Internal and production are untouched — they follow in a second PR once staging has soaked for a few main pushes.

## What changes

**Trigger.** `deploy-staging.yml` no longer fires on push to main. The image for a commit does not exist until `build-images.yml` finishes for it (~7 min), so the deploy now chains off `workflow_run: [Build & Publish Images] types: [completed]`, guarded on `conclusion == 'success' && head_branch == 'main'`. Tag builds have `head_branch == <tag>`, so releases don't trip it. `workflow_dispatch` still works and falls back to `origin/main`.

**Deploy script.** `docker compose build` + the temporary `docker build -t python-sandbox:latest` (added in AYC-588) are replaced by pulls under `COMPOSE_FILE=docker-compose.yml:compose.release.yml` with `CORE_TAG=sha-<short>`. The guard shape is unchanged: a failed pull aborts *before* `down`, so the running containers keep serving.

## Notes

- **The git checkout stays.** The compose files, both `.env` files and `postgres/init.sql` are all read from the host checkout — only the build is gone. The host resets to the exact commit that was built (`workflow_run.head_sha`) rather than `origin/main`, so the compose files and the image tag can't drift apart if another push lands mid-deploy.
- **The pull is scoped to app/code-execution/anonymize.** A bare `docker compose pull` would also refresh `minio:latest`, `dozzle:latest`, `redis:7-alpine` and `gotenberg:8`, which today are only ever pulled when first started — that would turn every deploy into a silent infra upgrade.
- **`python-sandbox` is pulled explicitly.** It isn't a compose service (code-execution pulls it through the docker-socket-proxy on first use), so `compose pull` doesn't cover it. Pulling it host-side lands it in the same daemon code-execution reads, keeps the first execution fast, and proves the tag exists before the swap.
- **Cleanup targets the Core tags explicitly instead of `prune -a`.** Pulled images are tagged, not dangling, so the old dangling-only prune would never reclaim them and staging would gain four images per main push. But `prune -a` is the wrong tool: the sandbox image is referenced only by ephemeral per-execution containers, so it always looks unused, and an `until=` cut-off can't protect it either — see the note below. The deploy now deletes exactly the `ghcr.io/ayunis-core/*` tags that aren't the one just deployed, which cannot touch what it pulled. Superseded tags stay in GHCR, so a rollback re-pulls them.
- **No registry auth anywhere.** The packages were made public in AYC-593, so the ticket's "add a GHCR pull credential" bullet is moot — verified by fetching the tag list from `ghcr.io` with no credentials.

## Verification

`workflow_run` triggers only take effect once the file is on `main`, so this can't be exercised from the PR branch. Verified locally instead:

- `docker compose config` with `CORE_TAG=sha-6155fa7` resolves all three services to `ghcr.io/ayunis-core/*:sha-6155fa7` and overrides `DOCKER_IMAGE` to the GHCR sandbox tag.
- `docker compose --dry-run pull app code-execution anonymize` resolves all three — compose does not skip them despite the base file's `build:` blocks.
- `docker image prune --filter until=` reads the image config's `Created`, which a cache-hit rebuild leaves untouched: the three published `python-sandbox` `sha-` tags, built in three separate CI runs, all carry `created=2026-07-30T18:04:26Z`. So no cut-off can keep a freshly pulled sandbox image alive — hence the targeted delete. (Caught by Bugbot on the stacked PR; the same bug was in this one.)
- `docker images --filter "reference=ghcr.io/ayunis-core/*"` verified to match one path segment (`quay.io/*` matches nothing, `quay.io/*/*` matches `quay.io/minio/minio`), and the `grep -v`/`xargs -r` pipeline exits 0 under `set -e` when nothing matches.
- Deploy script passes `bash -n`.

Post-merge, on the next main push:

1. `Deploy to Staging` starts only after `Build & Publish Images` succeeds, on the same `head_sha`.
2. `docker inspect --format '{{.Config.Image}}' ayunis-app-prod ayunis-code-execution-prod ayunis-anonymize-prod` → all three on `ghcr.io/…:sha-<short>`.
3. No `docker compose build` output in the deploy log.
4. Run Python in a staging chat; `docker compose logs code-execution` must find the pulled sandbox image.
5. `docker images` — old Core images reclaimed, base images survived.

Rollback: `CORE_TAG=<older-sha> docker compose -f docker-compose.yml -f compose.release.yml up -d --no-build` on the host, or revert this commit to restore the build path.

Part of AYC-353 (encryption at rest) — pull-based deploys are the prerequisite for moving prod to the LUKS box.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production-adjacent staging deploy timing and image source; mitigated by pull-before-down guards and pinned commit SHA, but a bad or missing image tag could still block deploys until fixed.
> 
> **Overview**
> Staging deploys no longer build on the host; they run **published GHCR images** for the commit that just finished in **Build & Publish Images**.
> 
> **Workflow trigger** drops `push` to `main` in favor of `workflow_run` (success + `head_branch == main`), with `workflow_dispatch` unchanged. The SSH step passes **`DEPLOY_SHA`** from `workflow_run.head_sha` so the host checkout matches the built commit.
> 
> **Deploy script** uses `compose.release.yml` with **`CORE_TAG=sha-<7-char>`** (truncation aligned with CI tagging), **`docker compose pull`** for app/code-execution/anonymize only, explicit **`docker pull`** for the python-sandbox image, then **`up -d --no-build`**. Failed pulls still abort before `down`. Post-deploy cleanup **removes old `ghcr.io/ayunis-core/*` tags** on the host instead of relying on dangling-only prune.
> 
> **DEPLOYMENT.md** notes public GHCR pulls and that staging already deploys this way; internal/prod remain host builds (rest of AYC-589).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 823bfea0c70dc50b9e780b04549b92a000579c87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->