### PR TITLE
fix(uploads): preserve special characters in uploaded document names

### DIFF
--- a/ayunis-core-backend/src/common/util/source-file-upload.spec.ts
+++ b/ayunis-core-backend/src/common/util/source-file-upload.spec.ts
@@ -1,6 +1,6 @@
 import { Readable } from 'stream';
 import * as fs from 'fs';
-import multer from 'multer';
+import multer, { type Options } from 'multer';
 import {
   removeUploadedFile,
   SOURCE_FILE_UPLOAD_OPTIONS,
@@ -40,7 +40,12 @@ function runUpload(filename: string): Promise<UploadedSourceFile> {
   const res = {} as unknown as Parameters<
     ReturnType<ReturnType<typeof multer>['single']>
   >[1];
-  const middleware = multer(SOURCE_FILE_UPLOAD_OPTIONS).single('file');
+  // NestJS's MulterOptions and @types/multer's Options diverge only on the
+  // `dest` declaration, which this config never sets, so the runtime shape is
+  // compatible.
+  const middleware = multer(
+    SOURCE_FILE_UPLOAD_OPTIONS as unknown as Options,
+  ).single('file');
 
   return new Promise((resolvePromise, reject) => {
     middleware(req as never, res, (err: unknown) => {

--- a/ayunis-core-backend/src/common/util/source-file-upload.spec.ts
+++ b/ayunis-core-backend/src/common/util/source-file-upload.spec.ts
@@ -1,0 +1,72 @@
+import { Readable } from 'stream';
+import * as fs from 'fs';
+import multer from 'multer';
+import {
+  removeUploadedFile,
+  SOURCE_FILE_UPLOAD_OPTIONS,
+  type UploadedSourceFile,
+} from './source-file-upload';
+
+// Browsers send the filename in the multipart part header as raw UTF-8 bytes.
+// Busboy (via multer) decodes those bytes as latin1 unless defParamCharset is
+// set, which turns umlauts into mojibake (e.g. "ü" -> "Ã¼"). This exercises the
+// real upload options over a crafted request to prove the name survives intact.
+function buildMultipartRequest(filename: string): Readable & {
+  headers: Record<string, string>;
+} {
+  const boundary = '----testboundary1234567890';
+  const header = Buffer.from(
+    `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="file"; filename="${filename}"\r\n` +
+      `Content-Type: text/plain\r\n\r\n`,
+    'utf8',
+  );
+  const body = Buffer.from('hello world', 'utf8');
+  const footer = Buffer.from(`\r\n--${boundary}--\r\n`, 'utf8');
+  const payload = Buffer.concat([header, body, footer]);
+
+  const req = Readable.from(payload) as Readable & {
+    headers: Record<string, string>;
+  };
+  req.headers = {
+    'content-type': `multipart/form-data; boundary=${boundary}`,
+    'content-length': String(payload.length),
+  };
+  return req;
+}
+
+function runUpload(filename: string): Promise<UploadedSourceFile> {
+  const req = buildMultipartRequest(filename);
+  const res = {} as unknown as Parameters<
+    ReturnType<ReturnType<typeof multer>['single']>
+  >[1];
+  const middleware = multer(SOURCE_FILE_UPLOAD_OPTIONS).single('file');
+
+  return new Promise((resolvePromise, reject) => {
+    middleware(req as never, res, (err: unknown) => {
+      if (err) {
+        reject(err instanceof Error ? err : new Error('upload failed'));
+        return;
+      }
+      resolvePromise((req as unknown as { file: UploadedSourceFile }).file);
+    });
+  });
+}
+
+describe('SOURCE_FILE_UPLOAD_OPTIONS', () => {
+  beforeAll(() => {
+    fs.mkdirSync('./uploads', { recursive: true });
+  });
+
+  it('preserves umlauts and other special characters in the filename', async () => {
+    const originalName = 'Grüße_Köln_Straße_€.txt';
+
+    const file = await runUpload(originalName);
+
+    try {
+      expect(file.originalname).toBe(originalName);
+    } finally {
+      removeUploadedFile(file.path);
+    }
+  });
+});

--- a/ayunis-core-backend/src/common/util/source-file-upload.ts
+++ b/ayunis-core-backend/src/common/util/source-file-upload.ts
@@ -43,6 +43,9 @@ export const SOURCE_FILE_UPLOAD_OPTIONS: MulterOptions = {
     },
   }),
   limits: { fileSize: MAX_SOURCE_FILE_SIZE_BYTES },
+  // Browsers send the multipart filename as raw UTF-8 bytes; busboy defaults to
+  // latin1, which garbles umlauts and other non-ASCII characters into mojibake.
+  defParamCharset: 'utf8',
 };
 
 export const SOURCE_FILE_API_BODY = {

--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
@@ -120,6 +120,9 @@ const DocumentUploadInterceptor = FileInterceptor('file', {
     },
   }),
   limits: { fileSize: KnowledgeBasesConstants.MAX_FILE_SIZE_BYTES },
+  // Browsers send the multipart filename as raw UTF-8 bytes; busboy defaults to
+  // latin1, which garbles umlauts and other non-ASCII characters into mojibake.
+  defParamCharset: 'utf8',
 });
 /* eslint-enable sonarjs/content-length */
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Uploaded document names with umlauts or other special characters render as garbled mojibake in the chat UI (e.g. `Grüße.pdf` → `GrÃ¼Ãe.pdf`).

Fixes [AYC-605](https://linear.app/ayunis/issue/AYC-605).

## Root cause

Browsers send the multipart part-header `filename` as raw UTF-8 bytes. `busboy` (used by `multer`) decodes those header params as **latin1** by default (`defParamCharset` unset), turning every non-ASCII byte into mojibake. The `originalname` then becomes the source/document display name, so the corruption surfaces directly in the UI.

## Fix

Set `defParamCharset: 'utf8'` on the multipart upload configs for the document/source upload flows where the filename becomes a displayed name:

- `SOURCE_FILE_UPLOAD_OPTIONS` — chat thread sources (the reported bug) and skill sources
- Knowledge-base `DocumentUploadInterceptor`

This is a one-line, type-safe option already documented by `@nestjs/platform-express` (its default is `latin1`).

## Test

Added `source-file-upload.spec.ts`, which drives the real `SOURCE_FILE_UPLOAD_OPTIONS` through `multer` over a crafted multipart request with a UTF-8 filename (`Grüße_Köln_Straße_€.txt`) and asserts `originalname` survives intact. Confirmed it fails before the fix (reproducing the exact `ü` → `Ã¼` garbling from the ticket screenshot) and passes after.

## Scope

Image, transcription, and letterhead uploads were intentionally left unchanged — none surface the raw uploaded filename as a displayed name (they rename to UUIDs or use a separate name field).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-605](https://linear.app/ayunis/issue/AYC-605/uploaded-document-names-render-special-characters-incorrectly)

<div><a href="https://cursor.com/agents/bc-197c4e3a-8bb0-4e49-902b-621cb5b5f350?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-197c4e3a-8bb0-4e49-902b-621cb5b5f350&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

