### PR TITLE
fix(runs): retry stalled streams and stop swallowing stall aborts (AYC-652)

### DIFF
--- a/ayunis-core-backend/src/common/streaming/relay-abort.ts
+++ b/ayunis-core-backend/src/common/streaming/relay-abort.ts
@@ -1,0 +1,19 @@
+/**
+ * Forwards an abort (and its reason) from a source signal onto a target
+ * controller. Needed wherever a provider call runs on its own controller —
+ * e.g. so a stall watchdog can abort one attempt without consuming the
+ * caller's signal. Returns a cleanup that detaches the listener.
+ */
+export function relayAbort(
+  source: AbortSignal | undefined,
+  target: AbortController,
+): () => void {
+  if (!source) return () => undefined;
+  const abort = () => target.abort(source.reason);
+  if (source.aborted) {
+    abort();
+    return () => undefined;
+  }
+  source.addEventListener('abort', abort, { once: true });
+  return () => source.removeEventListener('abort', abort);
+}

--- a/ayunis-core-backend/src/common/streaming/stream-idle-watchdog.spec.ts
+++ b/ayunis-core-backend/src/common/streaming/stream-idle-watchdog.spec.ts
@@ -4,7 +4,7 @@ describe('StreamIdleWatchdog', () => {
   beforeEach(() => jest.useFakeTimers());
   afterEach(() => jest.useRealTimers());
 
-  it('stays disarmed until the first chunk, leaving time-to-first-byte to the SDK', () => {
+  it('stays disarmed until the caller arms it', () => {
     const onStall = jest.fn();
     const watchdog = new StreamIdleWatchdog(1000, onStall);
 
@@ -12,6 +12,30 @@ describe('StreamIdleWatchdog', () => {
 
     expect(onStall).not.toHaveBeenCalled();
     watchdog.stop();
+  });
+
+  it('arms with a one-off budget for the first chunk', () => {
+    const onStall = jest.fn();
+    const watchdog = new StreamIdleWatchdog(1000, onStall);
+
+    watchdog.arm(5000);
+    jest.advanceTimersByTime(4999);
+    expect(onStall).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(onStall).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the idle budget once a chunk arrives after the initial arm', () => {
+    const onStall = jest.fn();
+    const watchdog = new StreamIdleWatchdog(1000, onStall);
+
+    watchdog.arm(5000);
+    jest.advanceTimersByTime(4000);
+    watchdog.notifyChunk();
+    jest.advanceTimersByTime(1000);
+
+    expect(onStall).toHaveBeenCalledTimes(1);
   });
 
   it('fires once the gap after a chunk exceeds the idle budget', () => {

--- a/ayunis-core-backend/src/common/streaming/stream-idle-watchdog.ts
+++ b/ayunis-core-backend/src/common/streaming/stream-idle-watchdog.ts
@@ -2,21 +2,38 @@
 export const STREAM_IDLE_TIMEOUT_MS = 45_000;
 
 /**
- * Detects a provider stream that stops producing chunks part-way through.
- * It arms on the first chunk, leaving time-to-first-byte to provider SDKs.
+ * Budget for the first chunk. Time-to-first-byte covers provider-side
+ * queueing and prompt processing, which is legitimately slower than the
+ * gaps between chunks once streaming has started.
+ */
+export const STREAM_FIRST_CHUNK_TIMEOUT_MS = 90_000;
+
+/**
+ * Detects a provider stream that stops producing chunks. Callers arm it when
+ * the request starts (typically with the first-chunk budget) and re-arm it
+ * per chunk via notifyChunk().
  */
 export class StreamIdleWatchdog {
   private timer: NodeJS.Timeout | null = null;
 
   constructor(
     private readonly idleMs: number,
-    private readonly onStall: () => void,
+    private readonly onStall: (elapsedMs: number) => void,
   ) {}
 
-  notifyChunk(): void {
+  /**
+   * (Re)starts the stall clock, optionally with a one-off budget. The budget
+   * that actually elapsed is handed to onStall so a first-chunk stall is
+   * reported with its own (longer) wait, not the inter-chunk one.
+   */
+  arm(budgetMs: number = this.idleMs): void {
     this.stop();
-    this.timer = setTimeout(this.onStall, this.idleMs);
+    this.timer = setTimeout(() => this.onStall(budgetMs), budgetMs);
     this.timer.unref();
+  }
+
+  notifyChunk(): void {
+    this.arm();
   }
 
   stop(): void {

--- a/ayunis-core-backend/src/domain/models/application/models.errors.ts
+++ b/ayunis-core-backend/src/domain/models/application/models.errors.ts
@@ -252,7 +252,7 @@ export class InferenceStreamStalledError extends ModelError {
       `Provider stream produced no data for ${idleMs}ms`,
       ModelErrorCode.INFERENCE_TIMEOUT,
       504,
-      metadata,
+      { idleMs, ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/models/infrastructure/runtime/runtime-stream-inference.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/runtime/runtime-stream-inference.handler.spec.ts
@@ -3,7 +3,10 @@ import type { ImageContentService } from 'src/domain/messages/application/servic
 import type { StreamInferenceInput } from '../../application/ports/stream-inference.handler';
 import { InferenceStreamStalledError } from '../../application/models.errors';
 import { RuntimeStreamInferenceHandler } from './runtime-stream-inference.handler';
-import { STREAM_IDLE_TIMEOUT_MS } from 'src/common/streaming/stream-idle-watchdog';
+import {
+  STREAM_FIRST_CHUNK_TIMEOUT_MS,
+  STREAM_IDLE_TIMEOUT_MS,
+} from 'src/common/streaming/stream-idle-watchdog';
 
 /** Rejects the way a provider SDK does when its request signal aborts. */
 function whenAborted(signal: AbortSignal | undefined): Promise<never> {
@@ -117,6 +120,139 @@ describe('RuntimeStreamInferenceHandler', () => {
     unsubscribe();
 
     expect(signal()?.aborted).toBe(true);
+  });
+
+  // Stainless SDKs (openai, anthropic) swallow their own abort: the stream
+  // ends "normally" after the watchdog fires, which used to persist a
+  // silently truncated message as a success.
+  it('fails the stream when the provider swallows the stall abort', async () => {
+    const provider: ModelProvider = {
+      name: 'test:swallowing',
+      async *stream(request) {
+        yield { textDelta: 'first' };
+        await new Promise<void>((resolve) => {
+          request.signal?.addEventListener('abort', () => resolve(), {
+            once: true,
+          });
+        });
+      },
+    };
+    const { arrived, failure } = firstChunkOf(new TestHandler(provider));
+
+    await arrived;
+    await jest.advanceTimersByTimeAsync(STREAM_IDLE_TIMEOUT_MS);
+
+    await expect(failure).resolves.toBeInstanceOf(InferenceStreamStalledError);
+  });
+
+  it('retries once when the stream stalls before the first chunk', async () => {
+    let calls = 0;
+    const provider: ModelProvider = {
+      name: 'test:slow-start',
+      async *stream(request) {
+        calls += 1;
+        if (calls === 1) {
+          await whenAborted(request.signal);
+        }
+        yield { textDelta: 'recovered' };
+      },
+    };
+
+    const deltas: (string | null)[] = [];
+    const completed = new Promise<void>((resolve, reject) => {
+      new TestHandler(provider).answer(makeInput()).subscribe({
+        next: (chunk) => deltas.push(chunk.textContentDelta),
+        complete: resolve,
+        error: reject,
+      });
+    });
+    await jest.advanceTimersByTimeAsync(STREAM_FIRST_CHUNK_TIMEOUT_MS);
+
+    await completed;
+    expect(deltas).toEqual(['recovered']);
+    expect(calls).toBe(2);
+  });
+
+  it('fails with the stall error when the retry also produces no chunk', async () => {
+    let calls = 0;
+    const provider: ModelProvider = {
+      name: 'test:never-starts',
+      async *stream(request) {
+        calls += 1;
+        yield await whenAborted(request.signal);
+      },
+    };
+
+    const failed = new Promise<unknown>((resolve) => {
+      new TestHandler(provider).answer(makeInput()).subscribe({
+        next: () => undefined,
+        error: resolve,
+      });
+    });
+    await jest.advanceTimersByTimeAsync(STREAM_FIRST_CHUNK_TIMEOUT_MS);
+    await jest.advanceTimersByTimeAsync(STREAM_FIRST_CHUNK_TIMEOUT_MS);
+
+    const failure = await failed;
+    expect(failure).toBeInstanceOf(InferenceStreamStalledError);
+    // The error must state the budget that actually elapsed — the
+    // first-chunk one — not the inter-chunk default.
+    expect((failure as Error).message).toContain(
+      String(STREAM_FIRST_CHUNK_TIMEOUT_MS),
+    );
+    expect(calls).toBe(2);
+  });
+
+  it('does not retry a stall once the subscriber has unsubscribed', async () => {
+    let calls = 0;
+    const provider: ModelProvider = {
+      name: 'test:stall-then-cancel',
+      async *stream(request) {
+        calls += 1;
+        // Swallows the abort like a stainless SDK — the stream ends without
+        // emitting — but settles a macrotask later so the cancellation can
+        // win the race against the retry decision.
+        const noChunks = new Promise<[]>((resolve) => {
+          request.signal?.addEventListener(
+            'abort',
+            () => setTimeout(() => resolve([]), 10),
+            { once: true },
+          );
+        });
+        yield* await noChunks;
+      },
+    };
+
+    const subscription = new TestHandler(provider)
+      .answer(makeInput())
+      .subscribe({
+        next: () => undefined,
+        error: () => undefined,
+      });
+    await jest.advanceTimersByTimeAsync(STREAM_FIRST_CHUNK_TIMEOUT_MS);
+    subscription.unsubscribe();
+    await jest.advanceTimersByTimeAsync(10);
+    await jest.advanceTimersByTimeAsync(STREAM_FIRST_CHUNK_TIMEOUT_MS);
+
+    expect(calls).toBe(1);
+  });
+
+  it('does not retry a stall that happens after chunks were already emitted', async () => {
+    let calls = 0;
+    const provider: ModelProvider = {
+      name: 'test:mid-stream-stall',
+      async *stream(request) {
+        calls += 1;
+        yield { textDelta: 'first' };
+        await whenAborted(request.signal);
+      },
+    };
+    const { arrived, failure } = firstChunkOf(new TestHandler(provider));
+
+    await arrived;
+    await jest.advanceTimersByTimeAsync(STREAM_IDLE_TIMEOUT_MS);
+
+    await expect(failure).resolves.toBeInstanceOf(InferenceStreamStalledError);
+    expect(calls).toBe(1);
   });
 
   it('passes chunks through and completes when the provider streams normally', async () => {

--- a/ayunis-core-backend/src/domain/models/infrastructure/runtime/runtime-stream-inference.handler.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/runtime/runtime-stream-inference.handler.ts
@@ -12,11 +12,36 @@ import { toProviderRequest } from './request.mapper';
 import { toStreamChunk } from './chunk.mapper';
 import type { ChunkTransform } from './chunk-transform';
 import { applyChunkTransform } from './chunk-transform';
+import { Logger } from '@nestjs/common';
 import {
   StreamIdleWatchdog,
+  STREAM_FIRST_CHUNK_TIMEOUT_MS,
   STREAM_IDLE_TIMEOUT_MS,
 } from 'src/common/streaming/stream-idle-watchdog';
+import { relayAbort } from 'src/common/streaming/relay-abort';
 import { InferenceStreamStalledError } from '../../application/models.errors';
+
+/**
+ * One retry, and only when the stalled attempt emitted nothing: once a chunk
+ * has reached the subscriber it may already be persisted downstream, so a
+ * second attempt would duplicate content.
+ */
+const MAX_STREAM_ATTEMPTS = 2;
+
+type ProviderStreamRequest = Parameters<ModelProvider['stream']>[0];
+
+interface StreamAttemptOutcome {
+  stalled?: InferenceStreamStalledError;
+  chunksEmitted: number;
+}
+
+function stalledReason(
+  signal: AbortSignal,
+): InferenceStreamStalledError | undefined {
+  return signal.aborted && signal.reason instanceof InferenceStreamStalledError
+    ? signal.reason
+    : undefined;
+}
 
 /**
  * Streaming inference handler backed by a `@ayunis` ModelProvider. Concrete
@@ -28,6 +53,7 @@ import { InferenceStreamStalledError } from '../../application/models.errors';
  * the `@ayunis` packages; this tier only owns host-side concerns.
  */
 export abstract class RuntimeStreamInferenceHandler extends StreamInferenceHandler {
+  private readonly logger = new Logger(RuntimeStreamInferenceHandler.name);
   private readonly providerCache = new Map<string, ModelProvider>();
 
   protected constructor(
@@ -80,45 +106,106 @@ export abstract class RuntimeStreamInferenceHandler extends StreamInferenceHandl
     input: StreamInferenceInput,
   ): Observable<StreamInferenceResponseChunk> {
     return new Observable<StreamInferenceResponseChunk>((subscriber) => {
-      const controller = new AbortController();
-      void this.streamResponse(input, subscriber, controller);
+      const cancellation = new AbortController();
+      // streamResponse routes every failure into the subscriber; this catch
+      // only guards against the subscriber itself throwing, which would
+      // otherwise become an unhandled rejection reported as a raw AbortError.
+      this.streamResponse(input, subscriber, cancellation.signal).catch(
+        (error: unknown) => {
+          this.logger.error('Stream pipeline failed outside the subscriber', {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        },
+      );
       // Unsubscribing (client disconnect, downstream error) cancels the
       // provider call. Without this the stream runs to completion unread and
       // the tokens are billed for nobody.
-      return () => controller.abort();
+      return () => cancellation.abort();
     });
   }
 
   private async streamResponse(
     input: StreamInferenceInput,
     subscriber: Subscriber<StreamInferenceResponseChunk>,
-    controller: AbortController,
+    cancelSignal: AbortSignal,
   ): Promise<void> {
-    const watchdog = new StreamIdleWatchdog(STREAM_IDLE_TIMEOUT_MS, () =>
-      controller.abort(new InferenceStreamStalledError(STREAM_IDLE_TIMEOUT_MS)),
-    );
     try {
       const request = await toProviderRequest(input, this.imageContentService);
       const provider = this.getProvider(input.model);
-      const transform = this.createChunkTransform();
+      for (let attempt = 1; ; attempt++) {
+        const outcome = await this.streamAttempt(
+          provider,
+          request,
+          subscriber,
+          cancelSignal,
+        );
+        if (!outcome.stalled) {
+          subscriber.complete();
+          return;
+        }
+        // No retry once the caller has cancelled — the subscriber is gone,
+        // so a second attempt would only bill tokens nobody reads.
+        if (
+          outcome.chunksEmitted > 0 ||
+          attempt >= MAX_STREAM_ATTEMPTS ||
+          cancelSignal.aborted
+        ) {
+          throw outcome.stalled;
+        }
+        this.logger.warn('Provider stream stalled before the first chunk', {
+          model: input.model.name,
+          provider: input.model.provider,
+          attempt,
+        });
+      }
+    } catch (error) {
+      subscriber.error(error);
+    }
+  }
+
+  /**
+   * Runs one provider attempt on its own controller so the stall watchdog
+   * can abort it without consuming the caller's cancellation signal. A stall
+   * is returned rather than thrown because SDKs disagree on what an abort
+   * looks like: some reject with a generic AbortError, the stainless SDKs
+   * (openai, anthropic) swallow it and end the stream as if it completed —
+   * which would otherwise persist a silently truncated message.
+   */
+  private async streamAttempt(
+    provider: ModelProvider,
+    request: ProviderStreamRequest,
+    subscriber: Subscriber<StreamInferenceResponseChunk>,
+    cancelSignal: AbortSignal,
+  ): Promise<StreamAttemptOutcome> {
+    const controller = new AbortController();
+    const stopRelayingAbort = relayAbort(cancelSignal, controller);
+    const watchdog = new StreamIdleWatchdog(
+      STREAM_IDLE_TIMEOUT_MS,
+      (elapsedMs) =>
+        controller.abort(new InferenceStreamStalledError(elapsedMs)),
+    );
+    const transform = this.createChunkTransform();
+    let chunksEmitted = 0;
+    try {
+      watchdog.arm(STREAM_FIRST_CHUNK_TIMEOUT_MS);
       for await (const chunk of provider.stream({
         ...request,
         signal: controller.signal,
       })) {
         watchdog.notifyChunk();
+        chunksEmitted += 1;
         subscriber.next(toStreamChunk(transform(chunk)));
       }
-      subscriber.complete();
+      return { stalled: stalledReason(controller.signal), chunksEmitted };
     } catch (error) {
-      // A stalled stream surfaces from the SDK as a generic AbortError, which
-      // the use case would otherwise read as a client cancellation. The abort
-      // reason carries what actually happened.
-      const reason: unknown = controller.signal.reason;
-      subscriber.error(
-        reason instanceof InferenceStreamStalledError ? reason : error,
-      );
+      const stalled = stalledReason(controller.signal);
+      if (stalled) {
+        return { stalled, chunksEmitted };
+      }
+      throw error;
     } finally {
       watchdog.stop();
+      stopRelayingAbort();
     }
   }
 }

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/run-event-stream.adapter.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/run-event-stream.adapter.spec.ts
@@ -466,7 +466,9 @@ describe('adaptRunEventsToStream', () => {
       },
       InferenceStreamStalledError,
       504,
-      undefined,
+      // The elapsed budget survives the round-trip on metadata so the
+      // reconstructed error reports the wait that actually happened.
+      { idleMs: 45_000 },
     ],
     [
       'generic inference error',

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-error.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-error.ts
@@ -35,10 +35,9 @@ export interface RuntimeModelErrorDetails extends Readonly<
 
 export function serializeRuntimeModelError(
   error: Error,
-  idleMs: number,
 ): RuntimeModelErrorDetails {
   return {
-    hostError: serializeError(error, idleMs),
+    hostError: serializeError(error),
   };
 }
 
@@ -50,15 +49,18 @@ export function reconstructRuntimeModelError(
   return reconstructError(serialized);
 }
 
-function serializeError(
-  error: Error,
-  idleMs: number,
-): SerializedRuntimeModelError {
+function serializeError(error: Error): SerializedRuntimeModelError {
   if (error instanceof ProviderUnavailableError) {
     return serializeProviderError(error);
   }
   if (error instanceof InferenceStreamStalledError) {
-    return { type: 'inference_stream_stalled', context: { idleMs } };
+    // The error's metadata carries the budget that actually elapsed — a
+    // first-chunk stall (90s) must not be reported as the inter-chunk
+    // default (45s).
+    return {
+      type: 'inference_stream_stalled',
+      context: error.metadata ?? {},
+    };
   }
   if (error instanceof InferenceImageTooLargeError) {
     return { type: 'inference_image_too_large', context: error.metadata ?? {} };

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-provider.decorator.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-provider.decorator.spec.ts
@@ -6,7 +6,10 @@ import type {
 } from '@ayunis/inference';
 import type { EventEmitter2 } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
-import { STREAM_IDLE_TIMEOUT_MS } from 'src/common/streaming/stream-idle-watchdog';
+import {
+  STREAM_FIRST_CHUNK_TIMEOUT_MS,
+  STREAM_IDLE_TIMEOUT_MS,
+} from 'src/common/streaming/stream-idle-watchdog';
 import type { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import { InferenceCompletedEvent } from '../events/inference-completed.event';
 import { RuntimeModelProviderDecorator } from './runtime-model-provider.decorator';
@@ -303,6 +306,138 @@ describe('RuntimeModelProviderDecorator', () => {
 
     await failure;
     expect(emitAsync).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  // Stainless SDKs swallow their own abort: without a post-loop check the
+  // runtime would accumulate a silently truncated turn as a success.
+  it('fails the call when the provider swallows the stall abort', async () => {
+    jest.useFakeTimers();
+    const provider: ModelProvider = {
+      name: 'test:swallowing',
+      async *stream(providerRequest) {
+        yield { textDelta: 'First chunk' };
+        await new Promise<void>((resolve) => {
+          providerRequest.signal?.addEventListener('abort', () => resolve(), {
+            once: true,
+          });
+        });
+      },
+    };
+    const { decorate } = buildHarness();
+    const iterator = decorate(provider).stream(request)[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { textDelta: 'First chunk' },
+    });
+    const failure = expect(iterator.next()).rejects.toMatchObject<
+      Partial<AgentRuntimeError>
+    >({
+      code: 'INFERENCE_TIMEOUT',
+    });
+    await jest.advanceTimersByTimeAsync(STREAM_IDLE_TIMEOUT_MS);
+
+    await failure;
+    jest.useRealTimers();
+  });
+
+  it('retries once when the stream stalls before the first chunk', async () => {
+    jest.useFakeTimers();
+    let calls = 0;
+    const provider: ModelProvider = {
+      name: 'test:slow-start',
+      async *stream(providerRequest) {
+        calls += 1;
+        if (calls === 1) {
+          yield await waitForAbort(providerRequest.signal);
+        }
+        yield { textDelta: 'Recovered' };
+      },
+    };
+    const { decorate, emitAsync } = buildHarness();
+
+    const collected = collect(decorate(provider));
+    await jest.advanceTimersByTimeAsync(STREAM_FIRST_CHUNK_TIMEOUT_MS);
+
+    await expect(collected).resolves.toEqual([{ textDelta: 'Recovered' }]);
+    expect(calls).toBe(2);
+    expect(emitAsync).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('fails with INFERENCE_TIMEOUT when the retry also produces no chunk', async () => {
+    jest.useFakeTimers();
+    let calls = 0;
+    const provider: ModelProvider = {
+      name: 'test:never-starts',
+      async *stream(providerRequest) {
+        calls += 1;
+        yield await waitForAbort(providerRequest.signal);
+      },
+    };
+    const { decorate } = buildHarness();
+
+    const collected = collect(decorate(provider));
+    const failure = expect(collected).rejects.toMatchObject<
+      Partial<AgentRuntimeError>
+    >({
+      code: 'INFERENCE_TIMEOUT',
+      // The serialized stall must report the budget that actually elapsed —
+      // the first-chunk one — not the inter-chunk default.
+      details: {
+        hostError: {
+          type: 'inference_stream_stalled',
+          context: { idleMs: STREAM_FIRST_CHUNK_TIMEOUT_MS },
+        },
+      },
+    });
+    await jest.advanceTimersByTimeAsync(STREAM_FIRST_CHUNK_TIMEOUT_MS);
+    await jest.advanceTimersByTimeAsync(STREAM_FIRST_CHUNK_TIMEOUT_MS);
+
+    await failure;
+    expect(calls).toBe(2);
+    jest.useRealTimers();
+  });
+
+  it('does not retry a stall once the run has been cancelled', async () => {
+    jest.useFakeTimers();
+    let calls = 0;
+    const controller = new AbortController();
+    const provider: ModelProvider = {
+      name: 'test:stall-then-cancel',
+      async *stream(providerRequest) {
+        calls += 1;
+        // Swallows the abort like a stainless SDK — the stream ends without
+        // emitting — but settles a macrotask later so the cancellation can
+        // win the race against the retry decision.
+        const noChunks = new Promise<[]>((resolve) => {
+          providerRequest.signal?.addEventListener(
+            'abort',
+            () => setTimeout(() => resolve([]), 10),
+            { once: true },
+          );
+        });
+        yield* await noChunks;
+      },
+    };
+    const { decorate } = buildHarness();
+
+    const collected = collect(decorate(provider), {
+      ...request,
+      signal: controller.signal,
+    });
+    const failure = expect(collected).rejects.toMatchObject<
+      Partial<AgentRuntimeError>
+    >({
+      code: 'INFERENCE_TIMEOUT',
+    });
+    await jest.advanceTimersByTimeAsync(STREAM_FIRST_CHUNK_TIMEOUT_MS);
+    controller.abort();
+    await jest.advanceTimersByTimeAsync(10);
+    await jest.advanceTimersByTimeAsync(STREAM_FIRST_CHUNK_TIMEOUT_MS);
+
+    await failure;
+    expect(calls).toBe(1);
     jest.useRealTimers();
   });
 

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-provider.decorator.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-provider.decorator.ts
@@ -15,9 +15,11 @@ import { extractUpstreamStatus } from 'src/common/errors/extract-upstream-status
 import { stripDisallowedNulls } from 'src/common/util/strip-disallowed-nulls';
 import { wrapProviderFailure } from 'src/common/errors/wrap-provider-failure.helper';
 import {
+  STREAM_FIRST_CHUNK_TIMEOUT_MS,
   STREAM_IDLE_TIMEOUT_MS,
   StreamIdleWatchdog,
 } from 'src/common/streaming/stream-idle-watchdog';
+import { relayAbort } from 'src/common/streaming/relay-abort';
 import {
   InferenceAbortedError,
   InferenceFailedError,
@@ -39,6 +41,18 @@ interface CallState {
   readonly controller: AbortController;
   readonly watchdog: StreamIdleWatchdog;
   readonly stopRelayingAbort: () => void;
+}
+
+/**
+ * One retry, and only when the stalled attempt yielded nothing: once a chunk
+ * has reached the runtime accumulator a second attempt would duplicate
+ * content.
+ */
+const MAX_STREAM_ATTEMPTS = 2;
+
+interface StreamAttemptOutcome {
+  stalled?: InferenceStreamStalledError;
+  chunksYielded: number;
 }
 
 @Injectable()
@@ -63,19 +77,12 @@ export class RuntimeModelProviderDecorator {
     context: RuntimeModelCallContext,
   ): AsyncIterable<ProviderChunk> {
     const startedAt = Date.now();
-    const state = createCallState(request.signal);
     let mappedError: ApplicationError | undefined;
     try {
       const sanitizedRequest = sanitizeReplayedToolInputs(request);
-      for await (const chunk of provider.stream({
-        ...sanitizedRequest,
-        signal: state.controller.signal,
-      })) {
-        state.watchdog.notifyChunk();
-        yield chunk;
-      }
+      yield* this.streamWithStallRetry(provider, sanitizedRequest, context);
     } catch (error) {
-      mappedError = mapProviderError(error, request, state.controller, context);
+      mappedError = mapProviderError(error, request, context);
       if (
         mappedError instanceof InferenceAbortedError &&
         request.signal?.aborted
@@ -84,12 +91,37 @@ export class RuntimeModelProviderDecorator {
       }
       throw toRuntimeError(mappedError, error);
     } finally {
-      state.watchdog.stop();
-      state.stopRelayingAbort();
       if (!mappedError && request.signal?.aborted) {
         mappedError = new InferenceAbortedError();
       }
       this.emitCompletion(context, startedAt, mappedError);
+    }
+  }
+
+  private async *streamWithStallRetry(
+    provider: ModelProvider,
+    request: ProviderRequest,
+    context: RuntimeModelCallContext,
+  ): AsyncGenerator<ProviderChunk, void> {
+    for (let attempt = 1; ; attempt++) {
+      const outcome = yield* streamAttempt(provider, request);
+      if (!outcome.stalled) {
+        return;
+      }
+      // No retry once the caller has cancelled — the run is gone, so a
+      // second attempt would only bill tokens nobody reads.
+      if (
+        outcome.chunksYielded > 0 ||
+        attempt >= MAX_STREAM_ATTEMPTS ||
+        request.signal?.aborted === true
+      ) {
+        throw outcome.stalled;
+      }
+      this.logger.warn('Provider stream stalled before the first chunk', {
+        model: context.model.name,
+        provider: context.model.provider,
+        attempt,
+      });
     }
   }
 
@@ -159,34 +191,64 @@ function sanitizeToolInput(
 function createCallState(sourceSignal: AbortSignal | undefined): CallState {
   const controller = new AbortController();
   const stopRelayingAbort = relayAbort(sourceSignal, controller);
-  const watchdog = new StreamIdleWatchdog(STREAM_IDLE_TIMEOUT_MS, () => {
-    controller.abort(new InferenceStreamStalledError(STREAM_IDLE_TIMEOUT_MS));
-  });
+  const watchdog = new StreamIdleWatchdog(
+    STREAM_IDLE_TIMEOUT_MS,
+    (elapsedMs) => {
+      controller.abort(new InferenceStreamStalledError(elapsedMs));
+    },
+  );
   return { controller, watchdog, stopRelayingAbort };
 }
 
-function relayAbort(
-  source: AbortSignal | undefined,
-  target: AbortController,
-): () => void {
-  if (!source) return () => undefined;
-  const abort = () => target.abort(source.reason);
-  if (source.aborted) {
-    abort();
-    return () => undefined;
+/**
+ * One provider attempt on its own controller. A stall is returned rather
+ * than thrown because SDKs disagree on what an abort looks like: some reject
+ * with a generic AbortError, the stainless SDKs (openai, anthropic) swallow
+ * it and end the stream as if it completed — which would otherwise let the
+ * runtime accumulate a silently truncated turn as a success.
+ */
+async function* streamAttempt(
+  provider: ModelProvider,
+  request: ProviderRequest,
+): AsyncGenerator<ProviderChunk, StreamAttemptOutcome> {
+  const state = createCallState(request.signal);
+  let chunksYielded = 0;
+  try {
+    state.watchdog.arm(STREAM_FIRST_CHUNK_TIMEOUT_MS);
+    for await (const chunk of provider.stream({
+      ...request,
+      signal: state.controller.signal,
+    })) {
+      state.watchdog.notifyChunk();
+      chunksYielded += 1;
+      yield chunk;
+    }
+    return { stalled: stalledReason(state.controller.signal), chunksYielded };
+  } catch (error) {
+    const stalled = stalledReason(state.controller.signal);
+    if (stalled) {
+      return { stalled, chunksYielded };
+    }
+    throw error;
+  } finally {
+    state.watchdog.stop();
+    state.stopRelayingAbort();
   }
-  source.addEventListener('abort', abort, { once: true });
-  return () => source.removeEventListener('abort', abort);
+}
+
+function stalledReason(
+  signal: AbortSignal,
+): InferenceStreamStalledError | undefined {
+  return signal.aborted && signal.reason instanceof InferenceStreamStalledError
+    ? signal.reason
+    : undefined;
 }
 
 function mapProviderError(
   error: unknown,
   request: ProviderRequest,
-  controller: AbortController,
   context: RuntimeModelCallContext,
 ): ApplicationError {
-  const abortReason: unknown = controller.signal.reason;
-  if (abortReason instanceof InferenceStreamStalledError) return abortReason;
   if (request.signal?.aborted && error === request.signal.reason) {
     return new InferenceAbortedError();
   }
@@ -219,7 +281,7 @@ function toRuntimeError(
   cause: unknown,
 ): AgentRuntimeError {
   return new AgentRuntimeError(mappedError.code, mappedError.message, {
-    details: serializeRuntimeModelError(mappedError, STREAM_IDLE_TIMEOUT_MS),
+    details: serializeRuntimeModelError(mappedError),
     cause,
   });
 }


### PR DESCRIPTION
## Problem

AppSignal incidents #513 (`INFERENCE_TIMEOUT`), #515 and a fresh #278 occurrence — raw `20: This operation was aborted` created at the stall watchdog's timer callback escaping on send-message and openai-compat, on 2.21.1.

## Root causes found

- **Stainless SDKs (openai, anthropic and derivatives) swallow their own abort**: after the 45s watchdog fired, the stream ended "normally" and a silently **truncated assistant message was persisted as a success** — `InferenceStreamStalledError` was effectively dead code for those providers. (Ollama-family rethrows and was mapped correctly.)
- The raw `20` incidents come from bare DOMExceptions minted by SDK abort listeners during `controller.abort(stalled)` escaping via unhandled rejections (the floating `void this.streamResponse(...)` promise), not from the mapped catch path.
- No recovery existed: a stall failed the whole message even when nothing had been produced yet.

## Changes

- Post-loop stall check in both paths (legacy `streamResponse`, agent-runtime decorator): a stream that ends after the watchdog fired now fails with `INFERENCE_TIMEOUT` instead of persisting truncated output
- Stall detection now covers time-to-first-chunk (90s budget, `STREAM_FIRST_CHUNK_TIMEOUT_MS`); a stall that produced **no chunks** is retried once on a fresh controller; stalls after the first chunk fail immediately (partial content may be persisted)
- Each attempt runs on its own controller with the caller's cancellation relayed (`relayAbort` extracted to `src/common/streaming/`)
- The floating stream promise is routed through a logging catch, closing the unhandled-rejection escape
- openai-compat inherits the legacy-path fix; the runtime path gets identical semantics in the decorator

## Verification

- New specs: swallowed-abort → INFERENCE_TIMEOUT (both paths), zero-chunk stall retried once, exhausted retry fails classified, mid-stream stall not retried
- Full backend suite: 3908 tests pass

Part of the AppSignal stack AYC-651…AYC-655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core streaming inference and agent-runtime model calls (timeouts, retries, error mapping); behavior changes can affect message persistence and billing on stall edge cases, but retries are narrowly scoped to zero-chunk stalls.
> 
> **Overview**
> Fixes **silent truncation** when OpenAI/Anthropic-style SDKs end a stream “normally” after the stall watchdog aborts, and adds **recovery** for stalls before any output is produced.
> 
> **Stall detection** now arms at request start with a **90s first-chunk budget** (`STREAM_FIRST_CHUNK_TIMEOUT_MS`), then uses the existing **45s inter-chunk** idle timeout. `StreamIdleWatchdog` is explicitly armed via `arm()`; stall callbacks report the **budget that actually elapsed**. `InferenceStreamStalledError` carries `idleMs` in metadata through serialization.
> 
> **Both** the legacy `RuntimeStreamInferenceHandler` and the agent-runtime `RuntimeModelProviderDecorator` run each attempt on its **own** `AbortController` with caller cancellation relayed via shared **`relayAbort`**. After the provider loop, a **post-loop stall check** turns swallowed aborts into `INFERENCE_TIMEOUT` instead of success. **One retry** is allowed only when **zero chunks** were emitted; mid-stream stalls and cancelled runs do not retry. The handler’s floating `streamResponse` promise gets a **logging `.catch()`** to avoid unhandled `AbortError` leaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba84ff1f9b0b53de87a4e67a6867d95f7ef1f64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->