### PR TITLE
fix(chat-ui): remove duplicate rename pencil icon from chat header (AYC-521)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/ui/ChatHeader.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatHeader.tsx
@@ -18,7 +18,7 @@ import {
 interface ChatHeaderProps {
   readonly threadTitle?: string;
   readonly isAnonymous: boolean;
-  readonly onRename: (openDialog?: boolean) => void;
+  readonly onRename: () => void;
   readonly onDelete: () => void;
 }
 
@@ -53,38 +53,23 @@ export default function ChatHeader({
       ]}
       badge={anonymousBadge}
       action={
-        <>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                onClick={() => onRename()}
-                variant="ghost"
-                size="icon"
-                aria-label={t('chat.renameThread')}
-              >
-                <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{t('chat.renameThread')}</TooltipContent>
-          </Tooltip>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <MoreVertical className="h-5 w-5 text-primary" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={() => onRename(true)}>
-                <Pencil className="h-4 w-4" />
-                <span>{t('chat.renameThread')}</span>
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={onDelete} variant="destructive">
-                <Trash2 />
-                <span>{t('chat.deleteThread')}</span>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon">
+              <MoreVertical className="h-5 w-5 text-primary" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={onRename}>
+              <Pencil className="h-4 w-4" />
+              <span>{t('chat.renameThread')}</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={onDelete} variant="destructive">
+              <Trash2 />
+              <span>{t('chat.deleteThread')}</span>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       }
     />
   );

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -354,14 +354,9 @@ export default function ChatPage({
     });
   }
 
-  function handleRenameThread(fromDropdown = false) {
-    // eslint-disable-next-line sonarjs/no-selector-parameter
-    if (fromDropdown) {
-      // Delay to allow dropdown menu to fully close first
-      setTimeout(() => setRenameDialogOpen(true), 0);
-    } else {
-      setRenameDialogOpen(true);
-    }
+  function handleRenameThread() {
+    // Delay to allow dropdown menu to fully close first
+    setTimeout(() => setRenameDialogOpen(true), 0);
   }
 
   const chatHeader = (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The chat header exposed the rename action twice: a standalone pencil icon button **and** a "Rename chat" item in the `⋮` dropdown menu. The pencil icon is redundant.

Resolves [AYC-521](https://linear.app/issue/AYC-521).

## Change

- Removed the pencil icon `Button` (and its tooltip wrapper) from `ChatHeader`, keeping the "Rename chat" dropdown menu item as the single rename entry point.
- Simplified `onRename` to a no-arg callback. The `openDialog`/`fromDropdown` parameter only existed to distinguish the pencil icon (immediate) from the dropdown (delayed to let the menu close). With only the dropdown remaining, `handleRenameThread` always applies the close-delay.

## Validation

- `tsc --noEmit` passes.
- ESLint clean on changed lines (a pre-existing `prefer-nullish-coalescing` unused-disable warning on an untouched line is a local toolchain-version artifact, unrelated to this change).

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-521](https://linear.app/ayunis/issue/AYC-521/chat-can-be-renamed-twice)

<div><a href="https://cursor.com/agents/bc-7d60a3e3-ac54-4082-9fc8-3d3424f5fafd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d60a3e3-ac54-4082-9fc8-3d3424f5fafd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

