### PR TITLE
ci: make deploy scripts actually abort on error (AYC-589)

### DIFF
--- a/.github/workflows/deploy-internal-manual.yml
+++ b/.github/workflows/deploy-internal-manual.yml
@@ -26,8 +26,11 @@ jobs:
           username: ${{ secrets.INTERNAL_USER }}
           key: ${{ secrets.INTERNAL_SSH_KEY }}
           envs: RELEASE_TAG
-          script_stop: true
           script: |
+            # `script_stop` is not an input of appleboy/ssh-action v1.2.5 — it
+            # was accepted here for years and silently ignored, so the script
+            # has to abort on error itself.
+            set -e
             cd /home/ayunis/apps/ayunis-core
             git fetch --all --tags
             if git show-ref --tags --verify --quiet "refs/tags/$RELEASE_TAG"; then

--- a/.github/workflows/deploy-production-manual.yml
+++ b/.github/workflows/deploy-production-manual.yml
@@ -26,8 +26,11 @@ jobs:
           username: ${{ secrets.PRODUCTION_USER }}
           key: ${{ secrets.PRODUCTION_SSH_KEY }}
           envs: RELEASE_TAG
-          script_stop: true
           script: |
+            # `script_stop` is not an input of appleboy/ssh-action v1.2.5 — it
+            # was accepted here for years and silently ignored, so the script
+            # has to abort on error itself.
+            set -e
             cd /home/ayunis/apps/ayunis-core
             git fetch --all --tags
             if git show-ref --tags --verify --quiet "refs/tags/$RELEASE_TAG"; then

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -36,8 +36,11 @@ jobs:
           username: ${{ secrets.STAGING_USER }}
           key: ${{ secrets.STAGING_SSH_KEY }}
           envs: DEPLOY_SHA
-          script_stop: true
           script: |
+            # `script_stop` is not an input of appleboy/ssh-action v1.2.5 — it
+            # was accepted here for years and silently ignored, so the script
+            # has to abort on error itself.
+            set -e
             cd /home/ayunis/apps/ayunis-core
             # The checkout still supplies the compose files, the .env files and
             # postgres/init.sql — only the build is gone. Reset to the exact

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -62,8 +62,11 @@ jobs:
           username: ${{ secrets.INTERNAL_USER }}
           key: ${{ secrets.INTERNAL_SSH_KEY }}
           envs: RELEASE_TAG
-          script_stop: true
           script: |
+            # `script_stop` is not an input of appleboy/ssh-action v1.2.5 — it
+            # was accepted here for years and silently ignored, so the script
+            # has to abort on error itself.
+            set -e
             cd /home/ayunis/apps/ayunis-core
             git fetch --all --tags
             git checkout -f "$RELEASE_TAG"
@@ -99,8 +102,11 @@ jobs:
           username: ${{ secrets.PRODUCTION_USER }}
           key: ${{ secrets.PRODUCTION_SSH_KEY }}
           envs: RELEASE_TAG
-          script_stop: true
           script: |
+            # `script_stop` is not an input of appleboy/ssh-action v1.2.5 — it
+            # was accepted here for years and silently ignored, so the script
+            # has to abort on error itself.
+            set -e
             cd /home/ayunis/apps/ayunis-core
             git fetch --all --tags
             git checkout -f "$RELEASE_TAG"


### PR DESCRIPTION
All five host-deploy scripts pass `script_stop: true` to `appleboy/ssh-action@v1.2.5`. That input does not exist — the action's `action.yml` accepts `script`, `script_path`, `envs`, `envs_format`, `sync`, `debug`, `request_pty`, `capture_stdout` and the connection/proxy set, and nothing else. Every deploy run has been logging:

```
##[warning]Unexpected input(s) 'script_stop', valid inputs are ['host', 'port', ...]
```

So the scripts have never aborted on error. This replaces the ignored input with a real `set -e` as the first line of each script, plus a comment so it doesn't get "fixed" back to `script_stop`.

Found while investigating a failed staging deploy — the deploy failed *correctly*, but only because that script's guards are explicit `if ! …; then exit 1; fi`. The unguarded statements around them were running unprotected.

## What this actually changes

Two consequences worth calling out, because deploys that used to report success can now fail:

- **The health gate becomes real.** `timeout 120 bash -c 'until docker compose ps app --format json | grep -q "(healthy)"; …'` returns 124 on timeout. Without `set -e` that status was discarded and the script carried on to `docker compose ps` and the prune, so the job went green with an unhealthy app. Now it fails. This applies to staging, internal and production.
- **Production and internal gain a pre-`down` guard they never had.** `deploy-production-manual.yml` and both `release-please.yml` deploy jobs run `docker compose build` and `docker build … sandbox` before `docker compose down`. A failure there used to fall through and tear down the running stack anyway — exactly the corepack-outage scenario the staging guard was written for, still live on prod. `set -e` closes it.

Smaller: a failed `git fetch`/`checkout`/`reset` no longer falls through to deploy whatever the host happened to have checked out. On `deploy-staging.yml` that specifically prevents computing `CORE_TAG` from a stale `HEAD` and pulling the wrong image.

## Scope

`set -e` only — deliberately not `-u` or `pipefail`. `pipefail` would change how the existing `docker images | grep -v | xargs docker rmi` pipeline reports (it is already `|| true`-guarded), and `-u` would turn any unset variable into an abort. Both are defensible on their own, neither is worth bundling into a fix for a silently-ignored flag on scripts that can't be dry-run.

## Verification

- `appleboy/ssh-action@v1.2.5`'s `action.yml` inputs enumerated directly from the tag — `script_stop` is absent.
- `actionlint` clean across all 23 workflows; every extracted script passes `bash -n` and has `set -e` as its first executable line.
- Real behaviour can only be confirmed on a deploy run; the staging deploy is the cheapest exercise of it.

Related: #1194 rewrites four of these five scripts for the GHCR pull switch and will need a restack onto this. Discovered under AYC-589 but independent of it — this is worth merging on its own.
