### PR TITLE
ci: centralize pull-based deploy safeguards (AYC-589)

### DIFF
--- a/.github/workflows/deploy-internal-manual.yml
+++ b/.github/workflows/deploy-internal-manual.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Git tag or branch to deploy'
+        description: 'Published Git tag or branch to deploy'
         required: false
         default: 'main'
 
@@ -21,136 +21,24 @@ jobs:
         uses: appleboy/ssh-action@v1.2.5
         env:
           RELEASE_TAG: ${{ inputs.tag }}
+          DEPLOY_WORKFLOW_SHA: ${{ github.sha }}
         with:
           host: ${{ secrets.INTERNAL_HOST }}
           username: ${{ secrets.INTERNAL_USER }}
           key: ${{ secrets.INTERNAL_SSH_KEY }}
-          envs: RELEASE_TAG
+          envs: RELEASE_TAG,DEPLOY_WORKFLOW_SHA
           script: |
-            # `script_stop` is not an input of appleboy/ssh-action v1.2.5 — it
-            # was accepted here for years and silently ignored, so the script
-            # has to abort on error itself.
             set -e
             cd /home/ayunis/apps/ayunis-core
-            # The checkout still supplies the compose files, the .env files and
-            # postgres/init.sql — only the build is gone (AYC-589).
             git fetch --all --tags
+            DEPLOY_SCRIPT=$(git show "$DEPLOY_WORKFLOW_SHA":scripts/deploy-core-images.sh)
             if git show-ref --tags --verify --quiet "refs/tags/$RELEASE_TAG"; then
-              git checkout -f "$RELEASE_TAG"
+              git checkout -f --detach "refs/tags/$RELEASE_TAG"
               CORE_TAG="$RELEASE_TAG"
             else
-              git checkout -f "$RELEASE_TAG"
-              git reset --hard "origin/$RELEASE_TAG"
-              # A branch has no version tag — run the sha- image built for the
-              # commit it points at (the input defaults to main). Plain
-              # truncation, not `git rev-parse --short=7`: --short is a
-              # *minimum* and git lengthens it when the prefix is ambiguous,
-              # while metadata-action's type=sha is an unconditional
-              # sha.substring(0, 7).
+              git checkout -f --detach "origin/$RELEASE_TAG"
               CORE_TAG="sha-$(git rev-parse HEAD | cut -c1-7)"
             fi
             export CORE_TAG
-            export COMPOSE_FILE=docker-compose.yml:compose.release.yml
             echo "Deploying $CORE_TAG"
-
-            # Reclaiming runs before the pull, not only after a successful
-            # swap. A pull that exhausts the disk exits before the trailing
-            # cleanup, so nothing is freed and every later deploy fails the
-            # same way until the host is cleaned by hand — staging wedged
-            # exactly like this before the ordering was fixed.
-            reclaim_images() {
-              # $1 = "keep-sandbox"; see the call site before the pull.
-              #
-              # This host built its images until this change, so it still
-              # carries a BuildKit cache that will never be reused again, plus
-              # the unprefixed `ayunis-core-*` tags those builds produced. The
-              # ghcr.io filter below reaches neither, and `prune -f` skips the
-              # tags because they are tagged, not dangling. On the first
-              # pull-based deploy the legacy tags are still in use by the
-              # running containers, so rmi refuses them — they are collected by
-              # the post-swap call once the GHCR images have taken over.
-              docker builder prune -af || true
-              docker images --filter "reference=ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
-                | xargs -r docker rmi || true
-              # Superseded Core tags. `prune -a` is the wrong tool: the sandbox
-              # image is referenced only by ephemeral per-execution containers,
-              # so it always looks unused, and an `until=` cut-off can't save it
-              # either — a cache-hit rebuild keeps the original Created date.
-              # The pattern is `ayunis-core-*`, not `*`: the hosts run other
-              # images from this org namespace (ayunis-backup).
-              #
-              # Before the swap this is safe for the compose services because
-              # `docker rmi` refuses an image a running container uses — that
-              # refusal is what spares the generation still serving traffic, so
-              # the `|| true` is load-bearing rather than defensive. The sandbox
-              # is the one image that refusal cannot protect, hence keep-sandbox.
-              victims=$(docker images --filter "reference=ghcr.io/ayunis-core/ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
-                | grep -v ":${CORE_TAG}$" || true)
-              if [ "${1:-}" = "keep-sandbox" ]; then
-                victims=$(printf '%s\n' "$victims" | grep -v 'ayunis-core-python-sandbox' || true)
-              fi
-              printf '%s\n' "$victims" | grep -v '^$' | xargs -r docker rmi || true
-              docker image prune -f
-            }
-
-            # Spare the sandbox here. Nothing long-lived holds that image — the
-            # per-execution containers are transient — so `docker rmi` would
-            # happily delete the tag the *running* code-execution service still
-            # points DOCKER_IMAGE at. It pulls the sandbox only when it is
-            # constructed (executor.py:28), and the execution path uses
-            # containers.create, which never pulls. Deleting it here and then
-            # failing the pull would leave code execution broken for as long as
-            # the deploy stays aborted — defeating the point of keeping the
-            # current containers up.
-            reclaim_images keep-sandbox
-
-            # Fail here rather than mid-blob: a full disk otherwise surfaces as
-            # `GetImageBlob...: no space left on device` buried in pull
-            # progress. The headroom has to cover a second copy of every Core
-            # image while the current ones still serve traffic.
-            #
-            # Sized against this host as measured 2026-07-31: 38 G total, 7.5 G
-            # free — and that is *before* the first pull-based deploy reclaims
-            # the BuildKit cache and the legacy build-on-host images, so it is
-            # the tightest this will ever be. A full new generation is ~5 G with
-            # the CPU-only anonymize, so 6 leaves margin while still catching a
-            # genuinely full disk. Deliberately below production's 9: this does
-            # not cover a rollback to a release tag from before the CPU-only
-            # torch change (~6 GB anonymize, ~9 G for two generations). Such a
-            # rollback would fail on the pull instead — which aborts before the
-            # swap and reclaims on the next run, so it degrades safely. Raise
-            # this toward 9 once the host has settled after its first deploy.
-            MIN_FREE_GB=6
-            FREE_GB=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
-            echo "Free disk: ${FREE_GB:-0}G (need ${MIN_FREE_GB}G)"
-            if [ "${FREE_GB:-0}" -lt "$MIN_FREE_GB" ]; then
-              echo "::error::only ${FREE_GB:-0}G free, need ${MIN_FREE_GB}G — not deploying"
-              exit 1
-            fi
-
-            # Pull while the old containers still serve traffic, and abort
-            # BEFORE touching them if anything is missing. Scoped to the Core
-            # services: a bare `compose pull` would also refresh
-            # minio/dozzle/redis/gotenberg, which are deliberately only pulled
-            # when first started.
-            if ! docker compose pull app code-execution anonymize; then
-              echo "::error::image pull failed — keeping current containers, not deploying"
-              exit 1
-            fi
-            # The sandbox is not a compose service; code-execution pulls it
-            # through the docker-socket-proxy on first use. Pulling it here
-            # keeps that first execution fast and proves the tag exists.
-            if ! docker pull "ghcr.io/ayunis-core/ayunis-core-python-sandbox:$CORE_TAG"; then
-              echo "::error::sandbox image pull failed — keeping current containers, not deploying"
-              exit 1
-            fi
-            docker compose down
-            docker compose up -d --no-build
-            sleep 60
-            docker compose ps
-            # Drop the generation just replaced, sandbox included: the new
-            # containers are up on CORE_TAG, which the filter spares, so the
-            # stale sandbox tag is now genuinely unreferenced. This is also the
-            # call that collects the legacy build-on-host images, which the
-            # pre-pull call could not touch while they were still running.
-            reclaim_images
+            printf '%s\n' "$DEPLOY_SCRIPT" | MIN_FREE_GB=6 PRUNE_BUILD_CACHE=true bash

--- a/.github/workflows/deploy-production-manual.yml
+++ b/.github/workflows/deploy-production-manual.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Git tag or branch to deploy'
+        description: 'Published Git tag or branch to deploy'
         required: false
         default: 'main'
 
@@ -21,133 +21,24 @@ jobs:
         uses: appleboy/ssh-action@v1.2.5
         env:
           RELEASE_TAG: ${{ inputs.tag }}
+          DEPLOY_WORKFLOW_SHA: ${{ github.sha }}
         with:
           host: ${{ secrets.PRODUCTION_HOST }}
           username: ${{ secrets.PRODUCTION_USER }}
           key: ${{ secrets.PRODUCTION_SSH_KEY }}
-          envs: RELEASE_TAG
+          envs: RELEASE_TAG,DEPLOY_WORKFLOW_SHA
           script: |
-            # `script_stop` is not an input of appleboy/ssh-action v1.2.5 — it
-            # was accepted here for years and silently ignored, so the script
-            # has to abort on error itself.
             set -e
             cd /home/ayunis/apps/ayunis-core
-            # The checkout still supplies the compose files, the .env files and
-            # postgres/init.sql — only the build is gone (AYC-589).
             git fetch --all --tags
+            DEPLOY_SCRIPT=$(git show "$DEPLOY_WORKFLOW_SHA":scripts/deploy-core-images.sh)
             if git show-ref --tags --verify --quiet "refs/tags/$RELEASE_TAG"; then
-              git checkout -f "$RELEASE_TAG"
+              git checkout -f --detach "refs/tags/$RELEASE_TAG"
               CORE_TAG="$RELEASE_TAG"
             else
-              git checkout -f "$RELEASE_TAG"
-              git reset --hard "origin/$RELEASE_TAG"
-              # A branch has no version tag — run the sha- image built for the
-              # commit it points at (the input defaults to main). Plain
-              # truncation, not `git rev-parse --short=7`: --short is a
-              # *minimum* and git lengthens it when the prefix is ambiguous,
-              # while metadata-action's type=sha is an unconditional
-              # sha.substring(0, 7).
+              git checkout -f --detach "origin/$RELEASE_TAG"
               CORE_TAG="sha-$(git rev-parse HEAD | cut -c1-7)"
             fi
             export CORE_TAG
-            export COMPOSE_FILE=docker-compose.yml:compose.release.yml
             echo "Deploying $CORE_TAG"
-
-            # Reclaiming runs before the pull, not only after a successful
-            # swap. A pull that exhausts the disk exits before the trailing
-            # cleanup, so nothing is freed and every later deploy fails the
-            # same way until the host is cleaned by hand — staging wedged
-            # exactly like this before the ordering was fixed.
-            reclaim_images() {
-              # $1 = "keep-sandbox"; see the call site before the pull.
-              #
-              # This host built its images until this change, so it still
-              # carries a BuildKit cache that will never be reused again, plus
-              # the unprefixed `ayunis-core-*` tags those builds produced. The
-              # ghcr.io filter below reaches neither, and `prune -f` skips the
-              # tags because they are tagged, not dangling. On the first
-              # pull-based deploy the legacy tags are still in use by the
-              # running containers, so rmi refuses them — they are collected by
-              # the post-swap call once the GHCR images have taken over.
-              docker builder prune -af || true
-              docker images --filter "reference=ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
-                | xargs -r docker rmi || true
-              # Superseded Core tags. `prune -a` is the wrong tool: the sandbox
-              # image is referenced only by ephemeral per-execution containers,
-              # so it always looks unused, and an `until=` cut-off can't save it
-              # either — a cache-hit rebuild keeps the original Created date.
-              # The pattern is `ayunis-core-*`, not `*`: the hosts run other
-              # images from this org namespace (ayunis-backup).
-              #
-              # Before the swap this is safe for the compose services because
-              # `docker rmi` refuses an image a running container uses — that
-              # refusal is what spares the generation still serving traffic, so
-              # the `|| true` is load-bearing rather than defensive. The sandbox
-              # is the one image that refusal cannot protect, hence keep-sandbox.
-              victims=$(docker images --filter "reference=ghcr.io/ayunis-core/ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
-                | grep -v ":${CORE_TAG}$" || true)
-              if [ "${1:-}" = "keep-sandbox" ]; then
-                victims=$(printf '%s\n' "$victims" | grep -v 'ayunis-core-python-sandbox' || true)
-              fi
-              printf '%s\n' "$victims" | grep -v '^$' | xargs -r docker rmi || true
-              docker image prune -f
-            }
-
-            # Spare the sandbox here. Nothing long-lived holds that image — the
-            # per-execution containers are transient — so `docker rmi` would
-            # happily delete the tag the *running* code-execution service still
-            # points DOCKER_IMAGE at. It pulls the sandbox only when it is
-            # constructed (executor.py:28), and the execution path uses
-            # containers.create, which never pulls. Deleting it here and then
-            # failing the pull would leave code execution broken for as long as
-            # the deploy stays aborted — defeating the point of keeping the
-            # current containers up.
-            reclaim_images keep-sandbox
-
-            # Fail here rather than mid-blob: a full disk otherwise surfaces as
-            # `GetImageBlob...: no space left on device` buried in pull
-            # progress. The headroom has to cover a second copy of every Core
-            # image while the current ones still serve traffic.
-            #
-            # Sized against this host as measured 2026-07-31: 150 G total, 59 G
-            # free, so 9 is comfortable. It covers the worst case rather than
-            # the current one — a rollback to a release tag from before the
-            # CPU-only torch change still carries a ~6 GB anonymize image, so
-            # two generations need ~9 G. Internal deliberately runs a lower
-            # threshold; it is a 38 G box.
-            MIN_FREE_GB=9
-            FREE_GB=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
-            echo "Free disk: ${FREE_GB:-0}G (need ${MIN_FREE_GB}G)"
-            if [ "${FREE_GB:-0}" -lt "$MIN_FREE_GB" ]; then
-              echo "::error::only ${FREE_GB:-0}G free, need ${MIN_FREE_GB}G — not deploying"
-              exit 1
-            fi
-
-            # Pull while the old containers still serve traffic, and abort
-            # BEFORE touching them if anything is missing. Scoped to the Core
-            # services: a bare `compose pull` would also refresh
-            # minio/dozzle/redis/gotenberg, which are deliberately only pulled
-            # when first started.
-            if ! docker compose pull app code-execution anonymize; then
-              echo "::error::image pull failed — keeping current containers, not deploying"
-              exit 1
-            fi
-            # The sandbox is not a compose service; code-execution pulls it
-            # through the docker-socket-proxy on first use. Pulling it here
-            # keeps that first execution fast and proves the tag exists.
-            if ! docker pull "ghcr.io/ayunis-core/ayunis-core-python-sandbox:$CORE_TAG"; then
-              echo "::error::sandbox image pull failed — keeping current containers, not deploying"
-              exit 1
-            fi
-            # Quick swap — downtime is only the restart
-            docker compose down
-            docker compose up -d --no-build
-            # Wait for app to be healthy (up to 120s)
-            timeout 120 bash -c 'until docker compose ps app --format json | grep -q "(healthy)"; do sleep 5; done'
-            docker compose ps
-            # Drop the generation just replaced, sandbox included: the new
-            # containers are up on CORE_TAG, which the filter spares, so the
-            # stale sandbox tag is now genuinely unreferenced. This is also the
-            # call that collects the legacy build-on-host images, which the
-            # pre-pull call could not touch while they were still running.
-            reclaim_images
+            printf '%s\n' "$DEPLOY_SCRIPT" | MIN_FREE_GB=9 PRUNE_BUILD_CACHE=true bash

--- a/.github/workflows/deploy-script-tests.yml
+++ b/.github/workflows/deploy-script-tests.yml
@@ -1,0 +1,27 @@
+name: Deploy Script Tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/deploy-core-images.sh'
+      - 'scripts/deploy-core-images.test.sh'
+      - '.github/workflows/deploy-*.yml'
+      - '.github/workflows/release-please.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/deploy-core-images.sh'
+      - 'scripts/deploy-core-images.test.sh'
+      - '.github/workflows/deploy-*.yml'
+      - '.github/workflows/release-please.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Test deploy behavior
+        run: bash scripts/deploy-core-images.test.sh

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -37,126 +37,14 @@ jobs:
           key: ${{ secrets.STAGING_SSH_KEY }}
           envs: DEPLOY_SHA
           script: |
-            # `script_stop` is not an input of appleboy/ssh-action v1.2.5 — it
-            # was accepted here for years and silently ignored, so the script
-            # has to abort on error itself.
             set -e
             cd /home/ayunis/apps/ayunis-core
-            # The checkout still supplies the compose files, the .env files and
-            # postgres/init.sql — only the build is gone. Reset to the exact
-            # built commit so the compose files and the image tag cannot drift
-            # apart if another push lands mid-deploy.
+            # Reset to the exact commit that produced the images so the compose
+            # files, deploy script, and image tag cannot drift apart.
             git fetch origin main
             git reset --hard "${DEPLOY_SHA:-origin/main}"
-            export COMPOSE_FILE=docker-compose.yml:compose.release.yml
-            # Plain truncation, not `git rev-parse --short=7`: --short is a
-            # *minimum* and git lengthens it when the prefix is ambiguous,
-            # while metadata-action's type=sha is an unconditional
-            # sha.substring(0, 7). A longer abbreviation would name a tag that
-            # was never published.
+            # Plain truncation matches metadata-action's fixed seven-character
+            # sha tag even when git would lengthen an ambiguous --short value.
             export CORE_TAG="sha-$(git rev-parse HEAD | cut -c1-7)"
             echo "Deploying $CORE_TAG"
-
-            # Reclaiming images used to be the last thing this script did, so a
-            # pull that ran out of disk exited before it — nothing was freed and
-            # every later deploy hit the same wall until someone cleaned the host
-            # by hand. Running it before the pull as well is what makes the
-            # failure recoverable instead of self-perpetuating.
-            reclaim_images() {
-              # Images built on the host before the GHCR switch. The base compose
-              # declares `build:` with no `image:`, so those builds are tagged
-              # `ayunis-core-*` with no registry prefix — the ghcr.io/... filter
-              # below never matches them, and `prune -f` skips them because they
-              # are tagged, not dangling. The migration left a full duplicate set
-              # (9.1 GB on staging) that nothing collected.
-              docker images --filter "reference=ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
-                | xargs -r docker rmi || true
-              # Superseded Core tags — pulled images are tagged, not dangling, so
-              # `prune -f` alone would never touch them and every main push would
-              # add four. `prune -a` is the wrong tool here: the sandbox image is
-              # referenced only by ephemeral per-execution containers, so it
-              # always looks unused, and no `until=` cut-off saves it either — a
-              # cache-hit rebuild keeps the original Created date, so a freshly
-              # pulled sandbox tag can already read as weeks old. Deleting exactly
-              # the Core tags that aren't the one being deployed cannot touch what
-              # this deploy pulls. Superseded tags stay in GHCR, so a rollback
-              # re-pulls them.
-              #
-              # Running this *before* the swap is safe for the compose services
-              # because `docker rmi` refuses to remove an image a running
-              # container uses — that refusal is what spares the generation still
-              # serving traffic, so the `|| true` is load-bearing rather than
-              # defensive. The sandbox is the one image that refusal cannot
-              # protect, hence keep-sandbox below.
-              #
-              # The pattern is `ayunis-core-*`, not `*`: the hosts run other
-              # images from this org namespace (ayunis-backup), and matching the
-              # whole namespace made the deploy try to delete them.
-              victims=$(docker images --filter "reference=ghcr.io/ayunis-core/ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
-                | grep -v ":${CORE_TAG}$" || true)
-              if [ "${1:-}" = "keep-sandbox" ]; then
-                victims=$(printf '%s\n' "$victims" | grep -v 'ayunis-core-python-sandbox' || true)
-              fi
-              printf '%s\n' "$victims" | grep -v '^$' | xargs -r docker rmi || true
-              docker image prune -f
-            }
-
-            # Spare the sandbox here. Nothing long-lived holds that image — the
-            # per-execution containers are transient — so `docker rmi` will
-            # happily delete the tag the *running* code-execution service still
-            # points DOCKER_IMAGE at. It pulls the sandbox only when it is
-            # constructed (executor.py:28), and the execution path uses
-            # containers.create, which never pulls. So deleting it here and then
-            # failing the pull would leave code execution broken for as long as
-            # the deploy stays aborted — defeating the whole point of keeping the
-            # current containers up.
-            reclaim_images keep-sandbox
-
-            # Fail here rather than mid-blob: a full disk otherwise surfaces as
-            # `write /var/lib/docker/tmp/GetImageBlob...: no space left on
-            # device` buried in progress output. The headroom has to cover a
-            # second copy of every Core image while the current ones still serve
-            # traffic, and anonymize alone is ~6 GB of that — so this can be
-            # lowered once that image sheds its CUDA payload. Erring high only
-            # costs a clear refusal to deploy; erring low costs a failed pull
-            # that leaves a half-fetched generation behind.
-            # `/` rather than /var/lib/docker: the
-            # deploy user cannot traverse the docker root, and these hosts run a
-            # single root filesystem.
-            MIN_FREE_GB=9
-            FREE_GB=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
-            echo "Free disk: ${FREE_GB:-0}G (need ${MIN_FREE_GB}G)"
-            if [ "${FREE_GB:-0}" -lt "$MIN_FREE_GB" ]; then
-              echo "::error::only ${FREE_GB:-0}G free, need ${MIN_FREE_GB}G — not deploying"
-              exit 1
-            fi
-
-            # Pull while the old containers still serve traffic. If a pull
-            # fails, abort BEFORE touching them — otherwise a missing image
-            # would tear down the app and leave it down while the deploy still
-            # reports success (see AYC: corepack outage).
-            # Scoped to the Core services on purpose: a bare `compose pull`
-            # would also refresh minio/redis/gotenberg, which are
-            # deliberately only pulled when first started.
-            if ! docker compose pull app code-execution anonymize; then
-              echo "::error::image pull failed — keeping current containers, not deploying"
-              exit 1
-            fi
-            # The sandbox is not a compose service; code-execution pulls it
-            # through the docker-socket-proxy on first use. Pulling it here
-            # keeps that first execution fast and proves the tag exists before
-            # the swap.
-            if ! docker pull "ghcr.io/ayunis-core/ayunis-core-python-sandbox:$CORE_TAG"; then
-              echo "::error::sandbox image pull failed — keeping current containers, not deploying"
-              exit 1
-            fi
-            # Quick swap — downtime is only the restart
-            docker compose down
-            docker compose up -d --no-build
-            # Wait for app to be healthy (up to 120s)
-            timeout 120 bash -c 'until docker compose ps app --format json | grep -q "(healthy)"; do sleep 5; done'
-            docker compose ps
-            # Drop the generation just replaced, sandbox included: the new
-            # containers are up on CORE_TAG, which the filter spares, so the
-            # stale sandbox tag is now genuinely unreferenced.
-            reclaim_images
+            MIN_FREE_GB=9 PRUNE_BUILD_CACHE=false bash scripts/deploy-core-images.sh

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -60,51 +60,13 @@ jobs:
           key: ${{ secrets.INTERNAL_SSH_KEY }}
           envs: RELEASE_TAG
           script: |
-            # `script_stop` is not an input of appleboy/ssh-action v1.2.5 — it
-            # was accepted here for years and silently ignored, so the script
-            # has to abort on error itself.
             set -e
             cd /home/ayunis/apps/ayunis-core
-            # The checkout still supplies the compose files, the .env files and
-            # postgres/init.sql — only the build is gone (AYC-589).
             git fetch --all --tags
-            git checkout -f "$RELEASE_TAG"
-            export COMPOSE_FILE=docker-compose.yml:compose.release.yml
+            git checkout -f --detach "refs/tags/$RELEASE_TAG"
             export CORE_TAG="$RELEASE_TAG"
-            # Pull while the old containers still serve traffic, and abort
-            # BEFORE touching them if anything is missing. Scoped to the Core
-            # services: a bare `compose pull` would also refresh
-            # minio/dozzle/redis/gotenberg, which are deliberately only pulled
-            # when first started.
-            if ! docker compose pull app code-execution anonymize; then
-              echo "::error::image pull failed — keeping current containers, not deploying"
-              exit 1
-            fi
-            # The sandbox is not a compose service; code-execution pulls it
-            # through the docker-socket-proxy on first use. Pulling it here
-            # keeps that first execution fast and proves the tag exists.
-            if ! docker pull "ghcr.io/ayunis-core/ayunis-core-python-sandbox:$CORE_TAG"; then
-              echo "::error::sandbox image pull failed — keeping current containers, not deploying"
-              exit 1
-            fi
-            # Quick swap — downtime is only the restart
-            docker compose down
-            docker compose up -d --no-build
-            # Wait for app to be healthy (up to 120s)
-            timeout 120 bash -c 'until docker compose ps app --format json | grep -q "(healthy)"; do sleep 5; done'
-            docker compose ps
-            # Reclaim superseded Core images — pulled images are tagged, not
-            # dangling, so `prune -f` alone would never touch them. `prune -a`
-            # is the wrong tool: the sandbox image is referenced only by
-            # ephemeral per-execution containers, so it always looks unused,
-            # and an `until=` cut-off can't save it either — a cache-hit
-            # rebuild keeps the original Created date. The pattern is
-            # `ayunis-core-*`, not `*`: the hosts run other images from this
-            # org namespace (ayunis-backup).
-            docker images --filter "reference=ghcr.io/ayunis-core/ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
-              | grep -v ":${CORE_TAG}$" \
-              | xargs -r docker rmi || true
-            docker image prune -f
+            echo "Deploying $CORE_TAG"
+            MIN_FREE_GB=6 PRUNE_BUILD_CACHE=true bash scripts/deploy-core-images.sh
 
   deploy-production:
     needs: [release-please, build-release-images, deploy-internal]
@@ -125,51 +87,13 @@ jobs:
           key: ${{ secrets.PRODUCTION_SSH_KEY }}
           envs: RELEASE_TAG
           script: |
-            # `script_stop` is not an input of appleboy/ssh-action v1.2.5 — it
-            # was accepted here for years and silently ignored, so the script
-            # has to abort on error itself.
             set -e
             cd /home/ayunis/apps/ayunis-core
-            # The checkout still supplies the compose files, the .env files and
-            # postgres/init.sql — only the build is gone (AYC-589).
             git fetch --all --tags
-            git checkout -f "$RELEASE_TAG"
-            export COMPOSE_FILE=docker-compose.yml:compose.release.yml
+            git checkout -f --detach "refs/tags/$RELEASE_TAG"
             export CORE_TAG="$RELEASE_TAG"
-            # Pull while the old containers still serve traffic, and abort
-            # BEFORE touching them if anything is missing. Scoped to the Core
-            # services: a bare `compose pull` would also refresh
-            # minio/dozzle/redis/gotenberg, which are deliberately only pulled
-            # when first started.
-            if ! docker compose pull app code-execution anonymize; then
-              echo "::error::image pull failed — keeping current containers, not deploying"
-              exit 1
-            fi
-            # The sandbox is not a compose service; code-execution pulls it
-            # through the docker-socket-proxy on first use. Pulling it here
-            # keeps that first execution fast and proves the tag exists.
-            if ! docker pull "ghcr.io/ayunis-core/ayunis-core-python-sandbox:$CORE_TAG"; then
-              echo "::error::sandbox image pull failed — keeping current containers, not deploying"
-              exit 1
-            fi
-            # Quick swap — downtime is only the restart
-            docker compose down
-            docker compose up -d --no-build
-            # Wait for app to be healthy (up to 120s)
-            timeout 120 bash -c 'until docker compose ps app --format json | grep -q "(healthy)"; do sleep 5; done'
-            docker compose ps
-            # Reclaim superseded Core images — pulled images are tagged, not
-            # dangling, so `prune -f` alone would never touch them. `prune -a`
-            # is the wrong tool: the sandbox image is referenced only by
-            # ephemeral per-execution containers, so it always looks unused,
-            # and an `until=` cut-off can't save it either — a cache-hit
-            # rebuild keeps the original Created date. The pattern is
-            # `ayunis-core-*`, not `*`: the hosts run other images from this
-            # org namespace (ayunis-backup).
-            docker images --filter "reference=ghcr.io/ayunis-core/ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
-              | grep -v ":${CORE_TAG}$" \
-              | xargs -r docker rmi || true
-            docker image prune -f
+            echo "Deploying $CORE_TAG"
+            MIN_FREE_GB=9 PRUNE_BUILD_CACHE=true bash scripts/deploy-core-images.sh
 
   notify-slack:
     name: Notify Slack

--- a/scripts/deploy-core-images.sh
+++ b/scripts/deploy-core-images.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${CORE_TAG:?CORE_TAG must name the published image tag to deploy}"
+: "${MIN_FREE_GB:?MIN_FREE_GB must set the required disk headroom}"
+
+export COMPOSE_FILE=docker-compose.yml:compose.release.yml
+PRUNE_BUILD_CACHE="${PRUNE_BUILD_CACHE:-false}"
+SANDBOX_IMAGE="ghcr.io/ayunis-core/ayunis-core-python-sandbox:$CORE_TAG"
+TARGET_COMPOSE_IMAGES=(
+  "ghcr.io/ayunis-core/ayunis-core-app:$CORE_TAG"
+  "ghcr.io/ayunis-core/ayunis-core-code-execution:$CORE_TAG"
+  "ghcr.io/ayunis-core/ayunis-core-anonymize:$CORE_TAG"
+)
+
+reclaim_images() {
+  local preserve_sandbox="${1:-}"
+  local victims
+
+  if [[ "$preserve_sandbox" == "keep-sandbox" && "$PRUNE_BUILD_CACHE" == "true" ]]; then
+    docker builder prune -af || true
+  fi
+
+  docker images --filter "reference=ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
+    | xargs -r docker rmi || true
+
+  victims=$(docker images --filter "reference=ghcr.io/ayunis-core/ayunis-core-*" --format '{{.Repository}}:{{.Tag}}' \
+    | awk -F: -v tag="$CORE_TAG" '$NF != tag' || true)
+  if [[ "$preserve_sandbox" == "keep-sandbox" ]]; then
+    victims=$(printf '%s\n' "$victims" | grep -Fv 'ayunis-core-python-sandbox' || true)
+  fi
+  printf '%s\n' "$victims" | grep -v '^$' | xargs -r docker rmi || true
+  docker image prune -f
+}
+
+remove_partial_target_images() {
+  # In-use images are protected by Docker. Unused images with the target tag
+  # came from an interrupted pull and must not make the next disk check fail.
+  docker rmi "${TARGET_COMPOSE_IMAGES[@]}" || true
+  docker image prune -f
+}
+
+# Pulls need room for a complete second image generation. Cleanup runs first
+# so a full disk cannot trap every later deployment behind the same failed
+# pull. The sandbox is preserved because no long-lived container pins it.
+reclaim_images keep-sandbox
+
+FREE_GB=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+if [[ "${FREE_GB:-0}" -lt "$MIN_FREE_GB" ]]; then
+  remove_partial_target_images
+  FREE_GB=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+fi
+echo "Free disk: ${FREE_GB:-0}G (need ${MIN_FREE_GB}G)"
+if [[ "${FREE_GB:-0}" -lt "$MIN_FREE_GB" ]]; then
+  echo "::error::only ${FREE_GB:-0}G free, need ${MIN_FREE_GB}G — not deploying"
+  exit 1
+fi
+
+if ! docker compose pull app code-execution anonymize; then
+  remove_partial_target_images
+  echo "::error::image pull failed — keeping current containers, not deploying"
+  exit 1
+fi
+if ! docker pull "$SANDBOX_IMAGE"; then
+  remove_partial_target_images
+  echo "::error::sandbox image pull failed — keeping current containers, not deploying"
+  exit 1
+fi
+
+docker compose down
+docker compose up -d --no-build
+timeout 120 bash -c 'until docker compose ps app --format json | grep -q "(healthy)"; do sleep 5; done'
+docker compose ps
+
+# Once the new generation is healthy, the old sandbox and legacy host-built
+# images are safe to remove too.
+reclaim_images

--- a/scripts/deploy-core-images.test.sh
+++ b/scripts/deploy-core-images.test.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DEPLOY_SCRIPT="$REPO_DIR/scripts/deploy-core-images.sh"
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ayunis-deploy-core-images.XXXXXX")"
+FAKE_BIN="$TEST_DIR/bin"
+DOCKER_LOG="$TEST_DIR/docker.log"
+COMPOSE_FILE_LOG="$TEST_DIR/compose-file.log"
+
+cleanup() {
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$FAKE_BIN"
+
+cat > "$FAKE_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_DOCKER_LOG"
+if [[ "$1" == 'compose' ]]; then
+  printf '%s\n' "${COMPOSE_FILE:-}" > "$FAKE_COMPOSE_FILE_LOG"
+fi
+
+if [[ "$*" == 'images --filter reference=ayunis-core-* --format {{.Repository}}:{{.Tag}}' ]]; then
+  printf '%s\n' 'ayunis-core-app:latest'
+elif [[ "$*" == 'images --filter reference=ghcr.io/ayunis-core/ayunis-core-* --format {{.Repository}}:{{.Tag}}' ]]; then
+  printf '%s\n' \
+    'ghcr.io/ayunis-core/ayunis-core-app:v-old' \
+    'ghcr.io/ayunis-core/ayunis-core-app:v1.2.30' \
+    'ghcr.io/ayunis-core/ayunis-core-python-sandbox:v-old' \
+    "ghcr.io/ayunis-core/ayunis-core-app:${CORE_TAG}" \
+    "ghcr.io/ayunis-core/ayunis-core-python-sandbox:${CORE_TAG}"
+elif [[ "$*" == 'compose pull app code-execution anonymize' ]]; then
+  exit "${FAKE_COMPOSE_PULL_EXIT:-0}"
+elif [[ "$1" == 'pull' ]]; then
+  exit "${FAKE_SANDBOX_PULL_EXIT:-0}"
+fi
+EOF
+
+cat > "$FAKE_BIN/df" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' \
+  'Avail' \
+  "${FAKE_FREE_GB:-20}G"
+EOF
+
+cat > "$FAKE_BIN/timeout" <<'EOF'
+#!/usr/bin/env bash
+printf 'timeout %s\n' "$*" >> "$FAKE_DOCKER_LOG"
+EOF
+
+chmod +x "$FAKE_BIN/docker" "$FAKE_BIN/df" "$FAKE_BIN/timeout"
+
+failures=0
+
+fail() {
+  printf '%s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+
+assert_log_order() {
+  local before="$1"
+  local after="$2"
+  local before_line
+  local after_line
+  before_line=$(grep -nF "$before" "$DOCKER_LOG" | head -1 | cut -d: -f1)
+  after_line=$(grep -nF "$after" "$DOCKER_LOG" | head -1 | cut -d: -f1)
+  if [[ -z "$before_line" || -z "$after_line" || "$before_line" -ge "$after_line" ]]; then
+    fail "Expected '$before' before '$after'."
+  fi
+}
+
+run_deploy() {
+  PATH="$FAKE_BIN:$PATH" \
+    CORE_TAG=v1.2.3 \
+    MIN_FREE_GB=9 \
+    PRUNE_BUILD_CACHE="${PRUNE_BUILD_CACHE:-true}" \
+    FAKE_DOCKER_LOG="$DOCKER_LOG" \
+    FAKE_COMPOSE_FILE_LOG="$COMPOSE_FILE_LOG" \
+    FAKE_FREE_GB="${FAKE_FREE_GB:-20}" \
+    FAKE_COMPOSE_PULL_EXIT="${FAKE_COMPOSE_PULL_EXIT:-0}" \
+    FAKE_SANDBOX_PULL_EXIT="${FAKE_SANDBOX_PULL_EXIT:-0}" \
+    bash "$DEPLOY_SCRIPT"
+}
+
+: > "$DOCKER_LOG"
+COMPOSE_FILE=unexpected-compose.yml run_deploy
+
+assert_log_order 'builder prune -af' 'compose pull app code-execution anonymize'
+assert_log_order 'compose pull app code-execution anonymize' 'compose down'
+assert_log_order 'compose down' 'compose up -d --no-build'
+assert_log_order 'compose up -d --no-build' 'timeout 120 bash -c'
+if [[ "$(cat "$COMPOSE_FILE_LOG")" != 'docker-compose.yml:compose.release.yml' ]]; then
+  fail "Expected the deploy script to force the release compose files."
+fi
+
+old_sandbox_removals=$(grep -F 'rmi ' "$DOCKER_LOG" | grep -Fc 'ghcr.io/ayunis-core/ayunis-core-python-sandbox:v-old' || true)
+if [[ "$old_sandbox_removals" -ne 1 ]]; then
+  fail "Expected the old sandbox to be preserved before pull and removed once after the swap."
+fi
+if grep -F 'rmi ' "$DOCKER_LOG" | tr ' ' '\n' | grep -Fxq 'ghcr.io/ayunis-core/ayunis-core-app:v1.2.3'; then
+  fail "Expected the deployed tag to be preserved during cleanup."
+fi
+if ! grep -F 'rmi ' "$DOCKER_LOG" | tr ' ' '\n' | grep -Fxq 'ghcr.io/ayunis-core/ayunis-core-app:v1.2.30'; then
+  fail "Expected a stale tag that extends the current tag to be removed."
+fi
+
+: > "$DOCKER_LOG"
+PRUNE_BUILD_CACHE=false run_deploy
+if grep -Fq 'builder prune -af' "$DOCKER_LOG"; then
+  fail "Expected staging to preserve the host build cache."
+fi
+
+: > "$DOCKER_LOG"
+set +e
+output=$(FAKE_FREE_GB=5 run_deploy 2>&1)
+status=$?
+set -e
+if [[ $status -eq 0 || "$output" != *'only 5G free, need 9G'* ]]; then
+  fail "Expected low disk space to abort with a clear error."
+fi
+if grep -Eq '^compose (pull|down)' "$DOCKER_LOG"; then
+  fail "Expected low disk space to abort before pull and shutdown."
+fi
+
+: > "$DOCKER_LOG"
+set +e
+output=$(FAKE_COMPOSE_PULL_EXIT=1 run_deploy 2>&1)
+status=$?
+set -e
+if [[ $status -eq 0 || "$output" != *'image pull failed'* ]]; then
+  fail "Expected a failed compose pull to abort the deploy."
+fi
+if grep -Fq 'compose down' "$DOCKER_LOG"; then
+  fail "Expected a failed compose pull to preserve the running containers."
+fi
+if ! grep -F 'rmi ' "$DOCKER_LOG" | tr ' ' '\n' | grep -Fxq 'ghcr.io/ayunis-core/ayunis-core-app:v1.2.3'; then
+  fail "Expected a failed pull to remove unused target-tagged compose images."
+fi
+
+: > "$DOCKER_LOG"
+set +e
+output=$(FAKE_SANDBOX_PULL_EXIT=1 run_deploy 2>&1)
+status=$?
+set -e
+if [[ $status -eq 0 || "$output" != *'sandbox image pull failed'* ]]; then
+  fail "Expected a failed sandbox pull to abort the deploy."
+fi
+if grep -Fq 'compose down' "$DOCKER_LOG"; then
+  fail "Expected a failed sandbox pull to preserve the running containers."
+fi
+
+workflow_expectations=(
+  'deploy-staging.yml:1'
+  'deploy-internal-manual.yml:1'
+  'deploy-production-manual.yml:1'
+  'release-please.yml:2'
+)
+
+for expectation in "${workflow_expectations[@]}"; do
+  workflow="${expectation%:*}"
+  expected_calls="${expectation##*:}"
+  workflow_path="$REPO_DIR/.github/workflows/$workflow"
+  actual_calls=$(grep -Fc 'scripts/deploy-core-images.sh' "$workflow_path" || true)
+  if [[ "$actual_calls" -ne "$expected_calls" ]]; then
+    fail "Expected $workflow to reference the shared deploy script $expected_calls time(s), got $actual_calls."
+  fi
+  if grep -Fq 'docker compose pull app code-execution anonymize' "$workflow_path"; then
+    fail "Expected $workflow to contain no inline Core image pull logic."
+  fi
+done
+
+if ! grep -Fq 'DEPLOY_WORKFLOW_SHA: ${{ github.sha }}' \
+  "$REPO_DIR/.github/workflows/deploy-internal-manual.yml" \
+  || ! grep -Fq 'DEPLOY_SCRIPT=$(git show "$DEPLOY_WORKFLOW_SHA":scripts/deploy-core-images.sh)' \
+  "$REPO_DIR/.github/workflows/deploy-internal-manual.yml" \
+  || ! grep -Fq "printf '%s\n' \"\$DEPLOY_SCRIPT\" | MIN_FREE_GB=6 PRUNE_BUILD_CACHE=true bash" \
+  "$REPO_DIR/.github/workflows/deploy-internal-manual.yml"; then
+  fail "Expected the internal manual workflow to execute the workflow commit's shared script."
+fi
+if ! grep -Fq 'git checkout -f --detach "refs/tags/$RELEASE_TAG"' \
+  "$REPO_DIR/.github/workflows/deploy-internal-manual.yml" \
+  || ! grep -Fq 'git checkout -f --detach "origin/$RELEASE_TAG"' \
+  "$REPO_DIR/.github/workflows/deploy-internal-manual.yml"; then
+  fail "Expected the internal manual workflow to use explicit tag and remote branch refs."
+fi
+if ! grep -Fq 'DEPLOY_WORKFLOW_SHA: ${{ github.sha }}' \
+  "$REPO_DIR/.github/workflows/deploy-production-manual.yml" \
+  || ! grep -Fq 'DEPLOY_SCRIPT=$(git show "$DEPLOY_WORKFLOW_SHA":scripts/deploy-core-images.sh)' \
+  "$REPO_DIR/.github/workflows/deploy-production-manual.yml" \
+  || ! grep -Fq "printf '%s\n' \"\$DEPLOY_SCRIPT\" | MIN_FREE_GB=9 PRUNE_BUILD_CACHE=true bash" \
+  "$REPO_DIR/.github/workflows/deploy-production-manual.yml"; then
+  fail "Expected the production manual workflow to execute the workflow commit's shared script."
+fi
+if ! grep -Fq 'git checkout -f --detach "refs/tags/$RELEASE_TAG"' \
+  "$REPO_DIR/.github/workflows/deploy-production-manual.yml" \
+  || ! grep -Fq 'git checkout -f --detach "origin/$RELEASE_TAG"' \
+  "$REPO_DIR/.github/workflows/deploy-production-manual.yml"; then
+  fail "Expected the production manual workflow to use explicit tag and remote branch refs."
+fi
+release_tag_checkouts=$(grep -Fc 'git checkout -f --detach "refs/tags/$RELEASE_TAG"' \
+  "$REPO_DIR/.github/workflows/release-please.yml" || true)
+if [[ "$release_tag_checkouts" -ne 2 ]]; then
+  fail "Expected both automated release deploys to use explicit tag refs."
+fi
+if ! grep -Fq 'bash scripts/deploy-core-images.test.sh' \
+  "$REPO_DIR/.github/workflows/deploy-script-tests.yml" 2>/dev/null; then
+  fail "Expected CI to execute the deploy regression tests."
+fi
+
+if [[ $failures -ne 0 ]]; then
+  printf '\nDocker command log:\n' >&2
+  cat "$DOCKER_LOG" >&2
+  exit 1
+fi
+
+printf 'deploy core image tests passed\n'


### PR DESCRIPTION
## Summary

- extract pull, disk-safety, swap, health-check, and cleanup behavior into `scripts/deploy-core-images.sh`
- use the shared implementation from staging, automated internal/production releases, and manual deploy workflows
- clean partial target-tagged pulls so retries cannot wedge behind their own disk usage
- pin manual deploy logic to the workflow commit and use explicit detached tag/remote refs
- add focused shell regression tests and run them in GitHub Actions

## Verification

- `bash scripts/deploy-core-images.test.sh`
- `bash -n` for the shared implementation, its tests, and every embedded SSH script
- YAML parsing for all changed workflows
- `git diff --check`
- five-lens local review with no remaining findings

## Stack

Depends on #1194.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production/staging deploy paths (image pull, swap, cleanup, and disk gates); behavior is intended to be equivalent but misconfiguration of manual script pinning or env thresholds could affect deploy outcomes.
> 
> **Overview**
> **Pull-based Core deploys** are consolidated into `scripts/deploy-core-images.sh`, replacing large inline SSH blocks in staging, release-please, and manual internal/production workflows. Each path now sets `CORE_TAG`, `MIN_FREE_GB`, and `PRUNE_BUILD_CACHE` and invokes that script (staging uses the checked-out repo copy; internal/production manual runs pipe the script from `DEPLOY_WORKFLOW_SHA` so deploy logic matches the workflow commit even when the host checks out another tag/branch).
> 
> The shared script keeps the same safety ordering—pre-pull cleanup (with sandbox preserved), disk headroom check, scoped compose + sandbox pulls before `compose down`, health wait, then full reclaim—and adds **cleanup of unused partially pulled target-tagged images** so a failed pull cannot wedge the next deploy on disk. Stale GHCR tag removal uses suffix-aware matching so tags like `v1.2.30` are not confused with `v1.2.3`. Manual deploys use **detached checkouts** on explicit `refs/tags/...` or `origin/...` refs.
> 
> A new **Deploy Script Tests** workflow runs `scripts/deploy-core-images.test.sh`, which fakes docker/df and asserts ordering, failure modes, and that workflows no longer duplicate pull logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3221bec1ea52870dc5af6c4062f7c750974759cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->