### PR TITLE
fix(welcome-video): backfill existing users as seen (AYC-407)

### DIFF
--- a/ayunis-core-backend/src/db/migration-tests/add-welcome-video-seen-at-to-onboarding.spec.ts
+++ b/ayunis-core-backend/src/db/migration-tests/add-welcome-video-seen-at-to-onboarding.spec.ts
@@ -1,0 +1,36 @@
+import type { QueryRunner } from 'typeorm';
+import { BackfillWelcomeVideoSeenForExistingUsers1786019986279 } from '../migrations/1786019986279-BackfillWelcomeVideoSeenForExistingUsers';
+
+describe('BackfillWelcomeVideoSeenForExistingUsers1786019986279', () => {
+  it('marks every existing user as having seen the welcome video', async () => {
+    const query = jest.fn().mockResolvedValue(undefined);
+    const queryRunner = { query } as unknown as QueryRunner;
+    const migration =
+      new BackfillWelcomeVideoSeenForExistingUsers1786019986279();
+
+    await migration.up(queryRunner);
+
+    expect(query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('INSERT INTO "onboarding"'),
+    );
+    expect(query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('SELECT gen_random_uuid()::text, "id", NOW()'),
+    );
+    expect(query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('FROM "users"'),
+    );
+    expect(query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('ON CONFLICT ("userId") DO UPDATE'),
+    );
+    expect(query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining(
+        'COALESCE(onboarding."welcomeVideoSeenAt", EXCLUDED."welcomeVideoSeenAt")',
+      ),
+    );
+  });
+});

--- a/ayunis-core-backend/src/db/migrations/1786019986279-BackfillWelcomeVideoSeenForExistingUsers.ts
+++ b/ayunis-core-backend/src/db/migrations/1786019986279-BackfillWelcomeVideoSeenForExistingUsers.ts
@@ -1,0 +1,21 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class BackfillWelcomeVideoSeenForExistingUsers1786019986279 implements MigrationInterface {
+  name = 'BackfillWelcomeVideoSeenForExistingUsers1786019986279';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `INSERT INTO "onboarding" ("id", "userId", "welcomeVideoSeenAt", "createdAt", "updatedAt")
+       SELECT gen_random_uuid()::text, "id", NOW(), NOW(), NOW()
+       FROM "users"
+       ON CONFLICT ("userId") DO UPDATE
+       SET "welcomeVideoSeenAt" = COALESCE(onboarding."welcomeVideoSeenAt", EXCLUDED."welcomeVideoSeenAt"),
+           "updatedAt" = NOW()`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // Clearing the marker would show the welcome video to existing users.
+    // Intentional no-op.
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> One-time migration updates or creates onboarding rows for all users; logic is upsert-safe with COALESCE but still touches broad production data at deploy time.
> 
> **Overview**
> Adds a TypeORM migration that **backfills** `welcomeVideoSeenAt` for every row in `users` so existing accounts are treated as having already seen the welcome video after the column was introduced.
> 
> The migration runs an `INSERT … SELECT` into `onboarding` with `ON CONFLICT ("userId") DO UPDATE`, setting `welcomeVideoSeenAt` via `COALESCE` so an existing non-null timestamp is preserved. **`down` is intentionally a no-op** to avoid resurfacing the video for legacy users.
> 
> A migration spec asserts the executed SQL includes the insert, user source, upsert, and `COALESCE` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4065eb3b14ae3274037e5854ee1a37e4b1a1cf4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->