### PR TITLE
feat(admin-models): use ChatInput model card design in admin model selection (AYC-524)

### DIFF
--- a/ayunis-core-frontend/src/widgets/model-select-options/index.ts
+++ b/ayunis-core-frontend/src/widgets/model-select-options/index.ts
@@ -1,3 +1,3 @@
 export { default as ModelSelectOptions } from './ui/ModelSelectOptions';
 export type { ModelOption } from './ui/ModelSelectOptions';
-export type { ModelInfoModel } from './ui/ModelInfoCard';
+export type { ModelInfoModel } from '@/widgets/model-type-card';

--- a/ayunis-core-frontend/src/widgets/model-select-options/ui/ModelSelectOptions.tsx
+++ b/ayunis-core-frontend/src/widgets/model-select-options/ui/ModelSelectOptions.tsx
@@ -14,7 +14,7 @@ import {
   getFlagByProvider,
   getHostingPriority,
 } from '@/shared/lib/model-provider-metadata';
-import ModelInfoCard, { type ModelInfoModel } from './ModelInfoCard';
+import { ModelInfoCard, type ModelInfoModel } from '@/widgets/model-type-card';
 
 export type ModelOption = ModelInfoModel & { id: string };
 

--- a/ayunis-core-frontend/src/widgets/model-type-card/ModelInfoCard.tsx
+++ b/ayunis-core-frontend/src/widgets/model-type-card/ModelInfoCard.tsx
@@ -1,8 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import { Badge } from '@/shared/ui/shadcn/badge';
 import { getFlagByProvider } from '@/shared/lib/model-provider-metadata';
-import { TierStars } from '@/widgets/model-type-card';
 import type { PermittedLanguageModelResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { TierStars } from './TierStars';
 
 export type ModelInfoModel = Pick<
   PermittedLanguageModelResponseDto,

--- a/ayunis-core-frontend/src/widgets/model-type-card/ModelInfoHoverCard.tsx
+++ b/ayunis-core-frontend/src/widgets/model-type-card/ModelInfoHoverCard.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from '@/shared/ui/shadcn/popover';
+import ModelInfoCard, { type ModelInfoModel } from './ModelInfoCard';
+
+interface ModelInfoHoverCardProps {
+  model: ModelInfoModel;
+  children: ReactNode;
+}
+
+export default function ModelInfoHoverCard({
+  model,
+  children,
+}: Readonly<ModelInfoHoverCardProps>) {
+  const [open, setOpen] = useState(false);
+  const closeTimerRef = useRef<number | null>(null);
+
+  const cancelScheduledClose = () => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  };
+
+  // Grace period so the cursor can travel from the trigger into the card
+  const scheduleClose = () => {
+    cancelScheduledClose();
+    closeTimerRef.current = window.setTimeout(() => setOpen(false), 150);
+  };
+
+  useEffect(() => cancelScheduledClose, []);
+
+  return (
+    <Popover open={open}>
+      <PopoverAnchor asChild>
+        <div
+          className="w-fit"
+          onMouseEnter={() => {
+            cancelScheduledClose();
+            setOpen(true);
+          }}
+          onMouseLeave={scheduleClose}
+        >
+          {children}
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        side="top"
+        align="start"
+        sideOffset={8}
+        className="pointer-events-auto w-80"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onMouseEnter={cancelScheduledClose}
+        onMouseLeave={scheduleClose}
+      >
+        <ModelInfoCard model={model} />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/ayunis-core-frontend/src/widgets/model-type-card/ModelTypeCard.tsx
+++ b/ayunis-core-frontend/src/widgets/model-type-card/ModelTypeCard.tsx
@@ -8,10 +8,7 @@ import {
 import { Switch } from '@/shared/ui/shadcn/switch';
 import { Label } from '@/shared/ui/shadcn/label';
 import { Separator } from '@/shared/ui/shadcn/separator';
-import {
-  ModelWithConfigResponseDtoTier,
-  type ModelWithConfigResponseDto,
-} from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import type { ModelWithConfigResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { useTranslation } from 'react-i18next';
 import {
   Item,
@@ -20,68 +17,12 @@ import {
   ItemDescription,
   ItemTitle,
 } from '@/shared/ui/shadcn/item';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/shared/ui/shadcn/tooltip';
-import { Star } from 'lucide-react';
 import { cn } from '@/shared/lib/shadcn/utils';
 import {
   getFlagByProvider,
   getHostingPriority,
 } from '@/shared/lib/model-provider-metadata';
-
-const TIER_FILLED_COUNT: Record<ModelWithConfigResponseDtoTier, number> = {
-  [ModelWithConfigResponseDtoTier.zero]: 0,
-  [ModelWithConfigResponseDtoTier.low]: 1,
-  [ModelWithConfigResponseDtoTier.medium]: 2,
-  [ModelWithConfigResponseDtoTier.high]: 3,
-};
-
-interface ModelTierStarsProps {
-  readonly tier: ModelWithConfigResponseDtoTier;
-}
-
-export function TierStars({ tier }: ModelTierStarsProps) {
-  const filled = TIER_FILLED_COUNT[tier];
-  return (
-    <span className="inline-flex items-center" aria-hidden="true">
-      {[0, 1, 2].map((index) => (
-        <Star
-          key={index}
-          className={cn(
-            'h-3 w-3',
-            index < filled
-              ? 'fill-current text-foreground'
-              : 'fill-none text-muted-foreground',
-          )}
-        />
-      ))}
-    </span>
-  );
-}
-
-export function ModelTierStars({ tier }: ModelTierStarsProps) {
-  const { t } = useTranslation('common');
-  const performance = t(`models.tierPerformance.${tier}`);
-  const usage = t(`models.tierUsage.${tier}`);
-  const tierLabel = `${performance} · ${usage}`;
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          className="ml-1 inline-flex items-center align-middle"
-          aria-label={tierLabel}
-          tabIndex={0}
-        >
-          <TierStars tier={tier} />
-        </span>
-      </TooltipTrigger>
-      <TooltipContent>{tierLabel}</TooltipContent>
-    </Tooltip>
-  );
-}
+import ModelInfoHoverCard from './ModelInfoHoverCard';
 
 export interface ModelActions {
   readonly deletePermittedModel: (permittedModelId: string) => void;
@@ -127,6 +68,7 @@ export default function ModelTypeCard({
   actions,
 }: ModelTypeCardProps) {
   const { t } = useTranslation('admin-settings-models');
+  const { t: tCommon } = useTranslation('common');
   const {
     deletePermittedModel,
     updatePermittedModel,
@@ -211,11 +153,17 @@ export default function ModelTypeCard({
                   )}
                 >
                   <ItemContent>
-                    <ItemTitle>
-                      {flag && <span className="mr-1">{flag}</span>}
-                      {model.displayName || model.name}
-                      {model.tier && <ModelTierStars tier={model.tier} />}
-                    </ItemTitle>
+                    <ModelInfoHoverCard model={model}>
+                      <ItemTitle>
+                        {flag && <span className="mr-1">{flag}</span>}
+                        {model.displayName || model.name}
+                        {model.tier && (
+                          <span className="text-muted-foreground text-xs font-normal">
+                            {tCommon(`models.category.${model.tier}`)}
+                          </span>
+                        )}
+                      </ItemTitle>
+                    </ModelInfoHoverCard>
                     {model.displayName && (
                       <ItemDescription>{model.name}</ItemDescription>
                     )}

--- a/ayunis-core-frontend/src/widgets/model-type-card/TierStars.tsx
+++ b/ayunis-core-frontend/src/widgets/model-type-card/TierStars.tsx
@@ -1,0 +1,60 @@
+import { ModelWithConfigResponseDtoTier } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { useTranslation } from 'react-i18next';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/shared/ui/shadcn/tooltip';
+import { Star } from 'lucide-react';
+import { cn } from '@/shared/lib/shadcn/utils';
+
+const TIER_FILLED_COUNT: Record<ModelWithConfigResponseDtoTier, number> = {
+  [ModelWithConfigResponseDtoTier.zero]: 0,
+  [ModelWithConfigResponseDtoTier.low]: 1,
+  [ModelWithConfigResponseDtoTier.medium]: 2,
+  [ModelWithConfigResponseDtoTier.high]: 3,
+};
+
+interface ModelTierStarsProps {
+  readonly tier: ModelWithConfigResponseDtoTier;
+}
+
+export function TierStars({ tier }: ModelTierStarsProps) {
+  const filled = TIER_FILLED_COUNT[tier];
+  return (
+    <span className="inline-flex items-center" aria-hidden="true">
+      {[0, 1, 2].map((index) => (
+        <Star
+          key={index}
+          className={cn(
+            'h-3 w-3',
+            index < filled
+              ? 'fill-current text-foreground'
+              : 'fill-none text-muted-foreground',
+          )}
+        />
+      ))}
+    </span>
+  );
+}
+
+export function ModelTierStars({ tier }: ModelTierStarsProps) {
+  const { t } = useTranslation('common');
+  const performance = t(`models.tierPerformance.${tier}`);
+  const usage = t(`models.tierUsage.${tier}`);
+  const tierLabel = `${performance} · ${usage}`;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="ml-1 inline-flex items-center align-middle"
+          aria-label={tierLabel}
+          tabIndex={0}
+        >
+          <TierStars tier={tier} />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{tierLabel}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/ayunis-core-frontend/src/widgets/model-type-card/index.ts
+++ b/ayunis-core-frontend/src/widgets/model-type-card/index.ts
@@ -1,6 +1,6 @@
-export {
-  default as ModelTypeCard,
-  ModelTierStars,
-  TierStars,
-} from './ModelTypeCard';
+export { default as ModelTypeCard } from './ModelTypeCard';
 export type { ModelActions } from './ModelTypeCard';
+export { ModelTierStars, TierStars } from './TierStars';
+export { default as ModelInfoCard } from './ModelInfoCard';
+export type { ModelInfoModel } from './ModelInfoCard';
+export { default as ModelInfoHoverCard } from './ModelInfoHoverCard';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In the admin model selection (org and team model settings), language models were still shown with the old inline **star-based** tier presentation. This was inconsistent with the updated user-facing model cards used in the `ChatInput` model selector.

Closes AYC-524.

## Change

Reuses the user-facing model card design in the admin permitted-models list:

- Each admin model row now shows the tier as a muted **category label** ("Powerful", "Balanced", ...) instead of 3 raw stars — matching the `ChatInput` list.
- Hovering a model row reveals the same **`ModelInfoCard`** popover used in `ChatInput` (display name, tier stars, description, performance/usage badges, and hosting region).
- The permitted / anonymous-only toggle switches are unchanged.

This applies to both the organization model settings and the team detail models tab, since both render the shared `model-type-card` widget.

## Implementation notes

- Relocated `ModelInfoCard` from `model-select-options` into the `model-type-card` widget (which owns the tier primitives), so the admin card can reuse it without a cross-widget cycle. `model-select-options` now imports it back from `model-type-card` (dependency direction it already had for `TierStars`).
- Extracted the `TierStars` / `ModelTierStars` primitives into their own `TierStars.tsx` to break the resulting import cycle (`ModelInfoCard → ModelTypeCard → ModelInfoHoverCard → ModelInfoCard`). Verified with `madge` — no circular dependencies.
- Added a small reusable `ModelInfoHoverCard` (hover popover with a grace-period close) mirroring the `ChatInput` behavior.

## Validation

- `pnpm run build` — passes
- `pnpm run lint` — no new errors (only pre-existing warnings in unrelated files)
- `madge` circular-dependency check — clean
- Pre-commit hook (ESLint, TypeScript, Prettier, dependency-cruiser, jscpd, file-size) — all passed

> Note: I could not access the ticket screenshots (Linear uploads require authentication that isn't available in this environment), so the visual match is based on the existing `ChatInput` `ModelInfoCard` design. Worth a quick visual check on the running app.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-524](https://linear.app/ayunis/issue/AYC-524/admin-model-selection-still-uses-old-star-based-model-display)

<div><a href="https://cursor.com/agents/bc-ed4ef887-e550-4cd3-9263-8b32b9e73cf2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed4ef887-e550-4cd3-9263-8b32b9e73cf2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

