### PR TITLE
fix(artifacts): prevent PDF export navigation stalls (AYC-558)

### DIFF
--- a/ayunis-core-backend/src/domain/artifacts/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/artifacts/SUMMARY.md
@@ -87,7 +87,7 @@ artifacts/
 - Reverting copies content from a target version into a new version (non-destructive)
 - Deleting a thread cascade-deletes all its artifacts and versions
 - PDF export resolves the artifact's letterhead, downloads its PDFs from storage, and composites the rendered content onto the first-page / continuation-page backgrounds; if letterhead resolution fails, export falls back to a plain PDF
-- Export delegates to `DocumentExportPort` for format conversion
+- Export delegates to `DocumentExportPort` for format conversion; PDF rendering blocks non-embedded resource requests and reports renderer deadlines as `ARTIFACT_EXPORT_TIMEOUT` (504) without retrying the same timed-out content
 - Spreadsheet export delegates to `SpreadsheetExportPort`; XLSX preserves original formula-cell provenance through PII de-anonymization and emits live formulas only after successful local evaluation and dependency validation, while unsupported formulas remain text and CSV formula-like values are neutralized
 - Document HTML sanitization (XSS prevention) before storage and export
 - Spreadsheet content uses the versioned `spreadsheet-v1` JSON format with shape, size, and formula-length validation plus row canonicalization; formulas remain inert until export

--- a/ayunis-core-backend/src/domain/artifacts/application/artifacts.errors.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/artifacts.errors.spec.ts
@@ -1,4 +1,7 @@
-import { UnexpectedArtifactError } from './artifacts.errors';
+import {
+  ArtifactExportTimeoutError,
+  UnexpectedArtifactError,
+} from './artifacts.errors';
 
 describe('UnexpectedArtifactError', () => {
   it('does not expose the caught error in the HTTP response', () => {
@@ -9,6 +12,20 @@ describe('UnexpectedArtifactError', () => {
     expect(error.toHttpException().getResponse()).toEqual({
       code: 'ARTIFACT_UNEXPECTED',
       message: 'Unexpected artifact error',
+    });
+  });
+});
+
+describe('ArtifactExportTimeoutError', () => {
+  it('returns a classified gateway timeout without exposing the renderer error', () => {
+    const cause = new Error('Navigation timeout of 30000 ms exceeded');
+    const error = new ArtifactExportTimeoutError(cause);
+
+    expect(error.cause).toBe(cause);
+    expect(error.toHttpException().getStatus()).toBe(504);
+    expect(error.toHttpException().getResponse()).toEqual({
+      code: 'ARTIFACT_EXPORT_TIMEOUT',
+      message: 'Artifact export timed out',
     });
   });
 });

--- a/ayunis-core-backend/src/domain/artifacts/application/artifacts.errors.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/artifacts.errors.ts
@@ -19,6 +19,7 @@ export enum ArtifactErrorCode {
   ARTIFACT_LETTERHEAD_NOT_SUPPORTED = 'ARTIFACT_LETTERHEAD_NOT_SUPPORTED',
   ARTIFACT_NOT_EXPORTABLE = 'ARTIFACT_NOT_EXPORTABLE',
   ARTIFACT_INVALID_SPREADSHEET_CONTENT = 'ARTIFACT_INVALID_SPREADSHEET_CONTENT',
+  ARTIFACT_EXPORT_TIMEOUT = 'ARTIFACT_EXPORT_TIMEOUT',
   ARTIFACT_UNEXPECTED = 'ARTIFACT_UNEXPECTED',
 }
 
@@ -159,6 +160,17 @@ export class InvalidSpreadsheetContentError extends ArtifactError {
       400,
       metadata,
     );
+  }
+}
+
+export class ArtifactExportTimeoutError extends ArtifactError {
+  constructor(cause: Error) {
+    super(
+      'Artifact export timed out',
+      ArtifactErrorCode.ARTIFACT_EXPORT_TIMEOUT,
+      504,
+    );
+    this.cause = cause;
   }
 }
 

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.spec.ts
@@ -10,6 +10,7 @@ import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { DocumentExportPort } from '../../ports/document-export.port';
 import { SpreadsheetExportPort } from '../../ports/spreadsheet-export.port';
 import {
+  ArtifactExportTimeoutError,
   ArtifactNotFoundError,
   ArtifactNotExportableError,
 } from '../../artifacts.errors';
@@ -266,6 +267,33 @@ describe('ExportArtifactUseCase', () => {
         continuationPageMargins: { top: 20, right: 15, bottom: 20, left: 15 },
       }),
     );
+  });
+
+  it('should not retry a timed-out letterhead render', async () => {
+    const artifact = createArtifact({ letterheadId: mockLetterheadId });
+    const letterhead = createLetterhead();
+    const timeout = new ArtifactExportTimeoutError(
+      new Error('Navigation timeout of 30000 ms exceeded'),
+    );
+
+    artifactsRepository.findByIdWithVersions.mockResolvedValue(artifact);
+    findLetterheadUseCase.execute.mockResolvedValue(letterhead);
+    downloadObjectUseCase.execute
+      .mockResolvedValueOnce(createBufferStream(Buffer.from('%PDF-first')))
+      .mockResolvedValueOnce(
+        createBufferStream(Buffer.from('%PDF-continuation')),
+      );
+    documentExportPort.exportToPdf.mockRejectedValue(timeout);
+
+    await expect(
+      useCase.execute(
+        new ExportArtifactCommand({
+          artifactId: mockArtifactId,
+          format: 'pdf',
+        }),
+      ),
+    ).rejects.toBe(timeout);
+    expect(documentExportPort.exportToPdf).toHaveBeenCalledTimes(1);
   });
 
   it('should export PDF without letterhead when letterhead is not found', async () => {

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
@@ -14,6 +14,7 @@ import {
   type ExportFormat,
 } from './export-artifact.command';
 import {
+  ArtifactExportTimeoutError,
   ArtifactNotFoundError,
   ArtifactNotExportableError,
   ArtifactVersionNotFoundError,
@@ -250,7 +251,9 @@ export class ExportArtifactUseCase {
         letterheadConfig,
       );
     } catch (error) {
-      if (!letterheadConfig) throw error;
+      if (error instanceof ArtifactExportTimeoutError || !letterheadConfig) {
+        throw error;
+      }
       const reason = error instanceof Error ? error.message : 'Unknown error';
       this.logger.warn(
         `Letterhead compositing failed, exporting without letterhead: ${reason}`,

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
@@ -1,6 +1,8 @@
 import { HtmlDocumentExportService } from './html-document-export.service';
 import type { PdfLetterheadCompositor } from './pdf-letterhead-compositor';
 import type { LetterheadConfig } from '../../application/ports/document-export.port';
+import { ArtifactExportTimeoutError } from '../../application/artifacts.errors';
+import { TimeoutError } from 'puppeteer-core';
 import * as JSZip from 'jszip';
 
 async function extractDocumentXml(buffer: Buffer): Promise<string> {
@@ -16,6 +18,8 @@ async function extractDocumentXml(buffer: Buffer): Promise<string> {
 const FAKE_PDF = Buffer.from('%PDF-1.4 fake');
 
 const mockPage = {
+  setRequestInterception: jest.fn().mockResolvedValue(undefined),
+  on: jest.fn(),
   setContent: jest.fn().mockResolvedValue(undefined),
   pdf: jest.fn().mockResolvedValue(FAKE_PDF),
   close: jest.fn().mockResolvedValue(undefined),
@@ -29,10 +33,15 @@ const mockBrowser = {
 
 const mockLaunch = jest.fn().mockResolvedValue(mockBrowser);
 
-jest.mock('puppeteer-core', () => ({
-  __esModule: true,
-  default: { launch: (...args: unknown[]) => mockLaunch(...args) },
-}));
+jest.mock('puppeteer-core', () => {
+  const { TimeoutError: ActualTimeoutError } =
+    jest.requireActual('puppeteer-core');
+  return {
+    __esModule: true,
+    TimeoutError: ActualTimeoutError,
+    default: { launch: (...args: unknown[]) => mockLaunch(...args) },
+  };
+});
 
 describe('HtmlDocumentExportService', () => {
   let service: HtmlDocumentExportService;
@@ -195,6 +204,60 @@ describe('HtmlDocumentExportService', () => {
         expect.stringContaining('Hello'),
         { waitUntil: 'networkidle0' },
       );
+    });
+
+    it('should abort remote resources before rendering', async () => {
+      await service.exportToPdf(
+        '<p>Agenda</p><img src="https://assets.example.org/header.png">',
+      );
+
+      expect(mockPage.setRequestInterception).toHaveBeenCalledWith(true);
+      expect(mockPage.on).toHaveBeenCalledWith('request', expect.any(Function));
+
+      const handleRequest = mockPage.on.mock.calls[0][1] as (request: {
+        url: () => string;
+        abort: () => void;
+        continue: () => void;
+      }) => void;
+      const request = {
+        url: () => 'https://assets.example.org/header.png',
+        abort: jest.fn(),
+        continue: jest.fn(),
+      };
+      handleRequest(request);
+
+      expect(request.abort).toHaveBeenCalled();
+      expect(request.continue).not.toHaveBeenCalled();
+    });
+
+    it('should allow embedded data resources', async () => {
+      await service.exportToPdf('<p>Agenda</p>');
+
+      const handleRequest = mockPage.on.mock.calls[0][1] as (request: {
+        url: () => string;
+        abort: () => void;
+        continue: () => void;
+      }) => void;
+      const request = {
+        url: () => 'data:image/png;base64,aGVhZGVy',
+        abort: jest.fn(),
+        continue: jest.fn(),
+      };
+      handleRequest(request);
+
+      expect(request.continue).toHaveBeenCalled();
+      expect(request.abort).not.toHaveBeenCalled();
+    });
+
+    it('should classify Puppeteer timeouts as artifact export timeouts', async () => {
+      mockPage.setContent.mockRejectedValueOnce(
+        new TimeoutError('Navigation timeout of 30000 ms exceeded'),
+      );
+
+      await expect(service.exportToPdf('<p>Agenda</p>')).rejects.toBeInstanceOf(
+        ArtifactExportTimeoutError,
+      );
+      expect(mockPage.close).toHaveBeenCalled();
     });
 
     it('should generate A4 PDF with correct margins when no letterhead', async () => {

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.ts
@@ -7,6 +7,8 @@ import { convertHtmlToDocx } from './html-to-docx-converter';
 import { PdfLetterheadCompositor } from './pdf-letterhead-compositor';
 import { LazyChromiumBrowser } from 'src/common/puppeteer/lazy-chromium-browser';
 import { sanitizeHtmlContent } from '../../application/helpers/sanitize-html-content';
+import { TimeoutError } from 'puppeteer-core';
+import { ArtifactExportTimeoutError } from '../../application/artifacts.errors';
 
 /** CSS for PDF export (Puppeteer supports full <style> blocks). */
 const PDF_CSS = `
@@ -78,6 +80,14 @@ export class HtmlDocumentExportService
     const page = await browser.newPage();
 
     try {
+      await page.setRequestInterception(true);
+      page.on('request', (request) => {
+        if (request.url().startsWith('data:')) {
+          void request.continue();
+          return;
+        }
+        void request.abort();
+      });
       await page.setContent(wrappedHtml, { waitUntil: 'networkidle0' });
 
       const pdfOptions = letterhead
@@ -96,6 +106,11 @@ export class HtmlDocumentExportService
         letterhead.firstPagePdf,
         letterhead.continuationPagePdf,
       );
+    } catch (error) {
+      if (error instanceof TimeoutError) {
+        throw new ArtifactExportTimeoutError(error);
+      }
+      throw error;
     } finally {
       await page.close();
     }


### PR DESCRIPTION
## Summary
- block non-embedded Chromium requests before artifact PDF rendering so remote images cannot hold `networkidle0` open
- classify Puppeteer renderer deadlines as `ARTIFACT_EXPORT_TIMEOUT` with HTTP 504
- avoid repeating a timed-out render during the letterhead fallback

## Scope
Kept the fix to the demonstrated artifact-export path. This does not add speculative browser watchdog/reset or `/dev/shm` handling.

## Validation
- `pnpm test --runInBand` (595 suites, 4259 tests)
- `pnpm exec tsc --noEmit`
- `pnpm run deps:check`
- staged ESLint, Prettier, complexity, dependency, duplication, file-size, and markdown checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes artifact PDF export behavior and API error codes; blocking remote assets may affect documents that relied on external images, but it reduces stall risk and avoids masking timeouts with a second render.
> 
> **Overview**
> **PDF export** no longer waits on remote assets during Puppeteer render: request interception **aborts** HTTP(S) loads and only allows `data:` URLs, which stops `networkidle0` from hanging on external images/links in document HTML.
> 
> **Puppeteer navigation timeouts** are surfaced as **`ARTIFACT_EXPORT_TIMEOUT`** (HTTP **504**) via `ArtifactExportTimeoutError`, without leaking renderer details. When letterhead compositing is enabled, that timeout is **not** retried as a plain PDF export—the previous “drop letterhead and try again” fallback still applies only to other compositing failures.
> 
> Module docs and unit tests cover the new error mapping, request blocking, and single-attempt behavior on timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef1bb52753cd9d9ef71d4b35f3285c4dda648df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->