### PR TITLE
fix(academy): use formal German address in certificate gate copy (AYC-597)

### DIFF
--- a/ayunis-core-frontend/src/shared/locales/de/academy.json
+++ b/ayunis-core-frontend/src/shared/locales/de/academy.json
@@ -27,7 +27,7 @@
     "title": "Quiz",
     "questionCounter": "Frage {{current}} von {{total}}",
     "submit": "Antworten absenden",
-    "answerAll": "Beantworte alle Fragen, um abzusenden",
+    "answerAll": "Beantworten Sie alle Fragen, um abzusenden",
     "retry": "Erneut versuchen",
     "backToAcademy": "Zurück zur Academy",
     "passed": {
@@ -37,32 +37,32 @@
       "title": "Noch nicht ganz"
     },
     "result": {
-      "score": "Du hast {{correct}} von {{total}} richtig ({{score}} %)",
-      "required": "Du brauchst {{required}} richtige Antworten zum Bestehen."
+      "score": "Sie haben {{correct}} von {{total}} richtig ({{score}} %)",
+      "required": "Sie brauchen {{required}} richtige Antworten zum Bestehen."
     },
     "completed": {
       "title": "Academy abgeschlossen!",
-      "description": "Du hast jedes Kapitel bestanden. Glückwunsch!"
+      "description": "Sie haben jedes Kapitel bestanden. Glückwunsch!"
     },
     "errors": {
       "loadFailed": "Das Quiz konnte nicht geladen werden.",
-      "loadFailedDescription": "Bitte versuche es erneut.",
+      "loadFailedDescription": "Bitte versuchen Sie es erneut.",
       "notAvailable": "Dieses Quiz ist nicht verfügbar.",
       "notAvailableDescription": "Dieses Kapitel hat derzeit kein Quiz.",
-      "invalidSubmission": "Deine Eingabe war ungültig. Bitte versuche es erneut.",
-      "submitFailed": "Deine Antworten konnten nicht gesendet werden. Bitte versuche es erneut."
+      "invalidSubmission": "Ihre Eingabe war ungültig. Bitte versuchen Sie es erneut.",
+      "submitFailed": "Ihre Antworten konnten nicht gesendet werden. Bitte versuchen Sie es erneut."
     }
   },
   "progress": {
     "passed": "Bestanden",
     "completed": {
       "title": "Academy abgeschlossen!",
-      "description": "Du hast jedes Kapitel bestanden."
+      "description": "Sie haben jedes Kapitel bestanden."
     },
     "renewalDue": "Erneuerung fällig"
   },
   "certificate": {
-    "downloadError": "Das Zertifikat konnte nicht heruntergeladen werden. Bitte versuche es erneut.",
+    "downloadError": "Das Zertifikat konnte nicht heruntergeladen werden. Bitte versuchen Sie es erneut.",
     "download": "Zertifikat herunterladen"
   },
   "gate": {

--- a/ayunis-core-frontend/src/shared/locales/de/academy.json
+++ b/ayunis-core-frontend/src/shared/locales/de/academy.json
@@ -67,9 +67,9 @@
   },
   "gate": {
     "title": "Zertifikat erforderlich",
-    "description": "Deine Organisation setzt den KI-Führerschein voraus, bevor du den Ayunis Core Chat nutzen kannst. Schließe die Academy ab, um ihn freizuschalten — deine bisherigen Chats bleiben in der Zwischenzeit lesbar.",
+    "description": "Ihre Organisation setzt den KI-Führerschein voraus, bevor Sie den Ayunis Core Chat nutzen können. Schließen Sie die Academy ab, um ihn freizuschalten — Ihre bisherigen Chats bleiben in der Zwischenzeit lesbar.",
     "action": "Zur Academy",
     "emptyTitle": "Noch keine Academy-Inhalte",
-    "emptyDescription": "Der Chat ist gesperrt, bis du das Zertifikat bestanden hast, aber es wurden noch keine Kapitel veröffentlicht. Bitte wende dich an deine Administration."
+    "emptyDescription": "Der Chat ist gesperrt, bis Sie das Zertifikat bestanden haben, aber es wurden noch keine Kapitel veröffentlicht. Bitte wenden Sie sich an Ihre Administration."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-academy.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-academy.json
@@ -1,10 +1,10 @@
 {
   "requirement": {
     "title": "KI-Führerschein-Pflicht",
-    "description": "Lege fest, ob Mitglieder deiner Organisation den KI-Führerschein in der Academy bestehen müssen, bevor sie den Ayunis Core Chat nutzen können. Das Lesen bestehender Chats wird nie blockiert.",
+    "description": "Legen Sie fest, ob Benutzer Ihrer Organisation den KI-Führerschein in der Academy bestehen müssen, bevor sie den Ayunis Core Chat nutzen können. Das Lesen bestehender Chats wird nie blockiert.",
     "saved": "Zertifikatspflicht aktualisiert",
     "error": "Zertifikatspflicht konnte nicht aktualisiert werden",
-    "errorUnexpected": "Beim Speichern ist etwas schiefgelaufen. Bitte versuche es erneut.",
+    "errorUnexpected": "Beim Speichern ist etwas schiefgelaufen. Bitte versuchen Sie es erneut.",
     "modes": {
       "unrestricted": {
         "label": "Nicht erforderlich",
@@ -12,11 +12,11 @@
       },
       "requiredOnce": {
         "label": "Einmalig erforderlich",
-        "description": "Mitglieder müssen den KI-Führerschein bestehen, bevor sie den Chat nutzen. Einmal bestanden, läuft er nie ab."
+        "description": "Benutzer müssen den KI-Führerschein bestehen, bevor sie den Chat nutzen. Einmal bestanden, läuft er nie ab."
       },
       "requiredAnnually": {
         "label": "Jährlich erforderlich",
-        "description": "Mitglieder müssen den KI-Führerschein bestehen und alle 12 Monate erneuern. Zum Erneuern muss die gesamte Academy erneut abgeschlossen werden."
+        "description": "Benutzer müssen den KI-Führerschein bestehen und alle 12 Monate erneuern. Zum Erneuern muss die gesamte Academy erneut abgeschlossen werden."
       }
     }
   }

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -200,7 +200,7 @@
         "other": "Personenbezogene Daten"
       }
     },
-    "academyCertificateRequiredError": "Deine Organisation setzt den KI-Führerschein voraus, bevor du Nachrichten senden kannst. Schließe die Academy ab, um den Chat freizuschalten."
+    "academyCertificateRequiredError": "Ihre Organisation setzt den KI-Führerschein voraus, bevor Sie Nachrichten senden können. Schließen Sie die Academy ab, um den Chat freizuschalten."
   },
   "newChat": {
     "newChat": "Neuer Chat",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adjusts the German copy in the Academy area to use the formal address, following the review feedback on [AYC-597](https://linear.app/ayunis/issue/AYC-597).

## What changed

Two wording adjustments across the German Academy locale strings:

1. **Formal address** — informal "du"/"deine"/"dich" (and matching imperative/verb forms) replaced with formal "Sie"/"Ihre".
2. **"Mitglieder" → "Benutzer"** in the admin requirement setting copy.

### Certificate gate (introduced by AYC-597)

- `de/academy.json` — `gate.description`, `gate.emptyDescription`
- `de/admin-settings-academy.json` — `requirement.description`, `requirement.errorUnexpected`, `modes.requiredOnce.description`, `modes.requiredAnnually.description`
- `de/chat.json` — `academyCertificateRequiredError`

### Rest of the Academy area (pre-existing copy)

- `de/academy.json` — quiz strings (`quiz.answerAll`, `quiz.result.score`, `quiz.result.required`, `quiz.completed.description`), quiz error strings (`quiz.errors.*`), the `progress.completed.description` banner, and `certificate.downloadError`

## Why

The rest of the German UI (e.g. the new-chat greeting, the "kein Modell" hint) already addresses users formally with "Sie". This brings the whole Academy area in line.

English strings are unaffected (already use "you"/"members"), no component strings were hardcoded, and the `super-admin-settings-academy.json` locale already used formal address.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-597](https://linear.app/ayunis/issue/AYC-597/certificate-gate-13-org-setting-core-access-gating)

<div><a href="https://cursor.com/agents/bc-dcb7df76-6649-4793-aa45-ba649571aa0b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcb7df76-6649-4793-aa45-ba649571aa0b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

