### PR TITLE
fix(anonymization): reject oversize input before service call (AYC-692)

### DIFF
--- a/ayunis-core-backend/src/common/anonymization/application/anonymization.errors.ts
+++ b/ayunis-core-backend/src/common/anonymization/application/anonymization.errors.ts
@@ -3,6 +3,7 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 export enum AnonymizationErrorCode {
   ANONYMIZATION_FAILED = 'ANONYMIZATION_FAILED',
+  ANONYMIZATION_INPUT_TOO_LONG = 'ANONYMIZATION_INPUT_TOO_LONG',
 }
 
 export abstract class AnonymizationError extends ApplicationError {
@@ -13,6 +14,17 @@ export abstract class AnonymizationError extends ApplicationError {
     metadata?: ErrorMetadata,
   ) {
     super(message, code, statusCode, metadata);
+  }
+}
+
+export class AnonymizationInputTooLongError extends AnonymizationError {
+  constructor(length: number, maxLength: number) {
+    super(
+      `Text exceeds maximum anonymization length: ${length} > ${maxLength}`,
+      AnonymizationErrorCode.ANONYMIZATION_INPUT_TOO_LONG,
+      422,
+      { length, maxLength },
+    );
   }
 }
 

--- a/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.spec.ts
+++ b/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.spec.ts
@@ -118,6 +118,27 @@ describe('PresidioAnonymizationProvider', () => {
     expect(detections).toHaveLength(0);
   });
 
+  it('rejects text beyond the service limit without sending it', async () => {
+    const result = provider.detect('A'.repeat(30_001));
+
+    await expect(result).rejects.toMatchObject({
+      code: 'ANONYMIZATION_INPUT_TOO_LONG',
+      statusCode: 422,
+    });
+    expect(mockAnalyzeTextAnalyzePost).not.toHaveBeenCalled();
+  });
+
+  it('counts Unicode code points like the anonymize service', async () => {
+    const text = '😀'.repeat(30_000);
+    mockResults([]);
+
+    await expect(provider.detect(text)).resolves.toEqual([]);
+    expect(mockAnalyzeTextAnalyzePost).toHaveBeenCalledWith({
+      text,
+      entities: null,
+    });
+  });
+
   it('throws AnonymizationFailedError when the service call fails', async () => {
     mockAnalyzeTextAnalyzePost.mockRejectedValue(
       new Error('connect ECONNREFUSED'),
@@ -168,9 +189,8 @@ describe('PresidioAnonymizationProvider', () => {
     });
   });
 
-  // A 422 means we built a bad request (e.g. over the service's text-length
-  // cap) — that is our defect and must stay a distinct incident, not blend
-  // into the outage taxonomy.
+  // A remaining 422 means our request shape drifted despite local validation.
+  // It must stay a distinct incident rather than blend into the outage taxonomy.
   it('keeps upstream 4xx failures as AnonymizationFailedError', async () => {
     mockAnalyzeTextAnalyzePost.mockRejectedValue(
       Object.assign(new Error('Request failed with status code 422'), {

--- a/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.ts
+++ b/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.ts
@@ -1,19 +1,44 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { AnonymizationPort } from '../../application/ports/anonymization.port';
-import { AnonymizationFailedError } from '../../application/anonymization.errors';
+import {
+  AnonymizationFailedError,
+  AnonymizationInputTooLongError,
+} from '../../application/anonymization.errors';
 import { wrapProviderFailure } from 'src/common/errors/wrap-provider-failure.helper';
 import { PiiDetection } from '../../domain/pii-detection';
 import { mapPresidioEntityToCategory } from './presidio-entity-category.mapper';
 import { getMSPresidioPIIDetectionAPI } from 'src/common/clients/anonymize/generated/mSPresidioPIIDetectionAPI';
 import type { RecognizerResult } from 'src/common/clients/anonymize/generated/mSPresidioPIIDetectionAPI.schemas';
 
+// Keep this synchronized with ayunis-core-anonymize/app/models.py.
+const MAX_ANONYMIZATION_TEXT_LENGTH = 30_000;
+
+function countCodePoints(text: string): number {
+  let count = 0;
+  for (let offset = 0; offset < text.length; offset += 1) {
+    count += 1;
+    if ((text.codePointAt(offset) ?? 0) > 0xffff) {
+      offset += 1;
+    }
+  }
+  return count;
+}
+
 @Injectable()
 export class PresidioAnonymizationProvider extends AnonymizationPort {
   private readonly logger = new Logger(PresidioAnonymizationProvider.name);
 
   async detect(text: string, entities?: string[]): Promise<PiiDetection[]> {
+    const textLength = countCodePoints(text);
+    if (textLength > MAX_ANONYMIZATION_TEXT_LENGTH) {
+      throw new AnonymizationInputTooLongError(
+        textLength,
+        MAX_ANONYMIZATION_TEXT_LENGTH,
+      );
+    }
+
     this.logger.debug('Detecting PII', {
-      textLength: text.length,
+      textLength,
       entities,
     });
 
@@ -33,19 +58,19 @@ export class PresidioAnonymizationProvider extends AnonymizationPort {
       );
 
       this.logger.debug('PII detection complete', {
-        textLength: text.length,
+        textLength,
         detectionCount: detections.length,
       });
 
       return detections;
     } catch (error: unknown) {
       this.logger.error('PII detection failed', { error: error as Error });
-      // Every caller treats a detect() failure as fatal and fail-closed (the
-      // user's message is blocked rather than sent unmasked), so this catch
-      // is the single classification point. Transport failures and upstream
-      // 5xx group under PROVIDER_UNAVAILABLE_*_ANONYMIZE; a 4xx means we
-      // built a bad request and stays a distinct AnonymizationFailedError
-      // (AYC-654).
+      // Every caller treats a service-call pipeline failure as fatal and
+      // fail-closed (the user's message is blocked rather than sent unmasked),
+      // so this catch is their single classification point. Transport failures
+      // and upstream 5xx group under PROVIDER_UNAVAILABLE_*_ANONYMIZE. A
+      // remaining 4xx means our request shape drifted despite local validation
+      // and stays a distinct AnonymizationFailedError (AYC-654).
       const providerError = wrapProviderFailure(error, {
         provider: 'anonymize',
       });

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.spec.ts
@@ -28,6 +28,7 @@ import type { CountTokensUseCase } from 'src/common/token-counter/application/us
 import type { ResolveModelProviderUseCase } from 'src/domain/models/application/use-cases/resolve-model-provider/resolve-model-provider.use-case';
 import type { CreateToolResultMessageUseCase } from 'src/domain/messages/application/use-cases/create-tool-result-message/create-tool-result-message.use-case';
 import type { AnonymizeTextForThreadUseCase } from 'src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case';
+import { AnonymizationInputTooLongError } from 'src/common/anonymization/application/anonymization.errors';
 import type { InferenceUsageGuard } from '../../services/inference-usage-guard.service';
 import type { ToolAssemblyService } from '../../services/tool-assembly.service';
 import type { MessageCleanupService } from '../../services/message-cleanup.service';
@@ -1085,6 +1086,25 @@ describe('ExecuteRunViaRuntimeUseCase', () => {
     // masks are streamed before the (redacted) user message
     expect(items[0]).toBeInstanceOf(RunPiiMasksUpdate);
     expect(items[1]).toMatchObject({ id: 'user-msg' });
+  });
+
+  it('preserves oversize validation and sends no unanonymized text', async () => {
+    const { useCase, anonymize, createUser, provider } = buildHarness({
+      anonymous: true,
+    });
+    const inputTooLongError = new AnonymizationInputTooLongError(
+      30_001,
+      30_000,
+    );
+    anonymize.mockRejectedValue(inputTooLongError);
+
+    const generator = await useCase.execute(
+      userCommand(new RunUserInput('A'.repeat(30_001))),
+    );
+
+    await expect(drain(generator)).rejects.toBe(inputTooLongError);
+    expect(createUser).not.toHaveBeenCalled();
+    expect(provider.requests).toHaveLength(0);
   });
 
   it('activates a requested skill before the run and folds in its instructions', async () => {

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.ts
@@ -3,6 +3,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { AnonymizationInputTooLongError } from 'src/common/anonymization/application/anonymization.errors';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -386,6 +387,9 @@ export class ExecuteRunViaRuntimeUseCase {
       );
       return { anonymizedText: result.anonymizedText, masks: result.masks };
     } catch (error) {
+      if (error instanceof AnonymizationInputTooLongError) {
+        throw error;
+      }
       throw new RunAnonymizationUnavailableError(
         {
           originalError:

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
@@ -1,4 +1,7 @@
-import { AnonymizationFailedError } from 'src/common/anonymization/application/anonymization.errors';
+import {
+  AnonymizationFailedError,
+  AnonymizationInputTooLongError,
+} from 'src/common/anonymization/application/anonymization.errors';
 import type { AnonymizeTextForThreadUseCase } from 'src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case';
 import { RunAnonymizationUnavailableError } from '../../runs.errors';
 import type { ContextService } from 'src/common/context/services/context.service';
@@ -357,6 +360,30 @@ describe('ExecuteRunUseCase', () => {
   });
 
   describe('anonymous mode anonymization failure', () => {
+    it('should preserve deterministic oversize validation without sending the message', async () => {
+      const thread = createMockThread({ isAnonymous: true });
+      findThreadUseCase.execute.mockResolvedValue({
+        thread,
+        isLongChat: false,
+      });
+      const inputTooLongError = new AnonymizationInputTooLongError(
+        30_001,
+        30_000,
+      );
+      anonymizeTextForThreadUseCase.execute.mockRejectedValue(
+        inputTooLongError,
+      );
+
+      const command = new ExecuteRunCommand({
+        threadId,
+        input: new RunUserInput('A'.repeat(30_001), []),
+        streaming: false,
+      });
+
+      const generator = await useCase.execute(command);
+      await expect(generator.next()).rejects.toBe(inputTooLongError);
+    });
+
     it('should throw RunAnonymizationUnavailableError when anonymize service is unavailable and thread is anonymous', async () => {
       const thread = createMockThread({ isAnonymous: true });
       findThreadUseCase.execute.mockResolvedValue({

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
@@ -22,6 +22,7 @@ import {
   RunToolResultInput,
 } from 'src/domain/runs/domain/run-input.entity';
 import { ApplicationError } from 'src/common/errors/base.error';
+import { AnonymizationInputTooLongError } from 'src/common/anonymization/application/anonymization.errors';
 import { FindThreadQuery } from 'src/domain/threads/application/use-cases/find-thread/find-thread.query';
 import { ExecuteRunCommand } from './execute-run.command';
 import { FindThreadUseCase } from 'src/domain/threads/application/use-cases/find-thread/find-thread.use-case';
@@ -446,6 +447,9 @@ export class ExecuteRunUseCase {
       }
       return { anonymizedText: result.anonymizedText, masks: result.masks };
     } catch (error) {
+      if (error instanceof AnonymizationInputTooLongError) {
+        throw error;
+      }
       this.logger.error('Anonymization service unavailable', {
         error: error as Error,
       });

--- a/ayunis-core-frontend/src/pages/chat/hooks/useRunErrorHandler.test.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/useRunErrorHandler.test.ts
@@ -14,6 +14,23 @@ vi.mock('react-i18next', () => ({
 vi.mock('@/shared/lib/toast', () => ({ showError }));
 
 describe('useRunErrorHandler', () => {
+  it('shows the anonymization limit explanation for an oversized message', () => {
+    const { result } = renderHook(() => useRunErrorHandler('thread-1'));
+    const error: RunErrorResponseDto = {
+      type: 'error',
+      message: 'Text exceeds maximum anonymization length: 30001 > 30000',
+      threadId: 'thread-1',
+      timestamp: '2026-08-10T18:00:00.000Z',
+      code: 'ANONYMIZATION_INPUT_TOO_LONG',
+    };
+
+    act(() => result.current(error));
+
+    expect(showError).toHaveBeenCalledWith(
+      'chat.errorAnonymizationInputTooLong',
+    );
+  });
+
   it('shows the context-budget explanation for an oversized latest turn', () => {
     const { result } = renderHook(() => useRunErrorHandler('thread-1'));
     const error: RunErrorResponseDto = {

--- a/ayunis-core-frontend/src/pages/chat/hooks/useRunErrorHandler.ts
+++ b/ayunis-core-frontend/src/pages/chat/hooks/useRunErrorHandler.ts
@@ -33,6 +33,9 @@ export function useRunErrorHandler(_threadId: string) {
         case 'RUN_ANONYMIZATION_UNAVAILABLE':
           showError(t('chat.errorAnonymizationUnavailable'));
           break;
+        case 'ANONYMIZATION_INPUT_TOO_LONG':
+          showError(t('chat.errorAnonymizationInputTooLong'));
+          break;
         case 'RUN_CONTEXT_BUDGET_EXCEEDED':
           showError(t('chat.errorContextBudgetExceeded'));
           break;

--- a/ayunis-core-frontend/src/shared/locales/de/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/de/chat.json
@@ -23,6 +23,7 @@
     "errorToolNotFound": "Tool nicht gefunden",
     "errorToolExecutionFailed": "Ein Tool ist wiederholt fehlgeschlagen. Bitte passen Sie Ihre Anfrage an und versuchen Sie es erneut.",
     "errorAnonymizationUnavailable": "Die Anonymisierung ist derzeit nicht verfügbar. Ihre Nachricht wurde nicht gesendet, um Ihre Daten zu schützen.",
+    "errorAnonymizationInputTooLong": "Ihre Nachricht überschreitet das Limit von 30.000 Zeichen für die Anonymisierung und wurde nicht gesendet. Bitte kürzen Sie sie und versuchen Sie es erneut.",
     "errorContextBudgetExceeded": "Die letzte Konversationsrunde ist zu groß für das Kontextfenster des Modells.",
     "errorSendMessage": "Nachricht konnte nicht gesendet werden. Bitte aktualisieren Sie die Seite und versuchen Sie es erneut.",
     "errorRestoreFailedSubmission": "Ihre vorherige Nachricht und Anhänge konnten nicht wiederhergestellt werden, da die Eingabe bereits einen Entwurf enthält.",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -23,6 +23,7 @@
     "errorToolNotFound": "Tool not found",
     "errorToolExecutionFailed": "A tool failed repeatedly. Please adjust your request and try again.",
     "errorAnonymizationUnavailable": "Anonymization is currently unavailable. Your message was not sent to protect your data.",
+    "errorAnonymizationInputTooLong": "Your message exceeds the 30,000-character anonymization limit and was not sent. Please shorten it and try again.",
     "errorContextBudgetExceeded": "The latest conversation turn is too large for the model context window.",
     "errorSendMessage": "Message could not be sent. Please refresh the page and try again.",
     "errorRestoreFailedSubmission": "Your previous message and attachments couldn't be restored because the input already contains a draft.",


### PR DESCRIPTION
## Summary

- reject anonymization input above the service's 30,000-code-point limit before the HTTP call
- return a deterministic `ANONYMIZATION_INPUT_TOO_LONG` 422 through both legacy and runtime run paths
- keep anonymous runs fail-closed so oversized raw text is never persisted or sent to inference

## Validation

- `pnpm exec eslint <touched files>`
- `pnpm exec eslint --config eslint.complexity.config.mjs <touched production files>`
- `pnpm exec tsc --noEmit`
- `pnpm test` — 595 suites, 4,258 tests passed
- pre-commit dependency, file-size, and duplication checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted validation and error surfacing on the anonymization path; anonymous runs remain fail-closed with added tests. No auth, payment, or broad architectural changes.
> 
> **Overview**
> **Anonymous chat** now rejects messages over the anonymize service’s **30,000 code-point** cap **before** calling Presidio, returning **`ANONYMIZATION_INPUT_TOO_LONG`** (422) with length metadata instead of a generic failure or upstream 422.
> 
> The Presidio provider enforces the same limit as `ayunis-core-anonymize` using a Unicode code-point counter (so emoji-heavy text is measured like the Python service). **Legacy and runtime** run paths rethrow this error instead of mapping it to **`RUN_ANONYMIZATION_UNAVAILABLE`**, so oversized input is not persisted or sent to inference.
> 
> The chat UI handles **`ANONYMIZATION_INPUT_TOO_LONG`** with dedicated EN/DE copy explaining the limit and that the message was not sent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6703cfce7a18f07ce10cf12526d3d5ed08a1520c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

