### PR TITLE
fix(chat): show model-unavailable notice instead of hiding chat input (AYC-666)

### DIFF
--- a/ayunis-core-frontend/src/app/routes/_authenticated/chats.$threadId.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/chats.$threadId.tsx
@@ -5,6 +5,7 @@ import {
   getThreadsControllerFindOneQueryKey,
   getModelsControllerIsEmbeddingModelEnabledQueryKey,
   modelsControllerIsEmbeddingModelEnabled,
+  getModelsControllerGetPermittedLanguageModelsQueryOptions,
 } from '@/shared/api/generated/ayunisCoreAPI';
 import ChatPage from '@/pages/chat/';
 
@@ -22,10 +23,18 @@ const queryIsEmbeddingModelEnabledOptions = () => ({
 export const Route = createFileRoute('/_authenticated/chats/$threadId')({
   component: RouteComponent,
   loader: async ({ params: { threadId }, context: { queryClient } }) => {
-    const thread = await queryClient.fetchQuery(threadQueryOptions(threadId));
-    const { isEmbeddingModelEnabled } = await queryClient.fetchQuery(
-      queryIsEmbeddingModelEnabledOptions(),
-    );
+    // Prefetch the permitted models so ChatPage can decide synchronously
+    // whether the thread's model is still available, instead of rendering
+    // the input and hiding it once the client-side fetch settles (AYC-666).
+    // prefetchQuery swallows errors, so a failing models request never
+    // blocks navigation.
+    const [thread, { isEmbeddingModelEnabled }] = await Promise.all([
+      queryClient.fetchQuery(threadQueryOptions(threadId)),
+      queryClient.fetchQuery(queryIsEmbeddingModelEnabledOptions()),
+      queryClient.prefetchQuery(
+        getModelsControllerGetPermittedLanguageModelsQueryOptions(),
+      ),
+    ]);
     return { thread, isEmbeddingModelEnabled };
   },
 });

--- a/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/ChatPage.tsx
@@ -14,6 +14,7 @@ import ChatInput, { getChatInputSubmissionState } from '@/widgets/chat-input';
 import { useMessageSend } from '../api/useMessageSend';
 import ChatHeader from './ChatHeader';
 import LongChatWarning from './LongChatWarning';
+import UnavailableModelNotice from './UnavailableModelNotice';
 import type { Thread, Message } from '../model/openapi';
 import { showError } from '@/shared/lib/toast';
 
@@ -79,7 +80,11 @@ export default function ChatPage({
   const { t } = useTranslation('chat');
   const { confirm } = useConfirmation();
   const navigate = useNavigate();
-  const { models, isLoading: isLoadingModels } = usePermittedModels();
+  const {
+    models,
+    isLoading: isLoadingModels,
+    error: isModelsError,
+  } = usePermittedModels();
   const [isStreaming, setIsStreaming] = useState(false);
   const { data: thread = initialThread } = useQuery({
     queryKey: getThreadsControllerFindOneQueryKey(initialThread.id),
@@ -105,11 +110,13 @@ export default function ChatPage({
   const isVisionEnabled = selectedModel?.canVision ?? false;
 
   // Detect if the model used in this thread is no longer accessible.
-  // Only flagged after loading completes to avoid flashing the warning.
+  // Only flagged after the permitted-models query succeeds — a loading or
+  // errored query must not hide the input (AYC-666).
   const isModelUnavailable = useMemo(() => {
-    if (thread.permittedModelId) return !isLoadingModels && !selectedModel;
+    if (thread.permittedModelId)
+      return !isLoadingModels && !isModelsError && !selectedModel;
     return false;
-  }, [thread.permittedModelId, selectedModel, isLoadingModels]);
+  }, [thread.permittedModelId, selectedModel, isLoadingModels, isModelsError]);
 
   const queryClient = useQueryClient();
   const chatInputRef = useRef<ChatInputRef>(null);
@@ -395,7 +402,9 @@ export default function ChatPage({
   );
 
   // Controls are always disabled — thread already has messages
-  const chatInput = isModelUnavailable ? null : (
+  const chatInput = isModelUnavailable ? (
+    <UnavailableModelNotice />
+  ) : (
     <>
       <p className="text-xs text-muted-foreground text-center mb-2">
         {t('chat.inputDisclaimer')}

--- a/ayunis-core-frontend/src/pages/chat/ui/UnavailableModelNotice.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/UnavailableModelNotice.tsx
@@ -1,0 +1,32 @@
+import { AlertTriangle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from '@tanstack/react-router';
+import { Button } from '@/shared/ui/shadcn/button';
+import { Alert, AlertTitle, AlertDescription } from '@/shared/ui/shadcn/alert';
+
+export default function UnavailableModelNotice() {
+  const { t } = useTranslation('chat');
+  const navigate = useNavigate();
+
+  function handleNewChat() {
+    void navigate({ to: '/chat' });
+  }
+
+  return (
+    <Alert variant="warning" className="mb-2">
+      <AlertTriangle />
+      <AlertTitle>{t('chat.modelUnavailableTitle')}</AlertTitle>
+      <AlertDescription>
+        {t('chat.modelUnavailableDescription')}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleNewChat}
+          className="mt-2"
+        >
+          {t('newChat.newChat')}
+        </Button>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -182,6 +182,8 @@
     "charts": {
       "emptyState": "Keine Diagrammdaten verfügbar"
     },
+    "modelUnavailableTitle": "KI-Modell nicht mehr verfügbar",
+    "modelUnavailableDescription": "Das in diesem Chat verwendete KI-Modell ist nicht mehr verfügbar, daher kann diese Konversation nicht fortgesetzt werden. Starten Sie einen neuen Chat, um weiterzuarbeiten.",
     "longChatWarningTitle": "Konversation zu lang",
     "longChatWarningDescription": "Für bessere Ergebnisse sollten Sie einen neuen Chat starten.",
     "inputDisclaimer": "Eingaben werden nicht für Training verwendet. KI kann Fehler machen—Antworten prüfen.",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -182,6 +182,8 @@
     "charts": {
       "emptyState": "No chart data available"
     },
+    "modelUnavailableTitle": "AI model no longer available",
+    "modelUnavailableDescription": "The AI model used in this chat is no longer available, so this conversation cannot be continued. Start a new chat to keep working.",
     "longChatWarningTitle": "Conversation too long",
     "longChatWarningDescription": "For better results, consider starting a new chat.",
     "inputDisclaimer": "Input not used for training. AI can make mistakes—verify answers.",


### PR DESCRIPTION
Fixes AYC-666 — the chat input field disappearing intermittently during active chats and permanently on older chats.

## Root cause

Since the agent-removal PR #720, `ChatPage` renders `null` instead of the chat input whenever the thread's `permittedModelId` is not found in the permitted-models list — with no explanation to the user. This fires in two situations:

1. **Permanently**, when the thread's model was deleted or un-permitted (org- or team-scoped) — old chats can never be continued.
2. **Intermittently**, when the permitted-models query errors (4xx responses are not retried and the list is not prefetched by the route loader) — the input vanishes mid-chat until a window-focus refetch.

## Changes

- Render an `UnavailableModelNotice` (warning alert with a "New chat" button) instead of silently hiding the input when the model is genuinely unavailable. Per product decision, the user is directed to start a new chat rather than switch the model of the existing thread.
- Treat a failed permitted-models query as *not* unavailable — transient fetch errors no longer hide the input.
- Prefetch the permitted-models list in the chat route loader (in parallel with the thread fetch, error-swallowing) so the availability decision is made synchronously on load instead of flashing the input and then removing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4BPvd2ZntpteMgXZjrAW5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized chat UI and route-loader prefetch only; no auth or API contract changes.
> 
> **Overview**
> Fixes chat UX when a thread’s **permitted model** is gone or when the models list is still loading or fails (AYC-666).
> 
> **`ChatPage`** now treats “model unavailable” only after permitted models load **successfully** and the thread’s model is missing—so transient fetch errors no longer remove the composer. When the model really is unavailable, it shows a warning **`UnavailableModelNotice`** (with **New chat**) instead of silently hiding the input.
> 
> The **`chats/$threadId`** route loader **prefetches** permitted language models in parallel with the thread and embedding flag, reducing the hard-reload flash where the input appeared then disappeared. EN/DE copy was added for the notice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca2ba995425102ba118bd9ddc7b5bf5fcdcf78b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->