### PR TITLE
chore(tooling): build workspace packages in worktrees (AYC-000)

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -12,9 +12,12 @@ for f in ayunis-core-backend/.env \
 done
 '''
 
-[post-start]
+[[post-start]]
 # Single root install: this is a pnpm workspace (workspace:* deps), so `npm ci`
 # fails with EUNSUPPORTEDPROTOCOL. One `pnpm install` links every workspace
 # (backend, frontend, and packages/*) and honors onlyBuiltDependencies.
 install-node = "pnpm install --frozen-lockfile"
+
+[[post-start]]
+build-node = "cd ayunis-core-backend && pnpm run build:deps"
 # install-python = "cd ayunis-core-anonymize && uv sync"  # uncomment if you work on anonymize


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only changes local worktree bootstrap in `.config/wt.toml`; no application, auth, or deployment code.
> 
> **Overview**
> Worktree startup now runs **`pnpm run build:deps`** in `ayunis-core-backend` after **`pnpm install`**, so fresh worktrees get built `@ayunis/*` packages without a manual step.
> 
> The **`.config/wt.toml`** post-start config is split into two **`[[post-start]]`** blocks: the existing frozen install stays; a new **`build-node`** hook was added for the deps build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 877b7f1f0ebca26bfcea11e3490c9c253c315f52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->