### PR TITLE
refactor(usage): decouple repository from query use cases (AYC-334)

### DIFF
--- a/ayunis-core-backend/.dependency-cruiser-known-violations.json
+++ b/ayunis-core-backend/.dependency-cruiser-known-violations.json
@@ -160,41 +160,5 @@
       "severity": "error",
       "name": "no-cross-module-port-imports"
     }
-  },
-  {
-    "type": "dependency",
-    "from": "src/domain/usage/infrastructure/persistence/local-usage/local-usage.repository.ts",
-    "to": "src/domain/usage/application/use-cases/get-model-distribution/get-model-distribution.query.ts",
-    "rule": {
-      "severity": "error",
-      "name": "adapters-no-use-cases"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/domain/usage/infrastructure/persistence/local-usage/local-usage.repository.ts",
-    "to": "src/domain/usage/application/use-cases/get-provider-usage/get-provider-usage.query.ts",
-    "rule": {
-      "severity": "error",
-      "name": "adapters-no-use-cases"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/domain/usage/infrastructure/persistence/local-usage/local-usage.repository.ts",
-    "to": "src/domain/usage/application/use-cases/get-usage-stats/get-usage-stats.query.ts",
-    "rule": {
-      "severity": "error",
-      "name": "adapters-no-use-cases"
-    }
-  },
-  {
-    "type": "dependency",
-    "from": "src/domain/usage/infrastructure/persistence/local-usage/local-usage.repository.ts",
-    "to": "src/domain/usage/application/use-cases/get-user-usage/get-user-usage.query.ts",
-    "rule": {
-      "severity": "error",
-      "name": "adapters-no-use-cases"
-    }
   }
 ]

--- a/ayunis-core-backend/src/domain/usage/application/ports/usage.repository.ts
+++ b/ayunis-core-backend/src/domain/usage/application/ports/usage.repository.ts
@@ -1,9 +1,6 @@
 import type { UUID } from 'crypto';
 import type { Usage } from '../../domain/usage.entity';
-import type { GetUserUsageQuery } from '../use-cases/get-user-usage/get-user-usage.query';
-import type { GetProviderUsageQuery } from '../use-cases/get-provider-usage/get-provider-usage.query';
-import type { GetModelDistributionQuery } from '../use-cases/get-model-distribution/get-model-distribution.query';
-import type { GetUsageStatsQuery } from '../use-cases/get-usage-stats/get-usage-stats.query';
+import type { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
 import type { Paginated } from 'src/common/pagination';
 import { UsageStats } from '../../domain/usage-stats.entity';
 import { ProviderUsage } from '../../domain/provider-usage.entity';
@@ -17,6 +14,33 @@ export {
   ModelDistribution,
   UserUsageItem,
 };
+
+interface UsageDateRangeParams {
+  organizationId: UUID;
+  startDate?: Date;
+  endDate?: Date;
+}
+
+export interface ProviderUsageParams extends UsageDateRangeParams {
+  includeTimeSeriesData: boolean;
+  provider?: ModelProvider;
+  modelId?: UUID;
+}
+
+export interface ModelDistributionParams extends UsageDateRangeParams {
+  maxModels: number;
+  modelId?: UUID;
+}
+
+export interface UserUsageParams extends UsageDateRangeParams {
+  limit: number;
+  offset: number;
+  searchTerm?: string;
+  sortBy: 'credits' | 'requests' | 'lastActivity' | 'userName';
+  sortOrder: 'asc' | 'desc';
+}
+
+export type UsageStatsParams = UsageDateRangeParams;
 
 export interface UserUsageResult {
   users: Paginated<UserUsageItem>;
@@ -42,13 +66,13 @@ export abstract class UsageRepository {
     endDate?: Date,
   ): Promise<Usage[]>;
   abstract getProviderUsage(
-    query: GetProviderUsageQuery,
+    params: ProviderUsageParams,
   ): Promise<ProviderUsage[]>;
   abstract getModelDistribution(
-    query: GetModelDistributionQuery,
+    params: ModelDistributionParams,
   ): Promise<ModelDistribution[]>;
-  abstract getUserUsage(query: GetUserUsageQuery): Promise<UserUsageResult>;
-  abstract getUsageStats(query: GetUsageStatsQuery): Promise<UsageStats>;
+  abstract getUserUsage(params: UserUsageParams): Promise<UserUsageResult>;
+  abstract getUsageStats(params: UsageStatsParams): Promise<UsageStats>;
   abstract getUsageCount(
     organizationId: UUID,
     startDate?: Date,

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/local-usage.repository.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/local-usage.repository.ts
@@ -7,12 +7,12 @@ import {
   UsageRepository,
   ProviderUsage,
   ModelDistribution,
+  type ProviderUsageParams,
+  type ModelDistributionParams,
+  type UserUsageParams,
+  type UsageStatsParams,
   type UserUsageResult,
 } from 'src/domain/usage/application/ports/usage.repository';
-import { GetProviderUsageQuery } from 'src/domain/usage/application/use-cases/get-provider-usage/get-provider-usage.query';
-import { GetModelDistributionQuery } from 'src/domain/usage/application/use-cases/get-model-distribution/get-model-distribution.query';
-import { GetUserUsageQuery } from 'src/domain/usage/application/use-cases/get-user-usage/get-user-usage.query';
-import { GetUsageStatsQuery } from 'src/domain/usage/application/use-cases/get-usage-stats/get-usage-stats.query';
 import { Paginated } from 'src/common/pagination';
 import { UsageStats } from 'src/domain/usage/domain/usage-stats.entity';
 import { UserUsageItem } from 'src/domain/usage/domain/user-usage-item.entity';
@@ -101,9 +101,7 @@ export class LocalUsageRepository extends UsageRepository {
     return this.usageMapper.toDomainArray(records);
   }
 
-  async getProviderUsage(
-    query: GetProviderUsageQuery,
-  ): Promise<ProviderUsage[]> {
+  async getProviderUsage(query: ProviderUsageParams): Promise<ProviderUsage[]> {
     // Get aggregated provider usage
     const providerStats = await getProviderStats({
       usageRepository: this.usageRepository,
@@ -141,7 +139,7 @@ export class LocalUsageRepository extends UsageRepository {
   }
 
   async getModelDistribution(
-    query: GetModelDistributionQuery,
+    query: ModelDistributionParams,
   ): Promise<ModelDistribution[]> {
     const modelStats = await getModelStats(
       this.usageRepository,
@@ -154,7 +152,7 @@ export class LocalUsageRepository extends UsageRepository {
     return this.usageQueryMapper.mapModelStatsToDistribution(modelStats).items;
   }
 
-  async getUserUsage(query: GetUserUsageQuery): Promise<UserUsageResult> {
+  async getUserUsage(query: UserUsageParams): Promise<UserUsageResult> {
     // Determine sort field and order
     const sortField = this.mapSortFieldForUsers(query.sortBy);
     const sortOrder = query.sortOrder.toUpperCase() as 'ASC' | 'DESC';
@@ -225,7 +223,7 @@ export class LocalUsageRepository extends UsageRepository {
     });
   }
 
-  async getUsageStats(query: GetUsageStatsQuery): Promise<UsageStats> {
+  async getUsageStats(query: UsageStatsParams): Promise<UsageStats> {
     const stats = (await getUsageAggregateStats(
       this.usageRepository,
       query.organizationId,


### PR DESCRIPTION
## Summary

- define usage analytics repository parameter contracts at the application port boundary
- keep use-case query objects in the application layer while removing them from the persistence adapter
- remove the four resolved `adapters-no-use-cases` baseline entries

## Validation

- `pnpm exec eslint src/domain/usage/application/ports/usage.repository.ts src/domain/usage/infrastructure/persistence/local-usage/local-usage.repository.ts`
- `pnpm exec tsc --noEmit`
- `pnpm test` (589 suites, 4220 tests)
- `pnpm run deps:check` (15 unrelated known violations remain; down from 19)
- `pnpm run deps:check:strict` confirms no usage `adapters-no-use-cases` violations

Linear Issue: [AYC-334](https://linear.app/ayunis/issue/AYC-334/fix-dependency-inversion-usage-repository-imports-query-use-cases)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of repository contracts and imports with no intended behavior change; use cases can still pass structurally identical query objects.
> 
> **Overview**
> **Decouples usage persistence from application query types** so infrastructure no longer imports use-case query classes, fixing `adapters-no-use-cases` dependency-cruiser violations.
> 
> `UsageRepository` analytics methods now take port-level parameter types (`ProviderUsageParams`, `ModelDistributionParams`, `UserUsageParams`, `UsageStatsParams`) defined beside the repository interface, instead of `Get*Query` objects from individual use-case folders. `LocalUsageRepository` is updated to import those param types only.
> 
> The known-violations allowlist drops the four entries for `local-usage.repository.ts` importing usage query modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee81801f877a9954664de330da714b51fda0c9e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->