### PR TITLE
fix(rag): sanitize embedding payload text to well-formed unicode (AYC-670)

### DIFF
--- a/ayunis-core-backend/src/common/util/unicode-sanitizer.spec.ts
+++ b/ayunis-core-backend/src/common/util/unicode-sanitizer.spec.ts
@@ -1,4 +1,8 @@
-import { sanitizeObject, sanitizeUnicodeEscapes } from './unicode-sanitizer';
+import {
+  sanitizeObject,
+  sanitizeUnicodeEscapes,
+  toWellFormedText,
+} from './unicode-sanitizer';
 
 describe('sanitizeUnicodeEscapes', () => {
   it('removes completed null escapes and real NULL characters', () => {
@@ -71,5 +75,33 @@ describe('sanitizeObject', () => {
     };
     const once = sanitizeObject(input);
     expect(sanitizeObject(once)).toEqual(once);
+  });
+});
+
+describe('toWellFormedText', () => {
+  it('replaces a lone surrogate with the replacement character', () => {
+    expect(toWellFormedText('a\uD800b')).toBe('a�b');
+    expect(toWellFormedText('a\uDC00b')).toBe('a�b');
+  });
+
+  it('keeps intact surrogate pairs (emoji) unchanged', () => {
+    expect(toWellFormedText('Bericht 📄 fertig')).toBe('Bericht 📄 fertig');
+  });
+
+  it('removes NULL characters', () => {
+    expect(toWellFormedText(`a${String.fromCharCode(0)}b`)).toBe('ab');
+  });
+
+  it('handles a surrogate pair split across a chunk boundary', () => {
+    const emoji = '📄';
+    const truncatedTail = emoji[0];
+    expect(toWellFormedText(`chunk ends mid-pair ${truncatedTail}`)).toBe(
+      'chunk ends mid-pair �',
+    );
+  });
+
+  it('returns well-formed plain text unchanged', () => {
+    const text = 'Wie beantrage ich einen Anwohnerparkausweis?';
+    expect(toWellFormedText(text)).toBe(text);
   });
 });

--- a/ayunis-core-backend/src/common/util/unicode-sanitizer.ts
+++ b/ayunis-core-backend/src/common/util/unicode-sanitizer.ts
@@ -45,6 +45,24 @@ function sanitizeUnicodeEscapesOnce(input: string): string {
   );
 }
 
+// A high surrogate not followed by a low one, or a low surrogate not
+// preceded by a high one — the two shapes of an unpaired UTF-16 half.
+const LONE_SURROGATE =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+
+/**
+ * Returns text that survives strict JSON/UTF-8 payload validation: lone
+ * UTF-16 surrogates (e.g. an emoji split in half at a chunk boundary) become
+ * U+FFFD, and NULL characters are removed. JSON.stringify escapes lone
+ * surrogates as \udXXX, which strict decoders — Mistral's embeddings API
+ * among them — reject with 400 "Invalid JSON payload" (incident #536).
+ * Surrogate handling matches String.prototype.toWellFormed, which the
+ * tsconfig ES2023 lib does not yet declare.
+ */
+export function toWellFormedText(input: string): string {
+  return input.replace(LONE_SURROGATE, '\uFFFD').replaceAll('\u0000', '');
+}
+
 /**
  * Ultra-simple safe JSON parser. Just tries to fix the most common issues.
  *

--- a/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case.spec.ts
@@ -81,3 +81,35 @@ describe('EmbedTextUseCase error mapping', () => {
     ).rejects.toBe(internal);
   });
 });
+
+describe('EmbedTextUseCase payload sanitization', () => {
+  it('sends well-formed text to the handler when input carries lone surrogates', async () => {
+    // Incident #536: a lone surrogate half (split emoji from OCR/splitter
+    // output) serializes to a \udXXX escape that Mistral's JSON decoder
+    // rejects with 400 "Invalid JSON payload".
+    const received: string[][] = [];
+    const registry = {
+      getHandler: () => ({
+        embed: (texts: string[]) => {
+          received.push(texts);
+          return Promise.resolve([]);
+        },
+      }),
+    };
+    const throttle = {
+      run: (_priority: unknown, fn: () => Promise<unknown>) => fn(),
+    };
+    const useCase = new EmbedTextUseCase(registry as never, throttle as never);
+
+    await useCase.execute(
+      new EmbedTextCommand({
+        model,
+        texts: ['chunk ends mid-pair \uD83D', 'intact text'],
+        orgId: '123e4567-e89b-12d3-a456-426614174000',
+      }),
+    );
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual(['chunk ends mid-pair �', 'intact text']);
+  });
+});

--- a/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case.ts
@@ -5,6 +5,7 @@ import { EmbeddingsThrottleService } from '../../services/embeddings-throttle.se
 import { Embedding } from 'src/domain/rag/embeddings/domain/embedding.entity';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { wrapProviderFailure } from 'src/common/errors/wrap-provider-failure.helper';
+import { toWellFormedText } from 'src/common/util/unicode-sanitizer';
 
 @Injectable()
 export class EmbedTextUseCase {
@@ -22,12 +23,18 @@ export class EmbedTextUseCase {
     try {
       const handler = this.providerRegistry.getHandler(command.model.provider);
 
+      // Lone surrogates (an emoji split at a chunk boundary) serialize to
+      // \udXXX escapes that strict provider JSON decoders reject with 400
+      // (incident #536), so every payload is made well-formed here — the
+      // single chokepoint all ingest and retrieval embeds pass through.
+      const texts = command.texts.map(toWellFormedText);
+
       // Route through the global throttle so ingestion floods can never
       // starve retrieval; retrieval embeds jump ahead of ingestion embeds.
       // The await is load-bearing: returning the bare promise would let
       // rejections bypass this catch block.
       return await this.throttle.run(command.priority, () =>
-        handler.embed(command.texts, command.model),
+        handler.embed(texts, command.model),
       );
     } catch (error) {
       if (error instanceof ApplicationError) {


### PR DESCRIPTION
- Lone UTF-16 surrogates in chunk text (emoji split at a chunk boundary,
  OCR artifacts) serialize to \udXXX escapes that strict provider JSON
  decoders reject with 400 Invalid JSON payload, permanently failing the
  document (AppSignal incident #536)
- Add toWellFormedText (lone surrogates -> U+FFFD, NUL removal) and apply
  it in EmbedTextUseCase, the chokepoint every ingest and retrieval embed
  passes through

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared RAG embedding path for all orgs, but behavior is limited to replacing invalid code units and is covered by targeted tests.
> 
> **Overview**
> Fixes **400 Invalid JSON payload** from strict embedding providers (e.g. Mistral, incident #536) when chunk text contains **lone UTF-16 surrogates**—often from emoji split at chunk boundaries or OCR—which `JSON.stringify` emits as `\udXXX` escapes.
> 
> Adds **`toWellFormedText`**: lone surrogates become U+FFFD, NULs are stripped; valid surrogate pairs (emoji) are left alone. **`EmbedTextUseCase`** maps every text through this helper before the throttled handler call, so ingest and retrieval embeds share one chokepoint.
> 
> Unit tests cover the sanitizer edge cases and that the use case forwards sanitized strings to the provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b1092b29fe01e394bd24859a42b6c9801db4301. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->