### PR TITLE
wip(academy-access): gate core chat writes on the certificate (AYC-597)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,6 +60,7 @@ ayunis-core/
 | [orgs](ayunis-core-backend/src/iam/orgs/SUMMARY.md) | Tenants | Multi-tenant organization management |
 | [subscriptions](ayunis-core-backend/src/iam/subscriptions/SUMMARY.md) | Billing | Package and subscription management |
 | [addons](ayunis-core-backend/src/iam/addons/SUMMARY.md) | Add-ons | Per-org add-on activation managed by super admins |
+| [academy-access](ayunis-core-backend/src/iam/academy-access/SUMMARY.md) | Access Gate | Per-org KI-Führerschein certificate requirement for the chat surface |
 | [quotas](ayunis-core-backend/src/iam/quotas/SUMMARY.md) | Limits | Usage quota enforcement |
 | [credit-limits](ayunis-core-backend/src/iam/credit-limits/SUMMARY.md) | Limits | Per-user and per-team monthly credit allowances |
 | [budget-alerts](ayunis-core-backend/src/iam/budget-alerts/SUMMARY.md) | Alerts | Budget-warning and budget-exhausted emails when credit budgets cross usage thresholds |

--- a/ayunis-core-backend/src/db/migrations/1785492658378-CreateOrgAcademyAccessSettingsTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1785492658378-CreateOrgAcademyAccessSettingsTable.ts
@@ -1,0 +1,33 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateOrgAcademyAccessSettingsTable1785492658378 implements MigrationInterface {
+  name = 'CreateOrgAcademyAccessSettingsTable1785492658378';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."org_academy_access_settings_mode_enum" AS ENUM('unrestricted', 'required_once', 'required_annually')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "org_academy_access_settings" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "orgId" character varying NOT NULL, "mode" "public"."org_academy_access_settings_mode_enum" NOT NULL DEFAULT 'unrestricted', CONSTRAINT "PK_975522dd723bc75ef8143c3d189" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_20ce40cacbf088c67928a1ef62" ON "org_academy_access_settings" ("orgId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "org_academy_access_settings" ADD CONSTRAINT "FK_20ce40cacbf088c67928a1ef62d" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "org_academy_access_settings" DROP CONSTRAINT "FK_20ce40cacbf088c67928a1ef62d"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_20ce40cacbf088c67928a1ef62"`,
+    );
+    await queryRunner.query(`DROP TABLE "org_academy_access_settings"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."org_academy_access_settings_mode_enum"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/runs/presenters/http/runs.controller.ts
+++ b/ayunis-core-backend/src/domain/runs/presenters/http/runs.controller.ts
@@ -62,6 +62,7 @@ import {
 } from './send-message.swagger';
 import { RunSsePresenter } from './sse/run-sse.presenter';
 import { SendMessageRequestValidator } from './validation/send-message-request.validator';
+import { RequireAcademyCertificate } from 'src/iam/academy-access/application/decorators/academy-certificate.decorator';
 
 @ApiTags('runs')
 @ApiExtraModels(
@@ -84,6 +85,7 @@ import { SendMessageRequestValidator } from './validation/send-message-request.v
   TextInput,
   ToolResultInput,
 )
+@RequireAcademyCertificate()
 @Controller('runs')
 export class RunsController {
   private readonly logger = new Logger(RunsController.name);

--- a/ayunis-core-backend/src/domain/threads/presenters/http/thread-knowledge-bases.controller.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/thread-knowledge-bases.controller.ts
@@ -17,9 +17,11 @@ import { AddKnowledgeBaseToThreadUseCase } from '../../application/use-cases/add
 import { AddKnowledgeBaseToThreadCommand } from '../../application/use-cases/add-knowledge-base-to-thread/add-knowledge-base-to-thread.command';
 import { RemoveKnowledgeBaseFromThreadUseCase } from '../../application/use-cases/remove-knowledge-base-from-thread/remove-knowledge-base-from-thread.use-case';
 import { RemoveKnowledgeBaseFromThreadCommand } from '../../application/use-cases/remove-knowledge-base-from-thread/remove-knowledge-base-from-thread.command';
+import { RequireAcademyCertificate } from 'src/iam/academy-access/application/decorators/academy-certificate.decorator';
 
 @ApiTags('threads')
 @RequireFeature(FeatureFlag.KnowledgeBases)
+@RequireAcademyCertificate()
 @Controller('threads')
 export class ThreadKnowledgeBasesController {
   private readonly logger = new Logger(ThreadKnowledgeBasesController.name);

--- a/ayunis-core-backend/src/domain/threads/presenters/http/thread-mcp-integrations.controller.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/thread-mcp-integrations.controller.ts
@@ -15,8 +15,10 @@ import { AddMcpIntegrationToThreadUseCase } from '../../application/use-cases/ad
 import { AddMcpIntegrationToThreadCommand } from '../../application/use-cases/add-mcp-integration-to-thread/add-mcp-integration-to-thread.command';
 import { RemoveMcpIntegrationFromThreadUseCase } from '../../application/use-cases/remove-mcp-integration-from-thread/remove-mcp-integration-from-thread.use-case';
 import { RemoveMcpIntegrationFromThreadCommand } from '../../application/use-cases/remove-mcp-integration-from-thread/remove-mcp-integration-from-thread.command';
+import { RequireAcademyCertificate } from 'src/iam/academy-access/application/decorators/academy-certificate.decorator';
 
 @ApiTags('threads')
+@RequireAcademyCertificate()
 @Controller('threads')
 export class ThreadMcpIntegrationsController {
   private readonly logger = new Logger(ThreadMcpIntegrationsController.name);

--- a/ayunis-core-backend/src/domain/threads/presenters/http/thread-sources.controller.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/thread-sources.controller.ts
@@ -68,6 +68,7 @@ import {
 } from 'src/domain/sources/application/sources.errors';
 import { SourceNotFoundError as SourceNotFoundInThreadError } from '../../application/threads.errors';
 import { Thread } from '../../domain/thread.entity';
+import { RequireAcademyCertificate } from 'src/iam/academy-access/application/decorators/academy-certificate.decorator';
 
 const SUPPORTED_FILE_TYPES = [
   'PDF',
@@ -84,6 +85,7 @@ const SUPPORTED_FILE_TYPES = [
 ];
 
 @ApiTags('threads')
+@RequireAcademyCertificate()
 @Controller('threads')
 export class ThreadSourcesController {
   private readonly logger = new Logger(ThreadSourcesController.name);

--- a/ayunis-core-backend/src/domain/threads/presenters/http/threads.controller.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/threads.controller.ts
@@ -49,8 +49,10 @@ import { GetThreadPiiMasksUseCase } from 'src/domain/thread-pii-masks/applicatio
 import { GetThreadPiiMasksQuery } from 'src/domain/thread-pii-masks/application/use-cases/get-thread-pii-masks/get-thread-pii-masks.query';
 import { GetMcpIntegrationsByIdsUseCase } from 'src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.use-case';
 import { GetMcpIntegrationsByIdsQuery } from 'src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.query';
+import { RequireAcademyCertificate } from 'src/iam/academy-access/application/decorators/academy-certificate.decorator';
 
 @ApiTags('threads')
+@RequireAcademyCertificate()
 @Controller('threads')
 export class ThreadsController {
   private readonly logger = new Logger(ThreadsController.name);

--- a/ayunis-core-backend/src/domain/transcriptions/presenters/http/decorators/api-transcribe.decorator.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/presenters/http/decorators/api-transcribe.decorator.ts
@@ -1,0 +1,56 @@
+import { applyDecorators, HttpStatus } from '@nestjs/common';
+import {
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiResponse,
+} from '@nestjs/swagger';
+import { TranscriptionResponseDto } from '../dtos/transcription-response.dto';
+
+/** API documentation for the audio transcription endpoint. */
+export function ApiTranscribe() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Transcribe audio file to text',
+      description:
+        'Upload an audio file and receive the transcribed text. ' +
+        'Supports webm, mp4, mp3, wav, and m4a formats.',
+    }),
+    ApiConsumes('multipart/form-data'),
+    ApiBody({
+      schema: {
+        type: 'object',
+        required: ['file'],
+        properties: {
+          file: {
+            type: 'string',
+            format: 'binary',
+            description: 'The audio file to transcribe',
+          },
+          language: {
+            type: 'string',
+            description: 'Optional language hint (e.g., "en", "de")',
+            example: 'en',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: HttpStatus.OK,
+      description: 'Audio successfully transcribed',
+      type: TranscriptionResponseDto,
+    }),
+    ApiResponse({
+      status: HttpStatus.BAD_REQUEST,
+      description: 'Invalid request or unsupported audio format',
+    }),
+    ApiResponse({
+      status: HttpStatus.UNAUTHORIZED,
+      description: 'Unauthorized',
+    }),
+    ApiResponse({
+      status: HttpStatus.INTERNAL_SERVER_ERROR,
+      description: 'Transcription failed',
+    }),
+  );
+}

--- a/ayunis-core-backend/src/domain/transcriptions/presenters/http/transcriptions.controller.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/presenters/http/transcriptions.controller.ts
@@ -8,20 +8,16 @@ import {
   Logger,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
-import {
-  ApiTags,
-  ApiOperation,
-  ApiConsumes,
-  ApiBody,
-  ApiResponse,
-  ApiBearerAuth,
-} from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { TranscribeUseCase } from '../../application/use-cases/transcribe/transcribe.use-case';
 import { TranscribeCommand } from '../../application/use-cases/transcribe/transcribe.command';
 import { TranscriptionResponseDto } from './dtos/transcription-response.dto';
+import { ApiTranscribe } from './decorators/api-transcribe.decorator';
+import { RequireAcademyCertificate } from 'src/iam/academy-access/application/decorators/academy-certificate.decorator';
 
 @ApiTags('transcriptions')
 @ApiBearerAuth()
+@RequireAcademyCertificate()
 @Controller('transcriptions')
 export class TranscriptionsController {
   private readonly logger = new Logger(TranscriptionsController.name);
@@ -34,62 +30,23 @@ export class TranscriptionsController {
       limits: { fileSize: 25 * 1024 * 1024 }, // 25 MB limit
     }),
   )
-  @ApiOperation({
-    summary: 'Transcribe audio file to text',
-    description:
-      'Upload an audio file and receive the transcribed text. ' +
-      'Supports webm, mp4, mp3, wav, and m4a formats.',
-  })
-  @ApiConsumes('multipart/form-data')
-  @ApiBody({
-    schema: {
-      type: 'object',
-      required: ['file'],
-      properties: {
-        file: {
-          type: 'string',
-          format: 'binary',
-          description: 'The audio file to transcribe',
-        },
-        language: {
-          type: 'string',
-          description: 'Optional language hint (e.g., "en", "de")',
-          example: 'en',
-        },
-      },
-    },
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'Audio successfully transcribed',
-    type: TranscriptionResponseDto,
-  })
-  @ApiResponse({
-    status: 400,
-    description: 'Invalid request or unsupported audio format',
-  })
-  @ApiResponse({
-    status: 401,
-    description: 'Unauthorized',
-  })
-  @ApiResponse({
-    status: 500,
-    description: 'Transcription failed',
-  })
+  @ApiTranscribe()
   async transcribe(
-    @UploadedFile() file: Express.Multer.File,
+    // Multer leaves this undefined when the request carries no file, so the
+    // guard clause has to come before the first dereference.
+    @UploadedFile() file: Express.Multer.File | undefined,
     @Body('language') language?: string,
   ): Promise<TranscriptionResponseDto> {
+    if (!file) {
+      throw new BadRequestException('No audio file provided');
+    }
+
     this.logger.log('Transcription request received', {
       fileName: file.originalname,
       mimeType: file.mimetype,
       fileSize: file.size,
       language,
     });
-
-    if (!file) {
-      throw new BadRequestException('No audio file provided');
-    }
 
     const command = new TranscribeCommand({
       file: file.buffer,

--- a/ayunis-core-backend/src/iam/academy-access/SUMMARY.md
+++ b/ayunis-core-backend/src/iam/academy-access/SUMMARY.md
@@ -1,0 +1,86 @@
+# Academy Access
+
+Per-org gate tying **Ayunis Core chat** to the KI-Führerschein certificate
+issued by the academy (`src/domain/academy`). An org admin picks one of three
+`AcademyAccessMode`s; users without a valid certificate cannot start or advance
+a conversation, while the academy itself stays reachable so they can earn one.
+
+## Model
+
+`OrgAcademyAccessSettings` — `{ id, orgId, mode }`, one row per org
+(`org_academy_access_settings`, unique `orgId`, FK to `orgs` `ON DELETE
+CASCADE`). **An absent row means `UNRESTRICTED`**, applied in the entity
+constructor, so the migration leaves every existing org ungated.
+
+`AcademyAccessMode`:
+
+- `unrestricted` — no gate (default, and the pre-gate behaviour)
+- `required_once` — the certificate must be earned once; the pass is permanent
+- `required_annually` — the certificate must be renewed every 12 months
+
+## Evaluation
+
+`EvaluateAcademyAccessUseCase({ userId, orgId })` →
+`{ mode, required, allowed, completedAt, expiresAt }`. It runs on every gated
+request, so the checks are ordered cheapest-first and short-circuit:
+
+1. Org settings. `UNRESTRICTED` returns immediately — the default org pays
+   exactly **one** indexed lookup and never touches the other two tables.
+2. `IsAddonActiveUseCase(AYUNIS_CORE_ACADEMY)`. An org without the add-on
+   **fails open**: it cannot take the certificate at all, so gating on it would
+   lock the org out with no way forward.
+3. `GetAcademyCompletionUseCase` (exported by `AcademyModule`) for
+   `completedAt`/`expiresAt`. Only the academy knows the validity period; this
+   module never imports it.
+
+`expiresAt` is reported only in `required_annually` — surfacing it elsewhere
+would imply a deadline that mode does not have. Nothing is cached: "passing
+immediately unlocks Core" rules out caching completion, and the short-circuit
+already makes the common path free.
+
+## Enforcement
+
+`@RequireAcademyCertificate()` marks a controller as part of the chat surface;
+`AcademyCertificateGuard` decides per request. It is bound globally by
+`IamModule` — the module owning the data owns the guard, mirroring
+`IpAllowlistGuard`.
+
+The guard blocks **state-changing requests only**: `GET`/`HEAD`/`OPTIONS` and
+`DELETE` pass through, so a blocked user keeps read access to their chat history
+and can still delete their own data. That is a verb-level rule — an endpoint
+that triggers inference from a `GET` would slip through and must be gated
+explicitly.
+
+Denials `throw AcademyCertificateRequiredError`
+(`ACADEMY_CERTIFICATE_REQUIRED`, 403, metadata `{ mode, expiresAt }`) rather
+than returning `false`, so the frontend can tell this apart from every other 403
+and point the user at the academy.
+
+Gated controllers: `runs` (`POST send-message`), `transcriptions`, `threads` and
+its thread-scoped sub-controllers (sources, knowledge bases, MCP integrations).
+
+Deliberately **not** gated:
+
+- `skills`, `artifacts`, `knowledge-bases` — authoring and configuration. They
+  consume no inference without a run, and gating them yields confusing 403s on
+  pages that otherwise work.
+- `openai-compat` — API-key authenticated, and `ApiKeyPrincipal` has no
+  `userId`; a machine principal has no certificate holder. The guard skips
+  api-key principals for the same reason. **Known gap:** an org that enables the
+  gate *and* issues API keys retains an ungated inference path.
+- `shares` — org-sharing admin surface; gating it would stop a lapsed user from
+  *un*sharing.
+
+## HTTP
+
+`AcademyAccessController` (`academy-access`):
+
+- `GET status` — any authenticated user, **not** gated (a blocked user has to be
+  able to read why). Returns the evaluation above.
+- `GET`/`PUT org-settings` — `@Roles(ADMIN)`.
+
+## Layout
+
+Standard hexagonal: `domain/` (settings entity + mode enum), `application/`
+(port, errors, decorator, guard, use cases), `infrastructure/persistence/postgres/`
+(record + mapper + repository), `presenters/http/`.

--- a/ayunis-core-backend/src/iam/academy-access/academy-access.module.ts
+++ b/ayunis-core-backend/src/iam/academy-access/academy-access.module.ts
@@ -1,0 +1,44 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { AcademyModule } from 'src/domain/academy/academy.module';
+import { AddonsModule } from '../addons/addons.module';
+
+import { OrgAcademyAccessSettingsRecord } from './infrastructure/persistence/postgres/schema/org-academy-access-settings.record';
+import { OrgAcademyAccessSettingsMapper } from './infrastructure/persistence/postgres/mappers/org-academy-access-settings.mapper';
+import { OrgAcademyAccessSettingsRepository } from './application/ports/org-academy-access-settings.repository';
+import { PostgresOrgAcademyAccessSettingsRepository } from './infrastructure/persistence/postgres/org-academy-access-settings.repository';
+
+import { GetOrgAcademyAccessSettingsUseCase } from './application/use-cases/get-org-academy-access-settings/get-org-academy-access-settings.use-case';
+import { UpsertOrgAcademyAccessSettingsUseCase } from './application/use-cases/upsert-org-academy-access-settings/upsert-org-academy-access-settings.use-case';
+import { EvaluateAcademyAccessUseCase } from './application/use-cases/evaluate-academy-access/evaluate-academy-access.use-case';
+
+import { AcademyCertificateGuard } from './application/guards/academy-certificate.guard';
+import { AcademyAccessController } from './presenters/http/academy-access.controller';
+
+/**
+ * Owns the guard as well as the setting, mirroring IpAllowlistModule: the
+ * module that has the data binds the guard, and IamModule owns the global
+ * APP_GUARD registration and its ordering.
+ */
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([OrgAcademyAccessSettingsRecord]),
+    AddonsModule,
+    AcademyModule,
+  ],
+  controllers: [AcademyAccessController],
+  providers: [
+    OrgAcademyAccessSettingsMapper,
+    {
+      provide: OrgAcademyAccessSettingsRepository,
+      useClass: PostgresOrgAcademyAccessSettingsRepository,
+    },
+    GetOrgAcademyAccessSettingsUseCase,
+    UpsertOrgAcademyAccessSettingsUseCase,
+    EvaluateAcademyAccessUseCase,
+    AcademyCertificateGuard,
+  ],
+  exports: [EvaluateAcademyAccessUseCase, AcademyCertificateGuard],
+})
+export class AcademyAccessModule {}

--- a/ayunis-core-backend/src/iam/academy-access/application/academy-access.errors.ts
+++ b/ayunis-core-backend/src/iam/academy-access/application/academy-access.errors.ts
@@ -1,0 +1,44 @@
+import type { ErrorMetadata } from 'src/common/errors/base.error';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+export enum AcademyAccessErrorCode {
+  ACADEMY_CERTIFICATE_REQUIRED = 'ACADEMY_CERTIFICATE_REQUIRED',
+  UNEXPECTED_ERROR = 'ACADEMY_ACCESS_UNEXPECTED_ERROR',
+}
+
+export abstract class AcademyAccessError extends ApplicationError {
+  constructor(
+    message: string,
+    code: AcademyAccessErrorCode,
+    statusCode: number,
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, code, statusCode, metadata);
+  }
+}
+
+/**
+ * Thrown instead of returning `false` from the guard so the frontend can tell
+ * this apart from every other 403 and point the user at the academy.
+ */
+export class AcademyCertificateRequiredError extends AcademyAccessError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'Using Ayunis Core chat requires a valid KI-Führerschein certificate.',
+      AcademyAccessErrorCode.ACADEMY_CERTIFICATE_REQUIRED,
+      403,
+      metadata,
+    );
+  }
+}
+
+export class UnexpectedAcademyAccessError extends AcademyAccessError {
+  constructor(error: Error) {
+    super(
+      'Unexpected academy access error',
+      AcademyAccessErrorCode.UNEXPECTED_ERROR,
+      500,
+      { error },
+    );
+  }
+}

--- a/ayunis-core-backend/src/iam/academy-access/application/decorators/academy-certificate.decorator.ts
+++ b/ayunis-core-backend/src/iam/academy-access/application/decorators/academy-certificate.decorator.ts
@@ -1,0 +1,14 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const REQUIRE_ACADEMY_CERTIFICATE_KEY = 'requiresAcademyCertificate';
+
+/**
+ * Marks a controller as part of the Ayunis Core chat surface, which orgs may
+ * gate behind the KI-Führerschein certificate.
+ *
+ * Apply at class level: `AcademyCertificateGuard` only blocks state-changing
+ * requests, so reads stay open and a blocked user keeps access to their chat
+ * history.
+ */
+export const RequireAcademyCertificate = () =>
+  SetMetadata(REQUIRE_ACADEMY_CERTIFICATE_KEY, true);

--- a/ayunis-core-backend/src/iam/academy-access/application/guards/academy-certificate.guard.spec.ts
+++ b/ayunis-core-backend/src/iam/academy-access/application/guards/academy-certificate.guard.spec.ts
@@ -1,0 +1,145 @@
+import type { ExecutionContext } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+import { AcademyCertificateGuard } from './academy-certificate.guard';
+import type { EvaluateAcademyAccessUseCase } from '../use-cases/evaluate-academy-access/evaluate-academy-access.use-case';
+import type { AcademyAccessEvaluation } from '../use-cases/evaluate-academy-access/evaluate-academy-access.use-case';
+import { AcademyAccessMode } from '../../domain/value-objects/academy-access-mode.enum';
+import { AcademyCertificateRequiredError } from '../academy-access.errors';
+import { REQUIRE_ACADEMY_CERTIFICATE_KEY } from '../decorators/academy-certificate.decorator';
+
+interface ContextOverrides {
+  gated?: boolean;
+  method?: string;
+  user?: { id?: UUID; orgId?: UUID } | { apiKeyId: UUID; orgId: UUID };
+}
+
+function createContext(overrides: ContextOverrides): {
+  context: ExecutionContext;
+  reflector: Reflector;
+} {
+  const reflector = new Reflector();
+  jest
+    .spyOn(reflector, 'getAllAndOverride')
+    .mockImplementation((key: unknown) =>
+      key === REQUIRE_ACADEMY_CERTIFICATE_KEY ? overrides.gated : undefined,
+    );
+
+  const request = {
+    method: overrides.method ?? 'POST',
+    url: '/runs/send-message',
+    headers: {},
+    socket: {},
+    user: overrides.user,
+  };
+
+  const context = {
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+    switchToHttp: () => ({ getRequest: () => request }),
+  } as unknown as ExecutionContext;
+
+  return { context, reflector };
+}
+
+describe('AcademyCertificateGuard', () => {
+  const orgId = randomUUID();
+  const userId = randomUUID();
+  const apiKeyId = randomUUID();
+
+  let evaluateAcademyAccessUseCase: jest.Mocked<EvaluateAcademyAccessUseCase>;
+
+  const denied: AcademyAccessEvaluation = {
+    mode: AcademyAccessMode.REQUIRED_ONCE,
+    required: true,
+    allowed: false,
+    completedAt: null,
+    expiresAt: null,
+  };
+
+  const allowed: AcademyAccessEvaluation = { ...denied, allowed: true };
+
+  beforeEach(() => {
+    evaluateAcademyAccessUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<EvaluateAcademyAccessUseCase>;
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  function guardFor(overrides: ContextOverrides) {
+    const { context, reflector } = createContext(overrides);
+    const guard = new AcademyCertificateGuard(
+      reflector,
+      evaluateAcademyAccessUseCase,
+    );
+    return { guard, context };
+  }
+
+  it('passes through undecorated routes without evaluating', async () => {
+    const { guard, context } = guardFor({ gated: undefined });
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect(evaluateAcademyAccessUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it.each(['GET', 'HEAD', 'OPTIONS', 'DELETE'])(
+    'leaves %s open so chat history stays readable while blocked',
+    async (method) => {
+      const { guard, context } = guardFor({
+        gated: true,
+        method,
+        user: { id: userId, orgId },
+      });
+
+      await expect(guard.canActivate(context)).resolves.toBe(true);
+      expect(evaluateAcademyAccessUseCase.execute).not.toHaveBeenCalled();
+    },
+  );
+
+  it('denies when no principal was resolved', async () => {
+    const { guard, context } = guardFor({ gated: true, user: undefined });
+
+    await expect(guard.canActivate(context)).resolves.toBe(false);
+    expect(evaluateAcademyAccessUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('skips api-key principals, which have no certificate holder', async () => {
+    const { guard, context } = guardFor({
+      gated: true,
+      user: { apiKeyId, orgId },
+    });
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect(evaluateAcademyAccessUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('allows a certified user', async () => {
+    evaluateAcademyAccessUseCase.execute.mockResolvedValue(allowed);
+    const { guard, context } = guardFor({
+      gated: true,
+      user: { id: userId, orgId },
+    });
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+  });
+
+  it('throws a coded error the frontend can branch on', async () => {
+    evaluateAcademyAccessUseCase.execute.mockResolvedValue(denied);
+    const { guard, context } = guardFor({
+      gated: true,
+      user: { id: userId, orgId },
+    });
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      AcademyCertificateRequiredError,
+    );
+    await expect(guard.canActivate(context)).rejects.toMatchObject({
+      code: 'ACADEMY_CERTIFICATE_REQUIRED',
+      statusCode: 403,
+    });
+  });
+});

--- a/ayunis-core-backend/src/iam/academy-access/application/guards/academy-certificate.guard.ts
+++ b/ayunis-core-backend/src/iam/academy-access/application/guards/academy-certificate.guard.ts
@@ -1,0 +1,105 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import type { UUID } from 'crypto';
+import { buildAccessDeniedAuditContext } from 'src/common/util/access-denied-audit.util';
+import { ActiveUser } from 'src/iam/authentication/domain/active-user.entity';
+import type { ApiKeyPrincipal } from 'src/iam/authentication/application/strategies/api-key.strategy';
+import { EvaluateAcademyAccessUseCase } from '../use-cases/evaluate-academy-access/evaluate-academy-access.use-case';
+import { EvaluateAcademyAccessQuery } from '../use-cases/evaluate-academy-access/evaluate-academy-access.query';
+import { AcademyCertificateRequiredError } from '../academy-access.errors';
+import { REQUIRE_ACADEMY_CERTIFICATE_KEY } from '../decorators/academy-certificate.decorator';
+
+interface RequestWithUser extends Request {
+  user?: ActiveUser | ApiKeyPrincipal;
+}
+
+/**
+ * Requests that never start or advance a conversation. Reads stay open so a
+ * blocked user keeps access to their chat history, and DELETE stays open so
+ * they can still clean up their own data.
+ *
+ * This is a verb-level rule: an endpoint that triggers inference from a GET
+ * would slip through and must be gated explicitly.
+ */
+const UNGATED_METHODS = new Set(['GET', 'HEAD', 'OPTIONS', 'DELETE']);
+
+@Injectable()
+export class AcademyCertificateGuard implements CanActivate {
+  private readonly logger = new Logger(AcademyCertificateGuard.name);
+
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly evaluateAcademyAccessUseCase: EvaluateAcademyAccessUseCase,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const gated = this.reflector.getAllAndOverride<boolean | undefined>(
+      REQUIRE_ACADEMY_CERTIFICATE_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (!gated) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<RequestWithUser>();
+    if (UNGATED_METHODS.has(request.method)) {
+      return true;
+    }
+
+    const principal = this.resolvePrincipal(request);
+    if (!principal) {
+      this.logger.warn(
+        'No principal found on request when checking academy certificate',
+        buildAccessDeniedAuditContext(request),
+      );
+      return false;
+    }
+
+    // The certificate belongs to a person; an API key has no holder to certify.
+    if (!principal.userId) {
+      this.logger.warn(
+        'Academy certificate gate skipped for api-key principal',
+        {
+          orgId: principal.orgId,
+        },
+      );
+      return true;
+    }
+
+    const evaluation = await this.evaluateAcademyAccessUseCase.execute(
+      new EvaluateAcademyAccessQuery(principal.userId, principal.orgId),
+    );
+    if (evaluation.allowed) {
+      return true;
+    }
+
+    this.logger.warn('Access denied: academy certificate required', {
+      ...buildAccessDeniedAuditContext(request, {
+        id: principal.userId,
+        orgId: principal.orgId,
+      }),
+      mode: evaluation.mode,
+    });
+    throw new AcademyCertificateRequiredError({
+      mode: evaluation.mode,
+      expiresAt: evaluation.expiresAt,
+    });
+  }
+
+  private resolvePrincipal(
+    request: RequestWithUser,
+  ): { userId: UUID | null; orgId: UUID } | null {
+    const user = request.user as unknown;
+    if (!user || typeof user !== 'object' || !('orgId' in user)) {
+      return null;
+    }
+    const { id, orgId } = user as { id?: UUID; orgId: UUID };
+    return { userId: id ?? null, orgId };
+  }
+}

--- a/ayunis-core-backend/src/iam/academy-access/application/ports/org-academy-access-settings.repository.ts
+++ b/ayunis-core-backend/src/iam/academy-access/application/ports/org-academy-access-settings.repository.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+import type { OrgAcademyAccessSettings } from '../../domain/org-academy-access-settings.entity';
+
+export abstract class OrgAcademyAccessSettingsRepository {
+  abstract findByOrgId(orgId: UUID): Promise<OrgAcademyAccessSettings | null>;
+  abstract upsert(
+    settings: OrgAcademyAccessSettings,
+  ): Promise<OrgAcademyAccessSettings>;
+}

--- a/ayunis-core-backend/src/iam/academy-access/application/use-cases/evaluate-academy-access/evaluate-academy-access.query.ts
+++ b/ayunis-core-backend/src/iam/academy-access/application/use-cases/evaluate-academy-access/evaluate-academy-access.query.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class EvaluateAcademyAccessQuery {
+  constructor(
+    public readonly userId: UUID,
+    public readonly orgId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/iam/academy-access/application/use-cases/evaluate-academy-access/evaluate-academy-access.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/academy-access/application/use-cases/evaluate-academy-access/evaluate-academy-access.use-case.spec.ts
@@ -1,0 +1,169 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { EvaluateAcademyAccessUseCase } from './evaluate-academy-access.use-case';
+import { EvaluateAcademyAccessQuery } from './evaluate-academy-access.query';
+import { GetOrgAcademyAccessSettingsUseCase } from '../get-org-academy-access-settings/get-org-academy-access-settings.use-case';
+import { IsAddonActiveUseCase } from 'src/iam/addons/application/use-cases/is-addon-active/is-addon-active.use-case';
+import { GetAcademyCompletionUseCase } from 'src/domain/academy/application/use-cases/get-academy-completion/get-academy-completion.use-case';
+import { OrgAcademyAccessSettings } from '../../../domain/org-academy-access-settings.entity';
+import { AcademyAccessMode } from '../../../domain/value-objects/academy-access-mode.enum';
+
+describe('EvaluateAcademyAccessUseCase', () => {
+  let useCase: EvaluateAcademyAccessUseCase;
+  let getOrgSettingsUseCase: jest.Mocked<GetOrgAcademyAccessSettingsUseCase>;
+  let isAddonActiveUseCase: jest.Mocked<IsAddonActiveUseCase>;
+  let getAcademyCompletionUseCase: jest.Mocked<GetAcademyCompletionUseCase>;
+
+  const userId = randomUUID();
+  const orgId = randomUUID();
+
+  const HOUR_MS = 60 * 60 * 1000;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EvaluateAcademyAccessUseCase,
+        {
+          provide: GetOrgAcademyAccessSettingsUseCase,
+          useValue: { execute: jest.fn() },
+        },
+        { provide: IsAddonActiveUseCase, useValue: { execute: jest.fn() } },
+        {
+          provide: GetAcademyCompletionUseCase,
+          useValue: { execute: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(EvaluateAcademyAccessUseCase);
+    getOrgSettingsUseCase = module.get(GetOrgAcademyAccessSettingsUseCase);
+    isAddonActiveUseCase = module.get(IsAddonActiveUseCase);
+    getAcademyCompletionUseCase = module.get(GetAcademyCompletionUseCase);
+
+    isAddonActiveUseCase.execute.mockResolvedValue(true);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  function withMode(mode: AcademyAccessMode): void {
+    getOrgSettingsUseCase.execute.mockResolvedValue(
+      new OrgAcademyAccessSettings({ orgId, mode }),
+    );
+  }
+
+  function withCompletion(completedAt: Date | null, expiresAt: Date | null) {
+    getAcademyCompletionUseCase.execute.mockResolvedValue({
+      completedAt,
+      expiresAt,
+    });
+  }
+
+  function evaluate() {
+    return useCase.execute(new EvaluateAcademyAccessQuery(userId, orgId));
+  }
+
+  describe('unrestricted', () => {
+    beforeEach(() => withMode(AcademyAccessMode.UNRESTRICTED));
+
+    it('allows without applying the gate', async () => {
+      await expect(evaluate()).resolves.toEqual({
+        mode: AcademyAccessMode.UNRESTRICTED,
+        required: false,
+        allowed: true,
+        completedAt: null,
+        expiresAt: null,
+      });
+    });
+
+    // The default org pays one indexed lookup per gated request and no more —
+    // this is what keeps the guard affordable on the hot path.
+    it('short-circuits before the add-on and completion lookups', async () => {
+      await evaluate();
+
+      expect(isAddonActiveUseCase.execute).not.toHaveBeenCalled();
+      expect(getAcademyCompletionUseCase.execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('add-on inactive', () => {
+    it('fails open, because the org cannot take the certificate at all', async () => {
+      withMode(AcademyAccessMode.REQUIRED_ONCE);
+      isAddonActiveUseCase.execute.mockResolvedValue(false);
+
+      const result = await evaluate();
+
+      expect(result.allowed).toBe(true);
+      expect(result.required).toBe(false);
+      expect(getAcademyCompletionUseCase.execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('required once', () => {
+    beforeEach(() => withMode(AcademyAccessMode.REQUIRED_ONCE));
+
+    it('denies a user who never completed the academy', async () => {
+      withCompletion(null, null);
+
+      const result = await evaluate();
+
+      expect(result).toEqual({
+        mode: AcademyAccessMode.REQUIRED_ONCE,
+        required: true,
+        allowed: false,
+        completedAt: null,
+        expiresAt: null,
+      });
+    });
+
+    it('allows a long-expired completion, since the pass is permanent', async () => {
+      const completedAt = new Date(Date.now() - 5000 * HOUR_MS);
+      withCompletion(completedAt, new Date(Date.now() - HOUR_MS));
+
+      const result = await evaluate();
+
+      expect(result.allowed).toBe(true);
+      // Surfacing an expiry here would imply a deadline this mode does not have.
+      expect(result.expiresAt).toBeNull();
+      expect(result.completedAt).toEqual(completedAt);
+    });
+  });
+
+  describe('required annually', () => {
+    beforeEach(() => withMode(AcademyAccessMode.REQUIRED_ANNUALLY));
+
+    it('denies a user who never completed the academy', async () => {
+      withCompletion(null, null);
+
+      const result = await evaluate();
+
+      expect(result.allowed).toBe(false);
+      expect(result.expiresAt).toBeNull();
+    });
+
+    it('allows a completion that has not expired yet', async () => {
+      const expiresAt = new Date(Date.now() + HOUR_MS);
+      withCompletion(new Date(Date.now() - HOUR_MS), expiresAt);
+
+      const result = await evaluate();
+
+      expect(result.allowed).toBe(true);
+      expect(result.expiresAt).toEqual(expiresAt);
+    });
+
+    it('denies an expired completion and reports when it lapsed', async () => {
+      const expiresAt = new Date(Date.now() - HOUR_MS);
+      withCompletion(new Date(Date.now() - 5000 * HOUR_MS), expiresAt);
+
+      const result = await evaluate();
+
+      expect(result.allowed).toBe(false);
+      expect(result.required).toBe(true);
+      expect(result.expiresAt).toEqual(expiresAt);
+    });
+  });
+});

--- a/ayunis-core-backend/src/iam/academy-access/application/use-cases/evaluate-academy-access/evaluate-academy-access.use-case.ts
+++ b/ayunis-core-backend/src/iam/academy-access/application/use-cases/evaluate-academy-access/evaluate-academy-access.use-case.ts
@@ -1,0 +1,100 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { AddonType } from 'src/iam/addons/domain/value-objects/addon-type.enum';
+import { IsAddonActiveUseCase } from 'src/iam/addons/application/use-cases/is-addon-active/is-addon-active.use-case';
+import { IsAddonActiveQuery } from 'src/iam/addons/application/use-cases/is-addon-active/is-addon-active.query';
+import { GetAcademyCompletionUseCase } from 'src/domain/academy/application/use-cases/get-academy-completion/get-academy-completion.use-case';
+import { GetAcademyCompletionQuery } from 'src/domain/academy/application/use-cases/get-academy-completion/get-academy-completion.query';
+import { AcademyAccessMode } from '../../../domain/value-objects/academy-access-mode.enum';
+import { UnexpectedAcademyAccessError } from '../../academy-access.errors';
+import { GetOrgAcademyAccessSettingsUseCase } from '../get-org-academy-access-settings/get-org-academy-access-settings.use-case';
+import { GetOrgAcademyAccessSettingsQuery } from '../get-org-academy-access-settings/get-org-academy-access-settings.query';
+import { EvaluateAcademyAccessQuery } from './evaluate-academy-access.query';
+
+export interface AcademyAccessEvaluation {
+  readonly mode: AcademyAccessMode;
+  /** Whether the gate applies at all — false for unrestricted orgs and orgs without the add-on. */
+  readonly required: boolean;
+  readonly allowed: boolean;
+  readonly completedAt: Date | null;
+  readonly expiresAt: Date | null;
+}
+
+@Injectable()
+export class EvaluateAcademyAccessUseCase {
+  private readonly logger = new Logger(EvaluateAcademyAccessUseCase.name);
+
+  constructor(
+    private readonly getOrgSettingsUseCase: GetOrgAcademyAccessSettingsUseCase,
+    private readonly isAddonActiveUseCase: IsAddonActiveUseCase,
+    private readonly getAcademyCompletionUseCase: GetAcademyCompletionUseCase,
+  ) {}
+
+  /**
+   * Runs on every gated request, so the checks are ordered cheapest-first and
+   * short-circuit: an unrestricted org — the default — costs a single indexed
+   * lookup and never touches the add-on or completion tables.
+   */
+  @HandleUnexpectedErrors(UnexpectedAcademyAccessError)
+  async execute(
+    query: EvaluateAcademyAccessQuery,
+  ): Promise<AcademyAccessEvaluation> {
+    const settings = await this.getOrgSettingsUseCase.execute(
+      new GetOrgAcademyAccessSettingsQuery(query.orgId),
+    );
+    if (settings.mode === AcademyAccessMode.UNRESTRICTED) {
+      return this.ungated(settings.mode);
+    }
+
+    // An org without the academy add-on cannot take the certificate at all, so
+    // gating on it would lock them out with no way forward.
+    const addonActive = await this.isAddonActiveUseCase.execute(
+      new IsAddonActiveQuery(query.orgId, AddonType.AYUNIS_CORE_ACADEMY),
+    );
+    if (!addonActive) {
+      this.logger.warn('Academy gate configured but add-on inactive', {
+        orgId: query.orgId,
+        mode: settings.mode,
+      });
+      return this.ungated(settings.mode);
+    }
+
+    return this.evaluateCompletion(settings.mode, query.userId);
+  }
+
+  private async evaluateCompletion(
+    mode: AcademyAccessMode,
+    userId: UUID,
+  ): Promise<AcademyAccessEvaluation> {
+    const { completedAt, expiresAt } =
+      await this.getAcademyCompletionUseCase.execute(
+        new GetAcademyCompletionQuery({ userId }),
+      );
+
+    const annual = mode === AcademyAccessMode.REQUIRED_ANNUALLY;
+    const allowed =
+      completedAt !== null &&
+      (!annual || (expiresAt !== null && expiresAt.getTime() > Date.now()));
+
+    return {
+      mode,
+      required: true,
+      allowed,
+      completedAt,
+      // Only annual orgs act on expiry; surfacing it elsewhere would suggest a
+      // deadline that does not exist.
+      expiresAt: annual ? expiresAt : null,
+    };
+  }
+
+  private ungated(mode: AcademyAccessMode): AcademyAccessEvaluation {
+    return {
+      mode,
+      required: false,
+      allowed: true,
+      completedAt: null,
+      expiresAt: null,
+    };
+  }
+}

--- a/ayunis-core-backend/src/iam/academy-access/application/use-cases/get-org-academy-access-settings/get-org-academy-access-settings.query.ts
+++ b/ayunis-core-backend/src/iam/academy-access/application/use-cases/get-org-academy-access-settings/get-org-academy-access-settings.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class GetOrgAcademyAccessSettingsQuery {
+  constructor(public readonly orgId: UUID) {}
+}

--- a/ayunis-core-backend/src/iam/academy-access/application/use-cases/get-org-academy-access-settings/get-org-academy-access-settings.use-case.ts
+++ b/ayunis-core-backend/src/iam/academy-access/application/use-cases/get-org-academy-access-settings/get-org-academy-access-settings.use-case.ts
@@ -1,0 +1,31 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { OrgAcademyAccessSettingsRepository } from '../../ports/org-academy-access-settings.repository';
+import { OrgAcademyAccessSettings } from '../../../domain/org-academy-access-settings.entity';
+import { UnexpectedAcademyAccessError } from '../../academy-access.errors';
+import { GetOrgAcademyAccessSettingsQuery } from './get-org-academy-access-settings.query';
+
+/**
+ * `orgId` is passed explicitly rather than read from `ContextService` because
+ * the guard calls this before the CLS store is populated.
+ */
+@Injectable()
+export class GetOrgAcademyAccessSettingsUseCase {
+  private readonly logger = new Logger(GetOrgAcademyAccessSettingsUseCase.name);
+
+  constructor(
+    private readonly repository: OrgAcademyAccessSettingsRepository,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedAcademyAccessError)
+  async execute(
+    query: GetOrgAcademyAccessSettingsQuery,
+  ): Promise<OrgAcademyAccessSettings> {
+    this.logger.debug('Getting org academy access settings', {
+      orgId: query.orgId,
+    });
+
+    const settings = await this.repository.findByOrgId(query.orgId);
+    return settings ?? new OrgAcademyAccessSettings({ orgId: query.orgId });
+  }
+}

--- a/ayunis-core-backend/src/iam/academy-access/application/use-cases/upsert-org-academy-access-settings/upsert-org-academy-access-settings.command.ts
+++ b/ayunis-core-backend/src/iam/academy-access/application/use-cases/upsert-org-academy-access-settings/upsert-org-academy-access-settings.command.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+import type { AcademyAccessMode } from '../../../domain/value-objects/academy-access-mode.enum';
+
+export class UpsertOrgAcademyAccessSettingsCommand {
+  constructor(
+    public readonly orgId: UUID,
+    public readonly mode: AcademyAccessMode,
+  ) {}
+}

--- a/ayunis-core-backend/src/iam/academy-access/application/use-cases/upsert-org-academy-access-settings/upsert-org-academy-access-settings.use-case.ts
+++ b/ayunis-core-backend/src/iam/academy-access/application/use-cases/upsert-org-academy-access-settings/upsert-org-academy-access-settings.use-case.ts
@@ -1,0 +1,37 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { OrgAcademyAccessSettingsRepository } from '../../ports/org-academy-access-settings.repository';
+import { OrgAcademyAccessSettings } from '../../../domain/org-academy-access-settings.entity';
+import { UnexpectedAcademyAccessError } from '../../academy-access.errors';
+import { UpsertOrgAcademyAccessSettingsCommand } from './upsert-org-academy-access-settings.command';
+
+@Injectable()
+export class UpsertOrgAcademyAccessSettingsUseCase {
+  private readonly logger = new Logger(
+    UpsertOrgAcademyAccessSettingsUseCase.name,
+  );
+
+  constructor(
+    private readonly repository: OrgAcademyAccessSettingsRepository,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedAcademyAccessError)
+  async execute(
+    command: UpsertOrgAcademyAccessSettingsCommand,
+  ): Promise<OrgAcademyAccessSettings> {
+    this.logger.log('Upserting org academy access settings', {
+      orgId: command.orgId,
+      mode: command.mode,
+    });
+
+    const existing = await this.repository.findByOrgId(command.orgId);
+    return this.repository.upsert(
+      new OrgAcademyAccessSettings({
+        id: existing?.id,
+        orgId: command.orgId,
+        mode: command.mode,
+        createdAt: existing?.createdAt,
+      }),
+    );
+  }
+}

--- a/ayunis-core-backend/src/iam/academy-access/domain/org-academy-access-settings.entity.ts
+++ b/ayunis-core-backend/src/iam/academy-access/domain/org-academy-access-settings.entity.ts
@@ -1,0 +1,26 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+import { AcademyAccessMode } from './value-objects/academy-access-mode.enum';
+
+export class OrgAcademyAccessSettings {
+  id: UUID;
+  orgId: UUID;
+  mode: AcademyAccessMode;
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor(params: {
+    id?: UUID;
+    orgId: UUID;
+    mode?: AcademyAccessMode;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    this.id = params.id ?? randomUUID();
+    this.orgId = params.orgId;
+    // No row means no gate, so existing orgs are unaffected by the migration.
+    this.mode = params.mode ?? AcademyAccessMode.UNRESTRICTED;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+}

--- a/ayunis-core-backend/src/iam/academy-access/domain/value-objects/academy-access-mode.enum.ts
+++ b/ayunis-core-backend/src/iam/academy-access/domain/value-objects/academy-access-mode.enum.ts
@@ -1,0 +1,12 @@
+/**
+ * How strictly an org ties Ayunis Core chat to the KI-Führerschein certificate.
+ * The catalogue is fixed at these three by the product requirement.
+ */
+export enum AcademyAccessMode {
+  /** Chat is usable without a certificate. Default, and the pre-gate behaviour. */
+  UNRESTRICTED = 'unrestricted',
+  /** The certificate must be earned once; the pass never expires. */
+  REQUIRED_ONCE = 'required_once',
+  /** The certificate must be renewed every 12 months. */
+  REQUIRED_ANNUALLY = 'required_annually',
+}

--- a/ayunis-core-backend/src/iam/academy-access/infrastructure/persistence/postgres/mappers/org-academy-access-settings.mapper.ts
+++ b/ayunis-core-backend/src/iam/academy-access/infrastructure/persistence/postgres/mappers/org-academy-access-settings.mapper.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { OrgAcademyAccessSettings } from 'src/iam/academy-access/domain/org-academy-access-settings.entity';
+import { OrgAcademyAccessSettingsRecord } from '../schema/org-academy-access-settings.record';
+
+@Injectable()
+export class OrgAcademyAccessSettingsMapper {
+  toDomain(record: OrgAcademyAccessSettingsRecord): OrgAcademyAccessSettings {
+    return new OrgAcademyAccessSettings({
+      id: record.id,
+      orgId: record.orgId,
+      mode: record.mode,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  toRecord(domain: OrgAcademyAccessSettings): OrgAcademyAccessSettingsRecord {
+    const record = new OrgAcademyAccessSettingsRecord();
+    record.id = domain.id;
+    record.orgId = domain.orgId;
+    record.mode = domain.mode;
+    record.createdAt = domain.createdAt;
+    record.updatedAt = domain.updatedAt;
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/iam/academy-access/infrastructure/persistence/postgres/org-academy-access-settings.repository.ts
+++ b/ayunis-core-backend/src/iam/academy-access/infrastructure/persistence/postgres/org-academy-access-settings.repository.ts
@@ -1,0 +1,46 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UUID } from 'crypto';
+import { OrgAcademyAccessSettingsRepository } from 'src/iam/academy-access/application/ports/org-academy-access-settings.repository';
+import { OrgAcademyAccessSettings } from 'src/iam/academy-access/domain/org-academy-access-settings.entity';
+import { OrgAcademyAccessSettingsRecord } from './schema/org-academy-access-settings.record';
+import { OrgAcademyAccessSettingsMapper } from './mappers/org-academy-access-settings.mapper';
+
+@Injectable()
+export class PostgresOrgAcademyAccessSettingsRepository extends OrgAcademyAccessSettingsRepository {
+  private readonly logger = new Logger(
+    PostgresOrgAcademyAccessSettingsRepository.name,
+  );
+
+  constructor(
+    @InjectRepository(OrgAcademyAccessSettingsRecord)
+    private readonly repository: Repository<OrgAcademyAccessSettingsRecord>,
+    private readonly mapper: OrgAcademyAccessSettingsMapper,
+  ) {
+    super();
+  }
+
+  async findByOrgId(orgId: UUID): Promise<OrgAcademyAccessSettings | null> {
+    const record = await this.repository.findOne({ where: { orgId } });
+    return record ? this.mapper.toDomain(record) : null;
+  }
+
+  async upsert(
+    settings: OrgAcademyAccessSettings,
+  ): Promise<OrgAcademyAccessSettings> {
+    this.logger.log('upsert', { orgId: settings.orgId, mode: settings.mode });
+
+    await this.repository.upsert(this.mapper.toRecord(settings), {
+      conflictPaths: ['orgId'],
+      skipUpdateIfNoValuesChanged: true,
+    });
+
+    // Re-read so the caller gets the surviving row's id, not the one a losing
+    // insert generated.
+    const saved = await this.repository.findOneOrFail({
+      where: { orgId: settings.orgId },
+    });
+    return this.mapper.toDomain(saved);
+  }
+}

--- a/ayunis-core-backend/src/iam/academy-access/infrastructure/persistence/postgres/schema/org-academy-access-settings.record.ts
+++ b/ayunis-core-backend/src/iam/academy-access/infrastructure/persistence/postgres/schema/org-academy-access-settings.record.ts
@@ -1,0 +1,24 @@
+import { UUID } from 'crypto';
+import { BaseRecord } from 'src/common/db/base-record';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { OrgRecord } from 'src/iam/orgs/infrastructure/repositories/local/schema/org.record';
+import { AcademyAccessMode } from 'src/iam/academy-access/domain/value-objects/academy-access-mode.enum';
+
+@Entity({ name: 'org_academy_access_settings' })
+export class OrgAcademyAccessSettingsRecord extends BaseRecord {
+  @Column({ nullable: false })
+  @Index({ unique: true })
+  orgId: UUID;
+
+  @ManyToOne(() => OrgRecord, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'orgId' })
+  org: OrgRecord;
+
+  @Column({
+    type: 'enum',
+    enum: AcademyAccessMode,
+    nullable: false,
+    default: AcademyAccessMode.UNRESTRICTED,
+  })
+  mode: AcademyAccessMode;
+}

--- a/ayunis-core-backend/src/iam/academy-access/presenters/http/academy-access.controller.ts
+++ b/ayunis-core-backend/src/iam/academy-access/presenters/http/academy-access.controller.ts
@@ -1,0 +1,89 @@
+import { Body, Controller, Get, HttpStatus, Logger, Put } from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import {
+  CurrentUser,
+  UserProperty,
+} from 'src/iam/authentication/application/decorators/current-user.decorator';
+import { Roles } from 'src/iam/authorization/application/decorators/roles.decorator';
+import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
+import { EvaluateAcademyAccessUseCase } from '../../application/use-cases/evaluate-academy-access/evaluate-academy-access.use-case';
+import { EvaluateAcademyAccessQuery } from '../../application/use-cases/evaluate-academy-access/evaluate-academy-access.query';
+import { GetOrgAcademyAccessSettingsUseCase } from '../../application/use-cases/get-org-academy-access-settings/get-org-academy-access-settings.use-case';
+import { GetOrgAcademyAccessSettingsQuery } from '../../application/use-cases/get-org-academy-access-settings/get-org-academy-access-settings.query';
+import { UpsertOrgAcademyAccessSettingsUseCase } from '../../application/use-cases/upsert-org-academy-access-settings/upsert-org-academy-access-settings.use-case';
+import { UpsertOrgAcademyAccessSettingsCommand } from '../../application/use-cases/upsert-org-academy-access-settings/upsert-org-academy-access-settings.command';
+import { AcademyAccessStatusResponseDto } from './dto/academy-access-status-response.dto';
+import { OrgAcademyAccessSettingsResponseDto } from './dto/org-academy-access-settings-response.dto';
+import { UpsertOrgAcademyAccessSettingsDto } from './dto/upsert-org-academy-access-settings.dto';
+
+@ApiTags('Academy Access')
+@Controller('academy-access')
+export class AcademyAccessController {
+  private readonly logger = new Logger(AcademyAccessController.name);
+
+  constructor(
+    private readonly evaluateAcademyAccessUseCase: EvaluateAcademyAccessUseCase,
+    private readonly getOrgSettingsUseCase: GetOrgAcademyAccessSettingsUseCase,
+    private readonly upsertOrgSettingsUseCase: UpsertOrgAcademyAccessSettingsUseCase,
+  ) {}
+
+  /**
+   * Deliberately not gated — a blocked user has to be able to read why they are
+   * blocked.
+   */
+  @Get('status')
+  @ApiOperation({
+    summary: 'Whether the current user may use Ayunis Core chat, and why not',
+  })
+  @ApiResponse({ status: HttpStatus.OK, type: AcademyAccessStatusResponseDto })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  async getStatus(
+    @CurrentUser(UserProperty.ID) userId: UUID,
+    @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
+  ): Promise<AcademyAccessStatusResponseDto> {
+    return this.evaluateAcademyAccessUseCase.execute(
+      new EvaluateAcademyAccessQuery(userId, orgId),
+    );
+  }
+
+  @Get('org-settings')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: "Get the org's academy certificate requirement" })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: OrgAcademyAccessSettingsResponseDto,
+  })
+  async getOrgSettings(
+    @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
+  ): Promise<OrgAcademyAccessSettingsResponseDto> {
+    const settings = await this.getOrgSettingsUseCase.execute(
+      new GetOrgAcademyAccessSettingsQuery(orgId),
+    );
+    return { mode: settings.mode };
+  }
+
+  @Put('org-settings')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: "Set the org's academy certificate requirement" })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: OrgAcademyAccessSettingsResponseDto,
+  })
+  async upsertOrgSettings(
+    @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
+    @Body() dto: UpsertOrgAcademyAccessSettingsDto,
+  ): Promise<OrgAcademyAccessSettingsResponseDto> {
+    this.logger.log('upsertOrgSettings', { orgId, mode: dto.mode });
+
+    const settings = await this.upsertOrgSettingsUseCase.execute(
+      new UpsertOrgAcademyAccessSettingsCommand(orgId, dto.mode),
+    );
+    return { mode: settings.mode };
+  }
+}

--- a/ayunis-core-backend/src/iam/academy-access/presenters/http/dto/academy-access-status-response.dto.ts
+++ b/ayunis-core-backend/src/iam/academy-access/presenters/http/dto/academy-access-status-response.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AcademyAccessMode } from '../../../domain/value-objects/academy-access-mode.enum';
+
+export class AcademyAccessStatusResponseDto {
+  @ApiProperty({
+    enum: AcademyAccessMode,
+    enumName: 'AcademyAccessMode',
+    description: "The certificate requirement configured for the user's org",
+  })
+  mode: AcademyAccessMode;
+
+  @ApiProperty({
+    type: 'boolean',
+    description:
+      'Whether the gate applies to this user at all. False for unrestricted orgs and for orgs without the academy add-on.',
+  })
+  required: boolean;
+
+  @ApiProperty({
+    type: 'boolean',
+    description: 'Whether the user may currently use Ayunis Core chat',
+  })
+  allowed: boolean;
+
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    nullable: true,
+    description:
+      'When the user last completed the academy. Null when the gate does not apply — read GET /academy/progress for the completion date in that case.',
+  })
+  completedAt: Date | null;
+
+  @ApiProperty({
+    type: 'string',
+    format: 'date-time',
+    nullable: true,
+    description:
+      'When the certificate stops being valid. Only populated when the org requires annual renewal.',
+  })
+  expiresAt: Date | null;
+}

--- a/ayunis-core-backend/src/iam/academy-access/presenters/http/dto/org-academy-access-settings-response.dto.ts
+++ b/ayunis-core-backend/src/iam/academy-access/presenters/http/dto/org-academy-access-settings-response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AcademyAccessMode } from '../../../domain/value-objects/academy-access-mode.enum';
+
+export class OrgAcademyAccessSettingsResponseDto {
+  @ApiProperty({
+    enum: AcademyAccessMode,
+    enumName: 'AcademyAccessMode',
+    description: 'The certificate requirement configured for the org',
+  })
+  mode: AcademyAccessMode;
+}

--- a/ayunis-core-backend/src/iam/academy-access/presenters/http/dto/upsert-org-academy-access-settings.dto.ts
+++ b/ayunis-core-backend/src/iam/academy-access/presenters/http/dto/upsert-org-academy-access-settings.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { AcademyAccessMode } from '../../../domain/value-objects/academy-access-mode.enum';
+
+export class UpsertOrgAcademyAccessSettingsDto {
+  @ApiProperty({
+    enum: AcademyAccessMode,
+    enumName: 'AcademyAccessMode',
+    description: 'The certificate requirement to apply to the org',
+  })
+  @IsEnum(AcademyAccessMode)
+  mode: AcademyAccessMode;
+}

--- a/ayunis-core-backend/src/iam/iam.module.spec.ts
+++ b/ayunis-core-backend/src/iam/iam.module.spec.ts
@@ -10,6 +10,7 @@ import { SubscriptionGuard } from './authorization/application/guards/subscripti
 import { RateLimitGuard } from 'src/common/guards/rate-limit.guard';
 import { AddonGuard } from './authorization/application/guards/addon.guard';
 import { UsageBasedSubscriptionGuard } from './authorization/application/guards/usage-based-subscription.guard';
+import { AcademyCertificateGuard } from './academy-access/application/guards/academy-certificate.guard';
 
 type GuardRef = abstract new (...args: never[]) => unknown;
 
@@ -53,6 +54,7 @@ describe('IamModule global guard order', () => {
       AddonGuard,
       SubscriptionGuard,
       UsageBasedSubscriptionGuard,
+      AcademyCertificateGuard,
       RateLimitGuard,
     ]);
   });
@@ -63,6 +65,27 @@ describe('IamModule global guard order', () => {
     expect(order.indexOf(JwtAuthGuard)).toBeGreaterThanOrEqual(0);
     expect(order.indexOf(JwtAuthGuard)).toBeLessThan(
       order.indexOf(IpAllowlistGuard),
+    );
+  });
+
+  // Up to three DB round-trips, so every cheaper denial should short-circuit
+  // ahead of it. RateLimitGuard stays terminal.
+  it('runs AcademyCertificateGuard after the cheaper authorization gates', () => {
+    const order = appGuardOrder();
+
+    for (const cheaper of [
+      JwtAuthGuard,
+      EmailConfirmGuard,
+      RolesGuard,
+      AddonGuard,
+      SubscriptionGuard,
+    ]) {
+      expect(order.indexOf(cheaper)).toBeLessThan(
+        order.indexOf(AcademyCertificateGuard),
+      );
+    }
+    expect(order.indexOf(AcademyCertificateGuard)).toBeLessThan(
+      order.indexOf(RateLimitGuard),
     );
   });
 });

--- a/ayunis-core-backend/src/iam/iam.module.ts
+++ b/ayunis-core-backend/src/iam/iam.module.ts
@@ -21,6 +21,7 @@ import { CreditLimitsModule } from './credit-limits/credit-limits.module';
 import { BudgetAlertsModule } from './budget-alerts/budget-alerts.module';
 import { PlatformConfigModule } from './platform-config/platform-config.module';
 import { AddonsModule } from './addons/addons.module';
+import { AcademyAccessModule } from './academy-access/academy-access.module';
 import { IpAllowlistModule } from './ip-allowlist/ip-allowlist.module';
 import { ApiKeysModule } from './api-keys/api-keys.module';
 import { MfaModule } from './mfa/mfa.module';
@@ -33,6 +34,7 @@ import { SubscriptionGuard } from './authorization/application/guards/subscripti
 import { RateLimitGuard } from 'src/common/guards/rate-limit.guard';
 import { AddonGuard } from './authorization/application/guards/addon.guard';
 import { UsageBasedSubscriptionGuard } from './authorization/application/guards/usage-based-subscription.guard';
+import { AcademyCertificateGuard } from './academy-access/application/guards/academy-certificate.guard';
 
 // Feature modules re-exported by IamModule. Listed once and spread into both
 // `imports` and `exports` so the two cannot drift out of sync.
@@ -54,6 +56,7 @@ const IAM_FEATURE_MODULES = [
   IpAllowlistModule,
   ApiKeysModule,
   AddonsModule,
+  AcademyAccessModule,
   MfaModule,
 ];
 
@@ -84,6 +87,13 @@ const GLOBAL_GUARD_PROVIDERS = [
   { provide: APP_GUARD, useExisting: AddonGuard },
   { provide: APP_GUARD, useExisting: SubscriptionGuard },
   { provide: APP_GUARD, useExisting: UsageBasedSubscriptionGuard },
+  // Last of the authorization gates: it reads request.user (so it must follow
+  // JwtAuthGuard) and is the most expensive of them, costing up to three DB
+  // round-trips. Guards short-circuit on the first denial, so a request that
+  // would fail any cheaper check — unauthenticated, IP-blocked, unverified
+  // email, wrong role, add-on inactive, no subscription — never pays for it.
+  // RateLimitGuard stays terminal.
+  { provide: APP_GUARD, useExisting: AcademyCertificateGuard },
   { provide: APP_GUARD, useExisting: RateLimitGuard },
 ];
 

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -4676,6 +4676,48 @@ export interface CreateApiKeyResponseDto {
   secret: string;
 }
 
+/**
+ * The certificate requirement configured for the user's org
+ */
+export type AcademyAccessMode = typeof AcademyAccessMode[keyof typeof AcademyAccessMode];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AcademyAccessMode = {
+  unrestricted: 'unrestricted',
+  required_once: 'required_once',
+  required_annually: 'required_annually',
+} as const;
+
+export interface AcademyAccessStatusResponseDto {
+  /** The certificate requirement configured for the user's org */
+  mode: AcademyAccessMode;
+  /** Whether the gate applies to this user at all. False for unrestricted orgs and for orgs without the academy add-on. */
+  required: boolean;
+  /** Whether the user may currently use Ayunis Core chat */
+  allowed: boolean;
+  /**
+   * When the user last completed the academy. Null when the gate does not apply — read GET /academy/progress for the completion date in that case.
+   * @nullable
+   */
+  completedAt: string | null;
+  /**
+   * When the certificate stops being valid. Only populated when the org requires annual renewal.
+   * @nullable
+   */
+  expiresAt: string | null;
+}
+
+export interface OrgAcademyAccessSettingsResponseDto {
+  /** The certificate requirement configured for the org */
+  mode: AcademyAccessMode;
+}
+
+export interface UpsertOrgAcademyAccessSettingsDto {
+  /** The certificate requirement to apply to the org */
+  mode: AcademyAccessMode;
+}
+
 export interface MfaStatusResponseDto {
   /** Whether the user has confirmed TOTP two-factor auth. */
   enabled: boolean;

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -25,6 +25,7 @@ import type {
 } from '@tanstack/react-query';
 
 import type {
+  AcademyAccessStatusResponseDto,
   AcademyChapterResponseDto,
   AcademyProgressResponseDto,
   AcceptInviteDto,
@@ -119,6 +120,7 @@ import type {
   ModelWithConfigResponseDto,
   ModelsControllerUpdatePermittedModel200,
   OnboardingResponseDto,
+  OrgAcademyAccessSettingsResponseDto,
   OrgChatSettingsResponseDto,
   OrgMfaRequirementResponseDto,
   OrgSystemPromptResponseDto,
@@ -224,6 +226,7 @@ import type {
   UpdateTrialRequestDto,
   UpdateUserNameDto,
   UpdateUserRoleDto,
+  UpsertOrgAcademyAccessSettingsDto,
   UpsertOrgChatSettingsDto,
   UpsertOrgSystemPromptDto,
   UpsertUserSystemPromptDto,
@@ -20433,6 +20436,256 @@ export const useApiKeysControllerRevokeApiKey = <TError = void,
       > => {
 
       const mutationOptions = getApiKeysControllerRevokeApiKeyMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Whether the current user may use Ayunis Core chat, and why not
+ */
+export const academyAccessControllerGetStatus = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<AcademyAccessStatusResponseDto>(
+      {url: `/academy-access/status`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getAcademyAccessControllerGetStatusQueryKey = () => {
+    return [
+    `/academy-access/status`
+    ] as const;
+    }
+
+    
+export const getAcademyAccessControllerGetStatusQueryOptions = <TData = Awaited<ReturnType<typeof academyAccessControllerGetStatus>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyAccessControllerGetStatus>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getAcademyAccessControllerGetStatusQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof academyAccessControllerGetStatus>>> = ({ signal }) => academyAccessControllerGetStatus(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof academyAccessControllerGetStatus>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type AcademyAccessControllerGetStatusQueryResult = NonNullable<Awaited<ReturnType<typeof academyAccessControllerGetStatus>>>
+export type AcademyAccessControllerGetStatusQueryError = void
+
+
+export function useAcademyAccessControllerGetStatus<TData = Awaited<ReturnType<typeof academyAccessControllerGetStatus>>, TError = void>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyAccessControllerGetStatus>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof academyAccessControllerGetStatus>>,
+          TError,
+          Awaited<ReturnType<typeof academyAccessControllerGetStatus>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAcademyAccessControllerGetStatus<TData = Awaited<ReturnType<typeof academyAccessControllerGetStatus>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyAccessControllerGetStatus>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof academyAccessControllerGetStatus>>,
+          TError,
+          Awaited<ReturnType<typeof academyAccessControllerGetStatus>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAcademyAccessControllerGetStatus<TData = Awaited<ReturnType<typeof academyAccessControllerGetStatus>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyAccessControllerGetStatus>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Whether the current user may use Ayunis Core chat, and why not
+ */
+
+export function useAcademyAccessControllerGetStatus<TData = Awaited<ReturnType<typeof academyAccessControllerGetStatus>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyAccessControllerGetStatus>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getAcademyAccessControllerGetStatusQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Get the org's academy certificate requirement
+ */
+export const academyAccessControllerGetOrgSettings = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<OrgAcademyAccessSettingsResponseDto>(
+      {url: `/academy-access/org-settings`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getAcademyAccessControllerGetOrgSettingsQueryKey = () => {
+    return [
+    `/academy-access/org-settings`
+    ] as const;
+    }
+
+    
+export const getAcademyAccessControllerGetOrgSettingsQueryOptions = <TData = Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>, TError = unknown>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getAcademyAccessControllerGetOrgSettingsQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>> = ({ signal }) => academyAccessControllerGetOrgSettings(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type AcademyAccessControllerGetOrgSettingsQueryResult = NonNullable<Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>>
+export type AcademyAccessControllerGetOrgSettingsQueryError = unknown
+
+
+export function useAcademyAccessControllerGetOrgSettings<TData = Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>, TError = unknown>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>,
+          TError,
+          Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAcademyAccessControllerGetOrgSettings<TData = Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>,
+          TError,
+          Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useAcademyAccessControllerGetOrgSettings<TData = Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get the org's academy certificate requirement
+ */
+
+export function useAcademyAccessControllerGetOrgSettings<TData = Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof academyAccessControllerGetOrgSettings>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getAcademyAccessControllerGetOrgSettingsQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Set the org's academy certificate requirement
+ */
+export const academyAccessControllerUpsertOrgSettings = (
+    upsertOrgAcademyAccessSettingsDto: UpsertOrgAcademyAccessSettingsDto,
+ ) => {
+      
+      
+      return customAxiosInstance<OrgAcademyAccessSettingsResponseDto>(
+      {url: `/academy-access/org-settings`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: upsertOrgAcademyAccessSettingsDto
+    },
+      );
+    }
+  
+
+
+export const getAcademyAccessControllerUpsertOrgSettingsMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof academyAccessControllerUpsertOrgSettings>>, TError,{data: UpsertOrgAcademyAccessSettingsDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof academyAccessControllerUpsertOrgSettings>>, TError,{data: UpsertOrgAcademyAccessSettingsDto}, TContext> => {
+
+const mutationKey = ['academyAccessControllerUpsertOrgSettings'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof academyAccessControllerUpsertOrgSettings>>, {data: UpsertOrgAcademyAccessSettingsDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  academyAccessControllerUpsertOrgSettings(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type AcademyAccessControllerUpsertOrgSettingsMutationResult = NonNullable<Awaited<ReturnType<typeof academyAccessControllerUpsertOrgSettings>>>
+    export type AcademyAccessControllerUpsertOrgSettingsMutationBody = UpsertOrgAcademyAccessSettingsDto
+    export type AcademyAccessControllerUpsertOrgSettingsMutationError = unknown
+
+    /**
+ * @summary Set the org's academy certificate requirement
+ */
+export const useAcademyAccessControllerUpsertOrgSettings = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof academyAccessControllerUpsertOrgSettings>>, TError,{data: UpsertOrgAcademyAccessSettingsDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof academyAccessControllerUpsertOrgSettings>>,
+        TError,
+        {data: UpsertOrgAcademyAccessSettingsDto},
+        TContext
+      > => {
+
+      const mutationOptions = getAcademyAccessControllerUpsertOrgSettingsMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -9864,6 +9864,77 @@
         "tags": ["api-keys"]
       }
     },
+    "/academy-access/status": {
+      "get": {
+        "operationId": "AcademyAccessController_getStatus",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcademyAccessStatusResponseDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated"
+          }
+        },
+        "summary": "Whether the current user may use Ayunis Core chat, and why not",
+        "tags": ["Academy Access"]
+      }
+    },
+    "/academy-access/org-settings": {
+      "get": {
+        "operationId": "AcademyAccessController_getOrgSettings",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgAcademyAccessSettingsResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get the org's academy certificate requirement",
+        "tags": ["Academy Access"]
+      },
+      "put": {
+        "operationId": "AcademyAccessController_upsertOrgSettings",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpsertOrgAcademyAccessSettingsDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgAcademyAccessSettingsResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Set the org's academy certificate requirement",
+        "tags": ["Academy Access"]
+      }
+    },
     "/mfa/status": {
       "get": {
         "operationId": "MfaController_getStatus",
@@ -17318,6 +17389,73 @@
           "createdAt",
           "secret"
         ]
+      },
+      "AcademyAccessMode": {
+        "type": "string",
+        "enum": ["unrestricted", "required_once", "required_annually"],
+        "description": "The certificate requirement configured for the user's org"
+      },
+      "AcademyAccessStatusResponseDto": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "description": "The certificate requirement configured for the user's org",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AcademyAccessMode"
+              }
+            ]
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Whether the gate applies to this user at all. False for unrestricted orgs and for orgs without the academy add-on."
+          },
+          "allowed": {
+            "type": "boolean",
+            "description": "Whether the user may currently use Ayunis Core chat"
+          },
+          "completedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "When the user last completed the academy. Null when the gate does not apply — read GET /academy/progress for the completion date in that case."
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "When the certificate stops being valid. Only populated when the org requires annual renewal."
+          }
+        },
+        "required": ["mode", "required", "allowed", "completedAt", "expiresAt"]
+      },
+      "OrgAcademyAccessSettingsResponseDto": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "description": "The certificate requirement configured for the org",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AcademyAccessMode"
+              }
+            ]
+          }
+        },
+        "required": ["mode"]
+      },
+      "UpsertOrgAcademyAccessSettingsDto": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "description": "The certificate requirement to apply to the org",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AcademyAccessMode"
+              }
+            ]
+          }
+        },
+        "required": ["mode"]
       },
       "MfaStatusResponseDto": {
         "type": "object",


### PR DESCRIPTION
Part 2 of 3 for [AYC-597](https://linear.app/ayunis/issue/AYC-597). Backend gate; the UI lands in the next PR.

## What

New IAM module `src/iam/academy-access` with a per-org `AcademyAccessMode`:

| mode | behaviour |
|---|---|
| `unrestricted` | no gate — **default**, and what every existing org gets |
| `required_once` | certificate must be earned once, never expires |
| `required_annually` | certificate must be renewed every 12 months |

An absent settings row means `unrestricted`, so the migration leaves existing orgs untouched.

`@RequireAcademyCertificate()` marks a controller as chat surface; `AcademyCertificateGuard` decides per request, bound globally from `IamModule`.

## Writes only — reads stay open

The guard exempts `GET`/`HEAD`/`OPTIONS` and `DELETE`. A lapsed user keeps read access to their entire chat history and can still delete their own data; they just cannot start or advance a conversation. This is a verb-level rule — an endpoint that triggers inference from a `GET` would slip through and must be gated explicitly.

Gated: `runs` (`POST send-message`), `transcriptions`, `threads` + its thread-scoped sub-controllers.

## Deliberately not gated

- **`skills`, `artifacts`, `knowledge-bases`** — authoring and configuration. They consume no inference without a run, and gating them yields confusing 403s on pages that otherwise work.
- **`openai-compat`** — API-key authenticated, and `ApiKeyPrincipal` has no `userId`; a machine principal has no certificate holder. ⚠️ **Known gap worth flagging to CS:** an org that enables the gate *and* issues API keys retains an ungated inference path. API keys are admin-created, so this is an admin choice rather than an escalation.
- **`shares`** — gating it would stop a lapsed user from *un*sharing.

## Design notes

- **Fails open when the academy add-on is inactive.** Such an org cannot take the certificate at all, so gating on it would lock them out with no way forward.
- **Cost.** Checks are ordered cheapest-first and short-circuit: an `unrestricted` org pays exactly one indexed lookup and never touches the add-on or completion tables. Specs assert the short-circuit so that budget cannot silently regress. Nothing is cached — "passing immediately unlocks Core" rules it out.
- **Guard lives in the feature module, not `authorization`.** Same shape as `IpAllowlistGuard`. Putting it in `AuthorizationModule` would drag `AcademyModule` (5 records, 6 controllers, the Puppeteer certificate renderer) into the injector of the most widely re-exported module in the app.
- `orgId` is passed explicitly rather than read from `ContextService` — global guards run before the CLS store is populated, which is why `AddonGuard` and `SubscriptionGuard` read `request.user` too.
- Denials throw `AcademyCertificateRequiredError` (`ACADEMY_CERTIFICATE_REQUIRED`, 403) instead of returning `false`, so the frontend can tell this apart from every other 403.

## Incidental

Touching `transcriptions.controller.ts` pulled a pre-existing 70-line method into the complexity gate. Extracted its Swagger block into a composed `@ApiTranscribe()` decorator (existing repo pattern) — verified the emitted OpenAPI is byte-identical. That surfaced a real bug the linter had been flagging as dead code: the `if (!file)` guard sat *after* `file.originalname` was dereferenced, so a request with no file returned a 500 rather than a 400. Fixed.

## Verified against a running stack

`unrestricted` unaffected · add-on inactive fails open · `required_once` blocks `POST /threads` and `POST /runs/send-message` with the right code while `GET /threads` and `/academy/*` stay 200 · inserting a completion unlocks with no restart · `required_annually` denies a 13-month-old completion and reports the lapse date · the same completion is still valid under `required_once`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tjt7mu9axFiVLMR6QGqMpH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization on core chat paths (runs, threads, transcriptions) with a known API-key bypass; guard order is tested but misconfiguration could block or over-allow inference.
> 
> **Overview**
> Adds a new **`academy-access`** IAM module so orgs can require a valid KI-Führerschein certificate before users can **start or advance** Ayunis Core chat. Per-org **`AcademyAccessMode`** (`unrestricted`, `required_once`, `required_annually`) is stored in **`org_academy_access_settings`** (migration + default **unrestricted** when no row exists).
> 
> **`EvaluateAcademyAccessUseCase`** short-circuits on unrestricted orgs, **fails open** if the academy add-on is inactive, then checks academy completion (once vs annual expiry). **`AcademyCertificateGuard`** is registered globally in **`IamModule`** after cheaper auth gates; **`@RequireAcademyCertificate()`** marks chat-surface controllers (`runs`, `transcriptions`, `threads` and sub-controllers). It blocks **state-changing** methods only (`GET`/`DELETE` etc. stay open); denials throw **`ACADEMY_CERTIFICATE_REQUIRED`** (403). API-key principals are skipped (documented gap vs `openai-compat`).
> 
> New HTTP: **`GET /academy-access/status`**, admin **`GET`/`PUT /academy-access/org-settings`**. Frontend OpenAPI client regenerated.
> 
> Incidental: transcriptions Swagger moved to **`@ApiTranscribe()`**; missing upload file now returns **400** before dereferencing `file`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfeb2cbcad8df2e9d0f3c7ad9e0557fdda0d98ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->