### PR TITLE
feat(academy): require the AI certificate for core chat (AYC-597)

### DIFF
--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -44,6 +44,7 @@ import { Route as AuthenticatedAdminSettingsIntegrationsRouteImport } from './ro
 import { Route as AuthenticatedAdminSettingsInstructionsRouteImport } from './routes/_authenticated/admin-settings.instructions'
 import { Route as AuthenticatedAdminSettingsApiKeysRouteImport } from './routes/_authenticated/admin-settings.api-keys'
 import { Route as AuthenticatedAdminSettingsAnonymizationRouteImport } from './routes/_authenticated/admin-settings.anonymization'
+import { Route as AuthenticatedAdminSettingsAcademyRouteImport } from './routes/_authenticated/admin-settings.academy'
 import { Route as AuthenticatedAcademyChapterIdRouteImport } from './routes/_authenticated/academy.$chapterId'
 import { Route as onboardingPasswordResetRouteImport } from './routes/(onboarding)/password.reset'
 import { Route as onboardingPasswordForgotRouteImport } from './routes/(onboarding)/password.forgot'
@@ -259,6 +260,12 @@ const AuthenticatedAdminSettingsAnonymizationRoute =
     path: '/admin-settings/anonymization',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedAdminSettingsAcademyRoute =
+  AuthenticatedAdminSettingsAcademyRouteImport.update({
+    id: '/admin-settings/academy',
+    path: '/admin-settings/academy',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedAcademyChapterIdRoute =
   AuthenticatedAcademyChapterIdRouteImport.update({
     id: '/academy/$chapterId',
@@ -381,6 +388,7 @@ export interface FileRoutesByFullPath {
   '/password/forgot': typeof onboardingPasswordForgotRoute
   '/password/reset': typeof onboardingPasswordResetRoute
   '/academy/$chapterId': typeof AuthenticatedAcademyChapterIdRoute
+  '/admin-settings/academy': typeof AuthenticatedAdminSettingsAcademyRoute
   '/admin-settings/anonymization': typeof AuthenticatedAdminSettingsAnonymizationRoute
   '/admin-settings/api-keys': typeof AuthenticatedAdminSettingsApiKeysRoute
   '/admin-settings/instructions': typeof AuthenticatedAdminSettingsInstructionsRoute
@@ -435,6 +443,7 @@ export interface FileRoutesByTo {
   '/password/forgot': typeof onboardingPasswordForgotRoute
   '/password/reset': typeof onboardingPasswordResetRoute
   '/academy/$chapterId': typeof AuthenticatedAcademyChapterIdRoute
+  '/admin-settings/academy': typeof AuthenticatedAdminSettingsAcademyRoute
   '/admin-settings/anonymization': typeof AuthenticatedAdminSettingsAnonymizationRoute
   '/admin-settings/api-keys': typeof AuthenticatedAdminSettingsApiKeysRoute
   '/admin-settings/instructions': typeof AuthenticatedAdminSettingsInstructionsRoute
@@ -491,6 +500,7 @@ export interface FileRoutesById {
   '/(onboarding)/password/forgot': typeof onboardingPasswordForgotRoute
   '/(onboarding)/password/reset': typeof onboardingPasswordResetRoute
   '/_authenticated/academy/$chapterId': typeof AuthenticatedAcademyChapterIdRoute
+  '/_authenticated/admin-settings/academy': typeof AuthenticatedAdminSettingsAcademyRoute
   '/_authenticated/admin-settings/anonymization': typeof AuthenticatedAdminSettingsAnonymizationRoute
   '/_authenticated/admin-settings/api-keys': typeof AuthenticatedAdminSettingsApiKeysRoute
   '/_authenticated/admin-settings/instructions': typeof AuthenticatedAdminSettingsInstructionsRoute
@@ -547,6 +557,7 @@ export interface FileRouteTypes {
     | '/password/forgot'
     | '/password/reset'
     | '/academy/$chapterId'
+    | '/admin-settings/academy'
     | '/admin-settings/anonymization'
     | '/admin-settings/api-keys'
     | '/admin-settings/instructions'
@@ -601,6 +612,7 @@ export interface FileRouteTypes {
     | '/password/forgot'
     | '/password/reset'
     | '/academy/$chapterId'
+    | '/admin-settings/academy'
     | '/admin-settings/anonymization'
     | '/admin-settings/api-keys'
     | '/admin-settings/instructions'
@@ -656,6 +668,7 @@ export interface FileRouteTypes {
     | '/(onboarding)/password/forgot'
     | '/(onboarding)/password/reset'
     | '/_authenticated/academy/$chapterId'
+    | '/_authenticated/admin-settings/academy'
     | '/_authenticated/admin-settings/anonymization'
     | '/_authenticated/admin-settings/api-keys'
     | '/_authenticated/admin-settings/instructions'
@@ -959,6 +972,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminSettingsAnonymizationRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/admin-settings/academy': {
+      id: '/_authenticated/admin-settings/academy'
+      path: '/admin-settings/academy'
+      fullPath: '/admin-settings/academy'
+      preLoaderRoute: typeof AuthenticatedAdminSettingsAcademyRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/academy/$chapterId': {
       id: '/_authenticated/academy/$chapterId'
       path: '/academy/$chapterId'
@@ -1091,6 +1111,7 @@ declare module '@tanstack/react-router' {
 interface AuthenticatedRouteChildren {
   AuthenticatedInstallRoute: typeof AuthenticatedInstallRoute
   AuthenticatedAcademyChapterIdRoute: typeof AuthenticatedAcademyChapterIdRoute
+  AuthenticatedAdminSettingsAcademyRoute: typeof AuthenticatedAdminSettingsAcademyRoute
   AuthenticatedAdminSettingsAnonymizationRoute: typeof AuthenticatedAdminSettingsAnonymizationRoute
   AuthenticatedAdminSettingsApiKeysRoute: typeof AuthenticatedAdminSettingsApiKeysRoute
   AuthenticatedAdminSettingsInstructionsRoute: typeof AuthenticatedAdminSettingsInstructionsRoute
@@ -1135,6 +1156,8 @@ interface AuthenticatedRouteChildren {
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedInstallRoute: AuthenticatedInstallRoute,
   AuthenticatedAcademyChapterIdRoute: AuthenticatedAcademyChapterIdRoute,
+  AuthenticatedAdminSettingsAcademyRoute:
+    AuthenticatedAdminSettingsAcademyRoute,
   AuthenticatedAdminSettingsAnonymizationRoute:
     AuthenticatedAdminSettingsAnonymizationRoute,
   AuthenticatedAdminSettingsApiKeysRoute:

--- a/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.academy.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.academy.tsx
@@ -1,0 +1,31 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { AcademySettingsPage } from '@/pages/admin-settings/academy-settings';
+import { isAcademyAddonActive } from '@/features/academy';
+import {
+  addonsControllerList,
+  getAddonsControllerListQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+
+export const Route = createFileRoute('/_authenticated/admin-settings/academy')({
+  component: RouteComponent,
+  beforeLoad: ({ context: { user } }) => {
+    if (user.role !== 'admin') {
+      throw redirect({ to: '/' });
+    }
+  },
+  // Without the add-on there is no certificate to require, so the setting has
+  // no meaning — the sidebar hides the entry for the same reason.
+  loader: async ({ context: { queryClient } }) => {
+    const addons = await queryClient.fetchQuery({
+      queryKey: getAddonsControllerListQueryKey(),
+      queryFn: () => addonsControllerList(),
+    });
+    if (!isAcademyAddonActive(addons)) {
+      throw redirect({ to: '/admin-settings/users' });
+    }
+  },
+});
+
+function RouteComponent() {
+  return <AcademySettingsPage />;
+}

--- a/ayunis-core-frontend/src/features/academy/index.ts
+++ b/ayunis-core-frontend/src/features/academy/index.ts
@@ -1,4 +1,6 @@
 export { isAcademyAddonActive } from './isAcademyAddonActive';
 export { useIsAcademyAddonActive } from './useIsAcademyAddonActive';
 export { useDownloadCertificate } from './useDownloadCertificate';
+export { useAcademyAccessStatus } from './useAcademyAccessStatus';
+export { default as AcademyGateNotice } from './ui/AcademyGateNotice';
 export { ACADEMY_LANDING_PAGE_URL } from './constants';

--- a/ayunis-core-frontend/src/features/academy/ui/AcademyGateNotice.tsx
+++ b/ayunis-core-frontend/src/features/academy/ui/AcademyGateNotice.tsx
@@ -1,0 +1,49 @@
+import { Lock } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from '@tanstack/react-router';
+import { Button } from '@/shared/ui/shadcn/button';
+import { Alert, AlertTitle, AlertDescription } from '@/shared/ui/shadcn/alert';
+import { useAcademyAccessStatus } from '../useAcademyAccessStatus';
+
+interface AcademyGateNoticeProps {
+  className?: string;
+  /** Hide the "go to the academy" button on the academy page itself. */
+  withAction?: boolean;
+}
+
+/**
+ * Explains why chat is locked and points at the academy. Renders nothing when
+ * the user is not gated, so callers can drop it in unconditionally.
+ */
+export default function AcademyGateNotice({
+  className,
+  withAction = true,
+}: Readonly<AcademyGateNoticeProps>) {
+  const { t } = useTranslation('academy');
+  const navigate = useNavigate();
+  const { isGated } = useAcademyAccessStatus();
+
+  if (!isGated) {
+    return null;
+  }
+
+  return (
+    <Alert variant="warning" className={className}>
+      <Lock />
+      <AlertTitle>{t('gate.title')}</AlertTitle>
+      <AlertDescription>
+        {t('gate.description')}
+        {withAction && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void navigate({ to: '/academy' })}
+            className="mt-2"
+          >
+            {t('gate.action')}
+          </Button>
+        )}
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/ayunis-core-frontend/src/features/academy/useAcademyAccessStatus.ts
+++ b/ayunis-core-frontend/src/features/academy/useAcademyAccessStatus.ts
@@ -1,0 +1,33 @@
+import {
+  useAcademyAccessControllerGetStatus,
+  getAcademyAccessControllerGetStatusQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import type { AcademyAccessStatusResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+interface AcademyAccessStatus {
+  status: AcademyAccessStatusResponseDto | undefined;
+  /**
+   * Whether the certificate gate is currently blocking this user. Stays false
+   * while the status is loading or errored: an outage of the access endpoint
+   * must never lock people out of the product.
+   */
+  isGated: boolean;
+  isLoading: boolean;
+}
+
+export function useAcademyAccessStatus(): AcademyAccessStatus {
+  const { data, isLoading } = useAcademyAccessControllerGetStatus({
+    query: {
+      queryKey: getAcademyAccessControllerGetStatusQueryKey(),
+      // The global client retries 5xx three times with backoff, which would
+      // leave the composer disabled for seconds during an outage.
+      retry: false,
+    },
+  });
+
+  return {
+    status: data,
+    isGated: data ? !data.allowed : false,
+    isLoading,
+  };
+}

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -60,6 +60,8 @@ import enSuperAdminSettingsAppAlerts from './shared/locales/en/super-admin-setti
 import deSuperAdminSettingsAppAlerts from './shared/locales/de/super-admin-settings-app-alerts.json';
 import enAdminSettingsSecurity from './shared/locales/en/admin-settings-security.json';
 import deAdminSettingsSecurity from './shared/locales/de/admin-settings-security.json';
+import enAdminSettingsAcademy from './shared/locales/en/admin-settings-academy.json';
+import deAdminSettingsAcademy from './shared/locales/de/admin-settings-academy.json';
 import enAdminSettingsAnonymization from './shared/locales/en/admin-settings-anonymization.json';
 import deAdminSettingsAnonymization from './shared/locales/de/admin-settings-anonymization.json';
 import enAdminSettingsRetention from './shared/locales/en/admin-settings-retention.json';
@@ -106,6 +108,7 @@ const resources = {
     'super-admin-settings-platform-config': enSuperAdminSettingsPlatformConfig,
     'super-admin-settings-app-alerts': enSuperAdminSettingsAppAlerts,
     'admin-settings-security': enAdminSettingsSecurity,
+    'admin-settings-academy': enAdminSettingsAcademy,
     'admin-settings-anonymization': enAdminSettingsAnonymization,
     'admin-settings-retention': enAdminSettingsRetention,
     'admin-settings-letterheads': enAdminSettingsLetterheads,
@@ -144,6 +147,7 @@ const resources = {
     'super-admin-settings-platform-config': deSuperAdminSettingsPlatformConfig,
     'super-admin-settings-app-alerts': deSuperAdminSettingsAppAlerts,
     'admin-settings-security': deAdminSettingsSecurity,
+    'admin-settings-academy': deAdminSettingsAcademy,
     'admin-settings-anonymization': deAdminSettingsAnonymization,
     'admin-settings-retention': deAdminSettingsRetention,
     'admin-settings-letterheads': deAdminSettingsLetterheads,

--- a/ayunis-core-frontend/src/pages/academy-chapter-quiz/api/useSubmitChapterQuiz.ts
+++ b/ayunis-core-frontend/src/pages/academy-chapter-quiz/api/useSubmitChapterQuiz.ts
@@ -6,6 +6,7 @@ import {
   useAcademyQuizControllerSubmitChapterQuiz,
   getAcademyQuizControllerGetProgressQueryKey,
   getAcademyChaptersControllerGetChaptersQueryKey,
+  getAcademyAccessControllerGetStatusQueryKey,
   type SubmitQuizRequestDto,
 } from '@/shared/api';
 import extractErrorData from '@/shared/api/extract-error-data';
@@ -23,6 +24,12 @@ export function useSubmitChapterQuiz() {
         });
         await queryClient.invalidateQueries({
           queryKey: getAcademyChaptersControllerGetChaptersQueryKey(),
+        });
+        // Passing the last chapter has to unlock chat immediately. router
+        // .invalidate() alone re-runs loaders against a still-fresh cache
+        // entry, so the gate would stay closed for the query's staleTime.
+        await queryClient.invalidateQueries({
+          queryKey: getAcademyAccessControllerGetStatusQueryKey(),
         });
       },
       onError: (error: unknown) => {

--- a/ayunis-core-frontend/src/pages/academy/ui/AcademyPage.tsx
+++ b/ayunis-core-frontend/src/pages/academy/ui/AcademyPage.tsx
@@ -13,11 +13,16 @@ import {
 } from '@/shared/ui/shadcn/item';
 import { Badge } from '@/shared/ui/shadcn/badge';
 import { Button } from '@/shared/ui/shadcn/button';
-import { CheckCircle2, Download, Trophy } from 'lucide-react';
+import { CheckCircle2, Download, RotateCcw, Trophy } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Link } from '@tanstack/react-router';
-import { useDownloadCertificate } from '@/features/academy';
+import {
+  AcademyGateNotice,
+  useAcademyAccessStatus,
+  useDownloadCertificate,
+} from '@/features/academy';
 import type { AcademyChapterResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { AcademyAccessMode } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { useAcademyProgress } from '../api/useAcademyProgress';
 
 interface AcademyPageProps {
@@ -28,10 +33,36 @@ export default function AcademyPage({ chapters }: Readonly<AcademyPageProps>) {
   const { t } = useTranslation('academy');
   const { progress } = useAcademyProgress();
   const { downloadCertificate, isDownloading } = useDownloadCertificate();
+  const { isGated, status } = useAcademyAccessStatus();
 
+  // Passes age out of the certificate's validity period platform-wide, but only
+  // an org on annual renewal actually has to redo anything. Surfacing expiry
+  // anywhere else would nag people about an obligation their org never set.
+  const renewalRequired = status?.mode === AcademyAccessMode.required_annually;
+
+  const chapterProgress = progress?.chapters ?? [];
+  // `passed` stays true forever; `passValid` is what still counts toward the
+  // certificate, so an expired pass reads as "redo this" rather than "done".
   const passedChapterIds = new Set(
-    (progress?.chapters ?? []).filter((c) => c.passed).map((c) => c.chapterId),
+    chapterProgress
+      .filter((c) => (renewalRequired ? c.passValid : c.passed))
+      .map((c) => c.chapterId),
   );
+  const expiredChapterIds = new Set(
+    renewalRequired
+      ? chapterProgress
+          .filter((c) => c.passed && !c.passValid)
+          .map((c) => c.chapterId)
+      : [],
+  );
+
+  // A lapsed completion in an annual org must not still read as "Academy
+  // complete!" right below the notice telling them chat is locked. In that mode
+  // `allowed` is precisely "holds a non-expired certificate", so lean on the
+  // server's answer rather than re-deriving expiry against the client clock.
+  const showCompletion =
+    Boolean(progress?.academyCompletedAt) &&
+    (!renewalRequired || status.allowed);
 
   const sortedChapters = [...chapters].sort((a, b) => a.position - b.position);
 
@@ -44,8 +75,10 @@ export default function AcademyPage({ chapters }: Readonly<AcademyPageProps>) {
       <AppLayout>
         <FullScreenMessageLayout header={header}>
           <EmptyState
-            title={t('emptyState.title')}
-            description={t('emptyState.description')}
+            title={isGated ? t('gate.emptyTitle') : t('emptyState.title')}
+            description={
+              isGated ? t('gate.emptyDescription') : t('emptyState.description')
+            }
           />
         </FullScreenMessageLayout>
       </AppLayout>
@@ -58,7 +91,8 @@ export default function AcademyPage({ chapters }: Readonly<AcademyPageProps>) {
         contentHeader={header}
         contentArea={
           <div className="space-y-3">
-            {progress?.academyCompletedAt && (
+            <AcademyGateNotice withAction={false} />
+            {showCompletion && (
               <Item variant="muted">
                 <ItemMedia variant="icon" className="text-brand">
                   <Trophy />
@@ -94,6 +128,12 @@ export default function AcademyPage({ chapters }: Readonly<AcademyPageProps>) {
                         <Badge variant="secondary" className="gap-1">
                           <CheckCircle2 className="h-3 w-3 text-green-600" />
                           {t('progress.passed')}
+                        </Badge>
+                      )}
+                      {expiredChapterIds.has(chapter.id) && (
+                        <Badge variant="outline" className="gap-1">
+                          <RotateCcw className="h-3 w-3" />
+                          {t('progress.renewalDue')}
                         </Badge>
                       )}
                     </ItemTitle>

--- a/ayunis-core-frontend/src/pages/admin-settings/academy-settings/api/useAcademyAccessOrgSettings.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/academy-settings/api/useAcademyAccessOrgSettings.ts
@@ -1,0 +1,61 @@
+import {
+  useAcademyAccessControllerGetOrgSettings,
+  useAcademyAccessControllerUpsertOrgSettings,
+  getAcademyAccessControllerGetOrgSettingsQueryKey,
+  getAcademyAccessControllerGetStatusQueryKey,
+} from '@/shared/api/generated/ayunisCoreAPI';
+import { AcademyAccessMode } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { useQueryClient } from '@tanstack/react-query';
+import { showSuccess, showError } from '@/shared/lib/toast';
+import { useTranslation } from 'react-i18next';
+import extractErrorData from '@/shared/api/extract-error-data';
+
+export function useAcademyAccessOrgSettings() {
+  const { t } = useTranslation('admin-settings-academy');
+  const queryClient = useQueryClient();
+  const queryKey = getAcademyAccessControllerGetOrgSettingsQueryKey();
+
+  const { data, isLoading, isError, refetch } =
+    useAcademyAccessControllerGetOrgSettings();
+
+  const updateMutation = useAcademyAccessControllerUpsertOrgSettings({
+    mutation: {
+      onSuccess: () => {
+        showSuccess(t('requirement.saved'));
+      },
+      onError: (error: unknown) => {
+        try {
+          const { code } = extractErrorData(error);
+          showError(
+            code === 'ACADEMY_ACCESS_UNEXPECTED_ERROR'
+              ? t('requirement.errorUnexpected')
+              : t('requirement.error'),
+          );
+        } catch {
+          showError(t('requirement.error'));
+        }
+      },
+      onSettled: async () => {
+        await queryClient.invalidateQueries({ queryKey });
+        // An admin who switches the org into a required mode without holding a
+        // certificate is gated too, so their own status has to re-evaluate.
+        await queryClient.invalidateQueries({
+          queryKey: getAcademyAccessControllerGetStatusQueryKey(),
+        });
+      },
+    },
+  });
+
+  function setMode(mode: AcademyAccessMode) {
+    updateMutation.mutate({ data: { mode } });
+  }
+
+  return {
+    mode: data?.mode ?? AcademyAccessMode.unrestricted,
+    isLoading,
+    isError,
+    refetch,
+    isUpdating: updateMutation.isPending,
+    setMode,
+  };
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/academy-settings/index.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/academy-settings/index.ts
@@ -1,0 +1,1 @@
+export { AcademySettingsPage } from './ui/AcademySettingsPage';

--- a/ayunis-core-frontend/src/pages/admin-settings/academy-settings/model/modes.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/academy-settings/model/modes.ts
@@ -1,0 +1,26 @@
+import { AcademyAccessMode } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+interface AcademyAccessModeOption {
+  value: AcademyAccessMode;
+  labelKey: string;
+  descriptionKey: string;
+}
+
+/** Ordered least to most restrictive, which is how the card presents them. */
+export const ACADEMY_ACCESS_MODE_OPTIONS: readonly AcademyAccessModeOption[] = [
+  {
+    value: AcademyAccessMode.unrestricted,
+    labelKey: 'requirement.modes.unrestricted.label',
+    descriptionKey: 'requirement.modes.unrestricted.description',
+  },
+  {
+    value: AcademyAccessMode.required_once,
+    labelKey: 'requirement.modes.requiredOnce.label',
+    descriptionKey: 'requirement.modes.requiredOnce.description',
+  },
+  {
+    value: AcademyAccessMode.required_annually,
+    labelKey: 'requirement.modes.requiredAnnually.label',
+    descriptionKey: 'requirement.modes.requiredAnnually.description',
+  },
+];

--- a/ayunis-core-frontend/src/pages/admin-settings/academy-settings/ui/AcademyRequirementCard.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/academy-settings/ui/AcademyRequirementCard.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from 'react-i18next';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import { useAcademyAccessOrgSettings } from '../api/useAcademyAccessOrgSettings';
+import { ACADEMY_ACCESS_MODE_OPTIONS } from '../model/modes';
+
+export function AcademyRequirementCard() {
+  const { t } = useTranslation('admin-settings-academy');
+  const { mode, isLoading, isUpdating, setMode } =
+    useAcademyAccessOrgSettings();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('requirement.title')}</CardTitle>
+        <CardDescription>{t('requirement.description')}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2">
+          {ACADEMY_ACCESS_MODE_OPTIONS.map((option) => (
+            <li key={option.value}>
+              <label className="flex cursor-pointer items-start gap-3 rounded-md border p-3 hover:bg-muted">
+                <input
+                  type="radio"
+                  name="academy-access-mode"
+                  className="mt-0.5 h-4 w-4 shrink-0"
+                  checked={mode === option.value}
+                  disabled={isLoading || isUpdating}
+                  onChange={() => setMode(option.value)}
+                />
+                <span className="space-y-1">
+                  <span className="block text-sm font-medium">
+                    {t(option.labelKey)}
+                  </span>
+                  <span className="block text-sm text-muted-foreground">
+                    {t(option.descriptionKey)}
+                  </span>
+                </span>
+              </label>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/academy-settings/ui/AcademySettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/academy-settings/ui/AcademySettingsPage.tsx
@@ -1,0 +1,13 @@
+import { useTranslation } from 'react-i18next';
+import SettingsLayout from '../../admin-settings-layout';
+import { AcademyRequirementCard } from './AcademyRequirementCard';
+
+export function AcademySettingsPage() {
+  const { t: tLayout } = useTranslation('admin-settings-layout');
+
+  return (
+    <SettingsLayout title={tLayout('layout.academy')}>
+      <AcademyRequirementCard />
+    </SettingsLayout>
+  );
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/admin-settings-layout/ui/AdminSettingsSidebar.tsx
@@ -10,6 +10,7 @@ import {
   ShieldCheck,
   MessageSquareText,
   Trash2,
+  GraduationCap,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -17,10 +18,12 @@ import {
   type SidebarMenuGroup,
 } from '@/widgets/settings-sidebar/ui/SettingsSidebarWidget';
 import { useIsLetterheadsEnabled } from '@/features/feature-toggles';
+import { useIsAcademyAddonActive } from '@/features/academy';
 
 export function AdminSettingsSidebar() {
   const { t } = useTranslation('admin-settings-layout');
   const isLetterheadsEnabled = useIsLetterheadsEnabled();
+  const academyAddonActive = useIsAcademyAddonActive();
 
   const groups: SidebarMenuGroup[] = [
     {
@@ -90,6 +93,15 @@ export function AdminSettingsSidebar() {
           icon: <Trash2 />,
           label: t('layout.retention'),
         },
+        ...(academyAddonActive
+          ? [
+              {
+                to: '/admin-settings/academy' as const,
+                icon: <GraduationCap />,
+                label: t('layout.academy'),
+              },
+            ]
+          : []),
       ],
     },
     {

--- a/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
+++ b/ayunis-core-frontend/src/pages/chat/api/useMessageSend.ts
@@ -233,6 +233,11 @@ export function useMessageSend(params: UseMessageSendParams) {
                   })
                 : t('chat.errorQuotaExceeded'),
             );
+          } else if (error.message.includes('ACADEMY_CERTIFICATE_REQUIRED')) {
+            // Must precede the generic 403 branch, which would otherwise tell a
+            // blocked user to upgrade to Pro. The thrown message interpolates
+            // the response body, so the error code is present in it.
+            showError(t('chat.academyCertificateRequiredError'));
           } else if (error.message.includes('403')) {
             showError(t('chat.upgradeToProError'));
           } else {

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -20,6 +20,7 @@ import { showError } from '@/shared/lib/toast';
 import { useConfirmation } from '@/widgets/confirmation-modal';
 import { RenameThreadDialog } from '@/widgets/rename-thread-dialog';
 import { useDeleteThread } from '@/features/useDeleteThread';
+import { AcademyGateNotice, useAcademyAccessStatus } from '@/features/academy';
 import { useNavigate } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import type {
@@ -187,6 +188,7 @@ export default function ChatPage({
     },
   });
 
+  const { isGated: isAcademyGated } = useAcademyAccessStatus();
   const { createFileSource, isLoading: isCreatingFileSource } =
     useCreateFileSource({
       threadId: thread.id,
@@ -289,8 +291,10 @@ export default function ChatPage({
 
   // Send is gated while a fresh upload is in flight or while server-side
   // processing of an attached source hasn't finished — both are reasons we
-  // want the user to wait before they can submit a message.
-  const isSendDisabled = isCreatingFileSource || hasProcessingSources;
+  // want the user to wait before they can submit a message. The academy gate
+  // adds a third: the org requires a certificate this user does not hold.
+  const isSendDisabled =
+    isCreatingFileSource || hasProcessingSources || isAcademyGated;
 
   async function handleSend(
     message: string,
@@ -419,6 +423,7 @@ export default function ChatPage({
         {t('chat.inputDisclaimer')}
       </p>
       {thread.isLongChat && <LongChatWarning />}
+      <AcademyGateNotice className="mb-2" />
       <ChatInput
         key={thread.id}
         ref={chatInputRef}

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -18,6 +18,7 @@ import {
   SourceResponseDtoType,
 } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { usePermittedModels } from '@/features/usePermittedModels';
+import { AcademyGateNotice, useAcademyAccessStatus } from '@/features/academy';
 import { useTimeBasedGreeting } from '../model/useTimeBasedGreeting';
 import { useFileFromUrl } from '@/shared/hooks/useFileFromUrl';
 import { useChatContext } from '@/shared/contexts/chat/useChatContext';
@@ -48,6 +49,7 @@ export default function NewChatPage({
 }: Readonly<NewChatPageProps>) {
   const { t } = useTranslation('chat');
   const { initiateChat, cancel, isCreating } = useInitiateChat();
+  const { isGated: isAcademyGated } = useAcademyAccessStatus();
   const { models } = usePermittedModels();
   const greeting = useTimeBasedGreeting();
   const { setPendingImages, setPendingSkillId } = useChatContext();
@@ -253,6 +255,8 @@ export default function NewChatPage({
               {t('chat.inputDisclaimer')}
             </p>
 
+            <AcademyGateNotice className="mb-2" />
+
             <ChatInput
               ref={chatInputRef}
               modelId={modelId}
@@ -260,6 +264,7 @@ export default function NewChatPage({
               knowledgeBases={selectedKnowledgeBases}
               mcpIntegrations={selectedIntegrations}
               submissionState={isCreating ? 'submitting' : 'idle'}
+              isSendDisabled={isAcademyGated}
               onModelChange={handleModelChange}
               onSend={handleSend}
               onCancel={handleCancel}

--- a/ayunis-core-frontend/src/shared/locales/de/academy.json
+++ b/ayunis-core-frontend/src/shared/locales/de/academy.json
@@ -58,10 +58,18 @@
     "completed": {
       "title": "Academy abgeschlossen!",
       "description": "Du hast jedes Kapitel bestanden."
-    }
+    },
+    "renewalDue": "Erneuerung fällig"
   },
   "certificate": {
     "downloadError": "Das Zertifikat konnte nicht heruntergeladen werden. Bitte versuche es erneut.",
     "download": "Zertifikat herunterladen"
+  },
+  "gate": {
+    "title": "Zertifikat erforderlich",
+    "description": "Deine Organisation setzt den KI-Führerschein voraus, bevor du den Ayunis Core Chat nutzen kannst. Schließe die Academy ab, um ihn freizuschalten — deine bisherigen Chats bleiben in der Zwischenzeit lesbar.",
+    "action": "Zur Academy",
+    "emptyTitle": "Noch keine Academy-Inhalte",
+    "emptyDescription": "Der Chat ist gesperrt, bis du das Zertifikat bestanden hast, aber es wurden noch keine Kapitel veröffentlicht. Bitte wende dich an deine Administration."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-academy.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-academy.json
@@ -1,0 +1,23 @@
+{
+  "requirement": {
+    "title": "KI-Führerschein-Pflicht",
+    "description": "Lege fest, ob Mitglieder deiner Organisation den KI-Führerschein in der Academy bestehen müssen, bevor sie den Ayunis Core Chat nutzen können. Das Lesen bestehender Chats wird nie blockiert.",
+    "saved": "Zertifikatspflicht aktualisiert",
+    "error": "Zertifikatspflicht konnte nicht aktualisiert werden",
+    "errorUnexpected": "Beim Speichern ist etwas schiefgelaufen. Bitte versuche es erneut.",
+    "modes": {
+      "unrestricted": {
+        "label": "Nicht erforderlich",
+        "description": "Alle können den Chat sofort nutzen. Die Academy bleibt freiwillig verfügbar."
+      },
+      "requiredOnce": {
+        "label": "Einmalig erforderlich",
+        "description": "Mitglieder müssen den KI-Führerschein bestehen, bevor sie den Chat nutzen. Einmal bestanden, läuft er nie ab."
+      },
+      "requiredAnnually": {
+        "label": "Jährlich erforderlich",
+        "description": "Mitglieder müssen den KI-Führerschein bestehen und alle 12 Monate erneuern. Zum Erneuern muss die gesamte Academy erneut abgeschlossen werden."
+      }
+    }
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-layout.json
@@ -14,7 +14,8 @@
     "retention": "Datenaufbewahrung",
     "instructions": "Chat",
     "letterheads": "Briefpapier",
-    "apiKeys": "API-Schlüssel"
+    "apiKeys": "API-Schlüssel",
+    "academy": "KI-Führerschein"
   },
   "groups": {
     "membersAccess": "Mitglieder & Zugriff",

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -196,7 +196,8 @@
         "nationality_religion_politics": "Nationalität, Religion oder Politik",
         "other": "Personenbezogene Daten"
       }
-    }
+    },
+    "academyCertificateRequiredError": "Deine Organisation setzt den KI-Führerschein voraus, bevor du Nachrichten senden kannst. Schließe die Academy ab, um den Chat freizuschalten."
   },
   "newChat": {
     "newChat": "Neuer Chat",

--- a/ayunis-core-frontend/src/shared/locales/en/academy.json
+++ b/ayunis-core-frontend/src/shared/locales/en/academy.json
@@ -58,10 +58,18 @@
     "completed": {
       "title": "Academy complete!",
       "description": "You've passed every chapter."
-    }
+    },
+    "renewalDue": "Renewal due"
   },
   "certificate": {
     "downloadError": "The certificate could not be downloaded. Please try again.",
     "download": "Download certificate"
+  },
+  "gate": {
+    "title": "Certificate required",
+    "description": "Your organization requires the AI certificate (KI-Führerschein) before you can use Ayunis Core chat. Complete the academy to unlock it — your existing chats stay readable in the meantime.",
+    "action": "Go to the academy",
+    "emptyTitle": "No academy content yet",
+    "emptyDescription": "Chat is locked until you pass the certificate, but no chapters have been published yet. Please contact your administrator."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-academy.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-academy.json
@@ -1,0 +1,23 @@
+{
+  "requirement": {
+    "title": "AI certificate requirement",
+    "description": "Decide whether members of your organization need to pass the AI certificate (KI-Führerschein) in the Academy before they can use Ayunis Core chat. Reading existing chats is never blocked.",
+    "saved": "Certificate requirement updated",
+    "error": "Could not update the certificate requirement",
+    "errorUnexpected": "Something went wrong while saving. Please try again.",
+    "modes": {
+      "unrestricted": {
+        "label": "Not required",
+        "description": "Everyone can use chat straight away. The Academy stays available on a voluntary basis."
+      },
+      "requiredOnce": {
+        "label": "Required once",
+        "description": "Members must pass the certificate before using chat. Once passed, it never expires."
+      },
+      "requiredAnnually": {
+        "label": "Required every year",
+        "description": "Members must pass the certificate before using chat and renew it every 12 months. Renewing means completing the whole Academy again."
+      }
+    }
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-layout.json
@@ -14,7 +14,8 @@
     "retention": "Data retention",
     "instructions": "Chat",
     "letterheads": "Letterheads",
-    "apiKeys": "API Keys"
+    "apiKeys": "API Keys",
+    "academy": "AI certificate"
   },
   "groups": {
     "membersAccess": "Members & Access",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -196,7 +196,8 @@
         "nationality_religion_politics": "Nationality, religion, or politics",
         "other": "Personal data"
       }
-    }
+    },
+    "academyCertificateRequiredError": "Your organization requires the AI certificate before you can send messages. Complete the academy to unlock chat."
   },
   "newChat": {
     "newChat": "New Chat",

--- a/ayunis-core-frontend/src/widgets/app-sidebar/ui/AppSidebar.tsx
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/ui/AppSidebar.tsx
@@ -45,6 +45,7 @@ import { useFeatureToggles } from '@/features/feature-toggles';
 import { useMarketplaceConfig } from '@/features/marketplace';
 import {
   useIsAcademyAddonActive,
+  useAcademyAccessStatus,
   ACADEMY_LANDING_PAGE_URL,
 } from '@/features/academy';
 import { OnboardingCard } from './OnboardingCard';
@@ -59,8 +60,12 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const featureToggles = useFeatureToggles();
   const marketplace = useMarketplaceConfig();
   const academyAddonActive = useIsAcademyAddonActive();
+  const { isGated: isAcademyGated } = useAcademyAccessStatus();
   const location = useLocation();
   useKeyboardShortcut(['j', 'Meta'], () => {
+    // Mirrors the disabled "New chat" item below — otherwise the shortcut
+    // bypasses the gate entirely.
+    if (isAcademyGated) return;
     void navigate({ to: '/chat' });
   });
 
@@ -70,6 +75,9 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       title: t('sidebar.newChat'),
       url: '/chat',
       icon: Plus,
+      // Starting a conversation is a write, so it is blocked without a
+      // certificate. Existing chats stay reachable.
+      disabled: isAcademyGated,
     },
     ...(featureToggles.skillsEnabled
       ? [
@@ -123,7 +131,12 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                       : location.pathname.startsWith(item.url)
                   }
                 >
-                  <Link to={item.url}>
+                  <Link
+                    to={item.url}
+                    // `disabled` is inert on an anchor; the sidebar variants
+                    // style aria-disabled and block pointer events for us.
+                    aria-disabled={item.disabled}
+                  >
                     <item.icon />
                     <span>{item.title}</span>
                   </Link>


### PR DESCRIPTION
Part 3 of 3 for [AYC-597](https://linear.app/ayunis/issue/AYC-597) — completes the feature.

## What

- **Admin settings → KI-Führerschein** (`/admin-settings/academy`): pick one of the three modes. Only shown when the academy add-on is active, since without it there is no certificate to require.
- **Chat is blocked where the write happens**: an explanatory alert above the composer, send disabled, "Neuer Chat" greyed out in the sidebar.
- **Academy page** shows the same notice, and per-chapter "Erneuerung fällig" badges once a pass ages out.

## No global route redirect

Because the backend only blocks writes, gating happens at the composer and the "New chat" entry point rather than by bouncing users out of `/chat`. That keeps chat history browsable — which is the point of the writes-only decision — and avoids restructuring `_authenticated.tsx`'s `beforeLoad`, whose catch-all `catch` turns any new failing `await` into a forced logout.

## Details worth a look

- **`useAcademyAccessStatus` fails open.** `isGated` stays false while the status is loading or errored, and the query sets `retry: false` — the global client retries 5xx three times with backoff, which would leave the composer disabled for seconds during an outage. An outage of the access endpoint must never lock people out.
- **`useSubmitChapterQuiz` invalidates the status key.** `router.invalidate()` alone re-runs loaders against a still-fresh cache entry, so without this the user would stay locked out for the query's 5-minute `staleTime` after passing.
- **`useMessageSend` 403 mapping.** That hook bypasses the orval client (raw `fetch` for SSE) and string-matches the error, so a gate 403 was surfacing as *"upgrade to Pro"*. New branch ahead of the generic `403` check.
- **Cmd+J is guarded** — the shortcut bypasses the sidebar item entirely.
- **Zero-chapters trap.** Gated + no published chapters would otherwise brick a user on a "content will appear here" screen. That case now reads "contact your administrator".
- **No radio-group component exists** in `shared/ui/shadcn`, and the `@ayunis` registry needs a token. Rather than hand-write into the synced shadcn folder, the picker uses native radios in labels — the pattern already used by `QuizQuestionCard`.

## Verified in the browser

Gated org: alert renders, send does nothing when clicked, "Neuer Chat" greyed out, academy reachable. Switching the org to "Nicht erforderlich" unlocks chat without a reload.


## Not in scope

Account "last passed / next renewal" view and the admin overview are [AYC-598](https://linear.app/ayunis/issue/AYC-598); expiry pop-ups and the countdown banner are part 3 of the parent. `GET /academy-access/status` already returns `completedAt`/`expiresAt`, so AYC-598 has what it needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tjt7mu9axFiVLMR6QGqMpH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who can use core chat writes across new/existing threads and admin org policy, with intentional fail-open if the access API is down (users may send until status loads).
> 
> **Overview**
> Adds **org-level AI certificate (KI-Führerschein) requirements** and **write-side chat gating** when a user lacks a valid certificate, without redirecting users away from existing threads.
> 
> **Admin:** New `/admin-settings/academy` route (admin + academy add-on only) lets orgs choose unrestricted, required once, or required annually; saving invalidates per-user access status.
> 
> **Users:** `useAcademyAccessStatus` drives `AcademyGateNotice`, disables send on new/existing chat, and greys out **New chat** plus **Cmd+J** when gated. Status **fails open** on load/error (`retry: false` on the status query). Quiz submit and org setting changes invalidate the access-status cache so chat unlocks immediately after passing.
> 
> **Academy UI:** Annual-renewal orgs get **renewal due** chapter badges, completion banner only when still allowed, and gated empty-state copy when no chapters exist.
> 
> **SSE sends:** `ACADEMY_CERTIFICATE_REQUIRED` is mapped before generic 403 so blocked users don’t see the Pro upgrade message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50721871e325e9d1a0f994acb6625fe19a7a3a71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->