### PR TITLE
fix(runs): surface real image-generation errors instead of a generic failure (AYC-562)

### DIFF
--- a/ayunis-core-backend/src/domain/tools/application/handlers/generate-image-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/generate-image-tool.handler.spec.ts
@@ -17,6 +17,7 @@ import { ImageGenerationResult } from 'src/domain/models/application/ports/image
 import { CheckQuotaUseCase } from 'src/iam/quotas/application/use-cases/check-quota/check-quota.use-case';
 import { QuotaType } from 'src/iam/quotas/domain/quota-type.enum';
 import { QuotaExceededError } from 'src/iam/quotas/application/quotas.errors';
+import { ImageGenerationFailedError } from 'src/domain/models/application/models.errors';
 
 describe('GenerateImageToolHandler', () => {
   let handler: GenerateImageToolHandler;
@@ -227,6 +228,33 @@ describe('GenerateImageToolHandler', () => {
         context: { orgId: mockOrgId, threadId: mockThreadId },
       }),
     ).rejects.toThrow(ToolExecutionFailedError);
+  });
+
+  it('should expose ApplicationError messages to the LLM, preserving the message', async () => {
+    // Provider errors like content-policy rejections carry a user-appropriate
+    // message; swallowing it left the model retrying blind until the
+    // repeated-failure breaker aborted the run with a generic error (AYC-562).
+    setupHappyPath();
+    const generationError = new ImageGenerationFailedError(
+      'The image could not be generated because the prompt was flagged by the content policy. Please revise your prompt and try again.',
+    );
+    mockGenerateImage.execute.mockRejectedValue(generationError);
+
+    let caught: unknown;
+    try {
+      await handler.execute({
+        tool: new GenerateImageTool(),
+        input: { prompt: 'A comic-style portrait' },
+        context: { orgId: mockOrgId, threadId: mockThreadId },
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(ToolExecutionFailedError);
+    const toolError = caught as ToolExecutionFailedError;
+    expect(toolError.exposeToLLM).toBe(true);
+    expect(toolError.message).toContain(generationError.message);
   });
 
   it('should throw ToolExecutionFailedError when save fails', async () => {

--- a/ayunis-core-backend/src/domain/tools/application/handlers/generate-image-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/generate-image-tool.handler.ts
@@ -18,7 +18,6 @@ import { ApplicationError } from 'src/common/errors/base.error';
 import { CheckQuotaUseCase } from 'src/iam/quotas/application/use-cases/check-quota/check-quota.use-case';
 import { CheckQuotaQuery } from 'src/iam/quotas/application/use-cases/check-quota/check-quota.query';
 import { QuotaType } from 'src/iam/quotas/domain/quota-type.enum';
-import { QuotaExceededError } from 'src/iam/quotas/application/quotas.errors';
 import { PermittedImageGenerationModel } from 'src/domain/models/domain/permitted-model.entity';
 
 type GenerateImageResult = Awaited<ReturnType<GenerateImageUseCase['execute']>>;
@@ -136,15 +135,16 @@ export class GenerateImageToolHandler extends ToolExecutionHandler {
       throw error;
     }
     this.logger.error('Failed to execute generate_image tool', error);
-    if (error instanceof QuotaExceededError) {
+    // ApplicationError messages (quota, content policy, provider outage) are
+    // curated for end users — expose them so the model can explain the
+    // failure instead of retrying blind into the repeated-failure breaker
+    // (AYC-562). A raw rethrow would reach the LLM as "unknown error".
+    if (error instanceof ApplicationError) {
       throw new ToolExecutionFailedError({
         toolName,
         message: error.message,
         exposeToLLM: true,
       });
-    }
-    if (error instanceof ApplicationError) {
-      throw error;
     }
     throw new ToolExecutionFailedError({
       toolName,

--- a/ayunis-core-frontend/src/pages/chat/hooks/useRunErrorHandler.test.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/useRunErrorHandler.test.ts
@@ -29,6 +29,21 @@ describe('useRunErrorHandler', () => {
     expect(showError).toHaveBeenCalledWith('chat.errorContextBudgetExceeded');
   });
 
+  it('shows the tool-failure explanation when the repeated-failure breaker aborts the run', () => {
+    const { result } = renderHook(() => useRunErrorHandler('thread-1'));
+    const error: RunErrorResponseDto = {
+      type: 'error',
+      message: "Tool 'generate_image' execution failed",
+      threadId: 'thread-1',
+      timestamp: '2026-08-06T12:00:00.000Z',
+      code: 'RUN_TOOL_EXECUTION_FAILED',
+    };
+
+    act(() => result.current(error));
+
+    expect(showError).toHaveBeenCalledWith('chat.errorToolExecutionFailed');
+  });
+
   it('shows the timeout explanation when the provider stream stalls', () => {
     const { result } = renderHook(() => useRunErrorHandler('thread-1'));
     const error: RunErrorResponseDto = {

--- a/ayunis-core-frontend/src/pages/chat/hooks/useRunErrorHandler.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/useRunErrorHandler.ts
@@ -27,6 +27,9 @@ export function useRunErrorHandler(_threadId: string) {
         case 'RUN_TOOL_NOT_FOUND':
           showError(t('chat.errorToolNotFound'));
           break;
+        case 'RUN_TOOL_EXECUTION_FAILED':
+          showError(t('chat.errorToolExecutionFailed'));
+          break;
         case 'RUN_ANONYMIZATION_UNAVAILABLE':
           showError(t('chat.errorAnonymizationUnavailable'));
           break;

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -21,6 +21,7 @@
     "errorNoModelFound": "Kein Modell gefunden",
     "errorMaxIterationsReached": "Maximale Anzahl an Iterationen erreicht",
     "errorToolNotFound": "Tool nicht gefunden",
+    "errorToolExecutionFailed": "Ein Tool ist wiederholt fehlgeschlagen. Bitte passen Sie Ihre Anfrage an und versuchen Sie es erneut.",
     "errorAnonymizationUnavailable": "Die Anonymisierung ist derzeit nicht verfügbar. Ihre Nachricht wurde nicht gesendet, um Ihre Daten zu schützen.",
     "errorContextBudgetExceeded": "Die letzte Konversationsrunde ist zu groß für das Kontextfenster des Modells.",
     "errorSendMessage": "Nachricht konnte nicht gesendet werden. Bitte aktualisieren Sie die Seite und versuchen Sie es erneut.",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -21,6 +21,7 @@
     "errorNoModelFound": "No model found",
     "errorMaxIterationsReached": "Maximal number of iterations reached",
     "errorToolNotFound": "Tool not found",
+    "errorToolExecutionFailed": "A tool failed repeatedly. Please adjust your request and try again.",
     "errorAnonymizationUnavailable": "Anonymization is currently unavailable. Your message was not sent to protect your data.",
     "errorContextBudgetExceeded": "The latest conversation turn is too large for the model context window.",
     "errorSendMessage": "Message could not be sent. Please refresh the page and try again.",


### PR DESCRIPTION
- Expose ApplicationError messages (content policy, quota, provider
  outage) to the LLM in the image tool handler so the model can explain
  the failure instead of retrying blind into the repeated-failure breaker
- Map RUN_TOOL_EXECUTION_FAILED to a specific toast in the frontend
  instead of falling through to the generic unexpected-error message

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to generate_image error mapping and chat error toasts; behavior is covered by new tests with no auth or data-model impact.
> 
> **Overview**
> Fixes **AYC-562** by changing how `generate_image` failures are reported to the model and how repeated tool failures appear in chat.
> 
> **Backend:** `handleError` in the image tool handler now wraps **any** `ApplicationError` (content policy via `ImageGenerationFailedError`, quota, provider issues) in `ToolExecutionFailedError` with `exposeToLLM: true` and the original message. Quota used to have a dedicated branch; other `ApplicationError` types were rethrown and could surface to the LLM as an opaque failure, leading to blind retries until the repeated-failure breaker fired.
> 
> **Frontend:** `RUN_TOOL_EXECUTION_FAILED` is handled in `useRunErrorHandler` with new `chat.errorToolExecutionFailed` copy (EN/DE) instead of the generic unexpected-error toast. A unit test covers this path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b122f29fb84bc82a5df34a61cf19b436f1b56b63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->