### PR TITLE
fix(chat-ui): show a clear timeout message when the model stream stalls (AYC-665)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/hooks/useRunErrorHandler.test.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/useRunErrorHandler.test.ts
@@ -28,4 +28,19 @@ describe('useRunErrorHandler', () => {
 
     expect(showError).toHaveBeenCalledWith('chat.errorContextBudgetExceeded');
   });
+
+  it('shows the timeout explanation when the provider stream stalls', () => {
+    const { result } = renderHook(() => useRunErrorHandler('thread-1'));
+    const error: RunErrorResponseDto = {
+      type: 'error',
+      message: 'Model stream produced no data for 180000ms',
+      threadId: 'thread-1',
+      timestamp: '2026-08-05T11:00:00.000Z',
+      code: 'INFERENCE_TIMEOUT',
+    };
+
+    act(() => result.current(error));
+
+    expect(showError).toHaveBeenCalledWith('chat.errorInferenceTimeout');
+  });
 });

--- a/ayunis-core-frontend/src/pages/chat/hooks/useRunErrorHandler.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/useRunErrorHandler.ts
@@ -15,6 +15,9 @@ export function useRunErrorHandler(_threadId: string) {
         case 'INFERENCE_IMAGE_TOO_LARGE':
           showError(t('chat.errorImageTooLarge'));
           break;
+        case 'INFERENCE_TIMEOUT':
+          showError(t('chat.errorInferenceTimeout'));
+          break;
         case 'RUN_NO_MODEL_FOUND':
           showError(t('chat.errorNoModelFound'));
           break;

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -16,6 +16,7 @@
     "upgradeToProError": "Sie müssen ein Abonnement haben, um diese Funktion zu verwenden.",
     "errorExecutionError": "Fehler beim Abruf der Antwort",
     "errorImageTooLarge": "Das Bild ist zu groß für das gewählte Modell. Bitte verkleinern Sie es (z. B. Auflösung reduzieren) und versuchen Sie es erneut.",
+    "errorInferenceTimeout": "Das Modell hat zu lange nicht geantwortet. Die Verbindung wurde getrennt — bitte versuchen Sie es erneut.",
     "errorUnexpected": "Ein unerwarteter Fehler ist aufgetreten",
     "errorNoModelFound": "Kein Modell gefunden",
     "errorMaxIterationsReached": "Maximale Anzahl an Iterationen erreicht",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -16,6 +16,7 @@
     "upgradeToProError": "You need to upgrade to a paid plan to use this feature.",
     "errorExecutionError": "Error fetching response",
     "errorImageTooLarge": "The image is too large for the selected model. Please reduce its size (e.g. lower the resolution) and try again.",
+    "errorInferenceTimeout": "The model stopped responding and the connection was closed. Please try again.",
     "errorUnexpected": "An unexpected error occurred",
     "errorNoModelFound": "No model found",
     "errorMaxIterationsReached": "Maximal number of iterations reached",


### PR DESCRIPTION
## Problem

When a provider stream stalls and the watchdog aborts the run (and the automatic retry could not save it), the SSE error frame carries `code: "INFERENCE_TIMEOUT"` — but the chat error handler has no case for it, so users see the generic "Ein unerwarteter Fehler ist aufgetreten". This is exactly what the affected customer saw in AYC-665.

## Fix

Map `INFERENCE_TIMEOUT` to an honest, actionable toast:

- DE: "Das Modell hat zu lange nicht geantwortet. Die Verbindung wurde getrennt — bitte versuchen Sie es erneut."
- EN: "The model stopped responding and the connection was closed. Please try again."

Note: users only ever see this toast when the auto-retry (#1246) couldn't recover the run — the common stall case stays invisible.

## Testing

- New unit test in `useRunErrorHandler.test.ts` asserting the code maps to the new message
- `tsc --noEmit`, eslint `--max-warnings=0`, vitest all clean

Part of AYC-665 / AYC-652 stack (on top of #1246).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-handling only; no auth, data, or inference logic changes.
> 
> **Overview**
> When a run fails with **`INFERENCE_TIMEOUT`** (provider stream stalled after the watchdog aborts and retry did not recover), chat no longer falls through to the generic unexpected-error toast.
> 
> **`useRunErrorHandler`** now maps that code to a dedicated i18n key, with new **EN/DE** copy explaining that the model stopped responding and the user should try again. A unit test asserts the mapping for a sample SSE error payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be34ee9758e89cf8edbe52f07d8ec026946ce057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->