### PR TITLE
fix(observability): drop raw transport duplicates of classified provider failures (AYC-616)

### DIFF
--- a/ayunis-core-backend/appsignal-hooks.cjs
+++ b/ayunis-core-backend/appsignal-hooks.cjs
@@ -159,6 +159,97 @@ const SUPPRESSIONS = [
       'which stay fully reported.',
     exceptionType: '20',
   },
+  // RAW TRANSPORT DUPLICATES OF THE CLASSIFIED PROVIDER TAXONOMY
+  //
+  // Since AYC-651/653/654/655, every path that acts on provider egress (LLM
+  // inference, embeddings, OCR, MCP, anonymize) classifies these transport
+  // codes into PROVIDER_UNAVAILABLE_* / MCP_CONNECTION_TIMEOUT before they
+  // can fail a request. The undici/http instrumentation still records the
+  // raw errno on the span underneath the handled retry — there is no
+  // "handled" bit to test (see the header) — so each outage double-reports:
+  // once classified, once raw (AYC-615/616/625, incidents #181 #329 #387
+  // #409 #457 #511 #521 recurring on 2.22.2 after the taxonomy deploy).
+  // The classified incidents stay fully reported and carry the AYC-538
+  // rate/anomaly alerting; only the raw errno duplicates are dropped.
+  {
+    id: 'transport-headers-timeout',
+    lever: 'ignoreErrors',
+    ticket: 'AYC-616',
+    reason:
+      'Provider took too long to start responding. Classified as ' +
+      'PROVIDER_UNAVAILABLE_TIMEOUT_* wherever it can fail a request; the ' +
+      'raw undici span exception is a duplicate (incidents #521, #181).',
+    exceptionType: 'UND_ERR_HEADERS_TIMEOUT',
+  },
+  {
+    id: 'transport-dns-again',
+    lever: 'ignoreErrors',
+    ticket: 'AYC-616',
+    reason:
+      'Transient DNS resolution failure on outbound egress. Classified as ' +
+      'PROVIDER_UNAVAILABLE_CONNECTION_* with one setup retry; the raw ' +
+      'getaddrinfo span exception is a duplicate (incident #409).',
+    exceptionType: 'EAI_AGAIN',
+  },
+  {
+    id: 'transport-connection-reset',
+    lever: 'ignoreErrors',
+    ticket: 'AYC-616',
+    reason:
+      'Peer closed the socket mid-request ("socket hang up"). Classified as ' +
+      'PROVIDER_UNAVAILABLE_CONNECTION_* with one setup retry; the raw span ' +
+      'exception is a duplicate (incident #387).',
+    exceptionType: 'ECONNRESET',
+  },
+  {
+    id: 'transport-connection-aborted',
+    lever: 'ignoreErrors',
+    ticket: 'AYC-616',
+    reason:
+      'Legacy axios deadline shape: without clarifyTimeoutError, axios ' +
+      'reports an exceeded timeout as ECONNABORTED (incident #457, ' +
+      'pre-2.22.2 anonymize calls). Classified under the provider taxonomy ' +
+      'wherever it can fail a request; the raw span exception is a ' +
+      'duplicate.',
+    exceptionType: 'ECONNABORTED',
+  },
+  {
+    id: 'transport-timed-out',
+    lever: 'ignoreErrors',
+    ticket: 'AYC-616',
+    reason:
+      'Socket/deadline timeout errno. The anonymize client surfaces its ' +
+      'deadline as ETIMEDOUT since AYC-654 (clarifyTimeoutError), grouped ' +
+      'as PROVIDER_UNAVAILABLE_TIMEOUT_* by the taxonomy; the raw span ' +
+      'exception is a duplicate. The latency root cause is tracked in ' +
+      'AYC-662 via the classified incident.',
+    exceptionType: 'ETIMEDOUT',
+  },
+  {
+    id: 'transport-broken-pipe',
+    lever: 'ignoreErrors',
+    ticket: 'AYC-616',
+    reason:
+      'Write to a socket whose peer already disconnected — an SSE client ' +
+      'that went away or a dropped provider connection. Both directions are ' +
+      'expected socket lifecycle, not defects; consequent application ' +
+      'failures still report under their own names (incident #511).',
+    exceptionType: 'EPIPE',
+  },
+  {
+    id: 'timeout-signal-cancellation',
+    lever: 'ignoreErrors',
+    ticket: 'AYC-625',
+    reason:
+      'The DOMException Node mints for AbortSignal.timeout() (name ' +
+      'TimeoutError, numeric code 23, so exceptionType "23") — the timeout ' +
+      'sibling of the AbortError suppression above. Recorded by undici ' +
+      'instrumentation below SDK deadlines the application already handles ' +
+      'and retries; real timeouts surface as classified application errors ' +
+      '(PROVIDER_UNAVAILABLE_TIMEOUT_*, MCP_CONNECTION_TIMEOUT), which stay ' +
+      'fully reported (incident #329).',
+    exceptionType: '23',
+  },
   {
     id: 'bullmq-retry-scheduled',
     lever: 'ignoreErrors',

--- a/ayunis-core-backend/src/common/util/appsignal-hooks.spec.ts
+++ b/ayunis-core-backend/src/common/util/appsignal-hooks.spec.ts
@@ -1,6 +1,7 @@
 // appsignal-hooks.cjs is a plain CJS module loaded by appsignal.cjs before
 // the app boots; require() mirrors how it is consumed there.
 import createHttpError from 'http-errors';
+import { errors as undiciErrors } from 'undici';
 import { JobRetryScheduledError } from '../../domain/sources/infrastructure/queue/bullmq-job.helpers';
 
 type UndiciRequest = {
@@ -219,6 +220,39 @@ const ERROR_SAMPLES: Record<string, () => Error> = {
     createHttpError(413, 'request entity too large', {
       type: 'entity.too.large',
     }),
+  'transport-headers-timeout': () => new undiciErrors.HeadersTimeoutError(),
+  // Node mints errno errors as plain Errors carrying `code`; these mirror
+  // the exact shapes seen in incidents #409, #387, #457, #511.
+  'transport-dns-again': () =>
+    Object.assign(new Error('getaddrinfo EAI_AGAIN core-connect.ayunis.de'), {
+      code: 'EAI_AGAIN',
+      hostname: 'core-connect.ayunis.de',
+    }),
+  'transport-connection-reset': () =>
+    Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }),
+  'transport-connection-aborted': () =>
+    Object.assign(new Error('timeout of 30000ms exceeded'), {
+      code: 'ECONNABORTED',
+    }),
+  // The shape axios produces with clarifyTimeoutError: true — the anonymize
+  // client's deadline errno since AYC-654.
+  'transport-timed-out': () =>
+    Object.assign(new Error('timeout of 60000ms exceeded'), {
+      code: 'ETIMEDOUT',
+    }),
+  'transport-broken-pipe': () =>
+    Object.assign(new Error('write EPIPE'), {
+      code: 'EPIPE',
+      errno: -32,
+      syscall: 'write',
+    }),
+  // The exact object Node mints for AbortSignal.timeout(): name
+  // 'TimeoutError', numeric code 23 — exceptionType stringifies to '23'.
+  'timeout-signal-cancellation': () =>
+    new DOMException(
+      'The operation was aborted due to timeout',
+      'TimeoutError',
+    ),
 };
 
 describe('SUPPRESSIONS registry', () => {

--- a/ayunis-core-backend/src/domain/mcp/application/mcp.errors.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/mcp.errors.spec.ts
@@ -1,0 +1,36 @@
+import {
+  McpConnectionFailedError,
+  McpConnectionTimeoutError,
+} from './mcp.errors';
+
+// These messages are user-visible (validation responses, tool soft-failure
+// results, warning logs), so the server URL must not leak anything beyond
+// origin + path: credentials, query strings, and fragments can all carry
+// tokens for integrations whose serverUrl is otherwise never exposed.
+describe('MCP connectivity error messages', () => {
+  const secretUrl =
+    'https://user:hunter2@mcp.example.com/api?api_key=s3cret&sig=abc#token=xyz';
+
+  it.each([
+    ['McpConnectionFailedError', () => new McpConnectionFailedError(secretUrl)],
+    [
+      'McpConnectionTimeoutError',
+      () => new McpConnectionTimeoutError(secretUrl, 30_000),
+    ],
+  ])('%s strips credentials, query, and fragment', (_name, build) => {
+    const message = build().message;
+
+    expect(message).toContain('https://mcp.example.com/api');
+    expect(message).not.toContain('hunter2');
+    expect(message).not.toContain('user');
+    expect(message).not.toContain('api_key');
+    expect(message).not.toContain('s3cret');
+    expect(message).not.toContain('token=xyz');
+  });
+
+  it('keeps an unparseable server url untouched', () => {
+    const error = new McpConnectionFailedError('not-a-url');
+
+    expect(error.message).toContain('not-a-url');
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/application/mcp.errors.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/mcp.errors.ts
@@ -9,6 +9,7 @@ export enum McpErrorCode {
   MCP_INTEGRATION_ACCESS_DENIED = 'MCP_INTEGRATION_ACCESS_DENIED',
   MCP_INTEGRATION_DISABLED = 'MCP_INTEGRATION_DISABLED',
   MCP_CONNECTION_TIMEOUT = 'MCP_CONNECTION_TIMEOUT',
+  MCP_CONNECTION_FAILED = 'MCP_CONNECTION_FAILED',
   MCP_AUTHENTICATION_FAILED = 'MCP_AUTHENTICATION_FAILED',
   MCP_VALIDATION_FAILED = 'MCP_VALIDATION_FAILED',
   MCP_TOOL_EXECUTION_FAILED = 'MCP_TOOL_EXECUTION_FAILED',
@@ -134,14 +135,15 @@ export class McpIntegrationDisabledError extends McpError {
   }
 }
 
-function redactCredentials(serverUrl: string): string {
+/**
+ * Reduces a server URL to origin + path for user-visible messages:
+ * credentials, query strings, and fragments can all carry tokens for
+ * integrations whose serverUrl is otherwise never exposed.
+ */
+function redactServerUrl(serverUrl: string): string {
   try {
     const url = new URL(serverUrl);
-    if (url.username || url.password) {
-      url.username = '***';
-      url.password = '';
-    }
-    return url.toString();
+    return `${url.origin}${url.pathname}`;
   } catch {
     return serverUrl;
   }
@@ -156,7 +158,7 @@ function redactCredentials(serverUrl: string): string {
 export class McpConnectionTimeoutError extends McpError {
   constructor(serverUrl: string, timeoutMs: number, cause?: unknown) {
     super(
-      `The MCP server at ${redactCredentials(serverUrl)} did not respond ` +
+      `The MCP server at ${redactServerUrl(serverUrl)} did not respond ` +
         `within ${Math.round(timeoutMs / 1000)}s. Please verify the server ` +
         `is running and accessible.`,
       McpErrorCode.MCP_CONNECTION_TIMEOUT,
@@ -166,6 +168,42 @@ export class McpConnectionTimeoutError extends McpError {
       this.cause = cause;
     }
   }
+}
+
+/**
+ * Transport-level connection failure toward an MCP server (DNS, reset,
+ * broken pipe) — the connection sibling of McpConnectionTimeoutError, with
+ * the same user-presentable message contract. Carries a stable code so
+ * outages stay visible in AppSignal after the raw errno duplicates were
+ * suppressed (AYC-616).
+ */
+export class McpConnectionFailedError extends McpError {
+  constructor(serverUrl: string, cause?: unknown) {
+    super(
+      `The MCP server at ${redactServerUrl(serverUrl)} could not be ` +
+        `reached. Please verify the server is running and accessible.`,
+      McpErrorCode.MCP_CONNECTION_FAILED,
+      502,
+    );
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
+  }
+}
+
+/**
+ * The two classified MCP connectivity outages. Soft-handling call sites
+ * (tool execution, run-time capability discovery) must report these to
+ * AppSignal before swallowing them — their raw transport duplicates are
+ * suppressed (AYC-616), so the classified error is the only outage signal.
+ */
+export function isMcpConnectivityOutage(
+  error: unknown,
+): error is McpConnectionFailedError | McpConnectionTimeoutError {
+  return (
+    error instanceof McpConnectionFailedError ||
+    error instanceof McpConnectionTimeoutError
+  );
 }
 
 export class McpAuthenticationFailedError extends McpError {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.spec.ts
@@ -2,6 +2,7 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
+import { setError } from '@appsignal/nodejs';
 import { ExecuteMcpToolUseCase } from './execute-mcp-tool.use-case';
 import { ExecuteMcpToolCommand } from './execute-mcp-tool.command';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
@@ -9,12 +10,18 @@ import { McpClientService } from '../../services/mcp-client.service';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
 import {
+  McpConnectionFailedError,
+  McpConnectionTimeoutError,
   McpIntegrationNotFoundError,
   McpIntegrationAccessDeniedError,
   McpIntegrationDisabledError,
   McpUnauthenticatedError,
   UnexpectedMcpError,
 } from '../../mcp.errors';
+
+jest.mock('@appsignal/nodejs', () => ({
+  setError: jest.fn(),
+}));
 import { PredefinedMcpIntegration } from 'src/domain/mcp/domain/integrations/predefined-mcp-integration.entity';
 import { aCustomMcpIntegration } from 'src/domain/mcp/application/testing/mcp-integration.fixtures';
 import { PredefinedMcpIntegrationSlug } from 'src/domain/mcp/domain/value-objects/predefined-mcp-integration-slug.enum';
@@ -138,6 +145,53 @@ describe('ExecuteMcpToolUseCase', () => {
     expect(result.isError).toBe(true);
     expect(result.errorMessage).toBe('tool failed');
     expect(loggerWarnSpy).toHaveBeenCalled();
+  });
+
+  // The soft-handled tool result is the only place classified MCP outages
+  // surface during a run — without reporting here, suppressing the raw
+  // transport errnos (AYC-616) would leave connection outages invisible.
+  it('reports a classified connection failure to AppSignal while soft-returning it to the LLM', async () => {
+    const integration = buildPredefined();
+    repository.findById.mockResolvedValue(integration);
+    contextService.get.mockReturnValue(mockOrgId);
+    const connectionError = new McpConnectionFailedError(
+      'https://example.com/mcp',
+      new Error('getaddrinfo EAI_AGAIN example.com'),
+    );
+    mcpClientService.callTool.mockRejectedValue(connectionError);
+
+    const result = await useCase.execute(buildCommand());
+
+    expect(result.isError).toBe(true);
+    expect(setError).toHaveBeenCalledWith(connectionError);
+  });
+
+  it('reports a classified connection timeout to AppSignal while soft-returning it to the LLM', async () => {
+    const integration = buildPredefined();
+    repository.findById.mockResolvedValue(integration);
+    contextService.get.mockReturnValue(mockOrgId);
+    const timeoutError = new McpConnectionTimeoutError(
+      'https://example.com/mcp',
+      30_000,
+    );
+    mcpClientService.callTool.mockRejectedValue(timeoutError);
+
+    const result = await useCase.execute(buildCommand());
+
+    expect(result.isError).toBe(true);
+    expect(setError).toHaveBeenCalledWith(timeoutError);
+  });
+
+  it('does not report tool-level failures that are not connection outages', async () => {
+    const integration = buildPredefined();
+    repository.findById.mockResolvedValue(integration);
+    contextService.get.mockReturnValue(mockOrgId);
+    mcpClientService.callTool.mockRejectedValue(new Error('Invalid params'));
+
+    const result = await useCase.execute(buildCommand());
+
+    expect(result.isError).toBe(true);
+    expect(setError).not.toHaveBeenCalled();
   });
 
   it('throws when integration does not exist', async () => {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.ts
@@ -3,8 +3,9 @@ import { ExecuteMcpToolCommand } from './execute-mcp-tool.command';
 import { McpToolCall } from '../../ports/mcp-client.port';
 import { McpClientService } from '../../services/mcp-client.service';
 import { ContextService } from 'src/common/context/services/context.service';
-import { UnexpectedMcpError } from '../../mcp.errors';
+import { isMcpConnectivityOutage, UnexpectedMcpError } from '../../mcp.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { reportUnexpectedError } from 'src/common/errors/report-unexpected-error.helper';
 import { ValidateIntegrationAccessService } from '../../services/validate-integration-access.service';
 
 /**
@@ -62,38 +63,71 @@ export class ExecuteMcpToolUseCase {
           ...(result.isError && { errorMessage: 'Tool execution failed' }),
         };
       } catch (toolError) {
-        const duration = Date.now() - startTime;
-        const errorMsg =
-          (toolError as Error).message || 'Tool execution failed';
-
-        this.logger.warn(
-          `[MCP] operation=execute_tool integration=${command.integrationId} name="${integration.name}" tool="${command.toolName}" status=error error="${errorMsg}" duration=${duration}ms`,
+        return this.toSoftFailureResult(
+          toolError,
+          command,
+          integration.name,
+          startTime,
         );
-
-        // Return error to LLM (don't throw)
-        return {
-          isError: true,
-          content: null,
-          errorMessage: errorMsg,
-        };
       }
     } catch (error) {
-      const duration = Date.now() - startTime;
-
-      if (error instanceof ApplicationError) {
-        this.logger.warn(
-          `[MCP] operation=execute_tool integration=${command.integrationId} tool="${command.toolName}" status=error error="${error.message}" duration=${duration}ms`,
-        );
-        throw error;
-      }
-
-      this.logger.error(
-        `[MCP] operation=execute_tool integration=${command.integrationId} tool="${command.toolName}" status=unexpected_error error="${(error as Error).message}" duration=${duration}ms`,
-        { error: error as Error },
-      );
-      throw new UnexpectedMcpError(
-        'Unexpected error occurred during tool execution',
-      );
+      this.rethrowExecutionError(error, command, startTime);
     }
+  }
+
+  private rethrowExecutionError(
+    error: unknown,
+    command: ExecuteMcpToolCommand,
+    startTime: number,
+  ): never {
+    const duration = Date.now() - startTime;
+
+    if (error instanceof ApplicationError) {
+      this.logger.warn(
+        `[MCP] operation=execute_tool integration=${command.integrationId} tool="${command.toolName}" status=error error="${error.message}" duration=${duration}ms`,
+      );
+      throw error;
+    }
+
+    this.logger.error(
+      `[MCP] operation=execute_tool integration=${command.integrationId} tool="${command.toolName}" status=unexpected_error error="${(error as Error).message}" duration=${duration}ms`,
+      { error: error as Error },
+    );
+    throw new UnexpectedMcpError(
+      'Unexpected error occurred during tool execution',
+    );
+  }
+
+  /**
+   * Converts a thrown tool-call failure into the error result handed to the
+   * LLM. This soft-return is the only place classified MCP outages surface
+   * during a run, and their raw transport duplicates are suppressed
+   * AppSignal-side (AYC-616) — so the classified failure must be reported
+   * here or connection outages become invisible. Tool-level failures (bad
+   * params, server-side tool bugs) stay unreported: they are the
+   * integration's expected outcome, not ours.
+   */
+  private toSoftFailureResult(
+    toolError: unknown,
+    command: ExecuteMcpToolCommand,
+    integrationName: string,
+    startTime: number,
+  ): ToolExecutionResult {
+    const duration = Date.now() - startTime;
+    const errorMsg = (toolError as Error).message || 'Tool execution failed';
+
+    this.logger.warn(
+      `[MCP] operation=execute_tool integration=${command.integrationId} name="${integrationName}" tool="${command.toolName}" status=error error="${errorMsg}" duration=${duration}ms`,
+    );
+
+    if (isMcpConnectivityOutage(toolError)) {
+      reportUnexpectedError(toolError);
+    }
+
+    return {
+      isError: true,
+      content: null,
+      errorMessage: errorMsg,
+    };
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.spec.ts
@@ -5,7 +5,10 @@ import {
 } from '@modelcontextprotocol/client';
 import { McpSdkClientAdapter } from './mcp-sdk-client.adapter';
 import type { McpConnectionConfig } from '../../application/ports/mcp-client.port';
-import { McpConnectionTimeoutError } from '../../application/mcp.errors';
+import {
+  McpConnectionFailedError,
+  McpConnectionTimeoutError,
+} from '../../application/mcp.errors';
 import { MarketplaceMcpIntegration } from '../../domain/integrations/marketplace-mcp-integration.entity';
 import { NoAuthMcpIntegrationAuth } from '../../domain/auth/no-auth-mcp-integration-auth.entity';
 import { randomUUID } from 'crypto';
@@ -327,9 +330,91 @@ describe('McpSdkClientAdapter', () => {
 
       expect((mapped as Error).cause).toBe(abortError);
     });
+  });
+
+  describe('connection failure classification', () => {
+    // Undici wraps errno failures in `TypeError: fetch failed` with the
+    // coded error on `cause` — the shape of incidents #409/#387.
+    const buildFetchFailedError = (code: string, message: string) =>
+      Object.assign(new TypeError('fetch failed'), {
+        cause: Object.assign(new Error(message), { code }),
+      });
+
+    it('maps a DNS failure from an operation to McpConnectionFailedError', async () => {
+      clientMock.listTools.mockRejectedValue(
+        buildFetchFailedError(
+          'EAI_AGAIN',
+          'getaddrinfo EAI_AGAIN core-connect.ayunis.de',
+        ),
+      );
+
+      await expect(adapter.listTools(config)).rejects.toThrow(
+        McpConnectionFailedError,
+      );
+    });
+
+    it('maps a connection reset during connect to McpConnectionFailedError', async () => {
+      clientMock.connect.mockRejectedValue(
+        buildFetchFailedError('ECONNRESET', 'socket hang up'),
+      );
+
+      await expect(adapter.listTools(config)).rejects.toThrow(
+        McpConnectionFailedError,
+      );
+    });
+
+    it('keeps the original error on the non-serialized cause', async () => {
+      const transportError = buildFetchFailedError(
+        'ECONNRESET',
+        'socket hang up',
+      );
+      clientMock.listTools.mockRejectedValue(transportError);
+
+      const mapped = await adapter.listTools(config).catch((e: unknown) => e);
+
+      expect((mapped as Error).cause).toBe(transportError);
+    });
+
+    it('passes non-transport operation errors through unchanged', async () => {
+      const protocolError = new Error('Method not found');
+      clientMock.listTools.mockRejectedValue(protocolError);
+
+      await expect(adapter.listTools(config)).rejects.toBe(protocolError);
+    });
+
+    // Timeout errnos outside the SDK's own codes must classify too: their
+    // raw span duplicates are suppressed (AYC-616), so an unclassified
+    // timeout would leave the outage invisible on soft-return paths.
+    it('maps an undici headers timeout to McpConnectionTimeoutError', async () => {
+      clientMock.listTools.mockRejectedValue(
+        buildFetchFailedError(
+          'UND_ERR_HEADERS_TIMEOUT',
+          'Headers Timeout Error',
+        ),
+      );
+
+      await expect(adapter.listTools(config)).rejects.toThrow(
+        McpConnectionTimeoutError,
+      );
+    });
+
+    it('maps an AbortSignal.timeout DOMException to McpConnectionTimeoutError', async () => {
+      clientMock.listTools.mockRejectedValue(
+        new DOMException(
+          'The operation was aborted due to timeout',
+          'TimeoutError',
+        ),
+      );
+
+      await expect(adapter.listTools(config)).rejects.toThrow(
+        McpConnectionTimeoutError,
+      );
+    });
 
     it('maps timeouts on callTool as well', async () => {
-      clientMock.callTool.mockRejectedValue(buildDomAbortError());
+      clientMock.callTool.mockRejectedValue(
+        new DOMException('This operation was aborted', 'AbortError'),
+      );
 
       await expect(
         adapter.callTool(config, { toolName: 'search', parameters: {} }),

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.ts
@@ -17,7 +17,12 @@ import { McpIntegrationsRepositoryPort } from '../../application/ports/mcp-integ
 import { SchemaConfiguredMcpIntegration } from '../../domain/integrations/schema-configured-mcp-integration.entity';
 import type { UUID } from 'crypto';
 import { McpOAuthFetchPort } from '../../application/ports/mcp-oauth-fetch.port';
-import { McpConnectionTimeoutError } from '../../application/mcp.errors';
+import {
+  McpConnectionFailedError,
+  McpConnectionTimeoutError,
+} from '../../application/mcp.errors';
+import { classifyTransportError } from 'src/common/errors/provider-transport-error.classifier';
+import { ProviderFailureClass } from 'src/common/errors/provider.errors';
 
 /**
  * Node's AbortController.abort() mints a DOMException with name 'AbortError'
@@ -240,12 +245,23 @@ export class McpSdkClientAdapter extends McpClientPort {
     error: unknown,
     config: McpConnectionConfig,
   ): unknown {
-    if (isTimeoutOrAbortError(error)) {
+    // Transport errnos (timeouts beyond the SDK's own codes, DNS, reset,
+    // broken pipe) must not escape raw either: their raw span duplicates
+    // are suppressed AppSignal-side (AYC-616), so the classified error is
+    // the only outage signal left.
+    const transport = classifyTransportError(error);
+    if (
+      isTimeoutOrAbortError(error) ||
+      transport?.failureClass === ProviderFailureClass.TIMEOUT
+    ) {
       return new McpConnectionTimeoutError(
         config.serverUrl,
         this.requestOptions.timeout,
         error,
       );
+    }
+    if (transport?.failureClass === ProviderFailureClass.CONNECTION) {
+      return new McpConnectionFailedError(config.serverUrl, error);
     }
     return error;
   }

--- a/ayunis-core-backend/src/domain/runs/application/services/mcp-tool-assembler.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/mcp-tool-assembler.service.spec.ts
@@ -1,0 +1,76 @@
+import { randomUUID } from 'crypto';
+import { setError } from '@appsignal/nodejs';
+import { Logger } from '@nestjs/common';
+import { McpToolAssemblerService } from './mcp-tool-assembler.service';
+import {
+  McpConnectionFailedError,
+  McpConnectionTimeoutError,
+} from 'src/domain/mcp/application/mcp.errors';
+import type { DiscoverMcpCapabilitiesUseCase } from 'src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case';
+import type { GetMcpIntegrationsByIdsUseCase } from 'src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.use-case';
+import type { Thread } from 'src/domain/threads/domain/thread.entity';
+
+jest.mock('@appsignal/nodejs', () => ({
+  setError: jest.fn(),
+}));
+
+describe('McpToolAssemblerService — discovery outage reporting (AYC-616)', () => {
+  const integrationId = randomUUID();
+
+  beforeAll(() => {
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const buildService = (discoveryRejection: Error) => {
+    const discover = {
+      execute: jest.fn().mockRejectedValue(discoveryRejection),
+    } as unknown as DiscoverMcpCapabilitiesUseCase;
+    const getByIds = {
+      execute: jest
+        .fn()
+        .mockResolvedValue([{ id: integrationId, name: 'Test Integration' }]),
+    } as unknown as GetMcpIntegrationsByIdsUseCase;
+    return new McpToolAssemblerService(discover, getByIds);
+  };
+
+  const thread = { mcpIntegrationIds: [integrationId] } as unknown as Thread;
+
+  it('reports a classified connection outage while still soft-skipping the integration', async () => {
+    const outage = new McpConnectionFailedError(
+      'https://example.com/mcp',
+      new Error('getaddrinfo EAI_AGAIN example.com'),
+    );
+    const service = buildService(outage);
+
+    const tools = await service.assemble(thread, new Set());
+
+    expect(tools).toEqual([]);
+    expect(setError).toHaveBeenCalledWith(outage);
+  });
+
+  it('reports a classified connection timeout while still soft-skipping the integration', async () => {
+    const timeout = new McpConnectionTimeoutError(
+      'https://example.com/mcp',
+      30_000,
+    );
+    const service = buildService(timeout);
+
+    const tools = await service.assemble(thread, new Set());
+
+    expect(tools).toEqual([]);
+    expect(setError).toHaveBeenCalledWith(timeout);
+  });
+
+  it('does not report discovery failures that are not connectivity outages', async () => {
+    const service = buildService(new Error('Method not found'));
+
+    const tools = await service.assemble(thread, new Set());
+
+    expect(tools).toEqual([]);
+    expect(setError).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/runs/application/services/mcp-tool-assembler.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/mcp-tool-assembler.service.ts
@@ -9,6 +9,8 @@ import { GetMcpIntegrationsByIdsQuery } from 'src/domain/mcp/application/use-cas
 import { McpIntegrationTool } from 'src/domain/tools/domain/tools/mcp-integration-tool.entity';
 import { McpIntegrationResource } from 'src/domain/tools/domain/tools/mcp-integration-resource.entity';
 import { MarketplaceMcpIntegration } from 'src/domain/mcp/domain/integrations/marketplace-mcp-integration.entity';
+import { isMcpConnectivityOutage } from 'src/domain/mcp/application/mcp.errors';
+import { reportUnexpectedError } from 'src/common/errors/report-unexpected-error.helper';
 
 type McpCapability = Awaited<
   ReturnType<DiscoverMcpCapabilitiesUseCase['execute']>
@@ -146,6 +148,13 @@ export class McpToolAssemblerService {
                 : 'Unknown error',
           },
         );
+        // The skip is the only place run-time discovery outages surface, and
+        // their raw transport duplicates are suppressed AppSignal-side
+        // (AYC-616) — report the classified failure or the outage is
+        // invisible, often before any tool call runs.
+        if (isMcpConnectivityOutage(result.reason)) {
+          reportUnexpectedError(result.reason);
+        }
         return null;
       })
       .filter((cap): cap is McpCapability => cap !== null);


### PR DESCRIPTION
- Since the AYC-651/653/654/655 taxonomy work every provider-egress path
  classifies transport failures into PROVIDER_UNAVAILABLE_* before they
  can fail a request, but the undici/http instrumentation still records
  the raw errno on the span — each outage double-reports (incidents #181
  #329 #387 #409 #457 #511 #521 kept recurring on 2.22.2 after the
  taxonomy deploy)
- Add ignoreErrors suppressions for UND_ERR_HEADERS_TIMEOUT, EAI_AGAIN,
  ECONNRESET, ECONNABORTED, EPIPE and the AbortSignal.timeout
  DOMException (code 23), each with a verified sample error in the
  registry spec
- Classified PROVIDER_UNAVAILABLE_* incidents stay fully reported and
  carry the AYC-538 rate alerting

Refs: AYC-615, AYC-625

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes observability filtering and MCP error reporting on paths that swallow errors; misclassification could hide outages, though classified 5xx errors are explicitly reported before suppression takes effect.
> 
> **Overview**
> Stops **duplicate AppSignal incidents** where classified provider/MCP outages already surface as `PROVIDER_UNAVAILABLE_*` or `MCP_CONNECTION_TIMEOUT`, but undici still records the underlying errno on the span. New `ignoreErrors` entries drop those raw types (`UND_ERR_HEADERS_TIMEOUT`, `EAI_AGAIN`, `ECONNRESET`, `ECONNABORTED`, `ETIMEDOUT`, `EPIPE`, and `AbortSignal.timeout` / code `23`), each backed by a sample error in the registry spec.
> 
> Because suppressing the raw signal would blind soft-handled MCP paths, the PR **classifies and explicitly reports** connectivity failures: adds `McpConnectionFailedError` (`MCP_CONNECTION_FAILED`), maps transport errors in the MCP SDK adapter via `classifyTransportError`, and calls `reportUnexpectedError` when tool execution or run-time capability discovery swallows `McpConnectionTimeoutError` / `McpConnectionFailedError`. User-visible MCP messages now use **origin + path only** in server URLs (no credentials, query, or fragment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 066130a3a29deab25ca1a577742bc86017860598. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->