### PR TITLE
wip(anonymization): enforce global whitelist in the pipeline and seed reported false positives (AYC-446)

### DIFF
--- a/ayunis-core-backend/src/common/anonymization/domain/whitelist-filter.spec.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/whitelist-filter.spec.ts
@@ -142,6 +142,48 @@ describe('filterWhitelistedDetections', () => {
     expect(filterWhitelistedDetections(detections, entries)).toEqual([]);
   });
 
+  it('exempts a detection when any of several entries of its category matches', () => {
+    const detections = [
+      detection({ text: 'Wir' }),
+      detection({ text: 'Mitarbeitende' }),
+      detection({ text: 'Moritz' }),
+    ];
+    const entries = [
+      new PiiWhitelistEntry(PiiCategory.PERSON_NAME, 'Wir'),
+      new PiiWhitelistEntry(PiiCategory.PERSON_NAME, 'Mitarbeitende'),
+    ];
+
+    expect(filterWhitelistedDetections(detections, entries)).toEqual([
+      detections[2],
+    ]);
+  });
+
+  it('unions an org pattern with additional word entries of the same category', () => {
+    const detections = [
+      detection({ text: 'Daniel' }),
+      detection({ text: 'Menschen' }),
+      detection({ text: 'Moritz' }),
+    ];
+    const entries = [
+      new PiiWhitelistEntry(PiiCategory.PERSON_NAME, 'dani(el)?'),
+      new PiiWhitelistEntry(PiiCategory.PERSON_NAME, 'Menschen'),
+    ];
+
+    expect(filterWhitelistedDetections(detections, entries)).toEqual([
+      detections[2],
+    ]);
+  });
+
+  it('still exempts via a valid entry when another entry of the category is invalid', () => {
+    const detections = [detection({ text: 'Wir' })];
+    const entries = [
+      new PiiWhitelistEntry(PiiCategory.PERSON_NAME, '(['),
+      new PiiWhitelistEntry(PiiCategory.PERSON_NAME, 'Wir'),
+    ];
+
+    expect(filterWhitelistedDetections(detections, entries)).toHaveLength(0);
+  });
+
   it('filters a mixed set of detections independently', () => {
     const exemptByCategory = detection({
       entityType: 'EMAIL_ADDRESS',

--- a/ayunis-core-backend/src/common/anonymization/domain/whitelist-filter.ts
+++ b/ayunis-core-backend/src/common/anonymization/domain/whitelist-filter.ts
@@ -2,10 +2,12 @@ import type { PiiCategory } from './pii-category.enum';
 import type { PiiDetection } from './pii-detection';
 import type { PiiWhitelistEntry } from './pii-whitelist-entry';
 
-type EntriesByCategory = Map<PiiCategory, PiiWhitelistEntry>;
+type EntriesByCategory = Map<PiiCategory, PiiWhitelistEntry[]>;
 
 /**
- * Drops detections that the org whitelist exempts from anonymization.
+ * Drops detections that the whitelist exempts from anonymization. Entries may
+ * repeat a category (org rule plus global words); a detection is exempt as
+ * soon as any entry of its category matches — union semantics.
  * Fail-safe: entries with invalid patterns never exempt anything.
  */
 export function filterWhitelistedDetections(
@@ -15,9 +17,15 @@ export function filterWhitelistedDetections(
   if (entries.length === 0) {
     return detections;
   }
-  const entriesByCategory = new Map(
-    entries.map((entry) => [entry.category, entry]),
-  );
+  const entriesByCategory: EntriesByCategory = new Map();
+  for (const entry of entries) {
+    const existing = entriesByCategory.get(entry.category);
+    if (existing) {
+      existing.push(entry);
+    } else {
+      entriesByCategory.set(entry.category, [entry]);
+    }
+  }
   return detections.filter(
     (detection) => !isExempt(detection, entriesByCategory),
   );
@@ -27,14 +35,14 @@ export function isExempt(
   detection: PiiDetection,
   entriesByCategory: EntriesByCategory,
 ): boolean {
-  const entry = entriesByCategory.get(detection.category);
-  if (!entry) {
+  const entries = entriesByCategory.get(detection.category);
+  if (!entries) {
     return false;
   }
-  if (entry.pattern === null) {
-    return true;
-  }
-  return fullyMatches(entry.pattern, detection.text);
+  return entries.some(
+    (entry) =>
+      entry.pattern === null || fullyMatches(entry.pattern, detection.text),
+  );
 }
 
 export function fullyMatches(pattern: string, value: string): boolean {

--- a/ayunis-core-backend/src/db/migrations/1786043153903-SeedGlobalAnonymizationWhitelistWords.ts
+++ b/ayunis-core-backend/src/db/migrations/1786043153903-SeedGlobalAnonymizationWhitelistWords.ts
@@ -1,0 +1,49 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SeedGlobalAnonymizationWhitelistWords1786043153903 implements MigrationInterface {
+  name = 'SeedGlobalAnonymizationWhitelistWords1786043153903';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Reported false positives: generic German terms the PII detector kept
+    // flagging as person names. wordLowercase is spelled out rather than
+    // derived via lower() so it matches the application's toLowerCase(),
+    // independent of the database collation.
+    await queryRunner.query(`
+            INSERT INTO "global_anonymization_whitelist_words" ("id", "category", "word", "wordLowercase", "createdByUserId")
+            SELECT gen_random_uuid()::text, 'person_name'::"public"."global_anonymization_whitelist_words_category_enum", w.word, w."wordLowercase", NULL
+            FROM (VALUES
+                ('Mitarbeitende', 'mitarbeitende'),
+                ('Führungskräfte', 'führungskräfte'),
+                ('Menschen', 'menschen'),
+                ('in', 'in'),
+                ('Wir', 'wir'),
+                ('Sie', 'sie'),
+                ('Ich', 'ich'),
+                ('Du', 'du'),
+                ('Kollege', 'kollege'),
+                ('Fachmann', 'fachmann')
+            ) AS w(word, "wordLowercase")
+            ON CONFLICT ("category", "wordLowercase") DO NOTHING
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            DELETE FROM "global_anonymization_whitelist_words"
+            WHERE "category" = 'person_name'
+              AND "createdByUserId" IS NULL
+              AND "wordLowercase" IN (
+                'mitarbeitende',
+                'führungskräfte',
+                'menschen',
+                'in',
+                'wir',
+                'sie',
+                'ich',
+                'du',
+                'kollege',
+                'fachmann'
+              )
+        `);
+  }
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/anonymization-settings/SUMMARY.md
@@ -17,6 +17,7 @@ anonymization-settings/
 ├── domain/
 │   ├── anonymization-whitelist-entry.entity.ts
 │   ├── global-anonymization-whitelist-word.entity.ts
+│   ├── global-word-whitelist-entry.ts
 │   └── validate-pattern.ts
 ├── application/
 │   ├── anonymization-settings.errors.ts
@@ -44,11 +45,11 @@ anonymization-settings/
 
 ## Key Flows
 
-- **Applying exceptions** — Detection runs in the `ayunis-core-anonymize` service; the common `AnonymizeTextUseCase` drops detections the whitelist exempts. There is no caching — every anonymization call reads the DB, so whitelist changes take effect immediately.
+- **Applying exceptions** — Detection runs in the `ayunis-core-anonymize` service; the common `AnonymizeTextUseCase` drops detections the whitelist exempts (union semantics: a detection is exempt when any entry of its category matches). Global words become literal, regex-escaped patterns via `domain/global-word-whitelist-entry.ts`. There is no caching — every anonymization call reads the DB, so whitelist changes take effect immediately.
 - **Org settings screen** — `GET/PUT /anonymization-settings/pii-whitelist` back the org admin page (`/admin-settings/anonymization`).
 - **Global list management** — `GET/POST/DELETE /super-admin/anonymization-whitelist` back the super-admin screen; each word records who added it and when (`createdByUserId`, SET NULL on user deletion).
 
 ## Consumers
 
-- `thread-pii-masks` — `AnonymizeTextForThreadUseCase` (the main chat path) injects `GetPiiWhitelistUseCase`.
+- `thread-pii-masks` — `AnonymizeTextForThreadUseCase` (the main chat path) injects `GetPiiWhitelistUseCase` and `GetGlobalPiiWhitelistUseCase` and merges both lists.
 - `runs` — uses `AnonymizeTextForOrgUseCase` for thread title generation.

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case.spec.ts
@@ -6,6 +6,8 @@ import type { AnonymizeTextUseCase } from 'src/common/anonymization/application/
 import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
 import { PiiWhitelistEntry } from 'src/common/anonymization/domain/pii-whitelist-entry';
 import { AnonymizationWhitelistEntry } from 'src/domain/anonymization-settings/domain/anonymization-whitelist-entry.entity';
+import { GlobalAnonymizationWhitelistWord } from 'src/domain/anonymization-settings/domain/global-anonymization-whitelist-word.entity';
+import type { GetGlobalPiiWhitelistUseCase } from '../get-global-pii-whitelist/get-global-pii-whitelist.use-case';
 import { AnonymizationFailedError } from 'src/common/anonymization/application/anonymization.errors';
 
 describe('AnonymizeTextForOrgUseCase', () => {
@@ -13,10 +15,12 @@ describe('AnonymizeTextForOrgUseCase', () => {
   const text = 'Ich bin der Dani aus Marl';
   let useCase: AnonymizeTextForOrgUseCase;
   let findByOrgId: jest.Mock;
+  let globalWhitelistExecute: jest.Mock;
   let anonymizeExecute: jest.Mock;
 
   beforeEach(() => {
     findByOrgId = jest.fn().mockResolvedValue([]);
+    globalWhitelistExecute = jest.fn().mockResolvedValue([]);
     anonymizeExecute = jest.fn().mockResolvedValue({
       originalText: text,
       anonymizedText: 'Ich bin der [PERSON] aus [LOCATION]',
@@ -27,6 +31,9 @@ describe('AnonymizeTextForOrgUseCase', () => {
         findByOrgId,
         replaceForOrg: jest.fn(),
       },
+      {
+        execute: globalWhitelistExecute,
+      } as unknown as GetGlobalPiiWhitelistUseCase,
       { execute: anonymizeExecute } as unknown as AnonymizeTextUseCase,
     );
     jest.spyOn(Logger.prototype, 'debug').mockImplementation();
@@ -69,6 +76,52 @@ describe('AnonymizeTextForOrgUseCase', () => {
       expect.objectContaining({ text, whitelist: [] }),
     );
     expect(result.anonymizedText).toBe('Ich bin der [PERSON] aus [LOCATION]');
+  });
+
+  it('appends global words to the org whitelist as literal patterns', async () => {
+    findByOrgId.mockResolvedValue([
+      new AnonymizationWhitelistEntry({
+        orgId,
+        category: PiiCategory.PERSON_NAME,
+        pattern: 'dani(el)?',
+      }),
+    ]);
+    globalWhitelistExecute.mockResolvedValue([
+      new GlobalAnonymizationWhitelistWord({
+        category: PiiCategory.PERSON_NAME,
+        word: 'Mitarbeitende',
+        createdByUserId: null,
+      }),
+    ]);
+
+    await useCase.execute(new AnonymizeTextForOrgCommand(text, orgId));
+
+    expect(anonymizeExecute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        whitelist: [
+          new PiiWhitelistEntry(PiiCategory.PERSON_NAME, 'dani(el)?'),
+          new PiiWhitelistEntry(PiiCategory.PERSON_NAME, 'Mitarbeitende'),
+        ],
+      }),
+    );
+  });
+
+  it('passes global words even when the org has no own entries', async () => {
+    globalWhitelistExecute.mockResolvedValue([
+      new GlobalAnonymizationWhitelistWord({
+        category: PiiCategory.PERSON_NAME,
+        word: 'Menschen',
+        createdByUserId: null,
+      }),
+    ]);
+
+    await useCase.execute(new AnonymizeTextForOrgCommand(text, orgId));
+
+    expect(anonymizeExecute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        whitelist: [new PiiWhitelistEntry(PiiCategory.PERSON_NAME, 'Menschen')],
+      }),
+    );
   });
 
   it('propagates engine failures unchanged for fail-safe handling', async () => {

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case.ts
@@ -6,6 +6,8 @@ import { PiiWhitelistEntry } from 'src/common/anonymization/domain/pii-whitelist
 import type { AnonymizationResult } from 'src/common/anonymization/application/ports/anonymization.port';
 import { AnonymizationWhitelistRepository } from '../../ports/anonymization-whitelist.repository';
 import { UnexpectedAnonymizationSettingsError } from '../../anonymization-settings.errors';
+import { GetGlobalPiiWhitelistUseCase } from '../get-global-pii-whitelist/get-global-pii-whitelist.use-case';
+import { toWhitelistEntry } from '../../../domain/global-word-whitelist-entry';
 import type { AnonymizeTextForOrgCommand } from './anonymize-text-for-org.command';
 
 /**
@@ -19,6 +21,7 @@ export class AnonymizeTextForOrgUseCase {
 
   constructor(
     private readonly repository: AnonymizationWhitelistRepository,
+    private readonly getGlobalPiiWhitelistUseCase: GetGlobalPiiWhitelistUseCase,
     private readonly anonymizeTextUseCase: AnonymizeTextUseCase,
   ) {}
 
@@ -29,9 +32,13 @@ export class AnonymizeTextForOrgUseCase {
 
     try {
       const entries = await this.repository.findByOrgId(command.orgId);
-      const whitelist = entries.map(
-        (entry) => new PiiWhitelistEntry(entry.category, entry.pattern),
-      );
+      const globalWords = await this.getGlobalPiiWhitelistUseCase.execute();
+      const whitelist = [
+        ...entries.map(
+          (entry) => new PiiWhitelistEntry(entry.category, entry.pattern),
+        ),
+        ...globalWords.map(toWhitelistEntry),
+      ];
 
       return await this.anonymizeTextUseCase.execute(
         new AnonymizeTextCommand(command.text, undefined, whitelist),

--- a/ayunis-core-backend/src/domain/anonymization-settings/domain/global-word-whitelist-entry.spec.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/domain/global-word-whitelist-entry.spec.ts
@@ -1,0 +1,40 @@
+import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+import { fullyMatches } from 'src/common/anonymization/domain/whitelist-filter';
+import { GlobalAnonymizationWhitelistWord } from './global-anonymization-whitelist-word.entity';
+import { toWhitelistEntry } from './global-word-whitelist-entry';
+
+function word(text: string): GlobalAnonymizationWhitelistWord {
+  return new GlobalAnonymizationWhitelistWord({
+    category: PiiCategory.PERSON_NAME,
+    word: text,
+    createdByUserId: null,
+  });
+}
+
+describe('toWhitelistEntry', () => {
+  it('produces a pattern matching the word case-insensitively as a whole', () => {
+    const entry = toWhitelistEntry(word('Wir'));
+
+    expect(entry.category).toBe(PiiCategory.PERSON_NAME);
+    expect(fullyMatches(entry.pattern as string, 'wir')).toBe(true);
+    expect(fullyMatches(entry.pattern as string, 'WIR')).toBe(true);
+  });
+
+  it('does not match values that merely contain the word', () => {
+    const entry = toWhitelistEntry(word('Wir'));
+
+    expect(fullyMatches(entry.pattern as string, 'Wirtschaft')).toBe(false);
+    expect(fullyMatches(entry.pattern as string, 'sagen wir mal')).toBe(false);
+  });
+
+  it('escapes regex metacharacters so words match only literally', () => {
+    const entry = toWhitelistEntry(word('Dr. Müller (Amt)'));
+
+    expect(fullyMatches(entry.pattern as string, 'Dr. Müller (Amt)')).toBe(
+      true,
+    );
+    expect(fullyMatches(entry.pattern as string, 'Drx Müller (Amt)')).toBe(
+      false,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/anonymization-settings/domain/global-word-whitelist-entry.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/domain/global-word-whitelist-entry.ts
@@ -1,0 +1,18 @@
+import { PiiWhitelistEntry } from 'src/common/anonymization/domain/pii-whitelist-entry';
+import type { GlobalAnonymizationWhitelistWord } from './global-anonymization-whitelist-word.entity';
+
+/**
+ * Converts a global whitelist word into a whitelist entry whose pattern
+ * matches the word literally — regex metacharacters are escaped so e.g.
+ * "Dr." cannot match "Drx". Case-insensitive whole-value matching comes
+ * from the whitelist filter itself.
+ */
+export function toWhitelistEntry(
+  word: GlobalAnonymizationWhitelistWord,
+): PiiWhitelistEntry {
+  return new PiiWhitelistEntry(word.category, escapeRegExp(word.word));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case.spec.ts
@@ -8,6 +8,8 @@ import { AnonymizationFailedError } from 'src/common/anonymization/application/a
 import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
 import { PiiWhitelistEntry } from 'src/common/anonymization/domain/pii-whitelist-entry';
 import { AnonymizationWhitelistEntry } from 'src/domain/anonymization-settings/domain/anonymization-whitelist-entry.entity';
+import { GlobalAnonymizationWhitelistWord } from 'src/domain/anonymization-settings/domain/global-anonymization-whitelist-word.entity';
+import type { GetGlobalPiiWhitelistUseCase } from 'src/domain/anonymization-settings/application/use-cases/get-global-pii-whitelist/get-global-pii-whitelist.use-case';
 import { ThreadPiiMask } from 'src/domain/thread-pii-masks/domain/thread-pii-mask.entity';
 import { UnexpectedThreadPiiMasksError } from '../../thread-pii-masks.errors';
 
@@ -19,12 +21,14 @@ describe('AnonymizeTextForThreadUseCase', () => {
   let findByThreadId: jest.Mock;
   let saveMany: jest.Mock;
   let whitelistExecute: jest.Mock;
+  let globalWhitelistExecute: jest.Mock;
   let anonymizeExecute: jest.Mock;
 
   beforeEach(() => {
     findByThreadId = jest.fn().mockResolvedValue([]);
     saveMany = jest.fn().mockResolvedValue(undefined);
     whitelistExecute = jest.fn().mockResolvedValue([]);
+    globalWhitelistExecute = jest.fn().mockResolvedValue([]);
     anonymizeExecute = jest.fn().mockResolvedValue({
       originalText: text,
       anonymizedText: 'Ich bin der {{pii:PERSON_NAME_1}}',
@@ -36,6 +40,9 @@ describe('AnonymizeTextForThreadUseCase', () => {
     useCase = new AnonymizeTextForThreadUseCase(
       { findByThreadId, saveMany },
       { execute: whitelistExecute } as unknown as GetPiiWhitelistUseCase,
+      {
+        execute: globalWhitelistExecute,
+      } as unknown as GetGlobalPiiWhitelistUseCase,
       { execute: anonymizeExecute } as unknown as AnonymizeTextUseCase,
     );
     jest.spyOn(Logger.prototype, 'debug').mockImplementation();
@@ -73,6 +80,34 @@ describe('AnonymizeTextForThreadUseCase', () => {
             maskIndex: 1,
             value: 'Moritz',
           },
+        ],
+      }),
+    );
+  });
+
+  it('unions the org whitelist with the global word list', async () => {
+    whitelistExecute.mockResolvedValue([
+      new AnonymizationWhitelistEntry({
+        orgId,
+        category: PiiCategory.LOCATION,
+        pattern: null,
+      }),
+    ]);
+    globalWhitelistExecute.mockResolvedValue([
+      new GlobalAnonymizationWhitelistWord({
+        category: PiiCategory.PERSON_NAME,
+        word: 'Mitarbeitende',
+        createdByUserId: null,
+      }),
+    ]);
+
+    await useCase.execute(command());
+
+    expect(anonymizeExecute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        whitelist: [
+          new PiiWhitelistEntry(PiiCategory.LOCATION, null),
+          new PiiWhitelistEntry(PiiCategory.PERSON_NAME, 'Mitarbeitende'),
         ],
       }),
     );

--- a/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case.ts
@@ -6,6 +6,8 @@ import { PiiWhitelistEntry } from 'src/common/anonymization/domain/pii-whitelist
 import type { AnonymizationResult } from 'src/common/anonymization/application/ports/anonymization.port';
 import { GetPiiWhitelistUseCase } from 'src/domain/anonymization-settings/application/use-cases/get-pii-whitelist/get-pii-whitelist.use-case';
 import { GetPiiWhitelistQuery } from 'src/domain/anonymization-settings/application/use-cases/get-pii-whitelist/get-pii-whitelist.query';
+import { GetGlobalPiiWhitelistUseCase } from 'src/domain/anonymization-settings/application/use-cases/get-global-pii-whitelist/get-global-pii-whitelist.use-case';
+import { toWhitelistEntry } from 'src/domain/anonymization-settings/domain/global-word-whitelist-entry';
 import { ThreadPiiMaskRepository } from '../../ports/thread-pii-mask.repository';
 import { ThreadPiiMask } from 'src/domain/thread-pii-masks/domain/thread-pii-mask.entity';
 import { UnexpectedThreadPiiMasksError } from '../../thread-pii-masks.errors';
@@ -30,6 +32,7 @@ export class AnonymizeTextForThreadUseCase {
   constructor(
     private readonly repository: ThreadPiiMaskRepository,
     private readonly getPiiWhitelistUseCase: GetPiiWhitelistUseCase,
+    private readonly getGlobalPiiWhitelistUseCase: GetGlobalPiiWhitelistUseCase,
     private readonly anonymizeTextUseCase: AnonymizeTextUseCase,
   ) {}
 
@@ -45,9 +48,13 @@ export class AnonymizeTextForThreadUseCase {
       const entries = await this.getPiiWhitelistUseCase.execute(
         new GetPiiWhitelistQuery(command.orgId),
       );
-      const whitelist = entries.map(
-        (entry) => new PiiWhitelistEntry(entry.category, entry.pattern),
-      );
+      const globalWords = await this.getGlobalPiiWhitelistUseCase.execute();
+      const whitelist = [
+        ...entries.map(
+          (entry) => new PiiWhitelistEntry(entry.category, entry.pattern),
+        ),
+        ...globalWords.map(toWhitelistEntry),
+      ];
       const existing = await this.repository.findByThreadId(command.threadId);
 
       const result = await this.anonymizeTextUseCase.execute(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes what text is sent to the model by widening exemptions in the PII pipeline; incorrect global words could reduce masking, though literals are escaped and invalid org patterns remain fail-safe.
> 
> **Overview**
> **Global PII whitelist words are now applied on every anonymization path**, merged with each org’s rules before detections are filtered. Org and thread flows load global words via `GetGlobalPiiWhitelistUseCase`, map them through `toWhitelistEntry` (regex-escaped literal whole-value patterns), and pass the combined list into `AnonymizeTextUseCase`.
> 
> **Whitelist matching no longer keeps only one rule per category.** `filterWhitelistedDetections` groups all entries by category and exempts a detection when **any** entry for that category matches (union semantics), including org regexes plus multiple global words. Invalid patterns still fail safe and do not block a valid sibling entry.
> 
> A migration seeds reported German `person_name` false positives (e.g. *Wir*, *Mitarbeitende*, *Menschen*) into `global_anonymization_whitelist_words`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57455e206f95e1097d7cdd23e2443f4a79179145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->