### PR TITLE
wip(anonymization): add super-admin api for the global whitelist (AYC-446)

### DIFF
--- a/ayunis-core-backend/src/domain/anonymization-settings/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/anonymization-settings/SUMMARY.md
@@ -27,6 +27,8 @@ anonymization-settings/
 │       ├── get-pii-whitelist/            # org entries for one org
 │       ├── update-pii-whitelist/         # full replacement of an org's entries
 │       ├── get-global-pii-whitelist/     # all global words (exported for consumers outside the module)
+│       ├── add-global-pii-whitelist-word/    # trim, reject empty + case-insensitive duplicates, record author
+│       ├── delete-global-pii-whitelist-word/
 │       └── anonymize-text-for-org/       # whitelist → common AnonymizeTextUseCase
 ├── infrastructure/
 │   └── persistence/postgres/
@@ -36,6 +38,7 @@ anonymization-settings/
 │       └── global-anonymization-whitelist.repository.ts
 ├── presenters/
 │   └── http/                             # org admin endpoints (@Roles(ADMIN), org-scoped via @CurrentUser)
+│                                         # + super-admin CRUD (@SystemRoles(SUPER_ADMIN), /super-admin/anonymization-whitelist)
 └── anonymization-settings.module.ts
 ```
 
@@ -43,6 +46,7 @@ anonymization-settings/
 
 - **Applying exceptions** — Detection runs in the `ayunis-core-anonymize` service; the common `AnonymizeTextUseCase` drops detections the whitelist exempts. There is no caching — every anonymization call reads the DB, so whitelist changes take effect immediately.
 - **Org settings screen** — `GET/PUT /anonymization-settings/pii-whitelist` back the org admin page (`/admin-settings/anonymization`).
+- **Global list management** — `GET/POST/DELETE /super-admin/anonymization-whitelist` back the super-admin screen; each word records who added it and when (`createdByUserId`, SET NULL on user deletion).
 
 ## Consumers
 

--- a/ayunis-core-backend/src/domain/anonymization-settings/anonymization-settings.module.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/anonymization-settings.module.ts
@@ -13,7 +13,10 @@ import { GetPiiWhitelistUseCase } from './application/use-cases/get-pii-whitelis
 import { UpdatePiiWhitelistUseCase } from './application/use-cases/update-pii-whitelist/update-pii-whitelist.use-case';
 import { AnonymizeTextForOrgUseCase } from './application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case';
 import { GetGlobalPiiWhitelistUseCase } from './application/use-cases/get-global-pii-whitelist/get-global-pii-whitelist.use-case';
+import { AddGlobalPiiWhitelistWordUseCase } from './application/use-cases/add-global-pii-whitelist-word/add-global-pii-whitelist-word.use-case';
+import { DeleteGlobalPiiWhitelistWordUseCase } from './application/use-cases/delete-global-pii-whitelist-word/delete-global-pii-whitelist-word.use-case';
 import { AnonymizationSettingsController } from './presenters/http/anonymization-settings.controller';
+import { SuperAdminAnonymizationWhitelistController } from './presenters/http/super-admin-anonymization-whitelist.controller';
 
 @Module({
   imports: [
@@ -23,7 +26,10 @@ import { AnonymizationSettingsController } from './presenters/http/anonymization
     ]),
     AnonymizationModule,
   ],
-  controllers: [AnonymizationSettingsController],
+  controllers: [
+    AnonymizationSettingsController,
+    SuperAdminAnonymizationWhitelistController,
+  ],
   providers: [
     {
       provide: AnonymizationWhitelistRepository,
@@ -37,6 +43,8 @@ import { AnonymizationSettingsController } from './presenters/http/anonymization
     UpdatePiiWhitelistUseCase,
     AnonymizeTextForOrgUseCase,
     GetGlobalPiiWhitelistUseCase,
+    AddGlobalPiiWhitelistWordUseCase,
+    DeleteGlobalPiiWhitelistWordUseCase,
   ],
   exports: [
     GetPiiWhitelistUseCase,

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/anonymization-settings.errors.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/anonymization-settings.errors.ts
@@ -6,7 +6,43 @@ export enum AnonymizationSettingsErrorCode {
   INVALID_PATTERN = 'INVALID_PATTERN',
   DUPLICATE_CATEGORY = 'DUPLICATE_CATEGORY',
   UNEXPECTED_ERROR = 'UNEXPECTED_ANONYMIZATION_SETTINGS_ERROR',
+  EMPTY_GLOBAL_WHITELIST_WORD = 'EMPTY_GLOBAL_WHITELIST_WORD',
+  DUPLICATE_GLOBAL_WHITELIST_WORD = 'DUPLICATE_GLOBAL_WHITELIST_WORD',
+  GLOBAL_WHITELIST_WORD_NOT_FOUND = 'GLOBAL_WHITELIST_WORD_NOT_FOUND',
   UNEXPECTED_GLOBAL_WHITELIST_ERROR = 'UNEXPECTED_GLOBAL_ANONYMIZATION_WHITELIST_ERROR',
+}
+
+export class EmptyGlobalWhitelistWordError extends ApplicationError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'A global whitelist word must not be empty',
+      AnonymizationSettingsErrorCode.EMPTY_GLOBAL_WHITELIST_WORD,
+      400,
+      metadata,
+    );
+  }
+}
+
+export class DuplicateGlobalWhitelistWordError extends ApplicationError {
+  constructor(category: PiiCategory, word: string, metadata?: ErrorMetadata) {
+    super(
+      `The word "${word}" is already on the global whitelist for category ${category}`,
+      AnonymizationSettingsErrorCode.DUPLICATE_GLOBAL_WHITELIST_WORD,
+      409,
+      { category, word, ...metadata },
+    );
+  }
+}
+
+export class GlobalWhitelistWordNotFoundError extends ApplicationError {
+  constructor(wordId: string, metadata?: ErrorMetadata) {
+    super(
+      `Global whitelist word with ID ${wordId} not found`,
+      AnonymizationSettingsErrorCode.GLOBAL_WHITELIST_WORD_NOT_FOUND,
+      404,
+      { wordId, ...metadata },
+    );
+  }
 }
 
 export class InvalidPatternError extends ApplicationError {

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/add-global-pii-whitelist-word/add-global-pii-whitelist-word.command.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/add-global-pii-whitelist-word/add-global-pii-whitelist-word.command.ts
@@ -1,0 +1,10 @@
+import type { UUID } from 'crypto';
+import type { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+
+export class AddGlobalPiiWhitelistWordCommand {
+  constructor(
+    public readonly category: PiiCategory,
+    public readonly word: string,
+    public readonly createdByUserId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/add-global-pii-whitelist-word/add-global-pii-whitelist-word.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/add-global-pii-whitelist-word/add-global-pii-whitelist-word.use-case.spec.ts
@@ -1,0 +1,94 @@
+import { randomUUID } from 'crypto';
+import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+import { GlobalAnonymizationWhitelistWord } from 'src/domain/anonymization-settings/domain/global-anonymization-whitelist-word.entity';
+import type { GlobalAnonymizationWhitelistRepository } from '../../ports/global-anonymization-whitelist.repository';
+import {
+  DuplicateGlobalWhitelistWordError,
+  EmptyGlobalWhitelistWordError,
+} from '../../anonymization-settings.errors';
+import { AddGlobalPiiWhitelistWordCommand } from './add-global-pii-whitelist-word.command';
+import { AddGlobalPiiWhitelistWordUseCase } from './add-global-pii-whitelist-word.use-case';
+
+describe('AddGlobalPiiWhitelistWordUseCase', () => {
+  const repository: jest.Mocked<GlobalAnonymizationWhitelistRepository> = {
+    findAll: jest.fn(),
+    findByCategoryAndWord: jest.fn(),
+    create: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  const useCase = new AddGlobalPiiWhitelistWordUseCase(repository);
+  const superAdminId = randomUUID();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repository.findByCategoryAndWord.mockResolvedValue(null);
+    repository.create.mockImplementation((word) => Promise.resolve(word));
+  });
+
+  it('should persist a trimmed word with the acting super admin as author', async () => {
+    const result = await useCase.execute(
+      new AddGlobalPiiWhitelistWordCommand(
+        PiiCategory.PERSON_NAME,
+        '  Mitarbeitende  ',
+        superAdminId,
+      ),
+    );
+
+    expect(result.word).toBe('Mitarbeitende');
+    expect(result.category).toBe(PiiCategory.PERSON_NAME);
+    expect(result.createdByUserId).toBe(superAdminId);
+    expect(repository.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject a word that is empty after trimming', async () => {
+    await expect(
+      useCase.execute(
+        new AddGlobalPiiWhitelistWordCommand(
+          PiiCategory.PERSON_NAME,
+          '   ',
+          superAdminId,
+        ),
+      ),
+    ).rejects.toBeInstanceOf(EmptyGlobalWhitelistWordError);
+    expect(repository.create).not.toHaveBeenCalled();
+  });
+
+  it('should reject a duplicate word within the same category case-insensitively', async () => {
+    repository.findByCategoryAndWord.mockResolvedValue(
+      new GlobalAnonymizationWhitelistWord({
+        category: PiiCategory.PERSON_NAME,
+        word: 'Wir',
+        createdByUserId: null,
+      }),
+    );
+
+    await expect(
+      useCase.execute(
+        new AddGlobalPiiWhitelistWordCommand(
+          PiiCategory.PERSON_NAME,
+          'wir',
+          superAdminId,
+        ),
+      ),
+    ).rejects.toBeInstanceOf(DuplicateGlobalWhitelistWordError);
+    expect(repository.findByCategoryAndWord).toHaveBeenCalledWith(
+      PiiCategory.PERSON_NAME,
+      'wir',
+    );
+    expect(repository.create).not.toHaveBeenCalled();
+  });
+
+  it('should allow the same word in a different category', async () => {
+    const result = await useCase.execute(
+      new AddGlobalPiiWhitelistWordCommand(
+        PiiCategory.ORGANIZATION,
+        'Wir',
+        superAdminId,
+      ),
+    );
+
+    expect(result.category).toBe(PiiCategory.ORGANIZATION);
+    expect(repository.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/add-global-pii-whitelist-word/add-global-pii-whitelist-word.use-case.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/add-global-pii-whitelist-word/add-global-pii-whitelist-word.use-case.ts
@@ -1,0 +1,49 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { GlobalAnonymizationWhitelistRepository } from '../../ports/global-anonymization-whitelist.repository';
+import {
+  DuplicateGlobalWhitelistWordError,
+  EmptyGlobalWhitelistWordError,
+  UnexpectedGlobalAnonymizationWhitelistError,
+} from '../../anonymization-settings.errors';
+import { GlobalAnonymizationWhitelistWord } from 'src/domain/anonymization-settings/domain/global-anonymization-whitelist-word.entity';
+import type { AddGlobalPiiWhitelistWordCommand } from './add-global-pii-whitelist-word.command';
+
+@Injectable()
+export class AddGlobalPiiWhitelistWordUseCase {
+  private readonly logger = new Logger(AddGlobalPiiWhitelistWordUseCase.name);
+
+  constructor(
+    private readonly repository: GlobalAnonymizationWhitelistRepository,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedGlobalAnonymizationWhitelistError)
+  async execute(
+    command: AddGlobalPiiWhitelistWordCommand,
+  ): Promise<GlobalAnonymizationWhitelistWord> {
+    this.logger.log('Adding global PII whitelist word', {
+      category: command.category,
+    });
+
+    const word = command.word.trim();
+    if (word.length === 0) {
+      throw new EmptyGlobalWhitelistWordError({ category: command.category });
+    }
+
+    const existing = await this.repository.findByCategoryAndWord(
+      command.category,
+      word,
+    );
+    if (existing) {
+      throw new DuplicateGlobalWhitelistWordError(command.category, word);
+    }
+
+    return await this.repository.create(
+      new GlobalAnonymizationWhitelistWord({
+        category: command.category,
+        word,
+        createdByUserId: command.createdByUserId,
+      }),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/delete-global-pii-whitelist-word/delete-global-pii-whitelist-word.command.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/delete-global-pii-whitelist-word/delete-global-pii-whitelist-word.command.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class DeleteGlobalPiiWhitelistWordCommand {
+  constructor(public readonly wordId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/delete-global-pii-whitelist-word/delete-global-pii-whitelist-word.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/delete-global-pii-whitelist-word/delete-global-pii-whitelist-word.use-case.spec.ts
@@ -1,0 +1,38 @@
+import { randomUUID } from 'crypto';
+import type { GlobalAnonymizationWhitelistRepository } from '../../ports/global-anonymization-whitelist.repository';
+import { GlobalWhitelistWordNotFoundError } from '../../anonymization-settings.errors';
+import { DeleteGlobalPiiWhitelistWordCommand } from './delete-global-pii-whitelist-word.command';
+import { DeleteGlobalPiiWhitelistWordUseCase } from './delete-global-pii-whitelist-word.use-case';
+
+describe('DeleteGlobalPiiWhitelistWordUseCase', () => {
+  const repository: jest.Mocked<GlobalAnonymizationWhitelistRepository> = {
+    findAll: jest.fn(),
+    findByCategoryAndWord: jest.fn(),
+    create: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  const useCase = new DeleteGlobalPiiWhitelistWordUseCase(repository);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should delete an existing word', async () => {
+    const wordId = randomUUID();
+    repository.delete.mockResolvedValue(true);
+
+    await expect(
+      useCase.execute(new DeleteGlobalPiiWhitelistWordCommand(wordId)),
+    ).resolves.toBeUndefined();
+    expect(repository.delete).toHaveBeenCalledWith(wordId);
+  });
+
+  it('should throw a not-found error for an unknown id', async () => {
+    repository.delete.mockResolvedValue(false);
+
+    await expect(
+      useCase.execute(new DeleteGlobalPiiWhitelistWordCommand(randomUUID())),
+    ).rejects.toBeInstanceOf(GlobalWhitelistWordNotFoundError);
+  });
+});

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/delete-global-pii-whitelist-word/delete-global-pii-whitelist-word.use-case.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/delete-global-pii-whitelist-word/delete-global-pii-whitelist-word.use-case.ts
@@ -1,0 +1,31 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { GlobalAnonymizationWhitelistRepository } from '../../ports/global-anonymization-whitelist.repository';
+import {
+  GlobalWhitelistWordNotFoundError,
+  UnexpectedGlobalAnonymizationWhitelistError,
+} from '../../anonymization-settings.errors';
+import type { DeleteGlobalPiiWhitelistWordCommand } from './delete-global-pii-whitelist-word.command';
+
+@Injectable()
+export class DeleteGlobalPiiWhitelistWordUseCase {
+  private readonly logger = new Logger(
+    DeleteGlobalPiiWhitelistWordUseCase.name,
+  );
+
+  constructor(
+    private readonly repository: GlobalAnonymizationWhitelistRepository,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedGlobalAnonymizationWhitelistError)
+  async execute(command: DeleteGlobalPiiWhitelistWordCommand): Promise<void> {
+    this.logger.log('Deleting global PII whitelist word', {
+      wordId: command.wordId,
+    });
+
+    const deleted = await this.repository.delete(command.wordId);
+    if (!deleted) {
+      throw new GlobalWhitelistWordNotFoundError(command.wordId);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/domain/global-anonymization-whitelist-word.entity.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/domain/global-anonymization-whitelist-word.entity.ts
@@ -7,6 +7,7 @@ export interface GlobalAnonymizationWhitelistWordParams {
   category: PiiCategory;
   word: string;
   createdByUserId: UUID | null;
+  createdByEmail?: string | null;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -21,6 +22,7 @@ export class GlobalAnonymizationWhitelistWord {
   category: PiiCategory;
   word: string;
   createdByUserId: UUID | null;
+  createdByEmail: string | null;
   createdAt: Date;
   updatedAt: Date;
 
@@ -29,6 +31,7 @@ export class GlobalAnonymizationWhitelistWord {
     this.category = params.category;
     this.word = params.word.trim();
     this.createdByUserId = params.createdByUserId;
+    this.createdByEmail = params.createdByEmail ?? null;
     this.createdAt = params.createdAt ?? new Date();
     this.updatedAt = params.updatedAt ?? new Date();
   }

--- a/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/global-anonymization-whitelist.repository.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/global-anonymization-whitelist.repository.ts
@@ -25,6 +25,7 @@ export class PostgresGlobalAnonymizationWhitelistRepository extends GlobalAnonym
     this.logger.debug('findAll');
 
     const records = await this.repository.find({
+      relations: { createdByUser: true },
       order: { category: 'ASC', wordLowercase: 'ASC' },
     });
 
@@ -56,8 +57,14 @@ export class PostgresGlobalAnonymizationWhitelistRepository extends GlobalAnonym
     const record = await this.repository.save(
       GlobalAnonymizationWhitelistWordMapper.toRecord(word),
     );
+    // Reload with the user relation so the returned word carries the
+    // author's email, same as findAll.
+    const reloaded = await this.repository.findOne({
+      where: { id: record.id },
+      relations: { createdByUser: true },
+    });
 
-    return GlobalAnonymizationWhitelistWordMapper.toDomain(record);
+    return GlobalAnonymizationWhitelistWordMapper.toDomain(reloaded ?? record);
   }
 
   async delete(id: UUID): Promise<boolean> {

--- a/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/mappers/global-anonymization-whitelist-word.mapper.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/mappers/global-anonymization-whitelist-word.mapper.ts
@@ -10,6 +10,7 @@ export class GlobalAnonymizationWhitelistWordMapper {
       category: record.category,
       word: record.word,
       createdByUserId: record.createdByUserId,
+      createdByEmail: record.createdByUser?.email ?? null,
       createdAt: record.createdAt,
       updatedAt: record.updatedAt,
     });

--- a/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/dtos/add-global-pii-whitelist-word-request.dto.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/dtos/add-global-pii-whitelist-word-request.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+
+export class AddGlobalPiiWhitelistWordRequestDto {
+  @ApiProperty({ enum: PiiCategory, enumName: 'PiiCategory' })
+  @IsEnum(PiiCategory)
+  category: PiiCategory;
+
+  @ApiProperty({
+    description: 'Plain word to exempt from anonymization (no patterns)',
+    maxLength: 200,
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  word: string;
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/dtos/global-pii-whitelist-word.dto.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/dtos/global-pii-whitelist-word.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+
+export class GlobalPiiWhitelistWordDto {
+  @ApiProperty({ format: 'uuid' })
+  id: UUID;
+
+  @ApiProperty({ enum: PiiCategory, enumName: 'PiiCategory' })
+  category: PiiCategory;
+
+  @ApiProperty({ description: 'The word exempted from anonymization' })
+  word: string;
+
+  @ApiProperty({
+    type: String,
+    nullable: true,
+    description: 'Email of the super admin who added the word',
+  })
+  createdByEmail: string | null;
+
+  @ApiProperty({ type: Date })
+  createdAt: Date;
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/super-admin-anonymization-whitelist.controller.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/super-admin-anonymization-whitelist.controller.ts
@@ -1,0 +1,114 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Param,
+  Post,
+} from '@nestjs/common';
+import { UUID } from 'crypto';
+import {
+  ApiBadRequestResponse,
+  ApiBody,
+  ApiConflictResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { SystemRoles } from 'src/iam/authorization/application/decorators/system-roles.decorator';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import {
+  CurrentUser,
+  UserProperty,
+} from 'src/iam/authentication/application/decorators/current-user.decorator';
+import { GlobalAnonymizationWhitelistWord } from '../../domain/global-anonymization-whitelist-word.entity';
+import { GetGlobalPiiWhitelistUseCase } from '../../application/use-cases/get-global-pii-whitelist/get-global-pii-whitelist.use-case';
+import { AddGlobalPiiWhitelistWordUseCase } from '../../application/use-cases/add-global-pii-whitelist-word/add-global-pii-whitelist-word.use-case';
+import { AddGlobalPiiWhitelistWordCommand } from '../../application/use-cases/add-global-pii-whitelist-word/add-global-pii-whitelist-word.command';
+import { DeleteGlobalPiiWhitelistWordUseCase } from '../../application/use-cases/delete-global-pii-whitelist-word/delete-global-pii-whitelist-word.use-case';
+import { DeleteGlobalPiiWhitelistWordCommand } from '../../application/use-cases/delete-global-pii-whitelist-word/delete-global-pii-whitelist-word.command';
+import { AddGlobalPiiWhitelistWordRequestDto } from './dtos/add-global-pii-whitelist-word-request.dto';
+import { GlobalPiiWhitelistWordDto } from './dtos/global-pii-whitelist-word.dto';
+
+@ApiTags('Super Admin Anonymization Whitelist')
+@Controller('super-admin/anonymization-whitelist')
+@SystemRoles(SystemRole.SUPER_ADMIN)
+export class SuperAdminAnonymizationWhitelistController {
+  private readonly logger = new Logger(
+    SuperAdminAnonymizationWhitelistController.name,
+  );
+
+  constructor(
+    private readonly getGlobalPiiWhitelistUseCase: GetGlobalPiiWhitelistUseCase,
+    private readonly addGlobalPiiWhitelistWordUseCase: AddGlobalPiiWhitelistWordUseCase,
+    private readonly deleteGlobalPiiWhitelistWordUseCase: DeleteGlobalPiiWhitelistWordUseCase,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all global anonymization whitelist words' })
+  @ApiResponse({ status: HttpStatus.OK, type: [GlobalPiiWhitelistWordDto] })
+  @ApiUnauthorizedResponse({ description: 'Not authorized as super admin' })
+  async list(): Promise<GlobalPiiWhitelistWordDto[]> {
+    this.logger.log('list');
+
+    const words = await this.getGlobalPiiWhitelistUseCase.execute();
+    return words.map((word) => this.toDto(word));
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Add a word to the global anonymization whitelist' })
+  @ApiBody({ type: AddGlobalPiiWhitelistWordRequestDto })
+  @ApiResponse({ status: HttpStatus.CREATED, type: GlobalPiiWhitelistWordDto })
+  @ApiBadRequestResponse({ description: 'Empty or invalid word' })
+  @ApiConflictResponse({
+    description: 'Word already on the whitelist for this category',
+  })
+  @ApiUnauthorizedResponse({ description: 'Not authorized as super admin' })
+  async add(
+    @Body() dto: AddGlobalPiiWhitelistWordRequestDto,
+    @CurrentUser(UserProperty.ID) userId: UUID,
+  ): Promise<GlobalPiiWhitelistWordDto> {
+    this.logger.log('add', { category: dto.category });
+
+    const word = await this.addGlobalPiiWhitelistWordUseCase.execute(
+      new AddGlobalPiiWhitelistWordCommand(dto.category, dto.word, userId),
+    );
+    return this.toDto(word);
+  }
+
+  @Delete(':wordId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Remove a word from the global anonymization whitelist',
+  })
+  @ApiParam({ name: 'wordId', format: 'uuid' })
+  @ApiResponse({ status: HttpStatus.NO_CONTENT, description: 'Word removed' })
+  @ApiNotFoundResponse({ description: 'Word not found' })
+  @ApiUnauthorizedResponse({ description: 'Not authorized as super admin' })
+  async remove(@Param('wordId') wordId: UUID): Promise<void> {
+    this.logger.log('remove', { wordId });
+
+    await this.deleteGlobalPiiWhitelistWordUseCase.execute(
+      new DeleteGlobalPiiWhitelistWordCommand(wordId),
+    );
+  }
+
+  private toDto(
+    word: GlobalAnonymizationWhitelistWord,
+  ): GlobalPiiWhitelistWordDto {
+    return {
+      id: word.id,
+      category: word.category,
+      word: word.word,
+      createdByEmail: word.createdByEmail,
+      createdAt: word.createdAt,
+    };
+  }
+}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3434,6 +3434,28 @@ export interface UpdatePiiWhitelistRequestDto {
   entries: PiiWhitelistEntryDto[];
 }
 
+export interface GlobalPiiWhitelistWordDto {
+  id: string;
+  category: PiiCategory;
+  /** The word exempted from anonymization */
+  word: string;
+  /**
+   * Email of the super admin who added the word
+   * @nullable
+   */
+  createdByEmail: string | null;
+  createdAt: string;
+}
+
+export interface AddGlobalPiiWhitelistWordRequestDto {
+  category: PiiCategory;
+  /**
+   * Plain word to exempt from anonymization (no patterns)
+   * @maxLength 200
+   */
+  word: string;
+}
+
 /**
  * The distribution mode of the skill template
  */

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -31,6 +31,7 @@ import type {
   AcceptInviteDto,
   AcceptInviteResponseDto,
   ActiveSubscriptionResponseDto,
+  AddGlobalPiiWhitelistWordRequestDto,
   AddTeamMemberDto,
   AddUrlToKnowledgeBaseDto,
   AddonStatusResponseDto,
@@ -90,6 +91,7 @@ import type {
   GeneratedImageUrlResponseDto,
   GetThreadResponseDto,
   GetThreadsResponseDto,
+  GlobalPiiWhitelistWordDto,
   GrantCrawlDomainRequestDto,
   ImageGenerationModelResponseDto,
   InstallMarketplaceIntegrationDto,
@@ -13178,6 +13180,226 @@ export const useAnonymizationSettingsControllerUpdate = <TError = void,
       > => {
 
       const mutationOptions = getAnonymizationSettingsControllerUpdateMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary List all global anonymization whitelist words
+ */
+export const superAdminAnonymizationWhitelistControllerList = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<GlobalPiiWhitelistWordDto[]>(
+      {url: `/super-admin/anonymization-whitelist`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getSuperAdminAnonymizationWhitelistControllerListQueryKey = () => {
+    return [
+    `/super-admin/anonymization-whitelist`
+    ] as const;
+    }
+
+    
+export const getSuperAdminAnonymizationWhitelistControllerListQueryOptions = <TData = Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>, TError = void>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getSuperAdminAnonymizationWhitelistControllerListQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>> = ({ signal }) => superAdminAnonymizationWhitelistControllerList(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type SuperAdminAnonymizationWhitelistControllerListQueryResult = NonNullable<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>>
+export type SuperAdminAnonymizationWhitelistControllerListQueryError = void
+
+
+export function useSuperAdminAnonymizationWhitelistControllerList<TData = Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>, TError = void>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminAnonymizationWhitelistControllerList<TData = Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>,
+          TError,
+          Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useSuperAdminAnonymizationWhitelistControllerList<TData = Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary List all global anonymization whitelist words
+ */
+
+export function useSuperAdminAnonymizationWhitelistControllerList<TData = Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>, TError = void>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerList>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getSuperAdminAnonymizationWhitelistControllerListQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Add a word to the global anonymization whitelist
+ */
+export const superAdminAnonymizationWhitelistControllerAdd = (
+    addGlobalPiiWhitelistWordRequestDto: AddGlobalPiiWhitelistWordRequestDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<GlobalPiiWhitelistWordDto>(
+      {url: `/super-admin/anonymization-whitelist`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: addGlobalPiiWhitelistWordRequestDto, signal
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAnonymizationWhitelistControllerAddMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerAdd>>, TError,{data: AddGlobalPiiWhitelistWordRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerAdd>>, TError,{data: AddGlobalPiiWhitelistWordRequestDto}, TContext> => {
+
+const mutationKey = ['superAdminAnonymizationWhitelistControllerAdd'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerAdd>>, {data: AddGlobalPiiWhitelistWordRequestDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  superAdminAnonymizationWhitelistControllerAdd(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAnonymizationWhitelistControllerAddMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerAdd>>>
+    export type SuperAdminAnonymizationWhitelistControllerAddMutationBody = AddGlobalPiiWhitelistWordRequestDto
+    export type SuperAdminAnonymizationWhitelistControllerAddMutationError = void
+
+    /**
+ * @summary Add a word to the global anonymization whitelist
+ */
+export const useSuperAdminAnonymizationWhitelistControllerAdd = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerAdd>>, TError,{data: AddGlobalPiiWhitelistWordRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerAdd>>,
+        TError,
+        {data: AddGlobalPiiWhitelistWordRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAnonymizationWhitelistControllerAddMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Remove a word from the global anonymization whitelist
+ */
+export const superAdminAnonymizationWhitelistControllerRemove = (
+    wordId: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/super-admin/anonymization-whitelist/${wordId}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getSuperAdminAnonymizationWhitelistControllerRemoveMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerRemove>>, TError,{wordId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerRemove>>, TError,{wordId: string}, TContext> => {
+
+const mutationKey = ['superAdminAnonymizationWhitelistControllerRemove'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerRemove>>, {wordId: string}> = (props) => {
+          const {wordId} = props ?? {};
+
+          return  superAdminAnonymizationWhitelistControllerRemove(wordId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SuperAdminAnonymizationWhitelistControllerRemoveMutationResult = NonNullable<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerRemove>>>
+    
+    export type SuperAdminAnonymizationWhitelistControllerRemoveMutationError = void
+
+    /**
+ * @summary Remove a word from the global anonymization whitelist
+ */
+export const useSuperAdminAnonymizationWhitelistControllerRemove = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerRemove>>, TError,{wordId: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof superAdminAnonymizationWhitelistControllerRemove>>,
+        TError,
+        {wordId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getSuperAdminAnonymizationWhitelistControllerRemoveMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -6434,6 +6434,98 @@
         "tags": ["anonymization-settings"]
       }
     },
+    "/super-admin/anonymization-whitelist": {
+      "get": {
+        "operationId": "SuperAdminAnonymizationWhitelistController_list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GlobalPiiWhitelistWordDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authorized as super admin"
+          }
+        },
+        "summary": "List all global anonymization whitelist words",
+        "tags": ["Super Admin Anonymization Whitelist"]
+      },
+      "post": {
+        "operationId": "SuperAdminAnonymizationWhitelistController_add",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddGlobalPiiWhitelistWordRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GlobalPiiWhitelistWordDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Empty or invalid word"
+          },
+          "401": {
+            "description": "Not authorized as super admin"
+          },
+          "409": {
+            "description": "Word already on the whitelist for this category"
+          }
+        },
+        "summary": "Add a word to the global anonymization whitelist",
+        "tags": ["Super Admin Anonymization Whitelist"]
+      }
+    },
+    "/super-admin/anonymization-whitelist/{wordId}": {
+      "delete": {
+        "operationId": "SuperAdminAnonymizationWhitelistController_remove",
+        "parameters": [
+          {
+            "name": "wordId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Word removed"
+          },
+          "401": {
+            "description": "Not authorized as super admin"
+          },
+          "404": {
+            "description": "Word not found"
+          }
+        },
+        "summary": "Remove a word from the global anonymization whitelist",
+        "tags": ["Super Admin Anonymization Whitelist"]
+      }
+    },
     "/super-admin/skill-templates": {
       "post": {
         "description": "Create a new skill template. Only accessible to super admins.",
@@ -15288,6 +15380,54 @@
           }
         },
         "required": ["entries"]
+      },
+      "GlobalPiiWhitelistWordDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "category": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PiiCategory"
+              }
+            ]
+          },
+          "word": {
+            "type": "string",
+            "description": "The word exempted from anonymization"
+          },
+          "createdByEmail": {
+            "type": "string",
+            "nullable": true,
+            "description": "Email of the super admin who added the word"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": ["id", "category", "word", "createdByEmail", "createdAt"]
+      },
+      "AddGlobalPiiWhitelistWordRequestDto": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PiiCategory"
+              }
+            ]
+          },
+          "word": {
+            "type": "string",
+            "description": "Plain word to exempt from anonymization (no patterns)",
+            "maxLength": 200
+          }
+        },
+        "required": ["category", "word"]
       },
       "CreateSkillTemplateDto": {
         "type": "object",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect platform-wide PII exemption rules; mistakes could weaken anonymization, though scope is limited to super-admin APIs with validation and existing auth.
> 
> **Overview**
> Super admins can manage the **global anonymization whitelist** via new endpoints under `/super-admin/anonymization-whitelist`: list words, add a category + plain word, and delete by id. Access is gated with `@SystemRoles(SUPER_ADMIN)`; adds record the acting user as `createdByUserId`.
> 
> **Add** trims input, rejects empty words (400), and blocks case-insensitive duplicates per category (409). **Delete** returns 404 when the id is missing. List and create responses expose `createdByEmail` by loading the `createdByUser` relation in the global whitelist repository and mapping it on the domain entity.
> 
> Application errors, unit tests, module registration, and `SUMMARY.md` are updated accordingly. OpenAPI and Orval-generated frontend types/hooks for the new routes are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dfde4f5d6e379bf5c33b0a570a9d6c415369c1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->