### PR TITLE
ci: reclaim disk before pulling images on staging (AYC-589)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -56,6 +56,81 @@ jobs:
             # was never published.
             export CORE_TAG="sha-$(git rev-parse HEAD | cut -c1-7)"
             echo "Deploying $CORE_TAG"
+
+            # Reclaiming images used to be the last thing this script did, so a
+            # pull that ran out of disk exited before it — nothing was freed and
+            # every later deploy hit the same wall until someone cleaned the host
+            # by hand. Running it before the pull as well is what makes the
+            # failure recoverable instead of self-perpetuating.
+            reclaim_images() {
+              # Images built on the host before the GHCR switch. The base compose
+              # declares `build:` with no `image:`, so those builds are tagged
+              # `ayunis-core-*` with no registry prefix — the ghcr.io/... filter
+              # below never matches them, and `prune -f` skips them because they
+              # are tagged, not dangling. The migration left a full duplicate set
+              # (9.1 GB on staging) that nothing collected.
+              docker images --filter "reference=ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
+                | xargs -r docker rmi || true
+              # Superseded Core tags — pulled images are tagged, not dangling, so
+              # `prune -f` alone would never touch them and every main push would
+              # add four. `prune -a` is the wrong tool here: the sandbox image is
+              # referenced only by ephemeral per-execution containers, so it
+              # always looks unused, and no `until=` cut-off saves it either — a
+              # cache-hit rebuild keeps the original Created date, so a freshly
+              # pulled sandbox tag can already read as weeks old. Deleting exactly
+              # the Core tags that aren't the one being deployed cannot touch what
+              # this deploy pulls. Superseded tags stay in GHCR, so a rollback
+              # re-pulls them.
+              #
+              # Running this *before* the swap is safe for the compose services
+              # because `docker rmi` refuses to remove an image a running
+              # container uses — that refusal is what spares the generation still
+              # serving traffic, so the `|| true` is load-bearing rather than
+              # defensive. The sandbox is the one image that refusal cannot
+              # protect, hence keep-sandbox below.
+              #
+              # The pattern is `ayunis-core-*`, not `*`: the hosts run other
+              # images from this org namespace (ayunis-backup), and matching the
+              # whole namespace made the deploy try to delete them.
+              victims=$(docker images --filter "reference=ghcr.io/ayunis-core/ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
+                | grep -v ":${CORE_TAG}$" || true)
+              if [ "${1:-}" = "keep-sandbox" ]; then
+                victims=$(printf '%s\n' "$victims" | grep -v 'ayunis-core-python-sandbox' || true)
+              fi
+              printf '%s\n' "$victims" | grep -v '^$' | xargs -r docker rmi || true
+              docker image prune -f
+            }
+
+            # Spare the sandbox here. Nothing long-lived holds that image — the
+            # per-execution containers are transient — so `docker rmi` will
+            # happily delete the tag the *running* code-execution service still
+            # points DOCKER_IMAGE at. It pulls the sandbox only when it is
+            # constructed (executor.py:28), and the execution path uses
+            # containers.create, which never pulls. So deleting it here and then
+            # failing the pull would leave code execution broken for as long as
+            # the deploy stays aborted — defeating the whole point of keeping the
+            # current containers up.
+            reclaim_images keep-sandbox
+
+            # Fail here rather than mid-blob: a full disk otherwise surfaces as
+            # `write /var/lib/docker/tmp/GetImageBlob...: no space left on
+            # device` buried in progress output. The headroom has to cover a
+            # second copy of every Core image while the current ones still serve
+            # traffic, and anonymize alone is ~6 GB of that — so this can be
+            # lowered once that image sheds its CUDA payload. Erring high only
+            # costs a clear refusal to deploy; erring low costs a failed pull
+            # that leaves a half-fetched generation behind.
+            # `/` rather than /var/lib/docker: the
+            # deploy user cannot traverse the docker root, and these hosts run a
+            # single root filesystem.
+            MIN_FREE_GB=9
+            FREE_GB=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+            echo "Free disk: ${FREE_GB:-0}G (need ${MIN_FREE_GB}G)"
+            if [ "${FREE_GB:-0}" -lt "$MIN_FREE_GB" ]; then
+              echo "::error::only ${FREE_GB:-0}G free, need ${MIN_FREE_GB}G — not deploying"
+              exit 1
+            fi
+
             # Pull while the old containers still serve traffic. If a pull
             # fails, abort BEFORE touching them — otherwise a missing image
             # would tear down the app and leave it down while the deploy still
@@ -81,21 +156,7 @@ jobs:
             # Wait for app to be healthy (up to 120s)
             timeout 120 bash -c 'until docker compose ps app --format json | grep -q "(healthy)"; do sleep 5; done'
             docker compose ps
-            # Reclaim superseded Core images — pulled images are tagged, not
-            # dangling, so `prune -f` alone would never touch them and every
-            # main push would add four. `prune -a` is the wrong tool here: the
-            # sandbox image is referenced only by ephemeral per-execution
-            # containers, so it always looks unused, and no `until=` cut-off
-            # saves it either — a cache-hit rebuild keeps the original Created
-            # date, so a freshly pulled sandbox tag can already read as weeks
-            # old. Deleting exactly the Core tags that aren't the one just
-            # deployed cannot touch what this deploy pulled. Superseded tags
-            # stay in GHCR, so a rollback re-pulls them.
-            #
-            # The pattern is `ayunis-core-*`, not `*`: the hosts run other
-            # images from this org namespace (ayunis-backup), and matching the
-            # whole namespace made the deploy try to delete them.
-            docker images --filter "reference=ghcr.io/ayunis-core/ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
-              | grep -v ":${CORE_TAG}$" \
-              | xargs -r docker rmi || true
-            docker image prune -f
+            # Drop the generation just replaced, sandbox included: the new
+            # containers are up on CORE_TAG, which the filter spares, so the
+            # stale sandbox tag is now genuinely unreferenced.
+            reclaim_images


### PR DESCRIPTION
The reclaim block ran only after a successful swap, so a pull that
exhausted the disk exited before ever reaching it. Nothing was freed and
every later deploy failed identically until the host was cleaned by
hand — two runs today wedged staging that way.

- Reclaim before the pull as well as after the swap. Calling it early is
  safe because docker rmi refuses an image a running container uses,
  which is what spares the generation still serving traffic.
- Also collect the unprefixed ayunis-core-* images left over from the
  build-on-host era. The ghcr.io/... filter never matched them and
  prune -f skips them because they are tagged, not dangling; that was
  9.1 GB sitting on staging.
- Fail with a clear error when free space is short, rather than
  surfacing as a GetImageBlob write failure buried in pull progress.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only the staging SSH deploy script but alters when images are deleted relative to pulls and swaps; incorrect sandbox or in-use image handling could break code execution or leave deploys stuck until manual cleanup.
> 
> **Overview**
> Fixes staging deploys wedging when disk fills during `docker pull` by freeing space **before** pulls instead of only after a successful swap.
> 
> The inline post-deploy image cleanup is refactored into **`reclaim_images`**, which also removes legacy unprefixed **`ayunis-core-*`** host-build images that GHCR filters and `prune -f` never collected. It runs once before pull with **`keep-sandbox`** so a failed pull does not delete the sandbox tag the running code-execution service still references, and again after the healthy swap without that guard.
> 
> A **`MIN_FREE_GB=9`** check on `/` aborts early with a clear GitHub Actions error instead of a mid-blob “no space left on device” during pull.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d30a92d9b42e215ec2146f9ff13f371223137438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->