### PR TITLE
fix(models): migrate azure chat inference to v1 (AYC-708)

### DIFF
--- a/ayunis-core-backend/.env.example
+++ b/ayunis-core-backend/.env.example
@@ -171,7 +171,6 @@ OTC_API_KEY=
 ## MS Azure OpenAI
 AZURE_OPENAI_API_KEY=
 AZURE_OPENAI_ENDPOINT=
-AZURE_OPENAI_API_VERSION=
 # Optional override; image edits require 2025-04-01-preview or later.
 AZURE_OPENAI_IMAGE_API_VERSION=
 ## Scaleway

--- a/ayunis-core-backend/src/config/models.config.ts
+++ b/ayunis-core-backend/src/config/models.config.ts
@@ -43,7 +43,6 @@ export const modelsConfig = registerAs('models', () => ({
   azure: {
     apiKey: process.env.AZURE_OPENAI_API_KEY,
     endpoint: process.env.AZURE_OPENAI_ENDPOINT,
-    apiVersion: process.env.AZURE_OPENAI_API_VERSION,
     imageApiVersion:
       process.env.AZURE_OPENAI_IMAGE_API_VERSION?.trim() ||
       '2025-04-01-preview',

--- a/ayunis-core-backend/src/domain/models/infrastructure/inference/azure.inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/inference/azure.inference.ts
@@ -20,8 +20,6 @@ export class AzureInferenceHandler extends RuntimeInferenceHandler {
     return azure({
       apiKey: this.configService.get<string>('models.azure.apiKey') ?? '',
       endpoint: this.configService.get<string>('models.azure.endpoint') ?? '',
-      apiVersion:
-        this.configService.get<string>('models.azure.apiVersion') ?? '',
       model: model.name,
       maxRetries: INFERENCE_MAX_RETRIES,
     });

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/azure.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/azure.stream-inference.ts
@@ -20,8 +20,6 @@ export class AzureStreamInferenceHandler extends RuntimeStreamInferenceHandler {
     return azure({
       apiKey: this.configService.get<string>('models.azure.apiKey') ?? '',
       endpoint: this.configService.get<string>('models.azure.endpoint') ?? '',
-      apiVersion:
-        this.configService.get<string>('models.azure.apiVersion') ?? '',
       model: model.name,
       maxRetries: INFERENCE_MAX_RETRIES,
     });

--- a/packages/provider-openai/src/client-construction.spec.ts
+++ b/packages/provider-openai/src/client-construction.spec.ts
@@ -31,16 +31,32 @@ describe('openai client construction', () => {
 });
 
 describe('azure client construction', () => {
-  it('bounds each request attempt with the default timeout', () => {
+  const insecureEndpoint = ['http:', '//my-resource.openai.azure.com'].join('');
+  it('uses the standard client with the Azure v1 base URL', () => {
     azure({
       apiKey: 'azure-key',
       endpoint: 'https://my-resource.openai.azure.com',
-      apiVersion: '2024-10-21',
       model: 'gpt-5.4',
     });
 
-    expect(azureCtor).toHaveBeenCalledWith(
-      expect.objectContaining({ timeout: DEFAULT_TIMEOUT_MS }),
+    expect(openaiCtor).toHaveBeenCalledWith({
+      apiKey: 'azure-key',
+      baseURL: 'https://my-resource.openai.azure.com/openai/v1/',
+      timeout: DEFAULT_TIMEOUT_MS,
+    });
+    expect(azureCtor).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'https://my-resource.openai.azure.com/',
+    'https://my-resource.openai.azure.com///',
+  ])('handles trailing endpoint slashes in %s', (endpoint) => {
+    azure({ apiKey: 'azure-key', endpoint, model: 'gpt-5.4' });
+
+    expect(openaiCtor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: 'https://my-resource.openai.azure.com/openai/v1/',
+      }),
     );
   });
 
@@ -48,13 +64,21 @@ describe('azure client construction', () => {
     azure({
       apiKey: 'azure-key',
       endpoint: 'https://my-resource.openai.azure.com',
-      apiVersion: '2024-10-21',
       model: 'gpt-5.4',
       timeoutMs: 45_000,
     });
 
-    expect(azureCtor).toHaveBeenCalledWith(
+    expect(openaiCtor).toHaveBeenCalledWith(
       expect.objectContaining({ timeout: 45_000 }),
     );
   });
+
+  it.each(['', 'not-an-endpoint', insecureEndpoint])(
+    'rejects invalid endpoint %j with an actionable error',
+    (endpoint) => {
+      expect(() =>
+        azure({ apiKey: 'azure-key', endpoint, model: 'gpt-5.4' }),
+      ).toThrow(/Azure OpenAI endpoint.*absolute HTTPS URL/);
+    },
+  );
 });

--- a/packages/provider-openai/src/openai-provider.spec.ts
+++ b/packages/provider-openai/src/openai-provider.spec.ts
@@ -63,7 +63,6 @@ describe('azure', () => {
     const provider = azure({
       apiKey: 'azure-test',
       endpoint: 'https://my-resource.openai.azure.com',
-      apiVersion: '2024-10-21',
       model: 'gpt-4o-deployment',
     });
     expect(provider.name).toBe('azure:gpt-4o-deployment');

--- a/packages/provider-openai/src/openai-provider.ts
+++ b/packages/provider-openai/src/openai-provider.ts
@@ -1,4 +1,4 @@
-import OpenAI, { AzureOpenAI } from 'openai';
+import OpenAI from 'openai';
 import type { ChatCompletionCreateParamsStreaming } from 'openai/resources/chat/completions';
 
 import type {
@@ -37,8 +37,6 @@ export interface AzureProviderOptions {
   apiKey: string;
   /** Azure resource endpoint, e.g. 'https://my-resource.openai.azure.com'. */
   endpoint: string;
-  /** Azure API version, e.g. '2024-10-21'. */
-  apiVersion: string;
   /** Azure deployment name, passed through as the model id. */
   model: string;
   /** SDK-level retry count for transient failures. Default: 2. */
@@ -64,16 +62,42 @@ export const openai = (options: OpenAIProviderOptions): ModelProvider => {
   return createProvider(client, `openai:${options.model}`, options.model);
 };
 
+const buildAzureV1BaseUrl = (endpoint: string): string => {
+  let url: URL;
+  try {
+    url = new URL(endpoint.trim());
+  } catch {
+    throw new Error(
+      `Azure OpenAI endpoint must be an absolute HTTPS URL; received ${JSON.stringify(endpoint)}`,
+    );
+  }
+  if (
+    url.protocol !== 'https:' ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error(
+      `Azure OpenAI endpoint must be an absolute HTTPS URL without credentials, query parameters, or a fragment; received ${JSON.stringify(endpoint)}`,
+    );
+  }
+  let pathname = url.pathname;
+  while (pathname.endsWith('/')) {
+    pathname = pathname.slice(0, -1);
+  }
+  url.pathname = `${pathname}/openai/v1/`;
+  return url.toString();
+};
+
 /**
- * Azure OpenAI ModelProvider. Same Chat Completions protocol as `openai`,
- * only the client differs (resource endpoint + API version). `model` is the
- * Azure deployment name.
+ * Azure OpenAI ModelProvider using the versionless v1 Chat Completions API.
+ * `model` is the Azure deployment name.
  */
 export const azure = (options: AzureProviderOptions): ModelProvider => {
-  const client = new AzureOpenAI({
+  const client = new OpenAI({
     apiKey: options.apiKey,
-    endpoint: options.endpoint,
-    apiVersion: options.apiVersion,
+    baseURL: buildAzureV1BaseUrl(options.endpoint),
     timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     ...(options.maxRetries !== undefined
       ? { maxRetries: options.maxRetries }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how all Azure chat/stream inference is routed; misconfigured endpoints now fail at client construction, but image Azure config is untouched.
> 
> **Overview**
> **Azure chat inference** no longer uses the dated `AzureOpenAI` SDK client or `AZURE_OPENAI_API_VERSION`. Chat calls go through the standard `OpenAI` client with `baseURL` set to `{endpoint}/openai/v1/` via new `buildAzureV1BaseUrl`, which normalizes trailing slashes and rejects non-HTTPS or malformed endpoints.
> 
> **Config and ops:** `AZURE_OPENAI_API_VERSION` is removed from `.env.example` and `models.config.ts`; Azure stream and non-stream inference handlers only pass key, endpoint, and deployment name. **`AZURE_OPENAI_IMAGE_API_VERSION`** is unchanged for image edits.
> 
> **Tests** assert v1 base URL construction, slash handling, invalid endpoints, and that `AzureOpenAI` is not instantiated for chat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ec897d5c866956bb066b6a1b364138146d18534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->