### PR TITLE
fix(chat): preserve chronological timeline order (AYC-634)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/lib/reconcile-thread-messages.test.ts
+++ b/ayunis-core-frontend/src/pages/chat/lib/reconcile-thread-messages.test.ts
@@ -71,6 +71,33 @@ describe('reconcileMessages', () => {
     expect(result[1].content).toEqual([invalidToolCall]);
   });
 
+  it('keeps a missing invalid-only message before later persisted turns', () => {
+    const current = [
+      message('user-1', 'user', [{ type: 'text', text: 'chart it' }]),
+      message('assistant-invalid', 'assistant', [invalidToolCall]),
+      message('user-2', 'user', [{ type: 'text', text: 'try again' }]),
+      message('assistant-2', 'assistant', [
+        { type: 'text', text: 'Here is the new reply.' },
+      ]),
+    ];
+    const persisted = [
+      message('user-1', 'user', [{ type: 'text', text: 'chart it' }]),
+      message('user-2', 'user', [{ type: 'text', text: 'try again' }]),
+      message('assistant-2', 'assistant', [
+        { type: 'text', text: 'Here is the new reply.' },
+      ]),
+    ];
+
+    const result = reconcile(current, persisted);
+
+    expect(result.map(({ id }) => id)).toEqual([
+      'user-1',
+      'assistant-invalid',
+      'user-2',
+      'assistant-2',
+    ]);
+  });
+
   it('does not retain in-progress tool calls', () => {
     const streamingToolCall = {
       ...invalidToolCall,

--- a/ayunis-core-frontend/src/pages/chat/lib/reconcile-thread-messages.ts
+++ b/ayunis-core-frontend/src/pages/chat/lib/reconcile-thread-messages.ts
@@ -35,6 +35,34 @@ function mergeInvalidToolCalls(
     : { ...message, content: [...message.content, ...missing] };
 }
 
+function toInvalidOnlyMessage(message: Message): Message | null {
+  const invalidToolCalls = getInvalidToolCalls(message);
+  return invalidToolCalls.length === 0
+    ? null
+    : ({ ...message, content: invalidToolCalls } as Message);
+}
+
+function interleaveMissingInvalidMessages(
+  reconciledMessages: readonly Message[],
+  currentMessages: readonly Message[],
+  persistedIds: ReadonlySet<string>,
+): Message[] {
+  const missingBeforeId = new Map<string, Message[]>();
+  let pending: Message[] = [];
+  for (const message of currentMessages) {
+    if (persistedIds.has(message.id)) {
+      if (pending.length > 0) missingBeforeId.set(message.id, pending);
+      pending = [];
+      continue;
+    }
+    const invalidOnlyMessage = toInvalidOnlyMessage(message);
+    if (invalidOnlyMessage) pending.push(invalidOnlyMessage);
+  }
+  return reconciledMessages
+    .flatMap((message) => [...(missingBeforeId.get(message.id) ?? []), message])
+    .concat(pending);
+}
+
 export function reconcileMessages(
   currentMessages: readonly Message[],
   previousThread: Pick<Thread, 'id'>,
@@ -54,13 +82,9 @@ export function reconcileMessages(
   const reconciled = persistedMessages.map((message) =>
     mergeInvalidToolCalls(message, invalidByMessageId.get(message.id) ?? []),
   );
-  const missing = currentMessages
-    .filter((message) => !persistedIds.has(message.id))
-    .flatMap((message) => {
-      const invalidToolCalls = getInvalidToolCalls(message);
-      return invalidToolCalls.length === 0
-        ? []
-        : [{ ...message, content: invalidToolCalls } as Message];
-    });
-  return [...reconciled, ...missing];
+  return interleaveMissingInvalidMessages(
+    reconciled,
+    currentMessages,
+    persistedIds,
+  );
 }

--- a/ayunis-core-frontend/src/pages/chat/ui/AssistantRunBlock.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/AssistantRunBlock.tsx
@@ -19,7 +19,7 @@ export default function AssistantRunBlock({
   onOpenArtifact,
 }: Readonly<AssistantRunBlockProps>) {
   const contentRef = useRef<HTMLDivElement>(null);
-  const hasFinalText = unit.finalText.length > 0;
+  const hasText = unit.blocks.some((block) => block.kind === 'text');
 
   return (
     <div
@@ -40,7 +40,7 @@ export default function AssistantRunBlock({
             onOpenArtifact={onOpenArtifact}
           />
         </div>
-        {hasFinalText && <CopyAssistantTextButton contentRef={contentRef} />}
+        {hasText && <CopyAssistantTextButton contentRef={contentRef} />}
       </div>
     </div>
   );

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -162,23 +162,6 @@ export default function ChatPage({
     threadId: thread.id,
   });
 
-  const sortedMessages = useMemo(() => {
-    return [...messages].sort((a, b) => (a.createdAt > b.createdAt ? 1 : -1));
-  }, [messages]);
-
-  const toolResultsByToolId = useMemo(() => {
-    const map: Record<string, string> = {};
-    for (const message of sortedMessages) {
-      if (message.role !== 'tool') continue;
-      for (const content of message.content) {
-        if (content.type === 'tool_result') {
-          map[content.toolId] = content.result;
-        }
-      }
-    }
-    return map;
-  }, [sortedMessages]);
-
   const { deleteChat } = useDeleteThread({
     onSuccess: () => {
       void navigate({ to: '/chat' });
@@ -392,12 +375,11 @@ export default function ChatPage({
 
   const renderUnits = useMemo(
     () =>
-      groupMessagesIntoRuns(sortedMessages, {
+      groupMessagesIntoRuns(messages, {
         isStreaming,
-        toolResultsByToolId,
         hasPendingUserTurn: pendingSubmission !== null,
       }),
-    [sortedMessages, isStreaming, toolResultsByToolId, pendingSubmission],
+    [messages, isStreaming, pendingSubmission],
   );
 
   const lastUnitKind =

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/index.ts
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/index.ts
@@ -4,5 +4,7 @@ export type {
   RenderUnit,
   UserUnit,
   AgentRunUnit,
+  AgentRunBlock,
   TimelineStep,
+  ToolTimelineStep,
 } from './model/types';

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/group-messages-into-runs.test.ts
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/group-messages-into-runs.test.ts
@@ -57,10 +57,189 @@ function toolResultMessage(toolId: string, result: string): Message {
 }
 
 describe('groupMessagesIntoRuns', () => {
+  it('preserves text, tool, and later text in chronological render order', () => {
+    const messages = [
+      userMessage('find it'),
+      assistantMessage([
+        { type: 'text', text: 'I will search.' },
+        { type: 'tool_use', id: 't1', name: 'internet_search' },
+      ]),
+      toolResultMessage('t1', 'search results'),
+      assistantMessage([{ type: 'text', text: 'Here is the answer.' }]),
+    ];
+
+    const units = groupMessagesIntoRuns(messages, {
+      isStreaming: false,
+    });
+
+    const run = units[1];
+    if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+    expect(run.blocks.map((block) => block.kind)).toEqual([
+      'text',
+      'activity',
+      'text',
+    ]);
+    const activity = run.blocks[1];
+    if (activity.kind !== 'activity') throw new Error('expected activity');
+    expect(activity.steps[0]).toMatchObject({
+      kind: 'tool',
+      result: 'search results',
+      status: 'done',
+    });
+  });
+
+  it('keeps a rich tool inline between surrounding assistant text', () => {
+    const messages = [
+      userMessage('chart it'),
+      assistantMessage([
+        { type: 'text', text: 'Building the chart.' },
+        { type: 'tool_use', id: 'chart-1', name: 'bar_chart' },
+      ]),
+      assistantMessage([{ type: 'text', text: 'The chart is ready.' }]),
+    ];
+
+    const units = groupMessagesIntoRuns(messages, {
+      isStreaming: false,
+    });
+
+    const run = units[1];
+    if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+    expect(run.blocks.map((block) => block.kind)).toEqual([
+      'text',
+      'rich-tool',
+      'text',
+    ]);
+  });
+
+  it('keeps a stable inline block while a streamed tool name resolves to a rich tool', () => {
+    const user = userMessage('chart it');
+    const partialToolCall = assistantMessage([
+      {
+        type: 'tool_use',
+        id: 'chart-1',
+        name: '',
+        stream: { status: 'streaming', argumentsJson: '{"title":' },
+      },
+    ]);
+    const resolvedToolCall = {
+      ...partialToolCall,
+      content: [
+        {
+          ...partialToolCall.content[0],
+          name: 'bar_chart',
+        },
+      ],
+    } as Message;
+
+    const partialUnits = groupMessagesIntoRuns([user, partialToolCall], {
+      isStreaming: true,
+    });
+    const resolvedUnits = groupMessagesIntoRuns([user, resolvedToolCall], {
+      isStreaming: true,
+    });
+
+    const partialRun = partialUnits[1];
+    const resolvedRun = resolvedUnits[1];
+    if (partialRun.kind !== 'agent-run' || resolvedRun.kind !== 'agent-run') {
+      throw new Error('expected agent-runs');
+    }
+    const partialBlock = partialRun.blocks[0];
+    const resolvedBlock = resolvedRun.blocks[0];
+    expect(partialBlock.kind).toBe('pending-tool');
+    expect(resolvedBlock.kind).toBe('rich-tool');
+    expect(resolvedBlock.key).toBe(partialBlock.key);
+  });
+
+  it('updates a tool result in place without changing its render key', () => {
+    const toolCall = assistantMessage([
+      { type: 'tool_use', id: 't1', name: 'internet_search' },
+    ]);
+    const streaming = groupMessagesIntoRuns([userMessage('go'), toolCall], {
+      isStreaming: true,
+    });
+    const completed = groupMessagesIntoRuns(
+      [userMessage('go'), toolCall, toolResultMessage('t1', 'done')],
+      {
+        isStreaming: true,
+      },
+    );
+
+    const streamingRun = streaming[1];
+    const completedRun = completed[1];
+    if (
+      streamingRun.kind !== 'agent-run' ||
+      completedRun.kind !== 'agent-run'
+    ) {
+      throw new Error('expected agent-runs');
+    }
+    const streamingBlock = streamingRun.blocks[0];
+    const completedBlock = completedRun.blocks[0];
+    expect(completedBlock.key).toBe(streamingBlock.key);
+    if (
+      streamingBlock.kind !== 'activity' ||
+      completedBlock.kind !== 'activity'
+    ) {
+      throw new Error('expected activity blocks');
+    }
+    expect(streamingBlock.steps[0].status).toBe('in_progress');
+    expect(completedBlock.steps[0]).toMatchObject({
+      status: 'done',
+      result: 'done',
+    });
+  });
+
+  it('keeps unresolved parallel tools in progress after a sibling result arrives', () => {
+    const messages = [
+      userMessage('check both'),
+      assistantMessage([
+        { type: 'tool_use', id: 't1', name: 'internet_search' },
+        { type: 'tool_use', id: 't2', name: 'read_document' },
+      ]),
+      toolResultMessage('t1', 'search results'),
+    ];
+
+    const units = groupMessagesIntoRuns(messages, {
+      isStreaming: true,
+    });
+
+    const run = units[1];
+    if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+    const block = run.blocks[0];
+    if (block.kind !== 'activity') throw new Error('expected activity');
+    expect(block.steps).toHaveLength(2);
+    expect(block.steps[0]).toMatchObject({
+      kind: 'tool',
+      result: 'search results',
+      status: 'done',
+    });
+    expect(block.steps[1]).toMatchObject({
+      kind: 'tool',
+      status: 'in_progress',
+    });
+  });
+
+  it('settles a display-only rich tool when the run stops without a result', () => {
+    const messages = [
+      userMessage('draft an email'),
+      assistantMessage([
+        { type: 'tool_use', id: 'email-1', name: 'send_email' },
+      ]),
+    ];
+
+    const units = groupMessagesIntoRuns(messages, {
+      isStreaming: false,
+    });
+
+    const run = units[1];
+    if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+    const block = run.blocks[0];
+    if (block.kind !== 'rich-tool') throw new Error('expected rich tool');
+    expect(block.step.status).toBe('done');
+  });
+
   it('returns empty array for empty input', () => {
     const result = groupMessagesIntoRuns([], {
       isStreaming: false,
-      toolResultsByToolId: {},
     });
     expect(result).toEqual([]);
   });
@@ -69,30 +248,29 @@ describe('groupMessagesIntoRuns', () => {
     const messages = [userMessage('hello'), userMessage('world')];
     const units = groupMessagesIntoRuns(messages, {
       isStreaming: false,
-      toolResultsByToolId: {},
     });
     expect(units).toHaveLength(2);
     expect(units[0].kind).toBe('user');
     expect(units[1].kind).toBe('user');
   });
 
-  it('groups assistant text reply as a single agent-run with finalText', () => {
+  it('groups an assistant text reply as a single text block', () => {
     const messages = [
       userMessage('hi'),
       assistantMessage([{ type: 'text', text: 'hello!' }]),
     ];
     const units = groupMessagesIntoRuns(messages, {
       isStreaming: false,
-      toolResultsByToolId: {},
     });
     expect(units).toHaveLength(2);
     expect(units[0].kind).toBe('user');
     const run = units[1];
     expect(run.kind).toBe('agent-run');
     if (run.kind !== 'agent-run') return;
-    expect(run.steps).toHaveLength(0);
-    expect(run.finalText).toHaveLength(1);
-    expect(run.finalText[0].text).toBe('hello!');
+    expect(run.blocks).toHaveLength(1);
+    expect(run.blocks[0].kind).toBe('text');
+    if (run.blocks[0].kind !== 'text') return;
+    expect(run.blocks[0].content.text).toBe('hello!');
     expect(run.isStreaming).toBe(false);
   });
 
@@ -110,18 +288,21 @@ describe('groupMessagesIntoRuns', () => {
     ];
     const units = groupMessagesIntoRuns(messages, {
       isStreaming: false,
-      toolResultsByToolId: { t1: 'search results', t2: 'doc body' },
     });
     expect(units).toHaveLength(2);
     const run = units[1];
     if (run.kind !== 'agent-run') throw new Error('expected agent-run');
-    expect(run.steps).toHaveLength(3); // thinking + 2 tool calls
-    expect(run.steps[0].kind).toBe('thinking');
-    expect(run.steps[1].kind).toBe('tool');
-    expect(run.steps[2].kind).toBe('tool');
-    expect(run.steps[1].status).toBe('done');
-    expect(run.steps[2].status).toBe('done');
-    expect(run.finalText[0].text).toBe('done!');
+    expect(run.blocks.map((block) => block.kind)).toEqual(['activity', 'text']);
+    const activity = run.blocks[0];
+    const text = run.blocks[1];
+    if (activity.kind !== 'activity' || text.kind !== 'text') {
+      throw new Error('expected activity and text blocks');
+    }
+    expect(activity.steps).toHaveLength(3); // thinking + 2 tool calls
+    expect(activity.steps[0].kind).toBe('thinking');
+    expect(activity.steps[1]).toMatchObject({ kind: 'tool', status: 'done' });
+    expect(activity.steps[2]).toMatchObject({ kind: 'tool', status: 'done' });
+    expect(text.content.text).toBe('done!');
   });
 
   it('marks tool steps without results as in_progress', () => {
@@ -131,16 +312,19 @@ describe('groupMessagesIntoRuns', () => {
     ];
     const units = groupMessagesIntoRuns(messages, {
       isStreaming: true,
-      toolResultsByToolId: {},
     });
     const run = units[1];
     if (run.kind !== 'agent-run') throw new Error('expected agent-run');
-    expect(run.steps[0].kind).toBe('tool');
-    expect(run.steps[0].status).toBe('in_progress');
+    const block = run.blocks[0];
+    if (block.kind !== 'activity') throw new Error('expected activity');
+    expect(block.steps[0]).toMatchObject({
+      kind: 'tool',
+      status: 'in_progress',
+    });
     expect(run.isStreaming).toBe(true);
   });
 
-  it('marks invalid tool calls as errors and does not create rich cards', () => {
+  it('marks invalid rich tool calls as ordinary error activity', () => {
     const messages = [
       userMessage('chart it'),
       assistantMessage([
@@ -158,31 +342,32 @@ describe('groupMessagesIntoRuns', () => {
 
     const units = groupMessagesIntoRuns(messages, {
       isStreaming: false,
-      toolResultsByToolId: {},
     });
 
     const run = units[1];
     if (run.kind !== 'agent-run') throw new Error('expected agent-run');
-    expect(run.steps[0].status).toBe('error');
-    expect(run.richCards).toHaveLength(0);
+    expect(run.blocks).toHaveLength(1);
+    const block = run.blocks[0];
+    if (block.kind !== 'activity') throw new Error('expected activity');
+    expect(block.steps[0].status).toBe('error');
   });
 
-  it('promotes streaming text without tool_use to finalText (so it renders outside the timeline)', () => {
+  it('emits streaming assistant text as a text block', () => {
     const messages = [
       userMessage('go'),
       assistantMessage([{ type: 'text', text: 'still typing' }]),
     ];
     const units = groupMessagesIntoRuns(messages, {
       isStreaming: true,
-      toolResultsByToolId: {},
     });
     const run = units[1];
     if (run.kind !== 'agent-run') throw new Error('expected agent-run');
-    expect(run.finalText).toHaveLength(1);
-    expect(run.finalText[0].text).toBe('still typing');
+    expect(run.blocks[0].kind).toBe('text');
+    if (run.blocks[0].kind !== 'text') return;
+    expect(run.blocks[0].content.text).toBe('still typing');
   });
 
-  it('routes text out of the timeline even when the same message has a tool_use', () => {
+  it('keeps text before a tool from the same assistant message', () => {
     const messages = [
       userMessage('go'),
       assistantMessage([
@@ -192,17 +377,16 @@ describe('groupMessagesIntoRuns', () => {
     ];
     const units = groupMessagesIntoRuns(messages, {
       isStreaming: true,
-      toolResultsByToolId: {},
     });
     const run = units[1];
     if (run.kind !== 'agent-run') throw new Error('expected agent-run');
-    expect(run.finalText).toHaveLength(1);
-    expect(run.finalText[0].text).toBe('Let me search...');
-    expect(run.steps).toHaveLength(1);
-    expect(run.steps[0].kind).toBe('tool');
+    expect(run.blocks.map((block) => block.kind)).toEqual(['text', 'activity']);
+    const text = run.blocks[0];
+    if (text.kind !== 'text') throw new Error('expected text');
+    expect(text.content.text).toBe('Let me search...');
   });
 
-  it('extracts rich-tool calls into richCards', () => {
+  it('keeps a rich tool inline while grouping adjacent ordinary activity', () => {
     const messages = [
       userMessage('chart it'),
       assistantMessage([
@@ -215,13 +399,18 @@ describe('groupMessagesIntoRuns', () => {
     ];
     const units = groupMessagesIntoRuns(messages, {
       isStreaming: false,
-      toolResultsByToolId: { t1: '{}', t2: 'results' },
     });
     const run = units[1];
     if (run.kind !== 'agent-run') throw new Error('expected agent-run');
-    expect(run.steps).toHaveLength(2);
-    expect(run.richCards).toHaveLength(1);
-    expect(run.richCards[0].toolUse.name).toBe('bar_chart');
+    expect(run.blocks.map((block) => block.kind)).toEqual([
+      'rich-tool',
+      'activity',
+      'text',
+    ]);
+    const richTool = run.blocks[0];
+    if (richTool.kind !== 'rich-tool') throw new Error('expected rich tool');
+    expect(richTool.step.toolUse.name).toBe('bar_chart');
+    expect(richTool.step.result).toBe('{}');
   });
 
   it('keeps run separate when followed by another user message', () => {
@@ -233,7 +422,6 @@ describe('groupMessagesIntoRuns', () => {
     ];
     const units = groupMessagesIntoRuns(messages, {
       isStreaming: false,
-      toolResultsByToolId: {},
     });
     expect(units.map((u) => u.kind)).toEqual([
       'user',
@@ -250,12 +438,49 @@ describe('groupMessagesIntoRuns', () => {
     ];
     const units = groupMessagesIntoRuns(messages, {
       isStreaming: true,
-      toolResultsByToolId: {},
       hasPendingUserTurn: true,
     });
     const run = units[1];
     if (run.kind !== 'agent-run') throw new Error('expected agent-run');
     expect(run.isStreaming).toBe(false);
+  });
+
+  it('does not reactivate a completed display tool while a new user turn is pending', () => {
+    const messages = [
+      userMessage('first'),
+      assistantMessage([
+        { type: 'tool_use', id: 'email-1', name: 'send_email' },
+      ]),
+    ];
+    const units = groupMessagesIntoRuns(messages, {
+      isStreaming: true,
+      hasPendingUserTurn: true,
+    });
+
+    const run = units[1];
+    if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+    const block = run.blocks[0];
+    if (block.kind !== 'rich-tool') throw new Error('expected rich tool');
+    expect(block.step.status).toBe('done');
+  });
+
+  it('does not reactivate a prior tool while a streamed user turn awaits its assistant message', () => {
+    const messages = [
+      userMessage('first'),
+      assistantMessage([
+        { type: 'tool_use', id: 'email-1', name: 'send_email' },
+      ]),
+      userMessage('second'),
+    ];
+    const units = groupMessagesIntoRuns(messages, {
+      isStreaming: true,
+    });
+
+    const priorRun = units[1];
+    if (priorRun.kind !== 'agent-run') throw new Error('expected agent-run');
+    const block = priorRun.blocks[0];
+    if (block.kind !== 'rich-tool') throw new Error('expected rich tool');
+    expect(block.step.status).toBe('done');
   });
 
   it('marks only the last agent-run as streaming when isStreaming is true', () => {
@@ -267,7 +492,6 @@ describe('groupMessagesIntoRuns', () => {
     ];
     const units = groupMessagesIntoRuns(messages, {
       isStreaming: true,
-      toolResultsByToolId: {},
     });
     const firstRun = units[1];
     const secondRun = units[3];
@@ -289,22 +513,22 @@ describe('groupMessagesIntoRuns', () => {
     ];
     const units = groupMessagesIntoRuns(messages, {
       isStreaming: false,
-      toolResultsByToolId: {},
     });
     const run = units[1];
     if (run.kind !== 'agent-run') throw new Error('expected agent-run');
-    expect(run.steps).toHaveLength(2);
-    expect(run.steps[0].kind).toBe('thinking');
-    if (run.steps[0].kind !== 'thinking') return;
-    expect(run.steps[0].transcript).toContain('first part');
-    expect(run.steps[0].transcript).toContain('second part');
+    const block = run.blocks[0];
+    if (block.kind !== 'activity') throw new Error('expected activity');
+    expect(block.steps).toHaveLength(2);
+    expect(block.steps[0].kind).toBe('thinking');
+    if (block.steps[0].kind !== 'thinking') return;
+    expect(block.steps[0].transcript).toContain('first part');
+    expect(block.steps[0].transcript).toContain('second part');
   });
 
   it('does not synthesize a pending agent-run when streaming has started but no assistant message arrived', () => {
     const messages = [userMessage('go')];
     const units = groupMessagesIntoRuns(messages, {
       isStreaming: true,
-      toolResultsByToolId: {},
     });
     expect(units).toHaveLength(1);
     expect(units[0].kind).toBe('user');
@@ -314,7 +538,6 @@ describe('groupMessagesIntoRuns', () => {
     const messages = [userMessage('go')];
     const units = groupMessagesIntoRuns(messages, {
       isStreaming: false,
-      toolResultsByToolId: {},
     });
     expect(units).toHaveLength(1);
     expect(units[0].kind).toBe('user');
@@ -335,16 +558,21 @@ describe('groupMessagesIntoRuns', () => {
     ];
     const units = groupMessagesIntoRuns(messages, {
       isStreaming: false,
-      toolResultsByToolId: {},
     });
     expect(units).toHaveLength(2);
     const run = units[1];
     if (run.kind !== 'agent-run') throw new Error('expected agent-run');
-    expect(run.steps).toHaveLength(1);
-    expect(run.steps[0].kind).toBe('skill_instruction');
-    if (run.steps[0].kind !== 'skill_instruction') return;
-    expect(run.steps[0].text).toBe('You are a poet.');
-    expect(run.finalText[0].text).toBe('Cherry blossoms fall');
+    expect(run.blocks.map((block) => block.kind)).toEqual(['activity', 'text']);
+    const activity = run.blocks[0];
+    const text = run.blocks[1];
+    if (activity.kind !== 'activity' || text.kind !== 'text') {
+      throw new Error('expected activity and text');
+    }
+    expect(activity.steps[0]).toMatchObject({
+      kind: 'skill_instruction',
+      text: 'You are a poet.',
+    });
+    expect(text.content.text).toBe('Cherry blossoms fall');
   });
 
   it('handles assistant message with empty content (mid-stream)', () => {
@@ -359,13 +587,11 @@ describe('groupMessagesIntoRuns', () => {
     ];
     const units = groupMessagesIntoRuns(messages, {
       isStreaming: true,
-      toolResultsByToolId: {},
     });
     expect(units).toHaveLength(2);
     const run = units[1];
     if (run.kind !== 'agent-run') throw new Error('expected agent-run');
-    expect(run.steps).toHaveLength(0);
-    expect(run.finalText).toHaveLength(0);
+    expect(run.blocks).toHaveLength(0);
     expect(run.isStreaming).toBe(true);
   });
 });

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/group-messages-into-runs.ts
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/group-messages-into-runs.ts
@@ -10,24 +10,25 @@ import type {
   AgentRunUnit,
   TimelineStep,
   StepStatus,
+  ToolTimelineStep,
 } from '../model/types';
 import { isRichTool } from './tool-classification';
 
 interface GroupingOptions {
   isStreaming: boolean;
-  toolResultsByToolId: Readonly<Record<string, string>>;
   /** New user turn is pending outside `messages` (optimistic bubble only). */
   hasPendingUserTurn?: boolean;
 }
 
 export function groupMessagesIntoRuns(
   messages: readonly Message[],
-  {
-    isStreaming,
-    toolResultsByToolId,
-    hasPendingUserTurn = false,
-  }: GroupingOptions,
+  { isStreaming, hasPendingUserTurn = false }: GroupingOptions,
 ): RenderUnit[] {
+  const toolResultsByToolId = indexToolResults(messages);
+  const isStreamingCurrentMessages = isStreaming && !hasPendingUserTurn;
+  const activeAssistantMessageIndex = isStreamingCurrentMessages
+    ? findActiveAssistantMessageIndex(messages)
+    : -1;
   const units: RenderUnit[] = [];
   let currentRun: AgentRunUnit | null = null;
   let pendingSkillSteps: TimelineStep[] = [];
@@ -61,23 +62,21 @@ export function groupMessagesIntoRuns(
     const run: AgentRunUnit = (currentRun ??= {
       kind: 'agent-run',
       key: `run-${message.id}`,
-      steps: pendingSkillSteps,
-      richCards: [],
-      finalText: [],
+      blocks: [],
       isStreaming: false,
     });
+    pendingSkillSteps.forEach((step) => appendActivityStep(run, step));
     pendingSkillSteps = [];
 
     appendAssistantMessage(run, message, {
-      isStreaming,
-      isLastMessage: i === messages.length - 1,
+      isActiveAssistantMessage: i === activeAssistantMessageIndex,
       toolResultsByToolId,
     });
   }
 
   closeRun();
 
-  if (isStreaming && !hasPendingUserTurn && units.length > 0) {
+  if (isStreamingCurrentMessages && units.length > 0) {
     const lastUnit = units[units.length - 1];
     if (lastUnit.kind === 'agent-run') {
       lastUnit.isStreaming = true;
@@ -85,6 +84,30 @@ export function groupMessagesIntoRuns(
   }
 
   return units;
+}
+
+function findActiveAssistantMessageIndex(messages: readonly Message[]): number {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const role = messages[index].role;
+    if (role === 'assistant') return index;
+    if (role === 'user' || role === 'system') return -1;
+  }
+  return -1;
+}
+
+function indexToolResults(
+  messages: readonly Message[],
+): Readonly<Record<string, string>> {
+  const results: Record<string, string> = {};
+  for (const message of messages) {
+    if (message.role !== 'tool') continue;
+    for (const content of message.content) {
+      if (content.type === 'tool_result') {
+        results[content.toolId] = content.result;
+      }
+    }
+  }
+  return results;
 }
 
 function collectSkillInstructionSteps(message: Message): TimelineStep[] {
@@ -104,31 +127,30 @@ function collectSkillInstructionSteps(message: Message): TimelineStep[] {
 }
 
 interface AppendOptions {
-  isStreaming: boolean;
-  isLastMessage: boolean;
+  isActiveAssistantMessage: boolean;
   toolResultsByToolId: Readonly<Record<string, string>>;
 }
 
 function getToolStatus(
   toolUse: ToolUseMessageContent,
   hasResult: boolean,
+  isStreaming: boolean,
 ): StepStatus {
   if (toolUse.stream?.status === 'invalid') return 'error';
-  return hasResult ? 'done' : 'in_progress';
+  return hasResult || !isStreaming ? 'done' : 'in_progress';
 }
 
 function appendAssistantMessage(
   run: AgentRunUnit,
   message: AssistantMessage,
-  { isStreaming, isLastMessage, toolResultsByToolId }: AppendOptions,
+  { isActiveAssistantMessage, toolResultsByToolId }: AppendOptions,
 ): void {
   const content = message.content;
-  const isStreamingThisMessage = isStreaming && isLastMessage;
 
   let pendingThinking: { transcript: string; key: string } | null = null;
   const flushThinking = (status: 'in_progress' | 'done') => {
     if (pendingThinking) {
-      run.steps.push({
+      appendActivityStep(run, {
         kind: 'thinking',
         key: pendingThinking.key,
         transcript: pendingThinking.transcript,
@@ -158,28 +180,59 @@ function appendAssistantMessage(
       const toolUse = block as ToolUseMessageContent;
       const hasResult = toolUse.id in toolResultsByToolId;
       const result = hasResult ? toolResultsByToolId[toolUse.id] : undefined;
-      const status = getToolStatus(toolUse, hasResult);
-      run.steps.push({
+      const status = getToolStatus(
+        toolUse,
+        hasResult,
+        isActiveAssistantMessage,
+      );
+      const step: ToolTimelineStep = {
         kind: 'tool',
         key: `${message.id}-tool-${toolUse.id}`,
         toolUse,
         result,
         status,
-      });
-      if (status !== 'error' && isRichTool(toolUse.name)) {
-        run.richCards.push({
-          key: `${message.id}-card-${toolUse.id}`,
-          toolUse,
-          result,
+      };
+      const isPendingTool =
+        toolUse.name.length === 0 && toolUse.stream?.status === 'streaming';
+      if (status !== 'error' && isPendingTool) {
+        run.blocks.push({
+          kind: 'pending-tool',
+          key: step.key,
+          step,
         });
+      } else if (status !== 'error' && isRichTool(toolUse.name)) {
+        run.blocks.push({
+          kind: 'rich-tool',
+          key: step.key,
+          step,
+        });
+      } else {
+        appendActivityStep(run, step);
       }
       return;
     }
 
     if (block.type === 'text') {
-      run.finalText.push(block as TextMessageContent);
+      run.blocks.push({
+        kind: 'text',
+        key: `${message.id}-text-${index}`,
+        content: block as TextMessageContent,
+      });
     }
   });
 
-  flushThinking(isStreamingThisMessage ? 'in_progress' : 'done');
+  flushThinking(isActiveAssistantMessage ? 'in_progress' : 'done');
+}
+
+function appendActivityStep(run: AgentRunUnit, step: TimelineStep): void {
+  const lastBlock = run.blocks.at(-1);
+  if (lastBlock?.kind === 'activity') {
+    lastBlock.steps.push(step);
+    return;
+  }
+  run.blocks.push({
+    kind: 'activity',
+    key: `activity-${step.key}`,
+    steps: [step],
+  });
 }

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/model/types.ts
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/model/types.ts
@@ -27,18 +27,41 @@ export type TimelineStep =
       status: StepStatus;
     };
 
-export interface RichCard {
+export type ToolTimelineStep = Extract<TimelineStep, { kind: 'tool' }>;
+
+export interface ActivityRunBlock {
+  kind: 'activity';
   key: string;
-  toolUse: ToolUseMessageContent;
-  result?: string;
+  steps: TimelineStep[];
 }
+
+export interface RichToolRunBlock {
+  kind: 'rich-tool';
+  key: string;
+  step: ToolTimelineStep;
+}
+
+export interface PendingToolRunBlock {
+  kind: 'pending-tool';
+  key: string;
+  step: ToolTimelineStep;
+}
+
+export type InlineToolRunBlock = RichToolRunBlock | PendingToolRunBlock;
+
+export interface TextRunBlock {
+  kind: 'text';
+  key: string;
+  content: TextMessageContent;
+}
+
+export type AgentRunBlock =
+  ActivityRunBlock | InlineToolRunBlock | TextRunBlock;
 
 export interface AgentRunUnit {
   kind: 'agent-run';
   key: string;
-  steps: TimelineStep[];
-  richCards: RichCard[];
-  finalText: TextMessageContent[];
+  blocks: AgentRunBlock[];
   isStreaming: boolean;
 }
 

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimeline.test.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimeline.test.tsx
@@ -1,0 +1,212 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentRunUnit } from '../model/types';
+import { renderRichToolCard } from '../lib/render-rich-tool-card';
+import AgentRunTimeline from './AgentRunTimeline';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/widgets/markdown', () => ({
+  Markdown: ({ children }: { children: string }) => (
+    <div data-testid={`text-${children}`}>{children}</div>
+  ),
+}));
+
+vi.mock('./AgentRunTimelineRow', () => ({
+  default: ({ step }: { step: { key: string } }) => (
+    <div data-testid={`step-${step.key}`} />
+  ),
+}));
+
+vi.mock('../lib/render-rich-tool-card', () => ({
+  renderRichToolCard: vi.fn(() => <div data-testid="rich-card" />),
+}));
+
+vi.mock('@/pages/chat/ui/ResponseStartOrb', () => ({
+  default: () => <div data-testid="response-start-orb" />,
+}));
+
+const unit: AgentRunUnit = {
+  kind: 'agent-run',
+  key: 'run-1',
+  isStreaming: false,
+  blocks: [
+    {
+      kind: 'text',
+      key: 'text-before',
+      content: { type: 'text', text: 'before' },
+    },
+    {
+      kind: 'activity',
+      key: 'ordinary-activity',
+      steps: [
+        {
+          kind: 'tool',
+          key: 'tool-ordinary-1',
+          status: 'done',
+          toolUse: {
+            type: 'tool_use',
+            id: 'ordinary-1',
+            name: 'internet_search',
+            params: {},
+          },
+        },
+      ],
+    },
+    {
+      kind: 'rich-tool',
+      key: 'tool-rich-1',
+      step: {
+        kind: 'tool',
+        key: 'tool-rich-1',
+        status: 'done',
+        toolUse: {
+          type: 'tool_use',
+          id: 'rich-1',
+          name: 'bar_chart',
+          params: {},
+        },
+      },
+    },
+    {
+      kind: 'text',
+      key: 'text-after',
+      content: { type: 'text', text: 'after' },
+    },
+  ],
+};
+
+describe('AgentRunTimeline', () => {
+  it('renders a rich tool row and card inline between surrounding text', () => {
+    render(<AgentRunTimeline unit={unit} />);
+
+    const before = screen.getByTestId('text-before');
+    const tool = screen.getByTestId('step-tool-rich-1');
+    const card = screen.getByTestId('rich-card');
+    const after = screen.getByTestId('text-after');
+
+    expect(screen.queryByTestId('step-tool-ordinary-1')).toBeNull();
+    expect(before.compareDocumentPosition(tool)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(tool.compareDocumentPosition(card)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(card.compareDocumentPosition(after)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
+  it('preserves the tool row while a streamed name resolves to a rich tool', () => {
+    const pendingStep = {
+      kind: 'tool' as const,
+      key: 'tool-streaming',
+      status: 'in_progress' as const,
+      toolUse: {
+        type: 'tool_use' as const,
+        id: 'streaming',
+        name: '',
+        params: {},
+        stream: {
+          status: 'streaming' as const,
+          argumentsJson: '{"title":',
+        },
+      },
+    };
+    const pendingUnit: AgentRunUnit = {
+      ...unit,
+      isStreaming: true,
+      blocks: [
+        {
+          kind: 'pending-tool',
+          key: pendingStep.key,
+          step: pendingStep,
+        },
+      ],
+    };
+    const resolvedUnit: AgentRunUnit = {
+      ...unit,
+      isStreaming: true,
+      blocks: [
+        {
+          kind: 'rich-tool',
+          key: pendingStep.key,
+          step: {
+            ...pendingStep,
+            toolUse: { ...pendingStep.toolUse, name: 'bar_chart' },
+          },
+        },
+      ],
+    };
+
+    const { rerender } = render(<AgentRunTimeline unit={pendingUnit} />);
+    const pendingRow = screen.getByTestId('step-tool-streaming');
+    expect(screen.queryByTestId('rich-card')).toBeNull();
+
+    rerender(<AgentRunTimeline unit={resolvedUnit} />);
+
+    expect(screen.getByTestId('step-tool-streaming')).toBe(pendingRow);
+    expect(screen.getByTestId('rich-card')).toBeTruthy();
+  });
+
+  it('does not render the response-start orb after timeline content exists', () => {
+    render(<AgentRunTimeline unit={{ ...unit, isStreaming: true }} />);
+
+    expect(screen.queryByTestId('response-start-orb')).toBeNull();
+    expect(vi.mocked(renderRichToolCard)).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isStreaming: false }),
+    );
+  });
+
+  it('renders a continuation indicator after a completed tool while streaming', () => {
+    const blocksThroughRichTool = unit.blocks.slice(0, 3);
+    render(
+      <AgentRunTimeline
+        unit={{ ...unit, blocks: blocksThroughRichTool, isStreaming: true }}
+      />,
+    );
+
+    const card = screen.getByTestId('rich-card');
+    const orb = screen.getByTestId('response-start-orb');
+    expect(card.compareDocumentPosition(orb)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(vi.mocked(renderRichToolCard)).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isStreaming: false }),
+    );
+  });
+
+  it('does not duplicate the working indicator while a tool is in progress', () => {
+    const activeToolUnit: AgentRunUnit = {
+      ...unit,
+      isStreaming: true,
+      blocks: [
+        {
+          kind: 'activity',
+          key: 'active-activity',
+          steps: [
+            {
+              kind: 'tool',
+              key: 'active-tool',
+              status: 'in_progress',
+              toolUse: {
+                type: 'tool_use',
+                id: 'active-tool',
+                name: 'internet_search',
+                params: {},
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    render(<AgentRunTimeline unit={activeToolUnit} />);
+
+    expect(screen.queryByTestId('response-start-orb')).toBeNull();
+  });
+});

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimeline.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimeline.tsx
@@ -8,7 +8,12 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/shared/ui/shadcn/collapsible';
-import type { AgentRunUnit } from '../model/types';
+import type {
+  ActivityRunBlock,
+  AgentRunBlock,
+  AgentRunUnit,
+  InlineToolRunBlock,
+} from '../model/types';
 import ResponseStartOrb from '@/pages/chat/ui/ResponseStartOrb';
 import AgentRunTimelineRow from './AgentRunTimelineRow';
 import { renderRichToolCard } from '../lib/render-rich-tool-card';
@@ -24,22 +29,10 @@ export default function AgentRunTimeline({
   threadId,
   onOpenArtifact,
 }: Readonly<AgentRunTimelineProps>) {
-  const { t } = useTranslation('chat');
-  const [userOpen, setUserOpen] = useState<boolean | null>(null);
-  const [lastStreaming, setLastStreaming] = useState(unit.isStreaming);
-  if (lastStreaming !== unit.isStreaming) {
-    setLastStreaming(unit.isStreaming);
-    setUserOpen(null);
-  }
-  const open = userOpen ?? unit.isStreaming;
-
-  const stepCount = unit.steps.length;
-
-  const headerLabel = unit.isStreaming
-    ? t('chat.timeline.working')
-    : t('chat.timeline.summary', { count: stepCount });
-
-  const showHeader = stepCount > 0;
+  const showPendingContinuation =
+    unit.isStreaming &&
+    unit.blocks.at(-1)?.kind !== 'text' &&
+    !unit.blocks.some(hasInProgressStep);
 
   return (
     // translate="no" while streaming: browser page translation rewrites
@@ -48,64 +41,143 @@ export default function AgentRunTimeline({
       className="flex flex-col gap-3 w-full"
       translate={unit.isStreaming ? 'no' : undefined}
     >
-      {showHeader && (
-        <Collapsible open={open} onOpenChange={setUserOpen}>
-          <div className="rounded-lg border border-border bg-muted/30">
-            <CollapsibleTrigger asChild>
-              <button
-                type="button"
-                className="flex items-center justify-between gap-2 w-full px-3 py-2 text-left"
-              >
-                <span
-                  className={cn(
-                    'text-sm text-muted-foreground',
-                    unit.isStreaming && 'animate-pulse',
-                  )}
-                >
-                  {headerLabel}
-                </span>
-                <ChevronDown
-                  className={cn(
-                    'h-4 w-4 text-muted-foreground flex-shrink-0 transition-transform',
-                    open && 'rotate-180',
-                  )}
-                />
-              </button>
-            </CollapsibleTrigger>
-            <CollapsibleContent>
-              <div className="px-3 pb-3 pt-1">
-                <div>
-                  {unit.steps.map((step) => (
-                    <AgentRunTimelineRow key={step.key} step={step} />
-                  ))}
-                </div>
-              </div>
-            </CollapsibleContent>
-          </div>
-        </Collapsible>
-      )}
+      {unit.blocks.map((block, index) => (
+        <RunBlock
+          key={block.key}
+          block={block}
+          index={index}
+          threadId={threadId}
+          onOpenArtifact={onOpenArtifact}
+        />
+      ))}
+      {showPendingContinuation && <ResponseStartOrb />}
+    </div>
+  );
+}
 
-      {unit.richCards.map((card, i) => {
-        const node = renderRichToolCard({
-          toolUse: card.toolUse,
-          result: card.result,
-          isStreaming: unit.isStreaming,
+function hasInProgressStep(block: AgentRunBlock): boolean {
+  if (block.kind === 'activity') {
+    return block.steps.some((step) => step.status === 'in_progress');
+  }
+  return (
+    (block.kind === 'rich-tool' || block.kind === 'pending-tool') &&
+    block.step.status === 'in_progress'
+  );
+}
+
+interface RunBlockProps {
+  block: AgentRunBlock;
+  index: number;
+  threadId?: string;
+  onOpenArtifact?: (artifactId: string) => void;
+}
+
+function RunBlock({
+  block,
+  index,
+  threadId,
+  onOpenArtifact,
+}: Readonly<RunBlockProps>) {
+  if (block.kind === 'activity') {
+    return <ActivityBlock block={block} />;
+  }
+  if (block.kind === 'rich-tool' || block.kind === 'pending-tool') {
+    return (
+      <InlineToolBlock
+        block={block}
+        index={index}
+        threadId={threadId}
+        onOpenArtifact={onOpenArtifact}
+      />
+    );
+  }
+  return (
+    <div data-copyable="true">
+      <Markdown>{block.content.text}</Markdown>
+    </div>
+  );
+}
+
+function ActivityBlock({ block }: Readonly<{ block: ActivityRunBlock }>) {
+  const { t } = useTranslation('chat');
+  const isActive = block.steps.some((step) => step.status === 'in_progress');
+  const [userOpen, setUserOpen] = useState<boolean | null>(null);
+  const [lastActive, setLastActive] = useState(isActive);
+  if (lastActive !== isActive) {
+    setLastActive(isActive);
+    setUserOpen(null);
+  }
+  const open = userOpen ?? isActive;
+  const headerLabel = isActive
+    ? t('chat.timeline.working')
+    : t('chat.timeline.summary', { count: block.steps.length });
+
+  return (
+    <Collapsible open={open} onOpenChange={setUserOpen}>
+      <div className="rounded-lg border border-border bg-muted/30">
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="flex items-center justify-between gap-2 w-full px-3 py-2 text-left"
+          >
+            <span
+              className={cn(
+                'text-sm text-muted-foreground',
+                isActive && 'animate-pulse',
+              )}
+            >
+              {headerLabel}
+            </span>
+            <ChevronDown
+              className={cn(
+                'h-4 w-4 text-muted-foreground flex-shrink-0 transition-transform',
+                open && 'rotate-180',
+              )}
+            />
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="px-3 pb-3 pt-1">
+            {block.steps.map((step) => (
+              <AgentRunTimelineRow key={step.key} step={step} />
+            ))}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}
+
+interface InlineToolBlockProps {
+  block: InlineToolRunBlock;
+  index: number;
+  threadId?: string;
+  onOpenArtifact?: (artifactId: string) => void;
+}
+
+function InlineToolBlock({
+  block,
+  index,
+  threadId,
+  onOpenArtifact,
+}: Readonly<InlineToolBlockProps>) {
+  const card =
+    block.kind === 'rich-tool'
+      ? renderRichToolCard({
+          toolUse: block.step.toolUse,
+          result: block.step.result,
+          isStreaming: block.step.status === 'in_progress',
           threadId,
           onOpenArtifact,
-          index: i,
-        });
-        return node ? <div key={card.key}>{node}</div> : null;
-      })}
-
-      {unit.finalText.length > 0 ? (
-        <div data-copyable="true" className="space-y-2">
-          {unit.finalText.map((text, i) => (
-            <Markdown key={`final-text-${i}`}>{text.text}</Markdown>
-          ))}
-        </div>
-      ) : (
-        unit.isStreaming && <ResponseStartOrb />
-      )}
+          index,
+        })
+      : null;
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="rounded-lg border border-border bg-muted/30 px-3 py-1">
+        <AgentRunTimelineRow step={block.step} />
+      </div>
+      {card}
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large chat UI/streaming refactor with new ordering and tool-status rules; behavior is heavily unit-tested but regressions in live streams or poll reconciliation are still plausible.
> 
> **Overview**
> Fixes assistant runs rendering out of turn order by modeling each run as an ordered **`blocks`** list (text, collapsible activity, rich/pending tools) instead of a single activity header, detached rich cards, and trailing “final” text.
> 
> **`groupMessagesIntoRuns`** now walks assistant content in sequence, indexes tool results from messages internally, and only treats the active assistant message as in-flight for tool status. Rich tools stay inline with stable keys while streamed tool names resolve; completed tools on prior turns no longer flip back to in-progress when a new user message is pending or streaming.
> 
> **`AgentRunTimeline`** renders block-by-block (per-activity collapsibles, inline tool row + card) and shows the continuation orb only when streaming continues after non-text content without an in-progress step.
> 
> **`reconcileMessages`** interleaves persisted-invalid assistant bubbles at their original position in the thread rather than appending them after later turns.
> 
> **`ChatPage`** drops message re-sorting and the separate `toolResultsByToolId` memo, feeding message order straight into grouping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 948ce0ebe0975896f1669e9660494b66426f403f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->