### PR TITLE
fix(artifacts): bound spreadsheet content before parsing it (AYC-153)

### DIFF
--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/schema/spreadsheet-artifact.record.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/schema/spreadsheet-artifact.record.ts
@@ -1,6 +1,6 @@
 import { ChildEntity } from 'typeorm';
 import { ArtifactRecord } from './artifact.record';
-import { ArtifactType } from '../../../../domain/value-objects/artifact-type.enum';
+import { ArtifactType } from 'src/domain/artifacts/domain/value-objects/artifact-type.enum';
 
 @ChildEntity(ArtifactType.SPREADSHEET)
 export class SpreadsheetArtifactRecord extends ArtifactRecord {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Import-path-only change on a TypeORM child entity record with no logic or schema changes.
> 
> **Overview**
> Updates **`SpreadsheetArtifactRecord`** so it imports **`ArtifactType`** via the `src/domain/artifacts/domain/value-objects/artifact-type.enum` path instead of a four-level relative path (`../../../../domain/...`).
> 
> This matches how other artifacts code resolves the enum and avoids brittle relative imports in the local persistence schema layer. **No runtime or persistence behavior changes**—only the module resolution for the `@ChildEntity(ArtifactType.SPREADSHEET)` discriminator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d670c91477df77e1d88b3f90dda6a45946f55200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->