### PR TITLE
ci: switch internal and production deploys to ghcr image pulls (AYC-589)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -7,9 +7,13 @@ name: Build & Publish Images
 #   ayunis-core-python-sandbox  — image user code executes in (DOCKER_IMAGE)
 #
 # Pushes to main produce sha-<commit> + latest tags (what staging pulls,
-# AYC-589); release tags produce vX.Y.Z. release-please dispatches this
-# workflow for its tags explicitly (GITHUB_TOKEN-created tags don't fire
-# push-tag workflows) — see release-please.yml.
+# AYC-589); release tags produce vX.Y.Z.
+#
+# release-please calls this workflow instead of pushing a tag that would
+# trigger it: GITHUB_TOKEN-created tags don't fire push-tag workflows, and
+# since AYC-589 its deploys pull these images, so the build has to be a real
+# `needs:` dependency rather than a fire-and-forget dispatch. The caller's ref
+# is then refs/heads/main, not the tag — hence release_tag.
 #
 # Each image is published as a multi-arch manifest list (AYC-589). This is not
 # optional: staging runs aarch64 while internal and production run x86_64, and
@@ -24,13 +28,24 @@ on:
     branches: [main]
     tags: ['v*']
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: Build this tag instead of the caller's ref, and tag the images with it
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
   packages: write
 
 concurrency:
-  group: build-images-${{ github.ref }}
+  # release_tag, not just github.ref: a release-please call runs with the
+  # caller's ref (main) and would otherwise share a group with the build
+  # triggered by the very push that created the release — where a third
+  # queued run would cancel it.
+  group: build-images-${{ inputs.release_tag || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -69,7 +84,11 @@ jobs:
             target: ''
     runs-on: ${{ matrix.platform == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     steps:
+      # github.sha, not github.ref: on the push path the ref's tip may already
+      # have moved past the commit whose sha- tag we're about to publish.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.release_tag || github.sha }}
 
       - name: Log in to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
@@ -179,10 +198,15 @@ jobs:
           # overwrite the main-branch latest that staging pulls.
           flavor: |
             latest=false
+          # A release_tag build runs with the caller's ref (main), so the
+          # ref-derived tags are gated off — otherwise it would republish
+          # sha-/latest and defeat the latest=false rule above. type=semver
+          # still covers a hand-pushed v* tag.
           tags: |
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern=v{{version}}
+            type=sha,prefix=sha-,enable=${{ inputs.release_tag == '' }}
+            type=raw,value=latest,enable=${{ inputs.release_tag == '' && github.ref == 'refs/heads/main' }}
+            type=semver,pattern=v{{version}},enable=${{ inputs.release_tag == '' }}
+            type=raw,value=${{ inputs.release_tag }},enable=${{ inputs.release_tag != '' }}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests
@@ -220,7 +244,12 @@ jobs:
   # and CI_APP_* org secrets shared with this repo.
   notify-infra:
     needs: merge
-    if: startsWith(github.ref, 'refs/tags/v')
+    # On the release-please path github.ref is main, so the ref check alone
+    # would silently stop pinging infra.
+    if: ${{ inputs.release_tag != '' || startsWith(github.ref, 'refs/tags/v') }}
+    # This Renovate wake-up is not part of publishing the images. A transient
+    # notification failure must not fail the reusable workflow and skip deploys.
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - name: Mint ayunis-infra token
@@ -236,7 +265,7 @@ jobs:
         env:
           INFRA_TOKEN: ${{ steps.infra-token.outputs.token }}
           IMAGE: ${{ github.repository }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.release_tag || github.ref_name }}
         run: |
           curl -fsS -X POST \
             -H "Authorization: Bearer ${INFRA_TOKEN}" \

--- a/.github/workflows/deploy-internal-manual.yml
+++ b/.github/workflows/deploy-internal-manual.yml
@@ -32,21 +32,125 @@ jobs:
             # has to abort on error itself.
             set -e
             cd /home/ayunis/apps/ayunis-core
+            # The checkout still supplies the compose files, the .env files and
+            # postgres/init.sql — only the build is gone (AYC-589).
             git fetch --all --tags
             if git show-ref --tags --verify --quiet "refs/tags/$RELEASE_TAG"; then
               git checkout -f "$RELEASE_TAG"
+              CORE_TAG="$RELEASE_TAG"
             else
               git checkout -f "$RELEASE_TAG"
               git reset --hard "origin/$RELEASE_TAG"
+              # A branch has no version tag — run the sha- image built for the
+              # commit it points at (the input defaults to main). Plain
+              # truncation, not `git rev-parse --short=7`: --short is a
+              # *minimum* and git lengthens it when the prefix is ambiguous,
+              # while metadata-action's type=sha is an unconditional
+              # sha.substring(0, 7).
+              CORE_TAG="sha-$(git rev-parse HEAD | cut -c1-7)"
+            fi
+            export CORE_TAG
+            export COMPOSE_FILE=docker-compose.yml:compose.release.yml
+            echo "Deploying $CORE_TAG"
+
+            # Reclaiming runs before the pull, not only after a successful
+            # swap. A pull that exhausts the disk exits before the trailing
+            # cleanup, so nothing is freed and every later deploy fails the
+            # same way until the host is cleaned by hand — staging wedged
+            # exactly like this before the ordering was fixed.
+            reclaim_images() {
+              # $1 = "keep-sandbox"; see the call site before the pull.
+              #
+              # This host built its images until this change, so it still
+              # carries a BuildKit cache that will never be reused again, plus
+              # the unprefixed `ayunis-core-*` tags those builds produced. The
+              # ghcr.io filter below reaches neither, and `prune -f` skips the
+              # tags because they are tagged, not dangling. On the first
+              # pull-based deploy the legacy tags are still in use by the
+              # running containers, so rmi refuses them — they are collected by
+              # the post-swap call once the GHCR images have taken over.
+              docker builder prune -af || true
+              docker images --filter "reference=ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
+                | xargs -r docker rmi || true
+              # Superseded Core tags. `prune -a` is the wrong tool: the sandbox
+              # image is referenced only by ephemeral per-execution containers,
+              # so it always looks unused, and an `until=` cut-off can't save it
+              # either — a cache-hit rebuild keeps the original Created date.
+              # The pattern is `ayunis-core-*`, not `*`: the hosts run other
+              # images from this org namespace (ayunis-backup).
+              #
+              # Before the swap this is safe for the compose services because
+              # `docker rmi` refuses an image a running container uses — that
+              # refusal is what spares the generation still serving traffic, so
+              # the `|| true` is load-bearing rather than defensive. The sandbox
+              # is the one image that refusal cannot protect, hence keep-sandbox.
+              victims=$(docker images --filter "reference=ghcr.io/ayunis-core/ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
+                | grep -v ":${CORE_TAG}$" || true)
+              if [ "${1:-}" = "keep-sandbox" ]; then
+                victims=$(printf '%s\n' "$victims" | grep -v 'ayunis-core-python-sandbox' || true)
+              fi
+              printf '%s\n' "$victims" | grep -v '^$' | xargs -r docker rmi || true
+              docker image prune -f
+            }
+
+            # Spare the sandbox here. Nothing long-lived holds that image — the
+            # per-execution containers are transient — so `docker rmi` would
+            # happily delete the tag the *running* code-execution service still
+            # points DOCKER_IMAGE at. It pulls the sandbox only when it is
+            # constructed (executor.py:28), and the execution path uses
+            # containers.create, which never pulls. Deleting it here and then
+            # failing the pull would leave code execution broken for as long as
+            # the deploy stays aborted — defeating the point of keeping the
+            # current containers up.
+            reclaim_images keep-sandbox
+
+            # Fail here rather than mid-blob: a full disk otherwise surfaces as
+            # `GetImageBlob...: no space left on device` buried in pull
+            # progress. The headroom has to cover a second copy of every Core
+            # image while the current ones still serve traffic.
+            #
+            # Sized against this host as measured 2026-07-31: 38 G total, 7.5 G
+            # free — and that is *before* the first pull-based deploy reclaims
+            # the BuildKit cache and the legacy build-on-host images, so it is
+            # the tightest this will ever be. A full new generation is ~5 G with
+            # the CPU-only anonymize, so 6 leaves margin while still catching a
+            # genuinely full disk. Deliberately below production's 9: this does
+            # not cover a rollback to a release tag from before the CPU-only
+            # torch change (~6 GB anonymize, ~9 G for two generations). Such a
+            # rollback would fail on the pull instead — which aborts before the
+            # swap and reclaims on the next run, so it degrades safely. Raise
+            # this toward 9 once the host has settled after its first deploy.
+            MIN_FREE_GB=6
+            FREE_GB=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+            echo "Free disk: ${FREE_GB:-0}G (need ${MIN_FREE_GB}G)"
+            if [ "${FREE_GB:-0}" -lt "$MIN_FREE_GB" ]; then
+              echo "::error::only ${FREE_GB:-0}G free, need ${MIN_FREE_GB}G — not deploying"
+              exit 1
+            fi
+
+            # Pull while the old containers still serve traffic, and abort
+            # BEFORE touching them if anything is missing. Scoped to the Core
+            # services: a bare `compose pull` would also refresh
+            # minio/dozzle/redis/gotenberg, which are deliberately only pulled
+            # when first started.
+            if ! docker compose pull app code-execution anonymize; then
+              echo "::error::image pull failed — keeping current containers, not deploying"
+              exit 1
+            fi
+            # The sandbox is not a compose service; code-execution pulls it
+            # through the docker-socket-proxy on first use. Pulling it here
+            # keeps that first execution fast and proves the tag exists.
+            if ! docker pull "ghcr.io/ayunis-core/ayunis-core-python-sandbox:$CORE_TAG"; then
+              echo "::error::sandbox image pull failed — keeping current containers, not deploying"
+              exit 1
             fi
             docker compose down
-            # Clean up old images and build cache before building new ones
-            docker image prune -af
-            docker builder prune -af
-            # Rebuild the sandbox image after the prune deleted it (not a
-            # compose service; code-execution fails hard without it — AYC-588.
-            # AYC-589 switches deploys to GHCR pulls.)
-            docker build -t python-sandbox:latest ayunis-core-code-execution/sandbox
-            docker compose up -d --build
+            docker compose up -d --no-build
             sleep 60
             docker compose ps
+            # Drop the generation just replaced, sandbox included: the new
+            # containers are up on CORE_TAG, which the filter spares, so the
+            # stale sandbox tag is now genuinely unreferenced. This is also the
+            # call that collects the legacy build-on-host images, which the
+            # pre-pull call could not touch while they were still running.
+            reclaim_images

--- a/.github/workflows/deploy-production-manual.yml
+++ b/.github/workflows/deploy-production-manual.yml
@@ -32,23 +32,122 @@ jobs:
             # has to abort on error itself.
             set -e
             cd /home/ayunis/apps/ayunis-core
+            # The checkout still supplies the compose files, the .env files and
+            # postgres/init.sql — only the build is gone (AYC-589).
             git fetch --all --tags
             if git show-ref --tags --verify --quiet "refs/tags/$RELEASE_TAG"; then
               git checkout -f "$RELEASE_TAG"
+              CORE_TAG="$RELEASE_TAG"
             else
               git checkout -f "$RELEASE_TAG"
               git reset --hard "origin/$RELEASE_TAG"
+              # A branch has no version tag — run the sha- image built for the
+              # commit it points at (the input defaults to main). Plain
+              # truncation, not `git rev-parse --short=7`: --short is a
+              # *minimum* and git lengthens it when the prefix is ambiguous,
+              # while metadata-action's type=sha is an unconditional
+              # sha.substring(0, 7).
+              CORE_TAG="sha-$(git rev-parse HEAD | cut -c1-7)"
             fi
-            # Build with cache while old containers still serve traffic
-            docker compose build
-            # Sandbox image: not a compose service, never built at runtime
-            # anymore (AYC-588); host-built until AYC-589 switches to GHCR pulls
-            docker build -t python-sandbox:latest ayunis-core-code-execution/sandbox
+            export CORE_TAG
+            export COMPOSE_FILE=docker-compose.yml:compose.release.yml
+            echo "Deploying $CORE_TAG"
+
+            # Reclaiming runs before the pull, not only after a successful
+            # swap. A pull that exhausts the disk exits before the trailing
+            # cleanup, so nothing is freed and every later deploy fails the
+            # same way until the host is cleaned by hand — staging wedged
+            # exactly like this before the ordering was fixed.
+            reclaim_images() {
+              # $1 = "keep-sandbox"; see the call site before the pull.
+              #
+              # This host built its images until this change, so it still
+              # carries a BuildKit cache that will never be reused again, plus
+              # the unprefixed `ayunis-core-*` tags those builds produced. The
+              # ghcr.io filter below reaches neither, and `prune -f` skips the
+              # tags because they are tagged, not dangling. On the first
+              # pull-based deploy the legacy tags are still in use by the
+              # running containers, so rmi refuses them — they are collected by
+              # the post-swap call once the GHCR images have taken over.
+              docker builder prune -af || true
+              docker images --filter "reference=ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
+                | xargs -r docker rmi || true
+              # Superseded Core tags. `prune -a` is the wrong tool: the sandbox
+              # image is referenced only by ephemeral per-execution containers,
+              # so it always looks unused, and an `until=` cut-off can't save it
+              # either — a cache-hit rebuild keeps the original Created date.
+              # The pattern is `ayunis-core-*`, not `*`: the hosts run other
+              # images from this org namespace (ayunis-backup).
+              #
+              # Before the swap this is safe for the compose services because
+              # `docker rmi` refuses an image a running container uses — that
+              # refusal is what spares the generation still serving traffic, so
+              # the `|| true` is load-bearing rather than defensive. The sandbox
+              # is the one image that refusal cannot protect, hence keep-sandbox.
+              victims=$(docker images --filter "reference=ghcr.io/ayunis-core/ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
+                | grep -v ":${CORE_TAG}$" || true)
+              if [ "${1:-}" = "keep-sandbox" ]; then
+                victims=$(printf '%s\n' "$victims" | grep -v 'ayunis-core-python-sandbox' || true)
+              fi
+              printf '%s\n' "$victims" | grep -v '^$' | xargs -r docker rmi || true
+              docker image prune -f
+            }
+
+            # Spare the sandbox here. Nothing long-lived holds that image — the
+            # per-execution containers are transient — so `docker rmi` would
+            # happily delete the tag the *running* code-execution service still
+            # points DOCKER_IMAGE at. It pulls the sandbox only when it is
+            # constructed (executor.py:28), and the execution path uses
+            # containers.create, which never pulls. Deleting it here and then
+            # failing the pull would leave code execution broken for as long as
+            # the deploy stays aborted — defeating the point of keeping the
+            # current containers up.
+            reclaim_images keep-sandbox
+
+            # Fail here rather than mid-blob: a full disk otherwise surfaces as
+            # `GetImageBlob...: no space left on device` buried in pull
+            # progress. The headroom has to cover a second copy of every Core
+            # image while the current ones still serve traffic.
+            #
+            # Sized against this host as measured 2026-07-31: 150 G total, 59 G
+            # free, so 9 is comfortable. It covers the worst case rather than
+            # the current one — a rollback to a release tag from before the
+            # CPU-only torch change still carries a ~6 GB anonymize image, so
+            # two generations need ~9 G. Internal deliberately runs a lower
+            # threshold; it is a 38 G box.
+            MIN_FREE_GB=9
+            FREE_GB=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+            echo "Free disk: ${FREE_GB:-0}G (need ${MIN_FREE_GB}G)"
+            if [ "${FREE_GB:-0}" -lt "$MIN_FREE_GB" ]; then
+              echo "::error::only ${FREE_GB:-0}G free, need ${MIN_FREE_GB}G — not deploying"
+              exit 1
+            fi
+
+            # Pull while the old containers still serve traffic, and abort
+            # BEFORE touching them if anything is missing. Scoped to the Core
+            # services: a bare `compose pull` would also refresh
+            # minio/dozzle/redis/gotenberg, which are deliberately only pulled
+            # when first started.
+            if ! docker compose pull app code-execution anonymize; then
+              echo "::error::image pull failed — keeping current containers, not deploying"
+              exit 1
+            fi
+            # The sandbox is not a compose service; code-execution pulls it
+            # through the docker-socket-proxy on first use. Pulling it here
+            # keeps that first execution fast and proves the tag exists.
+            if ! docker pull "ghcr.io/ayunis-core/ayunis-core-python-sandbox:$CORE_TAG"; then
+              echo "::error::sandbox image pull failed — keeping current containers, not deploying"
+              exit 1
+            fi
             # Quick swap — downtime is only the restart
             docker compose down
-            docker compose up -d
+            docker compose up -d --no-build
             # Wait for app to be healthy (up to 120s)
             timeout 120 bash -c 'until docker compose ps app --format json | grep -q "(healthy)"; do sleep 5; done'
             docker compose ps
-            # Clean up dangling images to reclaim disk space
-            docker image prune -f
+            # Drop the generation just replaced, sandbox included: the new
+            # containers are up on CORE_TAG, which the filter spares, so the
+            # stale sandbox tag is now genuinely unreferenced. This is also the
+            # call that collects the legacy build-on-host images, which the
+            # pre-pull call could not touch while they were still running.
+            reclaim_images

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  actions: write # dispatch build-images.yml for the release tag
 
 jobs:
   release-please:
@@ -26,26 +25,24 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  # Tags created with GITHUB_TOKEN don't trigger push-tag workflows, so
-  # dispatch the image build for the release tag explicitly. Separate job:
-  # the deploys build on the host and don't consume these images, so a
-  # failed dispatch must not gate them (the dispatch is fire-and-forget
-  # anyway — it never waited for the build to succeed).
+  # Tags created with GITHUB_TOKEN don't trigger push-tag workflows, so the
+  # image build is invoked explicitly. Since AYC-589 the deploys below pull
+  # these images, so this has to be a real dependency: a reusable-workflow
+  # call, not the fire-and-forget dispatch it used to be. secrets: inherit is
+  # required — build-images' notify-infra job mints the ayunis-infra app token.
   build-release-images:
     needs: release-please
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dispatch image build for release tag
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh workflow run build-images.yml \
-            --ref "${{ needs.release-please.outputs.tag_name }}" \
-            --repo "${{ github.repository }}"
+    uses: ./.github/workflows/build-images.yml
+    with:
+      release_tag: ${{ needs.release-please.outputs.tag_name }}
+    permissions:
+      contents: read
+      packages: write
+    secrets: inherit
 
   deploy-internal:
-    needs: release-please
+    needs: [release-please, build-release-images]
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     environment: internal
@@ -68,24 +65,49 @@ jobs:
             # has to abort on error itself.
             set -e
             cd /home/ayunis/apps/ayunis-core
+            # The checkout still supplies the compose files, the .env files and
+            # postgres/init.sql — only the build is gone (AYC-589).
             git fetch --all --tags
             git checkout -f "$RELEASE_TAG"
-            # Build with cache while old containers still serve traffic
-            docker compose build
-            # Sandbox image: not a compose service, never built at runtime
-            # anymore (AYC-588); host-built until AYC-589 switches to GHCR pulls
-            docker build -t python-sandbox:latest ayunis-core-code-execution/sandbox
+            export COMPOSE_FILE=docker-compose.yml:compose.release.yml
+            export CORE_TAG="$RELEASE_TAG"
+            # Pull while the old containers still serve traffic, and abort
+            # BEFORE touching them if anything is missing. Scoped to the Core
+            # services: a bare `compose pull` would also refresh
+            # minio/dozzle/redis/gotenberg, which are deliberately only pulled
+            # when first started.
+            if ! docker compose pull app code-execution anonymize; then
+              echo "::error::image pull failed — keeping current containers, not deploying"
+              exit 1
+            fi
+            # The sandbox is not a compose service; code-execution pulls it
+            # through the docker-socket-proxy on first use. Pulling it here
+            # keeps that first execution fast and proves the tag exists.
+            if ! docker pull "ghcr.io/ayunis-core/ayunis-core-python-sandbox:$CORE_TAG"; then
+              echo "::error::sandbox image pull failed — keeping current containers, not deploying"
+              exit 1
+            fi
             # Quick swap — downtime is only the restart
             docker compose down
-            docker compose up -d
+            docker compose up -d --no-build
             # Wait for app to be healthy (up to 120s)
             timeout 120 bash -c 'until docker compose ps app --format json | grep -q "(healthy)"; do sleep 5; done'
             docker compose ps
-            # Clean up dangling images to reclaim disk space
+            # Reclaim superseded Core images — pulled images are tagged, not
+            # dangling, so `prune -f` alone would never touch them. `prune -a`
+            # is the wrong tool: the sandbox image is referenced only by
+            # ephemeral per-execution containers, so it always looks unused,
+            # and an `until=` cut-off can't save it either — a cache-hit
+            # rebuild keeps the original Created date. The pattern is
+            # `ayunis-core-*`, not `*`: the hosts run other images from this
+            # org namespace (ayunis-backup).
+            docker images --filter "reference=ghcr.io/ayunis-core/ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
+              | grep -v ":${CORE_TAG}$" \
+              | xargs -r docker rmi || true
             docker image prune -f
 
   deploy-production:
-    needs: [release-please, deploy-internal]
+    needs: [release-please, build-release-images, deploy-internal]
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     environment: production
@@ -108,20 +130,45 @@ jobs:
             # has to abort on error itself.
             set -e
             cd /home/ayunis/apps/ayunis-core
+            # The checkout still supplies the compose files, the .env files and
+            # postgres/init.sql — only the build is gone (AYC-589).
             git fetch --all --tags
             git checkout -f "$RELEASE_TAG"
-            # Build with cache while old containers still serve traffic
-            docker compose build
-            # Sandbox image: not a compose service, never built at runtime
-            # anymore (AYC-588); host-built until AYC-589 switches to GHCR pulls
-            docker build -t python-sandbox:latest ayunis-core-code-execution/sandbox
+            export COMPOSE_FILE=docker-compose.yml:compose.release.yml
+            export CORE_TAG="$RELEASE_TAG"
+            # Pull while the old containers still serve traffic, and abort
+            # BEFORE touching them if anything is missing. Scoped to the Core
+            # services: a bare `compose pull` would also refresh
+            # minio/dozzle/redis/gotenberg, which are deliberately only pulled
+            # when first started.
+            if ! docker compose pull app code-execution anonymize; then
+              echo "::error::image pull failed — keeping current containers, not deploying"
+              exit 1
+            fi
+            # The sandbox is not a compose service; code-execution pulls it
+            # through the docker-socket-proxy on first use. Pulling it here
+            # keeps that first execution fast and proves the tag exists.
+            if ! docker pull "ghcr.io/ayunis-core/ayunis-core-python-sandbox:$CORE_TAG"; then
+              echo "::error::sandbox image pull failed — keeping current containers, not deploying"
+              exit 1
+            fi
             # Quick swap — downtime is only the restart
             docker compose down
-            docker compose up -d
+            docker compose up -d --no-build
             # Wait for app to be healthy (up to 120s)
             timeout 120 bash -c 'until docker compose ps app --format json | grep -q "(healthy)"; do sleep 5; done'
             docker compose ps
-            # Clean up dangling images to reclaim disk space
+            # Reclaim superseded Core images — pulled images are tagged, not
+            # dangling, so `prune -f` alone would never touch them. `prune -a`
+            # is the wrong tool: the sandbox image is referenced only by
+            # ephemeral per-execution containers, so it always looks unused,
+            # and an `until=` cut-off can't save it either — a cache-hit
+            # rebuild keeps the original Created date. The pattern is
+            # `ayunis-core-*`, not `*`: the hosts run other images from this
+            # org namespace (ayunis-backup).
+            docker images --filter "reference=ghcr.io/ayunis-core/ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
+              | grep -v ":${CORE_TAG}$" \
+              | xargs -r docker rmi || true
             docker image prune -f
 
   notify-slack:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -19,11 +19,16 @@ This guide covers deploying Ayunis Core to production and managing configuration
 > release from the registry instead of building on the host, use the
 > `compose.release.yml` overlay:
 > `CORE_TAG=vX.Y.Z docker compose -f docker-compose.yml -f compose.release.yml up -d --no-build`.
-> The packages are public, so no registry login is needed to pull them.
+> The packages are public, so no registry login is needed to pull them, and
+> each tag is a multi-arch manifest list (`linux/amd64` + `linux/arm64`), so a
+> host pulls whichever matches it.
 >
-> Staging deploys this way already — it pulls `sha-<short-commit>` after
-> `build-images.yml` finishes for that commit. Internal and production still
-> build on the host; switching them is the second half of AYC-589.
+> **All deployed environments run this way** (AYC-589) — none of them build on
+> the host any more. Staging pulls `sha-<short-commit>` once `build-images.yml`
+> finishes for that commit; internal and production pull `vX.Y.Z`. To roll an
+> environment back, run the command above with an older `CORE_TAG` on the host.
+> The steps below still describe a from-source deployment, which is the path
+> for self-hosters building their own images.
 
 ### Prerequisites
 


### PR DESCRIPTION
Stage 2 of AYC-589: internal and production stop building on the host, and the release pipeline stops racing the image build. Staging has been running this path since #1193.

Rebuilt on current `main` rather than rebased — see the note at the bottom.

## The part that isn't just "swap build for pull"

`release-please.yml` created the tag, fired `gh workflow run build-images.yml` **fire-and-forget**, and deployed immediately. That was safe only because the deploys built their own images. Once they pull, it's a hard race — on v2.20.1 the deploys started ~18:36 and the images landed 18:42.

So `build-images.yml` gains a `workflow_call` trigger and release-please invokes it as a real job with `needs:`, so a failed image build blocks the deploy instead of shipping into a missing tag. The `actions: write` permission goes away with the dispatch.

A reusable-workflow call runs with the **caller's** ref (`refs/heads/main`), not the tag, which is what `release_tag` corrects:

- **Checkout** takes `ref: ${{ inputs.release_tag || github.sha }}` — `github.sha`, not `github.ref`, since on the push path the branch tip may already have moved past the commit whose `sha-` tag is being published.
- **Tags** — the ref-derived entries are gated off for a `release_tag` build, which would otherwise republish `sha-`/`latest` and defeat the `latest=false` rule. These now live in the `merge` job, since that's where multi-arch manifest lists get tagged.
- **`notify-infra`** was gated on `startsWith(github.ref, 'refs/tags/v')`, false on this path — ayunis-infra would have silently stopped getting the Renovate ping. Now also fires on `release_tag`.
- **Concurrency** was keyed on `github.ref` alone, so a release call and the build from the push that created it shared a group; a third queued run cancels the pending one. Now keyed on `inputs.release_tag || github.ref`.

## Deploy scripts

All four (both release-please jobs, both manual workflows) now match the shape `deploy-staging.yml` has been running in production since #1193 — including everything learned from the staging outage:

- scoped `docker compose pull app code-execution anonymize`, explicit `docker pull` of the sandbox tag, guard aborting before `down`, `up -d --no-build`
- `set -e` retained from #1196 (the ignored `script_stop` input stays gone)
- cleanup narrowed to `ghcr.io/ayunis-core/ayunis-core-*` per #1199, so it can't touch `ayunis-backup`
- `CORE_TAG` from `git rev-parse HEAD | cut -c1-7`, matching metadata-action's unconditional 7-char truncation

Two environment-specific notes:

- **The manual workflows default their `tag` input to `main`**, which is not an image tag, so they resolve `CORE_TAG` from what they actually checked out — the version tag if `git show-ref` finds one, otherwise the `sha-` form.
- **`deploy-internal-manual.yml`'s cleanup moved after `up -d`.** Its unfiltered `docker image prune -af` used to run while everything was down; with pulls that would delete the images just pulled. `docker builder prune -af` stays at the end — the host no longer builds.

All five temporary `docker build -t python-sandbox:latest` lines from AYC-588 are now gone.

## Architecture

Internal and production are both `x86_64`; staging is `aarch64`. #1198 publishes every tag as a `linux/amd64` + `linux/arm64` manifest list, so all three are covered and each host pulls its own platform.

## Verification

- `actionlint` clean across all workflows; all five deploy scripts pass `bash -n`, start with `set -e`, use the narrowed cleanup filter, and contain no `rev-parse --short=7`.
- `git diff main` confirms this branch **adds to** main rather than reverting it: it touches only the four workflows plus `DEPLOYMENT.md`, leaves `ghcr-cleanup.yml` and `deploy-staging.yml` untouched, and the multi-arch `merge` job / `push-by-digest` / arm runners are all still present.
- Real behaviour can only be confirmed on a release. Cheapest rehearsal before that: `workflow_dispatch` `deploy-internal-manual.yml` with `tag: v2.20.1` — but note that tag predates multi-arch and is amd64-only, which is fine for internal (x86_64).

## Why rebuilt, not rebased

The previous revision was auto-restacked and resolved conflicts by reverting `main`: it dropped multi-arch entirely (no `merge` job, no `push-by-digest`, no arm runners), restored the bogus `script_stop`, and removed #1199's and #1200's changes. That revision was discarded and the intended changes re-applied on top of current `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes production and internal deployment mechanics and release ordering; mistakes could deploy before images exist, break code execution via sandbox image handling, or exhaust disk during pulls.
> 
> **Overview**
> **AYC-589 stage 2:** internal, production, and release-please deploy paths stop host `docker compose build` / local sandbox builds and use `compose.release.yml` with `CORE_TAG` (`vX.Y.Z` on releases, `sha-<7>` for branch/manual deploys).
> 
> **Release pipeline:** `build-images.yml` is callable via `workflow_call` with optional `release_tag`. Release-please invokes it with `needs:` instead of `gh workflow run`, so failed image builds block deploys. Checkout, image tagging, concurrency grouping, and `notify-infra` are adjusted for the reusable path where `github.ref` is `main`, not the release tag.
> 
> **Deploy scripts** (manual internal/production + release-please SSH steps) mirror staging: pre-pull Core services and sandbox before `down`, disk headroom checks, scoped image reclaim (including legacy host-built tags and BuildKit cache), and `up -d --no-build`. Manual workflows resolve `CORE_TAG` from the checked-out tag or commit.
> 
> **Docs:** `DEPLOYMENT.md` states all deployed environments pull from GHCR with multi-arch manifests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a22e3d51e11435200e85b8e3c8fe003902244a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->