### PR TITLE
fix(mcp): classify SDK timeouts and aborts as MCP_CONNECTION_TIMEOUT (AYC-651)

### DIFF
--- a/ayunis-core-backend/appsignal-hooks.cjs
+++ b/ayunis-core-backend/appsignal-hooks.cjs
@@ -145,6 +145,21 @@ const SUPPRESSIONS = [
     match: isMcpEventStreamRequest,
   },
   {
+    id: 'abort-signal-cancellation',
+    lever: 'ignoreErrors',
+    ticket: 'AYC-651',
+    reason:
+      'The DOMException Node mints for AbortController.abort() (name ' +
+      'AbortError, numeric code 20, so exceptionType "20"). An abort is ' +
+      'always a cancellation we or an SDK issued deliberately — MCP ' +
+      'transport close after a completed operation, SDK request timeouts, ' +
+      'stream watchdogs, client disconnects — never itself the failure. ' +
+      'Real timeouts surface as classified application errors ' +
+      '(MCP_CONNECTION_TIMEOUT, INFERENCE_TIMEOUT, PROVIDER_UNAVAILABLE_*), ' +
+      'which stay fully reported.',
+    exceptionType: '20',
+  },
+  {
     id: 'bullmq-retry-scheduled',
     lever: 'ignoreErrors',
     ticket: 'AYC-479',

--- a/ayunis-core-backend/src/common/util/appsignal-hooks.spec.ts
+++ b/ayunis-core-backend/src/common/util/appsignal-hooks.spec.ts
@@ -209,6 +209,10 @@ describe('exceptionTypeOf', () => {
 // A real instance of each error an `ignoreErrors` entry claims to suppress.
 // Keyed by suppression id so an entry cannot be added without one.
 const ERROR_SAMPLES: Record<string, () => Error> = {
+  // The exact object Node mints for AbortController.abort(): name
+  // 'AbortError', numeric code 20 — exceptionType stringifies to '20'.
+  'abort-signal-cancellation': () =>
+    new DOMException('This operation was aborted', 'AbortError'),
   'bullmq-retry-scheduled': () =>
     new JobRetryScheduledError(new Error('upstream failed')),
   'oversized-request-body': () =>

--- a/ayunis-core-backend/src/domain/mcp/application/mcp.errors.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/mcp.errors.ts
@@ -134,26 +134,37 @@ export class McpIntegrationDisabledError extends McpError {
   }
 }
 
+function redactCredentials(serverUrl: string): string {
+  try {
+    const url = new URL(serverUrl);
+    if (url.username || url.password) {
+      url.username = '***';
+      url.password = '';
+    }
+    return url.toString();
+  } catch {
+    return serverUrl;
+  }
+}
+
+/**
+ * The message is user-visible: validation endpoints copy it verbatim into
+ * `valid: false` responses, so it must explain the timeout without leaking
+ * SDK internals. The original SDK error travels on the non-serialized
+ * `cause` only.
+ */
 export class McpConnectionTimeoutError extends McpError {
-  constructor(
-    integrationId: string,
-    integrationName: string,
-    serverUrl: string,
-    metadata?: ErrorMetadata,
-  ) {
-    // Redact credentials from URL for logging.
-    // Single bounded quantifier with no nesting/alternation — linear, not
-    // backtracking-prone; the slow-regex heuristic is a false positive here.
-    // eslint-disable-next-line sonarjs/slow-regex
-    const redactedUrl = serverUrl.replace(/\/\/[^@]+@/, '//***@');
+  constructor(serverUrl: string, timeoutMs: number, cause?: unknown) {
     super(
-      `Connection to MCP integration '${integrationName}' (ID: ${integrationId}) timed out. ` +
-        `Please verify the server at ${redactedUrl} is running and accessible. ` +
-        `Check network connectivity and server status.`,
+      `The MCP server at ${redactCredentials(serverUrl)} did not respond ` +
+        `within ${Math.round(timeoutMs / 1000)}s. Please verify the server ` +
+        `is running and accessible.`,
       McpErrorCode.MCP_CONNECTION_TIMEOUT,
       504,
-      metadata,
     );
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
   }
 }
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.spec.ts
@@ -12,6 +12,7 @@ import {
   McpIntegrationNotFoundError,
   McpIntegrationAccessDeniedError,
   McpIntegrationDisabledError,
+  McpConnectionTimeoutError,
   UnexpectedMcpError,
 } from '../../mcp.errors';
 import { PredefinedMcpIntegration } from 'src/domain/mcp/domain/integrations/predefined-mcp-integration.entity';
@@ -316,6 +317,24 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
       ).rejects.toThrow(UnexpectedMcpError);
 
       expect(mcpClientService.listTools).toHaveBeenCalledTimes(1);
+    });
+
+    // A classified timeout must not be re-wrapped as UNEXPECTED_MCP_ERROR —
+    // the send-message assembler skips the integration on any rejection, and
+    // the classified code is what keeps AppSignal grouping stable (AYC-651).
+    it('propagates a classified connection timeout unchanged', async () => {
+      const integration = buildPredefinedIntegration();
+      arrangeSuccessfulClientCalls();
+
+      contextService.get.mockImplementation(mockContextGet);
+      repository.findById.mockResolvedValue(integration);
+      mcpClientService.listTools.mockRejectedValue(
+        new McpConnectionTimeoutError('https://mcp.example.com/mcp', 30000),
+      );
+
+      await expect(
+        useCase.execute(new DiscoverMcpCapabilitiesQuery(mockIntegrationId)),
+      ).rejects.toThrow(McpConnectionTimeoutError);
     });
 
     it('discovers with the integration state read at load time, not the access-check snapshot', async () => {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/validate-mcp-integration/validate-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/validate-mcp-integration/validate-mcp-integration.use-case.spec.ts
@@ -4,6 +4,7 @@ import { ValidateMcpIntegrationCommand } from './validate-mcp-integration.comman
 import type { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import type { McpClientService } from '../../services/mcp-client.service';
 import type { ContextService } from 'src/common/context/services/context.service';
+import { McpConnectionTimeoutError } from '../../mcp.errors';
 import { MarketplaceMcpIntegration } from 'src/domain/mcp/domain/integrations/marketplace-mcp-integration.entity';
 import { NoAuthMcpIntegrationAuth } from 'src/domain/mcp/domain/auth/no-auth-mcp-integration-auth.entity';
 
@@ -94,5 +95,20 @@ describe('ValidateMcpIntegrationUseCase', () => {
       integration,
     );
     expect(mcpClientService.listPrompts).toHaveBeenCalledWith(integration);
+  });
+
+  // A hanging MCP server is a validation outcome, not a server defect of
+  // ours: the endpoint must answer `isValid: false` with the classified
+  // timeout message instead of raising a 500 (AYC-651).
+  it('reports a server timeout as a validation failure with a user-presentable message', async () => {
+    const command = new ValidateMcpIntegrationCommand(integrationId);
+    mcpClientService.listTools.mockRejectedValue(
+      new McpConnectionTimeoutError('https://mcp.ayunis.de/locaboo', 30000),
+    );
+
+    const result = await useCase.execute(command);
+
+    expect(result.isValid).toBe(false);
+    expect(result.errorMessage).toMatch(/did not respond within 30s/);
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '@modelcontextprotocol/client';
 import { McpSdkClientAdapter } from './mcp-sdk-client.adapter';
 import type { McpConnectionConfig } from '../../application/ports/mcp-client.port';
+import { McpConnectionTimeoutError } from '../../application/mcp.errors';
 import { MarketplaceMcpIntegration } from '../../domain/integrations/marketplace-mcp-integration.entity';
 import { NoAuthMcpIntegrationAuth } from '../../domain/auth/no-auth-mcp-integration-auth.entity';
 import { randomUUID } from 'crypto';
@@ -254,6 +255,94 @@ describe('McpSdkClientAdapter', () => {
         { name: 'summarize', arguments: { topic: 'roads' } },
         REQUEST_TIMEOUT,
       );
+    });
+  });
+
+  describe('timeout and abort classification', () => {
+    // The DOMException Node mints for AbortController.abort() — name
+    // 'AbortError', numeric code 20 — the exact shape of AppSignal
+    // incident "20: This operation was aborted".
+    const buildDomAbortError = () =>
+      new DOMException('This operation was aborted', 'AbortError');
+
+    const buildSdkTimeoutError = () =>
+      Object.assign(new Error('Request timed out'), {
+        name: 'SdkError',
+        code: 'REQUEST_TIMEOUT',
+      });
+
+    it('maps a raw AbortError from an operation to McpConnectionTimeoutError', async () => {
+      clientMock.listTools.mockRejectedValue(buildDomAbortError());
+
+      await expect(adapter.listTools(config)).rejects.toThrow(
+        McpConnectionTimeoutError,
+      );
+    });
+
+    it('maps an SDK request timeout during connect to McpConnectionTimeoutError', async () => {
+      clientMock.connect.mockRejectedValue(buildSdkTimeoutError());
+
+      await expect(adapter.listTools(config)).rejects.toThrow(
+        McpConnectionTimeoutError,
+      );
+    });
+
+    it('maps an SDK request timeout from an operation to McpConnectionTimeoutError', async () => {
+      clientMock.listPrompts.mockRejectedValue(buildSdkTimeoutError());
+
+      await expect(adapter.listPrompts(config)).rejects.toThrow(
+        McpConnectionTimeoutError,
+      );
+    });
+
+    it('maps a version-negotiation failure whose cause is an abort', async () => {
+      const negotiationError = Object.assign(
+        new Error('Version negotiation probe failed'),
+        {
+          name: 'SdkError',
+          code: 'ERA_NEGOTIATION_FAILED',
+          data: { cause: buildDomAbortError() },
+        },
+      );
+      clientMock.connect.mockRejectedValue(negotiationError);
+
+      await expect(adapter.listTools(config)).rejects.toThrow(
+        McpConnectionTimeoutError,
+      );
+    });
+
+    it('produces a user-presentable message naming the 30s budget', async () => {
+      clientMock.listTools.mockRejectedValue(buildDomAbortError());
+
+      await expect(adapter.listTools(config)).rejects.toThrow(
+        /did not respond within 30s/,
+      );
+    });
+
+    it('keeps the original error on the non-serialized cause', async () => {
+      const abortError = buildDomAbortError();
+      clientMock.listTools.mockRejectedValue(abortError);
+
+      const mapped = await adapter.listTools(config).catch((e: unknown) => e);
+
+      expect((mapped as Error).cause).toBe(abortError);
+    });
+
+    it('maps timeouts on callTool as well', async () => {
+      clientMock.callTool.mockRejectedValue(buildDomAbortError());
+
+      await expect(
+        adapter.callTool(config, { toolName: 'search', parameters: {} }),
+      ).rejects.toThrow(McpConnectionTimeoutError);
+    });
+
+    it('passes non-timeout errors through unchanged', async () => {
+      const authError = Object.assign(new Error('Unauthorized'), {
+        code: 401,
+      });
+      clientMock.listTools.mockRejectedValue(authError);
+
+      await expect(adapter.listTools(config)).rejects.toBe(authError);
     });
   });
 

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.ts
@@ -17,6 +17,47 @@ import { McpIntegrationsRepositoryPort } from '../../application/ports/mcp-integ
 import { SchemaConfiguredMcpIntegration } from '../../domain/integrations/schema-configured-mcp-integration.entity';
 import type { UUID } from 'crypto';
 import { McpOAuthFetchPort } from '../../application/ports/mcp-oauth-fetch.port';
+import { McpConnectionTimeoutError } from '../../application/mcp.errors';
+
+/**
+ * Node's AbortController.abort() mints a DOMException with name 'AbortError'
+ * and numeric code 20 (DOMException.ABORT_ERR); the MCP SDK signals its own
+ * request timeouts as SdkError with string code 'REQUEST_TIMEOUT', and wraps
+ * version-negotiation probe failures with the original abort on `data.cause`.
+ * The protocol-level timeout answer is JSON-RPC error -32001.
+ */
+const SDK_TIMEOUT_CODES: ReadonlySet<unknown> = new Set([
+  20,
+  'REQUEST_TIMEOUT',
+  -32001,
+]);
+const MAX_CAUSE_DEPTH = 4;
+
+function isTimeoutOrAbortError(error: unknown, depth = 0): boolean {
+  if (depth >= MAX_CAUSE_DEPTH || typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const candidate = error as {
+    name?: unknown;
+    code?: unknown;
+    cause?: unknown;
+    data?: unknown;
+  };
+  if (
+    candidate.name === 'AbortError' ||
+    SDK_TIMEOUT_CODES.has(candidate.code)
+  ) {
+    return true;
+  }
+  const dataCause =
+    typeof candidate.data === 'object' && candidate.data !== null
+      ? (candidate.data as { cause?: unknown }).cause
+      : undefined;
+  return (
+    isTimeoutOrAbortError(candidate.cause, depth + 1) ||
+    isTimeoutOrAbortError(dataCause, depth + 1)
+  );
+}
 
 /**
  * Adapter that wraps @modelcontextprotocol/sdk to provide MCP client functionality.
@@ -46,30 +87,22 @@ export class McpSdkClientAdapter extends McpClientPort {
    * List all tools available on the MCP server
    */
   async listTools(config: McpConnectionConfig): Promise<McpTool[]> {
-    const client = await this.createClient(config);
-
-    try {
+    return this.withClient(config, async (client) => {
       const result = await client.listTools(undefined, this.requestOptions);
 
       return result.tools;
-    } finally {
-      await this.closeQuietly(client);
-    }
+    });
   }
 
   /**
    * List all resources available on the MCP server
    */
   async listResources(config: McpConnectionConfig): Promise<McpResource[]> {
-    const client = await this.createClient(config);
-
-    try {
+    return this.withClient(config, async (client) => {
       const result = await client.listResources(undefined, this.requestOptions);
 
       return result.resources;
-    } finally {
-      await this.closeQuietly(client);
-    }
+    });
   }
 
   /**
@@ -78,9 +111,7 @@ export class McpSdkClientAdapter extends McpClientPort {
   async listResourceTemplates(
     config: McpConnectionConfig,
   ): Promise<McpResource[]> {
-    const client = await this.createClient(config);
-
-    try {
+    return this.withClient(config, async (client) => {
       const result = await client.listResourceTemplates(
         undefined,
         this.requestOptions,
@@ -92,24 +123,18 @@ export class McpSdkClientAdapter extends McpClientPort {
         description: resourceTemplate.description,
         mimeType: resourceTemplate.mimeType,
       }));
-    } finally {
-      await this.closeQuietly(client);
-    }
+    });
   }
 
   /**
    * List all prompt templates available on the MCP server
    */
   async listPrompts(config: McpConnectionConfig): Promise<McpPrompt[]> {
-    const client = await this.createClient(config);
-
-    try {
+    return this.withClient(config, async (client) => {
       const result = await client.listPrompts(undefined, this.requestOptions);
 
       return result.prompts;
-    } finally {
-      await this.closeQuietly(client);
-    }
+    });
   }
 
   /**
@@ -119,9 +144,7 @@ export class McpSdkClientAdapter extends McpClientPort {
     config: McpConnectionConfig,
     call: McpToolCall,
   ): Promise<McpToolResult> {
-    const client = await this.createClient(config);
-
-    try {
+    return this.withClient(config, async (client) => {
       const result = await client.callTool(
         {
           name: call.toolName,
@@ -134,9 +157,7 @@ export class McpSdkClientAdapter extends McpClientPort {
         content: result.content,
         isError: Boolean(result.isError),
       };
-    } finally {
-      await this.closeQuietly(client);
-    }
+    });
   }
 
   /**
@@ -147,9 +168,7 @@ export class McpSdkClientAdapter extends McpClientPort {
     uri: string,
     parameters?: Record<string, unknown>,
   ): Promise<{ content: unknown; mimeType: string }> {
-    const client = await this.createClient(config);
-
-    try {
+    return this.withClient(config, async (client) => {
       const request = parameters ? { uri, arguments: parameters } : { uri };
 
       const result = await client.readResource(request, this.requestOptions);
@@ -163,9 +182,7 @@ export class McpSdkClientAdapter extends McpClientPort {
         content: content,
         mimeType: firstContent.mimeType || 'text/plain',
       };
-    } finally {
-      await this.closeQuietly(client);
-    }
+    });
   }
 
   /**
@@ -176,9 +193,7 @@ export class McpSdkClientAdapter extends McpClientPort {
     name: string,
     args: Record<string, string>,
   ): Promise<{ messages: unknown[] }> {
-    const client = await this.createClient(config);
-
-    try {
+    return this.withClient(config, async (client) => {
       const result = await client.getPrompt(
         {
           name,
@@ -190,9 +205,49 @@ export class McpSdkClientAdapter extends McpClientPort {
       return {
         messages: result.messages,
       };
+    });
+  }
+
+  /**
+   * Runs one operation on a fresh client and classifies its failure. SDK
+   * timeouts and transport aborts must never escape raw (AYC-651): they
+   * surface as McpConnectionTimeoutError so validation endpoints can show a
+   * clean user message and capability discovery can skip the integration.
+   * Everything else (auth, protocol, HTTP errors) passes through unchanged
+   * for the callers' own mapping.
+   */
+  private async withClient<T>(
+    config: McpConnectionConfig,
+    operation: (client: Client) => Promise<T>,
+  ): Promise<T> {
+    let client: Client;
+    try {
+      client = await this.createClient(config);
+    } catch (error) {
+      throw this.toOperationError(error, config);
+    }
+
+    try {
+      return await operation(client);
+    } catch (error) {
+      throw this.toOperationError(error, config);
     } finally {
       await this.closeQuietly(client);
     }
+  }
+
+  private toOperationError(
+    error: unknown,
+    config: McpConnectionConfig,
+  ): unknown {
+    if (isTimeoutOrAbortError(error)) {
+      return new McpConnectionTimeoutError(
+        config.serverUrl,
+        this.requestOptions.timeout,
+        error,
+      );
+    }
+    return error;
   }
 
   /**


### PR DESCRIPTION
## Problem

AppSignal incidents #278, #451, #534, #480 — raw `20: This operation was aborted` (DOMException, `DOMException.ABORT_ERR`) from `McpSdkClientAdapter` on send-message capability discovery and the MCP validation endpoints, still recurring on 2.21.x after #1201.

## Root cause

Two independent mechanisms, neither of them the operation promise:

1. **The undici OTel instrumentation records the abort itself.** `closeQuietly()` → `transport.close()` aborts the still-open JSON-RPC POST (whose SSE response stream is still being read) and the `server/discover` probe POST; undici publishes the abort DOMException on the request span and AppSignal forwards every span exception. The AYC-555 suppression only matched the GET listening stream, not POSTs.
2. **The adapter mapped no SDK errors at all** — SDK timeouts (`REQUEST_TIMEOUT`), protocol timeouts (-32001) and abort shapes escaped raw, and their raw text leaked into user-visible validation messages.

## Changes

- All adapter operations route through a shared `withClient` that maps abort/timeout shapes (incl. nested version-negotiation causes) to `McpConnectionTimeoutError` (504, user-presentable message naming the 30s budget, original error on `cause`)
- New `ignoreErrors` suppression for exceptionType `20`: an abort is always a deliberate cancellation, never itself the failure; classified errors keep reporting
- `/validate` answers `isValid: false` with the classified message; capability discovery propagates the classified error unchanged so send-message keeps skipping the integration (specs pin both)

## Verification

- New specs reproduce the DOMException (code 20) and SDK timeout shapes and assert classification; suppression registry spec enforces the new entry against a real DOMException instance
- Full backend suite: 3908 tests pass (3 pre-existing p-queue ESM suite failures, present on main)

Part of the AppSignal stack AYC-651…AYC-655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP egress error handling and broad AppSignal suppression of all exception type `20` aborts; misclassification could hide real failures, though classified timeouts remain reported.
> 
> **Overview**
> Stops noisy AppSignal **`20: This operation was aborted`** incidents and gives users clear MCP timeout feedback by **classifying** SDK aborts/timeouts instead of letting them escape raw.
> 
> **MCP SDK adapter** routes every operation through shared **`withClient`**, which maps `AbortError`, SDK `REQUEST_TIMEOUT`, JSON-RPC **-32001**, and nested negotiation causes to **`McpConnectionTimeoutError`** (504). Other failures (auth, protocol) pass through unchanged. **`McpConnectionTimeoutError`** is reshaped to take server URL + timeout budget, redact credentials via `URL`, expose a user-facing message (e.g. “did not respond within 30s”), and keep the original error on **`cause`**.
> 
> **AppSignal** adds an **`ignoreErrors`** entry for exception type **`20`** so deliberate `AbortController` cancellations from transport close/timeouts are not reported as incidents; classified **`MCP_CONNECTION_TIMEOUT`** errors still report.
> 
> **Specs** cover adapter classification, the new suppression sample (`DOMException`), validation returning **`isValid: false`** with the timeout message, and capability discovery propagating **`McpConnectionTimeoutError`** without re-wrapping as **`UNEXPECTED_MCP_ERROR`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe250cc9451013a440cc5849cd488010a7d73f74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->