### PR TITLE
fix(dev): harden local stack startup (AYC-000)

### DIFF
--- a/dev
+++ b/dev
@@ -70,6 +70,8 @@ export GOTENBERG_HOST_PORT=$((3100 + OFFSET))
 
 BACKEND_PORT=$((3000 + OFFSET))
 FRONTEND_PORT=$((3001 + OFFSET))
+BACKEND_HEALTH_URL="http://localhost:$BACKEND_PORT/api/health"
+FRONTEND_URL="http://localhost:$FRONTEND_PORT"
 
 PROJECT_NAME="ayunis-dev-${SLOT}"
 STATE_DIR="$REPO_DIR/.dev/slot-${SLOT}"
@@ -107,8 +109,19 @@ _infisical_preflight() {
     warn ".infisical.json missing — using local .env files"
     return
   fi
+  if ! (cd "$REPO_DIR" && infisical login status --silent >/dev/null 2>&1); then
+    local domain
+    local -a login_args=()
+    domain="$(sed -n 's/.*"domain"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$REPO_DIR/.infisical.json" | head -n 1)"
+    [ -n "$domain" ] && login_args+=("--domain=$domain")
+    info "Infisical session expired — starting login …"
+    if ! (cd "$REPO_DIR" && infisical login "${login_args[@]}"); then
+      warn "Infisical login failed — using local .env files"
+      return
+    fi
+  fi
   if ! (cd "$REPO_DIR" && infisical export --env=dev --path=/backend --format=dotenv >/dev/null 2>&1); then
-    warn "Infisical login expired or no project access — run: infisical login  (using local .env files)"
+    warn "Infisical dev /backend is unavailable — using local .env files"
     return
   fi
   INFISICAL_OK=true
@@ -276,10 +289,14 @@ EOF
   (cd "$REPO_DIR/ayunis-core-backend" && ${BACKEND_SECRETS_PREFIX}pnpm run migration:run:dev 2>&1) | tail -3
 
   # -- 4. Backend (native) ------------------------------------------------
-  if _pid_alive "$STATE_DIR/backend.pid" "$BACKEND_SESSION"; then
+  if _service_healthy "$STATE_DIR/backend.pid" "$BACKEND_SESSION" "$BACKEND_HEALTH_URL" "$BACKEND_PORT"; then
     info "Backend already running (PID $(cat "$STATE_DIR/backend.pid"))"
   else
-    _kill_port "$BACKEND_PORT" "Backend (stale)"
+    _refuse_unmanaged_listener "$STATE_DIR/backend.pid" "$BACKEND_PORT" "Backend"
+    if _pid_alive "$STATE_DIR/backend.pid" "$BACKEND_SESSION"; then
+      warn "Restarting unhealthy Backend (PID $(cat "$STATE_DIR/backend.pid")) …"
+      _kill_pid "$STATE_DIR/backend.pid" "Backend" "$BACKEND_PORT" "$BACKEND_SESSION"
+    fi
     info "Starting backend on port $BACKEND_PORT …"
     : > "$STATE_DIR/backend.log"
     _start_detached \
@@ -290,10 +307,14 @@ EOF
   fi
 
   # -- 5. Frontend (native) -----------------------------------------------
-  if _pid_alive "$STATE_DIR/frontend.pid" "$FRONTEND_SESSION"; then
+  if _service_healthy "$STATE_DIR/frontend.pid" "$FRONTEND_SESSION" "$FRONTEND_URL" "$FRONTEND_PORT"; then
     info "Frontend already running (PID $(cat "$STATE_DIR/frontend.pid"))"
   else
-    _kill_port "$FRONTEND_PORT" "Frontend (stale)"
+    _refuse_unmanaged_listener "$STATE_DIR/frontend.pid" "$FRONTEND_PORT" "Frontend"
+    if _pid_alive "$STATE_DIR/frontend.pid" "$FRONTEND_SESSION"; then
+      warn "Restarting unhealthy Frontend (PID $(cat "$STATE_DIR/frontend.pid")) …"
+      _kill_pid "$STATE_DIR/frontend.pid" "Frontend" "$FRONTEND_PORT" "$FRONTEND_SESSION"
+    fi
     info "Starting frontend on port $FRONTEND_PORT …"
     : > "$STATE_DIR/frontend.log"
     _start_detached \
@@ -305,10 +326,9 @@ EOF
 
   # -- 6. Wait for backend health -----------------------------------------
   info "Waiting for backend to become healthy …"
-  local url="http://localhost:$BACKEND_PORT/api/health"
   local attempts=0
   local max_attempts=90
-  while ! curl -sf "$url" > /dev/null 2>&1; do
+  while ! _url_healthy "$BACKEND_HEALTH_URL"; do
     attempts=$((attempts + 1))
     if [ $attempts -ge $max_attempts ]; then
       echo ""
@@ -373,15 +393,19 @@ cmd_status() {
   echo ""
 
   # Backend
-  if _pid_alive "$STATE_DIR/backend.pid" "$BACKEND_SESSION"; then
+  if _service_healthy "$STATE_DIR/backend.pid" "$BACKEND_SESSION" "$BACKEND_HEALTH_URL" "$BACKEND_PORT"; then
     echo "  Backend:   running  PID $(cat "$STATE_DIR/backend.pid")  http://localhost:$BACKEND_PORT"
+  elif _pid_alive "$STATE_DIR/backend.pid" "$BACKEND_SESSION"; then
+    echo "  Backend:   unhealthy  PID $(cat "$STATE_DIR/backend.pid")  http://localhost:$BACKEND_PORT"
   else
     echo "  Backend:   stopped"
   fi
 
   # Frontend
-  if _pid_alive "$STATE_DIR/frontend.pid" "$FRONTEND_SESSION"; then
+  if _service_healthy "$STATE_DIR/frontend.pid" "$FRONTEND_SESSION" "$FRONTEND_URL" "$FRONTEND_PORT"; then
     echo "  Frontend:  running  PID $(cat "$STATE_DIR/frontend.pid")  http://localhost:$FRONTEND_PORT"
+  elif _pid_alive "$STATE_DIR/frontend.pid" "$FRONTEND_SESSION"; then
+    echo "  Frontend:  unhealthy  PID $(cat "$STATE_DIR/frontend.pid")  http://localhost:$FRONTEND_PORT"
   else
     echo "  Frontend:  stopped"
   fi
@@ -438,6 +462,58 @@ _pid_alive() {
     return 0
   fi
   [ -n "$session" ] && _tmux_session_alive "$session"
+}
+
+_url_healthy() {
+  curl --fail --silent --max-time 2 "$1" > /dev/null 2>&1
+}
+
+_process_belongs_to_tree() {
+  local process_pid="$1"
+  local root_pid="$2"
+  local parent_pid
+
+  while [[ "$process_pid" =~ ^[0-9]+$ ]] && [ "$process_pid" -gt 1 ]; do
+    [ "$process_pid" = "$root_pid" ] && return 0
+    parent_pid="$(ps -o ppid= -p "$process_pid" 2>/dev/null | tr -d '[:space:]')"
+    [ -n "$parent_pid" ] || return 1
+    process_pid="$parent_pid"
+  done
+  return 1
+}
+
+_port_owned_by_pidfile() {
+  local pidfile="$1"
+  local port="$2"
+  local root_pid listener_pid
+  [ -f "$pidfile" ] || return 1
+  root_pid="$(cat "$pidfile")"
+
+  while IFS= read -r listener_pid; do
+    _process_belongs_to_tree "$listener_pid" "$root_pid" && return 0
+  done < <(lsof -nP -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
+  return 1
+}
+
+_refuse_unmanaged_listener() {
+  local pidfile="$1"
+  local port="$2"
+  local label="$3"
+  local listener_pids
+  listener_pids="$(lsof -nP -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null | paste -sd, - || true)"
+  [ -z "$listener_pids" ] && return 0
+  _port_owned_by_pidfile "$pidfile" "$port" && return 0
+  die "$label port $port is occupied by PID $listener_pids not managed by this checkout. Stop it or use another slot."
+}
+
+_service_healthy() {
+  local pidfile="$1"
+  local session="$2"
+  local url="$3"
+  local port="$4"
+  _pid_alive "$pidfile" "$session" \
+    && _port_owned_by_pidfile "$pidfile" "$port" \
+    && _url_healthy "$url"
 }
 
 _kill_pid() {

--- a/scripts/dev-status.test.sh
+++ b/scripts/dev-status.test.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ayunis-dev-status.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$TEST_DIR/.dev/slot-97" "$TEST_DIR/bin"
+cp "$REPO_DIR/dev" "$TEST_DIR/dev"
+chmod +x "$TEST_DIR/dev"
+printf '97\n' > "$TEST_DIR/.dev/slot"
+printf '%s\n' "$$" > "$TEST_DIR/.dev/slot-97/backend.pid"
+
+cat > "$TEST_DIR/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+cat > "$TEST_DIR/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+if [[ -n "${FAKE_BACKEND_READY:-}" ]]; then
+  [[ -f "$FAKE_BACKEND_READY" ]]
+  exit
+fi
+exit "${FAKE_CURL_EXIT:-1}"
+EOF
+
+cat > "$TEST_DIR/bin/lsof" <<'EOF'
+#!/usr/bin/env bash
+if [[ -n "${FAKE_LISTENER_PID:-}" && "$*" == *"TCP:${FAKE_LISTENER_PORT:-3970}"* ]]; then
+  echo "$FAKE_LISTENER_PID"
+fi
+EOF
+
+chmod +x "$TEST_DIR/bin/docker" "$TEST_DIR/bin/curl" "$TEST_DIR/bin/lsof"
+
+failures=0
+
+output="$(PATH="$TEST_DIR/bin:$PATH" FAKE_CURL_EXIT=1 "$TEST_DIR/dev" status)"
+if [[ "$output" != *"Backend:   unhealthy"* ]]; then
+  printf 'Expected an alive backend process without a health response to be unhealthy.\n%s\n' "$output" >&2
+  failures=$((failures + 1))
+fi
+
+output="$(
+  PATH="$TEST_DIR/bin:$PATH" \
+    FAKE_CURL_EXIT=0 \
+    FAKE_LISTENER_PID="$$" \
+    "$TEST_DIR/dev" status
+)"
+if [[ "$output" != *"Backend:   running"* ]]; then
+  printf 'Expected a healthy backend process to be running.\n%s\n' "$output" >&2
+  failures=$((failures + 1))
+fi
+
+output="$(
+  PATH="$TEST_DIR/bin:$PATH" \
+    FAKE_CURL_EXIT=0 \
+    FAKE_LISTENER_PID=999997 \
+    "$TEST_DIR/dev" status
+)"
+if [[ "$output" != *"Backend:   unhealthy"* ]]; then
+  printf 'Expected a healthy response from an unmanaged listener to be unhealthy.\n%s\n' "$output" >&2
+  failures=$((failures + 1))
+fi
+
+UP_DIR="$TEST_DIR/up"
+mkdir -p \
+  "$UP_DIR/.dev/slot-97" \
+  "$UP_DIR/ayunis-core-backend" \
+  "$UP_DIR/ayunis-core-frontend" \
+  "$UP_DIR/ayunis-core-code-execution/sandbox"
+cp "$REPO_DIR/dev" "$UP_DIR/dev"
+chmod +x "$UP_DIR/dev"
+printf '97\n' > "$UP_DIR/.dev/slot"
+printf '999999\n' > "$UP_DIR/.dev/slot-97/backend.pid"
+
+cat > "$TEST_DIR/bin/tmux" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  has-session)
+    [[ "${FAKE_BACKEND_SESSION:-0}" = "1" && "$*" == *backend* ]]
+    ;;
+  kill-session)
+    exit 0
+    ;;
+  new-session)
+    if [[ "$*" == *ayunis-core-backend* ]]; then
+      : > "$FAKE_BACKEND_READY"
+    fi
+    ;;
+  list-panes)
+    echo 999998
+    ;;
+esac
+EOF
+
+cat > "$TEST_DIR/bin/pnpm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+cat > "$TEST_DIR/bin/openssl" <<'EOF'
+#!/usr/bin/env bash
+echo test-secret
+EOF
+
+cat > "$TEST_DIR/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+chmod +x \
+  "$TEST_DIR/bin/tmux" \
+  "$TEST_DIR/bin/pnpm" \
+  "$TEST_DIR/bin/openssl" \
+  "$TEST_DIR/bin/sleep"
+
+set +e
+output="$(
+  PATH="$TEST_DIR/bin:$PATH" \
+    AYUNIS_NO_INFISICAL=1 \
+    FAKE_BACKEND_SESSION=1 \
+    FAKE_BACKEND_READY="$TEST_DIR/backend-ready" \
+    FAKE_LISTENER_PID=999999 \
+    "$UP_DIR/dev" up 2>&1
+)"
+status=$?
+set -e
+
+if [[ $status -ne 0 || "$output" != *"Restarting unhealthy Backend"* ]]; then
+  printf 'Expected dev up to restart a managed backend that is alive but unhealthy.\n%s\n' "$output" >&2
+  failures=$((failures + 1))
+fi
+
+rm -f "$TEST_DIR/backend-ready"
+printf '999999\n' > "$UP_DIR/.dev/slot-97/backend.pid"
+set +e
+output="$(
+  PATH="$TEST_DIR/bin:$PATH" \
+    AYUNIS_NO_INFISICAL=1 \
+    FAKE_BACKEND_SESSION=1 \
+    FAKE_BACKEND_READY="$TEST_DIR/backend-ready" \
+    FAKE_LISTENER_PID=999997 \
+    "$UP_DIR/dev" up 2>&1
+)"
+status=$?
+set -e
+
+if [[ $status -eq 0 || "$output" != *"not managed by this checkout"* ]]; then
+  printf 'Expected dev up to refuse to terminate an unmanaged listener.\n%s\n' "$output" >&2
+  failures=$((failures + 1))
+fi
+
+LOGIN_DIR="$TEST_DIR/login"
+mkdir -p \
+  "$LOGIN_DIR/.dev" \
+  "$LOGIN_DIR/ayunis-core-backend" \
+  "$LOGIN_DIR/ayunis-core-frontend" \
+  "$LOGIN_DIR/ayunis-core-code-execution/sandbox"
+cp "$REPO_DIR/dev" "$LOGIN_DIR/dev"
+chmod +x "$LOGIN_DIR/dev"
+printf '97\n' > "$LOGIN_DIR/.dev/slot"
+cat > "$LOGIN_DIR/.infisical.json" <<'EOF'
+{"workspaceId":"test-project","domain":"https://eu.infisical.com/api"}
+EOF
+
+cat > "$TEST_DIR/bin/infisical" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1 ${2:-}" = "login status" ]]; then
+  [[ -f "$FAKE_INFISICAL_AUTH" ]]
+  exit
+fi
+if [[ "$1" = "login" ]]; then
+  : > "$FAKE_INFISICAL_AUTH"
+  printf '%s\n' "$*" > "$FAKE_INFISICAL_LOGIN_CALLED"
+  exit 0
+fi
+if [[ "$1" = "export" ]]; then
+  [[ -f "$FAKE_INFISICAL_AUTH" ]] || exit 1
+  printf '%s\n' \
+    'MINIO_ACCESS_KEY=test-user' \
+    'MINIO_SECRET_KEY=test-password' \
+    'REDIS_PASSWORD=test-redis-password'
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$TEST_DIR/bin/infisical"
+
+rm -f "$TEST_DIR/backend-ready" "$TEST_DIR/infisical-auth" "$TEST_DIR/infisical-login-called"
+set +e
+output="$(
+  PATH="$TEST_DIR/bin:$PATH" \
+    FAKE_BACKEND_READY="$TEST_DIR/backend-ready" \
+    FAKE_INFISICAL_AUTH="$TEST_DIR/infisical-auth" \
+    FAKE_INFISICAL_LOGIN_CALLED="$TEST_DIR/infisical-login-called" \
+    "$LOGIN_DIR/dev" up 2>&1
+)"
+status=$?
+set -e
+
+login_used_configured_domain=false
+if [[ -f "$TEST_DIR/infisical-login-called" ]] \
+  && grep -Fq -- '--domain=https://eu.infisical.com/api' "$TEST_DIR/infisical-login-called"; then
+  login_used_configured_domain=true
+fi
+
+if [[ $status -ne 0 || "$login_used_configured_domain" != true || "$output" != *"Secrets:      Infisical"* ]]; then
+  printf 'Expected dev up to log in after an expired Infisical session and retry startup.\n%s\n' "$output" >&2
+  failures=$((failures + 1))
+fi
+
+if [[ $failures -ne 0 ]]; then
+  exit 1
+fi
+
+echo "dev script tests passed"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to the local `./dev` helper and a new test script; no application runtime, auth, or data paths are affected.
> 
> **Overview**
> **Hardens `./dev up` and `./dev status`** so backend/frontend are treated as running only when the managed process owns the slot port and the HTTP endpoint responds—not merely when a PID file exists.
> 
> **Port conflicts:** Replaces killing anything on the port with **`_refuse_unmanaged_listener`**, which errors if another process is listening so unrelated worktrees or manual servers are not terminated. Managed but unhealthy processes are restarted instead of skipped.
> 
> **Infisical:** On expired sessions, **`dev up`** prompts **`infisical login`** using the domain from **`.infisical.json`**, then retries export; export failure messaging is clarified.
> 
> Adds **`scripts/dev-status.test.sh`** with stubbed **`curl`**, **`lsof`**, **`tmux`**, and **`infisical`** to cover unhealthy/running status, restart behavior, unmanaged listener refusal, and auto-login.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad2a9fca20010b7bb14e4a5d0e1cecb19d9668ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->