### PR TITLE
fix(academy): cap lesson video width and move module list to a side panel (AYC-648)

### DIFF
--- a/ayunis-core-frontend/src/pages/academy-chapter/ui/ChapterDetailPage.tsx
+++ b/ayunis-core-frontend/src/pages/academy-chapter/ui/ChapterDetailPage.tsx
@@ -112,22 +112,45 @@ export default function ChapterDetailPage({
   const isFirst = currentIndex === 0;
   const isLast = currentIndex === modules.length - 1;
 
-  const moduleView = (
-    <div className="space-y-4">
-      {/* Full-width video */}
-      <div className="aspect-video overflow-hidden rounded-lg border bg-muted">
-        <iframe
-          key={currentModule.id}
-          src={toLoomEmbedUrl(currentModule.loomUrl)}
-          title={currentModule.title}
-          className="h-full w-full"
-          allowFullScreen
-          allow="autoplay; fullscreen; picture-in-picture"
-        />
-      </div>
+  const moduleList = (
+    <nav>
+      <p className="mb-2 px-2 text-sm font-medium text-muted-foreground">
+        {t('detail.modulesTitle')}
+      </p>
+      <ul className="space-y-1">
+        {modules.map((module, index) => (
+          <li key={module.id}>
+            <Button
+              variant={index === currentIndex ? 'secondary' : 'ghost'}
+              onClick={() => goToModule(index)}
+              className="w-full justify-start gap-2 text-left"
+            >
+              <span className="text-muted-foreground tabular-nums">
+                {index + 1}
+              </span>
+              <span className="truncate">{module.title}</span>
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
 
-      {/* Constrained text region: title, description, navigation, module list */}
-      <div className="mx-auto max-w-[800px] space-y-4">
+  const moduleView = (
+    <div className="mx-auto flex max-w-[1200px] flex-col gap-6 lg:flex-row lg:items-start">
+      {/* Main column: video capped so the page stays scannable, plus text/nav */}
+      <div className="min-w-0 flex-1 space-y-4">
+        <div className="aspect-video overflow-hidden rounded-lg border bg-muted">
+          <iframe
+            key={currentModule.id}
+            src={toLoomEmbedUrl(currentModule.loomUrl)}
+            title={currentModule.title}
+            className="h-full w-full"
+            allowFullScreen
+            allow="autoplay; fullscreen; picture-in-picture"
+          />
+        </div>
+
         <div>
           <h2 className="text-lg font-semibold">{currentModule.title}</h2>
           {currentModule.description && (
@@ -157,30 +180,10 @@ export default function ChapterDetailPage({
             </Button>
           )}
         </div>
-
-        {/* Module title list */}
-        <nav>
-          <p className="mb-2 px-2 text-sm font-medium text-muted-foreground">
-            {t('detail.modulesTitle')}
-          </p>
-          <ul className="space-y-1">
-            {modules.map((module, index) => (
-              <li key={module.id}>
-                <Button
-                  variant={index === currentIndex ? 'secondary' : 'ghost'}
-                  onClick={() => goToModule(index)}
-                  className="w-full justify-start gap-2 text-left"
-                >
-                  <span className="text-muted-foreground tabular-nums">
-                    {index + 1}
-                  </span>
-                  <span className="truncate">{module.title}</span>
-                </Button>
-              </li>
-            ))}
-          </ul>
-        </nav>
       </div>
+
+      {/* Side panel: module list, stacks below the video on small screens */}
+      <aside className="lg:w-72 lg:shrink-0">{moduleList}</aside>
     </div>
   );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In the Academy, the lesson video (e.g. the EU AI Act module) was rendered **full width**. On common viewports the video filled the screen, so it wasn't clear that more content (the module list) existed below the fold and that the page could be scrolled.

Linear: [AYC-648](https://linear.app/issue/AYC-648)

## Change

Reworked the module view in `ChapterDetailPage.tsx` into a responsive two-column layout:

- **Main column** — the video is now inside a `flex-1` column capped by a centered `max-w-[1200px]` container, so it stays a comfortable size (~880px wide) instead of spanning the full scroll region. Title, description, and prev/next navigation stay under the video.
- **Side panel** — the module list moved into an `<aside>` (`lg:w-72`) beside the video on large screens, so the available chapters/modules are visible at a glance rather than hidden below the fold. It stacks below the video on small screens (`flex-col` → `lg:flex-row`).

This directly implements the issue's requested solution: *"Reduce the video width and show the chapters on the side without making the video too narrow."*

No API, data, or routing changes — purely a layout adjustment.

## Validation

- `pnpm run lint` — 0 errors (only pre-existing warnings, none in the changed file)
- `pnpm run build` — succeeds
- Pre-commit hooks (prettier, eslint, typecheck, dependency, duplication, file-size) — all pass

## Notes

I wasn't able to load the reference screenshot from the ticket (Linear upload URL returned a network error), so I implemented the layout per the written solution. Screenshot verification of the rendered page is a good follow-up during review.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-648](https://linear.app/ayunis/issue/AYC-648/academy-lesson-video-is-displayed-too-large-and-hides-scroll)

<div><a href="https://cursor.com/agents/bc-92e92213-59ae-4cce-8049-80ad144f1d7c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92e92213-59ae-4cce-8049-80ad144f1d7c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

