### PR TITLE
ci: move image build cache from gha to ghcr (AYC-589)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -104,8 +104,22 @@ jobs:
           provenance: false
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=build-${{ matrix.image }}-${{ matrix.platform }}
-          cache-to: type=gha,mode=max,scope=build-${{ matrix.image }}-${{ matrix.platform }}
+          # Registry cache rather than type=gha: four images across two
+          # platforms export eight mode=max scopes, and the two anonymize layer
+          # blobs are ~2.7 GB each — the repo sat at 10.97 GB against GitHub's
+          # 10 GB per-repo cache quota. Over quota GitHub evicts LRU, so the
+          # 3 GB torch layer got rebuilt under a fresh digest on unpredictable
+          # pushes. A new digest means the staging host cannot share layers with
+          # the generation it is still running and has to hold two full copies
+          # of a 6 GB image, which is what exhausted its disk (AYC-589).
+          #
+          # Safe against ghcr-cleanup.yml: that workflow only deletes tags
+          # matching sha-*, so buildcache-* survives the weekly sweep, and its
+          # pinned v3.1.0 spares the child manifests of kept tags. Superseded
+          # cache blobs do go untagged and are collected — which is what keeps
+          # this from growing without bound.
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:buildcache-${{ matrix.platform }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:buildcache-${{ matrix.platform }},mode=max
 
       # The filename is the digest; the file itself is empty. `merge` only needs
       # the names.

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -25,6 +25,13 @@ name: GHCR Cleanup
 # First run should be a manual dispatch with dry-run: true — verify the
 # candidate list contains only untagged/sha-* versions before trusting the
 # schedule.
+#
+# build-images.yml stores its BuildKit cache in these same packages under
+# buildcache-<platform> tags. Those survive because image-tags is 'sha-*' and
+# v3.1.0 excludes kept tags' child manifests; superseded cache blobs go untagged
+# and are collected here, which is what bounds their growth. Widening image-tags
+# would delete the live build cache — every push to main would then rebuild the
+# 3 GB torch layer from scratch under a new digest.
 
 on:
   schedule:


### PR DESCRIPTION
Four images across two platforms export eight mode=max scopes; the two
anonymize layer blobs alone are ~2.7 GB each, and the repo sat at
10.97 GB against GitHub's 10 GB per-repo cache quota. Over quota GitHub
evicts LRU, so the 3 GB torch layer was rebuilt under a fresh digest on
unpredictable pushes.

That is what reached staging: a new digest means the host cannot share
layers with the generation it is still running, so it has to hold two
full copies of a 6 GB image while pulling — which exhausted its disk.

GHCR has no such quota, so the layer keeps a stable digest across
builds. buildcache-* tags survive ghcr-cleanup.yml, which only deletes
sha-*; superseded cache blobs go untagged and are collected there, which
bounds their growth. Noted in both files so the pairing is not broken by
a later filter change.

The first build after this lands rebuilds everything once — the registry
cache starts empty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI build caching and relies on `ghcr-cleanup` not widening `sha-*` deletion; a misconfigured cleanup could wipe live cache and force multi-GB rebuilds, but runtime app code is untouched.
> 
> **Overview**
> **Docker image builds** now use **GHCR registry cache** (`buildcache-<platform>` tags) instead of **GitHub Actions cache** (`type=gha`), so large layers (e.g. torch) keep stable digests and are not evicted when the repo exceeds the ~10 GB GHA cache quota.
> 
> `build-images.yml` documents why this fixes staging disk exhaustion (AYC-589) and how it interacts with weekly cleanup. **`ghcr-cleanup.yml`** adds matching notes: `buildcache-*` tags are kept because deletion only targets `sha-*`; untagged superseded cache blobs are still collected so cache size stays bounded.
> 
> Expect a **one-time full rebuild** after merge while the registry cache is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ae1e1d496df45c1f271aecc486a1077cf8b403d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->