### PR TITLE
fix(sources): surface distinct error when no embedding model is permitted (AYC-603)

### DIFF
--- a/ayunis-core-backend/src/domain/models/application/models.errors.ts
+++ b/ayunis-core-backend/src/domain/models/application/models.errors.ts
@@ -8,6 +8,7 @@ import type { UUID } from 'crypto';
  */
 export enum ModelErrorCode {
   MODEL_NOT_FOUND = 'MODEL_NOT_FOUND',
+  NO_PERMITTED_EMBEDDING_MODEL = 'NO_PERMITTED_EMBEDDING_MODEL',
   NO_DEFAULT_MODEL_FOUND = 'NO_DEFAULT_MODEL_FOUND',
   MODEL_INVALID = 'MODEL_INVALID',
   MODEL_PROVIDER_NOT_SUPPORTED = 'MODEL_PROVIDER_NOT_SUPPORTED',
@@ -115,7 +116,7 @@ export class PermittedEmbeddingModelNotFoundForOrgError extends ModelError {
   constructor(orgId: UUID, metadata?: ErrorMetadata) {
     super(
       `Permitted embedding model not found for org '${orgId}'`,
-      ModelErrorCode.MODEL_NOT_FOUND,
+      ModelErrorCode.NO_PERMITTED_EMBEDDING_MODEL,
       404,
       metadata,
     );

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case.spec.ts
@@ -14,6 +14,7 @@ import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
 import { EmbeddingDimensions } from 'src/domain/models/domain/value-objects/embedding-dimensions.enum';
 import {
+  ModelErrorCode,
   PermittedEmbeddingModelNotFoundForOrgError,
   UnexpectedModelError,
 } from '../../models.errors';
@@ -128,6 +129,16 @@ describe('GetPermittedEmbeddingModelUseCase', () => {
     ).rejects.toThrow(
       new PermittedEmbeddingModelNotFoundForOrgError(orgId).message,
     );
+  });
+
+  it('tags the not-found error with a distinctive code so the UI can surface it', async () => {
+    permittedModelsRepository.findOneEmbedding.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(new GetPermittedEmbeddingModelQuery({ orgId })),
+    ).rejects.toMatchObject({
+      code: ModelErrorCode.NO_PERMITTED_EMBEDDING_MODEL,
+    });
   });
 
   it('throws a not-found error when the repository returns a non-embedding permitted model', async () => {

--- a/ayunis-core-frontend/src/shared/lib/handle-source-upload-error.ts
+++ b/ayunis-core-frontend/src/shared/lib/handle-source-upload-error.ts
@@ -47,6 +47,9 @@ export default function handleSourceUploadError(
       case 'SOURCE_LIMIT_EXCEEDED':
         showError(t('sources.sourceLimitExceededError'));
         break;
+      case 'NO_PERMITTED_EMBEDDING_MODEL':
+        showError(t('sources.noEmbeddingModelError'));
+        break;
       default:
         showError(t('sources.failedToAdd'));
     }

--- a/ayunis-core-frontend/src/shared/locales/de/common.json
+++ b/ayunis-core-frontend/src/shared/locales/de/common.json
@@ -125,7 +125,8 @@
     "fileSourceServiceBusyError": "Der Dokumentenverarbeitungsdienst ist beschäftigt. Bitte versuchen Sie es später erneut.",
     "fileSourceTimeoutError": "Dokumentenverarbeitung hat das Zeitlimit überschritten. Die Datei ist möglicherweise zu komplex.",
     "fileSourceUnreadableError": "Dokument konnte nicht gelesen werden. Es ist möglicherweise beschädigt.",
-    "sourceLimitExceededError": "Ein Chat kann maximal 20 Quellen enthalten. Bitte entfernen Sie eine, bevor Sie eine weitere hinzufügen."
+    "sourceLimitExceededError": "Ein Chat kann maximal 20 Quellen enthalten. Bitte entfernen Sie eine, bevor Sie eine weitere hinzufügen.",
+    "noEmbeddingModelError": "Es ist kein Embedding-Modell aktiviert. Bitte bitten Sie Ihren Administrator, eines zu aktivieren, bevor Sie Dateien hochladen."
   },
   "models": {
     "availableHeading": "Verfügbare Modelle",

--- a/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
@@ -177,6 +177,7 @@
     "fileSourceServiceBusyError": "Der Dokumentenverarbeitungsdienst ist beschäftigt. Bitte versuchen Sie es später erneut.",
     "fileSourceTimeoutError": "Dokumentenverarbeitung hat das Zeitlimit überschritten. Die Datei ist möglicherweise zu komplex.",
     "fileSourceUnreadableError": "Das Dokument konnte nicht gelesen werden. Es ist möglicherweise beschädigt.",
-    "sourceLimitExceededError": "Eine Wissensdatenbank kann maximal 500 Dokumente enthalten. Bitte entfernen Sie eines, bevor Sie ein weiteres hinzufügen."
+    "sourceLimitExceededError": "Eine Wissensdatenbank kann maximal 500 Dokumente enthalten. Bitte entfernen Sie eines, bevor Sie ein weiteres hinzufügen.",
+    "noEmbeddingModelError": "Es ist kein Embedding-Modell aktiviert. Bitte bitten Sie Ihren Administrator, eines zu aktivieren, bevor Sie Dokumente hochladen."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/de/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/de/skill.json
@@ -120,7 +120,8 @@
     "fileSourceServiceBusyError": "Der Dokumentenverarbeitungsdienst ist ausgelastet. Bitte versuchen Sie es später erneut.",
     "fileSourceTimeoutError": "Die Dokumentenverarbeitung hat das Zeitlimit überschritten. Die Datei ist möglicherweise zu komplex.",
     "fileSourceUnreadableError": "Dokument konnte nicht gelesen werden. Es ist möglicherweise beschädigt.",
-    "sourceLimitExceededError": "Ein Skill kann maximal 20 Quellen enthalten. Bitte entfernen Sie eine, bevor Sie eine weitere hinzufügen."
+    "sourceLimitExceededError": "Ein Skill kann maximal 20 Quellen enthalten. Bitte entfernen Sie eine, bevor Sie eine weitere hinzufügen.",
+    "noEmbeddingModelError": "Es ist kein Embedding-Modell aktiviert. Bitte bitten Sie Ihren Administrator, eines zu aktivieren, bevor Sie Dateien hochladen."
   },
   "mcpIntegrations": {
     "title": "Integrationen",

--- a/ayunis-core-frontend/src/shared/locales/en/common.json
+++ b/ayunis-core-frontend/src/shared/locales/en/common.json
@@ -125,7 +125,8 @@
     "fileSourceServiceBusyError": "The document processing service is busy. Please try again later.",
     "fileSourceTimeoutError": "Document processing timed out. The file may be too complex.",
     "fileSourceUnreadableError": "Document could not be read. It may be corrupted.",
-    "sourceLimitExceededError": "A chat can have at most 20 sources. Please remove one before adding another."
+    "sourceLimitExceededError": "A chat can have at most 20 sources. Please remove one before adding another.",
+    "noEmbeddingModelError": "No embedding model is enabled. Please ask your administrator to enable one before uploading files."
   },
   "models": {
     "availableHeading": "Available models",

--- a/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
@@ -177,6 +177,7 @@
     "fileSourceServiceBusyError": "The document processing service is busy. Please try again later.",
     "fileSourceTimeoutError": "Document processing timed out. The file may be too complex.",
     "fileSourceUnreadableError": "Document could not be read. It may be corrupted.",
-    "sourceLimitExceededError": "A knowledge base can have at most 500 documents. Please remove one before adding another."
+    "sourceLimitExceededError": "A knowledge base can have at most 500 documents. Please remove one before adding another.",
+    "noEmbeddingModelError": "No embedding model is enabled. Please ask your administrator to enable one before uploading documents."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/skill.json
+++ b/ayunis-core-frontend/src/shared/locales/en/skill.json
@@ -120,7 +120,8 @@
     "fileSourceServiceBusyError": "The document processing service is busy. Please try again later.",
     "fileSourceTimeoutError": "Document processing timed out. The file may be too complex.",
     "fileSourceUnreadableError": "Document could not be read. It may be corrupted.",
-    "sourceLimitExceededError": "A skill can have at most 20 sources. Please remove one before adding another."
+    "sourceLimitExceededError": "A skill can have at most 20 sources. Please remove one before adding another.",
+    "noEmbeddingModelError": "No embedding model is enabled. Please ask your administrator to enable one before uploading files."
   },
   "mcpIntegrations": {
     "title": "Integrations",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When uploading files to skills or knowledge bases (and chat) while the organization has no permitted embedding model, the UI showed the generic *"Did not work, please try again"* toast. Users couldn't tell that the real cause was a missing embedding model.

The backend already fails fast in `StartDocumentProcessingUseCase` by calling `GetPermittedEmbeddingModelUseCase`, which throws `PermittedEmbeddingModelNotFoundForOrgError`. But that error used the generic `MODEL_NOT_FOUND` code, so the frontend's `handleSourceUploadError` fell through to the generic message.

## Fix

**Backend**
- Added a dedicated `NO_PERMITTED_EMBEDDING_MODEL` code to `ModelErrorCode` and used it for `PermittedEmbeddingModelNotFoundForOrgError` (status code unchanged at 404). This code is unique to the "no embedding model permitted" case, so the client can distinguish it from other model-not-found situations.
- Added a unit test asserting the distinctive code.

**Frontend**
- `handleSourceUploadError` now maps `NO_PERMITTED_EMBEDDING_MODEL` to a dedicated `sources.noEmbeddingModelError` message.
- Added `noEmbeddingModelError` translations (en + de) to the `skill`, `knowledge-bases`, and `common` namespaces (the three namespaces the shared handler is used with). This covers skills, knowledge bases, and chat file uploads.

## Testing

- `get-permitted-embedding-model.use-case.spec.ts` — 7 passed (incl. new code assertion)
- ESLint on changed backend + frontend files — clean
- All pre-commit checks (lint, typecheck, prettier, complexity, dep-check) passed

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-603](https://linear.app/ayunis/issue/AYC-603/if-no-embedding-model-is-permitted-show-an-error-on-file-upload)

<div><a href="https://cursor.com/agents/bc-0ffffcf3-3440-4a69-92e8-cbd4670b1889?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ffffcf3-3440-4a69-92e8-cbd4670b1889&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

