### PR TITLE
fix(runs): retry provider streams that complete without any output (AYC-678)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/helpers/stream-accumulation.helper.ts
+++ b/ayunis-core-backend/src/domain/runs/application/helpers/stream-accumulation.helper.ts
@@ -1,0 +1,121 @@
+import type { ProviderMetadata } from 'src/domain/messages/domain/message-contents/provider-metadata.type';
+
+/**
+ * Structural view of a streamed inference chunk — only the fields the
+ * accumulator reads. Kept local so this helper does not depend on the
+ * models module's ports (StreamInferenceResponseChunk satisfies it).
+ */
+export interface StreamedChunk {
+  thinkingDelta: string | null;
+  thinkingId?: string | null;
+  thinkingSignature?: string | null;
+  textContentDelta: string | null;
+  textProviderMetadata?: ProviderMetadata;
+  toolCallsDelta: StreamedToolCallDelta[];
+  finishReason?: string | null;
+}
+
+export interface StreamedToolCallDelta {
+  index: number;
+  id?: string | null;
+  name?: string | null;
+  argumentsDelta?: string | null;
+  providerMetadata?: ProviderMetadata;
+}
+
+export interface AccumulatedToolCall {
+  id: string | null;
+  name: string | null;
+  arguments: string;
+  providerMetadata: ProviderMetadata;
+}
+
+export interface AccumulatedState {
+  text: string;
+  thinking: string;
+  textProviderMetadata: ProviderMetadata;
+  thinkingId: string | null;
+  thinkingSignature: string | null;
+  toolCalls: Map<number, AccumulatedToolCall>;
+  finishReason: string | null;
+  /**
+   * Set when the turn's tool calls failed the integrity check. The whole
+   * tool phase must then be excluded from the saved message — persisting
+   * even the intact sibling calls would let the next run execute half a
+   * turn the model never saw results for.
+   */
+  toolCallsCorrupted: boolean;
+}
+
+export const initialAccumulatedState = (): AccumulatedState => ({
+  text: '',
+  thinking: '',
+  textProviderMetadata: null,
+  thinkingId: null,
+  thinkingSignature: null,
+  toolCalls: new Map(),
+  finishReason: null,
+  toolCallsCorrupted: false,
+});
+
+/**
+ * Folds one streamed chunk into the accumulated state. Returns whether the
+ * chunk carried content worth re-rendering (deltas), as opposed to
+ * metadata-only chunks (finish reason, signatures, usage).
+ */
+export function accumulateChunk(
+  chunk: StreamedChunk,
+  state: AccumulatedState,
+): boolean {
+  let shouldUpdate = false;
+
+  if (chunk.thinkingDelta) {
+    state.thinking += chunk.thinkingDelta;
+    shouldUpdate = true;
+  }
+  if (chunk.thinkingId) {
+    state.thinkingId = chunk.thinkingId;
+  }
+  if (chunk.thinkingSignature) {
+    state.thinkingSignature = chunk.thinkingSignature;
+  }
+
+  if (chunk.textContentDelta) {
+    state.text += chunk.textContentDelta;
+    shouldUpdate = true;
+  }
+  if (chunk.textProviderMetadata) {
+    state.textProviderMetadata = chunk.textProviderMetadata;
+  }
+
+  if (chunk.toolCallsDelta.length > 0) {
+    accumulateToolCalls(chunk.toolCallsDelta, state.toolCalls);
+    shouldUpdate = true;
+  }
+  if (chunk.finishReason) {
+    state.finishReason = chunk.finishReason;
+  }
+
+  return shouldUpdate;
+}
+
+function accumulateToolCalls(
+  deltas: StreamedToolCallDelta[],
+  toolCalls: Map<number, AccumulatedToolCall>,
+): void {
+  for (const toolCall of deltas) {
+    const existing = toolCalls.get(toolCall.index) ?? {
+      id: null,
+      name: null,
+      arguments: '',
+      providerMetadata: null,
+    };
+
+    toolCalls.set(toolCall.index, {
+      id: toolCall.id ?? existing.id,
+      name: toolCall.name ?? existing.name,
+      arguments: existing.arguments + (toolCall.argumentsDelta ?? ''),
+      providerMetadata: toolCall.providerMetadata ?? existing.providerMetadata,
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.spec.ts
@@ -438,6 +438,60 @@ describe('StreamingInferenceService.executeStreamingInference — tool-call inte
     expect(execute).toHaveBeenCalledTimes(1);
   });
 
+  it('retries once when the stream completes without emitting any content (incident #548)', async () => {
+    // An empty completed stream showed and persisted nothing, so a second
+    // attempt is exactly as safe as the stall retry.
+    const execute = jest
+      .fn()
+      .mockReturnValueOnce(from([] as StreamInferenceResponseChunk[]))
+      .mockReturnValueOnce(
+        from([
+          StreamInferenceResponseChunk.text('Die Antwort kommt doch noch.'),
+          finishChunk('stop'),
+        ]),
+      );
+    const { service, savedMessages } = buildServiceWithStream(execute);
+
+    const yielded = await consume(service);
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(yielded.length).toBeGreaterThan(0);
+    expect(savedMessages).toHaveLength(1);
+    const [text] = savedMessages[0].content;
+    expect((text as TextMessageContent).text).toContain('Antwort');
+  });
+
+  it('gives an empty stream only one retry before returning empty-handed', async () => {
+    const execute = jest
+      .fn()
+      .mockReturnValue(from([] as StreamInferenceResponseChunk[]));
+    const { service, savedMessages } = buildServiceWithStream(execute);
+
+    const yielded = await consume(service);
+
+    // The orchestrator turns a fully empty generator into
+    // RUN_EXECUTION_FAILED — the service must not loop beyond one retry.
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(yielded).toHaveLength(0);
+    expect(savedMessages).toHaveLength(0);
+  });
+
+  it('does not retry a stream that streamed text and completed normally', async () => {
+    const execute = jest
+      .fn()
+      .mockReturnValue(
+        from([
+          StreamInferenceResponseChunk.text('Fertige Antwort.'),
+          finishChunk('stop'),
+        ]),
+      );
+    const { service } = buildServiceWithStream(execute);
+
+    await consume(service);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
   it('does not retry non-stall stream failures', async () => {
     const execute = jest
       .fn()

--- a/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.ts
@@ -5,7 +5,6 @@ import { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-
 import { TextMessageContent } from 'src/domain/messages/domain/message-contents/text-message-content.entity';
 import { ThinkingMessageContent } from 'src/domain/messages/domain/message-contents/thinking-message-content.entity';
 import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
-import { ProviderMetadata } from 'src/domain/messages/domain/message-contents/provider-metadata.type';
 import { SaveAssistantMessageUseCase } from 'src/domain/messages/application/use-cases/save-assistant-message/save-assistant-message.use-case';
 import { SaveAssistantMessageCommand } from 'src/domain/messages/application/use-cases/save-assistant-message/save-assistant-message.command';
 import { StreamInferenceUseCase } from 'src/domain/models/application/use-cases/stream-inference/stream-inference.use-case';
@@ -32,6 +31,12 @@ import { InferenceCompletedEvent } from '../events/inference-completed.event';
 import { extractInferenceErrorInfo } from '../helpers/extract-inference-error-info.helper';
 import { observableToBufferedAsyncIterable } from '../helpers/buffered-stream.helper';
 import { extractUsageFromChunks } from '../helpers/stream-usage.helper';
+import {
+  AccumulatedState,
+  AccumulatedToolCall,
+  accumulateChunk,
+  initialAccumulatedState,
+} from '../helpers/stream-accumulation.helper';
 
 type AssistantContentBlock =
   TextMessageContent | ToolUseMessageContent | ThinkingMessageContent;
@@ -46,48 +51,22 @@ interface StreamingInferenceParams {
 }
 
 /**
- * Set as soon as an attempt streams durable content (text or thinking) —
- * after that, a retry would duplicate what the failed attempt already saved.
- * Tool-call deltas deliberately don't count: a failed attempt never persists
- * its tool calls, so a tool-only attempt leaves nothing to duplicate.
+ * `producedOutput` is set as soon as an attempt streams durable content
+ * (text or thinking) — after that, a retry would duplicate what the failed
+ * attempt already saved. Tool-call deltas deliberately don't count: a
+ * failed attempt never persists its tool calls, so a tool-only attempt
+ * leaves nothing to duplicate. `yieldedContent` tracks any yield at all —
+ * an attempt that completes without one produced an empty provider
+ * response (incident #548) and is retried like a stall.
  */
 interface OutputTracker {
   producedOutput: boolean;
+  yieldedContent: boolean;
 }
 
-interface AccumulatedToolCall {
-  id: string | null;
-  name: string | null;
-  arguments: string;
-  providerMetadata: ProviderMetadata;
-}
-
-interface AccumulatedState {
-  text: string;
-  thinking: string;
-  textProviderMetadata: ProviderMetadata;
-  thinkingId: string | null;
-  thinkingSignature: string | null;
-  toolCalls: Map<number, AccumulatedToolCall>;
-  finishReason: string | null;
-  /**
-   * Set when the turn's tool calls failed the integrity check. The whole
-   * tool phase must then be excluded from the saved message — persisting
-   * even the intact sibling calls would let the next run execute half a
-   * turn the model never saw results for.
-   */
-  toolCallsCorrupted: boolean;
-}
-
-const initialAccumulatedState = (): AccumulatedState => ({
-  text: '',
-  thinking: '',
-  textProviderMetadata: null,
-  thinkingId: null,
-  thinkingSignature: null,
-  toolCalls: new Map(),
-  finishReason: null,
-  toolCallsCorrupted: false,
+const freshTracker = (): OutputTracker => ({
+  producedOutput: false,
+  yieldedContent: false,
 });
 
 /**
@@ -109,7 +88,7 @@ export class StreamingInferenceService {
   async *executeStreamingInference(
     params: StreamingInferenceParams,
   ): AsyncGenerator<AssistantMessage, void, unknown> {
-    const tracker = { producedOutput: false };
+    const tracker = freshTracker();
     // One message entity for all attempts: the chat UI keys updates by
     // message id, so a retry under a fresh id would leave the failed
     // attempt's partial content on screen as a phantom message.
@@ -119,7 +98,17 @@ export class StreamingInferenceService {
     });
     try {
       yield* this.streamAttempt(params, tracker, assistantMessage);
-      return;
+      if (tracker.yieldedContent) {
+        return;
+      }
+      // The stream completed without a single chunk — an empty provider
+      // response. Nothing was shown or persisted, so one retry is as safe
+      // as the stall retry; a second empty attempt falls through to the
+      // orchestrator's RUN_EXECUTION_FAILED (incident #548).
+      this.logger.warn(
+        'Provider stream completed without any output; retrying once',
+        { threadId: params.threadId },
+      );
     } catch (error) {
       // A stall or a token-limit-truncated tool call is safe to retry as
       // long as no durable output was streamed: the failed attempt persisted
@@ -137,11 +126,7 @@ export class StreamingInferenceService {
         },
       );
     }
-    yield* this.streamAttempt(
-      params,
-      { producedOutput: false },
-      assistantMessage,
-    );
+    yield* this.streamAttempt(params, freshTracker(), assistantMessage);
   }
 
   private isRetryableBeforeOutput(
@@ -272,7 +257,7 @@ export class StreamingInferenceService {
     tracker: OutputTracker,
   ): AsyncGenerator<AssistantMessage, void, unknown> {
     for await (const chunk of asyncIterable) {
-      const shouldUpdate = this.accumulateChunk(chunk, state);
+      const shouldUpdate = accumulateChunk(chunk, state);
 
       // Same predicate as buildBaseContent's persistence check: a
       // whitespace-only prefix saves nothing, so it must not block a retry.
@@ -283,6 +268,7 @@ export class StreamingInferenceService {
         tracker.producedOutput = true;
       }
       if (shouldUpdate) {
+        tracker.yieldedContent = true;
         assistantMessage.content = this.buildMessageContent(state, tools);
         yield assistantMessage;
       }
@@ -297,64 +283,6 @@ export class StreamingInferenceService {
     } catch (error) {
       state.toolCallsCorrupted = true;
       throw error;
-    }
-  }
-
-  private accumulateChunk(
-    chunk: StreamInferenceResponseChunk,
-    state: AccumulatedState,
-  ): boolean {
-    let shouldUpdate = false;
-
-    if (chunk.thinkingDelta) {
-      state.thinking += chunk.thinkingDelta;
-      shouldUpdate = true;
-    }
-    if (chunk.thinkingId) {
-      state.thinkingId = chunk.thinkingId;
-    }
-    if (chunk.thinkingSignature) {
-      state.thinkingSignature = chunk.thinkingSignature;
-    }
-
-    if (chunk.textContentDelta) {
-      state.text += chunk.textContentDelta;
-      shouldUpdate = true;
-    }
-    if (chunk.textProviderMetadata) {
-      state.textProviderMetadata = chunk.textProviderMetadata;
-    }
-
-    if (chunk.toolCallsDelta.length > 0) {
-      this.accumulateToolCalls(chunk.toolCallsDelta, state.toolCalls);
-      shouldUpdate = true;
-    }
-    if (chunk.finishReason) {
-      state.finishReason = chunk.finishReason;
-    }
-
-    return shouldUpdate;
-  }
-
-  private accumulateToolCalls(
-    deltas: StreamInferenceResponseChunk['toolCallsDelta'],
-    toolCalls: Map<number, AccumulatedToolCall>,
-  ): void {
-    for (const toolCall of deltas) {
-      const existing = toolCalls.get(toolCall.index) ?? {
-        id: null,
-        name: null,
-        arguments: '',
-        providerMetadata: null,
-      };
-
-      toolCalls.set(toolCall.index, {
-        id: toolCall.id ?? existing.id,
-        name: toolCall.name ?? existing.name,
-        arguments: existing.arguments + (toolCall.argumentsDelta ?? ''),
-        providerMetadata:
-          toolCall.providerMetadata ?? existing.providerMetadata,
-      });
     }
   }
 


### PR DESCRIPTION
- A stream that finishes cleanly with zero chunks (empty provider
  response) previously failed the run outright as RUN_EXECUTION_FAILED
  'No final message received from streaming inference' (incident #548)
- An empty completed attempt showed and persisted nothing, so it now
  gets the same one-shot retry as a stall (AYC-652) or a pre-output
  token-limit truncation (AYC-669)
- A second empty attempt still falls through to the orchestrator's
  classified RUN_EXECUTION_FAILED, so the incident signal survives
- Extract pure chunk-accumulation logic into
  stream-accumulation.helper.ts to keep the service under the 500-line
  file cap

Refs: AYC-645, AYC-674

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core run streaming/retry behavior for empty provider responses; limited to one retry when nothing was yielded or persisted, with new tests covering edge cases.
> 
> **Overview**
> **Empty provider streams** that finish without emitting any chunks no longer fail the run immediately. `StreamingInferenceService` tracks `yieldedContent` on each attempt; if the first attempt completes without yielding anything (nothing shown or persisted), it logs a warning and performs **one** retry—same safety model as stall/token-limit retries before durable output. A second empty attempt still exits with no yields so the orchestrator can surface `RUN_EXECUTION_FAILED` (incident #548).
> 
> Chunk folding (text/thinking/tool-call deltas, `AccumulatedState`) is moved into **`stream-accumulation.helper.ts`** so the service stays under the file size cap; behavior is unchanged aside from setting `yieldedContent` when a chunk triggers a UI update.
> 
> Specs cover: retry then success on empty→text, cap at two execute calls when both attempts are empty, and no retry when text streamed normally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b559417a1c7641dee4d1e6b909ea76b7165650f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->