### PR TITLE
fix(models): route transient provider transport failures through the taxonomy with retry (AYC-653)

### DIFF
--- a/ayunis-core-backend/src/common/errors/provider-transport-error.classifier.spec.ts
+++ b/ayunis-core-backend/src/common/errors/provider-transport-error.classifier.spec.ts
@@ -1,4 +1,7 @@
-import { classifyTransportError } from './provider-transport-error.classifier';
+import {
+  classifyTransportError,
+  isRetryableSetupFailure,
+} from './provider-transport-error.classifier';
 import { ProviderFailureClass } from './provider.errors';
 
 function errorWithCode(message: string, code: string): Error {
@@ -131,6 +134,51 @@ describe('classifyTransportError', () => {
       expect(classifyTransportError(error)?.failureClass).toBe(
         ProviderFailureClass.CONNECTION,
       );
+    });
+  });
+
+  describe('name-matched nodes with numeric codes', () => {
+    // The exact incident shape from AbortSignal.timeout: DOMException with
+    // name 'TimeoutError' and numeric code 23 (AppSignal incident "23:").
+    it('classifies a DOMException TimeoutError and preserves its code', () => {
+      const error = new DOMException(
+        'The operation was aborted due to timeout',
+        'TimeoutError',
+      );
+
+      const result = classifyTransportError(error);
+
+      expect(result?.failureClass).toBe(ProviderFailureClass.TIMEOUT);
+      expect(result?.code).toBe('23');
+    });
+  });
+
+  describe('isRetryableSetupFailure', () => {
+    it.each(['EAI_AGAIN', 'ECONNRESET'])(
+      'treats %s as retryable during request setup',
+      (code) => {
+        expect(isRetryableSetupFailure(errorWithCode('boom', code))).toBe(true);
+      },
+    );
+
+    it('does not retry timeouts — that would double an already-long wait', () => {
+      expect(
+        isRetryableSetupFailure(
+          errorWithCode('headers timeout', 'UND_ERR_HEADERS_TIMEOUT'),
+        ),
+      ).toBe(false);
+    });
+
+    it('does not retry non-transport errors', () => {
+      expect(isRetryableSetupFailure(new Error('boom'))).toBe(false);
+    });
+
+    it('does not retry client aborts', () => {
+      expect(
+        isRetryableSetupFailure(
+          new DOMException('The operation was aborted', 'AbortError'),
+        ),
+      ).toBe(false);
     });
   });
 

--- a/ayunis-core-backend/src/common/errors/provider-transport-error.classifier.ts
+++ b/ayunis-core-backend/src/common/errors/provider-transport-error.classifier.ts
@@ -93,6 +93,26 @@ function collectChain(root: unknown): Record<string, unknown>[] {
   return chain;
 }
 
+/**
+ * Pause before the single setup retry — long enough for a DNS hiccup or a
+ * dropped TLS connection to clear, short enough not to matter for a user
+ * already waiting on inference.
+ */
+export const SETUP_RETRY_BACKOFF_MS = 500;
+
+/**
+ * Transient connection failures worth exactly one retry during request
+ * setup: before a provider has produced any output, resending the request is
+ * idempotent. Timeouts are excluded — retrying them doubles an already-long
+ * wait — as are stalls and aborts, which carry their own semantics.
+ */
+export function isRetryableSetupFailure(error: unknown): boolean {
+  return (
+    classifyTransportError(error)?.failureClass ===
+    ProviderFailureClass.CONNECTION
+  );
+}
+
 function classifyByCode(
   chain: Record<string, unknown>[],
 ): Omit<TransportFailure, 'host'> | undefined {
@@ -116,12 +136,27 @@ function classifyByName(
     const name = typeof node.name === 'string' ? node.name : undefined;
     if (!name) continue;
     if (TIMEOUT_NAMES.has(name)) {
-      return { failureClass: ProviderFailureClass.TIMEOUT };
+      return { failureClass: ProviderFailureClass.TIMEOUT, code: codeOf(node) };
     }
     if (CONNECTION_NAMES.has(name)) {
-      return { failureClass: ProviderFailureClass.CONNECTION };
+      return {
+        failureClass: ProviderFailureClass.CONNECTION,
+        code: codeOf(node),
+      };
     }
   }
+  return undefined;
+}
+
+/**
+ * A name-matched node can still carry a code the code sets do not know —
+ * e.g. a DOMException TimeoutError has the numeric code 23. Preserving it
+ * keeps `underlyingCode` in the incident metadata instead of losing which
+ * deadline fired.
+ */
+function codeOf(node: Record<string, unknown>): string | undefined {
+  if (typeof node.code === 'string') return node.code;
+  if (typeof node.code === 'number') return String(node.code);
   return undefined;
 }
 

--- a/ayunis-core-backend/src/common/errors/report-unexpected-error.helper.spec.ts
+++ b/ayunis-core-backend/src/common/errors/report-unexpected-error.helper.spec.ts
@@ -1,0 +1,62 @@
+import { setError } from '@appsignal/nodejs';
+import { BadRequestException, BadGatewayException } from '@nestjs/common';
+import { ApplicationError } from './base.error';
+import { reportUnexpectedError } from './report-unexpected-error.helper';
+
+jest.mock('@appsignal/nodejs', () => ({
+  setError: jest.fn(),
+}));
+
+class TestApplicationError extends ApplicationError {
+  constructor(statusCode: number) {
+    super('boom', 'TEST_ERROR', statusCode);
+  }
+}
+
+describe('reportUnexpectedError', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('reports ApplicationErrors with a 5xx status', () => {
+    const error = new TestApplicationError(504);
+
+    reportUnexpectedError(error);
+
+    expect(setError).toHaveBeenCalledWith(error);
+  });
+
+  it('does not report ApplicationErrors below 500 — expected client outcomes', () => {
+    reportUnexpectedError(new TestApplicationError(429));
+
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it('reports HttpExceptions with a 5xx status', () => {
+    const error = new BadGatewayException();
+
+    reportUnexpectedError(error);
+
+    expect(setError).toHaveBeenCalledWith(error);
+  });
+
+  it('does not report HttpExceptions below 500', () => {
+    reportUnexpectedError(new BadRequestException());
+
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it('reports unclassified errors', () => {
+    const error = new Error('unexpected');
+
+    reportUnexpectedError(error);
+
+    expect(setError).toHaveBeenCalledWith(error);
+  });
+
+  it('wraps non-Error throwables so they still reach AppSignal', () => {
+    reportUnexpectedError('string failure');
+
+    expect(setError).toHaveBeenCalledWith(expect.any(Error));
+    const reported = (setError as jest.Mock).mock.calls[0][0] as Error;
+    expect(reported.message).toBe('string failure');
+  });
+});

--- a/ayunis-core-backend/src/common/errors/report-unexpected-error.helper.ts
+++ b/ayunis-core-backend/src/common/errors/report-unexpected-error.helper.ts
@@ -1,0 +1,29 @@
+import { HttpException } from '@nestjs/common';
+import { setError } from '@appsignal/nodejs';
+import { ApplicationError } from './base.error';
+
+/**
+ * The reporting rule of ApplicationErrorFilter, extracted for response paths
+ * the filter can never reach — SSE streams whose 200 status is committed
+ * before the run executes, and the openai-compat error envelope. Without
+ * this, classified provider outages (PROVIDER_UNAVAILABLE_*, 5xx) on
+ * send-message produce no AppSignal incident at all, leaving only the raw
+ * transport error recorded by the undici instrumentation (AYC-653).
+ *
+ * 4xx ApplicationErrors and HttpExceptions are expected client outcomes and
+ * stay unreported, matching the filter.
+ */
+export function reportUnexpectedError(exception: unknown): void {
+  if (exception instanceof ApplicationError && exception.statusCode < 500) {
+    return;
+  }
+  if (exception instanceof HttpException && exception.getStatus() < 500) {
+    return;
+  }
+
+  // setError requires an Error-like value; wrap non-Error throwables so
+  // they still reach AppSignal.
+  const error =
+    exception instanceof Error ? exception : new Error(String(exception));
+  setError(error);
+}

--- a/ayunis-core-backend/src/common/filters/application-error.filter.ts
+++ b/ayunis-core-backend/src/common/filters/application-error.filter.ts
@@ -1,8 +1,8 @@
-import { Catch, ArgumentsHost, HttpException } from '@nestjs/common';
+import { Catch, ArgumentsHost } from '@nestjs/common';
 import { BaseExceptionFilter } from '@nestjs/core';
-import { setError } from '@appsignal/nodejs';
 import { Request, Response } from 'express';
 import { ApplicationError } from '../errors/base.error';
+import { reportUnexpectedError } from '../errors/report-unexpected-error.helper';
 
 /**
  * Global exception filter that:
@@ -19,7 +19,7 @@ import { ApplicationError } from '../errors/base.error';
 @Catch()
 export class ApplicationErrorFilter extends BaseExceptionFilter {
   catch(exception: unknown, host: ArgumentsHost) {
-    this.reportUnexpectedError(exception);
+    reportUnexpectedError(exception);
 
     if (exception instanceof ApplicationError) {
       this.handleApplicationError(exception, host);
@@ -28,21 +28,6 @@ export class ApplicationErrorFilter extends BaseExceptionFilter {
 
     // HttpExceptions, raw Errors, and anything else — delegate to NestJS defaults
     super.catch(exception, host);
-  }
-
-  private reportUnexpectedError(exception: unknown): void {
-    if (exception instanceof ApplicationError && exception.statusCode < 500) {
-      return;
-    }
-    if (exception instanceof HttpException && exception.getStatus() < 500) {
-      return;
-    }
-
-    // setError requires an Error-like value; wrap non-Error throwables so
-    // they still reach AppSignal.
-    const error =
-      exception instanceof Error ? exception : new Error(String(exception));
-    setError(error);
   }
 
   private handleApplicationError(

--- a/ayunis-core-backend/src/common/util/mistral-transient-error.spec.ts
+++ b/ayunis-core-backend/src/common/util/mistral-transient-error.spec.ts
@@ -48,4 +48,30 @@ describe('isTransientMistralError', () => {
   it('does not retry unknown errors', () => {
     expect(isTransientMistralError(new Error('unrelated failure'))).toBe(false);
   });
+
+  // The SDK's own timeout mapping only covers the fetch call; an
+  // AbortSignal.timeout that fires while the response body is read escapes
+  // as a raw DOMException TimeoutError (code 23) and must still be retried.
+  it('treats a DOMException TimeoutError as transient', () => {
+    const timeout = new DOMException(
+      'The operation was aborted due to timeout',
+      'TimeoutError',
+    );
+    expect(isTransientMistralError(timeout as unknown as Error)).toBe(true);
+  });
+
+  it('treats a bare undici headers timeout as transient', () => {
+    const timeout = Object.assign(new Error('Headers Timeout Error'), {
+      code: 'UND_ERR_HEADERS_TIMEOUT',
+      name: 'HeadersTimeoutError',
+    });
+    expect(isTransientMistralError(timeout)).toBe(true);
+  });
+
+  it('treats a bare DNS failure as transient', () => {
+    const dnsFailure = Object.assign(new Error('getaddrinfo EAI_AGAIN'), {
+      code: 'EAI_AGAIN',
+    });
+    expect(isTransientMistralError(dnsFailure)).toBe(true);
+  });
 });

--- a/ayunis-core-backend/src/common/util/mistral-transient-error.ts
+++ b/ayunis-core-backend/src/common/util/mistral-transient-error.ts
@@ -3,6 +3,7 @@ import {
   MistralError,
   RequestTimeoutError,
 } from '@mistralai/mistralai/models/errors';
+import { classifyTransportError } from 'src/common/errors/provider-transport-error.classifier';
 
 /**
  * Transient Mistral SDK failures worth a bounded retry: rate limits (429),
@@ -10,12 +11,21 @@ import {
  * Per-attempt `timeoutMs` on the client turns stalled connections into
  * `RequestTimeoutError`s, so retrying them is bounded — without it they
  * hang forever and never reach a retry predicate (AYC-422).
+ *
+ * Not everything arrives wrapped by the SDK: an AbortSignal.timeout that
+ * fires while the response body is read escapes as a raw DOMException
+ * TimeoutError, and undici deadlines (UND_ERR_HEADERS_TIMEOUT) or errno
+ * failures (EAI_AGAIN, ECONNRESET) can reach the predicate bare — the
+ * shared transport classifier recognizes those (AYC-653).
  */
 export function isTransientMistralError(error: Error): boolean {
   if (
     error instanceof RequestTimeoutError ||
     error instanceof ConnectionError
   ) {
+    return true;
+  }
+  if (classifyTransportError(error) !== undefined) {
     return true;
   }
   return (

--- a/ayunis-core-backend/src/domain/models/application/use-cases/generate-image/generate-image.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/generate-image/generate-image.use-case.spec.ts
@@ -107,6 +107,23 @@ describe('GenerateImageUseCase', () => {
       await expect(useCase.execute(command)).rejects.not.toThrow(/ENOTFOUND/);
     });
 
+    // Transport failures must group under the stable PROVIDER_UNAVAILABLE_*
+    // taxonomy instead of the generic image-generation error (AYC-653).
+    it('classifies transport failures under the provider taxonomy', async () => {
+      const command = new GenerateImageCommand({
+        model: mockModel,
+        prompt: 'a cat',
+      });
+
+      handler.generate.mockRejectedValue(
+        Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }),
+      );
+
+      await expect(useCase.execute(command)).rejects.toMatchObject({
+        code: 'PROVIDER_UNAVAILABLE_CONNECTION_AZURE',
+      });
+    });
+
     it('should re-throw ApplicationError exceptions as-is', async () => {
       const command = new GenerateImageCommand({
         model: mockModel,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/generate-image/generate-image.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/generate-image/generate-image.use-case.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { wrapProviderFailure } from 'src/common/errors/wrap-provider-failure.helper';
 import { ImageGenerationHandlerRegistry } from '../../registry/image-generation-handler.registry';
 import {
   ImageGenerationInput,
@@ -44,6 +45,13 @@ export class GenerateImageUseCase {
         provider: command.model.provider,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
+      const providerError = wrapProviderFailure(error, {
+        provider: command.model.provider,
+        modelId: command.model.name,
+      });
+      if (providerError) {
+        throw providerError;
+      }
       throw new ImageGenerationFailedError(
         'An unexpected error occurred during image generation',
       );

--- a/ayunis-core-backend/src/domain/models/infrastructure/runtime/runtime-stream-inference.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/runtime/runtime-stream-inference.handler.spec.ts
@@ -4,6 +4,7 @@ import type { StreamInferenceInput } from '../../application/ports/stream-infere
 import { InferenceStreamStalledError } from '../../application/models.errors';
 import { RuntimeStreamInferenceHandler } from './runtime-stream-inference.handler';
 import { STREAM_IDLE_TIMEOUT_MS } from 'src/common/streaming/stream-idle-watchdog';
+import { SETUP_RETRY_BACKOFF_MS } from 'src/common/errors/provider-transport-error.classifier';
 
 /** Rejects the way a provider SDK does when its request signal aborts. */
 function whenAborted(signal: AbortSignal | undefined): Promise<never> {
@@ -117,6 +118,127 @@ describe('RuntimeStreamInferenceHandler', () => {
     unsubscribe();
 
     expect(signal()?.aborted).toBe(true);
+  });
+
+  it('does not retry a stall that happens after chunks were already emitted', async () => {
+    let calls = 0;
+    const provider: ModelProvider = {
+      name: 'test:mid-stream-stall',
+      async *stream(request) {
+        calls += 1;
+        yield { textDelta: 'first' };
+        await whenAborted(request.signal);
+      },
+    };
+    const { arrived, failure } = firstChunkOf(new TestHandler(provider));
+
+    await arrived;
+    await jest.advanceTimersByTimeAsync(STREAM_IDLE_TIMEOUT_MS);
+
+    await expect(failure).resolves.toBeInstanceOf(InferenceStreamStalledError);
+    expect(calls).toBe(1);
+  });
+
+  it('retries once when a transient connection failure happens before the first chunk', async () => {
+    let calls = 0;
+    const provider: ModelProvider = {
+      name: 'test:flaky-dns',
+      async *stream() {
+        calls += 1;
+        if (calls === 1) {
+          yield await Promise.reject(
+            Object.assign(new Error('getaddrinfo EAI_AGAIN'), {
+              code: 'EAI_AGAIN',
+            }),
+          );
+        }
+        yield { textDelta: 'recovered' };
+      },
+    };
+
+    const deltas: (string | null)[] = [];
+    const completed = new Promise<void>((resolve, reject) => {
+      new TestHandler(provider).answer(makeInput()).subscribe({
+        next: (chunk) => deltas.push(chunk.textContentDelta),
+        complete: resolve,
+        error: reject,
+      });
+    });
+    await jest.advanceTimersByTimeAsync(SETUP_RETRY_BACKOFF_MS);
+
+    await completed;
+    expect(deltas).toEqual(['recovered']);
+    expect(calls).toBe(2);
+  });
+
+  it('does not retry a transient failure when the subscriber unsubscribes during the backoff', async () => {
+    let calls = 0;
+    const provider: ModelProvider = {
+      name: 'test:flaky-then-cancel',
+      async *stream() {
+        calls += 1;
+        yield await Promise.reject(
+          Object.assign(new Error('getaddrinfo EAI_AGAIN'), {
+            code: 'EAI_AGAIN',
+          }),
+        );
+      },
+    };
+
+    const subscription = new TestHandler(provider)
+      .answer(makeInput())
+      .subscribe({ next: () => undefined, error: () => undefined });
+    // Let the first attempt fail and the backoff start...
+    await jest.advanceTimersByTimeAsync(0);
+    // ...then disconnect while it is waiting.
+    subscription.unsubscribe();
+    await jest.advanceTimersByTimeAsync(SETUP_RETRY_BACKOFF_MS);
+
+    expect(calls).toBe(1);
+  });
+
+  it('does not retry a connection failure after chunks were already emitted', async () => {
+    let calls = 0;
+    const reset = Object.assign(new Error('read ECONNRESET'), {
+      code: 'ECONNRESET',
+    });
+    const provider: ModelProvider = {
+      name: 'test:mid-stream-reset',
+      async *stream() {
+        calls += 1;
+        yield { textDelta: 'first' };
+        throw reset;
+      },
+    };
+    const { arrived, failure } = firstChunkOf(new TestHandler(provider));
+
+    await arrived;
+    await expect(failure).resolves.toBe(reset);
+    expect(calls).toBe(1);
+  });
+
+  it('does not retry non-transport provider failures', async () => {
+    let calls = 0;
+    const rejection = Object.assign(new Error('rate limited'), {
+      status: 429,
+    });
+    const provider: ModelProvider = {
+      name: 'test:rejected',
+      async *stream() {
+        calls += 1;
+        yield await Promise.reject(rejection);
+      },
+    };
+
+    const failed = new Promise<unknown>((resolve) => {
+      new TestHandler(provider).answer(makeInput()).subscribe({
+        next: () => undefined,
+        error: resolve,
+      });
+    });
+
+    await expect(failed).resolves.toBe(rejection);
+    expect(calls).toBe(1);
   });
 
   it('passes chunks through and completes when the provider streams normally', async () => {

--- a/ayunis-core-backend/src/domain/models/infrastructure/runtime/runtime-stream-inference.handler.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/runtime/runtime-stream-inference.handler.ts
@@ -16,7 +16,27 @@ import {
   StreamIdleWatchdog,
   STREAM_IDLE_TIMEOUT_MS,
 } from 'src/common/streaming/stream-idle-watchdog';
+import { Logger } from '@nestjs/common';
+import {
+  isRetryableSetupFailure,
+  SETUP_RETRY_BACKOFF_MS,
+} from 'src/common/errors/provider-transport-error.classifier';
 import { InferenceStreamStalledError } from '../../application/models.errors';
+
+const logger = new Logger('RuntimeStreamInferenceHandler');
+
+/**
+ * One retry, and only when the failed attempt emitted nothing: once a chunk
+ * has reached the subscriber it may already be persisted downstream, so a
+ * second attempt would duplicate content.
+ */
+const MAX_STREAM_ATTEMPTS = 2;
+
+type ProviderStreamRequest = Parameters<ModelProvider['stream']>[0];
+
+function backoff(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 /**
  * Streaming inference handler backed by a `@ayunis` ModelProvider. Concrete
@@ -100,15 +120,33 @@ export abstract class RuntimeStreamInferenceHandler extends StreamInferenceHandl
     try {
       const request = await toProviderRequest(input, this.imageContentService);
       const provider = this.getProvider(input.model);
-      const transform = this.createChunkTransform();
-      for await (const chunk of provider.stream({
-        ...request,
-        signal: controller.signal,
-      })) {
-        watchdog.notifyChunk();
-        subscriber.next(toStreamChunk(transform(chunk)));
+      for (let attempt = 1; ; attempt++) {
+        const setupFailure = await this.streamAttempt(
+          provider,
+          request,
+          subscriber,
+          controller,
+          watchdog,
+        );
+        if (!setupFailure) {
+          return;
+        }
+        if (attempt >= MAX_STREAM_ATTEMPTS) {
+          throw setupFailure;
+        }
+        await backoff(SETUP_RETRY_BACKOFF_MS);
+        // No retry once the caller has cancelled — the subscriber is gone,
+        // so a second attempt would only bill tokens nobody reads.
+        if (controller.signal.aborted) {
+          throw setupFailure;
+        }
+        logger.warn('Provider stream failed before the first chunk', {
+          model: input.model.name,
+          provider: input.model.provider,
+          attempt,
+          error: setupFailure.message,
+        });
       }
-      subscriber.complete();
     } catch (error) {
       // A stalled stream surfaces from the SDK as a generic AbortError, which
       // the use case would otherwise read as a client cancellation. The abort
@@ -119,6 +157,45 @@ export abstract class RuntimeStreamInferenceHandler extends StreamInferenceHandl
       );
     } finally {
       watchdog.stop();
+    }
+  }
+
+  /**
+   * Runs one provider attempt. Returns the error when the attempt died of a
+   * transient transport failure before the first chunk (the one case worth a
+   * retry — stall retries live upstream in the run loops, AYC-652); completes
+   * the subscriber and returns null on success; rethrows everything else.
+   */
+  private async streamAttempt(
+    provider: ModelProvider,
+    request: ProviderStreamRequest,
+    subscriber: Subscriber<StreamInferenceResponseChunk>,
+    controller: AbortController,
+    watchdog: StreamIdleWatchdog,
+  ): Promise<Error | null> {
+    const transform = this.createChunkTransform();
+    let chunksEmitted = 0;
+    try {
+      for await (const chunk of provider.stream({
+        ...request,
+        signal: controller.signal,
+      })) {
+        chunksEmitted += 1;
+        watchdog.notifyChunk();
+        subscriber.next(toStreamChunk(transform(chunk)));
+      }
+      subscriber.complete();
+      return null;
+    } catch (error) {
+      if (
+        chunksEmitted === 0 &&
+        !controller.signal.aborted &&
+        error instanceof Error &&
+        isRetryableSetupFailure(error)
+      ) {
+        return error;
+      }
+      throw error;
     }
   }
 }

--- a/ayunis-core-backend/src/domain/openai-compat/presenters/http/filters/openai-exception.filter.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/presenters/http/filters/openai-exception.filter.ts
@@ -3,6 +3,7 @@ import { BaseExceptionFilter } from '@nestjs/core';
 import type { Request, Response } from 'express';
 import { OpenAIErrorMapper } from 'src/domain/openai-compat/application/mappers/openai-error.mapper';
 import { ApplicationErrorFilter } from 'src/common/filters/application-error.filter';
+import { reportUnexpectedError } from 'src/common/errors/report-unexpected-error.helper';
 
 /**
  * Wraps OpenAI-compat exceptions into the OpenAI error envelope. Registered
@@ -46,6 +47,12 @@ export class OpenAIExceptionFilter extends BaseExceptionFilter {
       this.applicationErrorFilter.catch(exception, host);
       return;
     }
+
+    // This filter answers with the OpenAI envelope instead of delegating to
+    // ApplicationErrorFilter, so it must also take over the filter's
+    // reporting duty — otherwise 5xx failures on openai-compat routes never
+    // reach AppSignal (AYC-653).
+    reportUnexpectedError(exception);
 
     const response = ctx.getResponse<Response>();
     const mapped = this.errorMapper.toEnvelope(exception);

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-provider.decorator.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-provider.decorator.spec.ts
@@ -7,6 +7,7 @@ import type {
 import type { EventEmitter2 } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
 import { STREAM_IDLE_TIMEOUT_MS } from 'src/common/streaming/stream-idle-watchdog';
+import { SETUP_RETRY_BACKOFF_MS } from 'src/common/errors/provider-transport-error.classifier';
 import type { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import { InferenceCompletedEvent } from '../events/inference-completed.event';
 import { RuntimeModelProviderDecorator } from './runtime-model-provider.decorator';
@@ -173,6 +174,8 @@ describe('RuntimeModelProviderDecorator', () => {
     });
   });
 
+  // Connection failures get one setup retry (AYC-653), so they record two
+  // model-call completions; everything else fails on the first attempt.
   it.each([
     [
       'connection failure',
@@ -181,37 +184,44 @@ describe('RuntimeModelProviderDecorator', () => {
       }),
       'PROVIDER_UNAVAILABLE_CONNECTION_ANTHROPIC',
       'provider_connection',
+      2,
     ],
     [
       'transport timeout',
       Object.assign(new Error('request timed out'), { code: 'ETIMEDOUT' }),
       'PROVIDER_UNAVAILABLE_TIMEOUT_ANTHROPIC',
       'provider_timeout',
+      1,
     ],
     [
       'upstream server failure',
       Object.assign(new Error('service unavailable'), { status: 503 }),
       'PROVIDER_UNAVAILABLE_SERVER_ANTHROPIC',
       'provider_server',
+      1,
     ],
     [
       'oversized image',
       Object.assign(new Error('image exceeds 5 MB maximum'), { status: 400 }),
       'INFERENCE_IMAGE_TOO_LARGE',
       'inference_image_too_large',
+      1,
     ],
     [
       'unknown failure',
       new Error('provider returned an invalid stream'),
       'INFERENCE_FAILED',
       'inference_failed',
+      1,
     ],
   ])(
     'classifies a %s and records the mapped failure',
-    async (_label, error, code, type) => {
+    async (_label, error, code, type, attempts) => {
+      jest.useFakeTimers();
       const { decorate, emitAsync } = buildHarness();
 
-      await expect(collect(decorate(throwingProvider(error)))).rejects.toEqual(
+      const collected = collect(decorate(throwingProvider(error)));
+      const failure = expect(collected).rejects.toEqual(
         expect.objectContaining({
           code,
           details: {
@@ -219,10 +229,15 @@ describe('RuntimeModelProviderDecorator', () => {
           },
         }),
       );
+      await jest.advanceTimersByTimeAsync(SETUP_RETRY_BACKOFF_MS);
+      await failure;
 
-      expect(emitAsync).toHaveBeenCalledTimes(1);
-      const event = emitAsync.mock.calls[0][1] as InferenceCompletedEvent;
+      expect(emitAsync).toHaveBeenCalledTimes(attempts);
+      const event = emitAsync.mock.calls[
+        attempts - 1
+      ][1] as InferenceCompletedEvent;
       expect(event.error?.message).toBeTruthy();
+      jest.useRealTimers();
     },
   );
 
@@ -339,6 +354,33 @@ describe('RuntimeModelProviderDecorator', () => {
 
     await failure;
     expect(emitAsync).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('retries once when a transient connection failure happens before the first chunk', async () => {
+    jest.useFakeTimers();
+    let calls = 0;
+    const provider: ModelProvider = {
+      name: 'test:flaky-dns',
+      async *stream() {
+        calls += 1;
+        if (calls === 1) {
+          yield await Promise.reject(
+            Object.assign(new Error('getaddrinfo EAI_AGAIN'), {
+              code: 'EAI_AGAIN',
+            }),
+          );
+        }
+        yield { textDelta: 'Recovered' };
+      },
+    };
+    const { decorate } = buildHarness();
+
+    const collected = collect(decorate(provider));
+    await jest.advanceTimersByTimeAsync(SETUP_RETRY_BACKOFF_MS);
+
+    await expect(collected).resolves.toEqual([{ textDelta: 'Recovered' }]);
+    expect(calls).toBe(2);
     jest.useRealTimers();
   });
 

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-provider.decorator.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-provider.decorator.ts
@@ -15,6 +15,10 @@ import { extractUpstreamStatus } from 'src/common/errors/extract-upstream-status
 import { stripDisallowedNulls } from 'src/common/util/strip-disallowed-nulls';
 import { wrapProviderFailure } from 'src/common/errors/wrap-provider-failure.helper';
 import {
+  isRetryableSetupFailure,
+  SETUP_RETRY_BACKOFF_MS,
+} from 'src/common/errors/provider-transport-error.classifier';
+import {
   STREAM_IDLE_TIMEOUT_MS,
   StreamIdleWatchdog,
 } from 'src/common/streaming/stream-idle-watchdog';
@@ -42,6 +46,10 @@ interface CallState {
   readonly stopRelayingAbort: () => void;
 }
 
+function backoff(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 @Injectable()
 export class RuntimeModelProviderDecorator {
   private readonly logger = new Logger(RuntimeModelProviderDecorator.name);
@@ -59,10 +67,12 @@ export class RuntimeModelProviderDecorator {
   }
 
   /**
-   * A stall before any visible content is safe to retry: nothing reached the
-   * accumulator or the client, so a second attempt is indistinguishable from
-   * a slow first one (usage chunks merge last-wins). After content, a retry
-   * would duplicate what the user already watched arrive.
+   * A failure before any visible content is safe to retry: nothing reached
+   * the accumulator or the client, so a second attempt is indistinguishable
+   * from a slow first one (usage chunks merge last-wins). After content, a
+   * retry would duplicate what the user already watched arrive. Covers both
+   * stalled streams (AYC-652) and transient transport failures raised before
+   * the first chunk (AYC-653) — the latter get a short backoff first.
    */
   private async *streamWithRetry(
     provider: ModelProvider,
@@ -77,16 +87,21 @@ export class RuntimeModelProviderDecorator {
       }
       return;
     } catch (error) {
-      if (
-        streamedContent ||
-        !isStalledStreamError(error) ||
-        request.signal?.aborted
-      ) {
+      const reason = retryReason(error, streamedContent, request.signal);
+      if (!reason) {
         throw error;
       }
+      if (reason === 'transient transport failure') {
+        await backoff(SETUP_RETRY_BACKOFF_MS);
+        // Recheck after the wait — a cancellation during the backoff must
+        // not start a second attempt either.
+        if (request.signal?.aborted) {
+          throw error;
+        }
+      }
       this.logger.warn(
-        'Provider stream stalled before producing output; retrying once',
-        { model: context.model.name },
+        'Provider stream failed before producing output; retrying once',
+        { model: context.model.name, reason },
       );
     }
     yield* this.stream(provider, request, context);
@@ -279,4 +294,26 @@ function isStalledStreamError(error: unknown): boolean {
   // string code survives on AgentRuntimeError.
   const stalledCode: string = ModelErrorCode.INFERENCE_TIMEOUT;
   return error instanceof AgentRuntimeError && error.code === stalledCode;
+}
+
+/**
+ * `stream()` wraps provider failures into AgentRuntimeError before they reach
+ * the retry layer; the raw transport error the classifier understands rides
+ * on `cause`.
+ */
+function isTransientSetupError(error: unknown): boolean {
+  return (
+    error instanceof AgentRuntimeError && isRetryableSetupFailure(error.cause)
+  );
+}
+
+function retryReason(
+  error: unknown,
+  streamedContent: boolean,
+  signal: AbortSignal | undefined,
+): 'stall' | 'transient transport failure' | null {
+  if (streamedContent || signal?.aborted) return null;
+  if (isStalledStreamError(error)) return 'stall';
+  if (isTransientSetupError(error)) return 'transient transport failure';
+  return null;
 }

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.spec.ts
@@ -23,6 +23,12 @@ import {
   QuotaErrorCode,
 } from 'src/iam/quotas/application/quotas.errors';
 import { QuotaType } from 'src/iam/quotas/domain/quota-type.enum';
+import { setError } from '@appsignal/nodejs';
+import { ProviderTimeoutError } from 'src/common/errors/provider.errors';
+
+jest.mock('@appsignal/nodejs', () => ({
+  setError: jest.fn(),
+}));
 
 describe('ExecuteRunAndSetTitleUseCase', () => {
   let useCase: ExecuteRunAndSetTitleUseCase;
@@ -282,6 +288,30 @@ describe('ExecuteRunAndSetTitleUseCase', () => {
       expect(events[events.length - 1]).toEqual(
         expect.objectContaining({ type: 'session', streaming: false }),
       );
+    });
+
+    // The SSE response is committed as 200 before the run executes, so the
+    // global exception filter never sees run failures. The catch here is the
+    // only place a classified provider outage can become an AppSignal
+    // incident (AYC-653).
+    it('reports 5xx failures to AppSignal from the SSE catch', async () => {
+      const outage = new ProviderTimeoutError({ provider: 'openai' });
+      executeRunUseCase.execute.mockRejectedValue(outage);
+
+      await drain(useCase.execute(command()));
+
+      expect(setError).toHaveBeenCalledWith(outage);
+    });
+
+    it('does not report expected client errors to AppSignal', async () => {
+      (setError as jest.Mock).mockClear();
+      executeRunUseCase.execute.mockRejectedValue(
+        new QuotaExceededError(QuotaType.FAIR_USE_MESSAGES_HIGH, 1, 1, 1),
+      );
+
+      await drain(useCase.execute(command()));
+
+      expect(setError).not.toHaveBeenCalled();
     });
   });
 });

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.ts
@@ -29,6 +29,7 @@ import { Thread } from '../../../../threads/domain/thread.entity';
 import { AnonymizeTextForOrgUseCase } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case';
 import { AnonymizeTextForOrgCommand } from 'src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.command';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { reportUnexpectedError } from 'src/common/errors/report-unexpected-error.helper';
 import { ContextService } from 'src/common/context/services/context.service';
 import { RunAnonymizationUnavailableError } from '../../runs.errors';
 import type { RunExecutionOutcome } from '../../run-execution-outcome';
@@ -53,6 +54,10 @@ export class ExecuteRunAndSetTitleUseCase {
       yield* this.executeRun(command);
     } catch (error) {
       this.logger.error('Error in executeRunAndSetTitle', error);
+      // The SSE response was committed as 200 before the run started, so the
+      // global exception filter never sees this failure — report it here or
+      // provider outages produce no AppSignal incident at all (AYC-653).
+      reportUnexpectedError(error);
       yield this.toErrorEvent(error, command.threadId);
     } finally {
       yield this.sessionEvent(command.threadId, false);

--- a/ayunis-core-backend/src/domain/transcriptions/application/transcription.errors.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/application/transcription.errors.ts
@@ -7,7 +7,6 @@ import { ApplicationError } from 'src/common/errors/base.error';
 export enum TranscriptionErrorCode {
   TRANSCRIPTION_FAILED = 'TRANSCRIPTION_FAILED',
   INVALID_AUDIO_FILE = 'INVALID_AUDIO_FILE',
-  TRANSCRIPTION_SERVICE_UNAVAILABLE = 'TRANSCRIPTION_SERVICE_UNAVAILABLE',
 }
 
 /**
@@ -39,19 +38,5 @@ export class InvalidAudioFileError extends TranscriptionError {
     metadata?: ErrorMetadata,
   ) {
     super(message, TranscriptionErrorCode.INVALID_AUDIO_FILE, 400, metadata);
-  }
-}
-
-export class TranscriptionServiceUnavailableError extends TranscriptionError {
-  constructor(
-    message: string = 'Transcription service unavailable',
-    metadata?: ErrorMetadata,
-  ) {
-    super(
-      message,
-      TranscriptionErrorCode.TRANSCRIPTION_SERVICE_UNAVAILABLE,
-      503,
-      metadata,
-    );
   }
 }

--- a/ayunis-core-backend/src/domain/transcriptions/infrastructure/mistral-transcription.service.spec.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/infrastructure/mistral-transcription.service.spec.ts
@@ -63,6 +63,29 @@ describe('MistralTranscriptionService', () => {
     );
   });
 
+  // A dropped TLS connection must group under the stable provider taxonomy
+  // instead of a hand-rolled availability guess; the retry predicate itself
+  // is covered by mistral-transient-error.spec (AYC-653).
+  it('classifies transport failures under the provider taxonomy', async () => {
+    const service = await createService({
+      'models.mistral.apiKey': 'test-api-key',
+      'models.mistral.transcriptionModel': 'voxtral-mini-2602',
+    });
+    mockClient.audio.transcriptions.complete.mockRejectedValue(
+      Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }),
+    );
+
+    await expect(
+      service.transcribe(
+        Buffer.from('fake audio content'),
+        'buergeranfrage.mp3',
+        'audio/mpeg',
+      ),
+    ).rejects.toMatchObject({
+      code: 'PROVIDER_UNAVAILABLE_CONNECTION_MISTRAL',
+    });
+  });
+
   it('should return the trimmed transcription text', async () => {
     const service = await createService({
       'models.mistral.apiKey': 'test-api-key',

--- a/ayunis-core-backend/src/domain/transcriptions/infrastructure/mistral-transcription.service.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/infrastructure/mistral-transcription.service.ts
@@ -1,13 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Mistral } from '@mistralai/mistralai';
-import { SDKError } from '@mistralai/mistralai/models/errors';
 import { TranscriptionPort } from '../application/ports/transcription.port';
-import {
-  TranscriptionFailedError,
-  TranscriptionServiceUnavailableError,
-} from '../application/transcription.errors';
+import { TranscriptionFailedError } from '../application/transcription.errors';
 import retryWithBackoff from 'src/common/util/retryWithBackoff';
+import { isTransientMistralError } from 'src/common/util/mistral-transient-error';
+import { wrapProviderFailure } from 'src/common/errors/wrap-provider-failure.helper';
 
 @Injectable()
 export class MistralTranscriptionService extends TranscriptionPort {
@@ -62,11 +60,14 @@ export class MistralTranscriptionService extends TranscriptionPort {
         error: error instanceof Error ? error.message : 'Unknown error',
       });
 
-      // Check if it's a service availability issue
-      if (this.isServiceUnavailableError(error)) {
-        throw new TranscriptionServiceUnavailableError(
-          'Mistral transcription service is currently unavailable',
-        );
+      // Availability failures (transport errors, SDK 5xx, timeouts) all
+      // classify here; what falls through is a request-shaped failure.
+      const providerError = wrapProviderFailure(error, {
+        provider: 'mistral',
+        modelId: this.model,
+      });
+      if (providerError) {
+        throw providerError;
       }
 
       throw new TranscriptionFailedError(
@@ -98,29 +99,12 @@ export class MistralTranscriptionService extends TranscriptionPort {
   }
 
   private shouldRetry(error: Error): boolean {
-    const isTransient = error instanceof SDKError && error.statusCode >= 500;
+    const isTransient = isTransientMistralError(error);
     if (isTransient) {
       this.logger.warn('Retrying Mistral transcription after transient error', {
-        statusCode: error.statusCode,
         message: error.message,
       });
     }
     return isTransient;
-  }
-
-  private isServiceUnavailableError(error: unknown): boolean {
-    // Check for common service unavailable indicators
-    if (error instanceof SDKError && error.statusCode >= 500) {
-      return true;
-    }
-    const err = error as { message?: string; name?: string } | undefined;
-    const timeoutNames = ['RequestTimeoutError', 'TimeoutError'];
-    if (err?.name !== undefined && timeoutNames.includes(err.name)) {
-      return true;
-    }
-    const message = err?.message ?? '';
-    return (
-      message.includes('service unavailable') || message.includes('timeout')
-    );
   }
 }


### PR DESCRIPTION
## Problem

AppSignal incidents #409 (`EAI_AGAIN`), #387 (`ECONNRESET`), #521/#181 (`UND_ERR_HEADERS_TIMEOUT`), #509 (`23` DOMException TimeoutError from `AbortSignal.timeout` in provider-mistral) — raw transport errors instead of the AYC-538 `PROVIDER_UNAVAILABLE_*` taxonomy.

## Root cause

On current main all four error types **are already wrapped** at the application layer. They still appear raw because:

1. The undici OTel instrumentation records the raw error on the outbound span independently of our handling, and
2. **the classified error was never reported at all on send-message**: the SSE response commits a 200 before the run executes, so the global exception filter is unreachable and the wrapped `PROVIDER_UNAVAILABLE_*` error was swallowed into an SSE frame. Same for the openai-compat envelope filter.

## Changes

- `reportUnexpectedError` helper (extracted from `ApplicationErrorFilter`) now also runs in the SSE catch and the openai-compat filter — provider outages on send-message finally produce classified incidents; 4xx stays unreported
- One-shot retry with 500ms backoff on transient connection failures (EAI_AGAIN, ECONNRESET, …) before the first chunk, both inference paths (`isRetryableSetupFailure` exported beside the classifier; timeouts deliberately excluded)
- Classifier preserves numeric DOMException codes (`23`) as `underlyingCode`
- `isTransientMistralError` consults the transport classifier — bare undici timeouts, DNS failures and body-read TimeoutErrors now retry within existing backoffs (OCR, embeddings, transcription)
- Wrapped the two remaining unwrapped call sites: image generation and Mistral transcription (replacing its message-substring matching)

## Verification

- New specs across classifier, wrap helper consumers, both retry seams, SSE/openai-compat reporting
- Full backend suite: 3908 tests pass

Part of the AppSignal stack AYC-651…AYC-655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core inference streaming retry semantics and observability on committed-200 SSE paths; behavior is heavily spec-covered but duplicate-chunk and double-billing edge cases depend on strict pre-first-chunk guards.
> 
> **Overview**
> **Provider transport handling (AYC-653)** tightens how transient outbound failures are classified, retried, and observed when the global exception filter never runs.
> 
> The transport classifier now keeps **numeric codes** (e.g. DOMException `TimeoutError` code `23`) on name-matched nodes and exports **`isRetryableSetupFailure`** plus **`SETUP_RETRY_BACKOFF_MS` (500ms)** — only **connection** class failures retry at setup; **timeouts are excluded** so waits are not doubled.
> 
> **AppSignal:** `reportUnexpectedError` is extracted from `ApplicationErrorFilter` and reused in the **send-message SSE catch** (`execute-run-and-set-title`) and **OpenAI-compat** filter so classified `PROVIDER_UNAVAILABLE_*` 5xx incidents are recorded; 4xx behavior matches the filter.
> 
> **Streaming:** `RuntimeStreamInferenceHandler` and `RuntimeModelProviderDecorator` perform **one retry** after backoff when a **connection** transport error occurs **before the first chunk** (no retry after content, on cancel, or for non-transport errors).
> 
> **Mistral / other call sites:** `isTransientMistralError` delegates bare undici/DNS/timeout shapes to the classifier. **Image generation** and **Mistral transcription** use `wrapProviderFailure` instead of generic or string-matched errors; `TranscriptionServiceUnavailableError` is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16128348a7227f0703290655519aff26d8a236da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->