### PR TITLE
docs(skills): sync agentfiles updates (AYC-000)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -46,6 +46,16 @@ Do NOT trust your own assessment of code correctness. Verify through observable 
 
 Only write a comment when it states something the code cannot: a non-obvious constraint, ordering requirement, or "why" (e.g., why an event fires *before* a delete). Never write comments that restate the name or body of the thing they annotate ("Returns the ids of every thread owned by a user" on `findAllIdsByUserId`, "// Delete the thread" above `threadsRepository.delete(...)`), narrate what the next line does, or summarize a well-named class a reader can grasp at a glance. If a comment would just paraphrase the code, improve the naming instead and write nothing.
 
+### 5. Simplest Sufficient Solution
+
+Lead with the solution a senior engineer would reach for, not the first mechanism that occurs to you. Before building bespoke machinery, ask whether this is a standard, already-solved problem — reach for the library/pattern/config that solves it directly.
+
+Watch for complexity creep. When a fix keeps growing — extra parameters, a watchdog, a budget, stall-reason plumbing — stop and name the tradeoff: *is the added complexity justified, or is a plainer approach enough?* Surface that question proactively rather than accreting machinery across iterations and waiting for the user to ask "is this worth it?". Often the right move is to challenge the constraint itself (e.g. "does a 300s ceiling even matter here?") instead of engineering around it.
+
+### 6. A Submitted PR Is Not Complete
+
+When work creates or updates a PR, submitting it is an intermediate step. Immediately load `finish-pr` and keep ownership until CI and Cursor Bugbot are clean on the latest submitted revision. Fix actionable findings, amend and resubmit, then repeat the verification loop. Never report PR work as complete while checks are pending or failing, Bugbot has not finished, or actionable findings remain. If verification is prevented by an external condition or the same finding survives three fix attempts, report the work as blocked with evidence instead of calling it done.
+
 ---
 
 ## Forbidden Actions
@@ -95,3 +105,15 @@ The following rules are enforced by ESLint, pre-commit hooks, and CI. Violations
 ## Development Skills
 
 For detailed development workflows, patterns, and validation checklists, load the appropriate skill. Skills are listed with descriptions in the system prompt — pick the one that matches the task.
+
+---
+
+## Communication
+
+Investigation reports, PR summaries, and status write-ups are decision tools, not essays. Default to terse and findings-first:
+
+- Lead with the answer or recommendation; the "why" goes underneath, not before.
+- One tight line per item. For a batch (several PRs, tickets, or findings), give each a one-line verdict — e.g. *fix now / follow-up ticket / close* — rather than a multi-section prose block per item.
+- Skip preamble, restated context, and multi-header scaffolding unless the depth was asked for.
+
+Expand only on request. When the user wants more, they'll say so — then go deep.

--- a/.claude/skills/appsignal-logs/SKILL.md
+++ b/.claude/skills/appsignal-logs/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: appsignal-logs
+description: Query Ayunis backend logs in AppSignal to inspect structured attributes (user.id, org.id, nestjs.context, custom metadata). Use when investigating production/staging log data or diagnosing an AppSignal incident — NOT for local dev logs (see backend-debugging).
+---
+
+# AppSignal Logs
+
+Ayunis ships backend logs to AppSignal. When you need to inspect what a log line
+actually carried in production/staging — structured attributes like `user.id`,
+`org.id`, `nestjs.context`, or custom metadata — query AppSignal's **v2 logs API
+directly**. Do not rely on `appsignal-cli`.
+
+## The `appsignal-cli` trap — it hides structured attributes
+
+`appsignal-cli` renders only AppSignal's **legacy `attributes` field**, which
+AppSignal is phasing out. Modern structured attributes are emitted under a separate
+**`json` field** that the CLI does not display — so the CLI shows `attributes: null`
+(or an empty object) even when the line is rich with structured data.
+
+**Consequence:** trusting the CLI produces a false-negative "the logs have no
+metadata / dotted keys are being dropped" diagnosis. That exact wrong conclusion has
+been reached twice from the CLI before the v2 API revealed the attributes were there
+all along. If a logging investigation hinges on "are attributes present?", query the
+API — never answer from the CLI.
+
+## Query the v2 logs API instead
+
+Structured attributes live in the `.json` field of each returned line:
+
+```bash
+# APPSIGNAL_API_TOKEN — a personal/organization API token from Bitwarden
+# (search AppSignal). Pass it in via env; never inline the secret.
+curl -s -X POST "https://appsignal.com/api/v2/logs/lines?token=${APPSIGNAL_API_TOKEN}" \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "site_id":  "<app/site id>",
+        "source_id":"<log source id>",
+        "query":    "",
+        "limit":    100
+      }' \
+| jq '.[] | {timestamp, message, json}'   # <-- .json holds the real attributes
+```
+
+- The **`.json`** field is where `user.id`, `org.id`, `nestjs.context` and custom
+  metadata appear. `.attributes` is the legacy field the CLI reads — expect it empty.
+- Get `site_id` (the AppSignal app) and `source_id` (the log source) from the AppSignal
+  UI URL for the logs view, or from `GET /api/v2/apps` with the same token.
+- Adjust `query`/time window to scope the search; `limit` defaults low, so set it.
+
+## Secrets
+
+The API token is a Bitwarden item (AppSignal). Per skill conventions, this SKILL.md
+names the secret; the agent fetches it (`get-secret`) and exports it as
+`APPSIGNAL_API_TOKEN` before running the curl. Scripts must never call Bitwarden
+internally.
+
+## Scope
+
+This skill is for **AppSignal** (deployed environments). For local dev-stack runtime
+errors, use the `backend-debugging` skill (`./dev logs backend`) — that is a different
+log source and a different workflow.

--- a/.claude/skills/ayunis-core-backend/SKILL.md
+++ b/.claude/skills/ayunis-core-backend/SKILL.md
@@ -75,7 +75,8 @@ if (providerError) throw providerError; // ProviderUnavailableError family
 ```
 
 - `wrapProviderFailure` returns `ProviderConnectionError` (502) / `ProviderTimeoutError` (504) / `ProviderServerError` (502) for transport failures (errno, undici, TLS codes, SDK wrapper names — cause chains are walked) and upstream 5xx; `undefined` for everything else.
-- **Grouping contract**: each error sets `name === code === PROVIDER_UNAVAILABLE_<CLASS>_<PROVIDER>` so AppSignal opens one incident per provider+failure-class on both reporting paths (HTTP `setError()` groups by `name`; BullMQ OTel `recordException` prefers `code`). Never add these errors to `ignoreErrors` in `appsignal.cjs` — per-occurrence notifications are disabled AppSignal-side so rate-based anomaly triggers keep working.
+- **Grouping contract**: each error sets `name === code === PROVIDER_UNAVAILABLE_<CLASS>_<PROVIDER>` so AppSignal opens one incident per provider+failure-class. There is only one reporting path — `setError()` *is* `span.recordException()`, and AppSignal's SpanProcessor forwards every `exception` span event from every span — and OpenTelemetry derives the grouping key `exception.type` as **`code ?? name`** (truthy `code` wins). Setting both to the same string is what makes the key stable no matter which span records it. Never add these errors to `ignoreErrors` in `appsignal.cjs` — per-occurrence notifications are disabled AppSignal-side so rate-based anomaly triggers keep working.
+- **Suppressions are a registry, not a config literal**: every `ignoreErrors` / `ignoreRequestHook` / disabled-instrumentation entry lives in `SUPPRESSIONS` in `appsignal-hooks.cjs` (AYC-563) and must carry a `reason` and an owning `ticket`. The spec asserts each `ignoreErrors` entry against a real instance of its error, because an entry naming a class whose instances carry a `.code` suppresses nothing at all — silently. `appsignal.cjs` only consumes the registry; it decides nothing.
 - Reference choke points: `stream-inference.use-case.ts`, `get-inference.use-case.ts` (models), `embed-text.use-case.ts` (embeddings), `mistral-file-retriever.handler.ts` (OCR, incl. `ProviderRequestRejectedError` for machine-generated 4xx — but not 401/403 auth-config bugs).
 - **Not a provider**: fetching customer-pasted URLs. Keep `UrlRetrieverRetrievalError` (422) and enrich its metadata with `classifyTransportError()` output instead.
 - This hand-written translate-catch at outbound choke points is the sanctioned exception to `use-case-reference`'s "no hand-written try/catch error boundaries" rule.
@@ -90,6 +91,20 @@ if (providerError) throw providerError; // ProviderUnavailableError family
 | OpenAPI spec                | `http://localhost:PORT/api/docs` (when running) |
 
 > [!IMPORTANT] Always update `ARCHITECTURE.md` and the module's `SUMMARY.md` file if necessary!
+
+## Running Tests
+
+Run backend tests with **`pnpm test`** from `ayunis-core-backend/` — never bare `jest` or `npx jest`.
+
+```bash
+cd ayunis-core-backend
+pnpm test                      # full suite
+pnpm test <path-or-pattern>    # a subset
+```
+
+`pnpm test` runs Jest through the project's configured runner (Node ESM flags, module-name mapping). Invoking `jest` / `npx jest` directly bypasses that setup, and the ESM-only `p-queue` dependency then fails to resolve — the `embeddings-throttle` and `ingest-bulk-content` RAG suites blow up with module-resolution errors.
+
+**Those failures are an artifact of the wrong invocation, not a real regression.** Do not report them as "pre-existing failures on main" or hang caveats on a PR summary because of them — re-run with `pnpm test` and they pass. A suite that fails under `pnpm test` is a genuine signal worth investigating.
 
 ## Health Check
 

--- a/.claude/skills/bugbot-triage/SKILL.md
+++ b/.claude/skills/bugbot-triage/SKILL.md
@@ -13,9 +13,13 @@ Bugbot posts as `cursor[bot]`. Findings live in **inline review comments**; the 
 
 ```bash
 gh pr view --json number --jq .number   # if no PR number given
-gh api repos/{owner}/{repo}/pulls/<number>/comments \
+gh api --paginate repos/{owner}/{repo}/pulls/<number>/comments \
   --jq '.[] | select(.user.login == "cursor[bot]") | {path, line, body}'
 ```
+
+**Always pass `--paginate`.** The comments endpoint returns 30 per page; without it, bugbot findings past the first page are silently dropped and you will report a PR clean while findings are still open. If you must build the URL yourself, add `?per_page=100` as a backstop, but `--paginate` is the reliable fix.
+
+**On a stacked PR, triage every PR in the stack — not just the top.** Bugbot comments on each PR independently, so a stack that looks clean at the tip can still carry open findings on a lower branch. After a restack or a round of fixes, re-fetch comments for *all* PRs in the stack (`gt log`/`gh pr list` to enumerate them) and confirm each is resolved before declaring the stack review-clean.
 
 Strip the HTML boilerplate (Fix-in-Cursor buttons, `BUGBOT_BUG_ID`); the substance is the severity line, the description, and the `LOCATIONS` block.
 

--- a/.claude/skills/finish-pr/SKILL.md
+++ b/.claude/skills/finish-pr/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: finish-pr
+description: "Complete the post-submit PR loop: wait for CI and Cursor Bugbot on the latest pushed revision, triage and fix actionable findings, amend and resubmit, and repeat until clean. MUST be used after creating or updating a PR before declaring implementation work complete."
+---
+
+# Finish PR
+
+Treat PR submission as the start of verification, not the end of the task. Keep ownership of the PR until its latest submitted revision is green and Bugbot-clean.
+
+## 1. Resolve the submitted PRs
+
+Load `git-workflow` and follow its Graphite safety rules throughout this workflow.
+
+Identify every PR whose branch was created or updated by the submission. For a Graphite stack, include every submitted PR in the stack, not only the current or top PR. Record each PR number, URL, branch, and remote head SHA:
+
+```bash
+gh pr view <branch-or-number> --json number,url,headRefName,headRefOid
+```
+
+Use the remote `headRefOid` as the revision under verification. If the remote head changes while waiting, discard the stale result and restart verification for the new SHA.
+
+## 2. Wait for CI and Bugbot
+
+Wait for all checks on every submitted PR:
+
+```bash
+gh pr checks <pr-number> --watch --interval 30
+```
+
+If no checks are visible immediately after submission, wait 30 seconds and query again. Do not interpret absent checks as success.
+
+After the watch completes, inspect the final state explicitly:
+
+```bash
+gh pr checks <pr-number> --json name,bucket,state,link
+```
+
+Treat `pending`, `fail`, and `cancel` buckets as unfinished. A skipped check is acceptable only when the workflow intentionally skipped it; mention that in the final report.
+
+Do not trust Cursor Bugbot's check conclusion by itself. A successful Bugbot check can still leave review comments.
+
+## 3. Address CI failures
+
+For each failing or cancelled check:
+
+1. Read the check details, annotations, and failed GitHub Actions logs. Use `gh run view <run-id> --log-failed` for Actions failures.
+2. Classify the failure before changing code:
+   - **PR-caused and actionable**: fix it in the existing PR.
+   - **Flaky or cancelled**: rerun it once, then wait for the rerun.
+   - **Infrastructure failure or demonstrably failing on the base revision**: gather evidence and report the PR as blocked; do not broaden the PR silently.
+3. Run the relevant local validation for any code change.
+4. Amend and resubmit with the process in `git-workflow`.
+
+After any resubmission, refresh every affected PR's remote head SHA and restart the full CI and Bugbot loop. Results from the previous SHA no longer count.
+
+## 4. Address Bugbot findings
+
+Load `bugbot-triage` and use its paginated comment fetching, full-stack scan, root-cause tracing, and verdicts. Do not recreate a shallower Bugbot review here.
+
+The implementation request that produced the PR authorizes fixes for actionable CI and Bugbot findings that stay within the PR's scope:
+
+- **Valid and simple**: implement the direct root-cause fix.
+- **Valid but symptom**: implement the structural fix recommended by the triage, unless that would materially expand the requested scope; if it would, stop and explain the decision needed.
+- **Invalid**: record the evidence, reply when useful, and resolve the thread if permitted.
+
+For valid findings, amend the existing PR rather than creating a separate fix PR. Resolve addressed threads when permitted. Resubmit and restart verification on the new head SHA.
+
+## 5. Completion gate
+
+Do not declare the task complete until all of these are true for every submitted PR:
+
+- The recorded remote head SHA is still the PR's current head.
+- Every CI check has completed successfully, or was intentionally skipped with a documented reason.
+- Cursor Bugbot completed on the current head.
+- All Bugbot comments across the submitted stack were triaged and no actionable finding remains.
+- The local worktree is clean and the submitted branches contain every fix.
+
+A polling timeout is not success. Continue waiting and provide occasional progress updates. Report **blocked**, never **done**, when authentication, infrastructure, or another external condition prevents verification.
+
+If the same CI failure or Bugbot finding survives three fix attempts, stop and escalate with the attempts and evidence. New findings on successive revisions are progress and restart the count for those findings.
+
+## Report
+
+Report the PR URLs and concise evidence for CI and Bugbot status. Mention fixes made during the loop. If blocked, name the exact unfinished check or finding and the evidence that prevents further progress.

--- a/.claude/skills/finish-pr/agents/openai.yaml
+++ b/.claude/skills/finish-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Finish PR"
+  short_description: "Close the CI and BugBot feedback loop"
+  default_prompt: "Use $finish-pr to wait for CI and BugBot, address findings, and leave the PR green."

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -92,6 +92,21 @@ gt restack                                             # rebase the stack onto f
 
 This is distinct from the pre-submit fetch check below — that guards against overwriting remote commits when pushing. This one keeps your *base* current so the work you're about to write applies cleanly.
 
+### Choosing the base — stack on a dependency, don't default to main
+
+Before opening a follow-up PR, decide the base *deliberately*. The default is **not** always main. Ask one question: **does this change only make sense once an in-flight, unmerged PR lands?**
+
+- **Yes — it depends on unmerged work** → stack it *on top of that branch*, not main. Typical cases: a cleanup that removes code the open PR replaces, or a follow-up that builds on an API/behaviour the open PR introduces. `gt checkout <parent-branch>` first, then edit so `gt create` stacks the new branch on the dependency.
+- **No — it stands alone against current `main`** → fresh stack off main (the flow below).
+
+Branching a dependent change off main is the common mistake: it can merge *before* its prerequisite and break the build, or land as an out-of-order changelog entry. When you're unsure whether the dependency is real, ask — don't assume main.
+
+If you already branched off main and only then realise the work depends on an unlanded PR, re-parent it — don't rebuild:
+
+```bash
+gt move --onto <parent-branch>   # re-parent the current branch onto its real dependency
+```
+
 ### Starting a new PR — verify the base branch BEFORE editing
 
 Before making **any edit** whose goal is a *new PR* / *new branch off main* / *port to a new PR*, verify that you are actually starting from the intended base. In a Graphite repo the working checkout is almost always mid-stack on some feature branch — being clean is not the same as being on main.

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -39,6 +39,31 @@ ln -sf "$REPO_ROOT/ayunis-core-frontend/.env" "$WORKTREE_DIR/ayunis-core-fronten
 # Never `npm install` inside a sub-project — that creates a stray package-lock.json
 # and resolves the wrong tree.
 cd "$WORKTREE_DIR" && pnpm install
+
+# Build the workspace packages so @ayunis/* types resolve (see below).
+cd "$WORKTREE_DIR" && pnpm run build:deps
+```
+
+## Build @ayunis/* deps before trusting a full typecheck
+
+A fresh worktree has `node_modules` (after `pnpm install`) but **not** the built
+`dist/index.d.ts` for the `@ayunis/*` workspace packages — those only exist after
+the `tsup` build. Until you run `pnpm run build:deps`, a full `pnpm exec tsc --noEmit`
+emits ~60 `TS2307 "Cannot find module '@ayunis/…'"` errors **on your branch AND on
+clean HEAD**.
+
+**Never wave those TS2307 errors off as "pre-existing on clean HEAD."** They are a
+missing-build artifact, not a real baseline — and treating them that way hides genuine
+type errors in your own new code behind the noise. In one session this masked a real
+bug (a raw `'mistral'` string passed where an `EmbeddingsProvider` enum was required).
+
+The pre-commit hook (`tsc-files`, staged-only) and `ts-jest` (transpile-only) both have
+blind spots that only a full post-build typecheck covers. So, in any worktree, before
+running or trusting `tsc --noEmit`:
+
+```bash
+cd "$WORKTREE_DIR" && pnpm run build:deps   # builds @ayunis/* dist/*.d.ts
+pnpm exec tsc --noEmit                       # now TS2307 noise is gone; real errors surface
 ```
 
 ## Empty Base Branch Gotcha


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and agent workflow guidance only; no runtime, auth, or deployment behavior changes.
> 
> **Overview**
> Updates **agent-facing docs only** (`.claude/CLAUDE.md` and skills) — no application code.
> 
> **`CLAUDE.md`** adds principles **5–6** (prefer simplest sufficient solutions; PRs aren’t done until CI + Bugbot are clean via `finish-pr`) and a **Communication** section (terse, findings-first write-ups).
> 
> **New skills:** `appsignal-logs` (v2 logs API vs `appsignal-cli` trap) and **`finish-pr`** (post-submit CI/Bugbot loop with completion gate), plus `finish-pr/agents/openai.yaml`.
> 
> **Skill tweaks:** `ayunis-core-backend` — AppSignal grouping/suppressions registry, **`pnpm test`** requirement; `bugbot-triage` — `--paginate`, full-stack triage; `git-workflow` — stack on dependency + `gt move --onto`; `worktree` — `build:deps` before trusting `tsc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e1a9e20ff74b1a202566e2ea7c883d35424d653. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->