### PR TITLE
wip(anonymization): show global whitelist entries read-only on the org admin screen (AYC-446)

### DIFF
--- a/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/anonymization-settings.controller.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/anonymization-settings.controller.ts
@@ -17,9 +17,11 @@ import { GetPiiWhitelistUseCase } from '../../application/use-cases/get-pii-whit
 import { GetPiiWhitelistQuery } from '../../application/use-cases/get-pii-whitelist/get-pii-whitelist.query';
 import { UpdatePiiWhitelistUseCase } from '../../application/use-cases/update-pii-whitelist/update-pii-whitelist.use-case';
 import { UpdatePiiWhitelistCommand } from '../../application/use-cases/update-pii-whitelist/update-pii-whitelist.command';
+import { GetGlobalPiiWhitelistUseCase } from '../../application/use-cases/get-global-pii-whitelist/get-global-pii-whitelist.use-case';
 import { UpdatePiiWhitelistRequestDto } from './dtos/update-pii-whitelist-request.dto';
 import { PiiWhitelistResponseDto } from './dtos/pii-whitelist-response.dto';
 import type { AnonymizationWhitelistEntry } from '../../domain/anonymization-whitelist-entry.entity';
+import type { GlobalAnonymizationWhitelistWord } from '../../domain/global-anonymization-whitelist-word.entity';
 
 @ApiTags('anonymization-settings')
 @Controller('anonymization-settings')
@@ -30,6 +32,7 @@ export class AnonymizationSettingsController {
   constructor(
     private readonly getPiiWhitelistUseCase: GetPiiWhitelistUseCase,
     private readonly updatePiiWhitelistUseCase: UpdatePiiWhitelistUseCase,
+    private readonly getGlobalPiiWhitelistUseCase: GetGlobalPiiWhitelistUseCase,
   ) {}
 
   @Get('pii-whitelist')
@@ -48,7 +51,8 @@ export class AnonymizationSettingsController {
     const entries = await this.getPiiWhitelistUseCase.execute(
       new GetPiiWhitelistQuery(orgId),
     );
-    return this.toResponse(entries);
+    const globalWords = await this.getGlobalPiiWhitelistUseCase.execute();
+    return this.toResponse(entries, globalWords);
   }
 
   @Put('pii-whitelist')
@@ -69,6 +73,10 @@ export class AnonymizationSettingsController {
   ): Promise<PiiWhitelistResponseDto> {
     this.logger.log(`Updating PII whitelist for org ${orgId}`);
 
+    // Read the global list before writing: if this read fails, nothing has
+    // been persisted yet, so the client never sees an error for a save that
+    // actually committed.
+    const globalWords = await this.getGlobalPiiWhitelistUseCase.execute();
     const entries = await this.updatePiiWhitelistUseCase.execute(
       new UpdatePiiWhitelistCommand(
         orgId,
@@ -78,16 +86,21 @@ export class AnonymizationSettingsController {
         })),
       ),
     );
-    return this.toResponse(entries);
+    return this.toResponse(entries, globalWords);
   }
 
   private toResponse(
     entries: AnonymizationWhitelistEntry[],
+    globalWords: GlobalAnonymizationWhitelistWord[],
   ): PiiWhitelistResponseDto {
     return {
       entries: entries.map((entry) => ({
         category: entry.category,
         pattern: entry.pattern,
+      })),
+      globalWords: globalWords.map((word) => ({
+        category: word.category,
+        word: word.word,
       })),
     };
   }

--- a/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/dtos/global-pii-whitelist-word-summary.dto.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/dtos/global-pii-whitelist-word-summary.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
+
+/**
+ * Read-only view of a global whitelist word as shown to org admins —
+ * no ids or audit data, just what is exempted.
+ */
+export class GlobalPiiWhitelistWordSummaryDto {
+  @ApiProperty({ enum: PiiCategory, enumName: 'PiiCategory' })
+  category: PiiCategory;
+
+  @ApiProperty({ description: 'The word exempted from anonymization' })
+  word: string;
+}

--- a/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/dtos/pii-whitelist-response.dto.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/dtos/pii-whitelist-response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { PiiWhitelistEntryDto } from './pii-whitelist-entry.dto';
+import { GlobalPiiWhitelistWordSummaryDto } from './global-pii-whitelist-word-summary.dto';
 
 export class PiiWhitelistResponseDto {
   @ApiProperty({
@@ -7,4 +8,11 @@ export class PiiWhitelistResponseDto {
     type: [PiiWhitelistEntryDto],
   })
   entries: PiiWhitelistEntryDto[];
+
+  @ApiProperty({
+    description:
+      'Words exempted platform-wide by Ayunis, read-only for org admins',
+    type: [GlobalPiiWhitelistWordSummaryDto],
+  })
+  globalWords: GlobalPiiWhitelistWordSummaryDto[];
 }

--- a/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/ui/AnonymizationSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/ui/AnonymizationSettingsPage.tsx
@@ -34,6 +34,18 @@ export function AnonymizationSettingsPage() {
   const { data, isLoading, isError, refetch } =
     useAnonymizationSettingsControllerGet();
   const serverRows = useMemo(() => buildRows(data?.entries ?? []), [data]);
+  // `?? []` also shields against an older API without globalWords during a
+  // rolling deploy — the generated type claims the field is always present.
+  const globalWords = data?.globalWords ?? [];
+  const globalWordsByCategory = useMemo(() => {
+    const grouped: Partial<Record<PiiCategory, string[]>> = {};
+    for (const { category, word } of data?.globalWords ?? []) {
+      const list = grouped[category] ?? [];
+      list.push(word);
+      grouped[category] = list;
+    }
+    return grouped;
+  }, [data]);
 
   const [draft, setDraft] = useState<RowsState | null>(null);
   const [errors, setErrors] = useState<RowErrors>({});
@@ -131,6 +143,11 @@ export function AnonymizationSettingsPage() {
         <CardHeader>
           <CardTitle>{t('piiWhitelist.heading')}</CardTitle>
           <CardDescription>{t('piiWhitelist.description')}</CardDescription>
+          {globalWords.length > 0 && (
+            <CardDescription>
+              {t('piiWhitelist.globalExplanation')}
+            </CardDescription>
+          )}
         </CardHeader>
         <CardContent className="space-y-4">
           {PII_CATEGORIES.map((category) => (
@@ -138,6 +155,7 @@ export function AnonymizationSettingsPage() {
               key={category}
               category={category}
               row={rows[category]}
+              globalWords={globalWordsByCategory[category] ?? []}
               error={errors[category]}
               disabled={updateMutation.isPending}
               onChange={(row) => handleRowChange(category, row)}

--- a/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/ui/PiiCategoryRow.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/anonymization-settings/ui/PiiCategoryRow.tsx
@@ -3,6 +3,7 @@ import { AlertCircle } from 'lucide-react';
 import { Switch } from '@/shared/ui/shadcn/switch';
 import { Input } from '@/shared/ui/shadcn/input';
 import { Label } from '@/shared/ui/shadcn/label';
+import { Badge } from '@/shared/ui/shadcn/badge';
 import {
   Item,
   ItemActions,
@@ -19,6 +20,7 @@ import type { RegexValidationError } from '../lib/validate-regex';
 interface PiiCategoryRowProps {
   category: PiiCategory;
   row: CategoryRowState;
+  globalWords: string[];
   error?: RegexValidationError;
   disabled: boolean;
   onChange: (row: CategoryRowState) => void;
@@ -27,6 +29,7 @@ interface PiiCategoryRowProps {
 export function PiiCategoryRow({
   category,
   row,
+  globalWords,
   error,
   disabled,
   onChange,
@@ -57,6 +60,21 @@ export function PiiCategoryRow({
           onCheckedChange={(enabled) => onChange({ ...row, enabled })}
         />
       </ItemActions>
+
+      {globalWords.length > 0 && (
+        <ItemFooter>
+          <div className="flex w-full flex-wrap items-center gap-1.5 opacity-70">
+            {globalWords.map((word) => (
+              <Badge key={word} variant="outline">
+                {word}
+                <span className="ml-1 text-muted-foreground">
+                  {t('piiWhitelist.globalBadge')}
+                </span>
+              </Badge>
+            ))}
+          </div>
+        </ItemFooter>
+      )}
 
       {row.enabled && (
         <ItemFooter>

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3421,9 +3421,17 @@ export interface PiiWhitelistEntryDto {
   pattern: string | null;
 }
 
+export interface GlobalPiiWhitelistWordSummaryDto {
+  category: PiiCategory;
+  /** The word exempted from anonymization */
+  word: string;
+}
+
 export interface PiiWhitelistResponseDto {
   /** Current whitelist entries for the org */
   entries: PiiWhitelistEntryDto[];
+  /** Words exempted platform-wide by Ayunis, read-only for org admins */
+  globalWords: GlobalPiiWhitelistWordSummaryDto[];
 }
 
 export interface UpdatePiiWhitelistRequestDto {

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -15354,6 +15354,23 @@
         },
         "required": ["category", "pattern"]
       },
+      "GlobalPiiWhitelistWordSummaryDto": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PiiCategory"
+              }
+            ]
+          },
+          "word": {
+            "type": "string",
+            "description": "The word exempted from anonymization"
+          }
+        },
+        "required": ["category", "word"]
+      },
       "PiiWhitelistResponseDto": {
         "type": "object",
         "properties": {
@@ -15363,9 +15380,16 @@
             "items": {
               "$ref": "#/components/schemas/PiiWhitelistEntryDto"
             }
+          },
+          "globalWords": {
+            "description": "Words exempted platform-wide by Ayunis, read-only for org admins",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GlobalPiiWhitelistWordSummaryDto"
+            }
           }
         },
-        "required": ["entries"]
+        "required": ["entries", "globalWords"]
       },
       "UpdatePiiWhitelistRequestDto": {
         "type": "object",

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-anonymization.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-anonymization.json
@@ -15,6 +15,8 @@
     "loadError": "Die Ausnahmen konnten nicht geladen werden.",
     "retry": "Erneut versuchen",
     "exemptBadge": "Nicht maskiert",
+    "globalBadge": "global",
+    "globalExplanation": "Mit \"global\" markierte Einträge werden von Ayunis zentral für alle Kunden gesetzt und nie anonymisiert. Sie können hier nicht bearbeitet werden — Ihre eigenen Ausnahmen gelten zusätzlich.",
     "categories": {
       "person_name": {
         "label": "Personennamen",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-anonymization.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-anonymization.json
@@ -15,6 +15,8 @@
     "loadError": "The anonymization exceptions could not be loaded.",
     "retry": "Retry",
     "exemptBadge": "Not masked",
+    "globalBadge": "global",
+    "globalExplanation": "Entries marked \"global\" are set centrally by Ayunis for all customers and are never anonymized. They cannot be edited here — your own exceptions apply in addition.",
     "categories": {
       "person_name": {
         "label": "Person names",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive, read-only API field and admin UI; org whitelist write behavior is unchanged aside from ordering global read before save.
> 
> **Overview**
> Org admins can now see **platform-wide PII whitelist words** alongside their own anonymization exceptions, without being able to edit them.
> 
> The **GET and PUT** `pii-whitelist` responses include a new read-only `globalWords` array (`category` + `word`), loaded via `GetGlobalPiiWhitelistUseCase` and documented with `GlobalPiiWhitelistWordSummaryDto`. On **PUT**, the global list is fetched **before** the org whitelist is persisted so a failed global read does not leave a successful save hidden behind an error response.
> 
> The **admin anonymization settings UI** groups `globalWords` by PII category, shows them as outline badges labeled “global”, and adds a short explanation when any global entries exist. The client uses `data?.globalWords ?? []` so a rolling deploy against an older API without the field still works. OpenAPI/generated types and EN/DE copy were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 474c0b7ed5db1f645e5ce952ee56542c44fb1936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->