### PR TITLE
fix(dev): make local supervisor health-aware (AYC-633)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,34 @@ two sources:
 The production setup above (copying `.env` files for `docker compose`) is
 unaffected.
 
+#### Coding-agent quick reference
+
+Use `./dev` for the whole local stack. It only stops or restarts native
+processes recorded for this checkout and slot; if another process owns a slot
+port, it exits with an actionable error instead of terminating that process.
+
+```bash
+# Start or converge a slot to a healthy stack. The slot is remembered.
+./dev up --slot 2
+
+# Check process/session state and backend/frontend HTTP readiness.
+./dev status --slot 2
+
+# Inspect failures without restarting anything.
+./dev logs --slot 2 backend
+./dev logs --slot 2 frontend
+./dev logs --slot 2 infra
+
+# Recover an unhealthy managed backend or frontend session.
+./dev up --slot 2
+```
+
+`./dev up` is idempotent: it verifies workspace dependencies with a frozen
+lockfile, preserves an already-healthy stack, and replaces stale slot-owned
+backend or frontend sessions before waiting for both services to become ready.
+Do not kill a process reported as an unmanaged port owner; stop it from its
+own checkout or choose another slot.
+
 ### Git Hooks (Husky)
 
 This project uses [Husky](https://typicode.github.io/husky/) to manage Git hooks for code quality checks.

--- a/dev
+++ b/dev
@@ -75,8 +75,9 @@ FRONTEND_URL="http://localhost:$FRONTEND_PORT"
 
 PROJECT_NAME="ayunis-dev-${SLOT}"
 STATE_DIR="$REPO_DIR/.dev/slot-${SLOT}"
-BACKEND_SESSION="${PROJECT_NAME}-backend"
-FRONTEND_SESSION="${PROJECT_NAME}-frontend"
+CHECKOUT_ID="$(printf '%s' "$REPO_DIR" | cksum | cut -d' ' -f1)"
+BACKEND_SESSION="${PROJECT_NAME}-${CHECKOUT_ID}-backend"
+FRONTEND_SESSION="${PROJECT_NAME}-${CHECKOUT_ID}-frontend"
 
 # ── Docker compose wrapper ─────────────────────────────────────────────────
 
@@ -201,6 +202,18 @@ mkdir -p "$STATE_DIR"
 cmd_up() {
   info "Starting slot $SLOT  (port offset +$OFFSET)"
 
+  _sync_dependencies
+  _export_infra_env
+
+  if _infra_healthy \
+    && _service_healthy "$STATE_DIR/backend.pid" "$BACKEND_SESSION" "$BACKEND_HEALTH_URL" "$BACKEND_PORT" \
+    && _service_healthy "$STATE_DIR/frontend.pid" "$FRONTEND_SESSION" "$FRONTEND_URL" "$FRONTEND_PORT"; then
+    info "Backend already running (PID $(_display_pid "$STATE_DIR/backend.pid"))"
+    info "Frontend already running (PID $(_display_pid "$STATE_DIR/frontend.pid"))"
+    _print_ready_summary
+    return
+  fi
+
   _infisical_preflight
 
   local env_dev="$REPO_DIR/ayunis-core-backend/.env.dev"
@@ -238,12 +251,16 @@ cmd_up() {
   # code-execution fails hard at startup when the sandbox image is missing
   # (it pulls but never builds), so build it before compose waits on health.
   # The image is host-global and shared across dev slots.
-  info "Building python-sandbox image …"
-  docker build -t python-sandbox:latest "$REPO_DIR/ayunis-core-code-execution/sandbox" 2>&1 | tail -2
+  if _infra_healthy; then
+    info "Docker infrastructure already healthy"
+  else
+    info "Building python-sandbox image …"
+    docker build -t python-sandbox:latest "$REPO_DIR/ayunis-core-code-execution/sandbox" 2>&1 | tail -2
 
-  # -- 1. Docker infrastructure -------------------------------------------
-  info "Starting Docker infrastructure …"
-  dc up -d --build --wait 2>&1 | tail -5
+    # -- 1. Docker infrastructure -----------------------------------------
+    info "Starting Docker infrastructure …"
+    dc up -d --build --wait 2>&1 | tail -5
+  fi
 
   # -- 2. Generate .env.dev for backend ------------------------------------
   # Slot selection only: the backend derives ports/URLs from DEV_PORT_OFFSET
@@ -290,12 +307,13 @@ EOF
 
   # -- 4. Backend (native) ------------------------------------------------
   if _service_healthy "$STATE_DIR/backend.pid" "$BACKEND_SESSION" "$BACKEND_HEALTH_URL" "$BACKEND_PORT"; then
-    info "Backend already running (PID $(cat "$STATE_DIR/backend.pid"))"
+    info "Backend already running (PID $(_display_pid "$STATE_DIR/backend.pid"))"
   else
     _refuse_unmanaged_listener "$STATE_DIR/backend.pid" "$BACKEND_PORT" "Backend"
     if _pid_alive "$STATE_DIR/backend.pid" "$BACKEND_SESSION"; then
-      warn "Restarting unhealthy Backend (PID $(cat "$STATE_DIR/backend.pid")) …"
-      _kill_pid "$STATE_DIR/backend.pid" "Backend" "$BACKEND_PORT" "$BACKEND_SESSION"
+      warn "Restarting unhealthy Backend (PID $(_display_pid "$STATE_DIR/backend.pid")) …"
+      _kill_pid "$STATE_DIR/backend.pid" "Backend" "$BACKEND_SESSION"
+      _refuse_unmanaged_listener "$STATE_DIR/backend.pid" "$BACKEND_PORT" "Backend"
     fi
     info "Starting backend on port $BACKEND_PORT …"
     : > "$STATE_DIR/backend.log"
@@ -308,12 +326,13 @@ EOF
 
   # -- 5. Frontend (native) -----------------------------------------------
   if _service_healthy "$STATE_DIR/frontend.pid" "$FRONTEND_SESSION" "$FRONTEND_URL" "$FRONTEND_PORT"; then
-    info "Frontend already running (PID $(cat "$STATE_DIR/frontend.pid"))"
+    info "Frontend already running (PID $(_display_pid "$STATE_DIR/frontend.pid"))"
   else
     _refuse_unmanaged_listener "$STATE_DIR/frontend.pid" "$FRONTEND_PORT" "Frontend"
     if _pid_alive "$STATE_DIR/frontend.pid" "$FRONTEND_SESSION"; then
-      warn "Restarting unhealthy Frontend (PID $(cat "$STATE_DIR/frontend.pid")) …"
-      _kill_pid "$STATE_DIR/frontend.pid" "Frontend" "$FRONTEND_PORT" "$FRONTEND_SESSION"
+      warn "Restarting unhealthy Frontend (PID $(_display_pid "$STATE_DIR/frontend.pid")) …"
+      _kill_pid "$STATE_DIR/frontend.pid" "Frontend" "$FRONTEND_SESSION"
+      _refuse_unmanaged_listener "$STATE_DIR/frontend.pid" "$FRONTEND_PORT" "Frontend"
     fi
     info "Starting frontend on port $FRONTEND_PORT …"
     : > "$STATE_DIR/frontend.log"
@@ -324,34 +343,16 @@ EOF
       "cd '$REPO_DIR/ayunis-core-frontend' && export VITE_API_BASE_URL='http://localhost:$BACKEND_PORT/api' && exec ${FRONTEND_SECRETS_PREFIX}pnpm exec vite --port '$FRONTEND_PORT'"
   fi
 
-  # -- 6. Wait for backend health -----------------------------------------
-  info "Waiting for backend to become healthy …"
-  local attempts=0
-  local max_attempts=90
-  while ! _url_healthy "$BACKEND_HEALTH_URL"; do
-    attempts=$((attempts + 1))
-    if [ $attempts -ge $max_attempts ]; then
-      echo ""
-      die "Backend did not become healthy after $((max_attempts * 2))s. Check logs:  ./dev logs --slot $SLOT backend"
-    fi
-    printf "."
-    sleep 2
-  done
-  echo ""
+  # -- 6. Wait for native service health ---------------------------------
+  _wait_for_service \
+    "Backend" "$STATE_DIR/backend.pid" "$BACKEND_SESSION" \
+    "$BACKEND_HEALTH_URL" "$BACKEND_PORT" "backend"
+  _wait_for_service \
+    "Frontend" "$STATE_DIR/frontend.pid" "$FRONTEND_SESSION" \
+    "$FRONTEND_URL" "$FRONTEND_PORT" "frontend"
 
   # -- 7. Summary ----------------------------------------------------------
-  echo ""
-  echo "✅ Slot $SLOT is ready"
-  echo ""
-  echo "  Backend:      http://localhost:$BACKEND_PORT"
-  echo "  Frontend:     http://localhost:$FRONTEND_PORT"
-  echo "  API docs:     http://localhost:$BACKEND_PORT/api/docs"
-  echo "  Postgres:     localhost:$POSTGRES_HOST_PORT"
-  echo "  MinIO:        localhost:$MINIO_HOST_PORT  (console: $MINIO_CONSOLE_HOST_PORT)"
-  echo "  Mailcatcher:  smtp :$MAILCATCHER_SMTP_HOST_PORT  web :$MAILCATCHER_WEB_HOST_PORT"
-  echo "  Code exec:    localhost:$CODE_EXEC_HOST_PORT"
-  echo "  Anonymize:    localhost:$ANONYMIZE_HOST_PORT"
-  echo "  Gotenberg:    localhost:$GOTENBERG_HOST_PORT"
+  _print_ready_summary
   echo ""
   if $INFISICAL_OK; then
     echo "  Secrets:      Infisical (dev, /backend + /frontend)"
@@ -367,9 +368,8 @@ cmd_down() {
   info "Stopping slot $SLOT …"
   _export_infra_env
 
-  # Stop native processes (pass ports to kill orphaned grandchild processes)
-  _kill_pid "$STATE_DIR/frontend.pid" "Frontend" "$FRONTEND_PORT" "$FRONTEND_SESSION"
-  _kill_pid "$STATE_DIR/backend.pid"  "Backend"  "$BACKEND_PORT" "$BACKEND_SESSION"
+  _kill_pid "$STATE_DIR/frontend.pid" "Frontend" "$FRONTEND_SESSION"
+  _kill_pid "$STATE_DIR/backend.pid"  "Backend"  "$BACKEND_SESSION"
 
   # Stop Docker infrastructure
   dc down
@@ -394,18 +394,22 @@ cmd_status() {
 
   # Backend
   if _service_healthy "$STATE_DIR/backend.pid" "$BACKEND_SESSION" "$BACKEND_HEALTH_URL" "$BACKEND_PORT"; then
-    echo "  Backend:   running  PID $(cat "$STATE_DIR/backend.pid")  http://localhost:$BACKEND_PORT"
+    echo "  Backend:   running  PID $(_display_pid "$STATE_DIR/backend.pid")  http://localhost:$BACKEND_PORT"
   elif _pid_alive "$STATE_DIR/backend.pid" "$BACKEND_SESSION"; then
-    echo "  Backend:   unhealthy  PID $(cat "$STATE_DIR/backend.pid")  http://localhost:$BACKEND_PORT"
+    echo "  Backend:   unhealthy  PID $(_display_pid "$STATE_DIR/backend.pid")  http://localhost:$BACKEND_PORT"
+  elif [ -n "$(_listener_pids "$BACKEND_PORT")" ]; then
+    echo "  Backend:   stopped  port $BACKEND_PORT occupied by unmanaged PID $(_listener_pids "$BACKEND_PORT")"
   else
     echo "  Backend:   stopped"
   fi
 
   # Frontend
   if _service_healthy "$STATE_DIR/frontend.pid" "$FRONTEND_SESSION" "$FRONTEND_URL" "$FRONTEND_PORT"; then
-    echo "  Frontend:  running  PID $(cat "$STATE_DIR/frontend.pid")  http://localhost:$FRONTEND_PORT"
+    echo "  Frontend:  running  PID $(_display_pid "$STATE_DIR/frontend.pid")  http://localhost:$FRONTEND_PORT"
   elif _pid_alive "$STATE_DIR/frontend.pid" "$FRONTEND_SESSION"; then
-    echo "  Frontend:  unhealthy  PID $(cat "$STATE_DIR/frontend.pid")  http://localhost:$FRONTEND_PORT"
+    echo "  Frontend:  unhealthy  PID $(_display_pid "$STATE_DIR/frontend.pid")  http://localhost:$FRONTEND_PORT"
+  elif [ -n "$(_listener_pids "$FRONTEND_PORT")" ]; then
+    echo "  Frontend:  stopped  port $FRONTEND_PORT occupied by unmanaged PID $(_listener_pids "$FRONTEND_PORT")"
   else
     echo "  Frontend:  stopped"
   fi
@@ -455,17 +459,100 @@ _read_env_var() {
   grep -E "^${key}=" "$file" 2>/dev/null | head -n 1 | cut -d= -f2- || true
 }
 
+_read_pid() {
+  local pidfile="$1"
+  local pid=""
+  [ -f "$pidfile" ] && pid="$(cat "$pidfile" 2>/dev/null || true)"
+  if [[ "$pid" =~ ^[0-9]+$ ]]; then
+    printf '%s' "$pid"
+  fi
+  return 0
+}
+
+_display_pid() {
+  local pid
+  pid="$(_read_pid "$1")"
+  printf '%s' "${pid:-unknown}"
+}
+
+_pid_process_alive() {
+  local pid
+  pid="$(_read_pid "$1")"
+  [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null
+}
+
 _pid_alive() {
   local pidfile="$1"
   local session="${2:-}"
-  if [ -f "$pidfile" ] && kill -0 "$(cat "$pidfile")" 2>/dev/null; then
-    return 0
-  fi
+  _pid_process_alive "$pidfile" && return 0
   [ -n "$session" ] && _tmux_session_alive "$session"
 }
 
 _url_healthy() {
   curl --fail --silent --max-time 2 "$1" > /dev/null 2>&1
+}
+
+_sync_dependencies() {
+  info "Checking workspace dependencies …"
+  if ! (cd "$REPO_DIR" && pnpm install --frozen-lockfile --prefer-offline); then
+    die "Dependency sync failed. Run 'pnpm install --frozen-lockfile' in $REPO_DIR and retry."
+  fi
+}
+
+_infra_healthy() {
+  local expected_services service status_line state health
+  expected_services="$(dc config --services 2>/dev/null)" || return 1
+  [ -n "$expected_services" ] || return 1
+
+  local service_status
+  service_status="$(dc ps --format '{{.Service}}|{{.State}}|{{.Health}}' 2>/dev/null)" || return 1
+  [ -n "$service_status" ] || return 1
+
+  while IFS= read -r service; do
+    status_line="$(printf '%s\n' "$service_status" | grep -E "^${service}\\|" | head -n 1 || true)"
+    [ -n "$status_line" ] || return 1
+    IFS='|' read -r _ state health <<< "$status_line"
+    [ "$state" = "running" ] || return 1
+    [[ -z "$health" || "$health" = "healthy" ]] || return 1
+  done <<< "$expected_services"
+}
+
+_wait_for_service() {
+  local label="$1"
+  local pidfile="$2"
+  local session="$3"
+  local url="$4"
+  local port="$5"
+  local log_target="$6"
+  local attempts=0
+  local max_attempts=90
+
+  info "Waiting for $label to become healthy …"
+  while ! _service_healthy "$pidfile" "$session" "$url" "$port"; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge "$max_attempts" ]; then
+      echo ""
+      die "$label did not become healthy after $((max_attempts * 2))s. Check logs:  ./dev logs --slot $SLOT $log_target"
+    fi
+    printf "."
+    sleep 2
+  done
+  echo ""
+}
+
+_print_ready_summary() {
+  echo ""
+  echo "✅ Slot $SLOT is ready"
+  echo ""
+  echo "  Backend:      http://localhost:$BACKEND_PORT"
+  echo "  Frontend:     http://localhost:$FRONTEND_PORT"
+  echo "  API docs:     http://localhost:$BACKEND_PORT/api/docs"
+  echo "  Postgres:     localhost:$POSTGRES_HOST_PORT"
+  echo "  MinIO:        localhost:$MINIO_HOST_PORT  (console: $MINIO_CONSOLE_HOST_PORT)"
+  echo "  Mailcatcher:  smtp :$MAILCATCHER_SMTP_HOST_PORT  web :$MAILCATCHER_WEB_HOST_PORT"
+  echo "  Code exec:    localhost:$CODE_EXEC_HOST_PORT"
+  echo "  Anonymize:    localhost:$ANONYMIZE_HOST_PORT"
+  echo "  Gotenberg:    localhost:$GOTENBERG_HOST_PORT"
 }
 
 _process_belongs_to_tree() {
@@ -486,8 +573,8 @@ _port_owned_by_pidfile() {
   local pidfile="$1"
   local port="$2"
   local root_pid listener_pid
-  [ -f "$pidfile" ] || return 1
-  root_pid="$(cat "$pidfile")"
+  root_pid="$(_read_pid "$pidfile")"
+  [ -n "$root_pid" ] || return 1
 
   while IFS= read -r listener_pid; do
     _process_belongs_to_tree "$listener_pid" "$root_pid" && return 0
@@ -495,12 +582,16 @@ _port_owned_by_pidfile() {
   return 1
 }
 
+_listener_pids() {
+  lsof -nP -tiTCP:"$1" -sTCP:LISTEN 2>/dev/null | paste -sd, - || true
+}
+
 _refuse_unmanaged_listener() {
   local pidfile="$1"
   local port="$2"
   local label="$3"
   local listener_pids
-  listener_pids="$(lsof -nP -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null | paste -sd, - || true)"
+  listener_pids="$(_listener_pids "$port")"
   [ -z "$listener_pids" ] && return 0
   _port_owned_by_pidfile "$pidfile" "$port" && return 0
   die "$label port $port is occupied by PID $listener_pids not managed by this checkout. Stop it or use another slot."
@@ -516,49 +607,42 @@ _service_healthy() {
     && _url_healthy "$url"
 }
 
+_terminate_process_tree() {
+  local pid="$1"
+  kill -TERM -- -"$pid" 2>/dev/null || true
+  pkill -TERM -P "$pid" 2>/dev/null || true
+  kill -TERM "$pid" 2>/dev/null || true
+  sleep 1
+  kill -9 -- -"$pid" 2>/dev/null || true
+  pkill -9 -P "$pid" 2>/dev/null || true
+  kill -9 "$pid" 2>/dev/null || true
+}
+
 _kill_pid() {
   local pidfile="$1"
   local label="${2:-process}"
-  local port="${3:-}"
-  local session="${4:-}"
-  if _pid_alive "$pidfile" "$session"; then
-    local pid
-    pid=$(cat "$pidfile")
-    info "Stopping $label (PID $pid) …"
-    # The PID is a subshell that is a process group leader.
-    # Kill the whole group, then fall back to pkill -P for any stragglers.
-    kill -TERM -- -"$pid" 2>/dev/null || true
-    pkill -TERM -P "$pid" 2>/dev/null || true
-    kill -TERM "$pid" 2>/dev/null || true
-    # Wait briefly, then force-kill stragglers
-    sleep 1
-    kill -9 -- -"$pid" 2>/dev/null || true
-    pkill -9 -P "$pid" 2>/dev/null || true
-    kill -9 "$pid" 2>/dev/null || true
-    rm -f "$pidfile"
-  fi
-  if [ -n "$session" ]; then
-    if command -v tmux >/dev/null 2>&1; then
-      tmux kill-session -t "$session" 2>/dev/null || true
-    fi
-  fi
-  # Safety net: kill any process still listening on the port.
-  # Handles orphaned grandchild processes (e.g., node spawned by npm).
-  if [ -n "$port" ]; then
-    _kill_port "$port" "$label"
-  fi
-}
+  local session="${3:-}"
+  local pid session_pid="" terminate_pid=""
+  pid="$(_read_pid "$pidfile")"
 
-_kill_port() {
-  local port="$1"
-  local label="${2:-process}"
-  local pid
-  pid=$(lsof -ti :"$port" 2>/dev/null || true)
-  if [ -n "$pid" ]; then
-    warn "Killing orphaned $label process on port $port (PID $pid)"
-    echo "$pid" | xargs kill -9 2>/dev/null || true
-    sleep 1
+  if [ -n "$session" ] && _tmux_session_alive "$session"; then
+    session_pid="$(tmux list-panes -t "$session" -F '#{pane_pid}' 2>/dev/null | head -n 1 || true)"
+    if [[ "$session_pid" =~ ^[0-9]+$ ]]; then
+      terminate_pid="$session_pid"
+    elif _pid_process_alive "$pidfile"; then
+      terminate_pid="$pid"
+    fi
+    info "Stopping $label (PID ${terminate_pid:-unknown}) …"
+    tmux kill-session -t "$session" 2>/dev/null || true
+  elif _pid_process_alive "$pidfile"; then
+    terminate_pid="$pid"
+    info "Stopping $label (PID $pid) …"
   fi
+
+  # tmux can exit before a watcher child; the pane's process group remains
+  # scoped to this checkout even after the session disappears.
+  [ -n "$terminate_pid" ] && _terminate_process_tree "$terminate_pid"
+  rm -f "$pidfile"
 }
 
 _show_log() {

--- a/scripts/dev-status.test.sh
+++ b/scripts/dev-status.test.sh
@@ -17,11 +17,37 @@ printf '%s\n' "$$" > "$TEST_DIR/.dev/slot-97/backend.pid"
 
 cat > "$TEST_DIR/bin/docker" <<'EOF'
 #!/usr/bin/env bash
+if [[ -n "${FAKE_DOCKER_CALLS:-}" ]]; then
+  printf '%s\n' "$*" >> "$FAKE_DOCKER_CALLS"
+fi
+if [[ "${FAKE_INFRA_HEALTHY:-0}" = "1" && "$*" == *" config --services"* ]]; then
+  printf '%s\n' postgres minio mailcatcher docker-socket-proxy code-execution anonymize redis gotenberg
+fi
+if [[ "${FAKE_INFRA_HEALTHY:-0}" = "1" && "$*" == *" ps --format"* ]]; then
+  printf '%s\n' \
+    'postgres|running|healthy' \
+    'minio|running|healthy' \
+    'mailcatcher|running|' \
+    'docker-socket-proxy|running|' \
+    'code-execution|running|healthy' \
+    'anonymize|running|healthy' \
+    'redis|running|healthy' \
+    'gotenberg|running|healthy'
+fi
 exit 0
 EOF
 
 cat > "$TEST_DIR/bin/curl" <<'EOF'
 #!/usr/bin/env bash
+url="${*: -1}"
+if [[ "$url" == *":3971"* && -n "${FAKE_FRONTEND_READY:-}" ]]; then
+  [[ -f "$FAKE_FRONTEND_READY" ]]
+  exit
+fi
+if [[ "$url" == *":3971"* && -n "${FAKE_BACKEND_READY:-}" ]]; then
+  [[ -f "$FAKE_BACKEND_READY.frontend" ]]
+  exit
+fi
 if [[ -n "${FAKE_BACKEND_READY:-}" ]]; then
   [[ -f "$FAKE_BACKEND_READY" ]]
   exit
@@ -31,12 +57,56 @@ EOF
 
 cat > "$TEST_DIR/bin/lsof" <<'EOF'
 #!/usr/bin/env bash
-if [[ -n "${FAKE_LISTENER_PID:-}" && "$*" == *"TCP:${FAKE_LISTENER_PORT:-3970}"* ]]; then
-  echo "$FAKE_LISTENER_PID"
+if [[ -n "${FAKE_SURVIVING_LISTENER:-}" \
+  && -f "$FAKE_SURVIVING_LISTENER" \
+  && "$*" == *":3970"* ]]; then
+  echo 999998
+  exit
+fi
+IFS=',' read -r -a ports <<< "${FAKE_LISTENER_PORTS:-${FAKE_LISTENER_PORT:-3970}}"
+for port in "${ports[@]}"; do
+  if [[ -n "${FAKE_LISTENER_PID:-}" \
+    && ( "$*" == *"TCP:$port"* || "$*" == *":$port"* ) ]]; then
+    echo "$FAKE_LISTENER_PID"
+    exit
+  fi
+done
+if [[ "$*" == *":3970"* \
+  && -n "${FAKE_BACKEND_READY:-}" \
+  && -f "$FAKE_BACKEND_READY" ]]; then
+  echo 999998
+fi
+if [[ "$*" == *":3971"* ]]; then
+  if [[ -n "${FAKE_FRONTEND_READY:-}" && -f "$FAKE_FRONTEND_READY" ]]; then
+    echo 999998
+  elif [[ -z "${FAKE_FRONTEND_READY:-}" && -f "${FAKE_BACKEND_READY:-missing}.frontend" ]]; then
+    echo 999998
+  fi
 fi
 EOF
 
-chmod +x "$TEST_DIR/bin/docker" "$TEST_DIR/bin/curl" "$TEST_DIR/bin/lsof"
+cat > "$TEST_DIR/bin/xargs" <<'EOF'
+#!/usr/bin/env bash
+if [[ -n "${FAKE_XARGS_CALLS:-}" ]]; then
+  printf '%s\n' "$*" >> "$FAKE_XARGS_CALLS"
+fi
+cat >/dev/null
+EOF
+
+cat > "$TEST_DIR/bin/pkill" <<'EOF'
+#!/usr/bin/env bash
+if [[ -n "${FAKE_SURVIVING_LISTENER:-}" && "$*" == *"-P 999998"* ]]; then
+  rm -f "$FAKE_SURVIVING_LISTENER"
+fi
+exit 0
+EOF
+
+chmod +x \
+  "$TEST_DIR/bin/docker" \
+  "$TEST_DIR/bin/curl" \
+  "$TEST_DIR/bin/lsof" \
+  "$TEST_DIR/bin/pkill" \
+  "$TEST_DIR/bin/xargs"
 
 failures=0
 
@@ -81,9 +151,18 @@ printf '999999\n' > "$UP_DIR/.dev/slot-97/backend.pid"
 
 cat > "$TEST_DIR/bin/tmux" <<'EOF'
 #!/usr/bin/env bash
+if [[ -n "${FAKE_TMUX_CALLS:-}" ]]; then
+  printf '%s\n' "$*" >> "$FAKE_TMUX_CALLS"
+fi
 case "$1" in
   has-session)
-    [[ "${FAKE_BACKEND_SESSION:-0}" = "1" && "$*" == *backend* ]]
+    if [[ "$*" == *backend* ]]; then
+      [[ "${FAKE_BACKEND_SESSION:-0}" = "1" || -f "${FAKE_BACKEND_READY:-missing}" ]]
+    elif [[ "$*" == *frontend* ]]; then
+      [[ -f "${FAKE_FRONTEND_READY:-${FAKE_BACKEND_READY:-missing}.frontend}" ]]
+    else
+      exit 1
+    fi
     ;;
   kill-session)
     exit 0
@@ -91,7 +170,14 @@ case "$1" in
   new-session)
     if [[ "$*" == *ayunis-core-backend* ]]; then
       : > "$FAKE_BACKEND_READY"
+    elif [[ "$*" == *ayunis-core-frontend* ]]; then
+      if [[ -n "${FAKE_FRONTEND_READY:-}" ]]; then
+        [[ "${FAKE_FRONTEND_STARTS_READY:-0}" = "1" ]] && : > "$FAKE_FRONTEND_READY"
+      else
+        : > "$FAKE_BACKEND_READY.frontend"
+      fi
     fi
+    exit 0
     ;;
   list-panes)
     echo 999998
@@ -101,6 +187,12 @@ EOF
 
 cat > "$TEST_DIR/bin/pnpm" <<'EOF'
 #!/usr/bin/env bash
+if [[ -n "${FAKE_PNPM_CALLS:-}" ]]; then
+  printf '%s\n' "$*" >> "$FAKE_PNPM_CALLS"
+fi
+if [[ "$1" = "install" && -n "${FAKE_PNPM_INSTALL_EXIT:-}" ]]; then
+  exit "$FAKE_PNPM_INSTALL_EXIT"
+fi
 exit 0
 EOF
 
@@ -126,7 +218,8 @@ output="$(
     AYUNIS_NO_INFISICAL=1 \
     FAKE_BACKEND_SESSION=1 \
     FAKE_BACKEND_READY="$TEST_DIR/backend-ready" \
-    FAKE_LISTENER_PID=999999 \
+    FAKE_PNPM_CALLS="$TEST_DIR/pnpm-calls" \
+    FAKE_TMUX_CALLS="$TEST_DIR/tmux-calls" \
     "$UP_DIR/dev" up 2>&1
 )"
 status=$?
@@ -134,6 +227,48 @@ set -e
 
 if [[ $status -ne 0 || "$output" != *"Restarting unhealthy Backend"* ]]; then
   printf 'Expected dev up to restart a managed backend that is alive but unhealthy.\n%s\n' "$output" >&2
+  failures=$((failures + 1))
+fi
+
+up_repo_dir="$(cd "$UP_DIR" && pwd)"
+checkout_id="$(printf '%s' "$up_repo_dir" | cksum | cut -d' ' -f1)"
+if ! grep -Fq -- "ayunis-dev-97-$checkout_id-backend" "$TEST_DIR/tmux-calls"; then
+  printf 'Expected tmux session ownership to include the checkout identity.\n' >&2
+  failures=$((failures + 1))
+fi
+
+if ! grep -Fq -- 'install --frozen-lockfile' "$TEST_DIR/pnpm-calls" 2>/dev/null; then
+  printf 'Expected dev up to synchronize workspace dependencies with a frozen-lockfile install.\n' >&2
+  failures=$((failures + 1))
+fi
+
+SURVIVOR_DIR="$TEST_DIR/survivor"
+mkdir -p \
+  "$SURVIVOR_DIR/.dev/slot-97" \
+  "$SURVIVOR_DIR/ayunis-core-backend" \
+  "$SURVIVOR_DIR/ayunis-core-frontend" \
+  "$SURVIVOR_DIR/ayunis-core-code-execution/sandbox"
+cp "$REPO_DIR/dev" "$SURVIVOR_DIR/dev"
+chmod +x "$SURVIVOR_DIR/dev"
+printf '97\n' > "$SURVIVOR_DIR/.dev/slot"
+printf '999998\n' > "$SURVIVOR_DIR/.dev/slot-97/backend.pid"
+: > "$TEST_DIR/surviving-listener"
+rm -f "$TEST_DIR/survivor-ready" "$TEST_DIR/survivor-ready.frontend"
+
+set +e
+output="$(
+  PATH="$TEST_DIR/bin:$PATH" \
+    AYUNIS_NO_INFISICAL=1 \
+    FAKE_BACKEND_SESSION=1 \
+    FAKE_BACKEND_READY="$TEST_DIR/survivor-ready" \
+    FAKE_SURVIVING_LISTENER="$TEST_DIR/surviving-listener" \
+    "$SURVIVOR_DIR/dev" up 2>&1
+)"
+status=$?
+set -e
+
+if [[ $status -ne 0 || -f "$TEST_DIR/surviving-listener" ]]; then
+  printf 'Expected dev up to clean up a listener that survives tmux session termination.\n%s\n' "$output" >&2
   failures=$((failures + 1))
 fi
 
@@ -153,6 +288,121 @@ set -e
 
 if [[ $status -eq 0 || "$output" != *"not managed by this checkout"* ]]; then
   printf 'Expected dev up to refuse to terminate an unmanaged listener.\n%s\n' "$output" >&2
+  failures=$((failures + 1))
+fi
+
+rm -f \
+  "$TEST_DIR/backend-ready" \
+  "$TEST_DIR/backend-ready.frontend" \
+  "$TEST_DIR/frontend-ready"
+printf '999999\n' > "$UP_DIR/.dev/slot-97/backend.pid"
+set +e
+output="$(
+  PATH="$TEST_DIR/bin:$PATH" \
+    AYUNIS_NO_INFISICAL=1 \
+    FAKE_BACKEND_SESSION=1 \
+    FAKE_BACKEND_READY="$TEST_DIR/backend-ready" \
+    FAKE_FRONTEND_READY="$TEST_DIR/frontend-ready" \
+    "$UP_DIR/dev" up 2>&1
+)"
+status=$?
+set -e
+
+if [[ $status -eq 0 || "$output" != *"Frontend did not become healthy"* ]]; then
+  printf 'Expected dev up to wait for frontend readiness before reporting success.\n%s\n' "$output" >&2
+  failures=$((failures + 1))
+fi
+
+HEALTHY_DIR="$TEST_DIR/healthy"
+mkdir -p \
+  "$HEALTHY_DIR/.dev/slot-97" \
+  "$HEALTHY_DIR/ayunis-core-backend" \
+  "$HEALTHY_DIR/ayunis-core-frontend" \
+  "$HEALTHY_DIR/ayunis-core-code-execution/sandbox"
+cp "$REPO_DIR/dev" "$HEALTHY_DIR/dev"
+chmod +x "$HEALTHY_DIR/dev"
+printf '97\n' > "$HEALTHY_DIR/.dev/slot"
+printf '%s\n' "$$" > "$HEALTHY_DIR/.dev/slot-97/backend.pid"
+printf '%s\n' "$$" > "$HEALTHY_DIR/.dev/slot-97/frontend.pid"
+: > "$TEST_DIR/docker-calls"
+: > "$TEST_DIR/pnpm-healthy-calls"
+
+set +e
+output="$(
+  PATH="$TEST_DIR/bin:$PATH" \
+    AYUNIS_NO_INFISICAL=1 \
+    FAKE_CURL_EXIT=0 \
+    FAKE_DOCKER_CALLS="$TEST_DIR/docker-calls" \
+    FAKE_INFRA_HEALTHY=1 \
+    FAKE_LISTENER_PID="$$" \
+    FAKE_LISTENER_PORTS=3970,3971 \
+    FAKE_PNPM_CALLS="$TEST_DIR/pnpm-healthy-calls" \
+    "$HEALTHY_DIR/dev" up 2>&1
+)"
+status=$?
+set -e
+
+if [[ $status -ne 0 \
+  || "$output" != *"Backend already running"* \
+  || "$output" != *"Frontend already running"* ]]; then
+  printf 'Expected dev up to preserve an already-healthy stack.\n%s\n' "$output" >&2
+  failures=$((failures + 1))
+fi
+if grep -Eq '(^| )build( |$)|up -d --build' "$TEST_DIR/docker-calls"; then
+  printf 'Expected the already-healthy path not to rebuild Docker services.\n' >&2
+  failures=$((failures + 1))
+fi
+if grep -Fq -- 'migration:run:dev' "$TEST_DIR/pnpm-healthy-calls"; then
+  printf 'Expected the already-healthy path not to rerun migrations.\n' >&2
+  failures=$((failures + 1))
+fi
+
+DOWN_DIR="$TEST_DIR/down"
+mkdir -p "$DOWN_DIR/.dev/slot-97"
+cp "$REPO_DIR/dev" "$DOWN_DIR/dev"
+chmod +x "$DOWN_DIR/dev"
+printf '97\n' > "$DOWN_DIR/.dev/slot"
+: > "$TEST_DIR/xargs-calls"
+
+output="$(PATH="$TEST_DIR/bin:$PATH" "$DOWN_DIR/dev" status)"
+if [[ "$output" != *"Backend:   stopped"* || "$output" != *"Frontend:  stopped"* ]]; then
+  printf 'Expected status to report services without a managed process as stopped.\n%s\n' "$output" >&2
+  failures=$((failures + 1))
+fi
+
+output="$(
+  PATH="$TEST_DIR/bin:$PATH" \
+    FAKE_LISTENER_PID=999997 \
+    FAKE_LISTENER_PORT=3970 \
+    "$DOWN_DIR/dev" status
+)"
+if [[ "$output" != *"Backend:   stopped  port 3970 occupied by unmanaged PID 999997"* ]]; then
+  printf 'Expected status to expose an unmanaged listener occupying a stopped service port.\n%s\n' "$output" >&2
+  failures=$((failures + 1))
+fi
+
+PATH="$TEST_DIR/bin:$PATH" \
+  FAKE_LISTENER_PID=999997 \
+  FAKE_LISTENER_PORT=3970 \
+  FAKE_XARGS_CALLS="$TEST_DIR/xargs-calls" \
+  "$DOWN_DIR/dev" down >/dev/null 2>&1
+
+if [[ -s "$TEST_DIR/xargs-calls" ]]; then
+  printf 'Expected dev down not to kill an unmanaged listener on the slot port.\n' >&2
+  failures=$((failures + 1))
+fi
+
+set +e
+output="$(
+  PATH="$TEST_DIR/bin:$PATH" \
+    FAKE_PNPM_INSTALL_EXIT=1 \
+    "$DOWN_DIR/dev" up 2>&1
+)"
+status=$?
+set -e
+
+if [[ $status -eq 0 || "$output" != *"pnpm install --frozen-lockfile"* ]]; then
+  printf 'Expected dependency repair failures to include the exact recovery command.\n%s\n' "$output" >&2
   failures=$((failures + 1))
 fi
 


### PR DESCRIPTION
## Summary

- check backend and frontend process ownership plus HTTP readiness
- recover stale checkout-owned tmux sessions without touching unmanaged port listeners
- repair workspace dependency drift with a frozen-lockfile install
- preserve an already-healthy stack without rebuilding infrastructure or rerunning migrations
- document the coding-agent startup, status, logging, and recovery workflow

## Root cause

The supervisor treated a live wrapper PID or tmux session as proof that the application child was available. When the child crashed, the stale wrapper survived, so status reported a running service and subsequent startup waited for the full health timeout. Session names were also slot-only, and the shutdown fallback could terminate any listener on the configured port.

## Impact

`./dev up --slot N` now converges the selected checkout and slot to a healthy stack. `./dev status --slot N` distinguishes healthy, unhealthy, stopped, and unmanaged occupied-port states. Recovery only targets recorded checkout-owned processes or checkout-specific tmux sessions.

## Validation

- `bash scripts/dev-status.test.sh`
- `bash -n dev scripts/dev-status.test.sh`
- `pnpm install --frozen-lockfile --prefer-offline`
- `pnpm exec markdownlint-cli2 README.md`
- pre-commit hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the local `dev` shell script and its tests; no production runtime, auth, or data paths are affected.
> 
> **Overview**
> Makes `./dev` converge each checkout and slot to a **healthy** stack instead of trusting wrapper PIDs or tmux alone.
> 
> **Supervisor behavior:** `up` runs a frozen-lockfile `pnpm install`, short-circuits when Docker infra plus backend and frontend already pass process, port-ownership, and HTTP checks (no rebuild or migrations on that path), and waits for **both** services before success. Tmux session names include a checkout id so parallel worktrees do not collide. Recovery restarts only recorded checkout-owned sessions/process trees; occupied ports from foreign PIDs fail fast on `up` and are labeled on `status`. `down` no longer force-kills whatever is listening on the slot ports.
> 
> **Docs & tests:** README adds a coding-agent quick reference for `up` / `status` / `logs` / recovery. `scripts/dev-status.test.sh` covers healthy short-circuit, frontend readiness, survivor cleanup, unmanaged listeners, dependency sync failures, and checkout-scoped sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0165e540783e6bd8d30faadf119bb0a2cd58a2ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->