### PR TITLE
fix(models): resolve defaults to effective team permits (AYC-531)

### DIFF
--- a/ayunis-core-backend/src/domain/models/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/models/SUMMARY.md
@@ -40,7 +40,7 @@ The models module is the central registry for AI model configuration. The abstra
 - **GetPermittedModelsUseCase** (`application/use-cases/get-permitted-models`): Retrieves all permitted models for an org.
 - **GetPermittedModelUseCase** (`application/use-cases/get-permitted-model`): Retrieves a single permitted model by ID.
 - **GetPermittedLanguageModelsUseCase** (`application/use-cases/get-permitted-language-models`): Retrieves permitted language models for an org.
-- **GetPermittedLanguageModelUseCase** (`application/use-cases/get-permitted-language-model`): Retrieves the single permitted language model by model ID.
+- **GetPermittedLanguageModelUseCase** (`application/use-cases/get-permitted-language-model`): Retrieves a language-model permit by ID only when it belongs to the current user's effective org/team model set.
 - **GetPermittedEmbeddingModelUseCase** (`application/use-cases/get-permitted-embedding-model`): Retrieves the single permitted embedding model for an org.
 - **GetPermittedImageGenerationModelUseCase** (`application/use-cases/get-permitted-image-generation-model`): Resolves the image-generation model effectively available to the current user. Image generation is team-restrictable: when the user belongs to one or more teams with model overrides enabled, image generation is only available if the org's image-generation model has been assigned to one of those override teams; users in no override team fall back to the org-level permitted model (mirrors `GetEffectiveLanguageModelsUseCase`).
 - **GetConfiguredModelsByTypeUseCase** (`application/use-cases/get-configured-models-by-type`): Retrieves all catalog models of a given type, used for populating model selection dropdowns.
@@ -58,7 +58,7 @@ The models module is the central registry for AI model configuration. The abstra
 - **SetUserDefaultLanguageModelUseCase** (`application/use-cases/set-user-default-language-model`): Sets a user's default language model.
 - **GetOrgDefaultModelUseCase** (`application/use-cases/get-org-default-model`): Retrieves the org-level default model.
 - **GetUserDefaultModelUseCase** (`application/use-cases/get-user-default-model`): Retrieves a user's default model.
-- **GetDefaultModelUseCase** (`application/use-cases/get-default-model`): Resolves the effective default model for a user (user → org → system fallback).
+- **GetDefaultModelUseCase** (`application/use-cases/get-default-model`): Resolves the effective default model for a user (user → team → org → alphabetical fallback) and returns the permit record from the user's current effective org/team model set.
 - **DeleteUserDefaultModelUseCase** (`application/use-cases/delete-user-default-model`): Removes a user's default model preference.
 - **DeleteUserDefaultModelsByModelIdUseCase** (`application/use-cases/delete-user-default-models-by-model-id`): Removes all user defaults referencing a specific model.
 - **ClearDefaultsByCatalogModelIdUseCase** (`application/use-cases/clear-defaults-by-catalog-model-id`): Clears all default references for a catalog model being deleted.

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.spec.ts
@@ -92,6 +92,7 @@ describe('GetDefaultModelUseCase', () => {
     // Default: no user default
     userDefaultModelsRepository.findByUserId.mockResolvedValue(null);
     permittedModelsRepository.findOrgDefaultLanguage.mockResolvedValue(null);
+    permittedModelsRepository.findTeamDefaultLanguage.mockResolvedValue(null);
   });
 
   it('should return user default when it is in the effective set', async () => {
@@ -110,6 +111,30 @@ describe('GetDefaultModelUseCase', () => {
     );
 
     expect(result).toBe(userDefault);
+  });
+
+  it('should return the effective team permit for a matching user default', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const userDefault = makePermittedLanguageModel(gpt4, {
+      id: '33333333-3333-3333-3333-333333333333',
+    });
+    const effectiveTeamModel = makePermittedLanguageModel(gpt4, {
+      id: '44444444-4444-4444-4444-444444444444',
+      scope: PermittedModelScope.TEAM,
+      scopeId: teamAId,
+    });
+
+    getEffectiveLanguageModelsUseCase.execute.mockResolvedValue({
+      models: [effectiveTeamModel],
+      overrideTeamIds: [teamAId],
+    });
+    userDefaultModelsRepository.findByUserId.mockResolvedValue(userDefault);
+
+    const result = await useCase.execute(
+      new GetDefaultModelQuery({ orgId, userId }),
+    );
+
+    expect(result).toBe(effectiveTeamModel);
   });
 
   it('should skip user default when it is NOT in the effective set', async () => {
@@ -228,6 +253,33 @@ describe('GetDefaultModelUseCase', () => {
     );
 
     expect(result).toBe(orgDefault);
+  });
+
+  it('should return the effective team permit for a matching org default', async () => {
+    const gpt4 = makeLanguageModel('gpt-4');
+    const orgDefault = makePermittedLanguageModel(gpt4, {
+      id: '55555555-5555-5555-5555-555555555555',
+      isDefault: true,
+    });
+    const effectiveTeamModel = makePermittedLanguageModel(gpt4, {
+      id: '66666666-6666-6666-6666-666666666666',
+      scope: PermittedModelScope.TEAM,
+      scopeId: teamAId,
+    });
+
+    getEffectiveLanguageModelsUseCase.execute.mockResolvedValue({
+      models: [effectiveTeamModel],
+      overrideTeamIds: [teamAId],
+    });
+    permittedModelsRepository.findOrgDefaultLanguage.mockResolvedValue(
+      orgDefault,
+    );
+
+    const result = await useCase.execute(
+      new GetDefaultModelQuery({ orgId, userId }),
+    );
+
+    expect(result).toBe(effectiveTeamModel);
   });
 
   it('should skip org default when NOT in effective set', async () => {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.ts
@@ -1,12 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common';
 import type { UUID } from 'crypto';
-import { GetDefaultModelQuery } from './get-default-model.query';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
+import {
+  DefaultModelNotFoundError,
+  UnexpectedModelError,
+} from '../../models.errors';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
-import { GetEffectiveLanguageModelsUseCase } from '../get-effective-language-models/get-effective-language-models.use-case';
 import { GetEffectiveLanguageModelsQuery } from '../get-effective-language-models/get-effective-language-models.query';
-import { DefaultModelNotFoundError, ModelError } from '../../models.errors';
+import { GetEffectiveLanguageModelsUseCase } from '../get-effective-language-models/get-effective-language-models.use-case';
+import { GetDefaultModelQuery } from './get-default-model.query';
 
 @Injectable()
 export class GetDefaultModelUseCase {
@@ -18,114 +22,97 @@ export class GetDefaultModelUseCase {
     private readonly getEffectiveLanguageModelsUseCase: GetEffectiveLanguageModelsUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(query: GetDefaultModelQuery): Promise<PermittedLanguageModel> {
     this.logger.log('execute', { query });
-
-    try {
-      const { models: effectiveModels, overrideTeamIds } =
-        await this.getEffectiveLanguageModelsUseCase.execute(
-          new GetEffectiveLanguageModelsQuery(query.orgId, query.userId),
-        );
-
-      const effectiveModelIds = new Set(effectiveModels.map((m) => m.model.id));
-
-      const isInEffectiveSet = (model: PermittedLanguageModel): boolean =>
-        effectiveModelIds.has(model.model.id) &&
-        !query.blacklistedModelIds?.includes(model.model.id);
-
-      // Step 1: User default
-      if (query.userId) {
-        const userDefault = await this.userDefaultModelsRepository.findByUserId(
-          query.userId,
-        );
-
-        if (userDefault && isInEffectiveSet(userDefault)) {
-          this.logger.debug('Using user default model', {
-            userId: query.userId,
-            modelId: userDefault.id,
-          });
-          return userDefault;
-        }
-      }
-
-      // Step 2: Team defaults (from override teams)
-      if (query.userId && overrideTeamIds.length > 0) {
-        const teamDefault = await this.resolveTeamDefault(
-          overrideTeamIds,
-          query.orgId,
-          effectiveModelIds,
-          query.blacklistedModelIds,
-        );
-        if (teamDefault) {
-          this.logger.debug('Using team default model', {
-            modelId: teamDefault.id,
-          });
-          return teamDefault;
-        }
-      }
-
-      // Step 3: Org default
-      const orgDefault =
-        await this.permittedModelsRepository.findOrgDefaultLanguage(
-          query.orgId,
-        );
-      if (orgDefault && isInEffectiveSet(orgDefault)) {
-        this.logger.debug('Using org default model', {
-          orgId: query.orgId,
-          modelId: orgDefault.id,
-        });
-        return orgDefault;
-      }
-
-      // Step 4: First available from effective set, alphabetically
-      const sorted = [...effectiveModels].sort((a, b) =>
-        a.model.name.localeCompare(b.model.name),
+    const { models, overrideTeamIds } =
+      await this.getEffectiveLanguageModelsUseCase.execute(
+        new GetEffectiveLanguageModelsQuery(query.orgId, query.userId),
       );
+    const effectiveModels = this.indexEffectiveModels(
+      models,
+      query.blacklistedModelIds,
+    );
 
-      for (const model of sorted) {
-        if (!query.blacklistedModelIds?.includes(model.model.id)) {
-          this.logger.debug('Using first available model alphabetically', {
-            modelId: model.id,
-          });
-          return model;
-        }
-      }
+    const userDefault = await this.resolveUserDefault(
+      query.userId,
+      effectiveModels,
+    );
+    if (userDefault) return userDefault;
 
+    const teamDefault = await this.resolveTeamDefault(
+      overrideTeamIds,
+      query.orgId,
+      effectiveModels,
+    );
+    if (teamDefault) return teamDefault;
+
+    const orgDefault = await this.resolveOrgDefault(
+      query.orgId,
+      effectiveModels,
+    );
+    if (orgDefault) return orgDefault;
+
+    if (effectiveModels.size === 0) {
       throw new DefaultModelNotFoundError(query.orgId);
-    } catch (error) {
-      if (error instanceof ModelError) {
-        throw error;
-      }
-      this.logger.error('Failed to get default model', {
-        orgId: query.orgId,
-        userId: query.userId,
-        error: error instanceof Error ? error : new Error('Unknown error'),
-      });
-      throw error;
     }
+    return [...effectiveModels.values()].sort((a, b) =>
+      a.model.name.localeCompare(b.model.name),
+    )[0];
+  }
+
+  private indexEffectiveModels(
+    models: PermittedLanguageModel[],
+    blacklistedModelIds?: UUID[],
+  ): Map<UUID, PermittedLanguageModel> {
+    return new Map(
+      models
+        .filter((model) => !blacklistedModelIds?.includes(model.model.id))
+        .map((model) => [model.model.id, model]),
+    );
+  }
+
+  private async resolveUserDefault(
+    userId: UUID | undefined,
+    effectiveModels: Map<UUID, PermittedLanguageModel>,
+  ): Promise<PermittedLanguageModel | null> {
+    if (!userId) return null;
+    const userDefault =
+      await this.userDefaultModelsRepository.findByUserId(userId);
+    return this.toEffectiveModel(userDefault, effectiveModels);
   }
 
   private async resolveTeamDefault(
-    overrideTeamIds: UUID[],
+    teamIds: UUID[],
     orgId: UUID,
-    effectiveModelIds: Set<UUID>,
-    blacklistedModelIds?: UUID[],
+    effectiveModels: Map<UUID, PermittedLanguageModel>,
   ): Promise<PermittedLanguageModel | null> {
-    const teamDefaults = await Promise.all(
-      overrideTeamIds.map((teamId) =>
+    const defaults = await Promise.all(
+      teamIds.map((teamId) =>
         this.permittedModelsRepository.findTeamDefaultLanguage(teamId, orgId),
       ),
     );
-
-    const validDefaults = teamDefaults
-      .filter(
-        (model): model is PermittedLanguageModel =>
-          model !== null &&
-          effectiveModelIds.has(model.model.id) &&
-          !blacklistedModelIds?.includes(model.model.id),
-      )
+    const effectiveDefaults = defaults
+      .map((model) => this.toEffectiveModel(model, effectiveModels))
+      .filter((model): model is PermittedLanguageModel => model !== null)
       .sort((a, b) => a.model.name.localeCompare(b.model.name));
+    return effectiveDefaults[0] ?? null;
+  }
 
-    return validDefaults[0] ?? null;
+  private async resolveOrgDefault(
+    orgId: UUID,
+    effectiveModels: Map<UUID, PermittedLanguageModel>,
+  ): Promise<PermittedLanguageModel | null> {
+    const orgDefault =
+      await this.permittedModelsRepository.findOrgDefaultLanguage(orgId);
+    return this.toEffectiveModel(orgDefault, effectiveModels);
+  }
+
+  private toEffectiveModel(
+    preferredModel: PermittedLanguageModel | null,
+    effectiveModels: Map<UUID, PermittedLanguageModel>,
+  ): PermittedLanguageModel | null {
+    if (!preferredModel) return null;
+    return effectiveModels.get(preferredModel.model.id) ?? null;
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-model/get-permitted-language-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-model/get-permitted-language-model.use-case.spec.ts
@@ -12,11 +12,14 @@ import { ModelProvider } from 'src/domain/models/domain/value-objects/model-prov
 import { PermittedModelScope } from 'src/domain/models/domain/value-objects/permitted-model-scope.enum';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { GetEffectiveLanguageModelsUseCase } from '../get-effective-language-models/get-effective-language-models.use-case';
 
 describe('GetPermittedLanguageModelUseCase', () => {
   let useCase: GetPermittedLanguageModelUseCase;
   let permittedModelsRepository: jest.Mocked<PermittedModelsRepository>;
+  let getEffectiveLanguageModelsUseCase: jest.Mocked<GetEffectiveLanguageModelsUseCase>;
 
+  const mockUserId = '123e4567-e89b-12d3-a456-426614174010' as UUID;
   const mockOrgId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
   const otherOrgId = '123e4567-e89b-12d3-a456-426614174099' as UUID;
   const mockPermittedModelId = '123e4567-e89b-12d3-a456-426614174002' as UUID;
@@ -54,9 +57,16 @@ describe('GetPermittedLanguageModelUseCase', () => {
           },
         },
         {
+          provide: GetEffectiveLanguageModelsUseCase,
+          useValue: {
+            execute: jest.fn(),
+          },
+        },
+        {
           provide: ContextService,
           useValue: {
             get: jest.fn((key: string) => {
+              if (key === 'userId') return mockUserId;
               if (key === 'orgId') return mockOrgId;
               if (key === 'systemRole') return null;
               return null;
@@ -68,6 +78,9 @@ describe('GetPermittedLanguageModelUseCase', () => {
 
     useCase = module.get(GetPermittedLanguageModelUseCase);
     permittedModelsRepository = module.get(PermittedModelsRepository);
+    getEffectiveLanguageModelsUseCase = module.get(
+      GetEffectiveLanguageModelsUseCase,
+    );
 
     jest.spyOn(Logger.prototype, 'log').mockImplementation();
     jest.spyOn(Logger.prototype, 'error').mockImplementation();
@@ -80,6 +93,10 @@ describe('GetPermittedLanguageModelUseCase', () => {
   it('should return the model when it belongs to the caller org', async () => {
     const model = permittedModelForOrg(mockOrgId);
     permittedModelsRepository.findOneLanguage.mockResolvedValue(model);
+    getEffectiveLanguageModelsUseCase.execute.mockResolvedValue({
+      models: [model],
+      overrideTeamIds: [],
+    });
 
     await expect(
       useCase.execute(
@@ -96,6 +113,29 @@ describe('GetPermittedLanguageModelUseCase', () => {
         new GetPermittedLanguageModelQuery({ id: mockPermittedModelId }),
       ),
     ).rejects.toBeInstanceOf(ModelNotFoundByIdError);
+  });
+
+  it('should reject an org model excluded by team overrides', async () => {
+    const orgModel = permittedModelForOrg(mockOrgId);
+    const teamId = '123e4567-e89b-12d3-a456-426614174021';
+    const effectiveTeamModel = new PermittedLanguageModel({
+      id: '123e4567-e89b-12d3-a456-426614174020',
+      model: mockLanguageModel,
+      orgId: mockOrgId,
+      scope: PermittedModelScope.TEAM,
+      scopeId: teamId,
+    });
+    permittedModelsRepository.findOneLanguage.mockResolvedValue(orgModel);
+    getEffectiveLanguageModelsUseCase.execute.mockResolvedValue({
+      models: [effectiveTeamModel],
+      overrideTeamIds: [teamId],
+    });
+
+    await expect(
+      useCase.execute(
+        new GetPermittedLanguageModelQuery({ id: mockPermittedModelId }),
+      ),
+    ).rejects.toBeInstanceOf(UnauthorizedAccessError);
   });
 
   it('should throw UnauthorizedAccessError when the model belongs to another org', async () => {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-model/get-permitted-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-model/get-permitted-language-model.use-case.ts
@@ -1,57 +1,58 @@
-import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
+import { Injectable, Logger } from '@nestjs/common';
+import { ContextService } from 'src/common/context/services/context.service';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
-import { GetPermittedLanguageModelQuery } from './get-permitted-language-model.query';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 import {
   ModelNotFoundByIdError,
   UnexpectedModelError,
 } from '../../models.errors';
-import { Injectable, Logger } from '@nestjs/common';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
-import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
+import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
+import { GetEffectiveLanguageModelsQuery } from '../get-effective-language-models/get-effective-language-models.query';
+import { GetEffectiveLanguageModelsUseCase } from '../get-effective-language-models/get-effective-language-models.use-case';
+import { GetPermittedLanguageModelQuery } from './get-permitted-language-model.query';
 
 @Injectable()
 export class GetPermittedLanguageModelUseCase {
   private readonly logger = new Logger(GetPermittedLanguageModelUseCase.name);
+
   constructor(
     private readonly permittedModelsRepository: PermittedModelsRepository,
+    private readonly getEffectiveLanguageModelsUseCase: GetEffectiveLanguageModelsUseCase,
     private readonly contextService: ContextService,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     query: GetPermittedLanguageModelQuery,
   ): Promise<PermittedLanguageModel> {
-    this.logger.log('getPermittedLanguageModel', {
-      query,
+    this.logger.log('getPermittedLanguageModel', { query });
+    const model = await this.permittedModelsRepository.findOneLanguage({
+      id: query.id,
     });
+    if (!model) {
+      throw new ModelNotFoundByIdError(query.id);
+    }
+
     const orgId = this.contextService.get('orgId');
     const systemRole = this.contextService.get('systemRole');
-
-    try {
-      const model = await this.permittedModelsRepository.findOneLanguage({
-        id: query.id,
-      });
-      // Existence is checked before ownership: `orgId === model?.orgId` is
-      // false for a missing model, so an ownership-first order reports a
-      // deleted id as a permission problem and never reaches this branch.
-      if (!model) {
-        this.logger.error('model not found', {
-          query,
-        });
-        throw new ModelNotFoundByIdError(query.id);
-      }
-      const isFromOrg = orgId === model.orgId;
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      if (!isFromOrg && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
-      return model;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      throw new UnexpectedModelError(error as Error);
+    const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
+    if (orgId !== model.orgId && !isSuperAdmin) {
+      throw new UnauthorizedAccessError();
     }
+
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
+    const { models } = await this.getEffectiveLanguageModelsUseCase.execute(
+      new GetEffectiveLanguageModelsQuery(model.orgId, userId),
+    );
+    const effectiveModel = models.find(({ id }) => id === model.id);
+    if (!effectiveModel) {
+      throw new UnauthorizedAccessError();
+    }
+    return effectiveModel;
   }
 }


### PR DESCRIPTION
- Return effective scoped permits for matching user and org defaults
- Reject thread model IDs outside the current user's effective model set

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which permit records are used for defaults and thread model IDs (authorization-ish model access); behavior shifts for users under team overrides but is covered by new tests.
> 
> **Overview**
> Aligns **default model resolution** and **permit-by-ID lookup** with each user's **effective org/team language model set** (team overrides included).
> 
> `GetDefaultModelUseCase` still walks user → team → org → alphabetical fallback, but user/org/team preferences are matched by **catalog model ID** and the returned row is the **scoped permit from the effective set** (e.g. a user default stored against an org permit now resolves to the team permit when overrides apply).
> 
> `GetPermittedLanguageModelUseCase` keeps org/super-admin checks, then requires a **userId** and verifies the requested permit **ID** appears in `GetEffectiveLanguageModelsUseCase` output—so stale org permit IDs on threads are rejected when team overrides replace the org list.
> 
> Both use cases adopt `@HandleUnexpectedErrors`; docs in `SUMMARY.md` reflect the new behavior. Specs cover team-permit substitution and excluded org models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 771b97dc21011351ec2997a71c57396e3a45f3c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->