### PR TITLE
fix(charts): downloaded charts no longer clipped on the right (AYC-532)

### DIFF
--- a/ayunis-core-frontend/src/widgets/charts/lib/useDownloadChartImage.ts
+++ b/ayunis-core-frontend/src/widgets/charts/lib/useDownloadChartImage.ts
@@ -12,9 +12,15 @@ export function useDownloadChartImage(title?: string) {
 
     setIsDownloading(true);
     try {
+      // Wide charts (many x-axis points) render wider than their scrollable
+      // container, so the node overflows horizontally. html-to-image sizes the
+      // capture from clientWidth/clientHeight by default, which clips the
+      // overflow on the right. Capture the full scroll size instead.
       const dataUrl = await toPng(node, {
         backgroundColor: '#ffffff',
         pixelRatio: 2,
+        width: node.scrollWidth,
+        height: node.scrollHeight,
       });
 
       const link = document.createElement('a');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Downloaded chart images are cut off on the right side ([AYC-532](https://linear.app/issue/AYC-532)). Labels and content near the right edge are missing from the exported PNG.

## Root cause

Charts with many x-axis points (`xCount > threshold`, default 10) get an explicit `dynamicWidth` on the `ChartContainer` (`xCount * perPointPx`). This makes the chart wider than the scrollable `CardContent`, so the `chartRef` wrapper `div` overflows horizontally (the card scrolls to reveal it).

`html-to-image` (`toPng`) sizes the capture from the node's `clientWidth`/`clientHeight` by default (`getImageSize` → `getNodeWidth` uses `node.clientWidth`). The wrapper's `clientWidth` is only the visible width, so everything overflowing to the right is clipped out of the PNG.

## Fix

Pass explicit `width`/`height` to `toPng` using the node's `scrollWidth`/`scrollHeight`, so the full rendered chart is captured. `html-to-image`'s `applyStyle` also widens the cloned node to `options.width`, so the overflow is no longer re-clipped. When there is no overflow, `scrollWidth === clientWidth`, so behavior is unchanged for narrow charts.

```ts
const dataUrl = await toPng(node, {
  backgroundColor: '#ffffff',
  pixelRatio: 2,
  width: node.scrollWidth,
  height: node.scrollHeight,
});
```

## Validation

- `tsc --noEmit` passes
- `eslint` passes on the changed file
- Pre-commit hooks (prettier, eslint, typecheck, dep check, duplication, file size) all pass

## Scope

- `ayunis-core-frontend/src/widgets/charts/lib/useDownloadChartImage.ts` (used by bar, line, and pie chart widgets via `ChartCard`).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-532](https://linear.app/ayunis/issue/AYC-532/heruntergeladene-charts-werden-rechts-abgeschnitten)

<div><a href="https://cursor.com/agents/bc-327c924e-3259-4b9d-944f-5088816bc045?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-327c924e-3259-4b9d-944f-5088816bc045&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

