### PR TITLE
wip(anonymization): add global whitelist domain, persistence and read use case (AYC-446)

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1786042564122-CreateGlobalAnonymizationWhitelistWordsTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1786042564122-CreateGlobalAnonymizationWhitelistWordsTable.ts
@@ -1,0 +1,29 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateGlobalAnonymizationWhitelistWordsTable1786042564122 implements MigrationInterface {
+  name = 'CreateGlobalAnonymizationWhitelistWordsTable1786042564122';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."global_anonymization_whitelist_words_category_enum" AS ENUM('person_name', 'organization', 'location', 'email_address', 'phone_number', 'url_or_ip', 'date_time', 'financial_account', 'government_id', 'nationality_religion_politics', 'other')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "global_anonymization_whitelist_words" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "category" "public"."global_anonymization_whitelist_words_category_enum" NOT NULL, "word" text NOT NULL, "wordLowercase" text NOT NULL, "createdByUserId" character varying, CONSTRAINT "UQ_911de3cde8ce5316dc9b545245a" UNIQUE ("category", "wordLowercase"), CONSTRAINT "PK_c6cfd087ebff53d8fe5226f6b16" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "global_anonymization_whitelist_words" ADD CONSTRAINT "FK_6556af0a49c65240e2985fa83c4" FOREIGN KEY ("createdByUserId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "global_anonymization_whitelist_words" DROP CONSTRAINT "FK_6556af0a49c65240e2985fa83c4"`,
+    );
+    await queryRunner.query(
+      `DROP TABLE "global_anonymization_whitelist_words"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."global_anonymization_whitelist_words_category_enum"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/anonymization-settings/SUMMARY.md
@@ -1,0 +1,50 @@
+# Anonymization Settings Module
+
+## Purpose
+
+Owns the whitelists that exempt detected PII from anonymization before text reaches the language model. Two scopes exist: the **org whitelist** (one optional regex rule per PII category, maintained by org admins) and the **global whitelist** (plain words maintained by super admins, applied in every organization on top of the org's own rules — AYC-446). Matching itself lives in `src/common/anonymization` (`whitelist-filter.ts`); this module stores the rules and provides them to the pipeline.
+
+## Domain Concepts
+
+- **AnonymizationWhitelistEntry** — Org-level rule: one PII category, optionally restricted to values fully matching a regex (`pattern === null` exempts the whole category). At most one entry per (org, category).
+- **GlobalAnonymizationWhitelistWord** — Platform-wide plain word for one category. Matching is case-insensitive against the whole detected value; the original casing is kept for display. Uniqueness is case-insensitive per category via a normalized `wordLowercase` column.
+- **validate-pattern** — Save-time guard for org regexes: max length, must compile, must pass `safe-regex2` (ReDoS).
+
+## Architecture
+
+```text
+anonymization-settings/
+├── domain/
+│   ├── anonymization-whitelist-entry.entity.ts
+│   ├── global-anonymization-whitelist-word.entity.ts
+│   └── validate-pattern.ts
+├── application/
+│   ├── anonymization-settings.errors.ts
+│   ├── ports/
+│   │   ├── anonymization-whitelist.repository.ts
+│   │   └── global-anonymization-whitelist.repository.ts
+│   └── use-cases/
+│       ├── get-pii-whitelist/            # org entries for one org
+│       ├── update-pii-whitelist/         # full replacement of an org's entries
+│       ├── get-global-pii-whitelist/     # all global words (exported for consumers outside the module)
+│       └── anonymize-text-for-org/       # whitelist → common AnonymizeTextUseCase
+├── infrastructure/
+│   └── persistence/postgres/
+│       ├── schema/                       # anonymization_whitelist_entries, global_anonymization_whitelist_words
+│       ├── mappers/
+│       ├── anonymization-whitelist.repository.ts
+│       └── global-anonymization-whitelist.repository.ts
+├── presenters/
+│   └── http/                             # org admin endpoints (@Roles(ADMIN), org-scoped via @CurrentUser)
+└── anonymization-settings.module.ts
+```
+
+## Key Flows
+
+- **Applying exceptions** — Detection runs in the `ayunis-core-anonymize` service; the common `AnonymizeTextUseCase` drops detections the whitelist exempts. There is no caching — every anonymization call reads the DB, so whitelist changes take effect immediately.
+- **Org settings screen** — `GET/PUT /anonymization-settings/pii-whitelist` back the org admin page (`/admin-settings/anonymization`).
+
+## Consumers
+
+- `thread-pii-masks` — `AnonymizeTextForThreadUseCase` (the main chat path) injects `GetPiiWhitelistUseCase`.
+- `runs` — uses `AnonymizeTextForOrgUseCase` for thread title generation.

--- a/ayunis-core-backend/src/domain/anonymization-settings/anonymization-settings.module.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/anonymization-settings.module.ts
@@ -3,17 +3,24 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AnonymizationModule } from 'src/common/anonymization/anonymization.module';
 import { AnonymizationWhitelistEntryRecord } from './infrastructure/persistence/postgres/schema/anonymization-whitelist-entry.record';
+import { GlobalAnonymizationWhitelistWordRecord } from './infrastructure/persistence/postgres/schema/global-anonymization-whitelist-word.record';
 import { AnonymizationWhitelistRepository } from './application/ports/anonymization-whitelist.repository';
 import { PostgresAnonymizationWhitelistRepository } from './infrastructure/persistence/postgres/anonymization-whitelist.repository';
+import { GlobalAnonymizationWhitelistRepository } from './application/ports/global-anonymization-whitelist.repository';
+import { PostgresGlobalAnonymizationWhitelistRepository } from './infrastructure/persistence/postgres/global-anonymization-whitelist.repository';
 
 import { GetPiiWhitelistUseCase } from './application/use-cases/get-pii-whitelist/get-pii-whitelist.use-case';
 import { UpdatePiiWhitelistUseCase } from './application/use-cases/update-pii-whitelist/update-pii-whitelist.use-case';
 import { AnonymizeTextForOrgUseCase } from './application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case';
+import { GetGlobalPiiWhitelistUseCase } from './application/use-cases/get-global-pii-whitelist/get-global-pii-whitelist.use-case';
 import { AnonymizationSettingsController } from './presenters/http/anonymization-settings.controller';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([AnonymizationWhitelistEntryRecord]),
+    TypeOrmModule.forFeature([
+      AnonymizationWhitelistEntryRecord,
+      GlobalAnonymizationWhitelistWordRecord,
+    ]),
     AnonymizationModule,
   ],
   controllers: [AnonymizationSettingsController],
@@ -22,14 +29,20 @@ import { AnonymizationSettingsController } from './presenters/http/anonymization
       provide: AnonymizationWhitelistRepository,
       useClass: PostgresAnonymizationWhitelistRepository,
     },
+    {
+      provide: GlobalAnonymizationWhitelistRepository,
+      useClass: PostgresGlobalAnonymizationWhitelistRepository,
+    },
     GetPiiWhitelistUseCase,
     UpdatePiiWhitelistUseCase,
     AnonymizeTextForOrgUseCase,
+    GetGlobalPiiWhitelistUseCase,
   ],
   exports: [
     GetPiiWhitelistUseCase,
     UpdatePiiWhitelistUseCase,
     AnonymizeTextForOrgUseCase,
+    GetGlobalPiiWhitelistUseCase,
   ],
 })
 export class AnonymizationSettingsModule {}

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/anonymization-settings.errors.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/anonymization-settings.errors.ts
@@ -6,6 +6,7 @@ export enum AnonymizationSettingsErrorCode {
   INVALID_PATTERN = 'INVALID_PATTERN',
   DUPLICATE_CATEGORY = 'DUPLICATE_CATEGORY',
   UNEXPECTED_ERROR = 'UNEXPECTED_ANONYMIZATION_SETTINGS_ERROR',
+  UNEXPECTED_GLOBAL_WHITELIST_ERROR = 'UNEXPECTED_GLOBAL_ANONYMIZATION_WHITELIST_ERROR',
 }
 
 export class InvalidPatternError extends ApplicationError {
@@ -26,6 +27,17 @@ export class DuplicateCategoryError extends ApplicationError {
       AnonymizationSettingsErrorCode.DUPLICATE_CATEGORY,
       400,
       { category, ...metadata },
+    );
+  }
+}
+
+export class UnexpectedGlobalAnonymizationWhitelistError extends ApplicationError {
+  constructor(error: Error) {
+    super(
+      'Unexpected global anonymization whitelist error',
+      AnonymizationSettingsErrorCode.UNEXPECTED_GLOBAL_WHITELIST_ERROR,
+      500,
+      { originalError: error.message },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/ports/global-anonymization-whitelist.repository.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/ports/global-anonymization-whitelist.repository.ts
@@ -1,0 +1,16 @@
+import type { UUID } from 'crypto';
+import type { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+import type { GlobalAnonymizationWhitelistWord } from '../../domain/global-anonymization-whitelist-word.entity';
+
+export abstract class GlobalAnonymizationWhitelistRepository {
+  abstract findAll(): Promise<GlobalAnonymizationWhitelistWord[]>;
+  abstract findByCategoryAndWord(
+    category: PiiCategory,
+    word: string,
+  ): Promise<GlobalAnonymizationWhitelistWord | null>;
+  abstract create(
+    word: GlobalAnonymizationWhitelistWord,
+  ): Promise<GlobalAnonymizationWhitelistWord>;
+  /** Returns false when no word with the given id exists. */
+  abstract delete(id: UUID): Promise<boolean>;
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/get-global-pii-whitelist/get-global-pii-whitelist.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/get-global-pii-whitelist/get-global-pii-whitelist.use-case.spec.ts
@@ -1,0 +1,47 @@
+import { randomUUID } from 'crypto';
+import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+import { GlobalAnonymizationWhitelistWord } from 'src/domain/anonymization-settings/domain/global-anonymization-whitelist-word.entity';
+import type { GlobalAnonymizationWhitelistRepository } from '../../ports/global-anonymization-whitelist.repository';
+import { UnexpectedGlobalAnonymizationWhitelistError } from '../../anonymization-settings.errors';
+import { GetGlobalPiiWhitelistUseCase } from './get-global-pii-whitelist.use-case';
+
+describe('GetGlobalPiiWhitelistUseCase', () => {
+  const repository: jest.Mocked<GlobalAnonymizationWhitelistRepository> = {
+    findAll: jest.fn(),
+    findByCategoryAndWord: jest.fn(),
+    create: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  const useCase = new GetGlobalPiiWhitelistUseCase(repository);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return all global whitelist words', async () => {
+    const words = [
+      new GlobalAnonymizationWhitelistWord({
+        category: PiiCategory.PERSON_NAME,
+        word: 'Mitarbeitende',
+        createdByUserId: randomUUID(),
+      }),
+      new GlobalAnonymizationWhitelistWord({
+        category: PiiCategory.ORGANIZATION,
+        word: 'Stadtverwaltung',
+        createdByUserId: null,
+      }),
+    ];
+    repository.findAll.mockResolvedValue(words);
+
+    await expect(useCase.execute()).resolves.toEqual(words);
+  });
+
+  it('should wrap repository failures in the module unexpected error', async () => {
+    repository.findAll.mockRejectedValue(new Error('connection refused'));
+
+    await expect(useCase.execute()).rejects.toBeInstanceOf(
+      UnexpectedGlobalAnonymizationWhitelistError,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/get-global-pii-whitelist/get-global-pii-whitelist.use-case.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/get-global-pii-whitelist/get-global-pii-whitelist.use-case.ts
@@ -1,0 +1,21 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { GlobalAnonymizationWhitelistRepository } from '../../ports/global-anonymization-whitelist.repository';
+import { UnexpectedGlobalAnonymizationWhitelistError } from '../../anonymization-settings.errors';
+import type { GlobalAnonymizationWhitelistWord } from 'src/domain/anonymization-settings/domain/global-anonymization-whitelist-word.entity';
+
+@Injectable()
+export class GetGlobalPiiWhitelistUseCase {
+  private readonly logger = new Logger(GetGlobalPiiWhitelistUseCase.name);
+
+  constructor(
+    private readonly repository: GlobalAnonymizationWhitelistRepository,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedGlobalAnonymizationWhitelistError)
+  async execute(): Promise<GlobalAnonymizationWhitelistWord[]> {
+    this.logger.debug('Getting global PII whitelist');
+
+    return await this.repository.findAll();
+  }
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/domain/global-anonymization-whitelist-word.entity.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/domain/global-anonymization-whitelist-word.entity.ts
@@ -1,0 +1,35 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+import type { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+
+export interface GlobalAnonymizationWhitelistWordParams {
+  id?: UUID;
+  category: PiiCategory;
+  word: string;
+  createdByUserId: UUID | null;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+/**
+ * Platform-wide word exempted from anonymization in every organization,
+ * maintained by super admins. Matching is case-insensitive against the
+ * whole detected value; the original casing is kept for display.
+ */
+export class GlobalAnonymizationWhitelistWord {
+  id: UUID;
+  category: PiiCategory;
+  word: string;
+  createdByUserId: UUID | null;
+  createdAt: Date;
+  updatedAt: Date;
+
+  constructor(params: GlobalAnonymizationWhitelistWordParams) {
+    this.id = params.id ?? randomUUID();
+    this.category = params.category;
+    this.word = params.word.trim();
+    this.createdByUserId = params.createdByUserId;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/global-anonymization-whitelist.repository.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/global-anonymization-whitelist.repository.ts
@@ -1,0 +1,69 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { UUID } from 'crypto';
+import type { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+import { GlobalAnonymizationWhitelistRepository } from 'src/domain/anonymization-settings/application/ports/global-anonymization-whitelist.repository';
+import { GlobalAnonymizationWhitelistWord } from 'src/domain/anonymization-settings/domain/global-anonymization-whitelist-word.entity';
+import { GlobalAnonymizationWhitelistWordRecord } from './schema/global-anonymization-whitelist-word.record';
+import { GlobalAnonymizationWhitelistWordMapper } from './mappers/global-anonymization-whitelist-word.mapper';
+
+@Injectable()
+export class PostgresGlobalAnonymizationWhitelistRepository extends GlobalAnonymizationWhitelistRepository {
+  private readonly logger = new Logger(
+    PostgresGlobalAnonymizationWhitelistRepository.name,
+  );
+
+  constructor(
+    @InjectRepository(GlobalAnonymizationWhitelistWordRecord)
+    private readonly repository: Repository<GlobalAnonymizationWhitelistWordRecord>,
+  ) {
+    super();
+  }
+
+  async findAll(): Promise<GlobalAnonymizationWhitelistWord[]> {
+    this.logger.debug('findAll');
+
+    const records = await this.repository.find({
+      order: { category: 'ASC', wordLowercase: 'ASC' },
+    });
+
+    return records.map((record) =>
+      GlobalAnonymizationWhitelistWordMapper.toDomain(record),
+    );
+  }
+
+  async findByCategoryAndWord(
+    category: PiiCategory,
+    word: string,
+  ): Promise<GlobalAnonymizationWhitelistWord | null> {
+    this.logger.debug('findByCategoryAndWord', { category });
+
+    const record = await this.repository.findOne({
+      where: { category, wordLowercase: word.trim().toLowerCase() },
+    });
+
+    return record
+      ? GlobalAnonymizationWhitelistWordMapper.toDomain(record)
+      : null;
+  }
+
+  async create(
+    word: GlobalAnonymizationWhitelistWord,
+  ): Promise<GlobalAnonymizationWhitelistWord> {
+    this.logger.debug('create', { category: word.category });
+
+    const record = await this.repository.save(
+      GlobalAnonymizationWhitelistWordMapper.toRecord(word),
+    );
+
+    return GlobalAnonymizationWhitelistWordMapper.toDomain(record);
+  }
+
+  async delete(id: UUID): Promise<boolean> {
+    this.logger.debug('delete', { id });
+
+    const result = await this.repository.delete({ id });
+    return (result.affected ?? 0) > 0;
+  }
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/mappers/global-anonymization-whitelist-word.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/mappers/global-anonymization-whitelist-word.mapper.spec.ts
@@ -1,0 +1,37 @@
+import { randomUUID } from 'crypto';
+import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+import { GlobalAnonymizationWhitelistWord } from 'src/domain/anonymization-settings/domain/global-anonymization-whitelist-word.entity';
+import { GlobalAnonymizationWhitelistWordMapper } from './global-anonymization-whitelist-word.mapper';
+
+describe('GlobalAnonymizationWhitelistWordMapper', () => {
+  it('should preserve all fields on a domain → record → domain round-trip', () => {
+    const word = new GlobalAnonymizationWhitelistWord({
+      category: PiiCategory.PERSON_NAME,
+      word: 'Mitarbeitende',
+      createdByUserId: randomUUID(),
+    });
+
+    const roundTripped = GlobalAnonymizationWhitelistWordMapper.toDomain(
+      GlobalAnonymizationWhitelistWordMapper.toRecord(word),
+    );
+
+    expect(roundTripped.id).toBe(word.id);
+    expect(roundTripped.category).toBe(word.category);
+    expect(roundTripped.word).toBe(word.word);
+    expect(roundTripped.createdByUserId).toBe(word.createdByUserId);
+    expect(roundTripped.createdAt).toEqual(word.createdAt);
+  });
+
+  it('should store a lowercased copy of the word for case-insensitive uniqueness', () => {
+    const record = GlobalAnonymizationWhitelistWordMapper.toRecord(
+      new GlobalAnonymizationWhitelistWord({
+        category: PiiCategory.PERSON_NAME,
+        word: 'Führungskräfte',
+        createdByUserId: null,
+      }),
+    );
+
+    expect(record.word).toBe('Führungskräfte');
+    expect(record.wordLowercase).toBe('führungskräfte');
+  });
+});

--- a/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/mappers/global-anonymization-whitelist-word.mapper.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/mappers/global-anonymization-whitelist-word.mapper.ts
@@ -1,0 +1,31 @@
+import { GlobalAnonymizationWhitelistWord } from 'src/domain/anonymization-settings/domain/global-anonymization-whitelist-word.entity';
+import { GlobalAnonymizationWhitelistWordRecord } from '../schema/global-anonymization-whitelist-word.record';
+
+export class GlobalAnonymizationWhitelistWordMapper {
+  static toDomain(
+    record: GlobalAnonymizationWhitelistWordRecord,
+  ): GlobalAnonymizationWhitelistWord {
+    return new GlobalAnonymizationWhitelistWord({
+      id: record.id,
+      category: record.category,
+      word: record.word,
+      createdByUserId: record.createdByUserId,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  static toRecord(
+    domain: GlobalAnonymizationWhitelistWord,
+  ): GlobalAnonymizationWhitelistWordRecord {
+    const record = new GlobalAnonymizationWhitelistWordRecord();
+    record.id = domain.id;
+    record.category = domain.category;
+    record.word = domain.word;
+    record.wordLowercase = domain.word.toLowerCase();
+    record.createdByUserId = domain.createdByUserId;
+    record.createdAt = domain.createdAt;
+    record.updatedAt = new Date();
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/schema/global-anonymization-whitelist-word.record.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/schema/global-anonymization-whitelist-word.record.ts
@@ -1,0 +1,27 @@
+import { Column, Entity, JoinColumn, ManyToOne, Unique } from 'typeorm';
+import type { UUID } from 'crypto';
+import { BaseRecord } from 'src/common/db/base-record';
+import { UserRecord } from 'src/iam/users/infrastructure/repositories/local/schema/user.record';
+import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+
+@Entity({ name: 'global_anonymization_whitelist_words' })
+@Unique(['category', 'wordLowercase'])
+export class GlobalAnonymizationWhitelistWordRecord extends BaseRecord {
+  @Column({ type: 'enum', enum: PiiCategory })
+  category: PiiCategory;
+
+  @Column({ type: 'text' })
+  word: string;
+
+  // Normalized duplicate of `word` so uniqueness is case-insensitive without
+  // an expression index (which TypeORM decorators cannot express).
+  @Column({ type: 'text' })
+  wordLowercase: string;
+
+  @Column({ nullable: true })
+  createdByUserId: UUID | null;
+
+  @ManyToOne(() => UserRecord, { onDelete: 'SET NULL', nullable: true })
+  @JoinColumn({ name: 'createdByUserId' })
+  createdByUser: UserRecord | null;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New persistence and exported read API touch PII handling boundaries; behavior is additive and not yet applied in the anonymize path, but mistakes in later wiring could leak PII past masking.
> 
> **Overview**
> Introduces **platform-wide PII whitelist words** (AYC-446): super-admin–managed plain terms per category that will exempt matching detections from anonymization in every org, alongside existing org regex rules.
> 
> Adds a Postgres migration for `global_anonymization_whitelist_words` (PII category, display `word`, `wordLowercase` for case-insensitive uniqueness per category, optional `createdByUserId`). The domain model, TypeORM record/mapper, and `GlobalAnonymizationWhitelistRepository` support list, lookup by category+word, create, and delete. **`GetGlobalPiiWhitelistUseCase`** loads all words and is registered/exported from `AnonymizationSettingsModule` for downstream consumers; a dedicated unexpected-error type and module `SUMMARY.md` document the two-tier whitelist design.
> 
> This slice is **read/storage foundation only**—no super-admin HTTP APIs or changes to the anonymization pipeline appear in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed98e30f6cef5467fd13b0f569fe0f248e7dfb43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->