### PR TITLE
fix: use shortDescription on integration install card

### DIFF
--- a/ayunis-core-frontend/src/pages/install/ui/InstallIntegrationPage.tsx
+++ b/ayunis-core-frontend/src/pages/install/ui/InstallIntegrationPage.tsx
@@ -270,7 +270,7 @@ function InstallIntegrationCardView({
               )}
             </div>
             <CardTitle className="text-xl">{integration.name}</CardTitle>
-            <CardDescription>{integration.description}</CardDescription>
+            <CardDescription>{integration.shortDescription}</CardDescription>
           </CardHeader>
 
           <CardContent className="space-y-4">


### PR DESCRIPTION
## Problem

On the marketplace integration install page (`/install?integration=…`), the card showed the **long** `description` below the headline instead of the short description — with long descriptions the card looks overloaded (see e.g. Civic Patches: Mark-a-Spot).

The analogous skill install card (`InstallSkillCard.tsx`) already uses `shortDescription` correctly.  
  
![image.png](https://app.graphite.com/user-attachments/assets/fff554ae-0f8e-4d03-abbc-d7153a248ca8.png)



## Fix

One-liner in `InstallIntegrationPage.tsx` (`InstallIntegrationCardView`): `integration.description` → `integration.shortDescription`. The field is already present on `MarketplaceIntegrationResponseDto`.

## Test

Verified locally against the local marketplace (integration "Bundesgesetze", which has both a short and a long description): the card now shows the short description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)