### PR TITLE
ci: narrow deploy image cleanup to the core repositories (AYC-589)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -91,7 +91,11 @@ jobs:
             # old. Deleting exactly the Core tags that aren't the one just
             # deployed cannot touch what this deploy pulled. Superseded tags
             # stay in GHCR, so a rollback re-pulls them.
-            docker images --filter "reference=ghcr.io/ayunis-core/*" --format '{{.Repository}}:{{.Tag}}' \
+            #
+            # The pattern is `ayunis-core-*`, not `*`: the hosts run other
+            # images from this org namespace (ayunis-backup), and matching the
+            # whole namespace made the deploy try to delete them.
+            docker images --filter "reference=ghcr.io/ayunis-core/ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
               | grep -v ":${CORE_TAG}$" \
               | xargs -r docker rmi || true
             docker image prune -f


### PR DESCRIPTION
The image cleanup added in #1193 matches the whole org namespace, not just the Core images. The last staging deploy tried to delete an unrelated image:

```
Error response from daemon: conflict: unable to remove repository reference
"ghcr.io/ayunis-core/ayunis-backup:0.1.23" (must force) - container 89d491fe2056 is using its reference
```

It survived only because a running container held the reference and `docker rmi` refuses without `--force`. Had that container been stopped during the deploy — which is exactly what `docker compose down` does a few lines earlier for anything in this project — the image would have been deleted.

One character class of a fix: `reference=ghcr.io/ayunis-core/*` → `reference=ghcr.io/ayunis-core/ayunis-core-*`, which matches the four Core repositories and nothing else in the namespace.

## Verification

Docker's `reference` filter is a path-aware glob: `*` does not cross `/`, but it does match a partial path segment. Both halves confirmed against a real daemon:

```
$ docker images --filter "reference=quay.io/*"            # (no match — * doesn't cross /)
$ docker images --filter "reference=quay.io/*/*"
quay.io/minio/minio:latest
$ docker images --filter "reference=ayunis-dev-*"         # partial-segment prefix works
ayunis-dev-5-anonymize:latest
ayunis-dev-2-code-execution:latest
...
```

`actionlint` clean; the script still passes `bash -n`.

## Note

#1194 carries the same over-broad filter in all four of its deploy scripts. It's still draft and needs re-applying on top of #1198 anyway, so the fix travels with that rework rather than being duplicated here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deploy-only housekeeping change; reduces accidental `docker rmi` scope on shared staging hosts.
> 
> **Overview**
> Fixes **staging deploy post-cleanup** so it only removes superseded **Core** images, not every image under the `ghcr.io/ayunis-core` org namespace.
> 
> The `docker images` filter changes from `ghcr.io/ayunis-core/*` to `ghcr.io/ayunis-core/ayunis-core-*`, with a short comment explaining that hosts also run other org images (e.g. **ayunis-backup**) and the broader pattern caused the deploy script to attempt deleting them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d11ed5ac256625dfced1c8aee0789df7bd0178b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->