### PR TITLE
fix(code-execution): tolerate a missing sandbox image at runtime (AYC-600)

### DIFF
--- a/ayunis-core-code-execution/executor.py
+++ b/ayunis-core-code-execution/executor.py
@@ -24,8 +24,11 @@ class PythonExecutor:
         )
         self.docker_client = docker.from_env()
 
-        # Ensure the sandbox image is available on startup
+        # Fail fast at startup on a genuinely unavailable image (main.py exits
+        # on this). The execution path re-checks per request to self-heal a tag
+        # that gets deleted while the service is running.
         self._ensure_sandbox_image()
+        print(f"Sandbox image ready: {self.config.docker_image}")
 
     def _ensure_sandbox_image(self) -> None:
         """Ensure the sandbox image exists locally, pulling it if missing.
@@ -33,11 +36,16 @@ class PythonExecutor:
         The image is defined in sandbox/Dockerfile and published to GHCR; it
         is never built here. Raises when unavailable — the service must not
         come up healthy without a runnable sandbox (main.py exits on this).
+
+        Called both at startup (fail-fast) and before every execution: the tag
+        is runtime-mutable, so anything from `docker image prune -a` to a deploy
+        image reclaim can delete it out from under a running service, and the
+        execution path (containers.create) has no implicit pull. images.get is
+        a local lookup, so re-checking on the hot path is cheap when present.
         """
         image = self.config.docker_image
         try:
             self.docker_client.images.get(image)
-            print(f"Sandbox image present: {image}")
             return
         except docker.errors.ImageNotFound:
             print(f"Sandbox image {image} not found locally, pulling...")
@@ -67,6 +75,10 @@ class PythonExecutor:
         execution_id = str(uuid.uuid4())[:8]
 
         try:
+            # Re-ensure the image before it is needed: the tag may have been
+            # deleted since startup, and containers.create does not pull.
+            self._ensure_sandbox_image()
+
             # Build in-memory tar archive with code, optional files, and output directory
             tar_stream = io.BytesIO()
             with tarfile.open(fileobj=tar_stream, mode="w") as tar:

--- a/ayunis-core-code-execution/pyproject.toml
+++ b/ayunis-core-code-execution/pyproject.toml
@@ -86,6 +86,7 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"

--- a/ayunis-core-code-execution/tests/test_executor.py
+++ b/ayunis-core-code-execution/tests/test_executor.py
@@ -1,0 +1,114 @@
+"""Tests for PythonExecutor image handling.
+
+These use a mocked docker client so they need neither a real Docker daemon nor
+the sandbox image. They focus on the invariant introduced for AYC-600: the
+sandbox tag is runtime-mutable, so the execution path must tolerate the image
+being deleted after the service has started.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import docker
+import pytest
+
+from executor import PythonExecutor
+from models import ExecutionRequest, ExecutorConfig
+
+
+def _make_executor(client: MagicMock) -> PythonExecutor:
+    """Construct an executor against a mocked docker client (image present)."""
+    client.images.get.return_value = object()
+    with patch("docker.from_env", return_value=client):
+        return PythonExecutor(ExecutorConfig(docker_image="python-sandbox:latest"))
+
+
+def test_ensure_sandbox_image_present_does_not_pull() -> None:
+    client = MagicMock()
+    executor = _make_executor(client)
+    client.images.pull.reset_mock()
+
+    executor._ensure_sandbox_image()
+
+    client.images.pull.assert_not_called()
+
+
+def test_ensure_sandbox_image_pulls_when_missing() -> None:
+    client = MagicMock()
+    executor = _make_executor(client)
+    client.images.get.side_effect = docker.errors.ImageNotFound("missing")
+
+    executor._ensure_sandbox_image()
+
+    client.images.pull.assert_called_once_with("python-sandbox:latest")
+
+
+def test_ensure_sandbox_image_raises_when_pull_fails() -> None:
+    client = MagicMock()
+    executor = _make_executor(client)
+    client.images.get.side_effect = docker.errors.ImageNotFound("missing")
+    client.images.pull.side_effect = docker.errors.APIError("registry down")
+
+    with pytest.raises(RuntimeError):
+        executor._ensure_sandbox_image()
+
+
+@pytest.mark.asyncio
+async def test_execute_repulls_when_image_deleted_after_construction() -> None:
+    """The core AYC-600 regression: image is present at construction, then the
+    tag is deleted before an execution. The execution must pull and succeed
+    rather than fail with ImageNotFound."""
+    client = MagicMock()
+    executor = _make_executor(client)
+
+    state = {"pulled": False}
+
+    def images_get(image: str) -> object:
+        if not state["pulled"]:
+            raise docker.errors.ImageNotFound(f"{image} was deleted")
+        return object()
+
+    def images_pull(image: str) -> object:
+        state["pulled"] = True
+        return object()
+
+    client.images.get.side_effect = images_get
+    client.images.pull.side_effect = images_pull
+
+    helper = MagicMock()
+    sandbox = MagicMock()
+    sandbox.wait.return_value = {"StatusCode": 0}
+    sandbox.logs.side_effect = lambda stdout, stderr: b"hello\n" if stdout else b""
+    sandbox.get_archive.side_effect = Exception("no output dir")
+
+    def containers_create(image: str, **_kwargs: object) -> MagicMock:
+        # Mirror docker-py: create has no implicit pull and fails hard when the
+        # tag is absent. Only the per-execution re-ensure can save this path.
+        if not state["pulled"]:
+            raise docker.errors.ImageNotFound(f"{image} was deleted")
+        return helper if client.containers.create.call_count == 1 else sandbox
+
+    client.containers.create.side_effect = containers_create
+    client.volumes.create.return_value = MagicMock()
+
+    result = await executor.execute(ExecutionRequest(code="print('hello')", files={}))
+
+    client.images.pull.assert_called_once_with("python-sandbox:latest")
+    assert result.success is True
+    assert result.exit_code == 0
+    assert "hello" in result.output
+
+
+@pytest.mark.asyncio
+async def test_execute_fails_gracefully_when_image_unavailable() -> None:
+    """When the image is gone and cannot be pulled, execute() returns a failed
+    response instead of raising, keeping the service process alive."""
+    client = MagicMock()
+    executor = _make_executor(client)
+    client.images.get.side_effect = docker.errors.ImageNotFound("gone")
+    client.images.pull.side_effect = docker.errors.APIError("registry down")
+
+    result = await executor.execute(ExecutionRequest(code="print('hello')", files={}))
+
+    assert result.success is False
+    assert result.exit_code == -1
+    client.containers.create.assert_not_called()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`PythonExecutor` treated the presence of the sandbox image as a **startup invariant** (`_ensure_sandbox_image()` was called only from `__init__`), but the tag is runtime-mutable. Anything that removes it between service start and an execution — `docker image prune -a` (the sandbox is only referenced by ephemeral per-execution containers, so it always looks unused), a deploy image reclaim, or a manual `docker rmi` — left code execution broken until the container restarted.

The execution path uses docker-py's `containers.create`, which has **no** implicit pull logic (only `containers.run` catches `ImageNotFound` and pulls). Since `ImageNotFound` surfaces per request and the process stays up, `restart: unless-stopped` never triggers, so nothing self-heals.

This was hit for real during AYC-589. That specific trigger was fixed in #1203 / #1194, but the deploy workflow is only one way to violate the invariant.

## Fix

Re-ensure the image before each execution. `images.get` is a local lookup, so the present case (the overwhelming majority) is effectively free; when the tag is gone it pulls once before the containers are created. This makes the bug class structurally impossible rather than avoided by convention.

The startup fail-fast check is kept — failing on a genuinely unavailable image is still correct (`main.py` exits on it, and the health gate depends on it). If a pull fails mid-flight, `execute()` returns a failed `ExecutionResponse` instead of raising, keeping the service process alive.

## Tests

Added `tests/test_executor.py` (mocked docker client — no real daemon or image required):
- image present → no pull
- `ImageNotFound` → pulls
- pull failure → raises `RuntimeError`
- **regression**: image present at construction, tag deleted before `execute()` (with `containers.create` faithfully raising `ImageNotFound` when absent) → execution pulls and succeeds
- image unavailable and unpullable → `execute()` returns a failed response without crashing

Verified the two behavior tests fail when the per-execution re-ensure is removed. Added `pythonpath = ["."]` to the pytest config so the flat-layout modules import under `testpaths = ["tests"]`.

Follow-up from AYC-589. Related: #1203, #1194.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-600](https://linear.app/ayunis/issue/AYC-600/make-code-execution-tolerate-a-missing-sandbox-image-at-runtime)

<div><a href="https://cursor.com/agents/bc-c60b2eb5-8534-4e21-a6ac-3c2b62bcde6b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c60b2eb5-8534-4e21-a6ac-3c2b62bcde6b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

