### PR TITLE
fix(models): route azure image edits through the model deployment (AYC-680)

### DIFF
--- a/ayunis-core-backend/src/domain/models/infrastructure/image-generation/azure.image-generation.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/image-generation/azure.image-generation.spec.ts
@@ -8,7 +8,7 @@ import {
 import { ImageGenerationFailedError } from '../../application/models.errors';
 import { ImageGenerationModel } from '../../domain/models/image-generation.model';
 import { ModelProvider } from '../../domain/value-objects/model-provider.enum';
-import { APIError } from 'openai';
+import { APIError, AzureOpenAI } from 'openai';
 
 // Mock the AzureOpenAI class
 const mockImagesGenerate = jest.fn();
@@ -22,6 +22,8 @@ jest.mock('openai', () => {
     })),
   };
 });
+
+const mockAzureOpenAICtor = jest.mocked(AzureOpenAI);
 
 describe('AzureImageGenerationHandler', () => {
   let handler: AzureImageGenerationHandler;
@@ -369,6 +371,77 @@ describe('AzureImageGenerationHandler', () => {
       const result = await handler.generate(createInput());
 
       expect(result.usage).toBeUndefined();
+    });
+  });
+
+  // The SDK only routes requests to /deployments/{name}/… when the client is
+  // constructed with `deployment`: for images.edit the body is multipart
+  // FormData by the time AzureOpenAI.buildRequest looks for a model name, so
+  // a deployment-less client sends edits to a URL Azure 404s on.
+  describe('client construction', () => {
+    const stubGenerate = () => {
+      mockImagesGenerate.mockResolvedValue({
+        data: [{ b64_json: Buffer.from('img').toString('base64') }],
+      });
+    };
+
+    it('should construct the client with the model name as deployment', async () => {
+      stubGenerate();
+
+      await handler.generate(createInput());
+
+      expect(mockAzureOpenAICtor).toHaveBeenCalledTimes(1);
+      expect(mockAzureOpenAICtor).toHaveBeenCalledWith(
+        expect.objectContaining({ deployment: 'gpt-image-1' }),
+      );
+    });
+
+    it('should construct the client with the deployment for reference-image edits', async () => {
+      mockImagesEdit.mockResolvedValue({
+        data: [{ b64_json: Buffer.from('img').toString('base64') }],
+      });
+
+      await handler.generate(
+        createInput({
+          referenceImages: [
+            { data: Buffer.from('uploaded-scan'), contentType: 'image/png' },
+          ],
+        }),
+      );
+
+      expect(mockAzureOpenAICtor).toHaveBeenCalledTimes(1);
+      expect(mockAzureOpenAICtor).toHaveBeenCalledWith(
+        expect.objectContaining({ deployment: 'gpt-image-1' }),
+      );
+    });
+
+    it('should reuse the cached client for the same model', async () => {
+      stubGenerate();
+
+      await handler.generate(createInput());
+      await handler.generate(createInput());
+
+      expect(mockAzureOpenAICtor).toHaveBeenCalledTimes(1);
+    });
+
+    it('should construct a separate client per model deployment', async () => {
+      stubGenerate();
+      const otherModel = new ImageGenerationModel({
+        name: 'gpt-image-1-mini',
+        provider: ModelProvider.AZURE,
+        displayName: 'GPT Image 1 Mini',
+        isArchived: false,
+      });
+
+      await handler.generate(createInput());
+      await handler.generate(
+        new ImageGenerationInput({ model: otherModel, prompt: 'a sunset' }),
+      );
+
+      expect(mockAzureOpenAICtor).toHaveBeenCalledTimes(2);
+      expect(mockAzureOpenAICtor).toHaveBeenLastCalledWith(
+        expect.objectContaining({ deployment: 'gpt-image-1-mini' }),
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/models/infrastructure/image-generation/azure.image-generation.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/image-generation/azure.image-generation.ts
@@ -49,19 +49,29 @@ function isValidQuality(value: string): value is ImageQuality {
 @Injectable()
 export class AzureImageGenerationHandler extends ImageGenerationHandler {
   private readonly logger = new Logger(AzureImageGenerationHandler.name);
-  private client: AzureOpenAI | null = null;
+  // Keyed by deployment: the SDK only prefixes /deployments/{name} when the
+  // client is constructed with `deployment` — for images.edit the body is
+  // multipart FormData by the time buildRequest looks for a model name, so a
+  // deployment-less client sends edits to a URL Azure 404s on. This handler
+  // is a singleton serving every org's model, hence one client per name.
+  private readonly clients = new Map<string, AzureOpenAI>();
 
   constructor(private readonly configService: ConfigService) {
     super();
   }
 
-  private getClient(): AzureOpenAI {
-    this.client ??= new AzureOpenAI({
-      apiKey: this.configService.get('models.azure.apiKey'),
-      endpoint: this.configService.get('models.azure.endpoint'),
-      apiVersion: this.configService.get('models.azure.apiVersion'),
-    });
-    return this.client;
+  private getClient(deploymentName: string): AzureOpenAI {
+    let client = this.clients.get(deploymentName);
+    if (!client) {
+      client = new AzureOpenAI({
+        apiKey: this.configService.get('models.azure.apiKey'),
+        endpoint: this.configService.get('models.azure.endpoint'),
+        apiVersion: this.configService.get('models.azure.apiVersion'),
+        deployment: deploymentName,
+      });
+      this.clients.set(deploymentName, client);
+    }
+    return client;
   }
 
   private validateParams(input: ImageGenerationInput): {
@@ -96,7 +106,7 @@ export class AzureImageGenerationHandler extends ImageGenerationHandler {
     });
 
     const { size, quality } = this.validateParams(input);
-    const client = this.getClient();
+    const client = this.getClient(input.model.name);
 
     try {
       const response = input.referenceImages?.length


### PR DESCRIPTION
- images.edit sent multipart bodies the SDK cannot read a model name
  from, so requests went to /openai/images/edits without a deployment
  segment and Azure returned 404 for every reference-image generation
- construct the AzureOpenAI client with the deployment option, cached
  per model name since the singleton handler serves all orgs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all Azure image API calls are routed (generate and edit); wrong deployment wiring would break image generation broadly, but scope is limited to the Azure image handler with new regression tests.
> 
> **Overview**
> Fixes **Azure reference-image generation** failing with 404s by constructing `AzureOpenAI` with **`deployment` set to the model name**, so the SDK hits `/deployments/{name}/…` instead of a deployment-less path that breaks on multipart `images.edit` requests.
> 
> The handler no longer keeps a single shared client: it **caches one client per deployment name** (reused for the same model, separate instances for different models) because the singleton serves all orgs’ Azure image models.
> 
> Adds **unit tests** that assert deployment is passed for generate and edit flows, cache reuse, and per-model clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c300e91623c7733db0afa7832ca56ea828c8439. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->