### PR TITLE
docs(agents): fix broken ARCHITECTURE.md link in agent guidelines (AYC-000)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,7 +2,7 @@
 
 > **Philosophy**: Code is opaque weights. Correctness is inferred from externally observable behavior.
 
-For architecture overview and module navigation, see [ARCHITECTURE.md](ARCHITECTURE.md).
+For architecture overview and module navigation, see [ARCHITECTURE.md](../ARCHITECTURE.md).
 
 ---
 


### PR DESCRIPTION
Fixes the relative link in `.claude/CLAUDE.md`: `[ARCHITECTURE.md](ARCHITECTURE.md)` resolved to `.claude/ARCHITECTURE.md`, which does not exist. The file lives at the repo root, so the link now points to `../ARCHITECTURE.md`.

All other paths referenced in the file were verified as correct (`scripts/check-file-size.sh`, both backend eslint configs, the Complexity Check workflow, and the `AGENTS.md` -> `.claude/CLAUDE.md` symlink).