### PR TITLE
fix(mcp): stop aborted mcp requests and cache capability discovery (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/mcp/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/mcp/SUMMARY.md
@@ -6,6 +6,7 @@ MCP integrations connect external tool servers to the platform using the Model C
 The MCP module manages connections to external Model Context Protocol servers at the organization level. Core entities include `McpIntegration` (abstract base with predefined, custom, and marketplace subtypes), `McpIntegrationUserConfig` (per-user configuration values for marketplace integrations), `McpTool`, `McpResource`, and `McpPrompt`—the latter three are ephemeral entities fetched from remote servers, not persisted locally. Authentication is handled through a hierarchy supporting bearer tokens, custom headers, OAuth, and no-auth. `MarketplaceMcpIntegration` adds a marketplace identifier, a typed config schema (org-level and user-level fields), and org-level config values.
 
 **Use Cases:**
+
 - `CreateMcpIntegrationUseCase` — Creates predefined or custom integrations
 - `InstallMarketplaceIntegrationUseCase` — Installs a marketplace integration by identifier, persisting org-level config values and config schema
 - `GetMcpIntegrationUseCase` — Fetches a single integration by ID
@@ -24,17 +25,21 @@ The MCP module manages connections to external Model Context Protocol servers at
 - `GetUserMcpConfigUseCase` — Retrieves per-user config values (with secret masking)
 
 **Services:**
+
 - `McpClientService` — Handles actual server communication via the MCP SDK
+- `McpCapabilityCacheService` — In-process TTL cache for discovered capabilities (per integration and user); invalidated on integration update, delete, and user-config changes
 - `MarketplaceConfigService` — Resolves effective server URL and auth headers by merging org-level and user-level config values against the integration's config schema
 - `ConnectionValidationService` — Validates MCP server connectivity, used by `ValidateMcpIntegrationUseCase`
 
 **Ports:**
+
 - `McpIntegrationsRepository` — Persistence port for MCP integrations
 - `McpIntegrationUserConfigRepository` — Persistence port for per-user config values
 - `McpClientPort` — Abstract port for MCP server communication
 - `McpCredentialEncryptionPort` — Abstract port for credential encryption/decryption
 
 **Presenters:**
+
 - `McpIntegrationsController` — REST controller exposing:
   - `POST /mcp-integrations/predefined` — Create predefined integration (admin)
   - `POST /mcp-integrations/custom` — Create custom integration (admin)
@@ -52,8 +57,10 @@ The MCP module manages connections to external Model Context Protocol servers at
   - `PATCH /mcp-integrations/:id/user-config` — Set user config (user, admin)
 
 **Module Dependencies:**
+
 - **marketplace** — `InstallMarketplaceIntegrationUseCase` uses `GetMarketplaceIntegrationUseCase` to fetch integration metadata from the marketplace
 
 **Dependent Modules:**
+
 - **agents** — Uses MCP integration assignment for agent tool access
 - **tools** — Wraps discovered MCP tools, resources, and prompts as executable tool entities

--- a/ayunis-core-backend/src/domain/mcp/application/mcp.errors.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/mcp.errors.ts
@@ -86,8 +86,25 @@ export class McpIntegrationAccessDeniedError extends McpError {
 }
 
 export class UnexpectedMcpError extends McpError {
-  constructor(message: string, metadata?: ErrorMetadata) {
-    super(message, McpErrorCode.UNEXPECTED_MCP_ERROR, 500, metadata);
+  // Accepts Error for @HandleUnexpectedErrors; the string form remains for
+  // call sites not yet migrated to the decorator. Message and metadata are
+  // serialized into the HTTP response by toHttpException(), so the wrapped
+  // error must only travel on the non-serialized `cause` — raw internals
+  // (driver queries, request configs, upstream error text) must never reach
+  // API callers.
+  constructor(cause: string | Error, metadata?: ErrorMetadata) {
+    if (typeof cause === 'string') {
+      super(cause, McpErrorCode.UNEXPECTED_MCP_ERROR, 500, metadata);
+      return;
+    }
+
+    super(
+      'Unexpected error occurred',
+      McpErrorCode.UNEXPECTED_MCP_ERROR,
+      500,
+      metadata,
+    );
+    this.cause = cause;
   }
 }
 

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-capability-cache.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-capability-cache.service.spec.ts
@@ -1,0 +1,247 @@
+import { randomUUID } from 'crypto';
+import type { DiscoveredCapabilities } from './mcp-capability-cache.service';
+import { McpCapabilityCacheService } from './mcp-capability-cache.service';
+
+describe('McpCapabilityCacheService', () => {
+  let cache: McpCapabilityCacheService;
+
+  const integrationId = randomUUID();
+  const userId = randomUUID();
+
+  const buildCapabilities = (toolName: string): DiscoveredCapabilities => ({
+    tools: [
+      {
+        name: toolName,
+        description: 'Search the registry',
+        inputSchema: { type: 'object' },
+      },
+    ],
+    resources: [],
+    resourceTemplates: [],
+    prompts: [],
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    cache = new McpCapabilityCacheService();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('loads capabilities through the loader on first access', async () => {
+    const loader = jest
+      .fn()
+      .mockResolvedValue(buildCapabilities('search_registry'));
+
+    const result = await cache.getOrLoad(integrationId, userId, loader);
+
+    expect(result.tools[0].name).toBe('search_registry');
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves a cached result without re-invoking the loader', async () => {
+    const loader = jest
+      .fn()
+      .mockResolvedValue(buildCapabilities('search_registry'));
+
+    await cache.getOrLoad(integrationId, userId, loader);
+    const result = await cache.getOrLoad(integrationId, userId, loader);
+
+    expect(result.tools[0].name).toBe('search_registry');
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-discovers after the success TTL expires', async () => {
+    const loader = jest
+      .fn()
+      .mockResolvedValue(buildCapabilities('search_registry'));
+
+    await cache.getOrLoad(integrationId, userId, loader);
+    jest.advanceTimersByTime(5 * 60 * 1000 + 1);
+    await cache.getOrLoad(integrationId, userId, loader);
+
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares one in-flight discovery between concurrent callers', async () => {
+    let resolveLoad: (value: DiscoveredCapabilities) => void;
+    const loader = jest.fn().mockReturnValue(
+      new Promise<DiscoveredCapabilities>((resolve) => {
+        resolveLoad = resolve;
+      }),
+    );
+
+    const first = cache.getOrLoad(integrationId, userId, loader);
+    const second = cache.getOrLoad(integrationId, userId, loader);
+    resolveLoad!(buildCapabilities('search_registry'));
+
+    await expect(first).resolves.toEqual(await second);
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches a discovery failure and rethrows it without re-invoking the loader', async () => {
+    const failure = new Error('MCP error -32001: Request timed out');
+    const loader = jest.fn().mockRejectedValue(failure);
+
+    await expect(
+      cache.getOrLoad(integrationId, userId, loader),
+    ).rejects.toThrow(failure);
+    await expect(
+      cache.getOrLoad(integrationId, userId, loader),
+    ).rejects.toThrow(failure);
+
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries discovery once the failure TTL expires', async () => {
+    const loader = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('MCP error -32001: Request timed out'))
+      .mockResolvedValue(buildCapabilities('search_registry'));
+
+    await expect(
+      cache.getOrLoad(integrationId, userId, loader),
+    ).rejects.toThrow('Request timed out');
+    jest.advanceTimersByTime(30 * 1000 + 1);
+    const result = await cache.getOrLoad(integrationId, userId, loader);
+
+    expect(result.tools[0].name).toBe('search_registry');
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches per user so user-specific credentials stay isolated', async () => {
+    const loader = jest
+      .fn()
+      .mockResolvedValue(buildCapabilities('search_registry'));
+    const otherUserId = randomUUID();
+
+    await cache.getOrLoad(integrationId, userId, loader);
+    await cache.getOrLoad(integrationId, otherUserId, loader);
+    await cache.getOrLoad(integrationId, undefined, loader);
+
+    expect(loader).toHaveBeenCalledTimes(3);
+  });
+
+  it('invalidates every entry of an integration across users', async () => {
+    const loader = jest
+      .fn()
+      .mockResolvedValue(buildCapabilities('search_registry'));
+    const otherIntegrationId = randomUUID();
+
+    await cache.getOrLoad(integrationId, userId, loader);
+    await cache.getOrLoad(integrationId, undefined, loader);
+    await cache.getOrLoad(otherIntegrationId, userId, loader);
+
+    cache.invalidate(integrationId);
+
+    await cache.getOrLoad(integrationId, userId, loader);
+    await cache.getOrLoad(integrationId, undefined, loader);
+    await cache.getOrLoad(otherIntegrationId, userId, loader);
+
+    expect(loader).toHaveBeenCalledTimes(5);
+  });
+
+  it('keeps sharing an in-flight load even past the success TTL', async () => {
+    let resolveLoad: (value: DiscoveredCapabilities) => void;
+    const loader = jest.fn().mockReturnValue(
+      new Promise<DiscoveredCapabilities>((resolve) => {
+        resolveLoad = resolve;
+      }),
+    );
+
+    const first = cache.getOrLoad(integrationId, userId, loader);
+    jest.advanceTimersByTime(5 * 60 * 1000 + 1);
+    const second = cache.getOrLoad(integrationId, userId, loader);
+    resolveLoad!(buildCapabilities('search_registry'));
+
+    await expect(first).resolves.toEqual(await second);
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches a loader that throws synchronously as a failure', async () => {
+    const loader = jest.fn(() => {
+      throw new Error('secret decryption failed');
+    });
+
+    await expect(
+      cache.getOrLoad(integrationId, userId, loader),
+    ).rejects.toThrow('secret decryption failed');
+    await expect(
+      cache.getOrLoad(integrationId, userId, loader),
+    ).rejects.toThrow('secret decryption failed');
+
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates only the given user when a userId is provided', async () => {
+    const loader = jest
+      .fn()
+      .mockResolvedValue(buildCapabilities('search_registry'));
+    const otherUserId = randomUUID();
+
+    await cache.getOrLoad(integrationId, userId, loader);
+    await cache.getOrLoad(integrationId, otherUserId, loader);
+    await cache.getOrLoad(integrationId, undefined, loader);
+
+    cache.invalidate(integrationId, userId);
+
+    await cache.getOrLoad(integrationId, userId, loader);
+    await cache.getOrLoad(integrationId, otherUserId, loader);
+    await cache.getOrLoad(integrationId, undefined, loader);
+
+    expect(loader).toHaveBeenCalledTimes(4);
+  });
+
+  it('prunes expired entries on access regardless of their key', async () => {
+    const loader = jest
+      .fn()
+      .mockResolvedValue(buildCapabilities('search_registry'));
+    const otherIntegrationId = randomUUID();
+    const thirdIntegrationId = randomUUID();
+
+    await cache.getOrLoad(integrationId, userId, loader);
+    await cache.getOrLoad(otherIntegrationId, userId, loader);
+    expect(cache.size()).toBe(2);
+
+    jest.advanceTimersByTime(5 * 60 * 1000 + 1);
+    await cache.getOrLoad(thirdIntegrationId, userId, loader);
+
+    expect(cache.size()).toBe(1);
+  });
+
+  it('does not retain a load that was invalidated while in flight', async () => {
+    let resolveLoad: (value: DiscoveredCapabilities) => void;
+    const loader = jest
+      .fn()
+      .mockReturnValueOnce(
+        new Promise<DiscoveredCapabilities>((resolve) => {
+          resolveLoad = resolve;
+        }),
+      )
+      .mockResolvedValue(buildCapabilities('fresh_tool'));
+
+    const pending = cache.getOrLoad(integrationId, userId, loader);
+    cache.invalidate(integrationId);
+    resolveLoad!(buildCapabilities('stale_tool'));
+    await pending;
+
+    const result = await cache.getOrLoad(integrationId, userId, loader);
+
+    expect(result.tools[0].name).toBe('fresh_tool');
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears all entries', async () => {
+    const loader = jest
+      .fn()
+      .mockResolvedValue(buildCapabilities('search_registry'));
+
+    await cache.getOrLoad(integrationId, userId, loader);
+    cache.clear();
+    await cache.getOrLoad(integrationId, userId, loader);
+
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-capability-cache.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-capability-cache.service.ts
@@ -1,0 +1,111 @@
+import { Injectable } from '@nestjs/common';
+import { UUID } from 'crypto';
+import { McpTool, McpResource, McpPrompt } from '../ports/mcp-client.port';
+
+export interface DiscoveredCapabilities {
+  readonly tools: readonly McpTool[];
+  readonly resources: readonly McpResource[];
+  readonly resourceTemplates: readonly McpResource[];
+  readonly prompts: readonly McpPrompt[];
+}
+
+interface CacheEntry {
+  promise: Promise<DiscoveredCapabilities>;
+  // Undefined while the load is in flight — pending entries never expire, so
+  // concurrent callers always share the same load no matter how long it runs.
+  expiresAt?: number;
+}
+
+const SUCCESS_TTL_MS = 5 * 60 * 1000;
+// Failures are cached briefly so a slow or down MCP server is not hammered
+// with a fresh 30s-timeout connection attempt on every message, while still
+// recovering quickly once the server is healthy again.
+const FAILURE_TTL_MS = 30 * 1000;
+
+/**
+ * In-process TTL cache for MCP capability discovery. Discovery opens several
+ * HTTP connections per integration, so serving repeat lookups from memory
+ * keeps message sends from re-querying every MCP server each time.
+ *
+ * Entries are keyed per integration and user because marketplace integrations
+ * resolve per-user credentials. The cache is per-instance; cross-instance
+ * invalidation is intentionally not handled — the short TTLs bound staleness.
+ */
+@Injectable()
+export class McpCapabilityCacheService {
+  private readonly entries = new Map<string, CacheEntry>();
+
+  getOrLoad(
+    integrationId: UUID,
+    userId: UUID | undefined,
+    loader: () => Promise<DiscoveredCapabilities>,
+  ): Promise<DiscoveredCapabilities> {
+    this.pruneExpired();
+
+    const key = this.buildKey(integrationId, userId);
+    const existing = this.entries.get(key);
+    if (existing) {
+      return existing.promise;
+    }
+
+    // Normalized through Promise.resolve so a synchronously throwing loader
+    // is cached and rethrown like any other failure.
+    const promise = Promise.resolve().then(loader);
+    const entry: CacheEntry = { promise };
+    this.entries.set(key, entry);
+
+    promise.then(
+      () => {
+        entry.expiresAt = Date.now() + SUCCESS_TTL_MS;
+      },
+      () => {
+        entry.expiresAt = Date.now() + FAILURE_TTL_MS;
+      },
+    );
+
+    return promise;
+  }
+
+  /**
+   * Removes cached capabilities for an integration — all users' entries, or
+   * only one user's when `userId` is given (e.g. that user changed their own
+   * credentials and no one else's discovery is affected).
+   */
+  invalidate(integrationId: UUID, userId?: UUID): void {
+    if (userId !== undefined) {
+      this.entries.delete(this.buildKey(integrationId, userId));
+      return;
+    }
+
+    const prefix = `${integrationId}:`;
+    for (const key of this.entries.keys()) {
+      if (key.startsWith(prefix)) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+
+  // Expired entries would otherwise linger until their exact key is accessed
+  // again; sweeping on every lookup bounds the map to live entries. The map
+  // stays small (integrations × active users), so a full scan is cheap.
+  private pruneExpired(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt !== undefined && entry.expiresAt <= now) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  private buildKey(integrationId: UUID, userId: UUID | undefined): string {
+    return `${integrationId}:${userId ?? 'org'}`;
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.spec.ts
@@ -7,6 +7,7 @@ import { DeleteMcpIntegrationCommand } from './delete-mcp-integration.command';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
+import { McpCapabilityCacheService } from '../../services/mcp-capability-cache.service';
 import {
   McpIntegrationNotFoundError,
   McpIntegrationAccessDeniedError,
@@ -21,6 +22,7 @@ describe('DeleteMcpIntegrationUseCase', () => {
   let repository: McpIntegrationsRepositoryPort;
   let userConfigRepository: McpIntegrationUserConfigRepositoryPort;
   let contextService: ContextService;
+  let capabilityCache: McpCapabilityCacheService;
   let loggerLogSpy: jest.SpyInstance;
   let loggerErrorSpy: jest.SpyInstance;
 
@@ -51,6 +53,7 @@ describe('DeleteMcpIntegrationUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeleteMcpIntegrationUseCase,
+        McpCapabilityCacheService,
         {
           provide: McpIntegrationsRepositoryPort,
           useValue: {
@@ -83,6 +86,9 @@ describe('DeleteMcpIntegrationUseCase', () => {
       McpIntegrationUserConfigRepositoryPort,
     );
     contextService = module.get<ContextService>(ContextService);
+    capabilityCache = module.get<McpCapabilityCacheService>(
+      McpCapabilityCacheService,
+    );
 
     // Spy on logger methods
     loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
@@ -91,6 +97,7 @@ describe('DeleteMcpIntegrationUseCase', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    capabilityCache.clear();
   });
 
   describe('execute', () => {
@@ -136,6 +143,30 @@ describe('DeleteMcpIntegrationUseCase', () => {
       expect(userConfigRepository.deleteByIntegrationId).toHaveBeenCalledWith(
         mockIntegrationId,
       );
+    });
+
+    it('should invalidate cached capabilities when deleting an integration', async () => {
+      // Arrange
+      const mockIntegration = buildIntegration();
+
+      jest.spyOn(contextService, 'get').mockReturnValue(mockOrgId);
+      jest.spyOn(repository, 'findById').mockResolvedValue(mockIntegration);
+      jest.spyOn(repository, 'delete').mockResolvedValue(undefined);
+
+      const loader = jest.fn().mockResolvedValue({
+        tools: [],
+        resources: [],
+        resourceTemplates: [],
+        prompts: [],
+      });
+      await capabilityCache.getOrLoad(mockIntegrationId, undefined, loader);
+
+      // Act
+      await useCase.execute(new DeleteMcpIntegrationCommand(mockIntegrationId));
+
+      // Assert
+      await capabilityCache.getOrLoad(mockIntegrationId, undefined, loader);
+      expect(loader).toHaveBeenCalledTimes(2);
     });
 
     it('should throw McpIntegrationNotFoundError when integration does not exist', async () => {
@@ -219,8 +250,8 @@ describe('DeleteMcpIntegrationUseCase', () => {
         UnexpectedMcpError,
       );
       expect(loggerErrorSpy).toHaveBeenCalledWith(
-        'Unexpected error deleting integration',
-        { error: unexpectedError },
+        'Unexpected use-case error',
+        expect.any(String),
       );
     });
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.ts
@@ -3,12 +3,13 @@ import { DeleteMcpIntegrationCommand } from './delete-mcp-integration.command';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
+import { McpCapabilityCacheService } from '../../services/mcp-capability-cache.service';
 import {
   McpIntegrationNotFoundError,
   McpIntegrationAccessDeniedError,
   UnexpectedMcpError,
 } from '../../mcp.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 
 /**
  * Use case for deleting an MCP integration.
@@ -21,6 +22,7 @@ export class DeleteMcpIntegrationUseCase {
     private readonly repository: McpIntegrationsRepositoryPort,
     private readonly userConfigRepository: McpIntegrationUserConfigRepositoryPort,
     private readonly contextService: ContextService,
+    private readonly capabilityCache: McpCapabilityCacheService,
   ) {}
 
   /**
@@ -30,48 +32,35 @@ export class DeleteMcpIntegrationUseCase {
    * @throws McpIntegrationAccessDeniedError if integration belongs to different org
    * @throws UnauthorizedException if user not authenticated
    */
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(command: DeleteMcpIntegrationCommand): Promise<void> {
     this.logger.log('deleteMcpIntegration', { id: command.integrationId });
 
-    try {
-      // Get organization ID from context
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-
-      // Fetch existing integration
-      const integration = await this.repository.findById(command.integrationId);
-      if (!integration) {
-        throw new McpIntegrationNotFoundError(command.integrationId);
-      }
-
-      // Verify access
-      if (integration.orgId !== orgId) {
-        throw new McpIntegrationAccessDeniedError(command.integrationId);
-      }
-
-      // Delete associated user configs before deleting the integration
-      await this.userConfigRepository.deleteByIntegrationId(
-        command.integrationId,
-      );
-
-      // Delete integration
-      await this.repository.delete(command.integrationId);
-    } catch (error) {
-      // Re-throw application errors and auth errors
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-
-      // Log and wrap unexpected errors
-      this.logger.error('Unexpected error deleting integration', {
-        error: error as Error,
-      });
-      throw new UnexpectedMcpError('Unexpected error occurred');
+    // Get organization ID from context
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
     }
+
+    // Fetch existing integration
+    const integration = await this.repository.findById(command.integrationId);
+    if (!integration) {
+      throw new McpIntegrationNotFoundError(command.integrationId);
+    }
+
+    // Verify access
+    if (integration.orgId !== orgId) {
+      throw new McpIntegrationAccessDeniedError(command.integrationId);
+    }
+
+    // Delete associated user configs before deleting the integration
+    await this.userConfigRepository.deleteByIntegrationId(
+      command.integrationId,
+    );
+
+    // Delete integration
+    await this.repository.delete(command.integrationId);
+
+    this.capabilityCache.invalidate(command.integrationId);
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.spec.ts
@@ -6,6 +6,7 @@ import { DiscoverMcpCapabilitiesUseCase } from './discover-mcp-capabilities.use-
 import { DiscoverMcpCapabilitiesQuery } from './discover-mcp-capabilities.query';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpClientService } from '../../services/mcp-client.service';
+import { McpCapabilityCacheService } from '../../services/mcp-capability-cache.service';
 import { ContextService } from 'src/common/context/services/context.service';
 import {
   McpIntegrationNotFoundError,
@@ -24,8 +25,8 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
   let repository: jest.Mocked<McpIntegrationsRepositoryPort>;
   let mcpClientService: jest.Mocked<McpClientService>;
   let contextService: jest.Mocked<ContextService>;
+  let capabilityCache: McpCapabilityCacheService;
   let loggerLogSpy: jest.SpyInstance;
-  let loggerWarnSpy: jest.SpyInstance;
   let loggerErrorSpy: jest.SpyInstance;
 
   const mockOrgId = randomUUID();
@@ -83,6 +84,7 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DiscoverMcpCapabilitiesUseCase,
+        McpCapabilityCacheService,
         {
           provide: McpIntegrationsRepositoryPort,
           useValue: {
@@ -111,14 +113,16 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
     repository = module.get(McpIntegrationsRepositoryPort);
     mcpClientService = module.get(McpClientService);
     contextService = module.get(ContextService);
+    capabilityCache = module.get(McpCapabilityCacheService);
 
     loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    loggerWarnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
     loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
+    capabilityCache.clear();
   });
 
   const arrangeSuccessfulClientCalls = () => {
@@ -232,10 +236,7 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
       ).rejects.toThrow(McpIntegrationNotFoundError);
 
       expect(mcpClientService.listTools).not.toHaveBeenCalled();
-      expect(loggerWarnSpy).toHaveBeenCalledWith(
-        'discoverMcpCapabilitiesFailed',
-        expect.objectContaining({ id: mockIntegrationId }),
-      );
+      expect(loggerErrorSpy).not.toHaveBeenCalled();
     });
 
     it('throws McpIntegrationAccessDeniedError for different organization', async () => {
@@ -274,24 +275,126 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
       expect(repository.findById).not.toHaveBeenCalled();
     });
 
-    it('wraps unexpected errors in UnexpectedMcpError', async () => {
+    it('serves repeated discoveries from the cache without re-contacting the server', async () => {
       const integration = buildPredefinedIntegration();
-      const unexpectedError = new Error('Connection timeout');
+      arrangeSuccessfulClientCalls();
+
+      contextService.get.mockImplementation(mockContextGet);
+      repository.findById.mockResolvedValue(integration);
+
+      const first = await useCase.execute(
+        new DiscoverMcpCapabilitiesQuery(mockIntegrationId),
+      );
+      const second = await useCase.execute(
+        new DiscoverMcpCapabilitiesQuery(mockIntegrationId),
+      );
+
+      expect(second.tools).toHaveLength(first.tools.length);
+      expect(second.resources).toHaveLength(first.resources.length);
+      expect(mcpClientService.listTools).toHaveBeenCalledTimes(1);
+      expect(mcpClientService.listResources).toHaveBeenCalledTimes(1);
+      expect(mcpClientService.listResourceTemplates).toHaveBeenCalledTimes(1);
+      expect(mcpClientService.listPrompts).toHaveBeenCalledTimes(1);
+    });
+
+    it('serves a cached discovery failure without re-contacting the server', async () => {
+      const integration = buildPredefinedIntegration();
+      arrangeSuccessfulClientCalls();
+
+      contextService.get.mockImplementation(mockContextGet);
+      repository.findById.mockResolvedValue(integration);
+      mcpClientService.listTools.mockRejectedValue(
+        new Error('This operation was aborted'),
+      );
+
+      await expect(
+        useCase.execute(new DiscoverMcpCapabilitiesQuery(mockIntegrationId)),
+      ).rejects.toThrow(UnexpectedMcpError);
+      await expect(
+        useCase.execute(new DiscoverMcpCapabilitiesQuery(mockIntegrationId)),
+      ).rejects.toThrow(UnexpectedMcpError);
+
+      expect(mcpClientService.listTools).toHaveBeenCalledTimes(1);
+    });
+
+    it('discovers with the integration state read at load time, not the access-check snapshot', async () => {
+      const staleIntegration = buildPredefinedIntegration({
+        name: 'Before Update',
+      });
+      const updatedIntegration = buildPredefinedIntegration({
+        name: 'After Update',
+      });
+      arrangeSuccessfulClientCalls();
+
+      contextService.get.mockImplementation(mockContextGet);
+      repository.findById
+        .mockResolvedValueOnce(staleIntegration)
+        .mockResolvedValueOnce(updatedIntegration);
+
+      await useCase.execute(
+        new DiscoverMcpCapabilitiesQuery(mockIntegrationId),
+      );
+
+      expect(mcpClientService.listTools).toHaveBeenCalledWith(
+        updatedIntegration,
+        mockUserId,
+      );
+      expect(mcpClientService.listPrompts).toHaveBeenCalledWith(
+        updatedIntegration,
+        mockUserId,
+      );
+    });
+
+    it('re-checks access and enabled state even on a cache hit', async () => {
+      const integration = buildPredefinedIntegration();
+      arrangeSuccessfulClientCalls();
+
+      contextService.get.mockImplementation(mockContextGet);
+      repository.findById.mockResolvedValue(integration);
+
+      await useCase.execute(
+        new DiscoverMcpCapabilitiesQuery(mockIntegrationId),
+      );
+
+      repository.findById.mockResolvedValue(
+        buildPredefinedIntegration({ enabled: false }),
+      );
+
+      await expect(
+        useCase.execute(new DiscoverMcpCapabilitiesQuery(mockIntegrationId)),
+      ).rejects.toThrow(McpIntegrationDisabledError);
+    });
+
+    it('wraps unexpected errors in UnexpectedMcpError without leaking internals', async () => {
+      const integration = buildPredefinedIntegration();
+      const unexpectedError = new Error(
+        'connect ECONNREFUSED internal-db:5432',
+      );
 
       contextService.get.mockImplementation(mockContextGet);
       repository.findById.mockResolvedValue(integration);
       mcpClientService.listTools.mockRejectedValue(unexpectedError);
 
-      await expect(
-        useCase.execute(new DiscoverMcpCapabilitiesQuery(mockIntegrationId)),
-      ).rejects.toThrow(UnexpectedMcpError);
+      const rejection = await useCase
+        .execute(new DiscoverMcpCapabilitiesQuery(mockIntegrationId))
+        .then(
+          () => {
+            throw new Error('expected execute to reject');
+          },
+          (error: unknown) => error,
+        );
 
+      expect(rejection).toBeInstanceOf(UnexpectedMcpError);
+      // The client-facing message and serialized metadata must stay generic;
+      // the original error travels on the non-serialized `cause`.
+      expect((rejection as UnexpectedMcpError).message).toBe(
+        'Unexpected error occurred',
+      );
+      expect((rejection as UnexpectedMcpError).cause).toBe(unexpectedError);
+      expect((rejection as UnexpectedMcpError).metadata).toBeUndefined();
       expect(loggerErrorSpy).toHaveBeenCalledWith(
-        'discoverMcpCapabilitiesUnexpectedError',
-        expect.objectContaining({
-          id: mockIntegrationId,
-          error: 'Connection timeout',
-        }),
+        'Unexpected use-case error',
+        expect.any(String),
       );
     });
   });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.ts
@@ -7,6 +7,10 @@ import {
   McpPrompt as McpPromptDto,
 } from '../../ports/mcp-client.port';
 import { McpClientService } from '../../services/mcp-client.service';
+import {
+  DiscoveredCapabilities,
+  McpCapabilityCacheService,
+} from '../../services/mcp-capability-cache.service';
 import { ContextService } from 'src/common/context/services/context.service';
 import {
   McpIntegrationNotFoundError,
@@ -14,7 +18,8 @@ import {
   McpIntegrationDisabledError,
   UnexpectedMcpError,
 } from '../../mcp.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { McpIntegration } from '../../../domain/mcp-integration.entity';
 import { McpTool } from '../../../domain/mcp-tool.entity';
 import {
   McpResource,
@@ -35,7 +40,9 @@ export interface CapabilitiesResult {
 
 /**
  * Use case for discovering capabilities from an MCP server.
- * Connects to the MCP server and retrieves available tools, resources, and prompts.
+ * Connects to the MCP server and retrieves available tools, resources, and
+ * prompts. Results are served from a short-lived cache so message sends do
+ * not re-query every MCP server; access and enabled checks always run fresh.
  */
 @Injectable()
 export class DiscoverMcpCapabilitiesUseCase {
@@ -45,101 +52,113 @@ export class DiscoverMcpCapabilitiesUseCase {
     private readonly repository: McpIntegrationsRepositoryPort,
     private readonly mcpClientService: McpClientService,
     private readonly contextService: ContextService,
+    private readonly capabilityCache: McpCapabilityCacheService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(
     query: DiscoverMcpCapabilitiesQuery,
   ): Promise<CapabilitiesResult> {
     this.logger.log('discoverMcpCapabilities', { id: query.integrationId });
 
-    try {
-      // Get current user's organization
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
+    const integration = await this.getAuthorizedIntegration(
+      query.integrationId,
+    );
+    const userId = this.contextService.get('userId');
 
-      // Fetch integration
-      const integration = await this.repository.findById(query.integrationId);
-      if (!integration) {
-        throw new McpIntegrationNotFoundError(query.integrationId);
-      }
+    const capabilities = await this.capabilityCache.getOrLoad(
+      query.integrationId,
+      userId,
+      () => this.fetchCapabilities(query.integrationId, userId),
+    );
 
-      // Verify organization access
-      if (integration.orgId !== orgId) {
-        throw new McpIntegrationAccessDeniedError(
-          query.integrationId,
-          integration.name,
-        );
-      }
+    return this.buildResult(integration, capabilities);
+  }
 
-      // Verify integration is enabled
-      if (!integration.enabled) {
-        throw new McpIntegrationDisabledError(
-          query.integrationId,
-          integration.name,
-        );
-      }
+  private async getAuthorizedIntegration(
+    integrationId: UUID,
+  ): Promise<McpIntegration> {
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
+    }
 
-      // Discover capabilities from MCP server
-      const userId = this.contextService.get('userId');
-      const [tools, resources, resourceTemplates, prompts] = await Promise.all([
-        this.mcpClientService.listTools(integration, userId),
-        this.mcpClientService.listResources(integration, userId),
-        this.mcpClientService.listResourceTemplates(integration, userId),
-        this.mcpClientService.listPrompts(integration, userId),
-      ]);
+    const integration = await this.repository.findById(integrationId);
+    if (!integration) {
+      throw new McpIntegrationNotFoundError(integrationId);
+    }
 
-      // Map to domain entities
-      const mcpTools = tools.map((tool) =>
-        this.mapToMcpTool(tool, query.integrationId),
-      );
-      const mcpResources = resources.map((resource) =>
-        this.mapToMcpResource(resource, query.integrationId),
-      );
-      const mcpResourceTemplates = resourceTemplates.map((resourceTemplate) =>
-        this.mapToMcpResource(resourceTemplate, query.integrationId),
-      );
-      const mcpPrompts = prompts.map((prompt) =>
-        this.mapToMcpPrompt(prompt, query.integrationId),
-      );
-
-      this.logger.log('discoverMcpCapabilitiesSucceeded', {
-        id: query.integrationId,
-        name: integration.name,
-        tools: mcpTools.length,
-        resources: mcpResources.length + mcpResourceTemplates.length,
-        prompts: mcpPrompts.length,
-      });
-
-      return {
-        tools: mcpTools,
-        resources: mcpResources.concat(mcpResourceTemplates),
-        prompts: mcpPrompts,
-        returnsPii: integration.returnsPii,
-      };
-    } catch (error) {
-      // Re-throw expected errors
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        this.logger.warn('discoverMcpCapabilitiesFailed', {
-          id: query.integrationId,
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
-        throw error;
-      }
-
-      // Wrap unexpected errors
-      this.logger.error('discoverMcpCapabilitiesUnexpectedError', {
-        id: query.integrationId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new UnexpectedMcpError(
-        error instanceof Error ? error.message : 'Unknown error',
+    if (integration.orgId !== orgId) {
+      throw new McpIntegrationAccessDeniedError(
+        integrationId,
+        integration.name,
       );
     }
+
+    if (!integration.enabled) {
+      throw new McpIntegrationDisabledError(integrationId, integration.name);
+    }
+
+    return integration;
+  }
+
+  private async fetchCapabilities(
+    integrationId: UUID,
+    userId: UUID | undefined,
+  ): Promise<DiscoveredCapabilities> {
+    // Re-read the integration inside the cache's miss path: an update that
+    // commits and invalidates between the access-check read and the cache
+    // insert would otherwise leave a discovery built from the pre-update
+    // snapshot in the cache until the TTL expires.
+    const integration = await this.repository.findById(integrationId);
+    if (!integration) {
+      throw new McpIntegrationNotFoundError(integrationId);
+    }
+
+    const [tools, resources, resourceTemplates, prompts] = await Promise.all([
+      this.mcpClientService.listTools(integration, userId),
+      this.mcpClientService.listResources(integration, userId),
+      this.mcpClientService.listResourceTemplates(integration, userId),
+      this.mcpClientService.listPrompts(integration, userId),
+    ]);
+
+    return { tools, resources, resourceTemplates, prompts };
+  }
+
+  private buildResult(
+    integration: McpIntegration,
+    capabilities: DiscoveredCapabilities,
+  ): CapabilitiesResult {
+    const integrationId = integration.id;
+
+    const mcpTools = capabilities.tools.map((tool) =>
+      this.mapToMcpTool(tool, integrationId),
+    );
+    const mcpResources = capabilities.resources.map((resource) =>
+      this.mapToMcpResource(resource, integrationId),
+    );
+    const mcpResourceTemplates = capabilities.resourceTemplates.map(
+      (resourceTemplate) =>
+        this.mapToMcpResource(resourceTemplate, integrationId),
+    );
+    const mcpPrompts = capabilities.prompts.map((prompt) =>
+      this.mapToMcpPrompt(prompt, integrationId),
+    );
+
+    this.logger.log('discoverMcpCapabilitiesSucceeded', {
+      id: integrationId,
+      name: integration.name,
+      tools: mcpTools.length,
+      resources: mcpResources.length + mcpResourceTemplates.length,
+      prompts: mcpPrompts.length,
+    });
+
+    return {
+      tools: mcpTools,
+      resources: mcpResources.concat(mcpResourceTemplates),
+      prompts: mcpPrompts,
+      returnsPii: integration.returnsPii,
+    };
   }
 
   /**

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.spec.ts
@@ -9,6 +9,7 @@ import { McpIntegrationUserConfig } from 'src/domain/mcp/domain/mcp-integration-
 import { NoAuthMcpIntegrationAuth } from 'src/domain/mcp/domain/auth/no-auth-mcp-integration-auth.entity';
 import { SECRET_MASK } from 'src/domain/mcp/domain/value-objects/secret-mask.constant';
 import { MarketplaceConfigService } from '../../services/marketplace-config.service';
+import { McpCapabilityCacheService } from '../../services/mcp-capability-cache.service';
 import {
   McpIntegrationNotFoundError,
   McpNotMarketplaceIntegrationError,
@@ -16,6 +17,7 @@ import {
   McpIntegrationAccessDeniedError,
   McpInvalidConfigKeysError,
   McpMissingRequiredConfigError,
+  UnexpectedMcpError,
 } from '../../mcp.errors';
 import type { UUID } from 'crypto';
 import type { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
@@ -27,6 +29,7 @@ describe('SetUserMcpConfigUseCase', () => {
   let credentialEncryption: jest.Mocked<McpCredentialEncryptionPort>;
   let contextService: jest.Mocked<ContextService>;
   let marketplaceConfigService: MarketplaceConfigService;
+  let capabilityCache: McpCapabilityCacheService;
 
   const userId = '770e8400-e29b-41d4-a716-446655440001' as UUID;
   const orgId = '660e8400-e29b-41d4-a716-446655440001' as UUID;
@@ -101,11 +104,14 @@ describe('SetUserMcpConfigUseCase', () => {
       credentialEncryption,
     );
 
+    capabilityCache = new McpCapabilityCacheService();
+
     useCase = new SetUserMcpConfigUseCase(
       integrationRepository,
       userConfigRepository,
       contextService,
       marketplaceConfigService,
+      capabilityCache,
     );
   });
 
@@ -142,6 +148,94 @@ describe('SetUserMcpConfigUseCase', () => {
       tenantId: 'my-tenant-123',
     });
     expect(userConfigRepository.save).toHaveBeenCalled();
+  });
+
+  it('should wrap unexpected errors in UnexpectedMcpError', async () => {
+    const integration = createMarketplaceIntegration([
+      {
+        key: 'personalToken',
+        type: 'secret' as const,
+        label: 'Personal Access Token',
+        headerName: 'Authorization',
+        prefix: 'Bearer ',
+        required: false,
+      },
+    ]);
+    integrationRepository.findById.mockResolvedValue(integration);
+    userConfigRepository.save.mockRejectedValue(
+      new Error('Database connection failed'),
+    );
+
+    await expect(
+      useCase.execute(
+        new SetUserMcpConfigCommand(integrationId, {
+          personalToken: 'my-personal-token',
+        }),
+      ),
+    ).rejects.toThrow(UnexpectedMcpError);
+  });
+
+  it('should invalidate cached capabilities after saving user config', async () => {
+    const integration = createMarketplaceIntegration([
+      {
+        key: 'personalToken',
+        type: 'secret' as const,
+        label: 'Personal Access Token',
+        headerName: 'Authorization',
+        prefix: 'Bearer ',
+        required: false,
+      },
+    ]);
+    integrationRepository.findById.mockResolvedValue(integration);
+
+    const loader = jest.fn().mockResolvedValue({
+      tools: [],
+      resources: [],
+      resourceTemplates: [],
+      prompts: [],
+    });
+    await capabilityCache.getOrLoad(integrationId, userId, loader);
+
+    await useCase.execute(
+      new SetUserMcpConfigCommand(integrationId, {
+        personalToken: 'my-personal-token',
+      }),
+    );
+
+    await capabilityCache.getOrLoad(integrationId, userId, loader);
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('should keep other users cached capabilities when one user saves config', async () => {
+    const integration = createMarketplaceIntegration([
+      {
+        key: 'personalToken',
+        type: 'secret' as const,
+        label: 'Personal Access Token',
+        headerName: 'Authorization',
+        prefix: 'Bearer ',
+        required: false,
+      },
+    ]);
+    integrationRepository.findById.mockResolvedValue(integration);
+
+    const otherUserId = '880e8400-e29b-41d4-a716-446655440002' as UUID;
+    const loader = jest.fn().mockResolvedValue({
+      tools: [],
+      resources: [],
+      resourceTemplates: [],
+      prompts: [],
+    });
+    await capabilityCache.getOrLoad(integrationId, otherUserId, loader);
+
+    await useCase.execute(
+      new SetUserMcpConfigCommand(integrationId, {
+        personalToken: 'my-personal-token',
+      }),
+    );
+
+    await capabilityCache.getOrLoad(integrationId, otherUserId, loader);
+    expect(loader).toHaveBeenCalledTimes(1);
   });
 
   it('should update existing user config and return masked result', async () => {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.ts
@@ -10,13 +10,16 @@ import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketpl
 import { ConfigField } from '../../../domain/value-objects/integration-config-schema';
 import { SECRET_MASK } from '../../../domain/value-objects/secret-mask.constant';
 import { MarketplaceConfigService } from '../../services/marketplace-config.service';
+import { McpCapabilityCacheService } from '../../services/mcp-capability-cache.service';
 import {
   McpIntegrationNotFoundError,
   McpIntegrationAccessDeniedError,
   McpNotMarketplaceIntegrationError,
   McpNoUserFieldsError,
   McpInvalidConfigKeysError,
+  UnexpectedMcpError,
 } from '../../mcp.errors';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 
 @Injectable()
 export class SetUserMcpConfigUseCase {
@@ -27,8 +30,10 @@ export class SetUserMcpConfigUseCase {
     private readonly userConfigRepository: McpIntegrationUserConfigRepositoryPort,
     private readonly contextService: ContextService,
     private readonly marketplaceConfigService: MarketplaceConfigService,
+    private readonly capabilityCache: McpCapabilityCacheService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(
     command: SetUserMcpConfigCommand,
   ): Promise<UserMcpConfigResult> {
@@ -44,26 +49,13 @@ export class SetUserMcpConfigUseCase {
       throw new UnauthorizedException('User not authenticated');
     }
 
-    const integration = await this.integrationRepository.findById(
+    const marketplaceIntegration = await this.getMarketplaceIntegrationOrThrow(
       command.integrationId,
+      orgId,
     );
-
-    if (!integration) {
-      throw new McpIntegrationNotFoundError(command.integrationId);
-    }
-
-    if (integration.orgId !== orgId) {
-      throw new McpIntegrationAccessDeniedError(command.integrationId);
-    }
-
-    if (!integration.isMarketplace()) {
-      throw new McpNotMarketplaceIntegrationError(command.integrationId);
-    }
-
-    const marketplaceIntegration = integration as MarketplaceMcpIntegration;
     const { userFields } = marketplaceIntegration.configSchema;
 
-    if (!userFields || userFields.length === 0) {
+    if (userFields.length === 0) {
       throw new McpNoUserFieldsError(command.integrationId);
     }
 
@@ -92,7 +84,31 @@ export class SetUserMcpConfigUseCase {
       existing,
     );
 
+    this.capabilityCache.invalidate(command.integrationId, userId);
+
     return this.maskResult(saved.configValues, userFields);
+  }
+
+  private async getMarketplaceIntegrationOrThrow(
+    integrationId: UUID,
+    orgId: UUID,
+  ): Promise<MarketplaceMcpIntegration> {
+    const integration =
+      await this.integrationRepository.findById(integrationId);
+
+    if (!integration) {
+      throw new McpIntegrationNotFoundError(integrationId);
+    }
+
+    if (integration.orgId !== orgId) {
+      throw new McpIntegrationAccessDeniedError(integrationId);
+    }
+
+    if (!integration.isMarketplace()) {
+      throw new McpNotMarketplaceIntegrationError(integrationId);
+    }
+
+    return integration as MarketplaceMcpIntegration;
   }
 
   private validateConfigKeys(
@@ -114,8 +130,10 @@ export class SetUserMcpConfigUseCase {
    * - If field is missing from new values → keep existing value
    */
   private async mergeUserConfigValues(
-    existingValues: Record<string, string>,
-    providedValues: Record<string, string>,
+    // Values are typed as possibly undefined because record lookups of
+    // missing keys yield undefined at runtime.
+    existingValues: Record<string, string | undefined>,
+    providedValues: Record<string, string | undefined>,
     userFields: ConfigField[],
   ): Promise<Record<string, string>> {
     const merged: Record<string, string> = {};

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
@@ -7,6 +7,7 @@ import type { ContextService } from 'src/common/context/services/context.service
 import type { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
 import { MarketplaceConfigService } from '../../services/marketplace-config.service';
 import { ConnectionValidationService } from '../../services/connection-validation.service';
+import { McpCapabilityCacheService } from '../../services/mcp-capability-cache.service';
 import type { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
 import { CustomMcpIntegration } from 'src/domain/mcp/domain/integrations/custom-mcp-integration.entity';
 import { MarketplaceMcpIntegration } from 'src/domain/mcp/domain/integrations/marketplace-mcp-integration.entity';
@@ -29,6 +30,7 @@ describe('UpdateMcpIntegrationUseCase', () => {
   let marketplaceConfigService: MarketplaceConfigService;
   let validateUseCase: jest.Mocked<ValidateMcpIntegrationUseCase>;
   let connectionValidationService: ConnectionValidationService;
+  let capabilityCache: McpCapabilityCacheService;
   let useCase: UpdateMcpIntegrationUseCase;
 
   beforeEach(() => {
@@ -60,12 +62,15 @@ describe('UpdateMcpIntegrationUseCase', () => {
       repository,
     );
 
+    capabilityCache = new McpCapabilityCacheService();
+
     useCase = new UpdateMcpIntegrationUseCase(
       repository,
       context,
       encryption,
       marketplaceConfigService,
       connectionValidationService,
+      capabilityCache,
     );
     context.get.mockReturnValue(orgId);
     repository.save.mockImplementation(async (integration) => integration);
@@ -107,6 +112,32 @@ describe('UpdateMcpIntegrationUseCase', () => {
       'encrypted-new',
     );
     expect(repository.save).toHaveBeenCalledWith(integration);
+  });
+
+  it('invalidates cached capabilities after an update', async () => {
+    const integration = new CustomMcpIntegration({
+      id: integrationId,
+      orgId,
+      name: 'Old Name',
+      serverUrl: 'https://example.com/mcp',
+      auth: new NoAuthMcpIntegrationAuth(),
+    });
+    repository.findById.mockResolvedValue(integration);
+
+    const loader = jest.fn().mockResolvedValue({
+      tools: [],
+      resources: [],
+      resourceTemplates: [],
+      prompts: [],
+    });
+    await capabilityCache.getOrLoad(integrationId, undefined, loader);
+
+    await useCase.execute(
+      new UpdateMcpIntegrationCommand({ integrationId, name: 'New Name' }),
+    );
+
+    await capabilityCache.getOrLoad(integrationId, undefined, loader);
+    expect(loader).toHaveBeenCalledTimes(2);
   });
 
   it('updates custom header name without encrypting when only header changes', async () => {
@@ -204,6 +235,52 @@ describe('UpdateMcpIntegrationUseCase', () => {
       expect(marketplace.orgConfigValues.endpointUrl).toBe(
         'https://new-endpoint.de/oparl/v1',
       );
+    });
+
+    it('invalidates cached capabilities before connection validation completes', async () => {
+      const integration = createMarketplaceIntegration();
+      repository.findById.mockResolvedValue(integration);
+
+      const loader = jest.fn().mockResolvedValue({
+        tools: [],
+        resources: [],
+        resourceTemplates: [],
+        prompts: [],
+      });
+      await capabilityCache.getOrLoad(integrationId, undefined, loader);
+
+      let resolveValidation!: (value: {
+        isValid: boolean;
+        toolCount: number;
+        resourceCount: number;
+        promptCount: number;
+      }) => void;
+      validateUseCase.execute.mockReturnValue(
+        new Promise((resolve) => {
+          resolveValidation = resolve;
+        }),
+      );
+
+      const pending = useCase.execute(
+        new UpdateMcpIntegrationCommand({
+          integrationId,
+          orgConfigValues: { endpointUrl: 'https://new-endpoint.de/oparl/v1' },
+        }),
+      );
+
+      // Let execute progress up to the in-flight connection validation.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      await capabilityCache.getOrLoad(integrationId, undefined, loader);
+      expect(loader).toHaveBeenCalledTimes(2);
+
+      resolveValidation({
+        isValid: true,
+        toolCount: 3,
+        resourceCount: 0,
+        promptCount: 0,
+      });
+      await pending;
     });
 
     it('retains existing encrypted value for omitted secret fields', async () => {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.ts
@@ -9,7 +9,7 @@ import {
   McpNotMarketplaceIntegrationError,
   UnexpectedMcpError,
 } from '../../mcp.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { McpIntegration } from '../../../domain/mcp-integration.entity';
 import { McpCredentialEncryptionPort } from '../../ports/mcp-credential-encryption.port';
 import { McpAuthMethod } from '../../../domain/value-objects/mcp-auth-method.enum';
@@ -19,6 +19,7 @@ import { McpValidationFailedError } from '../../mcp.errors';
 import { MarketplaceMcpIntegration } from '../../../domain/integrations/marketplace-mcp-integration.entity';
 import { MarketplaceConfigService } from '../../services/marketplace-config.service';
 import { ConnectionValidationService } from '../../services/connection-validation.service';
+import { McpCapabilityCacheService } from '../../services/mcp-capability-cache.service';
 
 @Injectable()
 export class UpdateMcpIntegrationUseCase {
@@ -30,72 +31,90 @@ export class UpdateMcpIntegrationUseCase {
     private readonly credentialEncryption: McpCredentialEncryptionPort,
     private readonly marketplaceConfigService: MarketplaceConfigService,
     private readonly connectionValidationService: ConnectionValidationService,
+    private readonly capabilityCache: McpCapabilityCacheService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(command: UpdateMcpIntegrationCommand): Promise<McpIntegration> {
     this.logger.log('updateMcpIntegration', { id: command.integrationId });
 
-    try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
+    const integration = await this.getAuthorizedIntegration(
+      command.integrationId as UUID,
+    );
 
-      const integration = await this.repository.findById(
-        command.integrationId as UUID,
-      );
-      if (!integration) {
-        throw new McpIntegrationNotFoundError(command.integrationId);
-      }
+    await this.applyUpdates(integration, command);
 
-      if (integration.orgId !== orgId) {
-        throw new McpIntegrationAccessDeniedError(command.integrationId);
-      }
+    const saved = await this.repository.save(integration);
 
-      // Update fields (only if provided)
-      if (command.name !== undefined) {
-        integration.updateName(command.name);
-      }
+    // Invalidate as soon as the new config is committed — the connection
+    // validation below runs live MCP requests that can take tens of seconds,
+    // and cached discoveries must not keep serving the pre-update tool list
+    // for that long.
+    this.capabilityCache.invalidate(command.integrationId as UUID);
 
-      if (command.returnsPii !== undefined) {
-        integration.updateReturnsPii(command.returnsPii);
-      }
+    return this.validateConnectionIfNeeded(saved, command);
+  }
 
-      if (
-        command.credentials !== undefined ||
-        command.authHeaderName !== undefined
-      ) {
-        await this.rotateCredentials(
-          integration,
-          command.credentials,
-          command.authHeaderName,
-        );
-      }
-
-      if (command.orgConfigValues !== undefined) {
-        await this.updateOrgConfigValues(integration, command.orgConfigValues);
-      }
-
-      let saved = await this.repository.save(integration);
-
-      if (command.orgConfigValues !== undefined) {
-        saved =
-          await this.connectionValidationService.validateAndUpdateStatus(saved);
-      }
-
-      return saved;
-    } catch (error) {
-      if (
-        error instanceof ApplicationError ||
-        error instanceof UnauthorizedException
-      ) {
-        throw error;
-      }
-      this.logger.error('Unexpected error updating integration', {
-        error: error as Error,
-      });
-      throw new UnexpectedMcpError('Unexpected error occurred');
+  private async getAuthorizedIntegration(
+    integrationId: UUID,
+  ): Promise<McpIntegration> {
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
     }
+
+    const integration = await this.repository.findById(integrationId);
+    if (!integration) {
+      throw new McpIntegrationNotFoundError(integrationId);
+    }
+
+    if (integration.orgId !== orgId) {
+      throw new McpIntegrationAccessDeniedError(integrationId);
+    }
+
+    return integration;
+  }
+
+  // Update fields (only if provided)
+  private async applyUpdates(
+    integration: McpIntegration,
+    command: UpdateMcpIntegrationCommand,
+  ): Promise<void> {
+    if (command.name !== undefined) {
+      integration.updateName(command.name);
+    }
+
+    if (command.returnsPii !== undefined) {
+      integration.updateReturnsPii(command.returnsPii);
+    }
+
+    if (
+      command.credentials !== undefined ||
+      command.authHeaderName !== undefined
+    ) {
+      await this.rotateCredentials(
+        integration,
+        command.credentials,
+        command.authHeaderName,
+      );
+    }
+
+    if (command.orgConfigValues !== undefined) {
+      await this.updateOrgConfigValues(integration, command.orgConfigValues);
+    }
+  }
+
+  private async validateConnectionIfNeeded(
+    integration: McpIntegration,
+    command: UpdateMcpIntegrationCommand,
+  ): Promise<McpIntegration> {
+    if (command.orgConfigValues !== undefined) {
+      return this.connectionValidationService.validateAndUpdateStatus(
+        integration,
+      );
+    }
+
+    return integration;
   }
 
   private async updateOrgConfigValues(
@@ -120,8 +139,7 @@ export class UpdateMcpIntegrationUseCase {
     credentials?: string,
     authHeaderName?: string,
   ): Promise<void> {
-    const auth = integration.auth;
-    const authMethod = auth.getMethod();
+    const authMethod = integration.auth.getMethod();
 
     switch (authMethod) {
       case McpAuthMethod.NO_AUTH: {
@@ -134,50 +152,14 @@ export class UpdateMcpIntegrationUseCase {
         }
         return;
       }
-      case McpAuthMethod.BEARER_TOKEN: {
-        if (authHeaderName !== undefined) {
-          throw new McpValidationFailedError(
-            integration.id,
-            integration.name,
-            'Bearer token integrations always use the Authorization header.',
-          );
-        }
-
-        if (credentials === undefined) {
-          return;
-        }
-
-        const encryptedToken =
-          await this.credentialEncryption.encrypt(credentials);
-        (auth as BearerMcpIntegrationAuth).setToken(encryptedToken);
-        return;
-      }
-      case McpAuthMethod.CUSTOM_HEADER: {
-        const customAuth = auth as CustomHeaderMcpIntegrationAuth;
-
-        if (credentials !== undefined) {
-          const encryptedSecret =
-            await this.credentialEncryption.encrypt(credentials);
-          const headerNameToUse =
-            authHeaderName ?? customAuth.getAuthHeaderName();
-          customAuth.setSecret(encryptedSecret, headerNameToUse);
-          return;
-        }
-
-        if (authHeaderName !== undefined) {
-          const currentSecret = customAuth.secret;
-          if (!currentSecret) {
-            throw new McpValidationFailedError(
-              integration.id,
-              integration.name,
-              'Credentials must be configured before updating the header name.',
-            );
-          }
-
-          customAuth.setSecret(currentSecret, authHeaderName);
-        }
-        return;
-      }
+      case McpAuthMethod.BEARER_TOKEN:
+        return this.rotateBearerToken(integration, credentials, authHeaderName);
+      case McpAuthMethod.CUSTOM_HEADER:
+        return this.rotateCustomHeader(
+          integration,
+          credentials,
+          authHeaderName,
+        );
       case McpAuthMethod.OAUTH: {
         if (credentials !== undefined || authHeaderName !== undefined) {
           throw new McpValidationFailedError(
@@ -189,5 +171,57 @@ export class UpdateMcpIntegrationUseCase {
         return;
       }
     }
+  }
+
+  private async rotateBearerToken(
+    integration: McpIntegration,
+    credentials?: string,
+    authHeaderName?: string,
+  ): Promise<void> {
+    if (authHeaderName !== undefined) {
+      throw new McpValidationFailedError(
+        integration.id,
+        integration.name,
+        'Bearer token integrations always use the Authorization header.',
+      );
+    }
+
+    if (credentials === undefined) {
+      return;
+    }
+
+    const encryptedToken = await this.credentialEncryption.encrypt(credentials);
+    (integration.auth as BearerMcpIntegrationAuth).setToken(encryptedToken);
+  }
+
+  private async rotateCustomHeader(
+    integration: McpIntegration,
+    credentials?: string,
+    authHeaderName?: string,
+  ): Promise<void> {
+    const customAuth = integration.auth as CustomHeaderMcpIntegrationAuth;
+
+    if (credentials !== undefined) {
+      const encryptedSecret =
+        await this.credentialEncryption.encrypt(credentials);
+      const headerNameToUse = authHeaderName ?? customAuth.getAuthHeaderName();
+      customAuth.setSecret(encryptedSecret, headerNameToUse);
+      return;
+    }
+
+    if (authHeaderName === undefined) {
+      return;
+    }
+
+    const currentSecret = customAuth.secret;
+    if (!currentSecret) {
+      throw new McpValidationFailedError(
+        integration.id,
+        integration.name,
+        'Credentials must be configured before updating the header name.',
+      );
+    }
+
+    customAuth.setSecret(currentSecret, authHeaderName);
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.spec.ts
@@ -1,0 +1,214 @@
+import { Logger } from '@nestjs/common';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { McpSdkClientAdapter } from './mcp-sdk-client.adapter';
+import type { McpConnectionConfig } from '../../application/ports/mcp-client.port';
+
+jest.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: jest.fn(),
+}));
+jest.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: jest.fn(),
+}));
+
+const REQUEST_TIMEOUT = { timeout: 30000 };
+
+describe('McpSdkClientAdapter', () => {
+  let adapter: McpSdkClientAdapter;
+  let clientMock: {
+    connect: jest.Mock;
+    close: jest.Mock;
+    listTools: jest.Mock;
+    listResources: jest.Mock;
+    listResourceTemplates: jest.Mock;
+    listPrompts: jest.Mock;
+    callTool: jest.Mock;
+    readResource: jest.Mock;
+    getPrompt: jest.Mock;
+  };
+
+  const config: McpConnectionConfig = {
+    serverUrl: 'https://mcp.example.com/mcp',
+    headers: { Authorization: 'Bearer token-value' },
+  };
+
+  const buildAbortError = () => {
+    const error = new Error('This operation was aborted');
+    error.name = 'AbortError';
+    return error;
+  };
+
+  beforeEach(() => {
+    clientMock = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      close: jest.fn().mockResolvedValue(undefined),
+      listTools: jest.fn().mockResolvedValue({ tools: [] }),
+      listResources: jest.fn().mockResolvedValue({ resources: [] }),
+      listResourceTemplates: jest
+        .fn()
+        .mockResolvedValue({ resourceTemplates: [] }),
+      listPrompts: jest.fn().mockResolvedValue({ prompts: [] }),
+      callTool: jest.fn().mockResolvedValue({ content: [], isError: false }),
+      readResource: jest.fn().mockResolvedValue({
+        contents: [{ text: 'resource text', mimeType: 'text/plain' }],
+      }),
+      getPrompt: jest.fn().mockResolvedValue({ messages: [] }),
+    };
+    (Client as unknown as jest.Mock).mockImplementation(() => clientMock);
+
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+    adapter = new McpSdkClientAdapter();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('listTools', () => {
+    it('returns the tools reported by the server', async () => {
+      const tools = [
+        {
+          name: 'search_registry',
+          description: 'Search the registry',
+          inputSchema: { type: 'object' },
+        },
+      ];
+      clientMock.listTools.mockResolvedValue({ tools });
+
+      await expect(adapter.listTools(config)).resolves.toEqual(tools);
+      expect(clientMock.close).toHaveBeenCalled();
+    });
+
+    it('enforces the timeout through the SDK request options', async () => {
+      await adapter.listTools(config);
+
+      expect(clientMock.connect).toHaveBeenCalledWith(
+        expect.anything(),
+        REQUEST_TIMEOUT,
+      );
+      expect(clientMock.listTools).toHaveBeenCalledWith(
+        undefined,
+        REQUEST_TIMEOUT,
+      );
+    });
+
+    it('still returns the result when closing the client fails', async () => {
+      const tools = [
+        {
+          name: 'search_registry',
+          description: 'Search the registry',
+          inputSchema: { type: 'object' },
+        },
+      ];
+      clientMock.listTools.mockResolvedValue({ tools });
+      clientMock.close.mockRejectedValue(buildAbortError());
+
+      await expect(adapter.listTools(config)).resolves.toEqual(tools);
+    });
+
+    it('preserves the operation error when closing the client also fails', async () => {
+      clientMock.listTools.mockRejectedValue(
+        new Error('MCP error -32001: Request timed out'),
+      );
+      clientMock.close.mockRejectedValue(buildAbortError());
+
+      await expect(adapter.listTools(config)).rejects.toThrow(
+        'Request timed out',
+      );
+    });
+
+    it('closes the client when the operation fails', async () => {
+      clientMock.listTools.mockRejectedValue(new Error('boom'));
+
+      await expect(adapter.listTools(config)).rejects.toThrow('boom');
+      expect(clientMock.close).toHaveBeenCalled();
+    });
+  });
+
+  describe('request timeout forwarding', () => {
+    it('passes the timeout to listResources', async () => {
+      await adapter.listResources(config);
+
+      expect(clientMock.listResources).toHaveBeenCalledWith(
+        undefined,
+        REQUEST_TIMEOUT,
+      );
+    });
+
+    it('passes the timeout to listResourceTemplates', async () => {
+      await adapter.listResourceTemplates(config);
+
+      expect(clientMock.listResourceTemplates).toHaveBeenCalledWith(
+        undefined,
+        REQUEST_TIMEOUT,
+      );
+    });
+
+    it('passes the timeout to listPrompts', async () => {
+      await adapter.listPrompts(config);
+
+      expect(clientMock.listPrompts).toHaveBeenCalledWith(
+        undefined,
+        REQUEST_TIMEOUT,
+      );
+    });
+
+    it('passes the timeout to callTool after the result schema slot', async () => {
+      await adapter.callTool(config, {
+        toolName: 'search_registry',
+        parameters: { query: 'water supply' },
+      });
+
+      expect(clientMock.callTool).toHaveBeenCalledWith(
+        { name: 'search_registry', arguments: { query: 'water supply' } },
+        undefined,
+        REQUEST_TIMEOUT,
+      );
+    });
+
+    it('passes the timeout to readResource', async () => {
+      await adapter.readResource(config, 'file://static.txt');
+
+      expect(clientMock.readResource).toHaveBeenCalledWith(
+        { uri: 'file://static.txt' },
+        REQUEST_TIMEOUT,
+      );
+    });
+
+    it('passes the timeout to getPrompt', async () => {
+      await adapter.getPrompt(config, 'summarize', { topic: 'roads' });
+
+      expect(clientMock.getPrompt).toHaveBeenCalledWith(
+        { name: 'summarize', arguments: { topic: 'roads' } },
+        REQUEST_TIMEOUT,
+      );
+    });
+  });
+
+  describe('validateConnection', () => {
+    it('reports the connection as valid when all listings succeed', async () => {
+      await expect(adapter.validateConnection(config)).resolves.toEqual({
+        valid: true,
+      });
+    });
+
+    it('reports the connection as valid even when closing the client fails', async () => {
+      clientMock.close.mockRejectedValue(buildAbortError());
+
+      await expect(adapter.validateConnection(config)).resolves.toEqual({
+        valid: true,
+      });
+    });
+
+    it('reports the underlying error message when a listing fails', async () => {
+      clientMock.listResources.mockRejectedValue(
+        new Error('MCP error -32001: Request timed out'),
+      );
+
+      await expect(adapter.validateConnection(config)).resolves.toEqual({
+        valid: false,
+        error: 'MCP error -32001: Request timed out',
+      });
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.ts
@@ -18,31 +18,28 @@ import {
  * Uses on-demand connection strategy:
  * - Creates new connection for each operation
  * - Closes connection immediately after operation completes
- * - Enforces 30-second timeout on all operations
+ * - Enforces a 30-second timeout via the SDK's per-request options, so the
+ *   SDK aborts its own request cleanly instead of leaving it in flight
  *
  * Uses Streamable HTTP transport for HTTP-based connections (MCP protocol 2024-11-05+).
  */
 @Injectable()
 export class McpSdkClientAdapter extends McpClientPort {
   private readonly logger = new Logger(McpSdkClientAdapter.name);
-  private readonly TIMEOUT_MS = 30000; // 30 seconds
+  private readonly requestOptions = { timeout: 30000 };
 
   /**
    * List all tools available on the MCP server
    */
   async listTools(config: McpConnectionConfig): Promise<McpTool[]> {
-    let client: Client | null = null;
+    const client = await this.createClient(config);
 
     try {
-      client = await this.createClient(config);
-
-      const result = await this.withTimeout(client.listTools());
+      const result = await client.listTools(undefined, this.requestOptions);
 
       return result.tools;
     } finally {
-      if (client) {
-        await client.close();
-      }
+      await this.closeQuietly(client);
     }
   }
 
@@ -50,18 +47,14 @@ export class McpSdkClientAdapter extends McpClientPort {
    * List all resources available on the MCP server
    */
   async listResources(config: McpConnectionConfig): Promise<McpResource[]> {
-    let client: Client | null = null;
+    const client = await this.createClient(config);
 
     try {
-      client = await this.createClient(config);
-
-      const result = await this.withTimeout(client.listResources());
+      const result = await client.listResources(undefined, this.requestOptions);
 
       return result.resources;
     } finally {
-      if (client) {
-        await client.close();
-      }
+      await this.closeQuietly(client);
     }
   }
 
@@ -71,11 +64,13 @@ export class McpSdkClientAdapter extends McpClientPort {
   async listResourceTemplates(
     config: McpConnectionConfig,
   ): Promise<McpResource[]> {
-    let client: Client | null = null;
+    const client = await this.createClient(config);
 
     try {
-      client = await this.createClient(config);
-      const result = await this.withTimeout(client.listResourceTemplates());
+      const result = await client.listResourceTemplates(
+        undefined,
+        this.requestOptions,
+      );
 
       return result.resourceTemplates.map((resourceTemplate) => ({
         uri: resourceTemplate.uriTemplate,
@@ -84,9 +79,7 @@ export class McpSdkClientAdapter extends McpClientPort {
         mimeType: resourceTemplate.mimeType,
       }));
     } finally {
-      if (client) {
-        await client.close();
-      }
+      await this.closeQuietly(client);
     }
   }
 
@@ -94,18 +87,14 @@ export class McpSdkClientAdapter extends McpClientPort {
    * List all prompt templates available on the MCP server
    */
   async listPrompts(config: McpConnectionConfig): Promise<McpPrompt[]> {
-    let client: Client | null = null;
+    const client = await this.createClient(config);
 
     try {
-      client = await this.createClient(config);
-
-      const result = await this.withTimeout(client.listPrompts());
+      const result = await client.listPrompts(undefined, this.requestOptions);
 
       return result.prompts;
     } finally {
-      if (client) {
-        await client.close();
-      }
+      await this.closeQuietly(client);
     }
   }
 
@@ -116,16 +105,16 @@ export class McpSdkClientAdapter extends McpClientPort {
     config: McpConnectionConfig,
     call: McpToolCall,
   ): Promise<McpToolResult> {
-    let client: Client | null = null;
+    const client = await this.createClient(config);
 
     try {
-      client = await this.createClient(config);
-
-      const result = await this.withTimeout(
-        client.callTool({
+      const result = await client.callTool(
+        {
           name: call.toolName,
           arguments: call.parameters,
-        }),
+        },
+        undefined,
+        this.requestOptions,
       );
 
       return {
@@ -133,9 +122,7 @@ export class McpSdkClientAdapter extends McpClientPort {
         isError: Boolean(result.isError),
       };
     } finally {
-      if (client) {
-        await client.close();
-      }
+      await this.closeQuietly(client);
     }
   }
 
@@ -147,14 +134,12 @@ export class McpSdkClientAdapter extends McpClientPort {
     uri: string,
     parameters?: Record<string, unknown>,
   ): Promise<{ content: unknown; mimeType: string }> {
-    let client: Client | null = null;
+    const client = await this.createClient(config);
 
     try {
-      client = await this.createClient(config);
-
       const request = parameters ? { uri, arguments: parameters } : { uri };
 
-      const result = await this.withTimeout(client.readResource(request));
+      const result = await client.readResource(request, this.requestOptions);
 
       // MCP resources can have text or blob content
       const firstContent = result.contents[0];
@@ -166,9 +151,7 @@ export class McpSdkClientAdapter extends McpClientPort {
         mimeType: firstContent.mimeType || 'text/plain',
       };
     } finally {
-      if (client) {
-        await client.close();
-      }
+      await this.closeQuietly(client);
     }
   }
 
@@ -180,25 +163,22 @@ export class McpSdkClientAdapter extends McpClientPort {
     name: string,
     args: Record<string, string>,
   ): Promise<{ messages: unknown[] }> {
-    let client: Client | null = null;
+    const client = await this.createClient(config);
 
     try {
-      client = await this.createClient(config);
-
-      const result = await this.withTimeout(
-        client.getPrompt({
+      const result = await client.getPrompt(
+        {
           name,
           arguments: args,
-        }),
+        },
+        this.requestOptions,
       );
 
       return {
         messages: result.messages,
       };
     } finally {
-      if (client) {
-        await client.close();
-      }
+      await this.closeQuietly(client);
     }
   }
 
@@ -215,9 +195,9 @@ export class McpSdkClientAdapter extends McpClientPort {
       client = await this.createClient(config);
 
       // Try to list all capabilities to validate connection
-      await this.withTimeout(client.listTools());
-      await this.withTimeout(client.listResources());
-      await this.withTimeout(client.listPrompts());
+      await client.listTools(undefined, this.requestOptions);
+      await client.listResources(undefined, this.requestOptions);
+      await client.listPrompts(undefined, this.requestOptions);
 
       return { valid: true };
     } catch (error) {
@@ -232,7 +212,7 @@ export class McpSdkClientAdapter extends McpClientPort {
       };
     } finally {
       if (client) {
-        await client.close();
+        await this.closeQuietly(client);
       }
     }
   }
@@ -256,23 +236,25 @@ export class McpSdkClientAdapter extends McpClientPort {
     // Create client with capabilities
     const client = new Client({ name: 'ayunis-core', version: '1.0.0' });
 
-    // Connect to server
-    await client.connect(transport);
+    // Connect to server (covers the initialize handshake with the same timeout)
+    await client.connect(transport, this.requestOptions);
 
     return client;
   }
 
   /**
-   * Wrap a promise with timeout enforcement
+   * close() aborts the transport, which can itself reject (e.g. AbortError
+   * from an in-flight SSE stream). Running in a finally block, that rejection
+   * would replace the operation's actual result or error — so it is only
+   * logged, never rethrown.
    */
-  private async withTimeout<T>(promise: Promise<T>): Promise<T> {
-    const timeoutPromise = new Promise<never>((_, reject) =>
-      setTimeout(
-        () => reject(new Error('MCP request timeout')),
-        this.TIMEOUT_MS,
-      ),
-    );
-
-    return Promise.race([promise, timeoutPromise]);
+  private async closeQuietly(client: Client): Promise<void> {
+    try {
+      await client.close();
+    } catch (error) {
+      this.logger.warn('Failed to close MCP client', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/mcp.module.ts
+++ b/ayunis-core-backend/src/domain/mcp/mcp.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { McpCredentialEncryptionPort } from './application/ports/mcp-credential-encryption.port';
 import { McpCredentialEncryptionService } from './infrastructure/encryption/mcp-credential-encryption.service';
 import { McpClientPort } from './application/ports/mcp-client.port';
+import { McpCapabilityCacheService } from './application/services/mcp-capability-cache.service';
 import { McpSdkClientAdapter } from './infrastructure/clients/mcp-sdk-client.adapter';
 import { McpClientService } from './application/services/mcp-client.service';
 import { MarketplaceConfigService } from './application/services/marketplace-config.service';
@@ -95,6 +96,7 @@ import { PredefinedConfigDtoMapper } from './presenters/http/mappers/predefined-
     McpIntegrationFactory,
     McpIntegrationAuthFactory,
     McpClientService,
+    McpCapabilityCacheService,
     MarketplaceConfigService,
     ConnectionValidationService,
     PredefinedMcpIntegrationRegistry,


### PR DESCRIPTION
## Problem

Production AppSignal has been flooded with MCP-related incidents during `POST /api/runs/send-message` and `POST /api/mcp-integrations/:id/validate`:

- `20: This operation was aborted` (incidents #278, #451) — raw `AbortError`s from in-flight fetches to MCP servers
- Every message send re-discovers MCP capabilities live: **4 fresh connections + initialize handshakes per integration per message**, so a slow MCP server times out constantly and the assistant silently loses that integration's tools for the message

Root causes in `McpSdkClientAdapter`:

1. The homemade `Promise.race` 30s timeout never cancelled the underlying SDK request; the `finally { await client.close() }` then aborted the still-pending fetch, and a throwing `close()` **replaced the real result or error** of the operation with a raw `AbortError`.
2. Capability discovery had no caching whatsoever.

## Changes

**Adapter (`mcp-sdk-client.adapter.ts`)**
- Enforce the 30s timeout through the SDK's per-request options (`connect()` included) so the SDK aborts its own requests cleanly and throws a meaningful `MCP error -32001: Request timed out`
- `closeQuietly()`: `close()` failures are logged, never rethrown — a failing close can no longer mask the operation's result or error
- Removes the leaked `setTimeout` from `Promise.race` (also fixed Jest's "did not exit" warning)

**Capability caching (`McpCapabilityCacheService`, new)**
- In-process TTL cache keyed by integration + user: 5 min success TTL, 30 s failure TTL (so a down server isn't hammered with 30s-timeout attempts on every message but recovers quickly), concurrent callers share one in-flight discovery
- `DiscoverMcpCapabilitiesUseCase` serves discovery from the cache; access/enabled checks still run fresh on every call
- Cache invalidated on integration update, delete, and per-user config changes

**Error boundaries via `@HandleUnexpectedErrors`**
- The four touched use cases (discover, update, delete, set-user-config) now use the shared decorator instead of hand-written try/catch translate blocks; `set-user-mcp-config` previously had no error boundary at all
- `UnexpectedMcpError` accepts `string | Error` so the decorator works while the module's remaining string call sites stay untouched (full migration follows the module-by-module series)

**Race fix (Bugbot finding)**
- The discovery loader re-reads the integration inside the cache's miss path, so an update that commits and invalidates between the access-check read and the cache insert can no longer leave a stale discovery cached until TTL expiry

**Cache hardening (review follow-ups)**
- `invalidate(integrationId, userId?)`: a user saving their own config no longer evicts other users' or the org's cached discovery
- Pending entries carry no expiry, so in-flight loads are always shared; expired entries are pruned on every lookup instead of lingering until their key is hit again; synchronously throwing loaders are normalized into cached failures; `DiscoveredCapabilities` is readonly
- Update use case invalidates the cache immediately after the DB commit, *before* the live connection validation — otherwise stale tool lists could be served for the duration of the validation's MCP round-trips (Bugbot finding)

**Security (Bugbot finding)**
- `UnexpectedMcpError`'s Error path now returns the generic message to clients and carries the wrapped error on the non-serialized `Error.cause` — `toHttpException()` serializes message and metadata into the response body, so raw internals (driver queries, request configs, upstream error text) must never ride there

**Complexity-gate refactors (behavior unchanged)**
- Split `execute`/`rotateCredentials` in `update-mcp-integration.use-case.ts` and `execute` in `set-user-mcp-config.use-case.ts` — pre-existing violations that block commits on changed files

## Validation

- 27 new/updated tests (adapter close-masking + timeout forwarding, cache TTL/failure/invalidation semantics, discovery cache behavior)
- Full backend suite: 3606 tests, 515 suites, all green
- `tsc --noEmit`, ESLint (`--max-warnings=0` scope), CI-equivalent complexity gate, dependency-cruiser, markdownlint: all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes message-send and discovery paths (caching can serve slightly stale tool lists until TTL/invalidation) and MCP HTTP client behavior; mitigated by invalidation hooks and fresh auth checks, but multi-instance deployments only get per-process cache coherence.
> 
> **Overview**
> **MCP capability discovery** now goes through a new in-process `McpCapabilityCacheService` (5 min success / 30 s failure TTL, per integration + user, shared in-flight loads). `DiscoverMcpCapabilitiesUseCase` serves cached tools/resources/prompts while still re-checking org access and enabled state on every call; the cache loader re-fetches the integration so post-update invalidation cannot leave stale snapshots. Cache entries are cleared on integration update/delete and on per-user marketplace config saves (other users’ entries unchanged).
> 
> **`McpSdkClientAdapter`** drops the homemade `Promise.race` timeout in favor of the SDK’s 30 s request options on connect and all RPCs, and **`closeQuietly`** so a failing `close()` no longer masks the real result or error (addressing production `AbortError` noise).
> 
> **Error handling:** `UnexpectedMcpError` accepts `string | Error` with generic API messages and `cause` for internals; discover/update/delete/set-user-config use `@HandleUnexpectedErrors` instead of hand-written catch blocks (including a new boundary on set-user-config).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b799a5c7708dc6e6c4dcdae2f509bbe261ca2db3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->