### PR TITLE
wip(auth): add sso persistence tables (AYC-638)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -73,6 +73,7 @@ ayunis-core/
 | [onboarding](ayunis-core-backend/src/iam/onboarding/SUMMARY.md) | Onboarding | Per-user onboarding progress |
 | [hashing](ayunis-core-backend/src/iam/hashing/SUMMARY.md) | Security | Password hashing |
 | [ip-allowlist](ayunis-core-backend/src/iam/ip-allowlist/SUMMARY.md) | Network Security | Per-organization IP allowlist enforcement |
+| [sso](ayunis-core-backend/src/iam/sso/SUMMARY.md) | Federated Identity | Municipal SSO connections and broker identity mappings |
 
 ### Infrastructure & Support
 

--- a/ayunis-core-backend/src/db/migrations/1786452570864-CreateSsoPersistenceTables.ts
+++ b/ayunis-core-backend/src/db/migrations/1786452570864-CreateSsoPersistenceTables.ts
@@ -1,0 +1,37 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateSsoPersistenceTables1786452570864 implements MigrationInterface {
+  name = 'CreateSsoPersistenceTables1786452570864';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "org_sso_connections" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "orgId" character varying NOT NULL, "emailDomain" character varying(253) NOT NULL, "domainVerifiedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "zitadelOrgId" character varying(255), "enabled" boolean NOT NULL DEFAULT false, "jitProvisioningEnabled" boolean NOT NULL DEFAULT false, CONSTRAINT "UQ_4f11a98a3183992bf0ac0090ac2" UNIQUE ("zitadelOrgId"), CONSTRAINT "UQ_f77aa036bc1422c9ce84a9a13ac" UNIQUE ("emailDomain"), CONSTRAINT "REL_62c35b470ecd255934b5d600f2" UNIQUE ("orgId"), CONSTRAINT "CHK_1ba5659d1b01dc71cde8266dae" CHECK (NOT "enabled" OR "zitadelOrgId" IS NOT NULL), CONSTRAINT "CHK_c34e321de4a0d740abdc1be8aa" CHECK ("zitadelOrgId" IS NULL OR ("zitadelOrgId" <> '' AND "zitadelOrgId" = btrim("zitadelOrgId"))), CONSTRAINT "CHK_3feae2d6977f38df9dba7d40d9" CHECK ("emailDomain" ~ '^([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9])([.]([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9]))+$'), CONSTRAINT "CHK_a9d6795bc6310fd249315648eb" CHECK ("emailDomain" = lower(btrim("emailDomain"))), CONSTRAINT "PK_99059cd7cff9f1895de54a08804" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "federated_identities" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "issuer" text NOT NULL, "subject" character varying(255) NOT NULL, "userId" character varying NOT NULL, CONSTRAINT "UQ_c9ea7918683e4d47f6e16d5fd33" UNIQUE ("issuer", "subject"), CONSTRAINT "PK_3e5b63cd07d7a2251e0131834a3" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_ed23d05acbc826a270bb135f0a" ON "federated_identities" ("userId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "org_sso_connections" ADD CONSTRAINT "FK_62c35b470ecd255934b5d600f27" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "federated_identities" ADD CONSTRAINT "FK_ed23d05acbc826a270bb135f0a5" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "federated_identities" DROP CONSTRAINT "FK_ed23d05acbc826a270bb135f0a5"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "org_sso_connections" DROP CONSTRAINT "FK_62c35b470ecd255934b5d600f27"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_ed23d05acbc826a270bb135f0a"`,
+    );
+    await queryRunner.query(`DROP TABLE "federated_identities"`);
+    await queryRunner.query(`DROP TABLE "org_sso_connections"`);
+  }
+}

--- a/ayunis-core-backend/src/iam/iam.module.ts
+++ b/ayunis-core-backend/src/iam/iam.module.ts
@@ -37,6 +37,7 @@ import { RateLimitGuard } from 'src/common/guards/rate-limit.guard';
 import { AddonGuard } from './authorization/application/guards/addon.guard';
 import { UsageBasedSubscriptionGuard } from './authorization/application/guards/usage-based-subscription.guard';
 import { AcademyCertificateGuard } from './academy-access/application/guards/academy-certificate.guard';
+import { SsoModule } from './sso/sso.module';
 
 // Feature modules re-exported by IamModule. Listed once and spread into both
 // `imports` and `exports` so the two cannot drift out of sync.
@@ -61,6 +62,7 @@ const IAM_FEATURE_MODULES = [
   AcademyAccessModule,
   PermissionsModule,
   MfaModule,
+  SsoModule,
 ];
 
 // Global guard execution order is declared HERE — explicitly, in array

--- a/ayunis-core-backend/src/iam/sso/SUMMARY.md
+++ b/ayunis-core-backend/src/iam/sso/SUMMARY.md
@@ -1,0 +1,6 @@
+SSO
+Persists organization SSO configuration and links validated broker identities to Ayunis users.
+
+Each organization can have one SSO connection with a unique verified email domain, its verification timestamp, and an optional unique Zitadel organization ID. The enabled flag is the runtime login switch and requires a broker organization mapping. JIT provisioning is an independent opt-in through `jitProvisioningEnabled`; invitations remain available regardless of that setting.
+
+Federated identities use the exact validated OIDC issuer and subject as their durable unique key and reference the internal Ayunis user. Organization and user deletion cascade to their corresponding SSO records. This module does not persist customer IdP credentials or the future self-service onboarding lifecycle, and it does not implement OIDC protocol handling, account linking, provisioning, or authorization decisions.

--- a/ayunis-core-backend/src/iam/sso/infrastructure/persistence/postgres/schema/federated-identity.record.ts
+++ b/ayunis-core-backend/src/iam/sso/infrastructure/persistence/postgres/schema/federated-identity.record.ts
@@ -1,0 +1,22 @@
+import type { UUID } from 'crypto';
+import { Column, Entity, Index, JoinColumn, ManyToOne, Unique } from 'typeorm';
+import { BaseRecord } from 'src/common/db/base-record';
+import { UserRecord } from 'src/iam/users/infrastructure/repositories/local/schema/user.record';
+
+@Entity({ name: 'federated_identities' })
+@Unique(['issuer', 'subject'])
+export class FederatedIdentityRecord extends BaseRecord {
+  @Column({ type: 'text' })
+  issuer: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  subject: string;
+
+  @Index()
+  @Column()
+  userId: UUID;
+
+  @ManyToOne(() => UserRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: UserRecord;
+}

--- a/ayunis-core-backend/src/iam/sso/infrastructure/persistence/postgres/schema/org-sso-connection.record.ts
+++ b/ayunis-core-backend/src/iam/sso/infrastructure/persistence/postgres/schema/org-sso-connection.record.ts
@@ -1,0 +1,40 @@
+import type { UUID } from 'crypto';
+import { Check, Column, Entity, JoinColumn, OneToOne, Unique } from 'typeorm';
+import { BaseRecord } from 'src/common/db/base-record';
+import { OrgRecord } from 'src/iam/orgs/infrastructure/repositories/local/schema/org.record';
+
+const DOMAIN_PATTERN =
+  '^([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9])([.]([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9]))+$';
+
+@Entity({ name: 'org_sso_connections' })
+@Unique(['emailDomain'])
+@Unique(['zitadelOrgId'])
+@Check('"emailDomain" = lower(btrim("emailDomain"))')
+@Check(`"emailDomain" ~ '${DOMAIN_PATTERN}'`)
+@Check(
+  '"zitadelOrgId" IS NULL OR ("zitadelOrgId" <> \'\' AND "zitadelOrgId" = btrim("zitadelOrgId"))',
+)
+@Check('NOT "enabled" OR "zitadelOrgId" IS NOT NULL')
+export class OrgSsoConnectionRecord extends BaseRecord {
+  @Column()
+  orgId: UUID;
+
+  @OneToOne(() => OrgRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'orgId' })
+  org: OrgRecord;
+
+  @Column({ type: 'varchar', length: 253 })
+  emailDomain: string;
+
+  @Column({ type: 'timestamptz', nullable: false })
+  domainVerifiedAt: Date;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  zitadelOrgId: string | null;
+
+  @Column({ default: false })
+  enabled: boolean;
+
+  @Column({ default: false })
+  jitProvisioningEnabled: boolean;
+}

--- a/ayunis-core-backend/src/iam/sso/infrastructure/persistence/postgres/sso-persistence.schema.spec.ts
+++ b/ayunis-core-backend/src/iam/sso/infrastructure/persistence/postgres/sso-persistence.schema.spec.ts
@@ -1,0 +1,96 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { FederatedIdentityRecord } from './schema/federated-identity.record';
+import { OrgSsoConnectionRecord } from './schema/org-sso-connection.record';
+
+type SsoRecord = typeof OrgSsoConnectionRecord | typeof FederatedIdentityRecord;
+
+function uniqueColumnsFor(target: SsoRecord): string[][] {
+  return getMetadataArgsStorage()
+    .uniques.filter((unique) => unique.target === target)
+    .map((unique) => (Array.isArray(unique.columns) ? unique.columns : []));
+}
+
+function relationFor(target: SsoRecord, propertyName: string) {
+  return getMetadataArgsStorage().relations.find(
+    (relation) =>
+      relation.target === target && relation.propertyName === propertyName,
+  );
+}
+
+function columnFor(target: SsoRecord, propertyName: string) {
+  return getMetadataArgsStorage().columns.find(
+    (column) =>
+      column.target === target && column.propertyName === propertyName,
+  );
+}
+
+function checksFor(target: SsoRecord): string[] {
+  return getMetadataArgsStorage()
+    .checks.filter((check) => check.target === target)
+    .map((check) => check.expression);
+}
+
+describe('SSO persistence schema', () => {
+  it('stores one unique verified domain per organization', () => {
+    expect(uniqueColumnsFor(OrgSsoConnectionRecord)).toEqual(
+      expect.arrayContaining([['emailDomain'], ['zitadelOrgId']]),
+    );
+    expect(relationFor(OrgSsoConnectionRecord, 'org')).toMatchObject({
+      relationType: 'one-to-one',
+      options: { onDelete: 'CASCADE' },
+    });
+  });
+
+  it('defaults new connections to disabled with JIT provisioning off', () => {
+    expect(columnFor(OrgSsoConnectionRecord, 'enabled')?.options).toMatchObject(
+      {
+        default: false,
+      },
+    );
+    expect(
+      columnFor(OrgSsoConnectionRecord, 'jitProvisioningEnabled')?.options,
+    ).toMatchObject({
+      default: false,
+    });
+  });
+
+  it('does not persist lifecycle or mutually exclusive provisioning modes', () => {
+    expect(columnFor(OrgSsoConnectionRecord, 'status')).toBeUndefined();
+    expect(
+      columnFor(OrgSsoConnectionRecord, 'provisioningMode'),
+    ).toBeUndefined();
+  });
+
+  it('keeps domain verification and Zitadel provisioning explicit', () => {
+    expect(
+      columnFor(OrgSsoConnectionRecord, 'verifiedEmailDomain'),
+    ).toBeUndefined();
+    expect(columnFor(OrgSsoConnectionRecord, 'brokerOrgId')).toBeUndefined();
+    expect(
+      columnFor(OrgSsoConnectionRecord, 'domainVerifiedAt')?.options,
+    ).toMatchObject({ nullable: false, type: 'timestamptz' });
+    expect(
+      columnFor(OrgSsoConnectionRecord, 'zitadelOrgId')?.options,
+    ).toMatchObject({ nullable: true });
+    expect(checksFor(OrgSsoConnectionRecord)).toEqual(
+      expect.arrayContaining([
+        '"emailDomain" = lower(btrim("emailDomain"))',
+        expect.stringContaining('"emailDomain" ~'),
+        '"zitadelOrgId" IS NULL OR ("zitadelOrgId" <> \'\' AND "zitadelOrgId" = btrim("zitadelOrgId"))',
+        'NOT "enabled" OR "zitadelOrgId" IS NOT NULL',
+      ]),
+    );
+  });
+
+  it('keys federated identities by issuer and subject and deletes them with the user', () => {
+    expect(uniqueColumnsFor(FederatedIdentityRecord)).toContainEqual([
+      'issuer',
+      'subject',
+    ]);
+    expect(relationFor(FederatedIdentityRecord, 'user')?.options).toMatchObject(
+      {
+        onDelete: 'CASCADE',
+      },
+    );
+  });
+});

--- a/ayunis-core-backend/src/iam/sso/sso.module.ts
+++ b/ayunis-core-backend/src/iam/sso/sso.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FederatedIdentityRecord } from './infrastructure/persistence/postgres/schema/federated-identity.record';
+import { OrgSsoConnectionRecord } from './infrastructure/persistence/postgres/schema/org-sso-connection.record';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([OrgSsoConnectionRecord, FederatedIdentityRecord]),
+  ],
+})
+export class SsoModule {}


### PR DESCRIPTION
## Summary

- add one SSO connection per organization with a unique verified `emailDomain`, required `domainVerifiedAt`, and Zitadel organization mapping
- use `enabled` only as the runtime switch; no onboarding lifecycle or duplicate candidate-domain field is persisted
- persist `jitProvisioningEnabled` independently; invitations remain available regardless
- map validated OIDC issuer/subject pairs to internal users

## Validation

- generated migration applied against a clean schema with zero TypeORM drift
- backend: 599 suites / 4,289 tests passed
- ESLint, TypeScript, and dependency checks passed

Linear: AYC-638

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches IAM identity data model and constraints that future auth will depend on, but this PR is schema-only with no request-path or login behavior changes.
> 
> **Overview**
> Introduces **database persistence** for municipal SSO ahead of protocol and login flows. A migration creates `org_sso_connections` (one row per org: unique normalized `emailDomain`, required `domainVerifiedAt`, optional unique `zitadelOrgId`, `enabled` and `jitProvisioningEnabled` defaulting off, with checks that SSO cannot be enabled without a Zitadel org mapping) and `federated_identities` (unique `issuer` + `subject` → `userId`, indexed by user, cascade on org/user delete).
> 
> A new **`SsoModule`** registers the TypeORM entities only; **`IamModule`** imports/exports it. **`ARCHITECTURE.md`** and **`sso/SUMMARY.md`** document the module scope (no IdP secrets, lifecycle, or OIDC handling in this slice). Metadata tests in **`sso-persistence.schema.spec.ts`** lock in uniques, defaults, and check constraints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6876f925587052a90735eff9d5fed9e07845dd24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->