### PR TITLE
fix(deps): apply layer-boundary rules to nested module groups (AYC-335)

### DIFF
--- a/ayunis-core-backend/.dependency-cruiser.cjs
+++ b/ayunis-core-backend/.dependency-cruiser.cjs
@@ -1,3 +1,16 @@
+// Two module groups nest their submodules one level deeper than flat modules:
+//   src/domain/rag/*        → embeddings, indexers, splitters
+//   src/domain/retrievers/* → file-retrievers, internet-search-retrievers, url-retrievers
+// The `(?:rag/|retrievers/)?` prefix lets the layer-boundary rules match those
+// submodules too. A literal alternation is used deliberately — depcruise's ReDoS
+// guard rejects the equivalent `(?:[^/]+/)?`.
+const MODULE_GROUP_PREFIX = '(?:rag/|retrievers/)?';
+
+// Matches the root of any module, e.g. `src/domain/threads` or
+// `src/domain/retrievers/url-retrievers`. `(domain|iam)` is a capture group;
+// rules that only need path scoping ignore it.
+const MODULE_ROOT = `^src/(domain|iam)/${MODULE_GROUP_PREFIX}[^/]+`;
+
 /** @type {import('dependency-cruiser').IConfiguration} */
 module.exports = {
   forbidden: [
@@ -11,10 +24,10 @@ module.exports = {
       comment: 'Domain layer cannot import infrastructure (repositories, records)',
       severity: 'error',
       from: {
-        path: '^src/(domain|iam)/[^/]+/domain/',
+        path: `${MODULE_ROOT}/domain/`,
       },
       to: {
-        path: '^src/(domain|iam)/[^/]+/infrastructure/',
+        path: `${MODULE_ROOT}/infrastructure/`,
       },
     },
     {
@@ -22,10 +35,10 @@ module.exports = {
       comment: 'Domain layer cannot import presenters (controllers, DTOs)',
       severity: 'error',
       from: {
-        path: '^src/(domain|iam)/[^/]+/domain/',
+        path: `${MODULE_ROOT}/domain/`,
       },
       to: {
-        path: '^src/(domain|iam)/[^/]+/presenters/',
+        path: `${MODULE_ROOT}/presenters/`,
       },
     },
     {
@@ -33,10 +46,10 @@ module.exports = {
       comment: 'Domain entities cannot import use cases (application layer)',
       severity: 'error',
       from: {
-        path: '^src/(domain|iam)/[^/]+/domain/',
+        path: `${MODULE_ROOT}/domain/`,
       },
       to: {
-        path: '^src/(domain|iam)/[^/]+/application/use-cases/',
+        path: `${MODULE_ROOT}/application/use-cases/`,
       },
     },
 
@@ -51,10 +64,10 @@ module.exports = {
       comment: 'Use cases cannot import infrastructure (repositories, records, mappers)',
       severity: 'error',
       from: {
-        path: '^src/(domain|iam)/[^/]+/application/use-cases/',
+        path: `${MODULE_ROOT}/application/use-cases/`,
       },
       to: {
-        path: '^src/(domain|iam)/[^/]+/infrastructure/',
+        path: `${MODULE_ROOT}/infrastructure/`,
       },
     },
     {
@@ -62,10 +75,10 @@ module.exports = {
       comment: 'Use cases cannot import presenters (controllers, HTTP DTOs, presenter mappers)',
       severity: 'error',
       from: {
-        path: '^src/(domain|iam)/[^/]+/application/use-cases/',
+        path: `${MODULE_ROOT}/application/use-cases/`,
       },
       to: {
-        path: '^src/(domain|iam)/[^/]+/presenters/',
+        path: `${MODULE_ROOT}/presenters/`,
       },
     },
 
@@ -81,10 +94,12 @@ module.exports = {
         'Modules must not import ports from other modules — use exported use cases instead',
       severity: 'error',
       from: {
-        path: '^src/(domain|iam)/([^/]+)/',
+        // `$2` captures the full module path (including any rag/retrievers group
+        // segment) so the same-module exemption backreference below stays exact.
+        path: `^src/(domain|iam)/(${MODULE_GROUP_PREFIX}[^/]+)/`,
       },
       to: {
-        path: '^src/(domain|iam)/[^/]+/application/ports/',
+        path: `${MODULE_ROOT}/application/ports/`,
         pathNot: '^src/$1/$2/application/ports/',
       },
     },
@@ -99,10 +114,10 @@ module.exports = {
       comment: 'Ports cannot import infrastructure implementations',
       severity: 'error',
       from: {
-        path: '^src/(domain|iam)/[^/]+/application/ports/',
+        path: `${MODULE_ROOT}/application/ports/`,
       },
       to: {
-        path: '^src/(domain|iam)/[^/]+/infrastructure/',
+        path: `${MODULE_ROOT}/infrastructure/`,
       },
     },
     {
@@ -110,10 +125,10 @@ module.exports = {
       comment: 'Ports cannot import presenters',
       severity: 'error',
       from: {
-        path: '^src/(domain|iam)/[^/]+/application/ports/',
+        path: `${MODULE_ROOT}/application/ports/`,
       },
       to: {
-        path: '^src/(domain|iam)/[^/]+/presenters/',
+        path: `${MODULE_ROOT}/presenters/`,
       },
     },
 
@@ -130,10 +145,7 @@ module.exports = {
         'Driven infrastructure adapters must not import use cases — infrastructure is called BY the application layer via ports, not the reverse. Queue consumers and scheduled tasks (driving adapters) are exempt.',
       severity: 'error',
       from: {
-        // `(?:rag/|retrievers/)?` tolerates the nested module groups whose
-        // submodules sit one level deeper than flat modules (domain/rag/*,
-        // domain/retrievers/*). A literal alternation keeps the regex ReDoS-safe.
-        path: '^src/(domain|iam)/(?:rag/|retrievers/)?[^/]+/infrastructure/',
+        path: `${MODULE_ROOT}/infrastructure/`,
         pathNot: [
           '/infrastructure/queue/', // BullMQ consumers/services (driving)
           '/infrastructure/tasks/', // scheduled cron tasks (driving)
@@ -141,7 +153,7 @@ module.exports = {
         ],
       },
       to: {
-        path: '^src/(domain|iam)/(?:rag/|retrievers/)?[^/]+/application/use-cases/',
+        path: `${MODULE_ROOT}/application/use-cases/`,
         // Don't count a nested sub-hexagon's own use cases as the forbidden target.
         pathNot: '/infrastructure/.+/application/use-cases/',
       },
@@ -157,10 +169,10 @@ module.exports = {
       comment: 'Infrastructure mappers cannot import use cases',
       severity: 'error',
       from: {
-        path: '^src/(domain|iam)/[^/]+/infrastructure/.*/mappers/',
+        path: `${MODULE_ROOT}/infrastructure/.*/mappers/`,
       },
       to: {
-        path: '^src/(domain|iam)/[^/]+/application/use-cases/',
+        path: `${MODULE_ROOT}/application/use-cases/`,
       },
     },
     {
@@ -168,10 +180,10 @@ module.exports = {
       comment: 'Infrastructure mappers cannot import presenters',
       severity: 'error',
       from: {
-        path: '^src/(domain|iam)/[^/]+/infrastructure/.*/mappers/',
+        path: `${MODULE_ROOT}/infrastructure/.*/mappers/`,
       },
       to: {
-        path: '^src/(domain|iam)/[^/]+/presenters/',
+        path: `${MODULE_ROOT}/presenters/`,
       },
     },
 
@@ -183,10 +195,10 @@ module.exports = {
       comment: 'Records cannot import use cases',
       severity: 'error',
       from: {
-        path: '^src/(domain|iam)/[^/]+/infrastructure/.*/schema/.*\\.record\\.ts$',
+        path: `${MODULE_ROOT}/infrastructure/.*/schema/.*\\.record\\.ts$`,
       },
       to: {
-        path: '^src/(domain|iam)/[^/]+/application/use-cases/',
+        path: `${MODULE_ROOT}/application/use-cases/`,
       },
     },
     {
@@ -194,10 +206,10 @@ module.exports = {
       comment: 'Records cannot import presenters',
       severity: 'error',
       from: {
-        path: '^src/(domain|iam)/[^/]+/infrastructure/.*/schema/.*\\.record\\.ts$',
+        path: `${MODULE_ROOT}/infrastructure/.*/schema/.*\\.record\\.ts$`,
       },
       to: {
-        path: '^src/(domain|iam)/[^/]+/presenters/',
+        path: `${MODULE_ROOT}/presenters/`,
       },
     },
 
@@ -210,10 +222,10 @@ module.exports = {
       comment: 'Controllers cannot import infrastructure directly (use cases instead)',
       severity: 'error',
       from: {
-        path: '^src/(domain|iam)/[^/]+/presenters/http/.*\\.controller\\.ts$',
+        path: `${MODULE_ROOT}/presenters/http/.*\\.controller\\.ts$`,
       },
       to: {
-        path: '^src/(domain|iam)/[^/]+/infrastructure/',
+        path: `${MODULE_ROOT}/infrastructure/`,
       },
     },
     {
@@ -221,10 +233,10 @@ module.exports = {
       comment: 'Controllers cannot import repository ports directly (use services instead)',
       severity: 'error',
       from: {
-        path: '^src/(domain|iam)/[^/]+/presenters/http/.*\\.controller\\.ts$',
+        path: `${MODULE_ROOT}/presenters/http/.*\\.controller\\.ts$`,
       },
       to: {
-        path: '^src/(domain|iam)/[^/]+/application/ports/',
+        path: `${MODULE_ROOT}/application/ports/`,
       },
     },
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Every rule in `ayunis-core-backend/.dependency-cruiser.cjs` matched module paths with `^src/(domain|iam)/[^/]+/…`, which only matches **one** path segment after `domain/`/`iam/`. Two module groups nest their submodules one level deeper, so the layer-boundary rules silently did **not** apply to them:

- `src/domain/rag/*` → `embeddings`, `indexers`, `splitters`
- `src/domain/retrievers/*` → `file-retrievers`, `internet-search-retrievers`, `url-retrievers`

This is the blind spot that let the AYC-266 infra→use-case import in `url-retrievers` go undetected until the `adapters-no-use-cases` rule was made nesting-aware. The remaining rules still had it.

## Change

- Factored the module-root pattern into two shared constants at the top of the config:
  - `MODULE_GROUP_PREFIX = '(?:rag/|retrievers/)?'` — a **literal** alternation (depcruise's ReDoS guard rejects the equivalent `(?:[^/]+/)?`).
  - `MODULE_ROOT = '^src/(domain|iam)/${MODULE_GROUP_PREFIX}[^/]+'`.
- Applied `MODULE_ROOT` to every module-scoped rule (`domain-no-*`, `use-cases-no-*`, `ports-no-*`, `adapters-no-use-cases`, `mappers-no-*`, `records-no-*`, `controllers-no-*`).
- For `no-cross-module-port-imports`, widened the `from` capture group to `(${MODULE_GROUP_PREFIX}[^/]+)` so `$2` captures the full nested module path (e.g. `retrievers/url-retrievers`) and the `$1/$2` same-module exemption stays exact.
- Also refactored the previously-inlined `adapters-no-use-cases` prefix to use the shared constants (single source of truth).

No behavior change for flat modules; the group prefix is optional.

## Verification

- `pnpm run deps:check` (what CI runs, `--ignore-known`): **clean** — no new violations surfaced beyond the existing baseline, so nothing new needs fixing or baselining.
- Temporarily injected violations to confirm the rules now fire on nested modules:
  - `domain-no-infrastructure` — `retrievers/url-retrievers/domain/…` → its `infrastructure/…` ✅ flagged
  - `domain-no-use-cases` — `rag/embeddings/domain/…` → its `application/use-cases/…` ✅ flagged
  - `no-cross-module-port-imports` — `retrievers/url-retrievers/infrastructure/…` → `models/application/ports/…` ✅ flagged
- Confirmed the same-module exemption still holds: `cheerio.url-retriever.ts` importing its **own** `application/ports/url-retriever.handler` is **not** flagged.

Closes AYC-335.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-335](https://linear.app/ayunis/issue/AYC-335/dependency-cruiser-rules-dont-cover-nested-module-groups-rag)

<div><a href="https://cursor.com/agents/bc-f69a7255-f414-4ad8-89c9-1c23e0055f5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f69a7255-f414-4ad8-89c9-1c23e0055f5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

