### PR TITLE
feat(anonymization): add a global allow list maintained by super admins (AYC-446)

### DIFF
--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -58,6 +58,7 @@ import { Route as AuthenticatedSuperAdminSettingsPlatformConfigIndexRouteImport 
 import { Route as AuthenticatedSuperAdminSettingsOrgsIndexRouteImport } from './routes/_authenticated/super-admin-settings.orgs.index'
 import { Route as AuthenticatedSuperAdminSettingsModelsCatalogIndexRouteImport } from './routes/_authenticated/super-admin-settings.models-catalog.index'
 import { Route as AuthenticatedSuperAdminSettingsAppAlertsIndexRouteImport } from './routes/_authenticated/super-admin-settings.app-alerts.index'
+import { Route as AuthenticatedSuperAdminSettingsAnonymizationIndexRouteImport } from './routes/_authenticated/super-admin-settings.anonymization.index'
 import { Route as AuthenticatedSuperAdminSettingsAcademyIndexRouteImport } from './routes/_authenticated/super-admin-settings.academy.index'
 import { Route as AuthenticatedAdminSettingsTeamsIndexRouteImport } from './routes/_authenticated/admin-settings.teams.index'
 import { Route as AuthenticatedAdminSettingsLetterheadsIndexRouteImport } from './routes/_authenticated/admin-settings.letterheads.index'
@@ -346,6 +347,12 @@ const AuthenticatedSuperAdminSettingsAppAlertsIndexRoute =
     path: '/super-admin-settings/app-alerts/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedSuperAdminSettingsAnonymizationIndexRoute =
+  AuthenticatedSuperAdminSettingsAnonymizationIndexRouteImport.update({
+    id: '/super-admin-settings/anonymization/',
+    path: '/super-admin-settings/anonymization/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedSuperAdminSettingsAcademyIndexRoute =
   AuthenticatedSuperAdminSettingsAcademyIndexRouteImport.update({
     id: '/super-admin-settings/academy/',
@@ -444,6 +451,7 @@ export interface FileRoutesByFullPath {
   '/admin-settings/letterheads/': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
   '/admin-settings/teams/': typeof AuthenticatedAdminSettingsTeamsIndexRoute
   '/super-admin-settings/academy/': typeof AuthenticatedSuperAdminSettingsAcademyIndexRoute
+  '/super-admin-settings/anonymization/': typeof AuthenticatedSuperAdminSettingsAnonymizationIndexRoute
   '/super-admin-settings/app-alerts/': typeof AuthenticatedSuperAdminSettingsAppAlertsIndexRoute
   '/super-admin-settings/models-catalog/': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   '/super-admin-settings/orgs/': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
@@ -501,6 +509,7 @@ export interface FileRoutesByTo {
   '/admin-settings/letterheads': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
   '/admin-settings/teams': typeof AuthenticatedAdminSettingsTeamsIndexRoute
   '/super-admin-settings/academy': typeof AuthenticatedSuperAdminSettingsAcademyIndexRoute
+  '/super-admin-settings/anonymization': typeof AuthenticatedSuperAdminSettingsAnonymizationIndexRoute
   '/super-admin-settings/app-alerts': typeof AuthenticatedSuperAdminSettingsAppAlertsIndexRoute
   '/super-admin-settings/models-catalog': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   '/super-admin-settings/orgs': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
@@ -561,6 +570,7 @@ export interface FileRoutesById {
   '/_authenticated/admin-settings/letterheads/': typeof AuthenticatedAdminSettingsLetterheadsIndexRoute
   '/_authenticated/admin-settings/teams/': typeof AuthenticatedAdminSettingsTeamsIndexRoute
   '/_authenticated/super-admin-settings/academy/': typeof AuthenticatedSuperAdminSettingsAcademyIndexRoute
+  '/_authenticated/super-admin-settings/anonymization/': typeof AuthenticatedSuperAdminSettingsAnonymizationIndexRoute
   '/_authenticated/super-admin-settings/app-alerts/': typeof AuthenticatedSuperAdminSettingsAppAlertsIndexRoute
   '/_authenticated/super-admin-settings/models-catalog/': typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   '/_authenticated/super-admin-settings/orgs/': typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
@@ -621,6 +631,7 @@ export interface FileRouteTypes {
     | '/admin-settings/letterheads/'
     | '/admin-settings/teams/'
     | '/super-admin-settings/academy/'
+    | '/super-admin-settings/anonymization/'
     | '/super-admin-settings/app-alerts/'
     | '/super-admin-settings/models-catalog/'
     | '/super-admin-settings/orgs/'
@@ -678,6 +689,7 @@ export interface FileRouteTypes {
     | '/admin-settings/letterheads'
     | '/admin-settings/teams'
     | '/super-admin-settings/academy'
+    | '/super-admin-settings/anonymization'
     | '/super-admin-settings/app-alerts'
     | '/super-admin-settings/models-catalog'
     | '/super-admin-settings/orgs'
@@ -737,6 +749,7 @@ export interface FileRouteTypes {
     | '/_authenticated/admin-settings/letterheads/'
     | '/_authenticated/admin-settings/teams/'
     | '/_authenticated/super-admin-settings/academy/'
+    | '/_authenticated/super-admin-settings/anonymization/'
     | '/_authenticated/super-admin-settings/app-alerts/'
     | '/_authenticated/super-admin-settings/models-catalog/'
     | '/_authenticated/super-admin-settings/orgs/'
@@ -1107,6 +1120,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSuperAdminSettingsAppAlertsIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/super-admin-settings/anonymization/': {
+      id: '/_authenticated/super-admin-settings/anonymization/'
+      path: '/super-admin-settings/anonymization'
+      fullPath: '/super-admin-settings/anonymization/'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsAnonymizationIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/super-admin-settings/academy/': {
       id: '/_authenticated/super-admin-settings/academy/'
       path: '/super-admin-settings/academy'
@@ -1244,6 +1264,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedAcademyChapterIdQuizRoute: typeof AuthenticatedAcademyChapterIdQuizRoute
   AuthenticatedSuperAdminSettingsOrgsIdRoute: typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
   AuthenticatedSuperAdminSettingsAcademyIndexRoute: typeof AuthenticatedSuperAdminSettingsAcademyIndexRoute
+  AuthenticatedSuperAdminSettingsAnonymizationIndexRoute: typeof AuthenticatedSuperAdminSettingsAnonymizationIndexRoute
   AuthenticatedSuperAdminSettingsAppAlertsIndexRoute: typeof AuthenticatedSuperAdminSettingsAppAlertsIndexRoute
   AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
   AuthenticatedSuperAdminSettingsOrgsIndexRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
@@ -1281,6 +1302,8 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
     AuthenticatedSuperAdminSettingsOrgsIdRoute,
   AuthenticatedSuperAdminSettingsAcademyIndexRoute:
     AuthenticatedSuperAdminSettingsAcademyIndexRoute,
+  AuthenticatedSuperAdminSettingsAnonymizationIndexRoute:
+    AuthenticatedSuperAdminSettingsAnonymizationIndexRoute,
   AuthenticatedSuperAdminSettingsAppAlertsIndexRoute:
     AuthenticatedSuperAdminSettingsAppAlertsIndexRoute,
   AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute:

--- a/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.anonymization.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.anonymization.index.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import AnonymizationWhitelistPage from '@/pages/super-admin-settings/anonymization-whitelist';
+import { MeResponseDtoSystemRole } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+export const Route = createFileRoute(
+  '/_authenticated/super-admin-settings/anonymization/',
+)({
+  component: RouteComponent,
+  beforeLoad: ({ context: { user } }) => {
+    if (user.systemRole !== MeResponseDtoSystemRole.super_admin) {
+      throw redirect({ to: '/' });
+    }
+  },
+});
+
+function RouteComponent() {
+  return <AnonymizationWhitelistPage />;
+}

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -58,6 +58,8 @@ import enSuperAdminSettingsPlatformConfig from './shared/locales/en/super-admin-
 import deSuperAdminSettingsPlatformConfig from './shared/locales/de/super-admin-settings-platform-config.json';
 import enSuperAdminSettingsAppAlerts from './shared/locales/en/super-admin-settings-app-alerts.json';
 import deSuperAdminSettingsAppAlerts from './shared/locales/de/super-admin-settings-app-alerts.json';
+import enSuperAdminSettingsAnonymization from './shared/locales/en/super-admin-settings-anonymization.json';
+import deSuperAdminSettingsAnonymization from './shared/locales/de/super-admin-settings-anonymization.json';
 import enAdminSettingsSecurity from './shared/locales/en/admin-settings-security.json';
 import deAdminSettingsSecurity from './shared/locales/de/admin-settings-security.json';
 import enAdminSettingsAcademy from './shared/locales/en/admin-settings-academy.json';
@@ -106,6 +108,7 @@ const resources = {
     'super-admin-settings-skills': enSuperAdminSettingsSkills,
     'super-admin-settings-super-admins': enSuperAdminSettingsSuperAdmins,
     'super-admin-settings-users': enSuperAdminSettingsUsers,
+    'super-admin-settings-anonymization': enSuperAdminSettingsAnonymization,
     'super-admin-settings-academy': enSuperAdminSettingsAcademy,
     academy: enAcademy,
     artifacts: enArtifacts,
@@ -147,6 +150,7 @@ const resources = {
     'super-admin-settings-skills': deSuperAdminSettingsSkills,
     'super-admin-settings-super-admins': deSuperAdminSettingsSuperAdmins,
     'super-admin-settings-users': deSuperAdminSettingsUsers,
+    'super-admin-settings-anonymization': deSuperAdminSettingsAnonymization,
     'super-admin-settings-academy': deSuperAdminSettingsAcademy,
     academy: deAcademy,
     artifacts: deArtifacts,

--- a/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/model/types.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/model/types.ts
@@ -1,19 +1,6 @@
-import { PiiCategory } from '@/shared/api';
+import type { PiiCategory } from '@/shared/api';
 
-/** Fixed display order of all PII categories. */
-export const PII_CATEGORIES: PiiCategory[] = [
-  PiiCategory.person_name,
-  PiiCategory.organization,
-  PiiCategory.location,
-  PiiCategory.email_address,
-  PiiCategory.phone_number,
-  PiiCategory.url_or_ip,
-  PiiCategory.date_time,
-  PiiCategory.financial_account,
-  PiiCategory.government_id,
-  PiiCategory.nationality_religion_politics,
-  PiiCategory.other,
-];
+export { PII_CATEGORIES } from '@/shared/lib/pii-categories';
 
 export interface CategoryRowState {
   enabled: boolean;

--- a/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/api/useAddGlobalWhitelistWord.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/api/useAddGlobalWhitelistWord.ts
@@ -1,0 +1,54 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import {
+  useSuperAdminAnonymizationWhitelistControllerAdd,
+  getSuperAdminAnonymizationWhitelistControllerListQueryKey,
+} from '@/shared/api';
+import type { PiiCategory } from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { showSuccess, showError } from '@/shared/lib/toast';
+
+interface AddWordParams {
+  category: PiiCategory;
+  word: string;
+  onSuccess?: () => void;
+}
+
+export function useAddGlobalWhitelistWord() {
+  const { t } = useTranslation('super-admin-settings-anonymization');
+  const queryClient = useQueryClient();
+
+  const mutation = useSuperAdminAnonymizationWhitelistControllerAdd({
+    mutation: {
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: getSuperAdminAnonymizationWhitelistControllerListQueryKey(),
+        });
+        showSuccess(t('add.success'));
+      },
+      onError: (error) => {
+        try {
+          const { code } = extractErrorData(error);
+          switch (code) {
+            case 'DUPLICATE_GLOBAL_WHITELIST_WORD':
+              showError(t('add.duplicate'));
+              break;
+            case 'EMPTY_GLOBAL_WHITELIST_WORD':
+              showError(t('add.empty'));
+              break;
+            default:
+              showError(t('add.error'));
+          }
+        } catch {
+          showError(t('add.error'));
+        }
+      },
+    },
+  });
+
+  function addWord({ category, word, onSuccess }: AddWordParams) {
+    mutation.mutate({ data: { category, word } }, { onSuccess });
+  }
+
+  return { addWord, isPending: mutation.isPending };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/api/useDeleteGlobalWhitelistWord.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/api/useDeleteGlobalWhitelistWord.ts
@@ -1,0 +1,48 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import {
+  useSuperAdminAnonymizationWhitelistControllerRemove,
+  getSuperAdminAnonymizationWhitelistControllerListQueryKey,
+} from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { showSuccess, showError } from '@/shared/lib/toast';
+
+export function useDeleteGlobalWhitelistWord() {
+  const { t } = useTranslation('super-admin-settings-anonymization');
+  const queryClient = useQueryClient();
+
+  const mutation = useSuperAdminAnonymizationWhitelistControllerRemove({
+    mutation: {
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: getSuperAdminAnonymizationWhitelistControllerListQueryKey(),
+        });
+        showSuccess(t('delete.success'));
+      },
+      onError: (error) => {
+        try {
+          const { code } = extractErrorData(error);
+          if (code === 'GLOBAL_WHITELIST_WORD_NOT_FOUND') {
+            // The word is gone on the server — refresh so the stale row
+            // disappears from the list too.
+            void queryClient.invalidateQueries({
+              queryKey:
+                getSuperAdminAnonymizationWhitelistControllerListQueryKey(),
+            });
+            showError(t('delete.notFound'));
+          } else {
+            showError(t('delete.error'));
+          }
+        } catch {
+          showError(t('delete.error'));
+        }
+      },
+    },
+  });
+
+  function deleteWord(wordId: string) {
+    mutation.mutate({ wordId });
+  }
+
+  return { deleteWord, isPending: mutation.isPending };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/api/useGlobalWhitelistWords.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/api/useGlobalWhitelistWords.ts
@@ -1,0 +1,15 @@
+import { useMemo } from 'react';
+import { useSuperAdminAnonymizationWhitelistControllerList } from '@/shared/api';
+import { groupWordsByCategory } from '../lib/group-words';
+
+export function useGlobalWhitelistWords() {
+  const { data, isLoading, isError, refetch } =
+    useSuperAdminAnonymizationWhitelistControllerList();
+
+  const wordsByCategory = useMemo(
+    () => groupWordsByCategory(data ?? []),
+    [data],
+  );
+
+  return { wordsByCategory, isLoading, isError, refetch };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/index.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ui/AnonymizationWhitelistPage';

--- a/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/lib/group-words.spec.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/lib/group-words.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { PiiCategory } from '@/shared/api';
+import type { GlobalPiiWhitelistWordDto } from '@/shared/api';
+import { groupWordsByCategory } from './group-words';
+
+function word(category: PiiCategory, text: string): GlobalPiiWhitelistWordDto {
+  return {
+    id: `id-${text}`,
+    category,
+    word: text,
+    createdByEmail: null,
+    createdAt: '2026-08-06T12:00:00.000Z',
+  };
+}
+
+describe('groupWordsByCategory', () => {
+  it('groups words under their category preserving order', () => {
+    const words = [
+      word(PiiCategory.person_name, 'Mitarbeitende'),
+      word(PiiCategory.organization, 'Stadtverwaltung'),
+      word(PiiCategory.person_name, 'Menschen'),
+    ];
+
+    const grouped = groupWordsByCategory(words);
+
+    expect(grouped[PiiCategory.person_name]?.map((w) => w.word)).toEqual([
+      'Mitarbeitende',
+      'Menschen',
+    ]);
+    expect(grouped[PiiCategory.organization]).toHaveLength(1);
+    expect(grouped[PiiCategory.location]).toBeUndefined();
+  });
+
+  it('returns an empty object for an empty list', () => {
+    expect(groupWordsByCategory([])).toEqual({});
+  });
+});

--- a/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/lib/group-words.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/lib/group-words.ts
@@ -1,0 +1,14 @@
+import type { GlobalPiiWhitelistWordDto } from '@/shared/api';
+import type { WordsByCategory } from '../model/types';
+
+export function groupWordsByCategory(
+  words: GlobalPiiWhitelistWordDto[],
+): WordsByCategory {
+  const grouped: WordsByCategory = {};
+  for (const word of words) {
+    const list = grouped[word.category] ?? [];
+    list.push(word);
+    grouped[word.category] = list;
+  }
+  return grouped;
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/model/types.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/model/types.ts
@@ -1,0 +1,6 @@
+import type { PiiCategory } from '@/shared/api';
+import type { GlobalPiiWhitelistWordDto } from '@/shared/api';
+
+export type WordsByCategory = Partial<
+  Record<PiiCategory, GlobalPiiWhitelistWordDto[]>
+>;

--- a/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/ui/AnonymizationWhitelistPage.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/ui/AnonymizationWhitelistPage.tsx
@@ -1,0 +1,73 @@
+import { useTranslation } from 'react-i18next';
+import { AlertCircle, Loader2 } from 'lucide-react';
+import SuperAdminSettingsLayout from '../../super-admin-settings-layout';
+import { Button } from '@/shared/ui/shadcn/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/shared/ui/shadcn/card';
+import { Alert, AlertDescription } from '@/shared/ui/shadcn/alert';
+import { PII_CATEGORIES } from '@/shared/lib/pii-categories';
+import { useGlobalWhitelistWords } from '../api/useGlobalWhitelistWords';
+import { CategoryWordSection } from './CategoryWordSection';
+
+export default function AnonymizationWhitelistPage() {
+  const { t } = useTranslation('super-admin-settings-anonymization');
+  const { wordsByCategory, isLoading, isError, refetch } =
+    useGlobalWhitelistWords();
+
+  if (isLoading) {
+    return (
+      <SuperAdminSettingsLayout pageTitle={t('title')}>
+        <Card>
+          <CardContent className="flex items-center justify-center py-12">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </CardContent>
+        </Card>
+      </SuperAdminSettingsLayout>
+    );
+  }
+
+  if (isError) {
+    return (
+      <SuperAdminSettingsLayout pageTitle={t('title')}>
+        <Card>
+          <CardContent className="pt-6">
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                {t('loadError')}
+                <Button variant="link" onClick={() => void refetch()}>
+                  {t('retry')}
+                </Button>
+              </AlertDescription>
+            </Alert>
+          </CardContent>
+        </Card>
+      </SuperAdminSettingsLayout>
+    );
+  }
+
+  return (
+    <SuperAdminSettingsLayout pageTitle={t('title')}>
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('heading')}</CardTitle>
+          <CardDescription>{t('description')}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {PII_CATEGORIES.map((category) => (
+            <CategoryWordSection
+              key={category}
+              category={category}
+              words={wordsByCategory[category] ?? []}
+            />
+          ))}
+        </CardContent>
+      </Card>
+    </SuperAdminSettingsLayout>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/ui/CategoryWordSection.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/anonymization-whitelist/ui/CategoryWordSection.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Plus, Trash2 } from 'lucide-react';
+import { Button } from '@/shared/ui/shadcn/button';
+import { Input } from '@/shared/ui/shadcn/input';
+import {
+  Item,
+  ItemContent,
+  ItemDescription,
+  ItemFooter,
+  ItemTitle,
+} from '@/shared/ui/shadcn/item';
+import type { GlobalPiiWhitelistWordDto, PiiCategory } from '@/shared/api';
+import { useAddGlobalWhitelistWord } from '../api/useAddGlobalWhitelistWord';
+import { useDeleteGlobalWhitelistWord } from '../api/useDeleteGlobalWhitelistWord';
+
+interface CategoryWordSectionProps {
+  readonly category: PiiCategory;
+  readonly words: GlobalPiiWhitelistWordDto[];
+}
+
+export function CategoryWordSection({
+  category,
+  words,
+}: CategoryWordSectionProps) {
+  const { t, i18n } = useTranslation('super-admin-settings-anonymization');
+  const [input, setInput] = useState('');
+  const { addWord, isPending: isAdding } = useAddGlobalWhitelistWord();
+  const { deleteWord, isPending: isDeleting } = useDeleteGlobalWhitelistWord();
+
+  function handleAdd() {
+    const word = input.trim();
+    if (word.length === 0) {
+      return;
+    }
+    addWord({ category, word, onSuccess: () => setInput('') });
+  }
+
+  function formatAudit(word: GlobalPiiWhitelistWordDto): string {
+    const date = new Date(word.createdAt).toLocaleDateString(i18n.language);
+    return word.createdByEmail
+      ? t('words.addedByOn', { email: word.createdByEmail, date })
+      : t('words.addedOn', { date });
+  }
+
+  return (
+    <Item variant="outline">
+      <ItemContent>
+        <ItemTitle>{t(`categories.${category}.label`)}</ItemTitle>
+        <ItemDescription>
+          {t(`categories.${category}.description`)}
+        </ItemDescription>
+      </ItemContent>
+      <ItemFooter>
+        <div className="w-full space-y-2">
+          {words.length > 0 && (
+            <ul className="space-y-1">
+              {words.map((word) => (
+                <li
+                  key={word.id}
+                  className="flex items-center justify-between rounded-md border px-3 py-1.5"
+                >
+                  <div className="flex min-w-0 items-baseline gap-3">
+                    <span className="truncate text-sm font-medium">
+                      {word.word}
+                    </span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {formatAudit(word)}
+                    </span>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label={t('words.deleteLabel', { word: word.word })}
+                    disabled={isDeleting}
+                    onClick={() => deleteWord(word.id)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+          <form
+            className="flex gap-2"
+            onSubmit={(event) => {
+              event.preventDefault();
+              handleAdd();
+            }}
+          >
+            <Input
+              value={input}
+              placeholder={t('add.placeholder')}
+              disabled={isAdding}
+              onChange={(event) => setInput(event.target.value)}
+            />
+            <Button
+              type="submit"
+              variant="secondary"
+              disabled={isAdding || input.trim().length === 0}
+            >
+              <Plus className="h-4 w-4" />
+              {t('add.button')}
+            </Button>
+          </form>
+        </div>
+      </ItemFooter>
+    </Item>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/super-admin-settings-layout/ui/SuperAdminSettingsSidebar.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/super-admin-settings-layout/ui/SuperAdminSettingsSidebar.tsx
@@ -7,6 +7,7 @@ import {
   GraduationCap,
   Users,
   Megaphone,
+  EyeOff,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -57,6 +58,11 @@ export function SuperAdminSettingsSidebar() {
       to: '/super-admin-settings/app-alerts',
       icon: <Megaphone />,
       label: t('layout.appAlerts'),
+    },
+    {
+      to: '/super-admin-settings/anonymization',
+      icon: <EyeOff />,
+      label: t('layout.anonymization'),
     },
   ];
 

--- a/ayunis-core-frontend/src/shared/lib/pii-categories.ts
+++ b/ayunis-core-frontend/src/shared/lib/pii-categories.ts
@@ -1,0 +1,19 @@
+import { PiiCategory } from '@/shared/api';
+
+/**
+ * Fixed display order of all PII categories, shared by the org admin and
+ * super admin anonymization screens.
+ */
+export const PII_CATEGORIES: PiiCategory[] = [
+  PiiCategory.person_name,
+  PiiCategory.organization,
+  PiiCategory.location,
+  PiiCategory.email_address,
+  PiiCategory.phone_number,
+  PiiCategory.url_or_ip,
+  PiiCategory.date_time,
+  PiiCategory.financial_account,
+  PiiCategory.government_id,
+  PiiCategory.nationality_religion_politics,
+  PiiCategory.other,
+];

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-anonymization.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-anonymization.json
@@ -1,0 +1,71 @@
+{
+  "title": "Anonymisierung",
+  "heading": "Globale Ausnahmen von der Anonymisierung",
+  "description": "Wörter auf dieser Liste werden nie anonymisiert — in jeder Organisation, zusätzlich zu den Ausnahmen, die eine Organisation selbst konfiguriert hat. Nutze die Liste, um gemeldete Fehlerkennungen zentral zu beheben: Das Wort einmal hinzufügen, und es wird sofort bei allen Kunden nicht mehr maskiert.",
+  "loadError": "Die globalen Ausnahmen von der Anonymisierung konnten nicht geladen werden.",
+  "retry": "Erneut versuchen",
+  "add": {
+    "placeholder": "Wort hinzufügen, z. B. Mitarbeitende",
+    "button": "Hinzufügen",
+    "success": "Wort gespeichert.",
+    "duplicate": "Dieses Wort steht für diesen Datentyp bereits auf der Liste.",
+    "empty": "Bitte ein Wort eingeben.",
+    "error": "Das Wort konnte nicht gespeichert werden."
+  },
+  "delete": {
+    "success": "Wort entfernt.",
+    "notFound": "Dieses Wort wurde bereits entfernt.",
+    "error": "Das Wort konnte nicht entfernt werden."
+  },
+  "words": {
+    "addedByOn": "hinzugefügt von {{email}} am {{date}}",
+    "addedOn": "hinzugefügt am {{date}}",
+    "deleteLabel": "{{word}} entfernen"
+  },
+  "categories": {
+    "person_name": {
+      "label": "Personennamen",
+      "description": "Vor- und Nachnamen natürlicher Personen"
+    },
+    "organization": {
+      "label": "Organisationen",
+      "description": "Namen von Unternehmen, Institutionen und Behörden"
+    },
+    "location": {
+      "label": "Orte & Adressen",
+      "description": "Städte, Länder, Straßen und Adressen"
+    },
+    "email_address": {
+      "label": "E-Mail-Adressen",
+      "description": "Persönliche und organisatorische E-Mail-Adressen"
+    },
+    "phone_number": {
+      "label": "Telefonnummern",
+      "description": "Festnetz- und Mobilfunknummern"
+    },
+    "url_or_ip": {
+      "label": "URLs & IP-Adressen",
+      "description": "Webadressen und IP-Adressen"
+    },
+    "date_time": {
+      "label": "Datums- & Zeitangaben",
+      "description": "Konkrete Daten und Uhrzeiten, z. B. Geburtsdaten"
+    },
+    "financial_account": {
+      "label": "Finanzdaten",
+      "description": "Kreditkartennummern, IBANs und Kontonummern"
+    },
+    "government_id": {
+      "label": "Amtliche Kennnummern",
+      "description": "Sozialversicherungs-, Pass-, Führerschein- und Approbationsnummern"
+    },
+    "nationality_religion_politics": {
+      "label": "Nationalität, Religion & Politik",
+      "description": "Hinweise auf Nationalität, religiöse oder politische Zugehörigkeit"
+    },
+    "other": {
+      "label": "Sonstige / nicht zugeordnet",
+      "description": "Von der Erkennung gefundene personenbezogene Daten ohne bekannte Kategorie"
+    }
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-layout.json
@@ -11,6 +11,7 @@
     "academy": "Academy",
     "superAdmins": "Super-Admins",
     "platformConfig": "Plattform-Konfiguration",
-    "appAlerts": "App-Hinweise"
+    "appAlerts": "App-Hinweise",
+    "anonymization": "Anonymisierung"
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-anonymization.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-anonymization.json
@@ -1,0 +1,71 @@
+{
+  "title": "Anonymization",
+  "heading": "Global anonymization exceptions",
+  "description": "Words on this list are never anonymized — in every organization, on top of whatever exceptions the organization has configured itself. Use it to fix reported false positives centrally: add the word once and it stops being masked for all customers immediately.",
+  "loadError": "The global anonymization exceptions could not be loaded.",
+  "retry": "Retry",
+  "add": {
+    "placeholder": "Add a word, e.g. Mitarbeitende",
+    "button": "Add",
+    "success": "Word saved.",
+    "duplicate": "This word is already on the list for this data type.",
+    "empty": "Please enter a word.",
+    "error": "Saving the word failed."
+  },
+  "delete": {
+    "success": "Word removed.",
+    "notFound": "This word was already removed.",
+    "error": "Removing the word failed."
+  },
+  "words": {
+    "addedByOn": "added by {{email}} on {{date}}",
+    "addedOn": "added on {{date}}",
+    "deleteLabel": "Remove {{word}}"
+  },
+  "categories": {
+    "person_name": {
+      "label": "Person names",
+      "description": "First and last names of natural persons"
+    },
+    "organization": {
+      "label": "Organizations",
+      "description": "Names of companies, institutions, and public bodies"
+    },
+    "location": {
+      "label": "Locations & addresses",
+      "description": "Cities, countries, streets, and addresses"
+    },
+    "email_address": {
+      "label": "Email addresses",
+      "description": "Personal and organizational email addresses"
+    },
+    "phone_number": {
+      "label": "Phone numbers",
+      "description": "Landline and mobile numbers"
+    },
+    "url_or_ip": {
+      "label": "URLs & IP addresses",
+      "description": "Web addresses and IP addresses"
+    },
+    "date_time": {
+      "label": "Dates & times",
+      "description": "Specific dates and times, e.g. dates of birth"
+    },
+    "financial_account": {
+      "label": "Financial accounts",
+      "description": "Credit card numbers, IBANs, and bank account numbers"
+    },
+    "government_id": {
+      "label": "Government IDs",
+      "description": "Social security, passport, driver's license, and medical license numbers"
+    },
+    "nationality_religion_politics": {
+      "label": "Nationality, religion & politics",
+      "description": "References to nationality, religious, or political affiliation"
+    },
+    "other": {
+      "label": "Other / unrecognized",
+      "description": "Personal data detected by the engine that does not fit a known category"
+    }
+  }
+}

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-layout.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-layout.json
@@ -11,6 +11,7 @@
     "academy": "Academy",
     "superAdmins": "Super Admins",
     "platformConfig": "Platform Config",
-    "appAlerts": "App Alerts"
+    "appAlerts": "App Alerts",
+    "anonymization": "Anonymization"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes platform-wide PII masking behavior via super-admin actions; mitigated by super_admin route guard and standard API error handling, but misconfigured whitelist entries could affect privacy across all tenants.
> 
> **Overview**
> Adds a **super-admin** screen at `/super-admin-settings/anonymization` to manage **platform-wide anonymization exceptions** (words that are never masked for any org), wired to the existing super-admin whitelist API (list / add / remove per PII category).
> 
> The UI lists words grouped by category with add/delete, loading and error states, toasts for duplicate/empty/not-found API codes, and audit hints (creator email + date). Navigation gets a new **Anonymization** sidebar entry; the route is **super_admin-only** via `beforeLoad`.
> 
> **`PII_CATEGORIES`** moves from org admin anonymization types into **`@/shared/lib/pii-categories`**, which org admin settings now re-exports. EN/DE copy is added for the new page and layout label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 703a0f9f40884a990cc42834f7618e0efdc583e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->