### PR TITLE
ci: revert staging to build-on-host deploys until images are multi-arch (AYC-589)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,13 +1,8 @@
 name: Deploy to Staging
 
-# Staging runs published GHCR images instead of building on the host (AYC-589).
-# Chained after build-images.yml rather than triggered by the push itself: the
-# image for a commit does not exist until that build finishes (~7 min).
-
 on:
-  workflow_run:
-    workflows: ["Build & Publish Images"]
-    types: [completed]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -16,79 +11,42 @@ concurrency:
 
 jobs:
   deploy:
-    # Tag builds have head_branch == the tag, so only main-branch builds deploy.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
     environment: staging
 
     steps:
       - name: Deploy to Staging
         uses: appleboy/ssh-action@v1.2.5
-        env:
-          # The commit whose images were just built. Empty on manual dispatch,
-          # where the script falls back to origin/main.
-          DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
         with:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USER }}
           key: ${{ secrets.STAGING_SSH_KEY }}
-          envs: DEPLOY_SHA
           script_stop: true
           script: |
             cd /home/ayunis/apps/ayunis-core
-            # The checkout still supplies the compose files, the .env files and
-            # postgres/init.sql — only the build is gone. Reset to the exact
-            # built commit so the compose files and the image tag cannot drift
-            # apart if another push lands mid-deploy.
             git fetch origin main
-            git reset --hard "${DEPLOY_SHA:-origin/main}"
-            export COMPOSE_FILE=docker-compose.yml:compose.release.yml
-            # Plain truncation, not `git rev-parse --short=7`: --short is a
-            # *minimum* and git lengthens it when the prefix is ambiguous,
-            # while metadata-action's type=sha is an unconditional
-            # sha.substring(0, 7). A longer abbreviation would name a tag that
-            # was never published.
-            export CORE_TAG="sha-$(git rev-parse HEAD | cut -c1-7)"
-            echo "Deploying $CORE_TAG"
-            # Pull while the old containers still serve traffic. If a pull
-            # fails, abort BEFORE touching them — otherwise a missing image
-            # would tear down the app and leave it down while the deploy still
-            # reports success (see AYC: corepack outage).
-            # Scoped to the Core services on purpose: a bare `compose pull`
-            # would also refresh minio/dozzle/redis/gotenberg, which are
-            # deliberately only pulled when first started.
-            if ! docker compose pull app code-execution anonymize; then
-              echo "::error::image pull failed — keeping current containers, not deploying"
+            git reset --hard origin/main
+            # Build with cache while old containers still serve traffic. If the
+            # build fails, abort BEFORE touching running containers — otherwise a
+            # broken build would tear down the app and restart the stale image
+            # while the deploy still reports success (see AYC: corepack outage).
+            if ! docker compose build; then
+              echo "::error::docker compose build failed — keeping current containers, not deploying"
               exit 1
             fi
-            # The sandbox is not a compose service; code-execution pulls it
-            # through the docker-socket-proxy on first use. Pulling it here
-            # keeps that first execution fast and proves the tag exists before
-            # the swap.
-            if ! docker pull "ghcr.io/ayunis-core/ayunis-core-python-sandbox:$CORE_TAG"; then
-              echo "::error::sandbox image pull failed — keeping current containers, not deploying"
+            # The sandbox is not a compose service and is never built at
+            # runtime anymore (AYC-588) — build it here until AYC-589 switches
+            # deploys to GHCR pulls. Same guard: abort before touching
+            # running containers.
+            if ! docker build -t python-sandbox:latest ayunis-core-code-execution/sandbox; then
+              echo "::error::sandbox image build failed — keeping current containers, not deploying"
               exit 1
             fi
             # Quick swap — downtime is only the restart
             docker compose down
-            docker compose up -d --no-build
+            docker compose up -d
             # Wait for app to be healthy (up to 120s)
             timeout 120 bash -c 'until docker compose ps app --format json | grep -q "(healthy)"; do sleep 5; done'
             docker compose ps
-            # Reclaim superseded Core images — pulled images are tagged, not
-            # dangling, so `prune -f` alone would never touch them and every
-            # main push would add four. `prune -a` is the wrong tool here: the
-            # sandbox image is referenced only by ephemeral per-execution
-            # containers, so it always looks unused, and no `until=` cut-off
-            # saves it either — a cache-hit rebuild keeps the original Created
-            # date, so a freshly pulled sandbox tag can already read as weeks
-            # old. Deleting exactly the Core tags that aren't the one just
-            # deployed cannot touch what this deploy pulled. Superseded tags
-            # stay in GHCR, so a rollback re-pulls them.
-            docker images --filter "reference=ghcr.io/ayunis-core/*" --format '{{.Repository}}:{{.Tag}}' \
-              | grep -v ":${CORE_TAG}$" \
-              | xargs -r docker rmi || true
+            # Clean up dangling images to reclaim disk space
             docker image prune -f

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -19,11 +19,8 @@ This guide covers deploying Ayunis Core to production and managing configuration
 > release from the registry instead of building on the host, use the
 > `compose.release.yml` overlay:
 > `CORE_TAG=vX.Y.Z docker compose -f docker-compose.yml -f compose.release.yml up -d --no-build`.
-> The packages are public, so no registry login is needed to pull them.
->
-> Staging deploys this way already — it pulls `sha-<short-commit>` after
-> `build-images.yml` finishes for that commit. Internal and production still
-> build on the host; switching them is the second half of AYC-589.
+> The deploy workflows still build on the host; switching them to pulls is
+> tracked separately (AYC-589).
 
 ### Prerequisites
 


### PR DESCRIPTION
Reverts #1193. **The staging host is `aarch64`; the published images are `amd64`-only.**

```
ayunis-code-execution-prod  | exec /usr/local/bin/python: exec format error
ayunis-anonymize-prod       | exec /usr/bin/uv: exec format error
```

`build-images.yml` doesn't set `platforms:`, so buildx builds for the GitHub runner's platform — `linux/amd64`. I confirmed from the registry that each tag is a single-platform OCI manifest with `architecture: amd64`, no index. Build-on-host always worked because it built natively on the ARM box.

Reverting restores the build-on-host path (including AYC-588's temporary `docker build -t python-sandbox:latest` line) so the next push to main doesn't break staging again. Re-land once the images are multi-arch.

## Impact of the failed deploy

Staging went down and the workflow still reported success — `anonymize` and `code-execution` crash-looped, so `app` was never created (its `depends_on` requires both `service_healthy`). The 120s health gate returned 124 and that status was discarded, because `script_stop` is not an input of `appleboy/ssh-action@v1.2.5` and has been silently ignored all along. **#1196 fixes that** and would have turned this into a red deploy instead of a green one over a dead stack; it's worth merging regardless of what happens to the GHCR switch.

## Follow-ups this exposes

1. **Multi-arch images.** This repo is public, so free `ubuntu-24.04-arm` hosted runners are available — a per-platform build matrix on native runners plus `docker buildx imagetools create` for the manifest list, rather than QEMU emulation (which would be painfully slow for numpy/pandas and the Nest build). Hosts pull only their own platform, so no extra disk on the boxes.
2. **Check production's and internal's architecture** before #1194 goes anywhere near them, and decide hetzner-03's architecture deliberately in AYC-590 rather than inheriting it.
3. **The image cleanup filter is too broad** — `reference=ghcr.io/ayunis-core/*` matches every image in the org namespace on the host, and the deploy tried to `docker rmi ghcr.io/ayunis-core/ayunis-backup:0.1.23`. It only survived because a running container held the reference. Narrowing to `ghcr.io/ayunis-core/ayunis-core-*` matches just the four Core repos (verified: Docker's `reference` filter supports partial-segment prefix globs). Needs fixing in #1194.

Staging disk is also at 92% (3.2G free), which is what made the *first* attempt fail before any of this surfaced — worth sizing up before retrying the switch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how staging is deployed (timing, build vs pull, longer deploys) but preserves abort-on-build-failure before tearing down running containers.
> 
> **Overview**
> **Staging deploys no longer wait on or pull GHCR images** — the workflow triggers on **push to `main`** again instead of after **Build & Publish Images**, and the SSH script builds on the host instead of using `compose.release.yml` and `sha-*` tags.
> 
> The remote deploy path resets to **`origin/main`**, runs **`docker compose build`** (and a local **`python-sandbox:latest`** build) with the same **fail-before-`down`** guard, then **`docker compose up -d`** without `--no-build`. Post-deploy cleanup is simplified to **`docker image prune -f`** instead of removing superseded `ghcr.io/ayunis-core/*` tags.
> 
> **`DEPLOYMENT.md`** now states that published images exist for manual/registry use, but **deploy workflows still build on the host** until registry-based deploys land under **AYC-589** (multi-arch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b8c2b3779063eca79f724e90a0945ea98e518b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->