### PR TITLE
fix(observability): separate appsignal staging environment via APPSIGNAL_APP_ENV override (AYC-480)

### DIFF
--- a/ayunis-core-backend/.env.example
+++ b/ayunis-core-backend/.env.example
@@ -30,6 +30,9 @@ WEBHOOK_SIGNING_SECRET=
 # Optional: Report errors/performance/logs to AppSignal (production only).
 # APP_REVISION additionally marks the running version (defaults to package.json version).
 # APPSIGNAL_APP_NAME overrides the dashboard app name (defaults to ayunis-core).
+# APPSIGNAL_APP_ENV overrides the AppSignal environment name (defaults to
+# NODE_ENV). Set to "staging" on staging hosts that run with
+# NODE_ENV=production so staging data stays out of production monitoring.
 APPSIGNAL_PUSH_API_KEY=
 # Optional, HTTP keep-alive timeout in ms (default 65000). Must exceed the
 # idle timeout of YOUR fronting proxy/load balancer, or idle sockets close

--- a/ayunis-core-backend/appsignal.cjs
+++ b/ayunis-core-backend/appsignal.cjs
@@ -21,7 +21,12 @@ config({ path: '.env.dev', quiet: true });
 config({ path: '.env', quiet: true });
 
 const pushApiKey = process.env.APPSIGNAL_PUSH_API_KEY;
-const environment = process.env.NODE_ENV ?? 'development';
+// APPSIGNAL_APP_ENV lets staging hosts (which run with NODE_ENV=production
+// for migrations/logger/CORS behavior) report into a separate AppSignal
+// environment. Must be resolved here: the explicit `environment` option
+// below overrides AppSignal's own APPSIGNAL_APP_ENV handling.
+const environment =
+  process.env.APPSIGNAL_APP_ENV ?? process.env.NODE_ENV ?? 'development';
 const revision = process.env.APP_REVISION ?? readPackageVersion();
 
 function readPackageVersion() {


### PR DESCRIPTION
- appsignal.cjs resolves the environment as APPSIGNAL_APP_ENV ?? NODE_ENV
  ?? development; the explicit constructor option otherwise ignores
  AppSignal's own APPSIGNAL_APP_ENV handling
- staging hosts run with NODE_ENV=production (migrations/logger/CORS), so
  without the override they would report into the production environment
- document APPSIGNAL_APP_ENV in .env.example

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only bootstrap change with no impact on auth, data, or request handling; misconfiguration could route staging signals to the wrong AppSignal environment.
> 
> **Overview**
> Staging can keep **`NODE_ENV=production`** for app behavior while sending AppSignal errors and performance data to a **separate dashboard environment**.
> 
> **`appsignal.cjs`** now sets the AppSignal `environment` from **`APPSIGNAL_APP_ENV`**, then **`NODE_ENV`**, then **`development`**. That value is passed explicitly into the Appsignal constructor, which otherwise would not honor **`APPSIGNAL_APP_ENV`** on its own. Operators can set **`APPSIGNAL_APP_ENV=staging`** on staging hosts so telemetry does not mix with production.
> 
> **`.env.example`** documents **`APPSIGNAL_APP_ENV`** and when to use it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6ee037bac6a331800debe870569f33a92a510a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->