### PR TITLE
test(frontend): fix teams setup and run suite in CI (AYC-667)

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Run linter
         run: pnpm run lint
 
+      - name: Run tests
+        run: pnpm run test
+
       - name: Type-check UI package
         working-directory: packages/ui
         run: pnpm run typecheck

--- a/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsSettingsPage.test.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/teams-settings/ui/TeamsSettingsPage.test.tsx
@@ -26,6 +26,10 @@ vi.mock('@tanstack/react-router', () => ({
   ),
 }));
 
+vi.mock('@/features/permissions', () => ({
+  PermissionGate: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
 vi.mock('../../admin-settings-layout', () => ({
   default: ({
     children,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test and workflow-only changes with no production runtime or security impact.
> 
> **Overview**
> **CI** now runs the frontend test suite (`pnpm run test`) in the `frontend-build` workflow after lint, so PRs that touch the app or UI package must pass tests before merge.
> 
> **Teams settings tests** mock `@/features/permissions` so `PermissionGate` renders its children in isolation, fixing setup failures when exercising `TeamsSettingsPage` empty state, filters, and search behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4af38bec1898b7b599c44b387d75cab0d3ed058b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->