### PR TITLE
fix(models): handle duplicate language model updates (AYC-696)

### DIFF
--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.spec.ts
@@ -8,7 +8,10 @@ import { ClearDefaultsByCatalogModelIdUseCase } from '../clear-defaults-by-catal
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
 import { ModelTier } from 'src/domain/models/domain/value-objects/model-tier.enum';
-import { ModelNotFoundByIdError } from '../../models.errors';
+import {
+  ModelAlreadyExistsError,
+  ModelNotFoundByIdError,
+} from '../../models.errors';
 import type { UUID } from 'crypto';
 
 describe('UpdateLanguageModelUseCase', () => {
@@ -183,6 +186,51 @@ describe('UpdateLanguageModelUseCase', () => {
 
       // Assert
       expect(callOrder).toEqual(['save', 'clearDefaults']);
+    });
+
+    it('should reject a name and provider used by another model', async () => {
+      const conflictingModelId = '123e4567-e89b-12d3-a456-426614174002' as UUID;
+      const existingModel = createMockLanguageModel(mockModelId, false);
+      const conflictingModel = createMockLanguageModel(
+        conflictingModelId,
+        false,
+      );
+      const command = createUpdateCommand(mockModelId, false);
+
+      modelsRepository.findOne
+        .mockResolvedValueOnce(existingModel)
+        .mockResolvedValueOnce(conflictingModel);
+
+      await expect(useCase.execute(command)).rejects.toThrow(
+        ModelAlreadyExistsError,
+      );
+      expect(modelsRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should allow an unchanged name and provider', async () => {
+      const existingModel = createMockLanguageModel(mockModelId, false);
+      const command = createUpdateCommand(mockModelId, false);
+
+      modelsRepository.findOne.mockResolvedValue(existingModel);
+      modelsRepository.save.mockResolvedValue();
+
+      await expect(useCase.execute(command)).resolves.toEqual(
+        expect.objectContaining({ id: mockModelId }),
+      );
+    });
+
+    it('should allow a unique name and provider', async () => {
+      const existingModel = createMockLanguageModel(mockModelId, false);
+      const command = createUpdateCommand(mockModelId, false);
+
+      modelsRepository.findOne
+        .mockResolvedValueOnce(existingModel)
+        .mockResolvedValueOnce(undefined);
+      modelsRepository.save.mockResolvedValue();
+
+      await expect(useCase.execute(command)).resolves.toEqual(
+        expect.objectContaining({ id: mockModelId }),
+      );
     });
 
     it('should throw ModelNotFoundByIdError when model does not exist', async () => {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.ts
@@ -2,10 +2,11 @@ import { UpdateLanguageModelCommand } from './update-language-model.command';
 import { ModelsRepository } from '../../ports/models.repository';
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import {
+  ModelAlreadyExistsError,
   ModelNotFoundByIdError,
   UnexpectedModelError,
 } from '../../models.errors';
-import { ApplicationError } from 'src/common/errors/base.error';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Injectable, Logger } from '@nestjs/common';
 import { ClearDefaultsByCatalogModelIdUseCase } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case';
 import { ClearDefaultsByCatalogModelIdCommand } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.command';
@@ -19,52 +20,56 @@ export class UpdateLanguageModelUseCase {
     private readonly clearDefaultsUseCase: ClearDefaultsByCatalogModelIdUseCase,
   ) {}
 
+  @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(command: UpdateLanguageModelCommand): Promise<LanguageModel> {
-    try {
-      const existingModel = await this.modelsRepository.findOne({
-        id: command.id,
-      });
+    this.logger.log('Updating language model', { modelId: command.id });
 
-      if (!existingModel) {
-        throw new ModelNotFoundByIdError(command.id);
-      }
-
-      // Check if model is being archived (isArchived: false -> true)
-      const isBeingArchived = !existingModel.isArchived && command.isArchived;
-
-      const model = new LanguageModel({
-        id: command.id,
-        name: command.name,
-        provider: command.provider,
-        displayName: command.displayName,
-        isArchived: command.isArchived,
-        canStream: command.canStream,
-        canUseTools: command.canUseTools,
-        isReasoning: command.isReasoning,
-        canVision: command.canVision,
-        inputTokenCost: command.inputTokenCost,
-        outputTokenCost: command.outputTokenCost,
-        tier: command.tier,
-        description: command.description,
-      });
-      await this.modelsRepository.save(model);
-
-      // Clear defaults if model is being archived
-      if (isBeingArchived) {
-        this.logger.log('Model is being archived, clearing defaults', {
-          modelId: command.id,
-        });
-        await this.clearDefaultsUseCase.execute(
-          new ClearDefaultsByCatalogModelIdCommand(command.id),
-        );
-      }
-
-      return model;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      throw new UnexpectedModelError(error as Error);
+    const existingModel = await this.modelsRepository.findOne({
+      id: command.id,
+    });
+    if (!existingModel) {
+      throw new ModelNotFoundByIdError(command.id);
     }
+
+    const modelWithSameKey = await this.modelsRepository.findOne({
+      name: command.name,
+      provider: command.provider,
+    });
+    if (modelWithSameKey && modelWithSameKey.id !== command.id) {
+      throw new ModelAlreadyExistsError(command.name, command.provider);
+    }
+
+    const isBeingArchived = !existingModel.isArchived && command.isArchived;
+    const model = this.createModel(command);
+    await this.modelsRepository.save(model);
+
+    if (isBeingArchived) {
+      this.logger.log('Model is being archived, clearing defaults', {
+        modelId: command.id,
+      });
+      await this.clearDefaultsUseCase.execute(
+        new ClearDefaultsByCatalogModelIdCommand(command.id),
+      );
+    }
+
+    return model;
+  }
+
+  private createModel(command: UpdateLanguageModelCommand): LanguageModel {
+    return new LanguageModel({
+      id: command.id,
+      name: command.name,
+      provider: command.provider,
+      displayName: command.displayName,
+      isArchived: command.isArchived,
+      canStream: command.canStream,
+      canUseTools: command.canUseTools,
+      isReasoning: command.isReasoning,
+      canVision: command.canVision,
+      inputTokenCost: command.inputTokenCost,
+      outputTokenCost: command.outputTokenCost,
+      tier: command.tier,
+      description: command.description,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/local-models.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/local-models.repository.spec.ts
@@ -1,4 +1,4 @@
-import type { Repository } from 'typeorm';
+import { QueryFailedError, type Repository } from 'typeorm';
 import type { UUID } from 'crypto';
 import { LocalModelsRepository } from './local-models.repository';
 import { ModelMapper } from './mappers/model.mapper';
@@ -13,6 +13,10 @@ import { EmbeddingModel } from 'src/domain/models/domain/models/embedding.model'
 import { ImageGenerationModel } from 'src/domain/models/domain/models/image-generation.model';
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
 import { EmbeddingDimensions } from 'src/domain/models/domain/value-objects/embedding-dimensions.enum';
+import {
+  ModelAlreadyExistsError,
+  ModelErrorCode,
+} from 'src/domain/models/application/models.errors';
 
 describe('LocalModelsRepository', () => {
   let repository: LocalModelsRepository;
@@ -75,6 +79,59 @@ describe('LocalModelsRepository', () => {
     record.updatedAt = new Date('2025-01-02T00:00:00Z');
     return record;
   };
+
+  describe('save', () => {
+    it('maps a concurrent unique constraint violation to a model conflict', async () => {
+      const model = new LanguageModel({
+        id: modelId,
+        name: 'gpt-4o',
+        provider: ModelProvider.OPENAI,
+        displayName: 'GPT-4o',
+        canStream: true,
+        canUseTools: true,
+        isReasoning: false,
+        canVision: true,
+        isArchived: false,
+      });
+      const driverError = Object.assign(new Error('duplicate key'), {
+        code: '23505',
+        constraint: 'IDX_7c11834d93fa8eaf208a48d66a',
+      });
+      localModelRepository.save.mockRejectedValue(
+        new QueryFailedError('UPDATE models', [], driverError),
+      );
+
+      const result = repository.save(model);
+
+      await expect(result).rejects.toMatchObject({
+        code: ModelErrorCode.MODEL_ALREADY_EXISTS,
+        statusCode: 409,
+      });
+      await expect(result).rejects.toBeInstanceOf(ModelAlreadyExistsError);
+    });
+
+    it('does not misclassify another unique constraint violation', async () => {
+      const model = new LanguageModel({
+        id: modelId,
+        name: 'gpt-4o',
+        provider: ModelProvider.OPENAI,
+        displayName: 'GPT-4o',
+        canStream: true,
+        canUseTools: true,
+        isReasoning: false,
+        canVision: true,
+        isArchived: false,
+      });
+      const driverError = Object.assign(new Error('duplicate primary key'), {
+        code: '23505',
+        constraint: 'PK_ef9ed7160ea69013636466bf2d5',
+      });
+      const queryError = new QueryFailedError('UPDATE models', [], driverError);
+      localModelRepository.save.mockRejectedValue(queryError);
+
+      await expect(repository.save(model)).rejects.toBe(queryError);
+    });
+  });
 
   describe('findOneImageGeneration', () => {
     it('returns the mapped domain model when the row is an image-generation record', async () => {

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/local-models.repository.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/local-models.repository.ts
@@ -17,6 +17,23 @@ import { ModelMapper } from './mappers/model.mapper';
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import { EmbeddingModel } from 'src/domain/models/domain/models/embedding.model';
 import { ImageGenerationModel } from 'src/domain/models/domain/models/image-generation.model';
+import { ModelAlreadyExistsError } from 'src/domain/models/application/models.errors';
+
+const PG_UNIQUE_VIOLATION = '23505';
+const MODEL_KEY_UNIQUE_CONSTRAINT = 'IDX_7c11834d93fa8eaf208a48d66a';
+
+function isModelKeyUniqueConstraintViolation(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const record = error as Record<string, unknown>;
+  const driverError = record.driverError as Record<string, unknown> | undefined;
+  const code = driverError?.code ?? record.code;
+  const constraint = driverError?.constraint ?? record.constraint;
+  return (
+    code === PG_UNIQUE_VIOLATION && constraint === MODEL_KEY_UNIQUE_CONSTRAINT
+  );
+}
 
 @Injectable()
 export class LocalModelsRepository extends ModelsRepository {
@@ -93,7 +110,14 @@ export class LocalModelsRepository extends ModelsRepository {
     });
 
     const modelEntity = this.localModelMapper.toRecord(model);
-    await this.localModelRepository.save(modelEntity);
+    try {
+      await this.localModelRepository.save(modelEntity);
+    } catch (error) {
+      if (isModelKeyUniqueConstraintViolation(error)) {
+        throw new ModelAlreadyExistsError(model.name, model.provider);
+      }
+      throw error;
+    }
   }
 
   async update<T extends Model>(id: UUID, model: T): Promise<T> {


### PR DESCRIPTION
## Summary
- reject language-model updates whose `(name, provider)` belongs to another model
- preserve unchanged and unique updates
- translate concurrent PostgreSQL conflicts on the model-key index to `MODEL_ALREADY_EXISTS` / HTTP 409

## Validation
- `pnpm exec eslint <changed files>`
- `pnpm exec tsc --noEmit`
- `pnpm test` (595 suites, 4259 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to model catalog update/save validation and error mapping; no auth or cross-domain behavior changes.
> 
> **Overview**
> **Update language model** now enforces catalog uniqueness on **name + provider** before save: if another model already uses that pair, the use case throws **`ModelAlreadyExistsError`** and skips **`save`**. Unchanged keys and unique renames still succeed.
> 
> The use case is refactored to use **`@HandleUnexpectedErrors`**, a **`createModel`** helper, and clearer logging; manual try/catch around **`ApplicationError`** is removed.
> 
> **`LocalModelsRepository.save`** catches PostgreSQL **`23505`** only for the model-key unique index and rethrows **`ModelAlreadyExistsError`** (409), so concurrent updates still get a domain conflict instead of a raw DB error; other unique violations pass through unchanged.
> 
> Specs cover conflict, allow, and not-found paths in the use case and constraint mapping in the repository.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5b98d29eb7e874356846236a8044cbcd53bd867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->