### PR TITLE
feat(api-keys): disable api key creation without usage-based subscription (AYC-284)

### DIFF
--- a/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.api-keys.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/admin-settings.api-keys.tsx
@@ -3,22 +3,30 @@ import { ApiKeysSettingsPage } from '@/pages/admin-settings/api-keys-settings';
 import {
   apiKeysControllerListApiKeys,
   getApiKeysControllerListApiKeysQueryKey,
+  getSubscriptionsControllerHasActiveSubscriptionQueryKey,
+  subscriptionsControllerHasActiveSubscription,
 } from '@/shared/api/generated/ayunisCoreAPI';
 
 export const Route = createFileRoute('/_authenticated/admin-settings/api-keys')(
   {
     component: RouteComponent,
     loader: async ({ context: { queryClient } }) => {
-      const apiKeys = await queryClient.fetchQuery({
-        queryKey: getApiKeysControllerListApiKeysQueryKey(),
-        queryFn: () => apiKeysControllerListApiKeys(),
-      });
-      return { apiKeys };
+      const [apiKeys, subscription] = await Promise.all([
+        queryClient.fetchQuery({
+          queryKey: getApiKeysControllerListApiKeysQueryKey(),
+          queryFn: () => apiKeysControllerListApiKeys(),
+        }),
+        queryClient.fetchQuery({
+          queryKey: getSubscriptionsControllerHasActiveSubscriptionQueryKey(),
+          queryFn: () => subscriptionsControllerHasActiveSubscription(),
+        }),
+      ]);
+      return { apiKeys, subscription };
     },
   },
 );
 
 function RouteComponent() {
-  const { apiKeys } = Route.useLoaderData();
-  return <ApiKeysSettingsPage apiKeys={apiKeys} />;
+  const { apiKeys, subscription } = Route.useLoaderData();
+  return <ApiKeysSettingsPage apiKeys={apiKeys} subscription={subscription} />;
 }

--- a/ayunis-core-frontend/src/pages/admin-settings/api-keys-settings/ui/ApiKeysSettingsPage.test.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/api-keys-settings/ui/ApiKeysSettingsPage.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { ApiKeysSettingsPage } from './ApiKeysSettingsPage';
+import type { ActiveSubscriptionResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../../admin-settings-layout', () => ({
+  default: ({
+    children,
+    action,
+    title,
+  }: {
+    children: ReactNode;
+    action: ReactNode;
+    title: string;
+  }) => (
+    <section>
+      <h1>{title}</h1>
+      {action}
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock('@/shared/ui/help-link/HelpLink', () => ({
+  HelpLink: () => <a href="/help">Help</a>,
+}));
+
+vi.mock('./ApiKeysList', () => ({
+  ApiKeysList: () => null,
+}));
+
+vi.mock('./CreateApiKeyDialog', () => ({
+  CreateApiKeyDialog: () => null,
+}));
+
+vi.mock('./RevealSecretDialog', () => ({
+  RevealSecretDialog: () => null,
+}));
+
+const subscription = (
+  overrides: Partial<ActiveSubscriptionResponseDto> = {},
+): ActiveSubscriptionResponseDto => ({
+  hasActiveSubscription: true,
+  subscriptionType: 'USAGE_BASED',
+  ...overrides,
+});
+
+describe('ApiKeysSettingsPage', () => {
+  it('enables creation without a hint on a usage-based subscription', () => {
+    render(<ApiKeysSettingsPage apiKeys={[]} subscription={subscription()} />);
+
+    const createButton = screen.getByRole('button', {
+      name: 'apiKeys.page.add',
+    });
+    expect(createButton.hasAttribute('disabled')).toBe(false);
+    expect(
+      screen.queryByText('apiKeys.createApiKey.subscriptionRequired'),
+    ).toBeNull();
+  });
+
+  it('disables creation and shows the hint on a seat-based subscription', () => {
+    render(
+      <ApiKeysSettingsPage
+        apiKeys={[]}
+        subscription={subscription({ subscriptionType: 'SEAT_BASED' })}
+      />,
+    );
+
+    const createButton = screen.getByRole('button', {
+      name: 'apiKeys.page.add',
+    });
+    expect(createButton.hasAttribute('disabled')).toBe(true);
+    expect(
+      screen.getByText('apiKeys.createApiKey.subscriptionRequired'),
+    ).toBeTruthy();
+  });
+
+  it('enables creation when there is no subscription type (self-hosted)', () => {
+    render(
+      <ApiKeysSettingsPage
+        apiKeys={[]}
+        subscription={subscription({ subscriptionType: null })}
+      />,
+    );
+
+    const createButton = screen.getByRole('button', {
+      name: 'apiKeys.page.add',
+    });
+    expect(createButton.hasAttribute('disabled')).toBe(false);
+    expect(
+      screen.queryByText('apiKeys.createApiKey.subscriptionRequired'),
+    ).toBeNull();
+  });
+});

--- a/ayunis-core-frontend/src/pages/admin-settings/api-keys-settings/ui/ApiKeysSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/api-keys-settings/ui/ApiKeysSettingsPage.tsx
@@ -1,7 +1,11 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Info } from 'lucide-react';
 import { Button } from '@/shared/ui/shadcn/button';
+import { Alert, AlertDescription } from '@/shared/ui/shadcn/alert';
 import { HelpLink } from '@/shared/ui/help-link/HelpLink';
+import { ActiveSubscriptionResponseDtoSubscriptionType } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import type { ActiveSubscriptionResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import SettingsLayout from '../../admin-settings-layout';
 import { ApiKeysList } from './ApiKeysList';
 import { CreateApiKeyDialog } from './CreateApiKeyDialog';
@@ -10,20 +14,30 @@ import type { ApiKey } from '../model/types';
 
 interface ApiKeysSettingsPageProps {
   apiKeys: ApiKey[];
+  subscription: ActiveSubscriptionResponseDto;
 }
 
 export function ApiKeysSettingsPage({
   apiKeys,
+  subscription,
 }: Readonly<ApiKeysSettingsPageProps>) {
   const { t } = useTranslation('admin-settings-api-keys');
   const { t: tLayout } = useTranslation('admin-settings-layout');
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
 
+  const requiresUsageBasedUpgrade =
+    subscription.subscriptionType ===
+    ActiveSubscriptionResponseDtoSubscriptionType.SEAT_BASED;
+
   const headerActions = (
     <div className="flex gap-2">
       <HelpLink path="settings/admin/api-keys/" />
-      <Button size="sm" onClick={() => setCreateDialogOpen(true)}>
+      <Button
+        size="sm"
+        onClick={() => setCreateDialogOpen(true)}
+        disabled={requiresUsageBasedUpgrade}
+      >
         {t('apiKeys.page.add')}
       </Button>
     </div>
@@ -32,6 +46,15 @@ export function ApiKeysSettingsPage({
   return (
     <SettingsLayout action={headerActions} title={tLayout('layout.apiKeys')}>
       <div className="space-y-4">
+        {requiresUsageBasedUpgrade && (
+          <Alert>
+            <Info className="h-4 w-4" />
+            <AlertDescription>
+              {t('apiKeys.createApiKey.subscriptionRequired')}
+            </AlertDescription>
+          </Alert>
+        )}
+
         <ApiKeysList apiKeys={apiKeys} />
 
         <CreateApiKeyDialog


### PR DESCRIPTION
- fetch the active subscription in the api-keys route loader
- disable the create button and show a hint reusing the existing
  subscriptionRequired wording when the org is on a seat-based plan
- self-hosted and usage-based orgs are unaffected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Admin UI gating only; no auth or API changes, with tests for subscription-type branches.
> 
> **Overview**
> **Seat-based orgs can no longer start API key creation from admin settings** until they’re on a usage-based plan. The api-keys route loader now fetches **active subscription** alongside the key list and passes it into `ApiKeysSettingsPage`.
> 
> When `subscriptionType` is **SEAT_BASED**, the **Add** button is disabled and an info **Alert** shows the existing `apiKeys.createApiKey.subscriptionRequired` copy (same message already used when create fails with `SUBSCRIPTION_REQUIRED`). **Usage-based** and **self-hosted** (`subscriptionType` null) behavior is unchanged.
> 
> Unit tests cover enabled/disabled states and the hint for the three subscription shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d72b187bd30a7f32b772a42366a89654e3380b01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->