### PR TITLE
fix(runs): retry token-limit truncated tool calls before durable output (AYC-669)

### DIFF
--- a/ayunis-core-backend/src/domain/models/application/models.errors.ts
+++ b/ayunis-core-backend/src/domain/models/application/models.errors.ts
@@ -13,6 +13,7 @@ export enum ModelErrorCode {
   MODEL_INVALID = 'MODEL_INVALID',
   MODEL_PROVIDER_NOT_SUPPORTED = 'MODEL_PROVIDER_NOT_SUPPORTED',
   INFERENCE_FAILED = 'INFERENCE_FAILED',
+  INFERENCE_TOKEN_LIMIT = 'INFERENCE_TOKEN_LIMIT',
   INFERENCE_ABORTED = 'INFERENCE_ABORTED',
   INFERENCE_IMAGE_TOO_LARGE = 'INFERENCE_IMAGE_TOO_LARGE',
   INFERENCE_INPUT_INVALID = 'INFERENCE_INPUT_INVALID',
@@ -58,9 +59,6 @@ export class UnexpectedModelError extends ModelError {
   }
 }
 
-/**
- * Error thrown when a model provider is not supported
- */
 export class ModelProviderNotSupportedError extends ModelError {
   constructor(provider: string, metadata?: ErrorMetadata) {
     super(
@@ -72,9 +70,6 @@ export class ModelProviderNotSupportedError extends ModelError {
   }
 }
 
-/**
- * Error thrown when a model is not found
- */
 export class ModelNotFoundError extends ModelError {
   constructor(modelId: UUID, metadata?: ErrorMetadata) {
     super(
@@ -86,7 +81,6 @@ export class ModelNotFoundError extends ModelError {
   }
 }
 
-/** Error thrown when a default model is not found */
 export class DefaultModelNotFoundError extends ModelError {
   constructor(orgId: string, metadata?: ErrorMetadata) {
     super(
@@ -134,7 +128,6 @@ export class PermittedImageGenerationModelNotFoundForOrgError extends ModelError
   }
 }
 
-/** Error thrown when deletion fails */
 export class PermittedModelDeletionFailedError extends ModelError {
   constructor(reason: string, metadata?: ErrorMetadata) {
     super(
@@ -146,7 +139,6 @@ export class PermittedModelDeletionFailedError extends ModelError {
   }
 }
 
-/** Error thrown when trying to delete the default model */
 export class CannotDeleteDefaultModelError extends ModelError {
   constructor(modelId?: string, metadata?: ErrorMetadata) {
     super(
@@ -158,7 +150,6 @@ export class CannotDeleteDefaultModelError extends ModelError {
   }
 }
 
-/** Error thrown when trying to delete the last permitted language model */
 export class CannotDeleteLastModelError extends ModelError {
   constructor(metadata?: ErrorMetadata) {
     super(
@@ -170,9 +161,6 @@ export class CannotDeleteLastModelError extends ModelError {
   }
 }
 
-/**
- * Error thrown when model input is invalid
- */
 export class ModelInvalidInputError extends ModelError {
   constructor(reason: string, metadata?: ErrorMetadata) {
     super(
@@ -184,14 +172,29 @@ export class ModelInvalidInputError extends ModelError {
   }
 }
 
-/**
- * Error thrown when inference fails
- */
 export class InferenceFailedError extends ModelError {
   constructor(reason: string, metadata?: ErrorMetadata) {
     super(
       `Inference failed: ${reason}`,
       ModelErrorCode.INFERENCE_FAILED,
+      500,
+      metadata,
+    );
+  }
+}
+
+/**
+ * The model hit its output-token budget while a tool call was still being
+ * emitted (finishReason 'length'), so the call's arguments cannot be
+ * trusted or executed (AYC-669). Distinct code so these group apart from
+ * other inference failures in AppSignal and the run pipeline can retry the
+ * attempt when nothing durable has streamed yet.
+ */
+export class InferenceTokenLimitError extends ModelError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'Inference failed: model response hit the token limit while emitting a tool call',
+      ModelErrorCode.INFERENCE_TOKEN_LIMIT,
       500,
       metadata,
     );
@@ -231,9 +234,6 @@ export class InferenceImageTooLargeError extends ModelError {
   }
 }
 
-/**
- * Error thrown when inference input is invalid
- */
 export class InferenceInputInvalidError extends ModelError {
   constructor(reason: string, metadata?: ErrorMetadata) {
     super(
@@ -257,9 +257,6 @@ export class InferenceStreamStalledError extends ModelError {
   }
 }
 
-/**
- * Error thrown when model rate limit is exceeded
- */
 export class ModelRateLimitExceededError extends ModelError {
   constructor(provider: string, metadata?: ErrorMetadata) {
     super(
@@ -271,9 +268,6 @@ export class ModelRateLimitExceededError extends ModelError {
   }
 }
 
-/**
- * Error thrown when trying to create a model that already exists
- */
 export class ModelAlreadyExistsError extends ModelError {
   constructor(name: string, provider: ModelProvider, metadata?: ErrorMetadata) {
     super(
@@ -285,9 +279,6 @@ export class ModelAlreadyExistsError extends ModelError {
   }
 }
 
-/**
- * Error thrown when model update fails
- */
 export class ModelUpdateFailedError extends ModelError {
   constructor(reason: string, metadata?: ErrorMetadata) {
     super(
@@ -299,9 +290,6 @@ export class ModelUpdateFailedError extends ModelError {
   }
 }
 
-/**
- * Error thrown when model creation fails
- */
 export class ModelCreationFailedError extends ModelError {
   constructor(reason: string, metadata?: ErrorMetadata) {
     super(
@@ -313,9 +301,6 @@ export class ModelCreationFailedError extends ModelError {
   }
 }
 
-/**
- * Error thrown when a model is not found by ID
- */
 export class ModelNotFoundByIdError extends ModelError {
   constructor(id: UUID, metadata?: ErrorMetadata) {
     super(
@@ -327,9 +312,6 @@ export class ModelNotFoundByIdError extends ModelError {
   }
 }
 
-/**
- * Error thrown when a model is not found by name and provider
- */
 export class ModelNotFoundByNameAndProviderError extends ModelError {
   constructor(name: string, provider: ModelProvider, metadata?: ErrorMetadata) {
     super(
@@ -341,9 +323,6 @@ export class ModelNotFoundByNameAndProviderError extends ModelError {
   }
 }
 
-/**
- * Error thrown when a model provider info is not found
- */
 export class ModelProviderInfoNotFoundError extends ModelError {
   constructor(provider: ModelProvider, metadata?: ErrorMetadata) {
     super(
@@ -355,9 +334,6 @@ export class ModelProviderInfoNotFoundError extends ModelError {
   }
 }
 
-/**
- * Error thrown when model deletion fails
- */
 export class ModelDeletionFailedError extends ModelError {
   constructor(reason: string, metadata?: ErrorMetadata) {
     super(
@@ -369,9 +345,6 @@ export class ModelDeletionFailedError extends ModelError {
   }
 }
 
-/**
- * Error thrown when multiple embedding models are not allowed
- */
 export class MultipleEmbeddingModelsNotAllowedError extends ModelError {
   constructor(metadata?: ErrorMetadata) {
     super(
@@ -383,9 +356,6 @@ export class MultipleEmbeddingModelsNotAllowedError extends ModelError {
   }
 }
 
-/**
- * Error thrown when multiple image-generation models are not allowed.
- */
 export class MultipleImageGenerationModelsNotAllowedError extends ModelError {
   constructor(metadata?: ErrorMetadata) {
     super(
@@ -397,9 +367,6 @@ export class MultipleImageGenerationModelsNotAllowedError extends ModelError {
   }
 }
 
-/**
- * Error thrown when an image-generation model uses an unsupported provider.
- */
 export class ImageGenerationModelProviderNotSupportedError extends ModelError {
   constructor(provider: ModelProvider, metadata?: ErrorMetadata) {
     super(
@@ -426,9 +393,6 @@ export class DuplicateTeamPermittedModelError extends ModelError {
   }
 }
 
-/**
- * Error thrown when the specified team does not exist in the caller's org.
- */
 export class TeamNotFoundInOrgError extends ModelError {
   constructor(teamId: UUID, metadata?: ErrorMetadata) {
     super(
@@ -440,9 +404,6 @@ export class TeamNotFoundInOrgError extends ModelError {
   }
 }
 
-/**
- * Error thrown when a permitted model does not belong to the specified team.
- */
 export class PermittedModelNotInTeamError extends ModelError {
   constructor(permittedModelId: UUID, teamId: UUID, metadata?: ErrorMetadata) {
     super(
@@ -454,9 +415,6 @@ export class PermittedModelNotInTeamError extends ModelError {
   }
 }
 
-/**
- * Error thrown when image generation fails.
- */
 export class ImageGenerationFailedError extends ModelError {
   constructor(reason: string, metadata?: ErrorMetadata) {
     super(
@@ -468,9 +426,6 @@ export class ImageGenerationFailedError extends ModelError {
   }
 }
 
-/**
- * Error thrown when a non-language model is used where a language model is required.
- */
 export class NotALanguageModelError extends ModelError {
   constructor(modelId: UUID, metadata?: ErrorMetadata) {
     super(

--- a/ayunis-core-backend/src/domain/runs/application/helpers/tool-call-arguments.helper.ts
+++ b/ayunis-core-backend/src/domain/runs/application/helpers/tool-call-arguments.helper.ts
@@ -1,6 +1,9 @@
 import { Logger } from '@nestjs/common';
 import { safeJsonParse } from 'src/common/util/unicode-sanitizer';
-import { InferenceFailedError } from 'src/domain/models/application/models.errors';
+import {
+  InferenceFailedError,
+  InferenceTokenLimitError,
+} from 'src/domain/models/application/models.errors';
 
 const logger = new Logger('ToolCallArguments');
 
@@ -42,10 +45,9 @@ export function assertToolCallArgumentsIntact(
   const calls = [...toolCalls].filter((call) => call.id && call.name);
   if (calls.length === 0) return;
   if (finishReason === 'length') {
-    throw new InferenceFailedError(
-      'model response hit the token limit while emitting a tool call',
-      { toolNames: calls.map((call) => call.name) },
-    );
+    throw new InferenceTokenLimitError({
+      toolNames: calls.map((call) => call.name),
+    });
   }
   const malformed = calls.filter(
     (call) => parseFinalToolArguments(call.arguments) === null,

--- a/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.spec.ts
@@ -9,6 +9,7 @@ import {
 import {
   InferenceFailedError,
   InferenceStreamStalledError,
+  InferenceTokenLimitError,
 } from 'src/domain/models/application/models.errors';
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
@@ -177,7 +178,7 @@ describe('StreamingInferenceService.executeStreamingInference — tool-call inte
   };
 
   const consume = async (service: StreamingInferenceService) => {
-    const yielded: AssistantMessage[] = [];
+    const yielded: { id: UUID }[] = [];
     for await (const message of service.executeStreamingInference({
       model,
       messages: [],
@@ -185,7 +186,9 @@ describe('StreamingInferenceService.executeStreamingInference — tool-call inte
       threadId,
       orgId,
     })) {
-      yielded.push(message);
+      // The generator yields the same mutable entity; snapshot the id so
+      // retry tests can assert identity across attempts.
+      yielded.push({ id: message.id });
     }
     return yielded;
   };
@@ -235,7 +238,7 @@ describe('StreamingInferenceService.executeStreamingInference — tool-call inte
     expect(toolUses).toHaveLength(0);
   });
 
-  it('throws InferenceFailedError when the stream hits the token limit while emitting tool calls', async () => {
+  it('throws InferenceTokenLimitError when the stream hits the token limit while emitting tool calls', async () => {
     const { service, savedMessages } = buildService([
       toolCallChunk({
         id: 'call_1',
@@ -245,7 +248,7 @@ describe('StreamingInferenceService.executeStreamingInference — tool-call inte
       finishChunk('length'),
     ]);
 
-    await expect(consume(service)).rejects.toThrow(InferenceFailedError);
+    await expect(consume(service)).rejects.toThrow(InferenceTokenLimitError);
 
     // Even parseable arguments from a token-limited turn must not be
     // persisted — the collector would execute them on the next run.
@@ -253,6 +256,102 @@ describe('StreamingInferenceService.executeStreamingInference — tool-call inte
       (block) => block instanceof ToolUseMessageContent,
     );
     expect(toolUses).toHaveLength(0);
+  });
+
+  it('retries once when the token limit truncates a tool call before any text or thinking streamed (AYC-669)', async () => {
+    // A failed tool-only attempt persists nothing (tool calls are excluded
+    // from the saved message), so a second attempt cannot duplicate content.
+    const truncatedChunks = [
+      toolCallChunk({
+        id: 'call_1',
+        name: 'create_document',
+        argumentsDelta: '{"title":"Bericht","content":"<h1>Unvollst',
+      }),
+      finishChunk('length'),
+    ];
+    const healthyChunks = [
+      toolCallChunk({
+        id: 'call_1',
+        name: 'create_document',
+        argumentsDelta: '{"title":"Bericht","content":"<h1>Kurz</h1>"}',
+      }),
+      finishChunk('tool_calls'),
+    ];
+    const execute = jest
+      .fn()
+      .mockReturnValueOnce(from(truncatedChunks))
+      .mockReturnValueOnce(from(healthyChunks));
+    const { service, savedMessages } = buildServiceWithStream(execute);
+
+    const yielded = await consume(service);
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    const toolUses = savedMessages
+      .flatMap((message) => message.content)
+      .filter((block) => block instanceof ToolUseMessageContent);
+    expect(toolUses).toHaveLength(1);
+    // Both attempts must stream under one message id — the chat UI keys
+    // updates by id, so a fresh id would leave the failed attempt's partial
+    // tool call on screen as a phantom message beside the retry.
+    expect(new Set(yielded.map((message) => message.id)).size).toBe(1);
+  });
+
+  it('retries a token-limit truncation when only whitespace streamed before the tool call', async () => {
+    // Persistence trims text before saving (buildBaseContent), so a
+    // whitespace-only prefix leaves nothing behind — it must not block the
+    // retry the way real text does.
+    const execute = jest
+      .fn()
+      .mockReturnValueOnce(
+        from([
+          StreamInferenceResponseChunk.text('\n\n'),
+          toolCallChunk({
+            id: 'call_1',
+            name: 'create_document',
+            argumentsDelta: '{"title":"Bericht","content":"<h1>Unvollst',
+          }),
+          finishChunk('length'),
+        ]),
+      )
+      .mockReturnValueOnce(
+        from([
+          toolCallChunk({
+            id: 'call_1',
+            name: 'create_document',
+            argumentsDelta: '{"title":"Bericht","content":"<h1>Kurz</h1>"}',
+          }),
+          finishChunk('tool_calls'),
+        ]),
+      );
+    const { service, savedMessages } = buildServiceWithStream(execute);
+
+    await consume(service);
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    const toolUses = savedMessages
+      .flatMap((message) => message.content)
+      .filter((block) => block instanceof ToolUseMessageContent);
+    expect(toolUses).toHaveLength(1);
+  });
+
+  it('does not retry a token-limit truncation after text was streamed', async () => {
+    // The streamed text is saved by the failed attempt; a retry would append
+    // a second answer to the thread.
+    const execute = jest.fn().mockReturnValue(
+      from([
+        StreamInferenceResponseChunk.text('Der Bericht beginnt hier'),
+        toolCallChunk({
+          id: 'call_1',
+          name: 'create_document',
+          argumentsDelta: '{"title":"Bericht","content":"<h1>Unvollst',
+        }),
+        finishChunk('length'),
+      ]),
+    );
+    const { service } = buildServiceWithStream(execute);
+
+    await expect(consume(service)).rejects.toThrow(InferenceTokenLimitError);
+    expect(execute).toHaveBeenCalledTimes(1);
   });
 
   it('discards intact sibling tool calls when one call of the turn is corrupted', async () => {

--- a/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.ts
@@ -23,7 +23,10 @@ import {
   assertToolCallArgumentsIntact,
   parseFinalToolArguments,
 } from '../helpers/tool-call-arguments.helper';
-import { InferenceStreamStalledError } from 'src/domain/models/application/models.errors';
+import {
+  InferenceStreamStalledError,
+  InferenceTokenLimitError,
+} from 'src/domain/models/application/models.errors';
 import { ContextService } from 'src/common/context/services/context.service';
 import { InferenceCompletedEvent } from '../events/inference-completed.event';
 import { extractInferenceErrorInfo } from '../helpers/extract-inference-error-info.helper';
@@ -42,7 +45,12 @@ interface StreamingInferenceParams {
   orgId: UUID;
 }
 
-/** Set as soon as an attempt streams visible content — after that, a retry would duplicate it. */
+/**
+ * Set as soon as an attempt streams durable content (text or thinking) —
+ * after that, a retry would duplicate what the failed attempt already saved.
+ * Tool-call deltas deliberately don't count: a failed attempt never persists
+ * its tool calls, so a tool-only attempt leaves nothing to duplicate.
+ */
 interface OutputTracker {
   producedOutput: boolean;
 }
@@ -102,36 +110,58 @@ export class StreamingInferenceService {
     params: StreamingInferenceParams,
   ): AsyncGenerator<AssistantMessage, void, unknown> {
     const tracker = { producedOutput: false };
+    // One message entity for all attempts: the chat UI keys updates by
+    // message id, so a retry under a fresh id would leave the failed
+    // attempt's partial content on screen as a phantom message.
+    const assistantMessage = new AssistantMessage({
+      threadId: params.threadId,
+      content: [],
+    });
     try {
-      yield* this.streamAttempt(params, tracker);
+      yield* this.streamAttempt(params, tracker, assistantMessage);
       return;
     } catch (error) {
-      // A stall before any output is safe to retry: nothing was streamed to
-      // the client and nothing was persisted, so the second attempt is
-      // indistinguishable from a slow first one. After output, a retry
-      // would duplicate content the user already watched arrive.
-      if (
-        !(error instanceof InferenceStreamStalledError) ||
-        tracker.producedOutput
-      ) {
+      // A stall or a token-limit-truncated tool call is safe to retry as
+      // long as no durable output was streamed: the failed attempt persisted
+      // nothing, so the second attempt is indistinguishable from a slow
+      // first one. After durable output, a retry would duplicate content
+      // the user already watched arrive (AYC-652, AYC-669).
+      if (!this.isRetryableBeforeOutput(error) || tracker.producedOutput) {
         throw error;
       }
       this.logger.warn(
-        'Provider stream stalled before producing output; retrying once',
-        { threadId: params.threadId },
+        'Recoverable inference failure before durable output; retrying once',
+        {
+          threadId: params.threadId,
+          reason: error.constructor.name,
+        },
       );
     }
-    yield* this.streamAttempt(params, { producedOutput: false });
+    yield* this.streamAttempt(
+      params,
+      { producedOutput: false },
+      assistantMessage,
+    );
+  }
+
+  private isRetryableBeforeOutput(
+    error: unknown,
+  ): error is InferenceStreamStalledError | InferenceTokenLimitError {
+    return (
+      error instanceof InferenceStreamStalledError ||
+      error instanceof InferenceTokenLimitError
+    );
   }
 
   private async *streamAttempt(
     params: StreamingInferenceParams,
     tracker: OutputTracker,
+    assistantMessage: AssistantMessage,
   ): AsyncGenerator<AssistantMessage, void, unknown> {
     const { model, tools, threadId, orgId } = params;
 
     const stream$ = this.startStream(params);
-    const assistantMessage = new AssistantMessage({ threadId, content: [] });
+    assistantMessage.content = [];
     const state = initialAccumulatedState();
     let streamCompletedSuccessfully = false;
     const allChunks: StreamInferenceResponseChunk[] = [];
@@ -244,8 +274,15 @@ export class StreamingInferenceService {
     for await (const chunk of asyncIterable) {
       const shouldUpdate = this.accumulateChunk(chunk, state);
 
-      if (shouldUpdate) {
+      // Same predicate as buildBaseContent's persistence check: a
+      // whitespace-only prefix saves nothing, so it must not block a retry.
+      if (
+        !tracker.producedOutput &&
+        (state.text.trim() !== '' || state.thinking.trim() !== '')
+      ) {
         tracker.producedOutput = true;
+      }
+      if (shouldUpdate) {
         assistantMessage.content = this.buildMessageContent(state, tools);
         yield assistantMessage;
       }


### PR DESCRIPTION
- A model hitting its output-token budget mid-tool-call now throws
  InferenceTokenLimitError (distinct code for AppSignal grouping,
  incident #544) instead of a generic InferenceFailedError
- Retry the attempt once when no text/thinking streamed yet — a failed
  tool-only attempt persists nothing, so a second attempt cannot
  duplicate content (mirrors the AYC-652 stall retry)
- Tool-call deltas no longer count as produced output for retry
  eligibility; they are display-only and excluded from the saved message
  on failure
- Drop name-restating comment banners in models.errors.ts to stay under
  the 500-line file cap

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core streaming inference retry and persistence rules for tool calls; wrong eligibility could duplicate thread content or skip needed retries, but behavior is narrowly scoped and heavily tested.
> 
> **Overview**
> When a model hits its output token budget mid–tool-call (`finishReason` `length`), the run now raises **`InferenceTokenLimitError`** (`INFERENCE_TOKEN_LIMIT`) instead of a generic **`InferenceFailedError`**, so AppSignal can group these separately and the pipeline can treat them as recoverable.
> 
> **`StreamingInferenceService`** extends the existing stall retry: it retries **once** on **`InferenceTokenLimitError`** (or stall) only if no **durable** output streamed yet—**text/thinking** (trimmed, matching what gets saved), not tool-call deltas. Failed tool-only attempts still don’t persist tool calls, so a retry shouldn’t duplicate thread content. Retries reuse one **`AssistantMessage`** id so the UI doesn’t show a phantom partial message beside the retry.
> 
> **`assertToolCallArgumentsIntact`** throws the new error on `length` with tool calls. **`models.errors.ts`** drops redundant comment banners (file length cap).
> 
> Specs cover retry success, whitespace-only prefix, and no retry after real text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd19dba1d411c3ab81564b1541c3aafbe429fbd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->