### PR TITLE
fix(artifacts): preserve line-height and margin in Word export (AYC-689)

### DIFF
--- a/ayunis-core-backend/src/domain/artifacts/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/artifacts/SUMMARY.md
@@ -54,6 +54,7 @@ artifacts/
 │   └── export/
 │       ├── html-document-export.service.ts
 │       ├── html-to-docx-converter.ts
+│       ├── paragraph-style-parser.ts
 │       ├── docx-document-config.ts
 │       ├── pdf-letterhead-compositor.ts
 │       └── xlsx-spreadsheet-export.service.ts

--- a/ayunis-core-backend/src/domain/artifacts/application/helpers/sanitize-html-content.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/helpers/sanitize-html-content.spec.ts
@@ -140,6 +140,22 @@ describe('sanitizeHtmlContent', () => {
       expect(sanitizeHtmlContent(html)).toBe(html);
     });
 
+    it('should preserve paragraph spacing styles for export', () => {
+      const html =
+        '<p style="line-height:1;margin-top:0pt;margin-bottom:0pt">Text</p>';
+      const result = sanitizeHtmlContent(html);
+      expect(result).toContain('line-height:1');
+      expect(result).toContain('margin-top:0pt');
+      expect(result).toContain('margin-bottom:0pt');
+    });
+
+    it('should strip spacing styles with unsupported units', () => {
+      const html = '<p style="line-height:1.5em;margin-bottom:2rem">Text</p>';
+      const result = sanitizeHtmlContent(html);
+      expect(result).not.toContain('line-height');
+      expect(result).not.toContain('margin-bottom');
+    });
+
     it('should handle empty HTML', () => {
       expect(sanitizeHtmlContent('')).toBe('');
     });

--- a/ayunis-core-backend/src/domain/artifacts/application/helpers/sanitize-html-content.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/helpers/sanitize-html-content.ts
@@ -80,6 +80,11 @@ const SANITIZE_OPTIONS: IOptions = {
       'text-align': [/^(left|right|center|justify)$/],
       'background-color': [/.*/],
       color: [/.*/],
+      // Paragraph spacing preserved for DOCX/PDF export (see
+      // html-to-docx-converter). Restricted to unitless / pt / px numbers.
+      'line-height': [/^\d+(\.\d+)?(pt|px)?$/],
+      'margin-top': [/^-?\d+(\.\d+)?(pt|px)?$/],
+      'margin-bottom': [/^-?\d+(\.\d+)?(pt|px)?$/],
     },
   },
 };

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
@@ -1,6 +1,14 @@
 import { HtmlDocumentExportService } from './html-document-export.service';
 import type { PdfLetterheadCompositor } from './pdf-letterhead-compositor';
 import type { LetterheadConfig } from '../../application/ports/document-export.port';
+import * as JSZip from 'jszip';
+
+async function extractDocumentXml(buffer: Buffer): Promise<string> {
+  const zip = await JSZip.loadAsync(buffer);
+  const docXml = zip.file('word/document.xml');
+  if (!docXml) throw new Error('No word/document.xml in DOCX');
+  return docXml.async('text');
+}
 
 // ---------------------------------------------------------------------------
 // Puppeteer mock — avoids launching a real browser in unit tests
@@ -150,6 +158,18 @@ describe('HtmlDocumentExportService', () => {
 
       expect(result).toBeInstanceOf(Buffer);
       expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('should preserve line-height and margin spacing through sanitization', async () => {
+      const html =
+        '<p style="line-height: 1; margin-top: 0pt; margin-bottom: 0pt; text-align: justify;">Body</p>';
+      const result = await service.exportToDocx(html);
+      const xml = await extractDocumentXml(result);
+
+      expect(xml).toMatch(/<w:spacing[^>]*w:line="240"[^>]*w:lineRule="auto"/);
+      expect(xml).toMatch(/<w:spacing[^>]*w:after="0"/);
+      expect(xml).toMatch(/<w:spacing[^>]*w:before="0"/);
+      expect(xml).toContain('both'); // JUSTIFIED alignment
     });
   });
 

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.spec.ts
@@ -255,4 +255,26 @@ describe('convertHtmlToDocx', () => {
     // 16px * 15 twips/px = 240
     expect(xml).toMatch(/<w:spacing[^>]*w:after="240"/);
   });
+
+  it('should render px line-height as exact line spacing', async () => {
+    const buffer = await convertHtmlToDocx(
+      '<p style="line-height: 16px">Fixed</p>',
+    );
+    const xml = await extractDocumentXml(buffer);
+
+    // 16px * 15 twips/px = 240, exact line rule
+    expect(xml).toMatch(/<w:spacing[^>]*w:line="240"[^>]*w:lineRule="exact"/);
+  });
+
+  it('should read table cell spacing from the nested paragraph', async () => {
+    const buffer = await convertHtmlToDocx(
+      '<table><tr><td><p style="line-height: 1; margin-bottom: 0pt; text-align: right">Cell</p></td></tr></table>',
+    );
+    const xml = await extractDocumentXml(buffer);
+
+    expect(xml).toContain('Cell');
+    expect(xml).toMatch(/<w:spacing[^>]*w:line="240"[^>]*w:lineRule="auto"/);
+    expect(xml).toMatch(/<w:spacing[^>]*w:after="0"/);
+    expect(xml).toContain('right');
+  });
 });

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.spec.ts
@@ -176,4 +176,83 @@ describe('convertHtmlToDocx', () => {
     expect(xml).toContain('Right Heading');
     expect(xml).toContain('right');
   });
+
+  it('should render line-height: 1 as single line spacing', async () => {
+    const buffer = await convertHtmlToDocx(
+      '<p style="line-height: 1">Single spaced</p>',
+    );
+    const xml = await extractDocumentXml(buffer);
+
+    expect(xml).toContain('Single spaced');
+    expect(xml).toMatch(/<w:spacing[^>]*w:line="240"[^>]*w:lineRule="auto"/);
+  });
+
+  it('should render line-height: 1.5 as one-and-a-half line spacing', async () => {
+    const buffer = await convertHtmlToDocx(
+      '<p style="line-height: 1.5">Loose</p>',
+    );
+    const xml = await extractDocumentXml(buffer);
+
+    expect(xml).toMatch(/<w:spacing[^>]*w:line="360"[^>]*w:lineRule="auto"/);
+  });
+
+  it('should render margin-bottom as spacing after the paragraph', async () => {
+    const buffer = await convertHtmlToDocx(
+      '<p style="margin-bottom: 0pt">No gap after</p>',
+    );
+    const xml = await extractDocumentXml(buffer);
+
+    expect(xml).toContain('No gap after');
+    expect(xml).toMatch(/<w:spacing[^>]*w:after="0"/);
+  });
+
+  it('should render margin-top as spacing before the paragraph', async () => {
+    const buffer = await convertHtmlToDocx(
+      '<p style="margin-top: 6pt">Gap before</p>',
+    );
+    const xml = await extractDocumentXml(buffer);
+
+    expect(xml).toMatch(/<w:spacing[^>]*w:before="120"/);
+  });
+
+  it('should preserve all paragraph spacing from combined inline styles', async () => {
+    const buffer = await convertHtmlToDocx(
+      '<p style="font-size: 12pt; line-height: 1; margin-top: 0pt; margin-bottom: 0pt; padding-top: 0; padding-bottom: 0; text-align: justify;">Body</p>',
+    );
+    const xml = await extractDocumentXml(buffer);
+
+    expect(xml).toContain('Body');
+    expect(xml).toContain('both'); // JUSTIFIED alignment renders as w:val="both"
+    expect(xml).toMatch(/w:line="240"/);
+    expect(xml).toMatch(/w:lineRule="auto"/);
+    expect(xml).toMatch(/w:after="0"/);
+    expect(xml).toMatch(/w:before="0"/);
+  });
+
+  it('should preserve spacing on headings, list items, and table cells', async () => {
+    const buffer = await convertHtmlToDocx(
+      '<h1 style="margin-bottom: 0pt">Heading</h1>' +
+        '<ul><li><p style="line-height: 1">Item</p></li></ul>' +
+        '<table><tr><td style="margin-bottom: 0pt">Cell</td></tr></table>',
+    );
+    const xml = await extractDocumentXml(buffer);
+
+    expect(xml).toContain('Heading');
+    expect(xml).toContain('Item');
+    expect(xml).toContain('Cell');
+    expect(
+      (xml.match(/<w:spacing[^>]*w:after="0"/g) ?? []).length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(xml).toMatch(/<w:spacing[^>]*w:line="240"/);
+  });
+
+  it('should convert px margins to twips', async () => {
+    const buffer = await convertHtmlToDocx(
+      '<p style="margin-bottom: 16px">Pixels</p>',
+    );
+    const xml = await extractDocumentXml(buffer);
+
+    // 16px * 15 twips/px = 240
+    expect(xml).toMatch(/<w:spacing[^>]*w:after="240"/);
+  });
 });

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.ts
@@ -6,7 +6,6 @@ import {
   TableRow,
   TableCell,
   HeadingLevel,
-  AlignmentType,
   BorderStyle,
   WidthType,
   TableLayoutType,
@@ -20,6 +19,7 @@ import type { HTMLElement, TextNode } from 'node-html-parser';
 import { parse, NodeType } from 'node-html-parser';
 
 import { buildDocument } from './docx-document-config';
+import { parseAlignment, parseSpacing } from './paragraph-style-parser';
 
 /** Inline formatting context accumulated while walking the tree. */
 interface InlineContext {
@@ -46,14 +46,17 @@ const HEADING_MAP: Record<
   h6: HeadingLevel.HEADING_6,
 };
 
-const ALIGNMENT_MAP: Record<
-  string,
-  (typeof AlignmentType)[keyof typeof AlignmentType]
-> = {
-  left: AlignmentType.LEFT,
-  center: AlignmentType.CENTER,
-  right: AlignmentType.RIGHT,
-  justify: AlignmentType.JUSTIFIED,
+/** Inline formatting flags contributed by each supported inline tag. */
+const INLINE_FORMAT_BY_TAG: Record<string, Partial<InlineContext>> = {
+  strong: { bold: true },
+  b: { bold: true },
+  em: { italic: true },
+  i: { italic: true },
+  u: { underline: true },
+  s: { strike: true },
+  del: { strike: true },
+  strike: { strike: true },
+  code: { code: true },
 };
 
 const TABLE_BORDER = {
@@ -147,6 +150,7 @@ function convertHeading(node: HTMLElement, tag: string): Paragraph {
   return new Paragraph({
     heading: HEADING_MAP[tag],
     alignment: parseAlignment(node),
+    spacing: parseSpacing(node),
     children: collectInlineRuns(node, {}),
   });
 }
@@ -155,6 +159,7 @@ function convertParagraph(node: HTMLElement): Paragraph {
   return new Paragraph({
     style: 'Normal',
     alignment: parseAlignment(node),
+    spacing: parseSpacing(node),
     children: collectInlineRuns(node, {}),
   });
 }
@@ -188,6 +193,7 @@ function convertBlockquote(node: HTMLElement): BlockChild[] {
           new Paragraph({
             ...blockquoteStyle,
             alignment: parseAlignment(child),
+            spacing: parseSpacing(child),
             children: collectInlineRuns(child, {}),
           }),
         );
@@ -255,6 +261,8 @@ function convertListItem(
       out.push(
         new Paragraph({
           children: collectInlineRuns(child, {}),
+          alignment: parseAlignment(child),
+          spacing: parseSpacing(child),
           ...listProps(ordered, level),
         }),
       );
@@ -345,7 +353,13 @@ function convertTableRow(tr: HTMLElement): TableRow | null {
     const rowSpan = rowspanAttr ? parseInt(rowspanAttr, 10) : undefined;
 
     return new TableCell({
-      children: [new Paragraph({ children: runs })],
+      children: [
+        new Paragraph({
+          children: runs,
+          alignment: parseAlignment(cell),
+          spacing: parseSpacing(cell),
+        }),
+      ],
       borders: TABLE_BORDERS,
       shading: isHeader ? { fill: 'F5F5F5' } : undefined,
       width: { size: 0, type: WidthType.AUTO },
@@ -426,34 +440,11 @@ function buildInlineContext(
   node: HTMLElement,
   ctx: InlineContext,
 ): InlineContext {
-  const newCtx = { ...ctx };
-
-  switch (tag) {
-    case 'strong':
-    case 'b':
-      newCtx.bold = true;
-      break;
-    case 'em':
-    case 'i':
-      newCtx.italic = true;
-      break;
-    case 'u':
-      newCtx.underline = true;
-      break;
-    case 's':
-    case 'del':
-    case 'strike':
-      newCtx.strike = true;
-      break;
-    case 'code':
-      newCtx.code = true;
-      break;
-    case 'a':
-      newCtx.link = node.getAttribute('href') ?? undefined;
-      break;
+  if (tag === 'a') {
+    return { ...ctx, link: node.getAttribute('href') ?? undefined };
   }
 
-  return newCtx;
+  return { ...ctx, ...INLINE_FORMAT_BY_TAG[tag] };
 }
 
 function formatFromContext(ctx: InlineContext): Partial<IRunOptions> {
@@ -464,12 +455,4 @@ function formatFromContext(ctx: InlineContext): Partial<IRunOptions> {
     ...(ctx.strike && { strike: true }),
     ...(ctx.code && { font: 'Courier New', size: 20 }),
   };
-}
-
-function parseAlignment(
-  node: HTMLElement,
-): (typeof AlignmentType)[keyof typeof AlignmentType] | undefined {
-  const style = node.getAttribute('style') ?? '';
-  const match = /text-align:\s*(left|center|right|justify)/.exec(style);
-  return match ? ALIGNMENT_MAP[match[1]] : undefined;
 }

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.ts
@@ -342,33 +342,39 @@ function convertTableRow(tr: HTMLElement): TableRow | null {
   if (cellElements.length === 0) return null;
 
   const isHeader = cellElements[0].tagName.toLowerCase() === 'th';
-  const cells = cellElements.map((cell) => {
-    const runs = collectInlineRuns(cell, {
-      bold: isHeader || undefined,
-    });
-
-    const colspanAttr = cell.getAttribute('colspan');
-    const rowspanAttr = cell.getAttribute('rowspan');
-    const columnSpan = colspanAttr ? parseInt(colspanAttr, 10) : undefined;
-    const rowSpan = rowspanAttr ? parseInt(rowspanAttr, 10) : undefined;
-
-    return new TableCell({
-      children: [
-        new Paragraph({
-          children: runs,
-          alignment: parseAlignment(cell),
-          spacing: parseSpacing(cell),
-        }),
-      ],
-      borders: TABLE_BORDERS,
-      shading: isHeader ? { fill: 'F5F5F5' } : undefined,
-      width: { size: 0, type: WidthType.AUTO },
-      ...(columnSpan && columnSpan > 1 && { columnSpan }),
-      ...(rowSpan && rowSpan > 1 && { rowSpan }),
-    });
-  });
+  const cells = cellElements.map((cell) => convertTableCell(cell, isHeader));
 
   return new TableRow({ children: cells });
+}
+
+function convertTableCell(cell: HTMLElement, isHeader: boolean): TableCell {
+  const runs = collectInlineRuns(cell, { bold: isHeader || undefined });
+
+  const columnSpan = parseSpan(cell.getAttribute('colspan'));
+  const rowSpan = parseSpan(cell.getAttribute('rowspan'));
+
+  // TipTap wraps cell content in a nested <p> that carries the paragraph
+  // styles; fall back to the cell itself when there is no inner paragraph.
+  const styleNode = cell.querySelector(':scope > p') ?? cell;
+
+  return new TableCell({
+    children: [
+      new Paragraph({
+        children: runs,
+        alignment: parseAlignment(styleNode) ?? parseAlignment(cell),
+        spacing: parseSpacing(styleNode) ?? parseSpacing(cell),
+      }),
+    ],
+    borders: TABLE_BORDERS,
+    shading: isHeader ? { fill: 'F5F5F5' } : undefined,
+    width: { size: 0, type: WidthType.AUTO },
+    ...(columnSpan && columnSpan > 1 && { columnSpan }),
+    ...(rowSpan && rowSpan > 1 && { rowSpan }),
+  });
+}
+
+function parseSpan(attr: string | undefined): number | undefined {
+  return attr ? parseInt(attr, 10) : undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/paragraph-style-parser.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/paragraph-style-parser.ts
@@ -1,0 +1,122 @@
+import { AlignmentType, LineRuleType, type ISpacingProperties } from 'docx';
+import type { HTMLElement } from 'node-html-parser';
+
+const ALIGNMENT_MAP: Record<
+  string,
+  (typeof AlignmentType)[keyof typeof AlignmentType]
+> = {
+  left: AlignmentType.LEFT,
+  center: AlignmentType.CENTER,
+  right: AlignmentType.RIGHT,
+  justify: AlignmentType.JUSTIFIED,
+};
+
+export function parseAlignment(
+  node: HTMLElement,
+): (typeof AlignmentType)[keyof typeof AlignmentType] | undefined {
+  const style = node.getAttribute('style') ?? '';
+  const match = /text-align:\s*(left|center|right|justify)/.exec(style);
+  return match ? ALIGNMENT_MAP[match[1]] : undefined;
+}
+
+/** Parses an inline `style` attribute into a `property -> value` map. */
+function parseStyleDeclarations(style: string): Map<string, string> {
+  const declarations = new Map<string, string>();
+
+  for (const declaration of style.split(';')) {
+    const separator = declaration.indexOf(':');
+    if (separator === -1) continue;
+
+    const property = declaration.slice(0, separator).trim().toLowerCase();
+    const value = declaration.slice(separator + 1).trim();
+    if (property && value) declarations.set(property, value);
+  }
+
+  return declarations;
+}
+
+/** Strict numeric parse (unlike parseFloat, rejects trailing units like `em`). */
+function toFiniteNumber(raw: string): number | undefined {
+  const trimmed = raw.trim();
+  if (trimmed === '') return undefined;
+  const value = Number(trimmed);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Converts a CSS length (`pt`, `px`, or a bare number) to twips (1/20 pt),
+ * the unit `docx` uses for paragraph spacing. Returns undefined for units we
+ * cannot resolve without a rendering context (e.g. `em`, `%`).
+ */
+function cssLengthToTwips(value: string): number | undefined {
+  const trimmed = value.trim();
+
+  // 1px = 1/96in and 1 twip = 1/1440in, so 1px = 15 twips. 1pt = 20 twips.
+  let twipsPerUnit = 20;
+  let numeric = trimmed;
+  if (trimmed.endsWith('px')) {
+    twipsPerUnit = 15;
+    numeric = trimmed.slice(0, -2);
+  } else if (trimmed.endsWith('pt')) {
+    numeric = trimmed.slice(0, -2);
+  }
+
+  const amount = toFiniteNumber(numeric);
+  return amount === undefined ? undefined : Math.round(amount * twipsPerUnit);
+}
+
+/** Maps a CSS `line-height` to `docx` line-spacing properties. */
+function parseLineHeight(
+  value: string,
+): Partial<ISpacingProperties> | undefined {
+  const trimmed = value.trim();
+
+  if (trimmed.endsWith('pt')) {
+    const pt = toFiniteNumber(trimmed.slice(0, -2));
+    return pt === undefined
+      ? undefined
+      : { line: Math.round(pt * 20), lineRule: LineRuleType.EXACT };
+  }
+
+  // A unitless multiplier maps to auto line spacing measured in 240ths of a
+  // line (240 = single, 360 = 1.5, 480 = double).
+  const multiplier = toFiniteNumber(trimmed);
+  return multiplier === undefined
+    ? undefined
+    : { line: Math.round(multiplier * 240), lineRule: LineRuleType.AUTO };
+}
+
+/**
+ * Extracts paragraph spacing (`margin-top`/`margin-bottom`/`line-height`) from
+ * an element's inline style. Without this, Word falls back to the defaults from
+ * the Normal style (8pt after, 1.5 line spacing), ignoring the HTML styling.
+ */
+export function parseSpacing(
+  node: HTMLElement,
+): ISpacingProperties | undefined {
+  const style = node.getAttribute('style') ?? '';
+  if (!style) return undefined;
+
+  const declarations = parseStyleDeclarations(style);
+  let spacing: ISpacingProperties = {};
+
+  const marginTop = declarations.get('margin-top');
+  if (marginTop !== undefined) {
+    const before = cssLengthToTwips(marginTop);
+    if (before !== undefined) spacing = { ...spacing, before };
+  }
+
+  const marginBottom = declarations.get('margin-bottom');
+  if (marginBottom !== undefined) {
+    const after = cssLengthToTwips(marginBottom);
+    if (after !== undefined) spacing = { ...spacing, after };
+  }
+
+  const lineHeight = declarations.get('line-height');
+  if (lineHeight !== undefined) {
+    const line = parseLineHeight(lineHeight);
+    if (line) spacing = { ...spacing, ...line };
+  }
+
+  return Object.keys(spacing).length > 0 ? spacing : undefined;
+}

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/paragraph-style-parser.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/paragraph-style-parser.ts
@@ -71,11 +71,12 @@ function parseLineHeight(
 ): Partial<ISpacingProperties> | undefined {
   const trimmed = value.trim();
 
-  if (trimmed.endsWith('pt')) {
-    const pt = toFiniteNumber(trimmed.slice(0, -2));
-    return pt === undefined
+  // An absolute unit (`pt`/`px`) maps to a fixed (exact) line height.
+  if (trimmed.endsWith('pt') || trimmed.endsWith('px')) {
+    const twips = cssLengthToTwips(trimmed);
+    return twips === undefined
       ? undefined
-      : { line: Math.round(pt * 20), lineRule: LineRuleType.EXACT };
+      : { line: twips, lineRule: LineRuleType.EXACT };
   }
 
   // A unitless multiplier maps to auto line spacing measured in 240ths of a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a document is exported to Word (DOCX), part of the inline paragraph styling was lost. Two things combined to cause it:

1. **The export sanitizer stripped the styles.** `exportToDocx` runs `sanitizeHtmlContent` first, and `allowedStyles` only whitelisted `text-align`, `background-color`, and `color` — so `line-height`, `margin-top`, and `margin-bottom` were removed before conversion.
2. **The converter never parsed them.** Even when present, the HTML→DOCX converter only read `text-align`, so spacing fell back to the `Normal` style defaults (`1.5` line spacing, `8pt` after).

`text-align: justify` and `margin-top: 0pt` appeared correct only because `text-align` is whitelisted and `margin-top: 0` coincidentally matches the default `before: 0`.

Fixes [AYC-689](https://linear.app/ayunis/issue/AYC-689).

## Fix

- **Sanitizer** (`sanitize-html-content.ts`): whitelist `line-height`, `margin-top`, `margin-bottom` in `allowedStyles`, restricted to unitless / `pt` / `px` numbers.
- **Converter** (`html-to-docx-converter.ts` + new `paragraph-style-parser.ts`): parse `margin-top` → `spacing.before`, `margin-bottom` → `spacing.after` (CSS length → twips), and `line-height` → `line`/`lineRule` (unitless multiplier → `auto`, e.g. `1` = single / `1.5`; a `pt` value → `exact`). Spacing (and alignment where missing) is applied to paragraphs, headings, list items, blockquotes, and table cells.
- Unsupported units (`em`, `%`) are ignored so existing defaults still apply.

## Notes

- Style parsing extracted into `paragraph-style-parser.ts` to keep the converter under the 500-line file-size limit; `buildInlineContext` refactored to a lookup map to stay under the complexity gate.
- `SUMMARY.md` updated with the new module.

## Testing

- End-to-end `exportToDocx` test asserts spacing survives sanitization and lands in `document.xml` (`w:line="240"`/`auto`, `w:after="0"`, `w:before="0"`, justified).
- Converter unit tests for single/1.5 spacing, margin→before/after twips, `px` conversion, and spacing on headings/list items/table cells.
- Sanitizer tests for supported and unsupported (`em`/`rem`) units.
- All artifacts export/sanitizer tests pass (72); lint, typecheck, and complexity gate clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-689](https://linear.app/ayunis/issue/AYC-689/word-export-does-not-fully-preserve-paragraph-formatting)

<div><a href="https://cursor.com/agents/bc-b7420f02-75c9-41da-9424-ff55917a692b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7420f02-75c9-41da-9424-ff55917a692b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

