### PR TITLE
fix(models): show granular catalog error toasts (AYC-696)

### DIFF
--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useCreateEmbeddingModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useCreateEmbeddingModel.ts
@@ -8,6 +8,7 @@ import {
 import { useRouter } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import extractErrorData from '@/shared/api/extract-error-data';
+import { resolveModelErrorToastKey } from '../lib/resolveModelErrorToastKey';
 
 export function useCreateEmbeddingModel(onSuccess?: () => void) {
   const { t } = useTranslation('super-admin-settings-org');
@@ -28,11 +29,7 @@ export function useCreateEmbeddingModel(onSuccess?: () => void) {
           console.error('Create embedding model failed:', error);
           try {
             const { code } = extractErrorData(error);
-            if (code === 'MODEL_ALREADY_EXISTS') {
-              showError(t('models.alreadyExists'));
-            } else {
-              showError(t('models.createError'));
-            }
+            showError(t(resolveModelErrorToastKey(code, 'models.createError')));
           } catch {
             // Non-AxiosError (network failure, request cancellation, etc.)
             showError(t('models.createError'));

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useCreateImageGenerationModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useCreateImageGenerationModel.ts
@@ -8,6 +8,7 @@ import {
 import { useRouter } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import extractErrorData from '@/shared/api/extract-error-data';
+import { resolveModelErrorToastKey } from '../lib/resolveModelErrorToastKey';
 
 export function useCreateImageGenerationModel(onSuccess?: () => void) {
   const { t } = useTranslation('super-admin-settings-org');
@@ -29,11 +30,9 @@ export function useCreateImageGenerationModel(onSuccess?: () => void) {
             console.error('Create image generation model failed:', error);
             try {
               const { code } = extractErrorData(error);
-              if (code === 'MODEL_ALREADY_EXISTS') {
-                showError(t('models.alreadyExists'));
-              } else {
-                showError(t('models.createError'));
-              }
+              showError(
+                t(resolveModelErrorToastKey(code, 'models.createError')),
+              );
             } catch {
               showError(t('models.createError'));
             }

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useCreateLanguageModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useCreateLanguageModel.ts
@@ -11,6 +11,7 @@ import {
 import { useRouter } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import extractErrorData from '@/shared/api/extract-error-data';
+import { resolveModelErrorToastKey } from '../lib/resolveModelErrorToastKey';
 export function useCreateLanguageModel(onSuccess?: () => void) {
   const { t } = useTranslation('super-admin-settings-org');
   const queryClient = useQueryClient();
@@ -43,11 +44,7 @@ export function useCreateLanguageModel(onSuccess?: () => void) {
           console.error('Create language model failed:', error);
           try {
             const { code } = extractErrorData(error);
-            if (code === 'MODEL_ALREADY_EXISTS') {
-              showError(t('models.alreadyExists'));
-            } else {
-              showError(t('models.createError'));
-            }
+            showError(t(resolveModelErrorToastKey(code, 'models.createError')));
           } catch {
             // Non-AxiosError (network failure, request cancellation, etc.)
             showError(t('models.createError'));

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useDeleteModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useDeleteModel.ts
@@ -7,6 +7,7 @@ import {
 import { useRouter } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import extractErrorData from '@/shared/api/extract-error-data';
+import { resolveModelErrorToastKey } from '../lib/resolveModelErrorToastKey';
 
 export function useDeleteModel() {
   const { t } = useTranslation('super-admin-settings-org');
@@ -25,11 +26,7 @@ export function useDeleteModel() {
         console.error('Delete model failed:', error);
         try {
           const { code } = extractErrorData(error);
-          if (code === 'MODEL_NOT_FOUND') {
-            showError(t('models.notFound'));
-          } else {
-            showError(t('models.deleteError'));
-          }
+          showError(t(resolveModelErrorToastKey(code, 'models.deleteError')));
         } catch {
           // Non-AxiosError (network failure, request cancellation, etc.)
           showError(t('models.deleteError'));

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useUpdateEmbeddingModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useUpdateEmbeddingModel.ts
@@ -8,6 +8,7 @@ import {
 import { useRouter } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import extractErrorData from '@/shared/api/extract-error-data';
+import { resolveModelErrorToastKey } from '../lib/resolveModelErrorToastKey';
 export function useUpdateEmbeddingModel(onSuccess?: () => void) {
   const { t } = useTranslation('super-admin-settings-org');
   const queryClient = useQueryClient();
@@ -27,11 +28,7 @@ export function useUpdateEmbeddingModel(onSuccess?: () => void) {
           console.error('Update embedding model failed:', error);
           try {
             const { code } = extractErrorData(error);
-            if (code === 'MODEL_NOT_FOUND') {
-              showError(t('models.notFound'));
-            } else {
-              showError(t('models.updateError'));
-            }
+            showError(t(resolveModelErrorToastKey(code, 'models.updateError')));
           } catch {
             // Non-AxiosError (network failure, request cancellation, etc.)
             showError(t('models.updateError'));

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useUpdateImageGenerationModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useUpdateImageGenerationModel.ts
@@ -8,6 +8,7 @@ import {
 import { useRouter } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import extractErrorData from '@/shared/api/extract-error-data';
+import { resolveModelErrorToastKey } from '../lib/resolveModelErrorToastKey';
 
 export function useUpdateImageGenerationModel(onSuccess?: () => void) {
   const { t } = useTranslation('super-admin-settings-org');
@@ -29,11 +30,9 @@ export function useUpdateImageGenerationModel(onSuccess?: () => void) {
             console.error('Update image generation model failed:', error);
             try {
               const { code } = extractErrorData(error);
-              if (code === 'MODEL_NOT_FOUND') {
-                showError(t('models.notFound'));
-              } else {
-                showError(t('models.updateError'));
-              }
+              showError(
+                t(resolveModelErrorToastKey(code, 'models.updateError')),
+              );
             } catch {
               showError(t('models.updateError'));
             }

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useUpdateLanguageModel.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/api/useUpdateLanguageModel.ts
@@ -11,6 +11,7 @@ import {
 import { useRouter } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import extractErrorData from '@/shared/api/extract-error-data';
+import { resolveModelErrorToastKey } from '../lib/resolveModelErrorToastKey';
 export function useUpdateLanguageModel(onSuccess?: () => void) {
   const { t } = useTranslation('super-admin-settings-org');
   const queryClient = useQueryClient();
@@ -43,11 +44,7 @@ export function useUpdateLanguageModel(onSuccess?: () => void) {
           console.error('Update language model failed:', error);
           try {
             const { code } = extractErrorData(error);
-            if (code === 'MODEL_NOT_FOUND') {
-              showError(t('models.notFound'));
-            } else {
-              showError(t('models.updateError'));
-            }
+            showError(t(resolveModelErrorToastKey(code, 'models.updateError')));
           } catch {
             // Non-AxiosError (network failure, request cancellation, etc.)
             showError(t('models.updateError'));

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/lib/resolveModelErrorToastKey.test.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/lib/resolveModelErrorToastKey.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { resolveModelErrorToastKey } from './resolveModelErrorToastKey';
+
+describe('resolveModelErrorToastKey', () => {
+  it.each([
+    ['MODEL_ALREADY_EXISTS', 'models.alreadyExists'],
+    ['MODEL_NOT_FOUND', 'models.notFound'],
+    ['MODEL_INVALID', 'models.invalid'],
+    ['VALIDATION_ERROR', 'models.invalid'],
+    ['MODEL_PROVIDER_NOT_SUPPORTED', 'models.providerNotSupported'],
+    [
+      'IMAGE_GENERATION_MODEL_PROVIDER_NOT_SUPPORTED',
+      'models.imageGenerationProviderNotSupported',
+    ],
+    ['MODEL_CREATION_FAILED', 'models.createError'],
+    ['MODEL_UPDATE_FAILED', 'models.updateError'],
+    ['MODEL_DELETION_FAILED', 'models.deleteError'],
+  ])('maps %s to %s', (code, expectedKey) => {
+    expect(resolveModelErrorToastKey(code, 'models.updateError')).toBe(
+      expectedKey,
+    );
+  });
+
+  it('uses the operation fallback for an unknown error code', () => {
+    expect(
+      resolveModelErrorToastKey('UNEXPECTED_MODEL_ERROR', 'models.deleteError'),
+    ).toBe('models.deleteError');
+  });
+});

--- a/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/lib/resolveModelErrorToastKey.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/models-catalog/lib/resolveModelErrorToastKey.ts
@@ -1,0 +1,30 @@
+export type ModelErrorFallbackKey =
+  'models.createError' | 'models.updateError' | 'models.deleteError';
+
+type ModelErrorToastKey =
+  | ModelErrorFallbackKey
+  | 'models.alreadyExists'
+  | 'models.notFound'
+  | 'models.invalid'
+  | 'models.providerNotSupported'
+  | 'models.imageGenerationProviderNotSupported';
+
+const MODEL_ERROR_TOAST_KEYS: Record<string, ModelErrorToastKey> = {
+  MODEL_ALREADY_EXISTS: 'models.alreadyExists',
+  MODEL_NOT_FOUND: 'models.notFound',
+  MODEL_INVALID: 'models.invalid',
+  VALIDATION_ERROR: 'models.invalid',
+  MODEL_PROVIDER_NOT_SUPPORTED: 'models.providerNotSupported',
+  IMAGE_GENERATION_MODEL_PROVIDER_NOT_SUPPORTED:
+    'models.imageGenerationProviderNotSupported',
+  MODEL_CREATION_FAILED: 'models.createError',
+  MODEL_UPDATE_FAILED: 'models.updateError',
+  MODEL_DELETION_FAILED: 'models.deleteError',
+};
+
+export function resolveModelErrorToastKey(
+  code: string,
+  fallbackKey: ModelErrorFallbackKey,
+): ModelErrorToastKey {
+  return MODEL_ERROR_TOAST_KEYS[code] ?? fallbackKey;
+}

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-org.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-org.json
@@ -371,6 +371,9 @@
     "deleteError": "Modell konnte nicht gelöscht werden. Bitte versuchen Sie es erneut.",
     "alreadyExists": "Ein Modell mit dieser Kennung existiert bereits.",
     "notFound": "Modell nicht gefunden. Es wurde möglicherweise gelöscht.",
+    "invalid": "Einige Modelldaten sind ungültig. Bitte überprüfen Sie Ihre Eingaben.",
+    "providerNotSupported": "Dieser Anbieter wird für dieses Modell nicht unterstützt.",
+    "imageGenerationProviderNotSupported": "Dieser Anbieter unterstützt keine Bilderzeugungsmodelle.",
     "tabs": {
       "active": "Aktiv",
       "archived": "Archiviert"

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-org.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-org.json
@@ -371,6 +371,9 @@
     "deleteError": "Failed to delete model. Please try again.",
     "alreadyExists": "A model with this identifier already exists.",
     "notFound": "Model not found. It may have been deleted.",
+    "invalid": "Some model details are invalid. Please review them and try again.",
+    "providerNotSupported": "This provider is not supported for this model.",
+    "imageGenerationProviderNotSupported": "This provider does not support image-generation models.",
     "tabs": {
       "active": "Active",
       "archived": "Archived"


### PR DESCRIPTION
## Summary
- map backend model error codes to granular catalog toasts
- show duplicate, validation, and unsupported-provider errors for create and update operations
- add localized English and German messages with regression coverage

## Validation
- `pnpm run build`
- `pnpm run lint`
- `pnpm run test` (48 files, 304 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Super-admin UI-only error messaging refactor; no API or persistence changes.
> 
> **Overview**
> Super-admin **models catalog** create/update/delete flows now show **specific error toasts** based on API error codes instead of only handling duplicate/not-found inline.
> 
> A shared **`resolveModelErrorToastKey`** maps codes such as `MODEL_INVALID`, `VALIDATION_ERROR`, provider-not-supported variants, and operation-failed codes to i18n keys; unknown codes still fall back to the per-operation generic message. All seven catalog mutation hooks use this helper. **EN/DE** copy was added for invalid input and unsupported provider cases, with **Vitest** coverage for the mapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db49dfb40cc273b210142faff28960da7287fc88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->