### PR TITLE
fix(mcp): reuse connections across operations (AYC-571)

### DIFF
--- a/ayunis-core-backend/appsignal-hooks.cjs
+++ b/ayunis-core-backend/appsignal-hooks.cjs
@@ -62,28 +62,6 @@ function isCrawlerRequest(request) {
 }
 
 /**
- * Identifies the listening stream the MCP SDK's StreamableHTTPClientTransport
- * opens in the background on connect. The client adapter opens one connection
- * per operation and always closes it, and close() unconditionally aborts that
- * still-open stream — so undici reports an AbortError on a request the
- * application deliberately cancelled and never consumed, after the operation
- * already succeeded (AYC-555).
- *
- * The listening stream is the only outbound GET sending exactly
- * `text/event-stream`; MCP JSON-RPC calls are POSTs sending
- * `application/json, text/event-stream`, so genuine connectivity and auth
- * failures stay fully instrumented. That "only" holds today because MCP is the
- * sole SSE client — a second one would silently widen this predicate, which is
- * why it is registered as a stopgap rather than a permanent scoping rule.
- */
-function isMcpEventStreamRequest(request) {
-  return (
-    request.method === 'GET' &&
-    headerValue(request.headers, 'accept') === 'text/event-stream'
-  );
-}
-
-/**
  * The key AppSignal's agent matches `ignoreErrors` against.
  *
  * OpenTelemetry derives it as `code` when truthy, falling back to `name`
@@ -133,18 +111,6 @@ const SUPPRESSIONS = [
     match: isCrawlerRequest,
   },
   {
-    id: 'mcp-listening-stream',
-    lever: 'ignoreRequestHook',
-    ticket: 'AYC-555',
-    stopgapFor: 'AYC-571',
-    reason:
-      'The MCP SDK opens a background SSE GET on connect and close() aborts ' +
-      'it, so undici records an AbortError after the operation already ' +
-      'succeeded. This covers for per-operation connect/close — remove it ' +
-      'once connections are reused.',
-    match: isMcpEventStreamRequest,
-  },
-  {
     id: 'abort-signal-cancellation',
     lever: 'ignoreErrors',
     ticket: 'AYC-651',
@@ -152,7 +118,7 @@ const SUPPRESSIONS = [
       'The DOMException Node mints for AbortController.abort() (name ' +
       'AbortError, numeric code 20, so exceptionType "20"). An abort is ' +
       'always a cancellation we or an SDK issued deliberately — MCP ' +
-      'transport close after a completed operation, SDK request timeouts, ' +
+      'transport teardown after going idle, SDK request timeouts, ' +
       'stream watchdogs, client disconnects — never itself the failure. ' +
       'Real timeouts surface as classified application errors ' +
       '(MCP_CONNECTION_TIMEOUT, INFERENCE_TIMEOUT, PROVIDER_UNAVAILABLE_*), ' +
@@ -345,7 +311,6 @@ function headerValue(headers, name) {
 module.exports = {
   SUPPRESSIONS,
   isCrawlerRequest,
-  isMcpEventStreamRequest,
   shouldIgnoreRequest,
   exceptionTypeOf,
   ignoredErrorTypes,

--- a/ayunis-core-backend/src/common/util/appsignal-hooks.spec.ts
+++ b/ayunis-core-backend/src/common/util/appsignal-hooks.spec.ts
@@ -24,7 +24,6 @@ type Suppression = {
 const hooks = require('../../../appsignal-hooks.cjs') as {
   SUPPRESSIONS: Suppression[];
   isCrawlerRequest: (request: UndiciRequest) => boolean;
-  isMcpEventStreamRequest: (request: UndiciRequest) => boolean;
   shouldIgnoreRequest: (request: UndiciRequest) => boolean;
   exceptionTypeOf: (error: unknown) => string | undefined;
   ignoredErrorTypes: string[];
@@ -35,7 +34,6 @@ const hooks = require('../../../appsignal-hooks.cjs') as {
 const {
   SUPPRESSIONS,
   isCrawlerRequest,
-  isMcpEventStreamRequest,
   shouldIgnoreRequest,
   exceptionTypeOf,
   ignoredErrorTypes,
@@ -99,61 +97,6 @@ describe('isCrawlerRequest', () => {
   });
 });
 
-describe('isMcpEventStreamRequest', () => {
-  it('matches the MCP SDK listening stream', () => {
-    expect(
-      isMcpEventStreamRequest({
-        method: 'GET',
-        headers: ['accept', 'text/event-stream'],
-      }),
-    ).toBe(true);
-  });
-
-  it('matches undici v5 string headers', () => {
-    expect(
-      isMcpEventStreamRequest({
-        method: 'GET',
-        headers: 'Accept: text/event-stream\r\n',
-      }),
-    ).toBe(true);
-  });
-
-  // The JSON-RPC POST sends `application/json, text/event-stream` — genuine
-  // connectivity and auth failures surface there and must keep reporting.
-  it('does not match the MCP JSON-RPC POST', () => {
-    expect(
-      isMcpEventStreamRequest({
-        method: 'POST',
-        headers: ['accept', 'application/json, text/event-stream'],
-      }),
-    ).toBe(false);
-  });
-
-  it('does not match a GET that merely accepts event streams among others', () => {
-    expect(
-      isMcpEventStreamRequest({
-        method: 'GET',
-        headers: ['accept', 'application/json, text/event-stream'],
-      }),
-    ).toBe(false);
-  });
-
-  it('does not match a plain GET', () => {
-    expect(
-      isMcpEventStreamRequest({
-        method: 'GET',
-        headers: ['accept', 'application/json'],
-      }),
-    ).toBe(false);
-  });
-
-  it('does not match when the method is absent', () => {
-    expect(
-      isMcpEventStreamRequest({ headers: ['accept', 'text/event-stream'] }),
-    ).toBe(false);
-  });
-});
-
 describe('shouldIgnoreRequest', () => {
   it('ignores crawler requests', () => {
     expect(
@@ -161,13 +104,13 @@ describe('shouldIgnoreRequest', () => {
     ).toBe(true);
   });
 
-  it('ignores the MCP listening stream', () => {
+  it('instruments MCP listening streams', () => {
     expect(
       shouldIgnoreRequest({
         method: 'GET',
         headers: ['accept', 'text/event-stream'],
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('instruments provider requests', () => {

--- a/ayunis-core-backend/src/domain/mcp/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/mcp/SUMMARY.md
@@ -26,7 +26,8 @@ The MCP module manages connections to external Model Context Protocol servers at
 
 **Services:**
 
-- `McpClientService` — Handles actual server communication via the MCP SDK
+- `McpClientService` — Handles authenticated server communication through the MCP SDK adapter
+- `McpClientPoolService` — Pools SDK connections per tenant, integration, user, and configuration; keeps at most 100 idle clients and invalidates sessions when integration or user credentials change
 - `McpCapabilityCacheService` — In-process TTL cache for discovered capabilities (per integration and user); invalidated on integration update, delete, and user-config changes
 - `McpConfigService` — Validates schemas and merges, encrypts, and retains organization/user config values
 - `ConnectionValidationService` — Validates MCP server connectivity, used by `ValidateMcpIntegrationUseCase`

--- a/ayunis-core-backend/src/domain/mcp/application/ports/mcp-client.port.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/ports/mcp-client.port.ts
@@ -1,11 +1,19 @@
 /**
  * Configuration for connecting to an MCP server
  */
+export interface McpConnectionScope {
+  orgId: string;
+  integrationId: string;
+  userId?: string;
+}
+
 export interface McpConnectionConfig {
   /** Base URL of the MCP server (uses Streamable HTTP transport, MCP protocol 2024-11-05+) */
   serverUrl: string;
   /** Optional headers to send with every MCP request (auth + config fields) */
   headers?: Record<string, string>;
+  /** Tenant and integration identity that scopes stateful MCP sessions. */
+  connectionScope: McpConnectionScope;
   /** Per-user OAuth context resolved by the infrastructure adapter. */
   oauth?: {
     integrationId: string;
@@ -70,12 +78,8 @@ export interface McpToolResult {
  * Port interface for MCP client operations.
  * Abstracts the MCP SDK to allow testing and alternative implementations.
  *
- * All methods use on-demand connection strategy:
- * 1. Create new client connection
- * 2. Execute operation
- * 3. Close connection (in finally block)
- *
- * All operations enforce 30-second timeout.
+ * Connections may be reused across operations with equivalent configuration.
+ * All operations enforce a 30-second timeout.
  */
 export abstract class McpClientPort {
   /**
@@ -137,4 +141,6 @@ export abstract class McpClientPort {
   abstract validateConnection(
     config: McpConnectionConfig,
   ): Promise<{ valid: boolean; error?: string }>;
+
+  abstract invalidateConnections(scope: McpConnectionScope): Promise<void>;
 }

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.spec.ts
@@ -29,6 +29,7 @@ class MockMcpClientPort extends McpClientPort {
   readResource = jest.fn();
   getPrompt = jest.fn();
   validateConnection = jest.fn();
+  invalidateConnections = jest.fn();
 }
 
 class MockCredentialEncryptionPort extends McpCredentialEncryptionPort {
@@ -84,6 +85,21 @@ describe('McpClientService', () => {
     jest.clearAllMocks();
   });
 
+  describe('invalidateConnections', () => {
+    it('invalidates the integration connection scope for one user', async () => {
+      const integration = aCustomMcpIntegration(baseIntegrationParams);
+      const userId = randomUUID();
+
+      await service.invalidateConnections(integration, userId);
+
+      expect(client.invalidateConnections).toHaveBeenCalledWith({
+        orgId: integration.orgId,
+        integrationId: integration.id,
+        userId,
+      });
+    });
+  });
+
   describe('buildConnectionConfig', () => {
     it('resolves schema-configured custom integration headers', async () => {
       const integration = aCustomMcpIntegration({
@@ -129,6 +145,11 @@ describe('McpClientService', () => {
         'X-Tenant-ID': 'council-42',
         Authorization: 'Bearer personal-token',
       });
+      expect(config.connectionScope).toEqual({
+        orgId: integration.orgId,
+        integrationId: integration.id,
+        userId,
+      });
     });
 
     it('returns base config with empty headers for no-auth integrations', async () => {
@@ -142,6 +163,11 @@ describe('McpClientService', () => {
       expect(config).toEqual({
         serverUrl: baseIntegrationParams.serverUrl,
         headers: {},
+        connectionScope: {
+          orgId: integration.orgId,
+          integrationId: integration.id,
+        },
+        oauth: undefined,
       });
       expect(encryption.decrypt).not.toHaveBeenCalled();
     });
@@ -163,6 +189,10 @@ describe('McpClientService', () => {
       expect(config).toEqual({
         serverUrl: baseIntegrationParams.serverUrl,
         headers: { Authorization: 'Bearer decrypted-token' },
+        connectionScope: {
+          orgId: integration.orgId,
+          integrationId: integration.id,
+        },
       });
     });
 
@@ -184,6 +214,10 @@ describe('McpClientService', () => {
       expect(config).toEqual({
         serverUrl: baseIntegrationParams.serverUrl,
         headers: { 'X-API-Key': 'decrypted-secret' },
+        connectionScope: {
+          orgId: integration.orgId,
+          integrationId: integration.id,
+        },
       });
     });
 
@@ -207,6 +241,10 @@ describe('McpClientService', () => {
       expect(config).toEqual({
         serverUrl: baseIntegrationParams.serverUrl,
         headers: { Authorization: 'Bearer decrypted-token' },
+        connectionScope: {
+          orgId: integration.orgId,
+          integrationId: integration.id,
+        },
       });
     });
 
@@ -279,6 +317,11 @@ describe('McpClientService', () => {
       expect(config).toEqual({
         serverUrl: 'https://mcp.ayunis.de/oparl',
         headers: { 'X-Oparl-Endpoint-Url': 'https://rim.ekom21.de/oparl' },
+        connectionScope: {
+          orgId: integration.orgId,
+          integrationId: integration.id,
+        },
+        oauth: undefined,
       });
       expect(encryption.decrypt).not.toHaveBeenCalled();
     });
@@ -649,6 +692,10 @@ describe('McpClientService', () => {
         {
           serverUrl: integration.serverUrl,
           headers: {},
+          connectionScope: {
+            orgId: integration.orgId,
+            integrationId: integration.id,
+          },
           oauth: undefined,
         },
       );

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.ts
@@ -28,11 +28,6 @@ import { McpOAuthUserTokenRepositoryPort } from '../ports/mcp-oauth-user-token.r
 import { McpCapabilityCacheService } from './mcp-capability-cache.service';
 import { handleMcpOperationError } from './mcp-operation-error';
 
-/**
- * Service for executing MCP operations with authentication.
- * Leverages the polymorphic authentication design of integration entities.
- * Handles credential decryption and connection configuration.
- */
 @Injectable()
 export class McpClientService {
   private readonly logger = new Logger(McpClientService.name);
@@ -47,16 +42,14 @@ export class McpClientService {
     private readonly capabilityCache?: McpCapabilityCacheService,
   ) {}
 
-  /**
-   * Builds MCP connection configuration from integration entity.
-   * Schema-configured integrations resolve organization and user fields.
-   * Other integrations delegate header generation to their auth entity.
-   *
-   * @param integration The MCP integration entity
-   * @param userId Optional user ID for per-user config resolution
-   * @returns Connection configuration for MCP client
-   * @throws McpAuthenticationError if authentication configuration fails
-   */
+  invalidateConnections(
+    integration: McpIntegration,
+    userId?: UUID,
+  ): Promise<void> {
+    return this.mcpClient.invalidateConnections(
+      this.buildConnectionScope(integration, userId),
+    );
+  }
 
   async buildConnectionConfig(
     integration: McpIntegration,
@@ -65,13 +58,9 @@ export class McpClientService {
     if (integration instanceof SchemaConfiguredMcpIntegration) {
       return this.buildSchemaConfiguredConnectionConfig(integration, userId);
     }
-    return this.buildAuthConnectionConfig(integration);
+    return this.buildAuthConnectionConfig(integration, userId);
   }
 
-  /**
-   * Builds connection config for schema-configured integrations by resolving
-   * config schema fields to HTTP headers, with optional user-level overrides.
-   */
   private async buildSchemaConfiguredConnectionConfig(
     integration: SchemaConfiguredMcpIntegration,
     userId?: UUID,
@@ -154,6 +143,7 @@ export class McpClientService {
     return {
       serverUrl: integration.serverUrl,
       headers,
+      connectionScope: this.buildConnectionScope(integration, userId),
       oauth:
         integration.configSchema.oauth && userId
           ? {
@@ -213,10 +203,15 @@ export class McpClientService {
 
   private async buildAuthConnectionConfig(
     integration: McpIntegration,
+    userId?: UUID,
   ): Promise<McpConnectionConfig> {
     try {
       const headers = await this.buildAuthHeaders(integration);
-      return { serverUrl: integration.serverUrl, headers };
+      return {
+        serverUrl: integration.serverUrl,
+        headers,
+        connectionScope: this.buildConnectionScope(integration, userId),
+      };
     } catch (error) {
       if (error instanceof McpAuthenticationError) {
         throw error;
@@ -228,6 +223,17 @@ export class McpClientService {
       });
       throw new McpAuthenticationError('Authentication configuration failed');
     }
+  }
+
+  private buildConnectionScope(
+    integration: McpIntegration,
+    userId?: UUID,
+  ): McpConnectionConfig['connectionScope'] {
+    return {
+      orgId: integration.orgId,
+      integrationId: integration.id,
+      ...(userId ? { userId } : {}),
+    };
   }
 
   private async buildAuthHeaders(
@@ -283,13 +289,6 @@ export class McpClientService {
     return headers;
   }
 
-  /**
-   * Lists all tools available on the MCP server.
-   *
-   * @param integration The MCP integration entity
-   * @returns List of available tools
-   * @throws McpAuthenticationError on 401 responses
-   */
   async listTools(
     integration: McpIntegration,
     userId?: UUID,

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-oauth-authorization.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-oauth-authorization.service.spec.ts
@@ -43,6 +43,7 @@ describe('McpOAuthAuthorizationService', () => {
   const registrations = { findByIntegrationAndIssuer: jest.fn() };
   const encryption = { encrypt: jest.fn(), decrypt: jest.fn() };
   const cache = { invalidate: jest.fn() };
+  const mcpClient = { invalidateConnections: jest.fn() };
   const config = { get: jest.fn() };
   const oauthFetch = new McpOAuthFetchService(config as never);
   let service: McpOAuthAuthorizationService;
@@ -67,6 +68,7 @@ describe('McpOAuthAuthorizationService', () => {
       encryption,
       cache as never,
       oauthFetch,
+      mcpClient as never,
     );
   });
 
@@ -124,6 +126,10 @@ describe('McpOAuthAuthorizationService', () => {
       fetchFn: oauthFetch.fetch,
     });
     expect(cache.invalidate).toHaveBeenCalledWith(integration.id, userId);
+    expect(mcpClient.invalidateConnections).toHaveBeenCalledWith(
+      integration,
+      userId,
+    );
   });
 
   it('rejects a callback when the SDK does not complete authorization', async () => {
@@ -187,6 +193,13 @@ describe('McpOAuthAuthorizationService', () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(tokens.delete).toHaveBeenCalledWith(integration.id, userId);
+    expect(mcpClient.invalidateConnections).toHaveBeenCalledWith(
+      integration,
+      userId,
+    );
+    expect(
+      mcpClient.invalidateConnections.mock.invocationCallOrder[0],
+    ).toBeLessThan(tokens.delete.mock.invocationCallOrder[0]);
   });
 
   function buildPending(state: string): McpOAuthPendingSession {

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-oauth-authorization.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-oauth-authorization.service.ts
@@ -15,6 +15,7 @@ import { McpOAuthUserTokenRepositoryPort } from '../ports/mcp-oauth-user-token.r
 import { McpOAuthClientRegistrationRepositoryPort } from '../ports/mcp-oauth-client-registration.repository.port';
 import { McpCredentialEncryptionPort } from '../ports/mcp-credential-encryption.port';
 import { McpOAuthFetchPort } from '../ports/mcp-oauth-fetch.port';
+import { McpClientService } from './mcp-client.service';
 
 export interface CompleteMcpOAuthInput {
   state: string;
@@ -35,6 +36,7 @@ export class McpOAuthAuthorizationService {
     private readonly encryption: McpCredentialEncryptionPort,
     private readonly capabilityCache: McpCapabilityCacheService,
     private readonly oauthFetch: McpOAuthFetchPort,
+    private readonly mcpClientService: McpClientService,
   ) {}
 
   async authorize(integrationId: UUID): Promise<{ authorizationUrl: string }> {
@@ -94,13 +96,20 @@ export class McpOAuthAuthorizationService {
       fetchFn: this.oauthFetch.fetch,
     });
     if (result !== 'AUTHORIZED') this.rejectCallback();
+    await this.mcpClientService.invalidateConnections(
+      integration,
+      identity.userId,
+    );
     this.capabilityCache.invalidate(integration.id, identity.userId);
     return { integrationId: integration.id };
   }
 
   async disconnect(integrationId: UUID): Promise<void> {
-    this.requireOAuthIntegration(await this.access.validate(integrationId));
+    const integration = this.requireOAuthIntegration(
+      await this.access.validate(integrationId),
+    );
     const { userId } = this.requireIdentity();
+    await this.mcpClientService.invalidateConnections(integration, userId);
     await this.revokeQuietly(integrationId, userId);
     await this.tokens.delete(integrationId, userId);
     this.capabilityCache.invalidate(integrationId, userId);

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-oauth-client-configuration.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-oauth-client-configuration.service.spec.ts
@@ -33,11 +33,15 @@ describe('McpOAuthClientConfigurationService', () => {
     consumeByStateHash: jest.fn(),
     deleteByIntegration: jest.fn(),
   } as jest.Mocked<McpOAuthPendingSessionRepositoryPort>;
+  const capabilityCache = { invalidate: jest.fn() };
+  const mcpClient = { invalidateConnections: jest.fn() };
   const service = new McpOAuthClientConfigurationService(
     encryption,
     registrations,
     tokens,
     pendingSessions,
+    capabilityCache as never,
+    mcpClient as never,
   );
 
   beforeEach(() => {
@@ -82,6 +86,10 @@ describe('McpOAuthClientConfigurationService', () => {
     expect(registrations.save.mock.invocationCallOrder[0]).toBeLessThan(
       tokens.deleteByIntegration.mock.invocationCallOrder[0],
     );
+    expect(mcpClient.invalidateConnections).toHaveBeenCalledWith(integration);
+    expect(
+      mcpClient.invalidateConnections.mock.invocationCallOrder[0],
+    ).toBeLessThan(tokens.deleteByIntegration.mock.invocationCallOrder[0]);
   });
 
   it('requires client information for static registration', async () => {

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-oauth-client-configuration.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-oauth-client-configuration.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Optional } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { SchemaConfiguredMcpIntegration } from '../../domain/integrations/schema-configured-mcp-integration.entity';
 import { McpOAuthClientRegistration } from '../../domain/mcp-oauth-client-registration.entity';
 import { McpValidationFailedError } from '../mcp.errors';
@@ -7,6 +7,7 @@ import { McpOAuthClientRegistrationRepositoryPort } from '../ports/mcp-oauth-cli
 import { McpOAuthPendingSessionRepositoryPort } from '../ports/mcp-oauth-pending-session.repository.port';
 import { McpOAuthUserTokenRepositoryPort } from '../ports/mcp-oauth-user-token.repository.port';
 import { McpCapabilityCacheService } from './mcp-capability-cache.service';
+import { McpClientService } from './mcp-client.service';
 
 export interface McpOAuthStaticClientInput {
   clientId: string;
@@ -20,8 +21,8 @@ export class McpOAuthClientConfigurationService {
     private readonly registrations: McpOAuthClientRegistrationRepositoryPort,
     private readonly tokens: McpOAuthUserTokenRepositoryPort,
     private readonly pendingSessions: McpOAuthPendingSessionRepositoryPort,
-    @Optional()
-    private readonly capabilityCache?: McpCapabilityCacheService,
+    private readonly capabilityCache: McpCapabilityCacheService,
+    private readonly mcpClientService: McpClientService,
   ) {}
 
   async initialize(
@@ -56,7 +57,7 @@ export class McpOAuthClientConfigurationService {
         createdAt: existing?.createdAt,
       }),
     );
-    await this.clearExistingAuthorization(integration.id, replacement.id);
+    await this.clearExistingAuthorization(integration, replacement.id);
   }
 
   validate(
@@ -95,16 +96,17 @@ export class McpOAuthClientConfigurationService {
   }
 
   private async clearExistingAuthorization(
-    integrationId: SchemaConfiguredMcpIntegration['id'],
+    integration: SchemaConfiguredMcpIntegration,
     replacementId: McpOAuthClientRegistration['id'],
   ): Promise<void> {
-    await this.pendingSessions.deleteByIntegration(integrationId);
-    await this.tokens.deleteByIntegration(integrationId);
+    await this.mcpClientService.invalidateConnections(integration);
+    await this.pendingSessions.deleteByIntegration(integration.id);
+    await this.tokens.deleteByIntegration(integration.id);
     await this.registrations.deleteByIntegrationExcept(
-      integrationId,
+      integration.id,
       replacementId,
     );
-    this.capabilityCache?.invalidate(integrationId);
+    this.capabilityCache.invalidate(integration.id);
   }
 
   private rejectClient(

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.spec.ts
@@ -8,6 +8,7 @@ import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repo
 import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
 import { McpCapabilityCacheService } from '../../services/mcp-capability-cache.service';
+import { McpClientService } from '../../services/mcp-client.service';
 import {
   McpIntegrationNotFoundError,
   McpIntegrationAccessDeniedError,
@@ -23,6 +24,9 @@ describe('DeleteMcpIntegrationUseCase', () => {
   let userConfigRepository: McpIntegrationUserConfigRepositoryPort;
   let contextService: ContextService;
   let capabilityCache: McpCapabilityCacheService;
+  let mcpClientService: jest.Mocked<
+    Pick<McpClientService, 'invalidateConnections'>
+  >;
   let loggerLogSpy: jest.SpyInstance;
   let loggerErrorSpy: jest.SpyInstance;
 
@@ -54,6 +58,10 @@ describe('DeleteMcpIntegrationUseCase', () => {
       providers: [
         DeleteMcpIntegrationUseCase,
         McpCapabilityCacheService,
+        {
+          provide: McpClientService,
+          useValue: { invalidateConnections: jest.fn() },
+        },
         {
           provide: McpIntegrationsRepositoryPort,
           useValue: {
@@ -89,6 +97,7 @@ describe('DeleteMcpIntegrationUseCase', () => {
     capabilityCache = module.get<McpCapabilityCacheService>(
       McpCapabilityCacheService,
     );
+    mcpClientService = module.get(McpClientService);
 
     // Spy on logger methods
     loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
@@ -118,6 +127,9 @@ describe('DeleteMcpIntegrationUseCase', () => {
       expect(contextService.get).toHaveBeenCalledWith('orgId');
       expect(repository.findById).toHaveBeenCalledWith(mockIntegrationId);
       expect(repository.delete).toHaveBeenCalledWith(mockIntegrationId);
+      expect(mcpClientService.invalidateConnections).toHaveBeenCalledWith(
+        mockIntegration,
+      );
       expect(loggerLogSpy).toHaveBeenCalledWith('deleteMcpIntegration', {
         id: mockIntegrationId,
       });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.ts
@@ -10,6 +10,7 @@ import {
   UnexpectedMcpError,
 } from '../../mcp.errors';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { McpClientService } from '../../services/mcp-client.service';
 
 /**
  * Use case for deleting an MCP integration.
@@ -23,6 +24,7 @@ export class DeleteMcpIntegrationUseCase {
     private readonly userConfigRepository: McpIntegrationUserConfigRepositoryPort,
     private readonly contextService: ContextService,
     private readonly capabilityCache: McpCapabilityCacheService,
+    private readonly mcpClientService: McpClientService,
   ) {}
 
   /**
@@ -61,6 +63,7 @@ export class DeleteMcpIntegrationUseCase {
     // Delete integration
     await this.repository.delete(command.integrationId);
 
+    await this.mcpClientService.invalidateConnections(integration);
     this.capabilityCache.invalidate(command.integrationId);
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.spec.ts
@@ -11,6 +11,7 @@ import { NoAuthMcpIntegrationAuth } from 'src/domain/mcp/domain/auth/no-auth-mcp
 import { SECRET_MASK } from 'src/domain/mcp/domain/value-objects/secret-mask.constant';
 import { McpConfigService } from '../../services/mcp-config.service';
 import { McpCapabilityCacheService } from '../../services/mcp-capability-cache.service';
+import type { McpClientService } from '../../services/mcp-client.service';
 import {
   McpIntegrationNotFoundError,
   McpIntegrationNotConfigurableError,
@@ -31,6 +32,9 @@ describe('SetUserMcpConfigUseCase', () => {
   let contextService: jest.Mocked<ContextService>;
   let configService: McpConfigService;
   let capabilityCache: McpCapabilityCacheService;
+  let mcpClientService: jest.Mocked<
+    Pick<McpClientService, 'invalidateConnections'>
+  >;
 
   const userId = '770e8400-e29b-41d4-a716-446655440001' as UUID;
   const orgId = '660e8400-e29b-41d4-a716-446655440001' as UUID;
@@ -104,6 +108,7 @@ describe('SetUserMcpConfigUseCase', () => {
     configService = new McpConfigService(credentialEncryption);
 
     capabilityCache = new McpCapabilityCacheService();
+    mcpClientService = { invalidateConnections: jest.fn() };
 
     useCase = new SetUserMcpConfigUseCase(
       integrationRepository,
@@ -111,6 +116,7 @@ describe('SetUserMcpConfigUseCase', () => {
       contextService,
       configService,
       capabilityCache,
+      mcpClientService as unknown as McpClientService,
     );
   });
 
@@ -147,6 +153,10 @@ describe('SetUserMcpConfigUseCase', () => {
       tenantId: 'my-tenant-123',
     });
     expect(userConfigRepository.save).toHaveBeenCalled();
+    expect(mcpClientService.invalidateConnections).toHaveBeenCalledWith(
+      integration,
+      userId,
+    );
   });
 
   it('should wrap unexpected errors in UnexpectedMcpError', async () => {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.ts
@@ -20,6 +20,7 @@ import {
   UnexpectedMcpError,
 } from '../../mcp.errors';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { McpClientService } from '../../services/mcp-client.service';
 
 @Injectable()
 export class SetUserMcpConfigUseCase {
@@ -31,6 +32,7 @@ export class SetUserMcpConfigUseCase {
     private readonly contextService: ContextService,
     private readonly configService: McpConfigService,
     private readonly capabilityCache: McpCapabilityCacheService,
+    private readonly mcpClientService: McpClientService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedMcpError)
@@ -82,6 +84,10 @@ export class SetUserMcpConfigUseCase {
       existing,
     );
 
+    await this.mcpClientService.invalidateConnections(
+      configurableIntegration,
+      userId,
+    );
     this.capabilityCache.invalidate(command.integrationId, userId);
 
     return this.maskResult(saved.configValues, userFields);

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
@@ -8,6 +8,7 @@ import type { McpCredentialEncryptionPort } from '../../ports/mcp-credential-enc
 import { McpConfigService } from '../../services/mcp-config.service';
 import { ConnectionValidationService } from '../../services/connection-validation.service';
 import { McpCapabilityCacheService } from '../../services/mcp-capability-cache.service';
+import type { McpClientService } from '../../services/mcp-client.service';
 import type { ValidateMcpIntegrationUseCase } from '../validate-mcp-integration/validate-mcp-integration.use-case';
 import { aCustomMcpIntegration } from 'src/domain/mcp/application/testing/mcp-integration.fixtures';
 import { PredefinedMcpIntegration } from 'src/domain/mcp/domain/integrations/predefined-mcp-integration.entity';
@@ -33,6 +34,9 @@ describe('UpdateMcpIntegrationUseCase', () => {
   let validateUseCase: jest.Mocked<ValidateMcpIntegrationUseCase>;
   let connectionValidationService: ConnectionValidationService;
   let capabilityCache: McpCapabilityCacheService;
+  let mcpClientService: jest.Mocked<
+    Pick<McpClientService, 'invalidateConnections'>
+  >;
   let useCase: UpdateMcpIntegrationUseCase;
 
   beforeEach(() => {
@@ -65,6 +69,7 @@ describe('UpdateMcpIntegrationUseCase', () => {
     );
 
     capabilityCache = new McpCapabilityCacheService();
+    mcpClientService = { invalidateConnections: jest.fn() };
 
     useCase = new UpdateMcpIntegrationUseCase(
       repository,
@@ -74,6 +79,7 @@ describe('UpdateMcpIntegrationUseCase', () => {
       connectionValidationService,
       capabilityCache,
       { initialize: jest.fn() } as never,
+      mcpClientService as unknown as McpClientService,
     );
     context.get.mockReturnValue(orgId);
     repository.save.mockImplementation(async (integration) => integration);
@@ -115,6 +121,9 @@ describe('UpdateMcpIntegrationUseCase', () => {
       'encrypted-new',
     );
     expect(repository.save).toHaveBeenCalledWith(integration);
+    expect(mcpClientService.invalidateConnections).toHaveBeenCalledWith(
+      integration,
+    );
   });
 
   it('rejects OAuth client updates before mutating a non-schema integration', async () => {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.ts
@@ -21,6 +21,7 @@ import { McpConfigService } from '../../services/mcp-config.service';
 import { ConnectionValidationService } from '../../services/connection-validation.service';
 import { McpCapabilityCacheService } from '../../services/mcp-capability-cache.service';
 import { McpOAuthClientConfigurationService } from '../../services/mcp-oauth-client-configuration.service';
+import { McpClientService } from '../../services/mcp-client.service';
 
 @Injectable()
 export class UpdateMcpIntegrationUseCase {
@@ -34,6 +35,7 @@ export class UpdateMcpIntegrationUseCase {
     private readonly connectionValidationService: ConnectionValidationService,
     private readonly capabilityCache: McpCapabilityCacheService,
     private readonly oauthClientConfiguration: McpOAuthClientConfigurationService,
+    private readonly mcpClientService: McpClientService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedMcpError)
@@ -60,9 +62,9 @@ export class UpdateMcpIntegrationUseCase {
     }
 
     // Invalidate as soon as the new config is committed — the connection
-    // validation below runs live MCP requests that can take tens of seconds,
-    // and cached discoveries must not keep serving the pre-update tool list
-    // for that long.
+    // validation below can take tens of seconds, while pooled sessions and
+    // discoveries must stop using the previous configuration immediately.
+    await this.mcpClientService.invalidateConnections(saved);
     this.capabilityCache.invalidate(command.integrationId as UUID);
 
     return this.validateConnectionIfNeeded(saved, command);

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-client-pool.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-client-pool.service.spec.ts
@@ -1,0 +1,255 @@
+import { Logger } from '@nestjs/common';
+import type { Client } from '@modelcontextprotocol/client';
+import { randomUUID } from 'crypto';
+import type { McpConnectionConfig } from '../../application/ports/mcp-client.port';
+import { McpClientPoolService } from './mcp-client-pool.service';
+
+describe('McpClientPoolService', () => {
+  let pool: McpClientPoolService;
+  let client: Client;
+  let close: jest.Mock;
+  let createClient: jest.Mock;
+
+  const config: McpConnectionConfig = {
+    serverUrl: 'https://mcp.example.com/mcp',
+    headers: { Authorization: 'Bearer council-token' },
+    connectionScope: {
+      orgId: randomUUID(),
+      integrationId: randomUUID(),
+      userId: randomUUID(),
+    },
+  };
+
+  beforeEach(() => {
+    close = jest.fn().mockResolvedValue(undefined);
+    client = { close } as unknown as Client;
+    createClient = jest.fn().mockResolvedValue(client);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    pool = new McpClientPoolService();
+  });
+
+  afterEach(async () => {
+    await pool.onModuleDestroy();
+    jest.restoreAllMocks();
+  });
+
+  it('reuses one client for repeated operations with the same config', async () => {
+    await pool.withClient(config, createClient, async () => 'tools');
+    await pool.withClient(config, createClient, async () => 'resources');
+
+    expect(createClient).toHaveBeenCalledTimes(1);
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('reuses a client when equivalent headers have different insertion order', async () => {
+    await pool.withClient(
+      {
+        ...config,
+        headers: { Authorization: 'Bearer council-token', Region: 'north' },
+      },
+      createClient,
+      async () => undefined,
+    );
+    await pool.withClient(
+      {
+        ...config,
+        headers: { Region: 'north', Authorization: 'Bearer council-token' },
+      },
+      createClient,
+      async () => undefined,
+    );
+
+    expect(createClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not share clients across different credentials', async () => {
+    await pool.withClient(config, createClient, async () => undefined);
+    await pool.withClient(
+      {
+        ...config,
+        headers: { Authorization: 'Bearer another-council-token' },
+      },
+      createClient,
+      async () => undefined,
+    );
+
+    expect(createClient).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not share sessions across different integration scopes', async () => {
+    await pool.withClient(
+      {
+        ...config,
+        connectionScope: {
+          ...config.connectionScope,
+          integrationId: randomUUID(),
+        },
+      },
+      createClient,
+      async () => undefined,
+    );
+    await pool.withClient(
+      {
+        ...config,
+        connectionScope: {
+          ...config.connectionScope,
+          integrationId: randomUUID(),
+        },
+      },
+      createClient,
+      async () => undefined,
+    );
+
+    expect(createClient).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates one user session without closing other integration sessions', async () => {
+    const otherUserConfig: McpConnectionConfig = {
+      ...config,
+      connectionScope: {
+        ...config.connectionScope,
+        userId: randomUUID(),
+      },
+    };
+    await pool.withClient(config, createClient, async () => undefined);
+    await pool.withClient(otherUserConfig, createClient, async () => undefined);
+
+    await pool.invalidateConnections(config.connectionScope);
+    await pool.withClient(config, createClient, async () => undefined);
+    await pool.withClient(otherUserConfig, createClient, async () => undefined);
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(createClient).toHaveBeenCalledTimes(3);
+  });
+
+  it('invalidates every user session for an integration', async () => {
+    await pool.withClient(config, createClient, async () => undefined);
+    await pool.withClient(
+      {
+        ...config,
+        connectionScope: {
+          ...config.connectionScope,
+          userId: randomUUID(),
+        },
+      },
+      createClient,
+      async () => undefined,
+    );
+
+    await pool.invalidateConnections({
+      orgId: config.connectionScope.orgId,
+      integrationId: config.connectionScope.integrationId,
+    });
+
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+
+  it('limits the idle pool to 100 clients', async () => {
+    for (let index = 0; index <= 100; index += 1) {
+      await pool.withClient(
+        {
+          ...config,
+          headers: { Authorization: `Bearer council-token-${index}` },
+        },
+        createClient,
+        async () => undefined,
+      );
+    }
+
+    expect(createClient).toHaveBeenCalledTimes(101);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes a client after it has been idle for one minute', async () => {
+    jest.useFakeTimers();
+    try {
+      await pool.withClient(config, createClient, async () => undefined);
+
+      await jest.advanceTimersByTimeAsync(59_999);
+      expect(close).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(1);
+      expect(close).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('closes cached clients when the module is destroyed', async () => {
+    await pool.withClient(config, createClient, async () => undefined);
+
+    await pool.onModuleDestroy();
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not create clients after module teardown starts', async () => {
+    await pool.onModuleDestroy();
+
+    await expect(
+      pool.withClient(config, createClient, async () => undefined),
+    ).rejects.toThrow('MCP client pool is shutting down');
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('keeps the client after an unsupported capability error', async () => {
+    const methodNotFound = Object.assign(new Error('Method not found'), {
+      code: -32601,
+    });
+
+    await expect(
+      pool.withClient(config, createClient, async () => {
+        throw methodNotFound;
+      }),
+    ).rejects.toBe(methodNotFound);
+    await pool.withClient(config, createClient, async () => undefined);
+
+    expect(createClient).toHaveBeenCalledTimes(1);
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('evicts and closes a client after an operation failure', async () => {
+    await expect(
+      pool.withClient(config, createClient, async () => {
+        throw new Error('temporary protocol failure');
+      }),
+    ).rejects.toThrow('temporary protocol failure');
+    await pool.withClient(config, createClient, async () => undefined);
+
+    expect(createClient).toHaveBeenCalledTimes(2);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes an evicted client during shutdown while another operation is active', async () => {
+    let finishOperation!: () => void;
+    const activeOperation = pool.withClient(
+      config,
+      createClient,
+      () =>
+        new Promise<void>((resolve) => {
+          finishOperation = resolve;
+        }),
+    );
+
+    await expect(
+      pool.withClient(config, createClient, async () => {
+        throw new Error('temporary protocol failure');
+      }),
+    ).rejects.toThrow('temporary protocol failure');
+    await pool.onModuleDestroy();
+
+    expect(close).toHaveBeenCalledTimes(1);
+    finishOperation();
+    await expect(activeOperation).resolves.toBeUndefined();
+  });
+
+  it('preserves the operation error when closing the client also fails', async () => {
+    close.mockRejectedValue(new Error('transport close failed'));
+
+    await expect(
+      pool.withClient(config, createClient, async () => {
+        throw new Error('operation failed');
+      }),
+    ).rejects.toThrow('operation failed');
+  });
+});

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-client-pool.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-client-pool.service.ts
@@ -1,0 +1,196 @@
+import { Injectable, Logger, type OnModuleDestroy } from '@nestjs/common';
+import type { Client } from '@modelcontextprotocol/client';
+import { createHash } from 'crypto';
+import type {
+  McpConnectionConfig,
+  McpConnectionScope,
+} from '../../application/ports/mcp-client.port';
+
+const CLIENT_IDLE_TIMEOUT_MS = 60_000;
+const MAX_IDLE_CLIENTS = 100;
+
+interface CachedClient {
+  key: string;
+  scope: McpConnectionScope;
+  client: Promise<Client>;
+  activeOperations: number;
+  idleTimer: NodeJS.Timeout | null;
+  stale: boolean;
+  closePromise?: Promise<void>;
+}
+
+@Injectable()
+export class McpClientPoolService implements OnModuleDestroy {
+  private readonly logger = new Logger(McpClientPoolService.name);
+  private readonly clients = new Map<string, CachedClient>();
+  private readonly liveClients = new Set<CachedClient>();
+  private shuttingDown = false;
+
+  async onModuleDestroy(): Promise<void> {
+    this.shuttingDown = true;
+    const clients = [...this.liveClients];
+    this.clients.clear();
+    for (const client of clients) this.markStale(client);
+    await Promise.all(clients.map((client) => this.closeClient(client)));
+  }
+
+  async withClient<T>(
+    config: McpConnectionConfig,
+    createClient: () => Promise<Client>,
+    operation: (client: Client) => Promise<T>,
+  ): Promise<T> {
+    const cached = this.acquireClient(config, createClient);
+    try {
+      return await operation(await cached.client);
+    } catch (error) {
+      if (!this.isMethodNotFoundError(error)) this.evictClient(cached);
+      throw error;
+    } finally {
+      await this.releaseClient(cached);
+    }
+  }
+
+  async invalidateConnections(scope: McpConnectionScope): Promise<void> {
+    const clients = [...this.clients.values()].filter((client) =>
+      this.matchesScope(client.scope, scope),
+    );
+    for (const client of clients) this.evictClient(client);
+    await Promise.all(
+      clients
+        .filter((client) => client.activeOperations === 0)
+        .map((client) => this.closeClient(client)),
+    );
+  }
+
+  private acquireClient(
+    config: McpConnectionConfig,
+    createClient: () => Promise<Client>,
+  ): CachedClient {
+    if (this.shuttingDown) {
+      throw new Error('MCP client pool is shutting down');
+    }
+    const key = this.connectionKey(config);
+    const cached = this.clients.get(key);
+    if (cached) {
+      if (cached.idleTimer) clearTimeout(cached.idleTimer);
+      cached.idleTimer = null;
+      cached.activeOperations += 1;
+      this.clients.delete(key);
+      this.clients.set(key, cached);
+      return cached;
+    }
+    const client: CachedClient = {
+      key,
+      scope: config.connectionScope,
+      client: createClient(),
+      activeOperations: 1,
+      idleTimer: null,
+      stale: false,
+    };
+    this.clients.set(key, client);
+    this.liveClients.add(client);
+    return client;
+  }
+
+  private async releaseClient(client: CachedClient): Promise<void> {
+    client.activeOperations -= 1;
+    if (client.activeOperations > 0) return;
+    if (client.stale) {
+      await this.closeClient(client);
+      return;
+    }
+    client.idleTimer = setTimeout(
+      () => this.expireIdleClient(client),
+      CLIENT_IDLE_TIMEOUT_MS,
+    );
+    client.idleTimer.unref();
+    await this.trimIdleClients();
+  }
+
+  private async trimIdleClients(): Promise<void> {
+    const idleClients = [...this.clients.values()].filter(
+      (client) => client.activeOperations === 0,
+    );
+    const excess = idleClients.slice(0, -MAX_IDLE_CLIENTS);
+    for (const client of excess) this.evictClient(client);
+    await Promise.all(excess.map((client) => this.closeClient(client)));
+  }
+
+  private matchesScope(
+    candidate: McpConnectionScope,
+    requested: McpConnectionScope,
+  ): boolean {
+    return (
+      candidate.orgId === requested.orgId &&
+      candidate.integrationId === requested.integrationId &&
+      (requested.userId === undefined || candidate.userId === requested.userId)
+    );
+  }
+
+  private expireIdleClient(client: CachedClient): void {
+    client.idleTimer = null;
+    if (this.clients.get(client.key) !== client) return;
+    this.clients.delete(client.key);
+    this.markStale(client);
+    void this.closeClient(client);
+  }
+
+  private isMethodNotFoundError(error: unknown): boolean {
+    return Boolean(
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      (error as { code?: unknown }).code === -32601,
+    );
+  }
+
+  private evictClient(client: CachedClient): void {
+    if (this.clients.get(client.key) === client) {
+      this.clients.delete(client.key);
+    }
+    this.markStale(client);
+  }
+
+  private markStale(client: CachedClient): void {
+    client.stale = true;
+    if (client.idleTimer) clearTimeout(client.idleTimer);
+    client.idleTimer = null;
+  }
+
+  private closeClient(client: CachedClient): Promise<void> {
+    client.closePromise ??= client.client
+      .then(
+        (connected) => this.closeQuietly(connected),
+        () => undefined,
+      )
+      .finally(() => this.liveClients.delete(client));
+    return client.closePromise;
+  }
+
+  private connectionKey(config: McpConnectionConfig): string {
+    const headers = Object.entries(config.headers ?? {}).sort(
+      ([left], [right]) => left.localeCompare(right),
+    );
+    const scope = [
+      config.connectionScope.orgId,
+      config.connectionScope.integrationId,
+      config.connectionScope.userId ?? null,
+    ];
+    const oauth = config.oauth
+      ? [config.oauth.integrationId, config.oauth.userId, config.oauth.orgId]
+      : null;
+    return createHash('sha256')
+      .update(JSON.stringify([config.serverUrl, headers, scope, oauth]))
+      .digest('base64url');
+  }
+
+  private async closeQuietly(client: Client): Promise<void> {
+    try {
+      await client.close();
+    } catch (error) {
+      this.logger.warn('Failed to close MCP client', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.spec.ts
@@ -4,6 +4,7 @@ import {
   StreamableHTTPClientTransport,
 } from '@modelcontextprotocol/client';
 import { McpSdkClientAdapter } from './mcp-sdk-client.adapter';
+import { McpClientPoolService } from './mcp-client-pool.service';
 import type { McpConnectionConfig } from '../../application/ports/mcp-client.port';
 import {
   McpConnectionFailedError,
@@ -22,6 +23,7 @@ const REQUEST_TIMEOUT = { timeout: 30000 };
 
 describe('McpSdkClientAdapter', () => {
   let adapter: McpSdkClientAdapter;
+  let clientPool: McpClientPoolService;
   let clientMock: {
     connect: jest.Mock;
     close: jest.Mock;
@@ -37,15 +39,15 @@ describe('McpSdkClientAdapter', () => {
   const config: McpConnectionConfig = {
     serverUrl: 'https://mcp.example.com/mcp',
     headers: { Authorization: 'Bearer token-value' },
-  };
-
-  const buildAbortError = () => {
-    const error = new Error('This operation was aborted');
-    error.name = 'AbortError';
-    return error;
+    connectionScope: {
+      orgId: randomUUID(),
+      integrationId: randomUUID(),
+      userId: randomUUID(),
+    },
   };
 
   beforeEach(() => {
+    jest.clearAllMocks();
     clientMock = {
       connect: jest.fn().mockResolvedValue(undefined),
       close: jest.fn().mockResolvedValue(undefined),
@@ -65,10 +67,12 @@ describe('McpSdkClientAdapter', () => {
 
     jest.spyOn(Logger.prototype, 'warn').mockImplementation();
 
-    adapter = new McpSdkClientAdapter();
+    clientPool = new McpClientPoolService();
+    adapter = new McpSdkClientAdapter(clientPool);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await clientPool.onModuleDestroy();
     jest.restoreAllMocks();
   });
 
@@ -119,16 +123,23 @@ describe('McpSdkClientAdapter', () => {
       };
       const oauthFetch = { fetch: jest.fn() };
       adapter = new McpSdkClientAdapter(
+        clientPool,
         providerFactory as never,
         integrations as never,
         oauthFetch,
       );
 
+      const userId = randomUUID();
       await adapter.listTools({
         serverUrl: config.serverUrl,
+        connectionScope: {
+          orgId: integration.orgId,
+          integrationId: integration.id,
+          userId,
+        },
         oauth: {
           integrationId: integration.id,
-          userId: randomUUID(),
+          userId,
           orgId: integration.orgId,
         },
       });
@@ -142,20 +153,6 @@ describe('McpSdkClientAdapter', () => {
       );
     });
 
-    it('returns the tools reported by the server', async () => {
-      const tools = [
-        {
-          name: 'search_registry',
-          description: 'Search the registry',
-          inputSchema: { type: 'object' },
-        },
-      ];
-      clientMock.listTools.mockResolvedValue({ tools });
-
-      await expect(adapter.listTools(config)).resolves.toEqual(tools);
-      expect(clientMock.close).toHaveBeenCalled();
-    });
-
     it('enforces the timeout through the SDK request options', async () => {
       await adapter.listTools(config);
 
@@ -167,38 +164,6 @@ describe('McpSdkClientAdapter', () => {
         undefined,
         REQUEST_TIMEOUT,
       );
-    });
-
-    it('still returns the result when closing the client fails', async () => {
-      const tools = [
-        {
-          name: 'search_registry',
-          description: 'Search the registry',
-          inputSchema: { type: 'object' },
-        },
-      ];
-      clientMock.listTools.mockResolvedValue({ tools });
-      clientMock.close.mockRejectedValue(buildAbortError());
-
-      await expect(adapter.listTools(config)).resolves.toEqual(tools);
-    });
-
-    it('preserves the operation error when closing the client also fails', async () => {
-      clientMock.listTools.mockRejectedValue(
-        new Error('MCP error -32001: Request timed out'),
-      );
-      clientMock.close.mockRejectedValue(buildAbortError());
-
-      await expect(adapter.listTools(config)).rejects.toThrow(
-        'Request timed out',
-      );
-    });
-
-    it('closes the client when the operation fails', async () => {
-      clientMock.listTools.mockRejectedValue(new Error('boom'));
-
-      await expect(adapter.listTools(config)).rejects.toThrow('boom');
-      expect(clientMock.close).toHaveBeenCalled();
     });
   });
 
@@ -433,14 +398,6 @@ describe('McpSdkClientAdapter', () => {
 
   describe('validateConnection', () => {
     it('reports the connection as valid when all listings succeed', async () => {
-      await expect(adapter.validateConnection(config)).resolves.toEqual({
-        valid: true,
-      });
-    });
-
-    it('reports the connection as valid even when closing the client fails', async () => {
-      clientMock.close.mockRejectedValue(buildAbortError());
-
       await expect(adapter.validateConnection(config)).resolves.toEqual({
         valid: true,
       });

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.ts
@@ -6,6 +6,7 @@ import {
 import {
   McpClientPort,
   McpConnectionConfig,
+  McpConnectionScope,
   McpTool,
   McpResource,
   McpPrompt,
@@ -23,6 +24,7 @@ import {
 } from '../../application/mcp.errors';
 import { classifyTransportError } from 'src/common/errors/provider-transport-error.classifier';
 import { ProviderFailureClass } from 'src/common/errors/provider.errors';
+import { McpClientPoolService } from './mcp-client-pool.service';
 
 /**
  * Node's AbortController.abort() mints a DOMException with name 'AbortError'
@@ -67,11 +69,9 @@ function isTimeoutOrAbortError(error: unknown, depth = 0): boolean {
 /**
  * Adapter that wraps @modelcontextprotocol/sdk to provide MCP client functionality.
  *
- * Uses on-demand connection strategy:
- * - Creates new connection for each operation
- * - Closes connection immediately after operation completes
- * - Enforces a 30-second timeout via the SDK's per-request options, so the
- *   SDK aborts its own request cleanly instead of leaving it in flight
+ * Reuses connections with the same server and authentication configuration,
+ * closing them after one minute without an active operation. Each request
+ * still has a 30-second SDK timeout.
  *
  * Uses Streamable HTTP transport for HTTP-based connections (MCP protocol 2024-11-05+).
  */
@@ -81,6 +81,7 @@ export class McpSdkClientAdapter extends McpClientPort {
   private readonly requestOptions = { timeout: 30000 };
 
   constructor(
+    private readonly clientPool: McpClientPoolService,
     @Optional() private readonly oauthProviderFactory?: McpOAuthProviderFactory,
     @Optional() private readonly integrations?: McpIntegrationsRepositoryPort,
     @Optional() private readonly oauthFetch?: McpOAuthFetchPort,
@@ -214,8 +215,7 @@ export class McpSdkClientAdapter extends McpClientPort {
   }
 
   /**
-   * Runs one operation on a fresh client and classifies its failure. SDK
-   * timeouts and transport aborts must never escape raw (AYC-651): they
+   * SDK timeouts and transport aborts must never escape raw (AYC-651): they
    * surface as McpConnectionTimeoutError so validation endpoints can show a
    * clean user message and capability discovery can skip the integration.
    * Everything else (auth, protocol, HTTP errors) passes through unchanged
@@ -225,19 +225,14 @@ export class McpSdkClientAdapter extends McpClientPort {
     config: McpConnectionConfig,
     operation: (client: Client) => Promise<T>,
   ): Promise<T> {
-    let client: Client;
     try {
-      client = await this.createClient(config);
+      return await this.clientPool.withClient(
+        config,
+        () => this.createClient(config),
+        operation,
+      );
     } catch (error) {
       throw this.toOperationError(error, config);
-    }
-
-    try {
-      return await operation(client);
-    } catch (error) {
-      throw this.toOperationError(error, config);
-    } finally {
-      await this.closeQuietly(client);
     }
   }
 
@@ -270,34 +265,29 @@ export class McpSdkClientAdapter extends McpClientPort {
    * Validate connection to an MCP server.
    * Attempts to connect and list all capabilities (tools, resources, prompts).
    */
+  invalidateConnections(scope: McpConnectionScope): Promise<void> {
+    return this.clientPool.invalidateConnections(scope);
+  }
+
   async validateConnection(
     config: McpConnectionConfig,
   ): Promise<{ valid: boolean; error?: string }> {
-    let client: Client | null = null;
-
     try {
-      client = await this.createClient(config);
-
-      // Try to list all capabilities to validate connection
-      await client.listTools(undefined, this.requestOptions);
-      await client.listResources(undefined, this.requestOptions);
-      await client.listPrompts(undefined, this.requestOptions);
-
+      await this.withClient(config, async (client) => {
+        await client.listTools(undefined, this.requestOptions);
+        await client.listResources(undefined, this.requestOptions);
+        await client.listPrompts(undefined, this.requestOptions);
+      });
       return { valid: true };
     } catch (error) {
       this.logger.warn('Connection validation failed', {
         serverUrl: config.serverUrl,
         error: error instanceof Error ? error.message : String(error),
       });
-
       return {
         valid: false,
         error: error instanceof Error ? error.message : String(error),
       };
-    } finally {
-      if (client) {
-        await this.closeQuietly(client);
-      }
     }
   }
 
@@ -357,21 +347,5 @@ export class McpSdkClientAdapter extends McpClientPort {
     if (!this.oauthFetch)
       throw new Error('OAuth fetch dependency is unavailable');
     return this.oauthFetch;
-  }
-
-  /**
-   * close() aborts the transport, which can itself reject (e.g. AbortError
-   * from an in-flight SSE stream). Running in a finally block, that rejection
-   * would replace the operation's actual result or error — so it is only
-   * logged, never rethrown.
-   */
-  private async closeQuietly(client: Client): Promise<void> {
-    try {
-      await client.close();
-    } catch (error) {
-      this.logger.warn('Failed to close MCP client', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/mcp.module.ts
+++ b/ayunis-core-backend/src/domain/mcp/mcp.module.ts
@@ -5,6 +5,7 @@ import { McpCredentialEncryptionService } from './infrastructure/encryption/mcp-
 import { McpClientPort } from './application/ports/mcp-client.port';
 import { McpCapabilityCacheService } from './application/services/mcp-capability-cache.service';
 import { McpSdkClientAdapter } from './infrastructure/clients/mcp-sdk-client.adapter';
+import { McpClientPoolService } from './infrastructure/clients/mcp-client-pool.service';
 import { McpClientService } from './application/services/mcp-client.service';
 import { McpConfigService } from './application/services/mcp-config.service';
 import { ConnectionValidationService } from './application/services/connection-validation.service';
@@ -101,6 +102,7 @@ import { McpIntegrationResponseMapper } from './presenters/http/mappers/mcp-inte
       provide: McpCredentialEncryptionPort,
       useClass: McpCredentialEncryptionService,
     },
+    McpClientPoolService,
     {
       provide: McpClientPort,
       useClass: McpSdkClientAdapter,


### PR DESCRIPTION
## Summary
- reuse MCP SDK connections for equivalent tenant, integration, user, and authentication configuration
- close idle, failed, and shutdown connections safely
- remove the MCP listening-stream AppSignal suppression so genuine stream failures are instrumented

## Validation
- `pnpm test` — 595 suites / 4256 tests passed
- ESLint + complexity checks passed
- TypeScript typecheck passed
- pre-commit dependency, duplication, file-size, and markdown checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Stateful pooled MCP sessions and broad invalidation on config/OAuth changes affect integration connectivity and auth correctness; removing the MCP SSE AppSignal hook may increase noise from deliberate transport aborts until idle teardown behavior is stable.
> 
> **Overview**
> **MCP SDK connections are pooled and reused** instead of opening and tearing down a client on every operation. `McpClientPoolService` keys sessions by org, integration, user, URL, headers, and OAuth context; it reuses clients for matching config, evicts on failures, caps idle clients at 100, and closes idle connections after one minute. `McpConnectionScope` / `connectionScope` on `McpConnectionConfig` scopes invalidation.
> 
> **Pooled sessions are dropped when credentials or integration state change** — integration update/delete, user config save, OAuth complete/disconnect, and static OAuth client rotation all call `invalidateConnections` before or alongside capability-cache invalidation.
> 
> **AppSignal:** the temporary `mcp-listening-stream` undici `ignoreRequestHook` (AYC-555 stopgap) is removed so MCP SSE listening streams are instrumented again; the global `AbortError` suppression text now refers to idle transport teardown instead of per-operation close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0644fd7174da7f2ca364b479770cc6e354d63bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->