### PR TITLE
fix(admin-settings): rename the academy sidebar item to Academy (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-layout.json
@@ -15,7 +15,7 @@
     "instructions": "Chat",
     "letterheads": "Briefpapier",
     "apiKeys": "API-Schlüssel",
-    "academy": "KI-Führerschein"
+    "academy": "Academy"
   },
   "groups": {
     "membersAccess": "Mitglieder & Zugriff",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-layout.json
@@ -15,7 +15,7 @@
     "instructions": "Chat",
     "letterheads": "Letterheads",
     "apiKeys": "API Keys",
-    "academy": "AI certificate"
+    "academy": "Academy"
   },
   "groups": {
     "membersAccess": "Members & Access",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Copy-only locale changes with no logic, routing, or security impact.
> 
> **Overview**
> Renames the admin settings **Academy** nav label to the product name **Academy** in English and German.
> 
> English `layout.academy` changes from **AI certificate** to **Academy**; German changes from **KI-Führerschein** to **Academy**. That string drives the privacy & compliance sidebar item and the Academy settings page title via `admin-settings-layout`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f226cbbaacff64428cde37ec2387f1d7925284c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->