### PR TITLE
fix(runs): retry once when a provider stream stalls before output (AYC-652)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-provider.decorator.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-provider.decorator.spec.ts
@@ -272,6 +272,42 @@ describe('RuntimeModelProviderDecorator', () => {
     ).rejects.toBeInstanceOf(RunAbortedError);
   });
 
+  it('retries once when the stream stalls before any content', async () => {
+    jest.useFakeTimers();
+    let calls = 0;
+    const provider: ModelProvider = {
+      name: 'test:stalls-then-recovers',
+      async *stream(providerRequest) {
+        calls += 1;
+        if (calls === 1) {
+          // Usage arrives, then the provider goes silent — nothing the user
+          // can see was produced, so the retry is invisible.
+          yield { usage: { inputTokens: 2048 } };
+          await waitForAbort(providerRequest.signal);
+          return;
+        }
+        yield { textDelta: 'Die Antwort nach dem zweiten Anlauf.' };
+      },
+    };
+    const { decorate, emitAsync } = buildHarness();
+    const iterator = decorate(provider).stream(request)[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { usage: { inputTokens: 2048 } },
+    });
+    const nextChunk = iterator.next();
+    await jest.advanceTimersByTimeAsync(STREAM_IDLE_TIMEOUT_MS);
+    await expect(nextChunk).resolves.toMatchObject({
+      value: { textDelta: 'Die Antwort nach dem zweiten Anlauf.' },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({ done: true });
+
+    expect(calls).toBe(2);
+    // One completion event per model call, like the legacy path.
+    expect(emitAsync).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
+  });
+
   it('aborts a stalled provider after the shared inter-chunk timeout', async () => {
     jest.useFakeTimers();
     const provider: ModelProvider = {

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-provider.decorator.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-provider.decorator.ts
@@ -23,6 +23,7 @@ import {
   InferenceFailedError,
   InferenceImageTooLargeError,
   InferenceStreamStalledError,
+  ModelErrorCode,
 } from 'src/domain/models/application/models.errors';
 import type { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import { InferenceCompletedEvent } from '../events/inference-completed.event';
@@ -53,8 +54,42 @@ export class RuntimeModelProviderDecorator {
   ): ModelProvider {
     return {
       name: provider.name,
-      stream: (request) => this.stream(provider, request, context),
+      stream: (request) => this.streamWithRetry(provider, request, context),
     };
+  }
+
+  /**
+   * A stall before any visible content is safe to retry: nothing reached the
+   * accumulator or the client, so a second attempt is indistinguishable from
+   * a slow first one (usage chunks merge last-wins). After content, a retry
+   * would duplicate what the user already watched arrive.
+   */
+  private async *streamWithRetry(
+    provider: ModelProvider,
+    request: ProviderRequest,
+    context: RuntimeModelCallContext,
+  ): AsyncIterable<ProviderChunk> {
+    let streamedContent = false;
+    try {
+      for await (const chunk of this.stream(provider, request, context)) {
+        streamedContent ||= isContentChunk(chunk);
+        yield chunk;
+      }
+      return;
+    } catch (error) {
+      if (
+        streamedContent ||
+        !isStalledStreamError(error) ||
+        request.signal?.aborted
+      ) {
+        throw error;
+      }
+      this.logger.warn(
+        'Provider stream stalled before producing output; retrying once',
+        { model: context.model.name },
+      );
+    }
+    yield* this.stream(provider, request, context);
   }
 
   private async *stream(
@@ -229,4 +264,19 @@ function isAbortError(error: unknown): boolean {
     (error instanceof Error || error instanceof DOMException) &&
     error.name === 'AbortError'
   );
+}
+
+function isContentChunk(chunk: ProviderChunk): boolean {
+  return Boolean(
+    chunk.textDelta ||
+    chunk.thinkingDelta ||
+    (chunk.toolCallDeltas && chunk.toolCallDeltas.length > 0),
+  );
+}
+
+function isStalledStreamError(error: unknown): boolean {
+  // The runtime boundary serializes classified errors, so only the plain
+  // string code survives on AgentRuntimeError.
+  const stalledCode: string = ModelErrorCode.INFERENCE_TIMEOUT;
+  return error instanceof AgentRuntimeError && error.code === stalledCode;
 }

--- a/ayunis-core-backend/src/domain/runs/application/helpers/stream-usage.helper.ts
+++ b/ayunis-core-backend/src/domain/runs/application/helpers/stream-usage.helper.ts
@@ -1,0 +1,72 @@
+import { Logger } from '@nestjs/common';
+
+const logger = new Logger('StreamUsage');
+
+/** The one facet of a stream chunk this helper reads — structural on purpose, so it needs no cross-module port import. */
+interface UsageBearingChunk {
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadInputTokens?: number;
+    cacheWriteInputTokens?: number;
+  };
+}
+
+export function extractUsageFromChunks(
+  chunks: UsageBearingChunk[],
+): { inputTokens: number; outputTokens: number } | undefined {
+  const usage = lastWinsUsage(chunks);
+  const uncachedInputTokens = usage.inputTokens ?? 0;
+  const cacheRead = usage.cacheReadInputTokens ?? 0;
+  const cacheWrite = usage.cacheWriteInputTokens ?? 0;
+  const hasCache = cacheRead > 0 || cacheWrite > 0;
+  if (
+    usage.inputTokens === undefined &&
+    usage.outputTokens === undefined &&
+    !hasCache
+  ) {
+    return undefined;
+  }
+  if (hasCache) {
+    logger.debug('Prompt cache activity', {
+      uncachedInputTokens,
+      cacheReadInputTokens: cacheRead,
+      cacheWriteInputTokens: cacheWrite,
+    });
+  }
+  // Cached prompt tokens are billed as ordinary input: the provider's
+  // inputTokens excludes tokens covered by the prompt cache, so without
+  // this the billed input collapses to the uncached remainder (~3 tokens).
+  return {
+    inputTokens: uncachedInputTokens + cacheRead + cacheWrite,
+    outputTokens: usage.outputTokens ?? 0,
+  };
+}
+
+/**
+ * Providers report cumulative usage on every chunk (Gemini repeats
+ * promptTokenCount on each chunk; candidatesTokenCount only appears on the
+ * final one). Summing across chunks would over-count, so take last-wins per
+ * field, matching the non-streaming accumulator (response-accumulator.ts).
+ */
+function lastWinsUsage(
+  chunks: UsageBearingChunk[],
+): NonNullable<UsageBearingChunk['usage']> {
+  const result: NonNullable<UsageBearingChunk['usage']> = {};
+  for (const chunk of chunks) {
+    if (!chunk.usage) continue;
+    if (chunk.usage.inputTokens !== undefined) {
+      result.inputTokens = chunk.usage.inputTokens;
+    }
+    if (chunk.usage.outputTokens !== undefined) {
+      result.outputTokens = chunk.usage.outputTokens;
+    }
+    if (chunk.usage.cacheReadInputTokens !== undefined) {
+      result.cacheReadInputTokens = chunk.usage.cacheReadInputTokens;
+    }
+    if (chunk.usage.cacheWriteInputTokens !== undefined) {
+      result.cacheWriteInputTokens = chunk.usage.cacheWriteInputTokens;
+    }
+  }
+  return result;
+}

--- a/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.spec.ts
@@ -1,11 +1,15 @@
-import { from } from 'rxjs';
+import { from, Observable, throwError } from 'rxjs';
 import type { UUID } from 'crypto';
 import { StreamingInferenceService } from './streaming-inference.service';
+import { extractUsageFromChunks } from '../helpers/stream-usage.helper';
 import {
   StreamInferenceResponseChunk,
   StreamInferenceResponseChunkToolCall,
 } from 'src/domain/models/application/ports/stream-inference.handler';
-import { InferenceFailedError } from 'src/domain/models/application/models.errors';
+import {
+  InferenceFailedError,
+  InferenceStreamStalledError,
+} from 'src/domain/models/application/models.errors';
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
 import type { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
@@ -18,17 +22,7 @@ import type { ContextService } from 'src/common/context/services/context.service
 import type { EventEmitter2 } from '@nestjs/event-emitter';
 import { ModelTier } from 'src/domain/models/domain/value-objects/model-tier.enum';
 
-describe('StreamingInferenceService.extractUsageFromChunks', () => {
-  // extractUsageFromChunks is a pure method that does not touch `this`, so we
-  // can exercise it without wiring up the service's dependencies.
-  const service = new StreamingInferenceService(
-    null as never,
-    null as never,
-    null as never,
-    null as never,
-    null as never,
-  );
-
+describe('extractUsageFromChunks', () => {
   const chunkWithUsage = (usage: {
     inputTokens?: number;
     outputTokens?: number;
@@ -44,7 +38,7 @@ describe('StreamingInferenceService.extractUsageFromChunks', () => {
 
   it('returns undefined when no chunk carries usage', () => {
     expect(
-      service.extractUsageFromChunks([
+      extractUsageFromChunks([
         StreamInferenceResponseChunk.text('a'),
         StreamInferenceResponseChunk.text('b'),
       ]),
@@ -54,7 +48,7 @@ describe('StreamingInferenceService.extractUsageFromChunks', () => {
   it('takes last-wins instead of summing cumulative per-chunk usage', () => {
     // Providers (e.g. Gemini, Mistral) report cumulative usage on every chunk.
     // Summing would over-count; the final values are the truth.
-    const usage = service.extractUsageFromChunks([
+    const usage = extractUsageFromChunks([
       chunkWithUsage({ inputTokens: 100, outputTokens: 10 }),
       chunkWithUsage({ inputTokens: 100, outputTokens: 25 }),
       chunkWithUsage({ inputTokens: 100, outputTokens: 42 }),
@@ -65,7 +59,7 @@ describe('StreamingInferenceService.extractUsageFromChunks', () => {
   it('carries forward the last defined value of each field independently', () => {
     // Gemini repeats promptTokenCount on every chunk but only emits
     // candidatesTokenCount on the final chunk.
-    const usage = service.extractUsageFromChunks([
+    const usage = extractUsageFromChunks([
       chunkWithUsage({ inputTokens: 100 }),
       chunkWithUsage({ inputTokens: 100 }),
       chunkWithUsage({ inputTokens: 100, outputTokens: 30 }),
@@ -77,7 +71,7 @@ describe('StreamingInferenceService.extractUsageFromChunks', () => {
     // Anthropic's input_tokens excludes tokens served by or written to the
     // prompt cache. Option A billing: customers pay for the full prompt as
     // if uncached, so cache read/write tokens count as input.
-    const usage = service.extractUsageFromChunks([
+    const usage = extractUsageFromChunks([
       chunkWithUsage({
         inputTokens: 3,
         cacheWriteInputTokens: 9677,
@@ -89,7 +83,7 @@ describe('StreamingInferenceService.extractUsageFromChunks', () => {
   });
 
   it('bills cache reads and writes together with uncached input', () => {
-    const usage = service.extractUsageFromChunks([
+    const usage = extractUsageFromChunks([
       chunkWithUsage({
         inputTokens: 10,
         cacheWriteInputTokens: 200,
@@ -147,9 +141,12 @@ describe('StreamingInferenceService.executeStreamingInference — tool-call inte
       finishReason,
     });
 
-  const buildService = (chunks: StreamInferenceResponseChunk[]) => {
+  const buildService = (chunks: StreamInferenceResponseChunk[]) =>
+    buildServiceWithStream(jest.fn().mockReturnValue(from(chunks)));
+
+  const buildServiceWithStream = (execute: jest.Mock) => {
     const streamInferenceUseCase = {
-      execute: jest.fn().mockReturnValue(from(chunks)),
+      execute,
     } as unknown as StreamInferenceUseCase;
     const savedMessages: AssistantMessage[] = [];
     const saveAssistantMessageUseCase = {
@@ -302,6 +299,54 @@ describe('StreamingInferenceService.executeStreamingInference — tool-call inte
     expect(savedMessages).toHaveLength(1);
     const [text] = savedMessages[0].content;
     expect(text).toBeInstanceOf(TextMessageContent);
+  });
+
+  it('retries once when the stream stalls before producing any output', async () => {
+    const stalled = new InferenceStreamStalledError(180_000);
+    const healthyChunks = [
+      StreamInferenceResponseChunk.text('Die Zugspitze ist der höchste Berg.'),
+      finishChunk('stop'),
+    ];
+    const execute = jest
+      .fn()
+      .mockReturnValueOnce(throwError(() => stalled))
+      .mockReturnValueOnce(from(healthyChunks));
+    const { service, savedMessages } = buildServiceWithStream(execute);
+
+    await consume(service);
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(savedMessages).toHaveLength(1);
+    const [text] = savedMessages[0].content;
+    expect((text as TextMessageContent).text).toContain('Zugspitze');
+  });
+
+  it('does not retry a stall that happens after output was streamed', async () => {
+    const stalled = new InferenceStreamStalledError(180_000);
+    // Emit the text a macrotask before the error so the consumer actually
+    // receives it, as it would with a real provider stream.
+    const execute = jest.fn().mockReturnValueOnce(
+      new Observable<StreamInferenceResponseChunk>((subscriber) => {
+        subscriber.next(
+          StreamInferenceResponseChunk.text('Die Antwort beginnt'),
+        );
+        setTimeout(() => subscriber.error(stalled), 0);
+      }),
+    );
+    const { service } = buildServiceWithStream(execute);
+
+    await expect(consume(service)).rejects.toThrow(InferenceStreamStalledError);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry non-stall stream failures', async () => {
+    const execute = jest
+      .fn()
+      .mockReturnValueOnce(throwError(() => new Error('provider exploded')));
+    const { service } = buildServiceWithStream(execute);
+
+    await expect(consume(service)).rejects.toThrow('provider exploded');
+    expect(execute).toHaveBeenCalledTimes(1);
   });
 
   it('treats a tool call that streamed no arguments as an empty object', async () => {

--- a/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.ts
@@ -23,13 +23,29 @@ import {
   assertToolCallArgumentsIntact,
   parseFinalToolArguments,
 } from '../helpers/tool-call-arguments.helper';
+import { InferenceStreamStalledError } from 'src/domain/models/application/models.errors';
 import { ContextService } from 'src/common/context/services/context.service';
 import { InferenceCompletedEvent } from '../events/inference-completed.event';
 import { extractInferenceErrorInfo } from '../helpers/extract-inference-error-info.helper';
 import { observableToBufferedAsyncIterable } from '../helpers/buffered-stream.helper';
+import { extractUsageFromChunks } from '../helpers/stream-usage.helper';
 
 type AssistantContentBlock =
   TextMessageContent | ToolUseMessageContent | ThinkingMessageContent;
+
+interface StreamingInferenceParams {
+  model: LanguageModel;
+  messages: Message[];
+  tools: Tool[];
+  instructions?: string;
+  threadId: UUID;
+  orgId: UUID;
+}
+
+/** Set as soon as an attempt streams visible content — after that, a retry would duplicate it. */
+interface OutputTracker {
+  producedOutput: boolean;
+}
 
 interface AccumulatedToolCall {
   id: string | null;
@@ -82,14 +98,36 @@ export class StreamingInferenceService {
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
-  async *executeStreamingInference(params: {
-    model: LanguageModel;
-    messages: Message[];
-    tools: Tool[];
-    instructions?: string;
-    threadId: UUID;
-    orgId: UUID;
-  }): AsyncGenerator<AssistantMessage, void, unknown> {
+  async *executeStreamingInference(
+    params: StreamingInferenceParams,
+  ): AsyncGenerator<AssistantMessage, void, unknown> {
+    const tracker = { producedOutput: false };
+    try {
+      yield* this.streamAttempt(params, tracker);
+      return;
+    } catch (error) {
+      // A stall before any output is safe to retry: nothing was streamed to
+      // the client and nothing was persisted, so the second attempt is
+      // indistinguishable from a slow first one. After output, a retry
+      // would duplicate content the user already watched arrive.
+      if (
+        !(error instanceof InferenceStreamStalledError) ||
+        tracker.producedOutput
+      ) {
+        throw error;
+      }
+      this.logger.warn(
+        'Provider stream stalled before producing output; retrying once',
+        { threadId: params.threadId },
+      );
+    }
+    yield* this.streamAttempt(params, { producedOutput: false });
+  }
+
+  private async *streamAttempt(
+    params: StreamingInferenceParams,
+    tracker: OutputTracker,
+  ): AsyncGenerator<AssistantMessage, void, unknown> {
     const { model, tools, threadId, orgId } = params;
 
     const stream$ = this.startStream(params);
@@ -114,6 +152,7 @@ export class StreamingInferenceService {
         assistantMessage,
         state,
         tools,
+        tracker,
       );
     } catch (error) {
       inferenceError = error;
@@ -159,7 +198,7 @@ export class StreamingInferenceService {
     chunks: StreamInferenceResponseChunk[],
     messageId: UUID,
   ): void {
-    const usage = this.extractUsageFromChunks(chunks);
+    const usage = extractUsageFromChunks(chunks);
     if (usage) {
       this.inferenceUsageGuard.collectUsage(model, usage, messageId);
     }
@@ -200,11 +239,13 @@ export class StreamingInferenceService {
     assistantMessage: AssistantMessage,
     state: AccumulatedState,
     tools: Tool[],
+    tracker: OutputTracker,
   ): AsyncGenerator<AssistantMessage, void, unknown> {
     for await (const chunk of asyncIterable) {
       const shouldUpdate = this.accumulateChunk(chunk, state);
 
       if (shouldUpdate) {
+        tracker.producedOutput = true;
         assistantMessage.content = this.buildMessageContent(state, tools);
         yield assistantMessage;
       }
@@ -417,64 +458,5 @@ export class StreamingInferenceService {
         ),
       );
     });
-  }
-
-  extractUsageFromChunks(
-    chunks: StreamInferenceResponseChunk[],
-  ): { inputTokens: number; outputTokens: number } | undefined {
-    const usage = this.lastWinsUsage(chunks);
-    const uncachedInputTokens = usage.inputTokens ?? 0;
-    const cacheRead = usage.cacheReadInputTokens ?? 0;
-    const cacheWrite = usage.cacheWriteInputTokens ?? 0;
-    const hasCache = cacheRead > 0 || cacheWrite > 0;
-    if (
-      usage.inputTokens === undefined &&
-      usage.outputTokens === undefined &&
-      !hasCache
-    ) {
-      return undefined;
-    }
-    if (hasCache) {
-      this.logger.debug('Prompt cache activity', {
-        uncachedInputTokens,
-        cacheReadInputTokens: cacheRead,
-        cacheWriteInputTokens: cacheWrite,
-      });
-    }
-    // Cached prompt tokens are billed as ordinary input: the provider's
-    // inputTokens excludes tokens covered by the prompt cache, so without
-    // this the billed input collapses to the uncached remainder (~3 tokens).
-    return {
-      inputTokens: uncachedInputTokens + cacheRead + cacheWrite,
-      outputTokens: usage.outputTokens ?? 0,
-    };
-  }
-
-  /**
-   * Providers report cumulative usage on every chunk (Gemini repeats
-   * promptTokenCount on each chunk; candidatesTokenCount only appears on the
-   * final one). Summing across chunks would over-count, so take last-wins per
-   * field, matching the non-streaming accumulator (response-accumulator.ts).
-   */
-  private lastWinsUsage(
-    chunks: StreamInferenceResponseChunk[],
-  ): NonNullable<StreamInferenceResponseChunk['usage']> {
-    const result: NonNullable<StreamInferenceResponseChunk['usage']> = {};
-    for (const chunk of chunks) {
-      if (!chunk.usage) continue;
-      if (chunk.usage.inputTokens !== undefined) {
-        result.inputTokens = chunk.usage.inputTokens;
-      }
-      if (chunk.usage.outputTokens !== undefined) {
-        result.outputTokens = chunk.usage.outputTokens;
-      }
-      if (chunk.usage.cacheReadInputTokens !== undefined) {
-        result.cacheReadInputTokens = chunk.usage.cacheReadInputTokens;
-      }
-      if (chunk.usage.cacheWriteInputTokens !== undefined) {
-        result.cacheWriteInputTokens = chunk.usage.cacheWriteInputTokens;
-      }
-    }
-    return result;
   }
 }


### PR DESCRIPTION
## Problem ([AYC-652](https://linear.app/ayunis/issue/AYC-652))

When a provider stream genuinely stalls, the run currently fails outright — even when the stall happened before a single token reached the user, where a retry would be completely invisible.

## Change

Both run loops now **retry the model call once** when the stream stalls having produced no visible content (no text, thinking, or tool-call deltas):

- legacy loop: `StreamingInferenceService` wraps its streaming attempt and re-issues it once on a content-less `InferenceStreamStalledError`;
- runtime loop: `RuntimeModelProviderDecorator.streamWithRetry` does the same around the decorated provider stream (usage chunks merge last-wins, so an attempt-1 usage chunk is harmless).

A stall *after* visible content still fails immediately — retrying would duplicate what the user already watched arrive. One completion event is emitted per attempt, matching existing metrics semantics. The usage math moved to a pure `stream-usage.helper.ts` to keep the service under the 500-line cap.

Part 2/2 on top of #1245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core inference/run loops and can issue a duplicate provider call on stall, but guards limit retries to pre-output stalls and cap at one attempt; billing semantics rely on last-wins usage merging.
> 
> **Overview**
> Adds a **single automatic retry** when a model stream hits an idle-timeout stall **before** any user-visible output (text, thinking, or tool-call deltas). The legacy path wraps `executeStreamingInference` in `streamAttempt` with an `OutputTracker`; the agent-runtime path routes decorated providers through `streamWithRetry` and treats `INFERENCE_TIMEOUT` on `AgentRuntimeError` as retriable.
> 
> Stalls **after** content has started still fail immediately, and other errors are not retried. Usage-only chunks on a failed attempt do not block retry (runtime treats them as non-content; billing stays last-wins). **Stream usage aggregation** moves from `StreamingInferenceService` into shared `extractUsageFromChunks` in `stream-usage.helper.ts`, with specs updated for retry behavior and the extracted helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1295e6ff22abcf10a256e84b5125cf69be8b75cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->