### PR TITLE
fix(admin): make removing a user credit limit discoverable in the dialog (AYC-482)

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/api/useUserCreditLimits.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/api/useUserCreditLimits.ts
@@ -17,7 +17,10 @@ export interface CreditLimitInfo {
   creditsUsed: number;
 }
 
-export function useUserCreditLimits(onSetSuccess?: () => void) {
+export function useUserCreditLimits(
+  onSetSuccess?: () => void,
+  onRemoveSuccess?: () => void,
+) {
   const queryClient = useQueryClient();
   const router = useRouter();
   const hasCreditBudget = useHasCreditBudget();
@@ -71,7 +74,10 @@ export function useUserCreditLimits(onSetSuccess?: () => void) {
 
   const removeMutation = useCreditLimitsControllerRemoveUserLimit({
     mutation: {
-      onSuccess: () => showSuccess(t('creditLimits.remove.success')),
+      onSuccess: () => {
+        showSuccess(t('creditLimits.remove.success'));
+        onRemoveSuccess?.();
+      },
       onError: (error) => {
         try {
           const { code } = extractErrorData(error);

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/SetUserCreditLimitDialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/SetUserCreditLimitDialog.tsx
@@ -18,8 +18,10 @@ interface SetUserCreditLimitDialogProps {
   targetName: string;
   initialMonthlyCredits?: number;
   isSaving: boolean;
+  isRemoving?: boolean;
   onOpenChange: (open: boolean) => void;
   onSubmit: (monthlyCredits: number) => void;
+  onRemove?: () => void;
 }
 
 interface FormValues {
@@ -32,9 +34,12 @@ export function SetUserCreditLimitDialog({
   targetName,
   initialMonthlyCredits,
   onSubmit,
+  onRemove,
   isSaving,
+  isRemoving,
 }: Readonly<SetUserCreditLimitDialogProps>) {
   const { t } = useTranslation('admin-settings-credit-limits');
+  const hasExistingLimit = initialMonthlyCredits !== undefined;
 
   const {
     register,
@@ -95,19 +100,38 @@ export function SetUserCreditLimitDialog({
                 {errors.monthlyCredits.message}
               </p>
             )}
+            {hasExistingLimit && onRemove && (
+              <p className="text-muted-foreground text-xs">
+                {t('creditLimits.dialog.removeHint')}
+              </p>
+            )}
           </div>
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-            >
-              {t('creditLimits.dialog.cancel')}
-            </Button>
-            <Button type="submit" disabled={isSaving}>
-              {t('creditLimits.dialog.save')}
-            </Button>
+          <DialogFooter className="sm:justify-between">
+            {hasExistingLimit && onRemove ? (
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={onRemove}
+                disabled={isSaving || isRemoving}
+              >
+                {t('creditLimits.dialog.removeLimit')}
+              </Button>
+            ) : (
+              <span className="hidden sm:block" />
+            )}
+            <div className="flex flex-col-reverse gap-2 sm:flex-row">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                {t('creditLimits.dialog.cancel')}
+              </Button>
+              <Button type="submit" disabled={isSaving || isRemoving}>
+                {t('creditLimits.dialog.save')}
+              </Button>
+            </div>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/SetUserCreditLimitDialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/SetUserCreditLimitDialog.tsx
@@ -40,6 +40,14 @@ export function SetUserCreditLimitDialog({
 }: Readonly<SetUserCreditLimitDialogProps>) {
   const { t } = useTranslation('admin-settings-credit-limits');
   const hasExistingLimit = initialMonthlyCredits !== undefined;
+  const isBusy = isSaving || isRemoving;
+
+  function handleOpenChange(next: boolean) {
+    if (!next && isBusy) {
+      return;
+    }
+    onOpenChange(next);
+  }
 
   const {
     register,
@@ -64,7 +72,7 @@ export function SetUserCreditLimitDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[425px]">
         <form onSubmit={(e) => void handleSubmit(submit)(e)}>
           <DialogHeader>
@@ -107,31 +115,29 @@ export function SetUserCreditLimitDialog({
             )}
           </div>
 
-          <DialogFooter className="sm:justify-between">
-            {hasExistingLimit && onRemove ? (
+          <DialogFooter>
+            {hasExistingLimit && onRemove && (
               <Button
                 type="button"
                 variant="destructive"
+                className="sm:mr-auto"
                 onClick={onRemove}
-                disabled={isSaving || isRemoving}
+                disabled={isBusy}
               >
                 {t('creditLimits.dialog.removeLimit')}
               </Button>
-            ) : (
-              <span className="hidden sm:block" />
             )}
-            <div className="flex flex-col-reverse gap-2 sm:flex-row">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => onOpenChange(false)}
-              >
-                {t('creditLimits.dialog.cancel')}
-              </Button>
-              <Button type="submit" disabled={isSaving || isRemoving}>
-                {t('creditLimits.dialog.save')}
-              </Button>
-            </div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isBusy}
+            >
+              {t('creditLimits.dialog.cancel')}
+            </Button>
+            <Button type="submit" disabled={isBusy}>
+              {t('creditLimits.dialog.save')}
+            </Button>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/UsersSection.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/users-settings/ui/UsersSection.tsx
@@ -75,8 +75,11 @@ export default function UsersSection({
   const [creditLimitUser, setCreditLimitUser] = useState<User | null>(null);
   const hasCreditBudget = useHasCreditBudget();
   const { user: currentUser } = useMe();
-  const { userLimits, setUserLimit, removeUserLimit, isSaving } =
-    useUserCreditLimits(() => setCreditLimitUser(null));
+  const { userLimits, setUserLimit, removeUserLimit, isSaving, isRemoving } =
+    useUserCreditLimits(
+      () => setCreditLimitUser(null),
+      () => setCreditLimitUser(null),
+    );
 
   const renderCreditLimit = (limit: CreditLimitInfo | undefined) =>
     limit ? (
@@ -339,7 +342,13 @@ export default function UsersSection({
           onSubmit={(monthlyCredits) =>
             setUserLimit(creditLimitUser.id, monthlyCredits)
           }
+          onRemove={
+            userLimits.has(creditLimitUser.id)
+              ? () => removeUserLimit(creditLimitUser.id)
+              : undefined
+          }
           isSaving={isSaving}
+          isRemoving={isRemoving}
         />
       )}
     </Card>

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-credit-limits.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-credit-limits.json
@@ -34,6 +34,8 @@
       "creditsRequired": "Bitte einen Credit-Betrag eingeben",
       "creditsMin": "Muss 0 oder größer sein",
       "creditsHint": "Credits pro Kalendermonat. 0 sperrt das Ziel vollständig.",
+      "removeHint": "Wenn Sie das Limit entfernen, kann dieser Nutzer ohne individuelle Obergrenze innerhalb des Organisationsbudgets abrechnen.",
+      "removeLimit": "Limit entfernen",
       "cancel": "Abbrechen",
       "save": "Speichern"
     }

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-credit-limits.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-credit-limits.json
@@ -34,6 +34,8 @@
       "creditsRequired": "Please enter a credit amount",
       "creditsMin": "Must be 0 or greater",
       "creditsHint": "Credits per calendar month. 0 freezes the target entirely.",
+      "removeHint": "Removing the limit lets this user spend within the organization budget without an individual cap.",
+      "removeLimit": "Remove limit",
       "cancel": "Cancel",
       "save": "Save"
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

[AYC-482](https://linear.app/issue/AYC-482) — When editing an existing user credit limit, there was no way to clear it from the dialog. The dialog text says you can "remove the limit to make it unlimited", but leaving the field empty just triggered a validation error. The only working removal action lived in the user row's `⋯` menu (**Remove credit limit**), which customers did not find.

## Change

Made removal discoverable directly in the edit dialog:

- Added a destructive **Remove limit** button in `SetUserCreditLimitDialog`, shown only when the user already has a limit set.
- Added a short hint explaining what removing the limit does (spend within the org budget without an individual cap).
- The dialog now closes automatically after a successful removal (`useUserCreditLimits` gained an `onRemoveSuccess` callback; `isRemoving` disables the buttons while in flight).
- Added `removeLimit` / `removeHint` i18n strings for English and German.

The existing row-menu **Remove credit limit** action is unchanged and still works; this only adds a second, more obvious entry point. Team credit limits already had an equivalent in-card remove button, so this brings the user flow in line with it.

## Scope

Frontend only. No backend/API changes — reuses the existing `removeUserLimit` mutation.

## Validation

- `pnpm run lint` — passes (no new errors)
- `pnpm run build` — succeeds
- Pre-commit hooks (prettier, eslint, typecheck, dependency/duplication/file-size checks) — all pass

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-482](https://linear.app/ayunis/issue/AYC-482/removing-user-credit-limits-is-not-discoverable)

<div><a href="https://cursor.com/agents/bc-968ab3ca-faca-4704-8e7b-42e8feaa7329?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-968ab3ca-faca-4704-8e7b-42e8feaa7329&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

