### PR TITLE
feat(runs): increase agent run iteration limit to 50 (AYC-577)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.spec.ts
@@ -649,7 +649,7 @@ describe('ExecuteRunViaRuntimeUseCase', () => {
       parameters: { type: 'object' },
       execute,
     };
-    const turns = Array.from({ length: 20 }, (_, iteration) =>
+    const turns = Array.from({ length: 50 }, (_, iteration) =>
       toolCallTurn({
         id: `records-${iteration}`,
         name: lookupTool.name,
@@ -665,8 +665,8 @@ describe('ExecuteRunViaRuntimeUseCase', () => {
       drain(await useCase.execute(userCommand())),
     ).rejects.toBeInstanceOf(RunMaxIterationsReachedError);
 
-    expect(execute).toHaveBeenCalledTimes(20);
-    expect(createToolResult).toHaveBeenCalledTimes(20);
+    expect(execute).toHaveBeenCalledTimes(50);
+    expect(createToolResult).toHaveBeenCalledTimes(50);
     expect(cleanup).not.toHaveBeenCalled();
   });
 
@@ -678,7 +678,7 @@ describe('ExecuteRunViaRuntimeUseCase', () => {
       parameters: { type: 'object' },
       execute,
     };
-    const turns = Array.from({ length: 20 }, (_, iteration) =>
+    const turns = Array.from({ length: 50 }, (_, iteration) =>
       toolCallTurn({
         id: `records-${iteration}`,
         name: lookupTool.name,
@@ -690,7 +690,7 @@ describe('ExecuteRunViaRuntimeUseCase', () => {
       turns,
     });
     createToolResult.mockImplementation(async (createCommand) => {
-      if (createToolResult.mock.calls.length === 20) {
+      if (createToolResult.mock.calls.length === 50) {
         throw new Error('database unavailable');
       }
       return new ToolResultMessage({
@@ -704,8 +704,8 @@ describe('ExecuteRunViaRuntimeUseCase', () => {
       'Run execution failed',
     );
 
-    expect(execute).toHaveBeenCalledTimes(20);
-    expect(createToolResult).toHaveBeenCalledTimes(21);
+    expect(execute).toHaveBeenCalledTimes(50);
+    expect(createToolResult).toHaveBeenCalledTimes(51);
     expect(cleanup).toHaveBeenCalledWith(threadId);
   });
 

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.ts
@@ -65,7 +65,7 @@ import type {
   PreparedRuntimeTools,
 } from './execute-run-via-runtime.types';
 
-const RUNTIME_MAX_ITERATIONS = 20;
+const RUNTIME_MAX_ITERATIONS = 50;
 const MAX_CONTEXT_TOKENS = 80000;
 
 interface SeededInput {

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
@@ -189,7 +189,7 @@ export class ExecuteRunUseCase {
     params: RunParams,
   ): AsyncGenerator<RunStreamItem, void, void> {
     this.logger.log('orchestrateRun', { threadId: params.thread.id });
-    const iterations = 20;
+    const iterations = 50;
     const breaker = new ToolFailureBreaker();
     let succeeded = false;
     let preserveTranscript = false;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Higher iteration ceilings allow more inference and tool calls per run, increasing cost and run duration exposure without changing auth or data handling.
> 
> **Overview**
> Raises the **maximum agent run iterations** from **20 to 50** so longer tool loops can finish before `RunMaxIterationsReachedError`.
> 
> The cap is updated in both execution paths: `RUNTIME_MAX_ITERATIONS` passed to `@ayunis/agent-runtime` in `execute-run-via-runtime.use-case.ts`, and the legacy `orchestrateRun` loop in `execute-run.use-case.ts`. Specs that simulate hitting the iteration cap now use 50 tool-call turns and matching assertion counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abf9ceb724cc6373fcd9f4470464e86cb005dccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->