### PR TITLE
fix(chat): show one widget for repeated edits of the same artifact (AYC-476)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/group-messages-into-runs.test.ts
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/group-messages-into-runs.test.ts
@@ -234,7 +234,7 @@ describe('groupMessagesIntoRuns', () => {
     if (run.kind !== 'agent-run') throw new Error('expected agent-run');
     const block = run.blocks[0];
     if (block.kind !== 'rich-tool') throw new Error('expected rich tool');
-    expect(block.step.status).toBe('done');
+    expect(block.steps[0].status).toBe('done');
   });
 
   it('returns empty array for empty input', () => {
@@ -409,8 +409,8 @@ describe('groupMessagesIntoRuns', () => {
     ]);
     const richTool = run.blocks[0];
     if (richTool.kind !== 'rich-tool') throw new Error('expected rich tool');
-    expect(richTool.step.toolUse.name).toBe('bar_chart');
-    expect(richTool.step.result).toBe('{}');
+    expect(richTool.steps[0].toolUse.name).toBe('bar_chart');
+    expect(richTool.steps[0].result).toBe('{}');
   });
 
   it('keeps run separate when followed by another user message', () => {
@@ -461,7 +461,7 @@ describe('groupMessagesIntoRuns', () => {
     if (run.kind !== 'agent-run') throw new Error('expected agent-run');
     const block = run.blocks[0];
     if (block.kind !== 'rich-tool') throw new Error('expected rich tool');
-    expect(block.step.status).toBe('done');
+    expect(block.steps[0].status).toBe('done');
   });
 
   it('does not reactivate a prior tool while a streamed user turn awaits its assistant message', () => {
@@ -480,7 +480,7 @@ describe('groupMessagesIntoRuns', () => {
     if (priorRun.kind !== 'agent-run') throw new Error('expected agent-run');
     const block = priorRun.blocks[0];
     if (block.kind !== 'rich-tool') throw new Error('expected rich tool');
-    expect(block.step.status).toBe('done');
+    expect(block.steps[0].status).toBe('done');
   });
 
   it('marks only the last agent-run as streaming when isStreaming is true', () => {
@@ -573,6 +573,443 @@ describe('groupMessagesIntoRuns', () => {
       text: 'You are a poet.',
     });
     expect(text.content.text).toBe('Cherry blossoms fall');
+  });
+
+  describe('same-artifact widget dedup', () => {
+    it('merges consecutive edits of the same artifact into one rich-tool block', () => {
+      const messages = [
+        userMessage('polish the policy'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e1',
+            name: 'edit_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('e1', 'edited v2'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e2',
+            name: 'edit_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('e2', 'edited v3'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e3',
+            name: 'edit_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('e3', 'edited v4'),
+        assistantMessage([{ type: 'text', text: 'All polished.' }]),
+      ];
+
+      const units = groupMessagesIntoRuns(messages, { isStreaming: false });
+
+      const run = units[1];
+      if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+      expect(run.blocks.map((block) => block.kind)).toEqual([
+        'rich-tool',
+        'text',
+      ]);
+      const richTool = run.blocks[0];
+      if (richTool.kind !== 'rich-tool') throw new Error('expected rich tool');
+      expect(richTool.steps).toHaveLength(3);
+      expect(richTool.steps.map((step) => step.toolUse.id)).toEqual([
+        'e1',
+        'e2',
+        'e3',
+      ]);
+      expect(richTool.steps.at(-1)).toMatchObject({
+        result: 'edited v4',
+        status: 'done',
+      });
+      expect(richTool.key).toBe(richTool.steps[0].key);
+    });
+
+    it('keeps separate widgets for edits of different artifacts', () => {
+      const messages = [
+        userMessage('edit both'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e1',
+            name: 'edit_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('e1', 'ok'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e2',
+            name: 'edit_document',
+            params: { artifact_id: 'art-2' },
+          },
+        ]),
+        toolResultMessage('e2', 'ok'),
+      ];
+
+      const units = groupMessagesIntoRuns(messages, { isStreaming: false });
+
+      const run = units[1];
+      if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+      expect(run.blocks.map((block) => block.kind)).toEqual([
+        'rich-tool',
+        'rich-tool',
+      ]);
+    });
+
+    it('keeps the create widget separate from subsequent edits', () => {
+      const messages = [
+        userMessage('create and refine'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'c1',
+            name: 'create_document',
+            params: { title: 'AI Policy' },
+          },
+        ]),
+        toolResultMessage('c1', 'Artifact ID: art-1, version: 1'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e1',
+            name: 'edit_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('e1', 'ok'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e2',
+            name: 'edit_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('e2', 'ok'),
+      ];
+
+      const units = groupMessagesIntoRuns(messages, { isStreaming: false });
+
+      const run = units[1];
+      if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+      expect(run.blocks.map((block) => block.kind)).toEqual([
+        'rich-tool',
+        'rich-tool',
+      ]);
+      const createBlock = run.blocks[0];
+      const editBlock = run.blocks[1];
+      if (createBlock.kind !== 'rich-tool' || editBlock.kind !== 'rich-tool') {
+        throw new Error('expected rich tools');
+      }
+      expect(createBlock.steps).toHaveLength(1);
+      expect(editBlock.steps).toHaveLength(2);
+    });
+
+    it('merges same-artifact edits across intervening thinking', () => {
+      const messages = [
+        userMessage('refine'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e1',
+            name: 'edit_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('e1', 'ok'),
+        assistantMessage([
+          { type: 'thinking', thinking: 'what else to fix' },
+          {
+            type: 'tool_use',
+            id: 'e2',
+            name: 'edit_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('e2', 'ok'),
+      ];
+
+      const units = groupMessagesIntoRuns(messages, { isStreaming: false });
+
+      const run = units[1];
+      if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+      expect(run.blocks.map((block) => block.kind)).toEqual([
+        'rich-tool',
+        'activity',
+      ]);
+      const richTool = run.blocks[0];
+      if (richTool.kind !== 'rich-tool') throw new Error('expected rich tool');
+      expect(richTool.steps).toHaveLength(2);
+    });
+
+    it('merges same-artifact edits across intervening ordinary tool activity', () => {
+      const messages = [
+        userMessage('refine'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e1',
+            name: 'edit_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('e1', 'ok'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'r1',
+            name: 'read_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('r1', 'current content'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e2',
+            name: 'edit_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('e2', 'ok'),
+      ];
+
+      const units = groupMessagesIntoRuns(messages, { isStreaming: false });
+
+      const run = units[1];
+      if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+      expect(run.blocks.map((block) => block.kind)).toEqual([
+        'rich-tool',
+        'activity',
+      ]);
+      const richTool = run.blocks[0];
+      if (richTool.kind !== 'rich-tool') throw new Error('expected rich tool');
+      expect(richTool.steps).toHaveLength(2);
+    });
+
+    it('does not merge edits separated by assistant prose', () => {
+      const messages = [
+        userMessage('refine'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e1',
+            name: 'edit_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('e1', 'ok'),
+        assistantMessage([
+          { type: 'text', text: 'First pass done, now tightening wording.' },
+          {
+            type: 'tool_use',
+            id: 'e2',
+            name: 'edit_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('e2', 'ok'),
+      ];
+
+      const units = groupMessagesIntoRuns(messages, { isStreaming: false });
+
+      const run = units[1];
+      if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+      expect(run.blocks.map((block) => block.kind)).toEqual([
+        'rich-tool',
+        'text',
+        'rich-tool',
+      ]);
+    });
+
+    it('merges update_document and edit_document calls on the same artifact', () => {
+      const messages = [
+        userMessage('rework it'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'u1',
+            name: 'update_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('u1', 'ok'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e1',
+            name: 'edit_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('e1', 'ok'),
+      ];
+
+      const units = groupMessagesIntoRuns(messages, { isStreaming: false });
+
+      const run = units[1];
+      if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+      expect(run.blocks.map((block) => block.kind)).toEqual(['rich-tool']);
+      const richTool = run.blocks[0];
+      if (richTool.kind !== 'rich-tool') throw new Error('expected rich tool');
+      expect(richTool.steps).toHaveLength(2);
+    });
+
+    it('merges a follow-up edit into the previous widget while its arguments still stream', () => {
+      const messages = [
+        userMessage('refine'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e1',
+            name: 'edit_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('e1', 'ok'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e2',
+            name: 'edit_document',
+            params: {},
+            stream: {
+              status: 'streaming',
+              argumentsJson: '{"artifact_id": "art-',
+            },
+          },
+        ]),
+      ];
+
+      const units = groupMessagesIntoRuns(messages, { isStreaming: true });
+
+      const run = units[1];
+      if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+      expect(run.blocks.map((block) => block.kind)).toEqual(['rich-tool']);
+      const richTool = run.blocks[0];
+      if (richTool.kind !== 'rich-tool') throw new Error('expected rich tool');
+      expect(richTool.steps).toHaveLength(2);
+      expect(richTool.steps.at(-1)).toMatchObject({ status: 'in_progress' });
+    });
+
+    it('does not merge a streaming edit into a widget of another artifact family', () => {
+      const messages = [
+        userMessage('refine'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'd1',
+            name: 'update_diagram',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('d1', 'ok'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e1',
+            name: 'edit_document',
+            params: {},
+            stream: {
+              status: 'streaming',
+              argumentsJson: '{"artifact_id": "art-',
+            },
+          },
+        ]),
+      ];
+
+      const units = groupMessagesIntoRuns(messages, { isStreaming: true });
+
+      const run = units[1];
+      if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+      expect(run.blocks.map((block) => block.kind)).toEqual([
+        'rich-tool',
+        'rich-tool',
+      ]);
+    });
+
+    it('does not merge a completed edit whose params lack an artifact id', () => {
+      const messages = [
+        userMessage('refine'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e1',
+            name: 'edit_document',
+            params: { artifact_id: 'art-1' },
+          },
+        ]),
+        toolResultMessage('e1', 'ok'),
+        assistantMessage([
+          {
+            type: 'tool_use',
+            id: 'e2',
+            name: 'edit_document',
+            params: {},
+          },
+        ]),
+        toolResultMessage('e2', 'ok'),
+      ];
+
+      const units = groupMessagesIntoRuns(messages, { isStreaming: false });
+
+      const run = units[1];
+      if (run.kind !== 'agent-run') throw new Error('expected agent-run');
+      expect(run.blocks.map((block) => block.kind)).toEqual([
+        'rich-tool',
+        'rich-tool',
+      ]);
+    });
+
+    it('keeps the merged block key stable while the latest edit streams in', () => {
+      const first = assistantMessage([
+        {
+          type: 'tool_use',
+          id: 'e1',
+          name: 'edit_document',
+          params: { artifact_id: 'art-1' },
+        },
+      ]);
+      const second = assistantMessage([
+        {
+          type: 'tool_use',
+          id: 'e2',
+          name: 'edit_document',
+          params: { artifact_id: 'art-1' },
+        },
+      ]);
+      const user = userMessage('refine');
+      const result1 = toolResultMessage('e1', 'ok');
+
+      const before = groupMessagesIntoRuns([user, first, result1], {
+        isStreaming: true,
+      });
+      const after = groupMessagesIntoRuns([user, first, result1, second], {
+        isStreaming: true,
+      });
+
+      const beforeRun = before[1];
+      const afterRun = after[1];
+      if (beforeRun.kind !== 'agent-run' || afterRun.kind !== 'agent-run') {
+        throw new Error('expected agent-runs');
+      }
+      expect(afterRun.blocks).toHaveLength(1);
+      expect(afterRun.blocks[0].key).toBe(beforeRun.blocks[0].key);
+      const merged = afterRun.blocks[0];
+      if (merged.kind !== 'rich-tool') throw new Error('expected rich tool');
+      expect(merged.steps.at(-1)).toMatchObject({
+        status: 'in_progress',
+      });
+    });
   });
 
   it('handles assistant message with empty content (mid-stream)', () => {

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/group-messages-into-runs.ts
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/group-messages-into-runs.ts
@@ -11,8 +11,14 @@ import type {
   TimelineStep,
   StepStatus,
   ToolTimelineStep,
+  RichToolRunBlock,
 } from '../model/types';
-import { isRichTool } from './tool-classification';
+import {
+  getArtifactMutationFamily,
+  getArtifactToolTarget,
+  isRichTool,
+} from './tool-classification';
+import type { ArtifactFamily } from './tool-classification';
 
 interface GroupingOptions {
   isStreaming: boolean;
@@ -185,30 +191,13 @@ function appendAssistantMessage(
         hasResult,
         isActiveAssistantMessage,
       );
-      const step: ToolTimelineStep = {
+      appendToolStep(run, {
         kind: 'tool',
         key: `${message.id}-tool-${toolUse.id}`,
         toolUse,
         result,
         status,
-      };
-      const isPendingTool =
-        toolUse.name.length === 0 && toolUse.stream?.status === 'streaming';
-      if (status !== 'error' && isPendingTool) {
-        run.blocks.push({
-          kind: 'pending-tool',
-          key: step.key,
-          step,
-        });
-      } else if (status !== 'error' && isRichTool(toolUse.name)) {
-        run.blocks.push({
-          kind: 'rich-tool',
-          key: step.key,
-          step,
-        });
-      } else {
-        appendActivityStep(run, step);
-      }
+      });
       return;
     }
 
@@ -222,6 +211,90 @@ function appendAssistantMessage(
   });
 
   flushThinking(isActiveAssistantMessage ? 'in_progress' : 'done');
+}
+
+function appendToolStep(run: AgentRunUnit, step: ToolTimelineStep): void {
+  const { toolUse, status } = step;
+  const isPendingTool =
+    toolUse.name.length === 0 && toolUse.stream?.status === 'streaming';
+  if (status !== 'error' && isPendingTool) {
+    run.blocks.push({
+      kind: 'pending-tool',
+      key: step.key,
+      step,
+    });
+    return;
+  }
+  if (status !== 'error' && isRichTool(toolUse.name)) {
+    const mergeTarget = findSameArtifactRichBlock(run, toolUse);
+    if (mergeTarget) {
+      mergeTarget.steps.push(step);
+    } else {
+      run.blocks.push({
+        kind: 'rich-tool',
+        key: step.key,
+        steps: [step],
+      });
+    }
+    return;
+  }
+  appendActivityStep(run, step);
+}
+
+/**
+ * Repeated mutations of the same artifact (e.g. six edit_document calls in a
+ * row) share one rich-tool block, so the chat shows a single widget with the
+ * latest state instead of one widget per call (AYC-476). The backward search
+ * deliberately skips ALL activity blocks — thinking as well as ordinary tool
+ * calls like read_document that the model interleaves with its edits — because
+ * stopping at them would re-split the widget in the common read/edit loop.
+ * Only non-activity blocks end the search: assistant prose (and another
+ * artifact's widget) legitimately separates widgets.
+ *
+ * A mutation call whose arguments are still streaming has no parseable
+ * artifact_id yet, so it merges optimistically into a preceding block of the
+ * same family. Once the arguments parse, the next grouping pass re-evaluates:
+ * the common same-artifact case stays merged, a different artifact splits out
+ * into its own widget.
+ */
+function findSameArtifactRichBlock(
+  run: AgentRunUnit,
+  toolUse: ToolUseMessageContent,
+): RichToolRunBlock | null {
+  const criteria = getMergeCriteria(toolUse);
+  if (!criteria) return null;
+  const block = findTrailingRichBlock(run);
+  const lastStep = block?.steps.at(-1);
+  const previous = lastStep ? getArtifactToolTarget(lastStep.toolUse) : null;
+  if (previous?.family !== criteria.family) return null;
+  const sameArtifact =
+    criteria.artifactId === null || previous.artifactId === criteria.artifactId;
+  return sameArtifact ? block : null;
+}
+
+interface MergeCriteria {
+  family: ArtifactFamily;
+  /** null while the call's arguments are still streaming: match family only. */
+  artifactId: string | null;
+}
+
+function getMergeCriteria(
+  toolUse: ToolUseMessageContent,
+): MergeCriteria | null {
+  const target = getArtifactToolTarget(toolUse);
+  if (target) return target;
+  if (toolUse.stream?.status !== 'streaming') return null;
+  const family = getArtifactMutationFamily(toolUse.name);
+  return family ? { family, artifactId: null } : null;
+}
+
+function findTrailingRichBlock(run: AgentRunUnit): RichToolRunBlock | null {
+  for (let i = run.blocks.length - 1; i >= 0; i--) {
+    const block = run.blocks[i];
+    if (block.kind === 'activity') continue;
+    return block.kind === 'rich-tool' ? block : null;
+  }
+  return null;
 }
 
 function appendActivityStep(run: AgentRunUnit, step: TimelineStep): void {

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/tool-classification.ts
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/lib/tool-classification.ts
@@ -1,3 +1,5 @@
+import type { ToolUseMessageContent } from '@/pages/chat/model/openapi';
+
 const RICH_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
   'create_document',
   'update_document',
@@ -16,4 +18,42 @@ const RICH_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
 
 export function isRichTool(toolName: string): boolean {
   return RICH_TOOL_NAMES.has(toolName);
+}
+
+const ARTIFACT_MUTATION_TOOLS: ReadonlyMap<string, 'document' | 'diagram'> =
+  new Map([
+    ['edit_document', 'document'],
+    ['update_document', 'document'],
+    ['update_diagram', 'diagram'],
+  ]);
+
+export type ArtifactFamily = 'document' | 'diagram';
+
+export interface ArtifactToolTarget {
+  family: ArtifactFamily;
+  artifactId: string;
+}
+
+export function getArtifactMutationFamily(
+  toolName: string,
+): ArtifactFamily | null {
+  return ARTIFACT_MUTATION_TOOLS.get(toolName) ?? null;
+}
+
+/**
+ * Identifies the artifact a mutation tool call targets, so repeated calls on
+ * the same artifact can share one widget. Create tools are excluded: they
+ * carry no artifact_id param and their widget shows the title, which the
+ * mutation widgets cannot.
+ */
+export function getArtifactToolTarget(
+  toolUse: ToolUseMessageContent,
+): ArtifactToolTarget | null {
+  const family = getArtifactMutationFamily(toolUse.name);
+  if (!family) return null;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- params may be undefined during streaming even if typed as required
+  const params = (toolUse.params || {}) as { artifact_id?: unknown };
+  const artifactId = params.artifact_id;
+  if (typeof artifactId !== 'string' || artifactId.length === 0) return null;
+  return { family, artifactId };
 }

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/model/types.ts
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/model/types.ts
@@ -38,7 +38,11 @@ export interface ActivityRunBlock {
 export interface RichToolRunBlock {
   kind: 'rich-tool';
   key: string;
-  step: ToolTimelineStep;
+  /**
+   * Non-empty. Holds one step per tool call; consecutive mutations of the
+   * same artifact are merged here so only the last step's widget is rendered.
+   */
+  steps: ToolTimelineStep[];
 }
 
 export interface PendingToolRunBlock {

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimeline.test.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimeline.test.tsx
@@ -60,17 +60,19 @@ const unit: AgentRunUnit = {
     {
       kind: 'rich-tool',
       key: 'tool-rich-1',
-      step: {
-        kind: 'tool',
-        key: 'tool-rich-1',
-        status: 'done',
-        toolUse: {
-          type: 'tool_use',
-          id: 'rich-1',
-          name: 'bar_chart',
-          params: {},
+      steps: [
+        {
+          kind: 'tool',
+          key: 'tool-rich-1',
+          status: 'done',
+          toolUse: {
+            type: 'tool_use',
+            id: 'rich-1',
+            name: 'bar_chart',
+            params: {},
+          },
         },
-      },
+      ],
     },
     {
       kind: 'text',
@@ -135,10 +137,12 @@ describe('AgentRunTimeline', () => {
         {
           kind: 'rich-tool',
           key: pendingStep.key,
-          step: {
-            ...pendingStep,
-            toolUse: { ...pendingStep.toolUse, name: 'bar_chart' },
-          },
+          steps: [
+            {
+              ...pendingStep,
+              toolUse: { ...pendingStep.toolUse, name: 'bar_chart' },
+            },
+          ],
         },
       ],
     };
@@ -151,6 +155,95 @@ describe('AgentRunTimeline', () => {
 
     expect(screen.getByTestId('step-tool-streaming')).toBe(pendingRow);
     expect(screen.getByTestId('rich-card')).toBeTruthy();
+  });
+
+  it('renders one card from the latest step of a merged rich-tool block', () => {
+    const editStep = (id: string) => ({
+      kind: 'tool' as const,
+      key: `tool-${id}`,
+      status: 'done' as const,
+      toolUse: {
+        type: 'tool_use' as const,
+        id,
+        name: 'edit_document',
+        params: { artifact_id: 'art-1' },
+      },
+    });
+    const mergedUnit: AgentRunUnit = {
+      ...unit,
+      blocks: [
+        {
+          kind: 'rich-tool',
+          key: 'tool-e1',
+          steps: [editStep('e1'), editStep('e2'), editStep('e3')],
+        },
+      ],
+    };
+
+    render(<AgentRunTimeline unit={mergedUnit} />);
+
+    expect(screen.getByTestId('step-tool-e1')).toBeTruthy();
+    expect(screen.getByTestId('step-tool-e2')).toBeTruthy();
+    expect(screen.getByTestId('step-tool-e3')).toBeTruthy();
+    expect(screen.getAllByTestId('rich-card')).toHaveLength(1);
+    expect(vi.mocked(renderRichToolCard)).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        toolUse: expect.objectContaining({ id: 'e3' }),
+      }),
+    );
+  });
+
+  it('renders the card from the last step with an artifact id while a follow-up edit streams', () => {
+    const mergedUnit: AgentRunUnit = {
+      ...unit,
+      isStreaming: true,
+      blocks: [
+        {
+          kind: 'rich-tool',
+          key: 'tool-e1',
+          steps: [
+            {
+              kind: 'tool',
+              key: 'tool-e1',
+              status: 'done',
+              toolUse: {
+                type: 'tool_use',
+                id: 'e1',
+                name: 'edit_document',
+                params: { artifact_id: 'art-1' },
+              },
+            },
+            {
+              kind: 'tool',
+              key: 'tool-e2',
+              status: 'in_progress',
+              toolUse: {
+                type: 'tool_use',
+                id: 'e2',
+                name: 'edit_document',
+                params: {},
+                stream: {
+                  status: 'streaming',
+                  argumentsJson: '{"artifact_id": "art-',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    render(<AgentRunTimeline unit={mergedUnit} />);
+
+    expect(vi.mocked(renderRichToolCard)).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        toolUse: expect.objectContaining({
+          id: 'e1',
+          params: { artifact_id: 'art-1' },
+        }),
+        isStreaming: true,
+      }),
+    );
   });
 
   it('does not render the response-start orb after timeline content exists', () => {

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimeline.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimeline.tsx
@@ -17,6 +17,7 @@ import type {
 import ResponseStartOrb from '@/pages/chat/ui/ResponseStartOrb';
 import AgentRunTimelineRow from './AgentRunTimelineRow';
 import { renderRichToolCard } from '../lib/render-rich-tool-card';
+import { getArtifactToolTarget } from '../lib/tool-classification';
 
 interface AgentRunTimelineProps {
   unit: AgentRunUnit;
@@ -56,13 +57,10 @@ export default function AgentRunTimeline({
 }
 
 function hasInProgressStep(block: AgentRunBlock): boolean {
-  if (block.kind === 'activity') {
+  if (block.kind === 'activity' || block.kind === 'rich-tool') {
     return block.steps.some((step) => step.status === 'in_progress');
   }
-  return (
-    (block.kind === 'rich-tool' || block.kind === 'pending-tool') &&
-    block.step.status === 'in_progress'
-  );
+  return block.kind === 'pending-tool' && block.step.status === 'in_progress';
 }
 
 interface RunBlockProps {
@@ -161,12 +159,20 @@ function InlineToolBlock({
   threadId,
   onOpenArtifact,
 }: Readonly<InlineToolBlockProps>) {
+  const steps = block.kind === 'rich-tool' ? block.steps : [block.step];
+  const latestStep = steps[steps.length - 1];
+  // A still-streaming mutation step has no parseable artifact_id yet, which
+  // would disable the card's open action; fall back to the newest step whose
+  // target is resolved so the merged card stays openable while args stream.
+  const cardStep =
+    [...steps].reverse().find((step) => getArtifactToolTarget(step.toolUse)) ??
+    latestStep;
   const card =
     block.kind === 'rich-tool'
       ? renderRichToolCard({
-          toolUse: block.step.toolUse,
-          result: block.step.result,
-          isStreaming: block.step.status === 'in_progress',
+          toolUse: cardStep.toolUse,
+          result: cardStep.result,
+          isStreaming: latestStep.status === 'in_progress',
           threadId,
           onOpenArtifact,
           index,
@@ -175,7 +181,9 @@ function InlineToolBlock({
   return (
     <div className="flex flex-col gap-2">
       <div className="rounded-lg border border-border bg-muted/30 px-3 py-1">
-        <AgentRunTimelineRow step={block.step} />
+        {steps.map((step) => (
+          <AgentRunTimelineRow key={step.key} step={step} />
+        ))}
       </div>
       {card}
     </div>


### PR DESCRIPTION
- merge consecutive same-artifact document/diagram mutation tool calls
  into one rich-tool block rendering a single widget with latest state
- skip intervening thinking activity when merging; assistant prose still
  separates widgets
- create tools keep their own widget (title-bearing card)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to chat timeline grouping and rich-tool rendering; behavior is heavily covered by new unit tests with no auth or data-layer changes.
> 
> **Overview**
> Repeated **document/diagram mutations** on the same artifact (`edit_document`, `update_document`, `update_diagram`) are **merged into one `rich-tool` block** with a **`steps[]` array** instead of one widget per tool call.
> 
> `groupMessagesIntoRuns` walks backward past **activity** blocks (thinking, `read_document`, etc.) to attach the next mutation to the trailing rich-tool widget, but **assistant text** or another artifact’s widget still starts a new block. **Create** tools stay separate; streaming edits without `artifact_id` merge by **artifact family** until args parse.
> 
> **`AgentRunTimeline`** lists every merged step in the row strip but renders **a single rich card** from the latest step (or the newest step with a resolved artifact id while a follow-up streams), keeping block keys stable for streaming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ea1c32fbe8104cc66bd8a2b5bc2357cd798245f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->