### PR TITLE
chore(infra): remove dozzle from the docker stack (AYC-687)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -136,7 +136,7 @@ jobs:
             # would tear down the app and leave it down while the deploy still
             # reports success (see AYC: corepack outage).
             # Scoped to the Core services on purpose: a bare `compose pull`
-            # would also refresh minio/dozzle/redis/gotenberg, which are
+            # would also refresh minio/redis/gotenberg, which are
             # deliberately only pulled when first started.
             if ! docker compose pull app code-execution anonymize; then
               echo "::error::image pull failed — keeping current containers, not deploying"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -302,28 +302,6 @@ services:
         reservations:
           memory: 512M
 
-  dozzle:
-    image: amir20/dozzle:latest
-    container_name: ayunis-dozzle-prod
-    restart: unless-stopped
-    ports:
-      - "127.0.0.1:8888:8080" # localhost only for security
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    # No network needed - Dozzle only requires the Docker socket.
-    # Keeping it off ayunis-network ensures the 127.0.0.1 port binding
-    # is the only access path (other containers cannot reach dozzle:8080).
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
-    deploy:
-      resources:
-        limits:
-          memory: 128M
-          cpus: "0.25"
-
 volumes:
   postgres-data:
     driver: local


### PR DESCRIPTION
- drop the dozzle service from docker-compose.yml
- update the deploy-staging pull comment accordingly

Existing ayunis-dozzle-prod containers on deployed hosts become
compose orphans and need a one-time manual removal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Infra-only removal of an optional log UI with no app, auth, or data-path changes; main follow-up is cleaning orphan containers on deployed hosts.
> 
> **Overview**
> **Removes Dozzle** from the production Docker Compose stack (`amir20/dozzle:latest`, localhost `8888`, read-only Docker socket). The stack no longer runs a built-in log viewer alongside minio, redis, and gotenberg.
> 
> The staging deploy workflow comment is updated so the scoped `compose pull` note no longer mentions dozzle.
> 
> **Ops note:** Existing `ayunis-dozzle-prod` containers on hosts will become compose orphans and need a one-time manual removal after deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a186a90e49b57ffe7379a42ea1797d7b8d80e043. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->