### PR TITLE
feat(observability): frontend appsignal sourcemaps, ignore rules and context tags (AYC-539)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -103,6 +103,12 @@ jobs:
           platforms: linux/${{ matrix.platform }}
           provenance: false
           labels: ${{ steps.meta.outputs.labels }}
+          # Consumed only by the app Dockerfile: inlined into the frontend
+          # bundle as VITE_APP_REVISION and exported as ENV APP_REVISION, so
+          # both ends report the built commit to AppSignal and the
+          # `sourcemaps` job below uploads maps under the same revision.
+          build-args: |
+            APP_REVISION=${{ github.sha }}
           outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
           # Registry cache rather than type=gha: four images across two
           # platforms export eight mode=max scopes, and the two anonymize layer
@@ -243,3 +249,99 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/ayunis-core/ayunis-infra/dispatches \
             -d "$(jq -nc --arg image "$IMAGE" --arg tag "$TAG" '{event_type:"image-published",client_payload:{image:$image,tag:$tag}}')"
+
+  # Uploads the frontend sourcemaps for this commit to AppSignal (AYC-539).
+  # Vite builds with `sourcemap: 'hidden'`; the image deletes the maps (they
+  # must not be publicly served), so this job rebuilds the frontend and
+  # uploads them out of band. Rollup's content-addressed asset names depend
+  # only on source + lockfile, both pinned to the same commit the image
+  # build uses — and node is pinned to the Dockerfile's version to keep the
+  # toolchain identical — so the names here match the published bundles.
+  #
+  # The frontend client normalizes backtrace paths to `assets/<chunk>.js`
+  # (matchBacktracePaths in src/shared/lib/appsignal.ts), which is exactly
+  # the name each map is uploaded under — one upload serves every
+  # deployment hostname. Revision is the git sha, the same APP_REVISION the
+  # image reports.
+  #
+  # Requires the APPSIGNAL_PUSH_API_KEY secret (the org push key appsignal.cjs
+  # also uses on the hosts). Optional repo variables:
+  #   APPSIGNAL_FRONTEND_APP_NAME     — AppSignal app to upload to
+  #                                     (default: ayunis-core-frontend)
+  #   APPSIGNAL_FRONTEND_ENVIRONMENTS — space-separated environments
+  #                                     (default: staging production)
+  # Skips with a notice instead of failing while the secret is not set up.
+  sourcemaps:
+    runs-on: ubuntu-latest
+    env:
+      APPSIGNAL_PUSH_API_KEY: ${{ secrets.APPSIGNAL_PUSH_API_KEY }}
+      APPSIGNAL_FRONTEND_APP_NAME: ${{ vars.APPSIGNAL_FRONTEND_APP_NAME || 'ayunis-core-frontend' }}
+      APPSIGNAL_FRONTEND_ENVIRONMENTS: ${{ vars.APPSIGNAL_FRONTEND_ENVIRONMENTS || 'staging production' }}
+    steps:
+      - name: Check for push API key
+        id: gate
+        run: |
+          if [ -z "$APPSIGNAL_PUSH_API_KEY" ]; then
+            echo "::notice::APPSIGNAL_PUSH_API_KEY is not configured - skipping sourcemap upload"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        if: steps.gate.outputs.enabled == 'true'
+
+      - name: Install pnpm
+        if: steps.gate.outputs.enabled == 'true'
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v6.3.1
+
+      - name: Setup Node.js
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          # Same node as the image build (root Dockerfile) so the toolchain
+          # producing the hashed asset names is identical.
+          node-version: '24.16.0'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        if: steps.gate.outputs.enabled == 'true'
+        working-directory: ayunis-core-frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend with sourcemaps
+        if: steps.gate.outputs.enabled == 'true'
+        working-directory: ayunis-core-frontend
+        env:
+          VITE_APP_REVISION: ${{ github.sha }}
+        run: pnpm run build
+
+      - name: Upload sourcemaps to AppSignal
+        if: steps.gate.outputs.enabled == 'true'
+        working-directory: ayunis-core-frontend/dist
+        env:
+          REVISION: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          maps=$(find . -name '*.js.map' | sort)
+          if [ -z "$maps" ]; then
+            echo "::error::no sourcemaps found in dist - is build.sourcemap disabled?"
+            exit 1
+          fi
+          count=0
+          for map in $maps; do
+            asset="${map#./}"
+            asset="${asset%.map}"
+            for environment in $APPSIGNAL_FRONTEND_ENVIRONMENTS; do
+              echo "Uploading $map as $asset (env: $environment)"
+              curl -fsS -X POST \
+                -F "name[]=${asset}" \
+                -F "revision=${REVISION}" \
+                -F "file=@${map}" \
+                "https://appsignal.com/api/sourcemaps?push_api_key=${APPSIGNAL_PUSH_API_KEY}&app_name=${APPSIGNAL_FRONTEND_APP_NAME}&environment=${environment}" \
+                > /dev/null
+              count=$((count + 1))
+            done
+          done
+          echo "Uploaded $count sourcemap(s) for revision $REVISION"

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,15 @@ RUN pnpm install --frozen-lockfile
 # No .env is consulted: environment-specific frontend values are injected at
 # runtime via the backend's GET /config.js, so the same image serves every
 # environment.
-RUN pnpm --filter core-frontend-tanstack run build
+#
+# APP_REVISION (the git sha in CI, see build-images.yml) is inlined into the
+# frontend bundle so AppSignal reports carry the revision its sourcemaps were
+# uploaded under, and exported as ENV below so the backend reports the same
+# one. The maps themselves (vite build.sourcemap: 'hidden') are deleted —
+# they must not be publicly served; CI uploads them to AppSignal instead.
+ARG APP_REVISION
+RUN VITE_APP_REVISION=$APP_REVISION pnpm --filter core-frontend-tanstack run build
+RUN find ayunis-core-frontend/dist -name '*.map' -delete
 RUN cp -r ayunis-core-frontend/dist ayunis-core-backend/frontend
 # Build the workspace packages the backend depends on (@ayunis/inference,
 # @ayunis/provider-anthropic, @ayunis/provider-openai, @ayunis/agent-runtime)
@@ -75,6 +83,10 @@ COPY --from=build /usr/src/app/ayunis-core-backend/appsignal-hooks.cjs ./appsign
 RUN mkdir -p uploads
 
 ENV NODE_ENV=production
+# Same revision the frontend bundle was built with (empty outside CI, where
+# appsignal.cjs falls back to the backend package version).
+ARG APP_REVISION
+ENV APP_REVISION=$APP_REVISION
 # Heap sized well below the container limit so allocations outside the V8 heap
 # (Chromium, file buffers) have room. Deliberately no
 # --heapsnapshot-near-heap-limit: a snapshot persists prompts, PII and

--- a/ayunis-core-backend/appsignal.cjs
+++ b/ayunis-core-backend/appsignal.cjs
@@ -27,7 +27,9 @@ const pushApiKey = process.env.APPSIGNAL_PUSH_API_KEY;
 // below overrides AppSignal's own APPSIGNAL_APP_ENV handling.
 const environment =
   process.env.APPSIGNAL_APP_ENV ?? process.env.NODE_ENV ?? 'development';
-const revision = process.env.APP_REVISION ?? readPackageVersion();
+// `||`, not `??`: images built without the APP_REVISION build arg (local
+// compose) carry it as an empty string, which must fall back too.
+const revision = process.env.APP_REVISION || readPackageVersion();
 
 function readPackageVersion() {
   try {

--- a/ayunis-core-backend/src/iam/authentication/presenters/http/dtos/auth-response.dto.ts
+++ b/ayunis-core-backend/src/iam/authentication/presenters/http/dtos/auth-response.dto.ts
@@ -52,6 +52,18 @@ export class MfaLoginConfirmResponseDto {
 
 export class MeResponseDto {
   @ApiProperty({
+    description: 'User id',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Organization id',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  orgId: string;
+
+  @ApiProperty({
     description: 'User email address',
     example: 'user@example.com',
   })

--- a/ayunis-core-backend/src/iam/authentication/presenters/http/mappers/me-response-dto.mapper.ts
+++ b/ayunis-core-backend/src/iam/authentication/presenters/http/mappers/me-response-dto.mapper.ts
@@ -6,6 +6,8 @@ import { Injectable } from '@nestjs/common';
 export class MeResponseDtoMapper {
   toDto(user: ActiveUser): MeResponseDto {
     return {
+      id: user.id,
+      orgId: user.orgId,
       email: user.email,
       role: user.role,
       systemRole: user.systemRole,

--- a/ayunis-core-frontend/src/app/routes/_authenticated.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated.tsx
@@ -19,6 +19,7 @@ import {
 import { queryOptions } from '@tanstack/react-query';
 import extractErrorData from '@/shared/api/extract-error-data';
 import { currentPathWithSearch } from '@/shared/lib/current-path-with-search';
+import { setAppsignalTags, clearAppsignalTags } from '@/shared/lib/appsignal';
 
 const meQueryOptions = () =>
   queryOptions({
@@ -40,12 +41,14 @@ export const Route = createFileRoute('/_authenticated')({
   beforeLoad: async ({ context: { queryClient } }) => {
     try {
       const user = await queryClient.fetchQuery(meQueryOptions());
+      setAppsignalTags({ userId: user.id, orgId: user.orgId });
       await queryClient.fetchQuery({
         queryKey: getAppControllerIsCloudQueryKey(),
         queryFn: () => appControllerIsCloud(),
       });
       return { user };
     } catch (error) {
+      clearAppsignalTags();
       try {
         const { code } = extractErrorData(error);
         if (code === 'IP_NOT_ALLOWED') {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -4752,6 +4752,10 @@ export const MeResponseDtoSystemRole = {
 } as const;
 
 export interface MeResponseDto {
+  /** User id */
+  id: string;
+  /** Organization id */
+  orgId: string;
   /** User email address */
   email: string;
   /** User role */

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -17587,6 +17587,16 @@
       "MeResponseDto": {
         "type": "object",
         "properties": {
+          "id": {
+            "type": "string",
+            "description": "User id",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "orgId": {
+            "type": "string",
+            "description": "Organization id",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
           "email": {
             "type": "string",
             "description": "User email address",
@@ -17610,7 +17620,7 @@
             "example": "John Doe"
           }
         },
-        "required": ["email", "role", "systemRole", "name"]
+        "required": ["id", "orgId", "email", "role", "systemRole", "name"]
       },
       "MfaCodeRequestDto": {
         "type": "object",

--- a/ayunis-core-frontend/src/shared/lib/appsignal.test.ts
+++ b/ayunis-core-frontend/src/shared/lib/appsignal.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { Span } from '@appsignal/javascript';
+import {
+  ignoredErrorPatterns,
+  backtracePathMatchers,
+  dropBrowserExtensionErrors,
+  isBrowserExtensionError,
+  setAppsignalTags,
+  clearAppsignalTags,
+  applyContextTags,
+} from './appsignal';
+
+function spanWithStack(stack: string): Span {
+  const error = new Error('boom');
+  error.stack = stack;
+  return new Span().setError(error);
+}
+
+const matchesAnyIgnore = (message: string) =>
+  ignoredErrorPatterns.some((pattern) => pattern.test(message));
+
+describe('ignoredErrorPatterns', () => {
+  it.each([
+    'The user aborted a request.',
+    'The operation was aborted.',
+    'signal is aborted without reason',
+    'canceled',
+    'Failed to fetch',
+    'NetworkError when attempting to fetch a resource.',
+    'Network Error',
+    'Load failed',
+    'ResizeObserver loop limit exceeded',
+    'ResizeObserver loop completed with undelivered notifications.',
+  ])('ignores expected browser noise: %s', (message) => {
+    expect(matchesAnyIgnore(message)).toBe(true);
+  });
+
+  it.each([
+    "Cannot read properties of undefined (reading 'map')",
+    'Maximum update depth exceeded',
+    'Objects are not valid as a React child',
+    // Unrecovered deploy skew, reported by the ErrorBoundary after the
+    // chunk-reload guard gives up — must never be filtered.
+    'Failed to fetch dynamically imported module: https://app.example.com/assets/ChatPage-abc.js',
+  ])('keeps real application errors: %s', (message) => {
+    expect(matchesAnyIgnore(message)).toBe(false);
+  });
+});
+
+describe('backtracePathMatchers', () => {
+  it('captures the origin-independent asset path', () => {
+    const match = backtracePathMatchers[0].exec(
+      'https://ki.example-municipality.de/assets/index-CmFbNJ3T.js',
+    );
+    expect(match?.[1]).toBe('assets/index-CmFbNJ3T.js');
+  });
+
+  it('does not match non-asset paths', () => {
+    expect(backtracePathMatchers[0].test('https://example.com/config.js')).toBe(
+      false,
+    );
+  });
+});
+
+describe('dropBrowserExtensionErrors', () => {
+  it('drops errors whose origin frame is a browser extension', () => {
+    const span = spanWithStack(
+      [
+        'TypeError: boom',
+        '    at inject (chrome-extension://abcdefgh/content.js:10:5)',
+        '    at https://app.example.com/assets/index-abc.js:1:100',
+      ].join('\n'),
+    );
+    expect(dropBrowserExtensionErrors(span)).toBe(false);
+  });
+
+  it('keeps errors originating in application code', () => {
+    const span = spanWithStack(
+      [
+        'TypeError: boom',
+        '    at render (https://app.example.com/assets/index-abc.js:1:100)',
+        '    at wrapped (moz-extension://abcdefgh/content.js:10:5)',
+      ].join('\n'),
+    );
+    expect(dropBrowserExtensionErrors(span)).toBe(span);
+  });
+
+  it('keeps errors without any backtrace URLs', () => {
+    const span = spanWithStack('Error: boom');
+    expect(dropBrowserExtensionErrors(span)).toBe(span);
+  });
+
+  it('classifies extension origin frames', () => {
+    const span = spanWithStack(
+      'Error: boom\n    at safari-web-extension://xyz/content.js:1:1',
+    );
+    expect(isBrowserExtensionError(span)).toBe(true);
+  });
+});
+
+describe('context tags', () => {
+  afterEach(() => clearAppsignalTags());
+
+  it('tags spans with the current user and org ids', () => {
+    setAppsignalTags({ userId: 'user-1', orgId: 'org-1' });
+    const span = applyContextTags(new Span());
+    expect(span.getTags()).toEqual({ user_id: 'user-1', org_id: 'org-1' });
+  });
+
+  it('applies no tags after clearing', () => {
+    setAppsignalTags({ userId: 'user-1', orgId: 'org-1' });
+    clearAppsignalTags();
+    const span = applyContextTags(new Span());
+    expect(span.getTags()).toEqual({});
+  });
+});

--- a/ayunis-core-frontend/src/shared/lib/appsignal.ts
+++ b/ayunis-core-frontend/src/shared/lib/appsignal.ts
@@ -1,6 +1,84 @@
 import Appsignal from '@appsignal/javascript';
+import type { Span } from '@appsignal/javascript';
+
+// The package does not re-export its hook types (only Breadcrumb and Span).
+type Override = (span: Span) => Span | false;
 import { plugin as windowEventsPlugin } from '@appsignal/plugin-window-events';
 import { runtimeEnv } from '@/shared/config/runtime-env';
+
+/**
+ * Expected browser noise, matched against the error message (AppSignal
+ * `ignoreErrors`). Mirrors the backend policy of not alerting on expected
+ * client behavior: cancelled requests, network blips and ResizeObserver
+ * warnings are not actionable incidents (AYC-539).
+ */
+export const ignoredErrorPatterns: RegExp[] = [
+  // Aborted fetch/XHR: "The user aborted a request." (Chrome), "The
+  // operation was aborted." (Firefox), "Fetch is aborted" (Safari),
+  // "signal is aborted without reason" (AbortController default).
+  /\baborted\b/i,
+  // Axios CanceledError, thrown when a request is cancelled on unmount
+  // or navigation.
+  /^canceled$/i,
+  // Network blips: Chrome fetch, Firefox fetch, axios, Safari fetch.
+  // Anchored: Vite's "Failed to fetch dynamically imported module" must
+  // stay reportable — it is the unrecovered-deploy-skew signal the
+  // ErrorBoundary deliberately reports after chunk-reload recovery fails.
+  /^Failed to fetch$/i,
+  /NetworkError/i,
+  /Network Error/i,
+  /^Load failed$/i,
+  // Spec-mandated benign warning, surfaces as a window error event.
+  /ResizeObserver loop/i,
+];
+
+/**
+ * Strips the deployment-specific origin from backtrace paths so all
+ * environments report `assets/<chunk>.js`. CI uploads sourcemaps under
+ * exactly these names (see the sourcemaps job in build-images.yml), which
+ * is what lets one build's maps resolve traces from every hostname.
+ */
+export const backtracePathMatchers: RegExp[] = [
+  /https?:\/\/[^/]+\/(assets\/[^\s?#]+)/,
+];
+
+const extensionUrlPattern =
+  /(?:chrome|moz|safari|safari-web|ms-browser)-extension:\/\//;
+
+/**
+ * True when the topmost frame with a location is extension-injected —
+ * the error originated in browser-extension code, not ours.
+ */
+export function isBrowserExtensionError(span: Span): boolean {
+  const backtrace = span.getError()?.backtrace ?? [];
+  const originFrame = backtrace.find((line) => line.includes('://'));
+  return originFrame !== undefined && extensionUrlPattern.test(originFrame);
+}
+
+// Returning false is how an AppSignal Override drops a span.
+export const dropBrowserExtensionErrors: Override = (span) =>
+  isBrowserExtensionError(span) ? false : span;
+
+let contextTags: Record<string, string> = {};
+
+/** Ids only — no names, emails or chat content (same policy as the backend). */
+export function setAppsignalTags(tags: {
+  userId?: string;
+  orgId?: string;
+}): void {
+  contextTags = {
+    ...(tags.userId ? { user_id: tags.userId } : {}),
+    ...(tags.orgId ? { org_id: tags.orgId } : {}),
+  };
+}
+
+export function clearAppsignalTags(): void {
+  contextTags = {};
+}
+
+export function applyContextTags(span: Span): Span {
+  return span.setTags(contextTags);
+}
 
 let appsignal: Appsignal | undefined;
 
@@ -8,7 +86,18 @@ export function initAppsignal() {
   const key = runtimeEnv('VITE_APPSIGNAL_FRONTEND_KEY');
 
   if (import.meta.env.PROD && key) {
-    appsignal = new Appsignal({ key });
+    appsignal = new Appsignal({
+      key,
+      // Baked in at build time (Dockerfile build arg), matching the
+      // APP_REVISION the backend reports — incidents map to deploys and
+      // to the sourcemaps CI uploaded for this revision.
+      revision:
+        (import.meta.env.VITE_APP_REVISION as string | undefined) || undefined,
+      ignoreErrors: ignoredErrorPatterns,
+      matchBacktracePaths: backtracePathMatchers,
+    });
+    appsignal.addDecorator(applyContextTags);
+    appsignal.addOverride(dropBrowserExtensionErrors);
     // Captures uncaught errors and unhandled promise rejections
     appsignal.use(windowEventsPlugin());
   }

--- a/ayunis-core-frontend/src/widgets/app-sidebar/api/useLogout.ts
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/api/useLogout.ts
@@ -1,6 +1,7 @@
 import { useAuthenticationControllerLogout } from '@/shared/api/generated/ayunisCoreAPI';
 import { useNavigate } from '@tanstack/react-router';
 import { useQueryClient } from '@tanstack/react-query';
+import { clearAppsignalTags } from '@/shared/lib/appsignal';
 
 export function useLogout() {
   const navigate = useNavigate();
@@ -11,6 +12,7 @@ export function useLogout() {
       onSuccess: () => {
         // Clear all queries to ensure user data is removed from cache
         queryClient.clear();
+        clearAppsignalTags();
         // Redirect to login page
         void navigate({ to: '/login' });
       },
@@ -19,6 +21,7 @@ export function useLogout() {
         // Even if logout fails on the server, we should still redirect to login
         // as the user intended to log out
         queryClient.clear();
+        clearAppsignalTags();
         void navigate({ to: '/login' });
       },
     },

--- a/ayunis-core-frontend/vite.config.js
+++ b/ayunis-core-frontend/vite.config.js
@@ -19,6 +19,12 @@ export default defineConfig({
     viteReact(),
     tailwindcss(),
   ],
+  build: {
+    // Emit sourcemaps without referencing them from the bundles. The maps
+    // never ship (the Dockerfile deletes them); CI uploads them to AppSignal
+    // keyed by revision (see the sourcemaps job in build-images.yml).
+    sourcemap: "hidden",
+  },
   server: {
     port: port,
   },


### PR DESCRIPTION
- Build the frontend with hidden sourcemaps; delete the maps from the
  image and upload them to AppSignal from CI, keyed by the git sha the
  image also reports as APP_REVISION (backend env + VITE_APP_REVISION)
- Normalize backtrace paths to assets/<chunk>.js so one sourcemap
  upload serves every deployment hostname
- Ignore expected browser noise before send: aborted/cancelled
  requests, network blips, ResizeObserver loop warnings, and errors
  originating in browser-extension frames
- Tag frontend reports with user_id/org_id (ids only, same policy as
  the backend); MeResponseDto now exposes id and orgId

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release pipeline and `/auth/me` response shape; misaligned sourcemap uploads would break stack traces until the next good deploy, but there is no change to auth or data-handling logic.
> 
> **Overview**
> Improves **frontend AppSignal** so production errors tie to deploys, de-noise the feed, and carry tenant context—without shipping sourcemaps publicly.
> 
> **Build & CI:** Image builds pass **`APP_REVISION=${{ github.sha }}`** into the app Dockerfile; the frontend bundle gets **`VITE_APP_REVISION`**, maps are stripped from the image, and the backend runs with **`ENV APP_REVISION`**. A new **`sourcemaps`** workflow job rebuilds the frontend (pinned Node/pnpm) and uploads `*.js.map` to AppSignal under the same revision and `assets/<chunk>.js` names; it no-ops when **`APPSIGNAL_PUSH_API_KEY`** is missing. Vite uses **`sourcemap: 'hidden'`**.
> 
> **Frontend client:** **`initAppsignal`** sets revision, **`ignoreErrors`**, **`matchBacktracePaths`**, drops extension-origin errors, and decorates spans with **`user_id` / `org_id`** (ids only). Tags are set after **`/me`** in **`_authenticated`**, cleared on auth failure and logout.
> 
> **API:** **`MeResponseDto`** (and OpenAPI/generated types) now include **`id`** and **`orgId`** so the client can tag reports.
> 
> **Backend bootstrap:** **`appsignal.cjs`** uses **`||`** for revision so an empty **`APP_REVISION`** from local images still falls back to package version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bce8c3786b201669b33cd67609f8b934fae0629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->