### PR TITLE
docs: record why the ghcr cleanup action version is load-bearing (AYC-589)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -88,9 +88,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      # provenance: false keeps one manifest per tag — the default attestation
-      # manifests show up as untagged children in GHCR, which clutters the
-      # package view and makes the untagged-version cleanup workflow unsafe.
+      # provenance: false keeps the index children to just the architectures
+      # published here — the default attestation manifests add further untagged
+      # children on top, cluttering the package view. (The per-architecture
+      # children are untagged too and are unavoidable for a manifest list;
+      # ghcr-cleanup.yml relies on its pinned action version to spare them.)
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -8,6 +8,15 @@ name: GHCR Cleanup
 # image-tags filter (partial matches are kept and logged as warnings — see
 # filter_by_matchers in the action's select_package_versions.rs).
 #
+# The pinned action version is load-bearing, not incidental. Since the images
+# went multi-arch (AYC-589) each tag is an image index whose per-architecture
+# child manifests are stored untagged — exactly what this workflow deletes.
+# v3.1.0 is the first release that resolves kept tags' manifests and excludes
+# their children from the deletion candidates (fail-closed: it skips the whole
+# package if a manifest can't be fetched). Do not downgrade below v3.1.0 or
+# swap in another cleanup tool without checking for the same guarantee —
+# deleting one child silently breaks every tag pointing at it.
+#
 # GITHUB_TOKEN works because the packages are published from this repo with
 # GITHUB_TOKEN, which links them with admin access. If a run ever fails on
 # permissions, fall back to a fine-grained PAT org secret (read+delete


### PR DESCRIPTION
Comments only, no behaviour change.

Since #1198 each tag is an image index whose per-architecture child manifests are stored **untagged** — which is exactly what `ghcr-cleanup.yml` deletes. Deleting a child silently breaks every tag pointing at it.

We're safe by one patch release: the workflow pins `snok/container-retention-policy@d3bdcf5c` (confirmed = `v3.1.0`), and v3.1.0 is the first version that resolves kept tags' manifests, excludes their children from the deletion candidates, and fails closed if a manifest can't be fetched. On v3.0.1 the Monday cron would have started orphaning children.

Nothing recorded that, so this adds it in both places a future reader would look:

- `ghcr-cleanup.yml` — the pin is load-bearing; don't downgrade below v3.1.0 or swap tools without checking for the same guarantee.
- `build-images.yml` — the `provenance: false` rationale said untagged children "make the untagged-version cleanup workflow unsafe", which now reads as contradicted, since the images have untagged children by design. Reworded to say what `provenance: false` still buys.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes to GitHub Actions workflows; no runtime or deployment logic is modified.
> 
> **Overview**
> Adds **workflow comments only**—no CI behavior changes.
> 
> In **`ghcr-cleanup.yml`**, documents why **`snok/container-retention-policy` v3.1.0+** must stay pinned: multi-arch tags are manifest lists whose per-arch children appear untagged in GHCR, so an older cleanup action could delete those children and break every tag that references them; v3.1.0 excludes kept tags’ manifest children (fail-closed on fetch errors).
> 
> In **`build-images.yml`**, refreshes the **`provenance: false`** note to distinguish attestation clutter from unavoidable untagged per-arch index children, and points readers to **`ghcr-cleanup.yml`** for how those children are protected during cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 802409f95b3af58fc3653b0ce02cc686e5947a28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->