### PR TITLE
fix(chat-input): render source filenames correctly (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/widgets/chat-input/ui/SourcesList.test.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/SourcesList.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { SourcesList } from './SourcesList';
+
+const LONG_SOURCE_NAME =
+  'Benutzungs- und Gebu\u0308hrenordnung fu\u0308r o\u0308ffentliche Einrichtungen.pdf';
+
+beforeAll(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      disconnect() {}
+    },
+  );
+});
+
+describe('SourcesList', () => {
+  it('renders a source name with combining characters in one text element', () => {
+    render(
+      <SourcesList
+        sources={[
+          {
+            id: 'source-1',
+            name: LONG_SOURCE_NAME,
+            type: 'text',
+          },
+        ]}
+        onRemove={() => undefined}
+      />,
+    );
+
+    const sourceName = screen.getByText(LONG_SOURCE_NAME);
+
+    expect(sourceName.textContent).toBe(LONG_SOURCE_NAME);
+    expect(sourceName.getAttribute('data-slot')).not.toBe('badge');
+  });
+});

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/SourcesList.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/SourcesList.tsx
@@ -158,7 +158,7 @@ export function SourcesList({
             {isProcessing && <Loader2 className="h-3 w-3 animate-spin" />}
             {isFailed && <AlertCircle className="h-3 w-3" />}
             {!isProcessing && !isFailed && getSourceIcon(source)}
-            {source.name}
+            <span>{source.name}</span>
             {!isProcessing && (
               <div
                 className="cursor-pointer"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UI-only change in chat source chips with a focused regression test; no API or auth impact.
> 
> **Overview**
> Fixes broken display of attached source filenames in the chat input, especially names that use **combining Unicode characters** (e.g. German `ü` as base letter + combining diaeresis).
> 
> In `SourcesList`, the source `name` is now wrapped in a `<span>` inside the `Badge` instead of being rendered as a bare text child of the badge. That keeps the full filename in a single text element and avoids the label being tied to the badge root (`data-slot="badge"`).
> 
> Adds a Vitest test with a long German PDF filename and stubs `ResizeObserver` for the list container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39c2b33dacef6366227f36560336953d84230fbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->