### PR TITLE
fix(models): raise output-token budget for Claude (direct Anthropic + Bedrock) (AYC-674)

### DIFF
--- a/ayunis-core-backend/src/domain/models/infrastructure/inference/anthropic.inference.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/inference/anthropic.inference.spec.ts
@@ -1,0 +1,52 @@
+import type { ConfigService } from '@nestjs/config';
+import type { ModelProvider } from '@ayunis/inference';
+import { AnthropicInferenceHandler } from './anthropic.inference';
+import { ANTHROPIC_MAX_OUTPUT_TOKENS } from '../runtime/inference-config';
+import type { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
+import type { Model } from '../../domain/model.entity';
+
+const anthropicMock = jest.fn<ModelProvider, [unknown]>();
+
+jest.mock('@ayunis/provider-anthropic', () => ({
+  anthropic: (options: unknown) => anthropicMock(options),
+}));
+
+type CreateProvider = (model: Model) => ModelProvider;
+
+describe('AnthropicInferenceHandler', () => {
+  beforeEach(() => {
+    anthropicMock.mockReset();
+    anthropicMock.mockReturnValue({
+      name: 'anthropic:test',
+      stream: jest.fn(),
+    });
+  });
+
+  const buildHandler = () => {
+    const configService = {
+      get: jest.fn().mockReturnValue('sk-ant-test'),
+    } as unknown as ConfigService;
+    const handler = new AnthropicInferenceHandler(
+      configService,
+      {} as ImageContentService,
+    );
+    const createProvider = (
+      handler as unknown as { createProvider: CreateProvider }
+    ).createProvider.bind(handler);
+    return { createProvider };
+  };
+
+  it('raises the output-token budget above the conservative default (AYC-674)', () => {
+    const { createProvider } = buildHandler();
+
+    createProvider({ name: 'claude-opus-5' } as Model);
+
+    expect(anthropicMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'claude-opus-5',
+        maxTokens: ANTHROPIC_MAX_OUTPUT_TOKENS,
+      }),
+    );
+    expect(ANTHROPIC_MAX_OUTPUT_TOKENS).toBeGreaterThan(16_384);
+  });
+});

--- a/ayunis-core-backend/src/domain/models/infrastructure/inference/anthropic.inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/inference/anthropic.inference.ts
@@ -5,7 +5,10 @@ import type { ModelProvider } from '@ayunis/inference';
 import { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 import { RuntimeInferenceHandler } from '../runtime/runtime-inference.handler';
 import type { Model } from '../../domain/model.entity';
-import { INFERENCE_MAX_RETRIES } from '../runtime/inference-config';
+import {
+  ANTHROPIC_MAX_OUTPUT_TOKENS,
+  INFERENCE_MAX_RETRIES,
+} from '../runtime/inference-config';
 
 @Injectable()
 export class AnthropicInferenceHandler extends RuntimeInferenceHandler {
@@ -21,6 +24,7 @@ export class AnthropicInferenceHandler extends RuntimeInferenceHandler {
       apiKey: this.configService.get<string>('models.anthropic.apiKey') ?? '',
       model: model.name,
       maxRetries: INFERENCE_MAX_RETRIES,
+      maxTokens: ANTHROPIC_MAX_OUTPUT_TOKENS,
     });
   }
 }

--- a/ayunis-core-backend/src/domain/models/infrastructure/inference/anthropic.inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/inference/anthropic.inference.ts
@@ -6,7 +6,7 @@ import { ImageContentService } from 'src/domain/messages/application/services/im
 import { RuntimeInferenceHandler } from '../runtime/runtime-inference.handler';
 import type { Model } from '../../domain/model.entity';
 import {
-  ANTHROPIC_MAX_OUTPUT_TOKENS,
+  CLAUDE_MAX_OUTPUT_TOKENS,
   INFERENCE_MAX_RETRIES,
 } from '../runtime/inference-config';
 
@@ -24,7 +24,7 @@ export class AnthropicInferenceHandler extends RuntimeInferenceHandler {
       apiKey: this.configService.get<string>('models.anthropic.apiKey') ?? '',
       model: model.name,
       maxRetries: INFERENCE_MAX_RETRIES,
-      maxTokens: ANTHROPIC_MAX_OUTPUT_TOKENS,
+      maxTokens: CLAUDE_MAX_OUTPUT_TOKENS,
     });
   }
 }

--- a/ayunis-core-backend/src/domain/models/infrastructure/inference/bedrock.inference.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/inference/bedrock.inference.spec.ts
@@ -1,32 +1,29 @@
 import type { ConfigService } from '@nestjs/config';
 import type { ModelProvider } from '@ayunis/inference';
-import { AnthropicInferenceHandler } from './anthropic.inference';
+import { BedrockInferenceHandler } from './bedrock.inference';
 import { CLAUDE_MAX_OUTPUT_TOKENS } from '../runtime/inference-config';
 import type { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 import type { Model } from '../../domain/model.entity';
 
-const anthropicMock = jest.fn<ModelProvider, [unknown]>();
+const bedrockMock = jest.fn<ModelProvider, [unknown]>();
 
-jest.mock('@ayunis/provider-anthropic', () => ({
-  anthropic: (options: unknown) => anthropicMock(options),
+jest.mock('@ayunis/provider-anthropic/bedrock', () => ({
+  bedrock: (options: unknown) => bedrockMock(options),
 }));
 
 type CreateProvider = (model: Model) => ModelProvider;
 
-describe('AnthropicInferenceHandler', () => {
+describe('BedrockInferenceHandler', () => {
   beforeEach(() => {
-    anthropicMock.mockReset();
-    anthropicMock.mockReturnValue({
-      name: 'anthropic:test',
-      stream: jest.fn(),
-    });
+    bedrockMock.mockReset();
+    bedrockMock.mockReturnValue({ name: 'bedrock:test', stream: jest.fn() });
   });
 
   const buildHandler = () => {
     const configService = {
-      get: jest.fn().mockReturnValue('sk-ant-test'),
+      get: jest.fn().mockReturnValue(undefined),
     } as unknown as ConfigService;
-    const handler = new AnthropicInferenceHandler(
+    const handler = new BedrockInferenceHandler(
       configService,
       {} as ImageContentService,
     );
@@ -39,11 +36,11 @@ describe('AnthropicInferenceHandler', () => {
   it('raises the output-token budget above the conservative default (AYC-674)', () => {
     const { createProvider } = buildHandler();
 
-    createProvider({ name: 'claude-opus-5' } as Model);
+    createProvider({ name: 'eu.anthropic.claude-opus-5' } as Model);
 
-    expect(anthropicMock).toHaveBeenCalledWith(
+    expect(bedrockMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: 'claude-opus-5',
+        model: 'eu.anthropic.claude-opus-5',
         maxTokens: CLAUDE_MAX_OUTPUT_TOKENS,
       }),
     );

--- a/ayunis-core-backend/src/domain/models/infrastructure/inference/bedrock.inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/inference/bedrock.inference.ts
@@ -5,7 +5,10 @@ import type { ModelProvider } from '@ayunis/inference';
 import { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 import { RuntimeInferenceHandler } from '../runtime/runtime-inference.handler';
 import type { Model } from '../../domain/model.entity';
-import { INFERENCE_MAX_RETRIES } from '../runtime/inference-config';
+import {
+  CLAUDE_MAX_OUTPUT_TOKENS,
+  INFERENCE_MAX_RETRIES,
+} from '../runtime/inference-config';
 
 @Injectable()
 export class BedrockInferenceHandler extends RuntimeInferenceHandler {
@@ -20,6 +23,7 @@ export class BedrockInferenceHandler extends RuntimeInferenceHandler {
     return bedrock({
       model: model.name,
       maxRetries: INFERENCE_MAX_RETRIES,
+      maxTokens: CLAUDE_MAX_OUTPUT_TOKENS,
       awsRegion: this.configService.get<string>('models.bedrock.awsRegion'),
       awsAccessKey: this.configService.get<string>(
         'models.bedrock.awsAccessKeyId',

--- a/ayunis-core-backend/src/domain/models/infrastructure/runtime/inference-config.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/runtime/inference-config.ts
@@ -5,3 +5,18 @@
  * deliberate choice.
  */
 export const INFERENCE_MAX_RETRIES = 3;
+
+/**
+ * Output-token budget for the direct Anthropic API (AYC-674). The provider's
+ * `DEFAULT_MAX_TOKENS` (16_384) is deliberately conservative because Bedrock
+ * reserves `input_tokens + max_tokens` against the account's TPM quota, so an
+ * oversized budget there triggers throttling. The direct Anthropic API has no
+ * such admission reservation, and that low cap truncated large tool calls
+ * (e.g. a long `create_document` payload) mid-output: the model hit the limit
+ * while emitting the tool call, the truncated arguments failed the integrity
+ * check, every retry hit the same wall, and generation fell back to plain
+ * text. 32_000 is the maximum output supported by Claude Opus (Sonnet 4.5
+ * allows more), so it is the safe ceiling shared across the modern Anthropic
+ * models this handler serves.
+ */
+export const ANTHROPIC_MAX_OUTPUT_TOKENS = 32_000;

--- a/ayunis-core-backend/src/domain/models/infrastructure/runtime/inference-config.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/runtime/inference-config.ts
@@ -7,16 +7,18 @@
 export const INFERENCE_MAX_RETRIES = 3;
 
 /**
- * Output-token budget for the direct Anthropic API (AYC-674). The provider's
- * `DEFAULT_MAX_TOKENS` (16_384) is deliberately conservative because Bedrock
- * reserves `input_tokens + max_tokens` against the account's TPM quota, so an
- * oversized budget there triggers throttling. The direct Anthropic API has no
- * such admission reservation, and that low cap truncated large tool calls
- * (e.g. a long `create_document` payload) mid-output: the model hit the limit
- * while emitting the tool call, the truncated arguments failed the integrity
- * check, every retry hit the same wall, and generation fell back to plain
- * text. 32_000 is the maximum output supported by Claude Opus (Sonnet 4.5
- * allows more), so it is the safe ceiling shared across the modern Anthropic
- * models this handler serves.
+ * Output-token budget for the Claude handlers — both the direct Anthropic API
+ * and Anthropic-on-Bedrock (AYC-674). The provider's `DEFAULT_MAX_TOKENS`
+ * (16_384) is too low for large tool-call outputs: a long `create_document`
+ * payload hit the cap mid-call, so the model stopped with finishReason
+ * 'length', the truncated arguments failed the integrity check, every retry
+ * hit the same wall, and generation fell back to plain text.
+ *
+ * 32_000 is the maximum output supported by Claude Opus (Sonnet 4.5 allows
+ * more), so it is the safe ceiling shared across the modern Claude models
+ * these handlers serve. Bedrock reserves `input_tokens + max_tokens` against
+ * the account's TPM quota at admission, so this larger budget raises that
+ * reservation — an accepted trade-off, because a budget that actually
+ * completes the document is worth more than avoiding a rare throttle.
  */
-export const ANTHROPIC_MAX_OUTPUT_TOKENS = 32_000;
+export const CLAUDE_MAX_OUTPUT_TOKENS = 32_000;

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/anthropic.stream-inference.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/anthropic.stream-inference.spec.ts
@@ -1,7 +1,7 @@
 import type { ConfigService } from '@nestjs/config';
 import type { ModelProvider } from '@ayunis/inference';
 import { AnthropicStreamInferenceHandler } from './anthropic.stream-inference';
-import { ANTHROPIC_MAX_OUTPUT_TOKENS } from '../runtime/inference-config';
+import { CLAUDE_MAX_OUTPUT_TOKENS } from '../runtime/inference-config';
 import type { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 import type { Model } from '../../domain/model.entity';
 
@@ -44,9 +44,9 @@ describe('AnthropicStreamInferenceHandler', () => {
     expect(anthropicMock).toHaveBeenCalledWith(
       expect.objectContaining({
         model: 'claude-opus-5',
-        maxTokens: ANTHROPIC_MAX_OUTPUT_TOKENS,
+        maxTokens: CLAUDE_MAX_OUTPUT_TOKENS,
       }),
     );
-    expect(ANTHROPIC_MAX_OUTPUT_TOKENS).toBeGreaterThan(16_384);
+    expect(CLAUDE_MAX_OUTPUT_TOKENS).toBeGreaterThan(16_384);
   });
 });

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/anthropic.stream-inference.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/anthropic.stream-inference.spec.ts
@@ -1,0 +1,52 @@
+import type { ConfigService } from '@nestjs/config';
+import type { ModelProvider } from '@ayunis/inference';
+import { AnthropicStreamInferenceHandler } from './anthropic.stream-inference';
+import { ANTHROPIC_MAX_OUTPUT_TOKENS } from '../runtime/inference-config';
+import type { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
+import type { Model } from '../../domain/model.entity';
+
+const anthropicMock = jest.fn<ModelProvider, [unknown]>();
+
+jest.mock('@ayunis/provider-anthropic', () => ({
+  anthropic: (options: unknown) => anthropicMock(options),
+}));
+
+type CreateProvider = (model: Model) => ModelProvider;
+
+describe('AnthropicStreamInferenceHandler', () => {
+  beforeEach(() => {
+    anthropicMock.mockReset();
+    anthropicMock.mockReturnValue({
+      name: 'anthropic:test',
+      stream: jest.fn(),
+    });
+  });
+
+  const buildHandler = () => {
+    const configService = {
+      get: jest.fn().mockReturnValue('sk-ant-test'),
+    } as unknown as ConfigService;
+    const handler = new AnthropicStreamInferenceHandler(
+      configService,
+      {} as ImageContentService,
+    );
+    const createProvider = (
+      handler as unknown as { createProvider: CreateProvider }
+    ).createProvider.bind(handler);
+    return { createProvider };
+  };
+
+  it('raises the output-token budget above the conservative default (AYC-674)', () => {
+    const { createProvider } = buildHandler();
+
+    createProvider({ name: 'claude-opus-5' } as Model);
+
+    expect(anthropicMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'claude-opus-5',
+        maxTokens: ANTHROPIC_MAX_OUTPUT_TOKENS,
+      }),
+    );
+    expect(ANTHROPIC_MAX_OUTPUT_TOKENS).toBeGreaterThan(16_384);
+  });
+});

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/anthropic.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/anthropic.stream-inference.ts
@@ -5,7 +5,10 @@ import type { ModelProvider } from '@ayunis/inference';
 import { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 import { RuntimeStreamInferenceHandler } from '../runtime/runtime-stream-inference.handler';
 import type { Model } from '../../domain/model.entity';
-import { INFERENCE_MAX_RETRIES } from '../runtime/inference-config';
+import {
+  ANTHROPIC_MAX_OUTPUT_TOKENS,
+  INFERENCE_MAX_RETRIES,
+} from '../runtime/inference-config';
 
 @Injectable()
 export class AnthropicStreamInferenceHandler extends RuntimeStreamInferenceHandler {
@@ -21,6 +24,7 @@ export class AnthropicStreamInferenceHandler extends RuntimeStreamInferenceHandl
       apiKey: this.configService.get<string>('models.anthropic.apiKey') ?? '',
       model: model.name,
       maxRetries: INFERENCE_MAX_RETRIES,
+      maxTokens: ANTHROPIC_MAX_OUTPUT_TOKENS,
     });
   }
 }

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/anthropic.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/anthropic.stream-inference.ts
@@ -6,7 +6,7 @@ import { ImageContentService } from 'src/domain/messages/application/services/im
 import { RuntimeStreamInferenceHandler } from '../runtime/runtime-stream-inference.handler';
 import type { Model } from '../../domain/model.entity';
 import {
-  ANTHROPIC_MAX_OUTPUT_TOKENS,
+  CLAUDE_MAX_OUTPUT_TOKENS,
   INFERENCE_MAX_RETRIES,
 } from '../runtime/inference-config';
 
@@ -24,7 +24,7 @@ export class AnthropicStreamInferenceHandler extends RuntimeStreamInferenceHandl
       apiKey: this.configService.get<string>('models.anthropic.apiKey') ?? '',
       model: model.name,
       maxRetries: INFERENCE_MAX_RETRIES,
-      maxTokens: ANTHROPIC_MAX_OUTPUT_TOKENS,
+      maxTokens: CLAUDE_MAX_OUTPUT_TOKENS,
     });
   }
 }

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/bedrock.stream-inference.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/bedrock.stream-inference.spec.ts
@@ -1,32 +1,29 @@
 import type { ConfigService } from '@nestjs/config';
 import type { ModelProvider } from '@ayunis/inference';
-import { AnthropicInferenceHandler } from './anthropic.inference';
+import { BedrockStreamInferenceHandler } from './bedrock.stream-inference';
 import { CLAUDE_MAX_OUTPUT_TOKENS } from '../runtime/inference-config';
 import type { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 import type { Model } from '../../domain/model.entity';
 
-const anthropicMock = jest.fn<ModelProvider, [unknown]>();
+const bedrockMock = jest.fn<ModelProvider, [unknown]>();
 
-jest.mock('@ayunis/provider-anthropic', () => ({
-  anthropic: (options: unknown) => anthropicMock(options),
+jest.mock('@ayunis/provider-anthropic/bedrock', () => ({
+  bedrock: (options: unknown) => bedrockMock(options),
 }));
 
 type CreateProvider = (model: Model) => ModelProvider;
 
-describe('AnthropicInferenceHandler', () => {
+describe('BedrockStreamInferenceHandler', () => {
   beforeEach(() => {
-    anthropicMock.mockReset();
-    anthropicMock.mockReturnValue({
-      name: 'anthropic:test',
-      stream: jest.fn(),
-    });
+    bedrockMock.mockReset();
+    bedrockMock.mockReturnValue({ name: 'bedrock:test', stream: jest.fn() });
   });
 
   const buildHandler = () => {
     const configService = {
-      get: jest.fn().mockReturnValue('sk-ant-test'),
+      get: jest.fn().mockReturnValue(undefined),
     } as unknown as ConfigService;
-    const handler = new AnthropicInferenceHandler(
+    const handler = new BedrockStreamInferenceHandler(
       configService,
       {} as ImageContentService,
     );
@@ -39,11 +36,11 @@ describe('AnthropicInferenceHandler', () => {
   it('raises the output-token budget above the conservative default (AYC-674)', () => {
     const { createProvider } = buildHandler();
 
-    createProvider({ name: 'claude-opus-5' } as Model);
+    createProvider({ name: 'eu.anthropic.claude-opus-5' } as Model);
 
-    expect(anthropicMock).toHaveBeenCalledWith(
+    expect(bedrockMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: 'claude-opus-5',
+        model: 'eu.anthropic.claude-opus-5',
         maxTokens: CLAUDE_MAX_OUTPUT_TOKENS,
       }),
     );

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/bedrock.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/bedrock.stream-inference.ts
@@ -5,7 +5,10 @@ import type { ModelProvider } from '@ayunis/inference';
 import { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 import { RuntimeStreamInferenceHandler } from '../runtime/runtime-stream-inference.handler';
 import type { Model } from '../../domain/model.entity';
-import { INFERENCE_MAX_RETRIES } from '../runtime/inference-config';
+import {
+  CLAUDE_MAX_OUTPUT_TOKENS,
+  INFERENCE_MAX_RETRIES,
+} from '../runtime/inference-config';
 
 @Injectable()
 export class BedrockStreamInferenceHandler extends RuntimeStreamInferenceHandler {
@@ -20,6 +23,7 @@ export class BedrockStreamInferenceHandler extends RuntimeStreamInferenceHandler
     return bedrock({
       model: model.name,
       maxRetries: INFERENCE_MAX_RETRIES,
+      maxTokens: CLAUDE_MAX_OUTPUT_TOKENS,
       awsRegion: this.configService.get<string>('models.bedrock.awsRegion'),
       awsAccessKey: this.configService.get<string>(
         'models.bedrock.awsAccessKeyId',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Generating a large document (the customer's ~1000-line "Baubeschreibung") with **Claude Opus 5** stalled and repeatedly failed, eventually degrading to plain text for copy/paste instead of a usable document (AYC-674).

## Root cause

The Claude inference handlers built their provider without passing `maxTokens`, so they inherited the provider's `DEFAULT_MAX_TOKENS = 16_384`. With a 16K output cap, a large `create_document` tool call gets truncated mid-output — the model hits `max_tokens` (`finishReason: 'length'`) while still emitting the tool call:

- `assertToolCallArgumentsIntact` (AYC-669) correctly throws `InferenceTokenLimitError` because truncated arguments can't be executed faithfully.
- The run retries once (AYC-652/AYC-669), but every attempt hits the *same* wall because the document is genuinely larger than 16K output tokens (reasoning tokens count against the budget too).
- After exhausting retries, generation falls back to plain text — exactly the reported behavior.

The customer's Claude Opus 5 is routed through **Bedrock** (the default permitted model in the fixtures is `eu.anthropic.claude-sonnet-4-6` on Bedrock), which shared the same low cap — so the fix must cover both the direct Anthropic API and Anthropic-on-Bedrock.

## Fix

Introduce `CLAUDE_MAX_OUTPUT_TOKENS = 32_000` and pass it from all four Claude handlers:

- `AnthropicStreamInferenceHandler`, `AnthropicInferenceHandler` (direct API)
- `BedrockStreamInferenceHandler`, `BedrockInferenceHandler` (Bedrock)

`32_000` is the maximum output supported by Claude Opus (Sonnet 4.5 supports more), so it's the safe shared ceiling across the modern Claude models these handlers serve.

## Files

- `infrastructure/runtime/inference-config.ts` — new `CLAUDE_MAX_OUTPUT_TOKENS` constant with rationale.
- `infrastructure/stream-inference/anthropic.stream-inference.ts` + `inference/anthropic.inference.ts` — pass `maxTokens`.
- `infrastructure/stream-inference/bedrock.stream-inference.ts` + `inference/bedrock.inference.ts` — pass `maxTokens`.
- Added specs for all four handlers asserting the raised budget is forwarded to the provider.

## Testing

- New unit tests pass (`pnpm test` on all four spec files).
- Full backend `tsc --noEmit` clean; ESLint (`--max-warnings=0`) clean; pre-commit hooks passed.

## Notes / trade-offs

- On **Bedrock**, `input_tokens + max_tokens` is reserved against the account's TPM quota at admission, so the larger budget raises that reservation. This is an accepted trade-off (documented at the constant): a budget that actually completes the document is worth more than avoiding a rare throttle.
- Legacy `claude-3-5-*` models (8_192 output max) would reject a 32K request, but the modern lineup an org would use today (Opus 5, Sonnet 4.5, Haiku 4.5) all support ≥32K.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-674](https://linear.app/ayunis/issue/AYC-674/document-creation-in-ayunis-core-stalls-and-falls-back-to-plain-text)

<div><a href="https://cursor.com/agents/bc-d6785efa-33a6-4fef-b40a-7144d77db9f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6785efa-33a6-4fef-b40a-7144d77db9f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

