### PR TITLE
wip(workspaces): add the workspaces module, feature flag and table (AYC-700)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,6 +51,7 @@ ayunis-core/
 | [anonymization-settings](ayunis-core-backend/src/domain/anonymization-settings) | Privacy Config | Org-level PII whitelist for anonymous mode |
 | [thread-pii-masks](ayunis-core-backend/src/domain/thread-pii-masks/SUMMARY.md) | Privacy | Per-thread PII mask dictionary for anonymous mode |
 | [favorites](ayunis-core-backend/src/domain/favorites/SUMMARY.md) | Favorites | User-owned ordered references resolved for navigation |
+| [workspaces](ayunis-core-backend/src/domain/workspaces/SUMMARY.md) | Folders | Personal folders ("Projekte") that group a user's chats |
 
 ### IAM Modules — Identity & Access Management
 

--- a/ayunis-core-backend/.env.example
+++ b/ayunis-core-backend/.env.example
@@ -262,6 +262,7 @@ AYUNIS_METRICS_PASSWORD=changeme
 # FEATURE_PROMPTS_ENABLED=true
 # Disabled by default
 # FEATURE_SKILLS_ENABLED=false
+# FEATURE_WORKSPACES_ENABLED=false
 
 # Internal Services
 # URLs of the companion services (defaults target the local docker compose stack)

--- a/ayunis-core-backend/src/app/app.module.ts
+++ b/ayunis-core-backend/src/app/app.module.ts
@@ -31,6 +31,7 @@ import { AcademyModule } from '../domain/academy/academy.module';
 import { ArtifactsModule } from '../domain/artifacts/artifacts.module';
 import { LetterheadsModule } from '../domain/letterheads/letterheads.module';
 import { FavoritesModule } from '../domain/favorites/favorites.module';
+import { WorkspacesModule } from '../domain/workspaces/workspaces.module';
 import { OpenAICompatModule } from '../domain/openai-compat/openai-compat.module';
 import { IamModule } from '../iam/iam.module';
 
@@ -140,6 +141,7 @@ import { IntegrationsModule } from '../integrations/integrations.module';
     ArtifactsModule,
     LetterheadsModule,
     FavoritesModule,
+    WorkspacesModule,
     OpenAICompatModule,
     IamModule.register({
       authProvider:

--- a/ayunis-core-backend/src/app/presenters/http/app.controller.spec.ts
+++ b/ayunis-core-backend/src/app/presenters/http/app.controller.spec.ts
@@ -10,6 +10,7 @@ describe('AppController', () => {
       knowledgeBasesEnabled: true,
       letterheadsEnabled: false,
       skillsEnabled: true,
+      workspacesEnabled: true,
       agentRuntimeEnabled: true,
     };
     const controller = new AppController(

--- a/ayunis-core-backend/src/app/presenters/http/app.controller.ts
+++ b/ayunis-core-backend/src/app/presenters/http/app.controller.ts
@@ -88,6 +88,7 @@ export class AppController {
       knowledgeBasesEnabled: this.features.knowledgeBasesEnabled,
       letterheadsEnabled: this.features.letterheadsEnabled,
       skillsEnabled: this.features.skillsEnabled,
+      workspacesEnabled: this.features.workspacesEnabled,
       agentRuntimeEnabled: this.features.agentRuntimeEnabled,
     };
   }

--- a/ayunis-core-backend/src/app/presenters/http/dto/feature-toggles-response.dto.ts
+++ b/ayunis-core-backend/src/app/presenters/http/dto/feature-toggles-response.dto.ts
@@ -20,6 +20,12 @@ export class FeatureTogglesResponseDto {
   skillsEnabled: boolean;
 
   @ApiProperty({
+    description: 'Whether the workspaces feature is enabled',
+    example: false,
+  })
+  workspacesEnabled: boolean;
+
+  @ApiProperty({
     description: 'Whether runs use the independent agent runtime',
     example: false,
   })

--- a/ayunis-core-backend/src/config/env.validation.ts
+++ b/ayunis-core-backend/src/config/env.validation.ts
@@ -159,6 +159,7 @@ export class EnvironmentVariables {
   @IsOptional() @IsIn(BOOLEAN_STRINGS) FEATURE_KNOWLEDGE_BASES_ENABLED?: string;
   @IsOptional() @IsIn(BOOLEAN_STRINGS) FEATURE_LETTERHEADS_ENABLED?: string;
   @IsOptional() @IsIn(BOOLEAN_STRINGS) FEATURE_SKILLS_ENABLED?: string;
+  @IsOptional() @IsIn(BOOLEAN_STRINGS) FEATURE_WORKSPACES_ENABLED?: string;
   @IsOptional() @IsIn(BOOLEAN_STRINGS) FEATURE_AGENT_RUNTIME_ENABLED?: string;
 
   // Retention

--- a/ayunis-core-backend/src/config/features.config.ts
+++ b/ayunis-core-backend/src/config/features.config.ts
@@ -4,6 +4,7 @@ export enum FeatureFlag {
   KnowledgeBases = 'knowledgeBasesEnabled',
   Letterheads = 'letterheadsEnabled',
   Skills = 'skillsEnabled',
+  Workspaces = 'workspacesEnabled',
   AgentRuntime = 'agentRuntimeEnabled',
 }
 
@@ -30,6 +31,12 @@ export const featuresConfig = registerAs('features', (): FeaturesConfig => ({
   ),
   skillsEnabled: parseBooleanWithDefault(
     process.env.FEATURE_SKILLS_ENABLED,
+    false,
+  ),
+  // Workspaces ("Projekte") group chats into folders. Off until the six-iteration
+  // rollout is far enough along to expose (AYC-700).
+  workspacesEnabled: parseBooleanWithDefault(
+    process.env.FEATURE_WORKSPACES_ENABLED,
     false,
   ),
   // Routes runs through the extracted @ayunis/agent-runtime loop instead of the

--- a/ayunis-core-backend/src/db/migrations/1786529193314-CreateWorkspacesTable.ts
+++ b/ayunis-core-backend/src/db/migrations/1786529193314-CreateWorkspacesTable.ts
@@ -1,0 +1,39 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateWorkspacesTable1786529193314 implements MigrationInterface {
+  name = 'CreateWorkspacesTable1786529193314';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "workspaces" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "name" character varying(255) NOT NULL, "description" character varying(1000), "icon" character varying(64) NOT NULL, "color" character varying(32) NOT NULL, "userId" character varying NOT NULL, "orgId" character varying NOT NULL, CONSTRAINT "PK_098656ae401f3e1a4586f47fd8e" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_dc53b3d0b16419a8f5f1745840" ON "workspaces" ("userId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_5e468208a8112a1dc246758a52" ON "workspaces" ("orgId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspaces" ADD CONSTRAINT "FK_dc53b3d0b16419a8f5f17458403" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspaces" ADD CONSTRAINT "FK_5e468208a8112a1dc246758a527" FOREIGN KEY ("orgId") REFERENCES "orgs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "workspaces" DROP CONSTRAINT "FK_5e468208a8112a1dc246758a527"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspaces" DROP CONSTRAINT "FK_dc53b3d0b16419a8f5f17458403"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_5e468208a8112a1dc246758a52"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_dc53b3d0b16419a8f5f1745840"`,
+    );
+    await queryRunner.query(`DROP TABLE "workspaces"`);
+  }
+}

--- a/ayunis-core-backend/src/domain/favorites/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/favorites/SUMMARY.md
@@ -35,6 +35,11 @@ prevents duplicate favorites, and a user/position constraint protects order.
 - **`RemoveFavoriteReferenceUseCase`** — Deletes every favorite row matching a
   reference type/id (used when a target is deleted).
 
+## Event Listeners
+
+- **`FavoriteWorkspaceDeletionRequestedListener`** — Removes workspace
+  favorites when a workspace is deleted.
+
 ## Infrastructure
 
 - **`LocalFavoritesRepository`** — TypeORM implementation backed by the

--- a/ayunis-core-backend/src/domain/favorites/application/listeners/workspace-deletion-requested.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/listeners/workspace-deletion-requested.listener.spec.ts
@@ -1,0 +1,35 @@
+import type { UUID } from 'crypto';
+import type { RemoveFavoriteReferenceUseCase } from '../use-cases/remove-favorite-reference/remove-favorite-reference.use-case';
+import { WorkspaceDeletionRequestedEvent } from 'src/domain/workspaces/application/events/workspace-deletion-requested.event';
+import { FavoriteReferenceType } from '../../domain/value-objects/favorite-reference-type.enum';
+import { FavoriteWorkspaceDeletionRequestedListener } from './workspace-deletion-requested.listener';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111' as UUID;
+const ORG_ID = '22222222-2222-4222-8222-222222222222' as UUID;
+const WORKSPACE_ID = '33333333-3333-4333-8333-333333333333' as UUID;
+
+describe('FavoriteWorkspaceDeletionRequestedListener', () => {
+  it('defers favorite cleanup until the workspace row is deleted', async () => {
+    const removeFavoriteReferenceUseCase = { execute: jest.fn() };
+    const listener = new FavoriteWorkspaceDeletionRequestedListener(
+      removeFavoriteReferenceUseCase as unknown as RemoveFavoriteReferenceUseCase,
+    );
+    const event = new WorkspaceDeletionRequestedEvent(
+      WORKSPACE_ID,
+      USER_ID,
+      ORG_ID,
+    );
+
+    listener.handle(event);
+
+    expect(removeFavoriteReferenceUseCase.execute).not.toHaveBeenCalled();
+    const [cleanup] = event.takeCleanupTasks();
+    await cleanup.run();
+    expect(removeFavoriteReferenceUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        referenceType: FavoriteReferenceType.Workspace,
+        referenceId: WORKSPACE_ID,
+      }),
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/favorites/application/listeners/workspace-deletion-requested.listener.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/listeners/workspace-deletion-requested.listener.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { WorkspaceDeletionRequestedEvent } from 'src/domain/workspaces/application/events/workspace-deletion-requested.event';
+import { FavoriteReferenceType } from '../../domain/value-objects/favorite-reference-type.enum';
+import { RemoveFavoriteReferenceCommand } from '../use-cases/remove-favorite-reference/remove-favorite-reference.command';
+import { RemoveFavoriteReferenceUseCase } from '../use-cases/remove-favorite-reference/remove-favorite-reference.use-case';
+
+@Injectable()
+export class FavoriteWorkspaceDeletionRequestedListener {
+  constructor(
+    private readonly removeFavoriteReferenceUseCase: RemoveFavoriteReferenceUseCase,
+  ) {}
+
+  @OnEvent(WorkspaceDeletionRequestedEvent.EVENT_NAME)
+  handle(event: WorkspaceDeletionRequestedEvent): void {
+    event.deferCleanup('remove workspace favorite references', async () => {
+      await this.removeFavoriteReferenceUseCase.execute(
+        new RemoveFavoriteReferenceCommand(
+          FavoriteReferenceType.Workspace,
+          event.workspaceId,
+        ),
+      );
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/favorites/favorites.module.ts
+++ b/ayunis-core-backend/src/domain/favorites/favorites.module.ts
@@ -3,6 +3,7 @@ import { AddFavoriteUseCase } from './application/use-cases/add-favorite/add-fav
 import { ReorderFavoritesUseCase } from './application/use-cases/reorder-favorites/reorder-favorites.use-case';
 import { RemoveFavoriteReferenceUseCase } from './application/use-cases/remove-favorite-reference/remove-favorite-reference.use-case';
 import { LocalFavoritesRepositoryModule } from './infrastructure/persistence/local/local-favorites-repository.module';
+import { FavoriteWorkspaceDeletionRequestedListener } from './application/listeners/workspace-deletion-requested.listener';
 
 @Module({
   imports: [LocalFavoritesRepositoryModule],
@@ -10,6 +11,7 @@ import { LocalFavoritesRepositoryModule } from './infrastructure/persistence/loc
     AddFavoriteUseCase,
     ReorderFavoritesUseCase,
     RemoveFavoriteReferenceUseCase,
+    FavoriteWorkspaceDeletionRequestedListener,
   ],
   exports: [
     AddFavoriteUseCase,

--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -1,0 +1,87 @@
+# Workspaces Module
+
+## Purpose
+
+Workspaces are folders that group a user's chats. A workspace carries a name, an
+optional description and an appearance (icon key + colour). User-specific
+favorites and their order are owned by the `favorites` module.
+
+User-facing copy calls them "Projekte"; the code, tables and routes say
+`workspace` throughout. See AYC-700 (iteration 1 of the Workspaces/Projects
+plan) — sharing, skills, knowledge and retention settings arrive in later
+iterations.
+
+The whole module sits behind the `workspacesEnabled` feature flag
+(`FEATURE_WORKSPACES_ENABLED`, off by default), applied at the controller.
+
+## Domain Concepts
+
+- **Workspace** — owned by exactly one user and scoped to their org.
+- **Per-user favorite state** — owned by the favorites module; a workspace row
+  carries no pin or order state. Access checks stay with the workspace use
+  cases — favorites trusts its callers.
+- **Appearance** — `icon` and `color` are opaque keys owned by the frontend
+  catalogue. The backend only guards their shape (`WORKSPACE_ICON_PATTERN`,
+  `WORKSPACE_COLOR_PATTERN`); `color` is either a palette key or a `#rrggbb`
+  literal produced by the custom-colour picker.
+- **Deletion** — `DeleteWorkspaceUseCase` emits `WorkspaceDeletionRequestedEvent`
+  *before* the row delete and drains the listeners' deferred cleanup only after
+  it succeeds, so a failed delete loses nothing. The favorites module listens
+  to remove workspace favorites; the threads integration that deletes a
+  workspace's chats (and purges their object-storage assets, which no database
+  cascade can reach) arrives with the threads module changes.
+- **Creation** — `CreateWorkspaceUseCase` saves the workspace, then calls
+  `AddFavoriteUseCase` so new workspaces appear in the user's favorites.
+
+## Architecture
+
+```text
+workspaces/
+├── domain/
+│   ├── workspace.entity.ts          # rename/describe/restyle
+│   └── workspaces.constants.ts      # limits, defaults, icon/colour patterns
+├── application/
+│   ├── workspaces.errors.ts
+│   ├── util/workspace-fields.ts     # field validation (name/description/appearance)
+│   ├── events/
+│   │   └── workspace-deletion-requested.event.ts
+│   ├── ports/workspaces-repository.port.ts
+│   ├── testing/workspace.fixtures.ts
+│   └── use-cases/
+│       ├── create-workspace/
+│       ├── find-all-workspaces/
+│       ├── find-workspace/
+│       ├── update-workspace/
+│       └── delete-workspace/
+├── infrastructure/persistence/local/
+│   ├── schema/workspace.record.ts   # table `workspaces`
+│   ├── mappers/workspace.mapper.ts
+│   ├── local-workspaces.repository.ts
+│   └── local-workspaces-repository.module.ts
+├── presenters/http/
+│   ├── workspaces.controller.ts
+│   ├── dtos/
+│   └── mappers/workspace-dto.mapper.ts
+└── workspaces.module.ts
+```
+
+## HTTP API
+
+| Method | Route | Purpose |
+| --- | --- | --- |
+| POST | `/workspaces` | Create a workspace |
+| GET | `/workspaces` | List by most recently updated |
+| GET | `/workspaces/:id` | Read one |
+| PATCH | `/workspaces/:id` | Update name / description / icon / colour |
+| DELETE | `/workspaces/:id` | Delete the workspace and its chats |
+
+## Cross-Module Boundaries
+
+`CreateWorkspaceUseCase` imports `AddFavoriteUseCase` from the favorites module.
+On deletion, the module emits `WorkspaceDeletionRequestedEvent` without
+importing favorites; `FavoritesModule` listens to clean up references.
+`ThreadsModule` may depend on workspaces to validate a thread's `workspaceId`
+and listen for `WorkspaceDeletionRequestedEvent`.
+
+The repository port is deliberately not exported — cross-module access goes
+through the exported use cases.

--- a/ayunis-core-backend/src/domain/workspaces/application/events/workspace-deletion-requested.event.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/events/workspace-deletion-requested.event.ts
@@ -1,0 +1,25 @@
+import type { UUID } from 'crypto';
+import { DeferredCleanupEvent } from 'src/common/events/deferred-cleanup.event';
+
+/**
+ * Emitted synchronously *before* a workspace row is deleted. Once the threads
+ * integration lands, the workspace's threads (and their messages and
+ * artifacts) will go with it via a `threads.workspaceId` cascade, but
+ * object-storage assets (MinIO) live outside any cascade and need explicit
+ * cleanup.
+ *
+ * Listeners resolve their cleanup targets while the rows still exist and
+ * register the destructive work via `deferCleanup`; the emitting use case runs
+ * the deferred tasks only after the row delete succeeds.
+ */
+export class WorkspaceDeletionRequestedEvent extends DeferredCleanupEvent {
+  static readonly EVENT_NAME = 'workspace.deletion-requested';
+
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly userId: UUID,
+    public readonly orgId: UUID,
+  ) {
+    super();
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/ports/workspaces-repository.port.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/ports/workspaces-repository.port.ts
@@ -1,0 +1,11 @@
+import type { UUID } from 'crypto';
+import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+
+export abstract class WorkspacesRepository {
+  /** Ordered by the workspace's last update, newest first. */
+  abstract findAllByUserId(userId: UUID): Promise<Workspace[]>;
+  abstract findById(userId: UUID, id: UUID): Promise<Workspace | null>;
+  abstract save(workspace: Workspace): Promise<Workspace>;
+  /** Throws `WorkspaceNotFoundError` when the user owns no such workspace. */
+  abstract delete(userId: UUID, id: UUID): Promise<void>;
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/testing/workspace.fixtures.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/testing/workspace.fixtures.ts
@@ -1,0 +1,45 @@
+import type { UUID } from 'crypto';
+import type { ContextService } from 'src/common/context/services/context.service';
+import { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import type { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+
+export const TEST_USER_ID = '11111111-1111-4111-8111-111111111111' as UUID;
+export const TEST_ORG_ID = '22222222-2222-4222-8222-222222222222' as UUID;
+export const TEST_WORKSPACE_ID = '33333333-3333-4333-8333-333333333333' as UUID;
+
+export function aWorkspace(overrides: Partial<Workspace> = {}): Workspace {
+  return new Workspace({
+    id: TEST_WORKSPACE_ID,
+    userId: TEST_USER_ID,
+    orgId: TEST_ORG_ID,
+    name: 'Bürgeranfragen',
+    description: null,
+    icon: 'folder',
+    color: 'violet',
+    createdAt: new Date('2026-08-01T10:00:00.000Z'),
+    updatedAt: new Date('2026-08-02T10:00:00.000Z'),
+    ...overrides,
+  });
+}
+
+export function createMockContextService(
+  values: { userId?: UUID; orgId?: UUID } = {
+    userId: TEST_USER_ID,
+    orgId: TEST_ORG_ID,
+  },
+): jest.Mocked<ContextService> {
+  return {
+    get: jest.fn((key: string) => values[key as keyof typeof values]),
+  } as unknown as jest.Mocked<ContextService>;
+}
+
+export function createMockWorkspacesRepository(): jest.Mocked<WorkspacesRepository> {
+  return {
+    findAllByUserId: jest.fn().mockResolvedValue([]),
+    findById: jest.fn().mockResolvedValue(null),
+    save: jest
+      .fn()
+      .mockImplementation((workspace: Workspace) => Promise.resolve(workspace)),
+    delete: jest.fn().mockResolvedValue(undefined),
+  };
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/create-workspace/create-workspace.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/create-workspace/create-workspace.command.ts
@@ -1,0 +1,18 @@
+export class CreateWorkspaceCommand {
+  readonly name: string;
+  readonly description: string | null;
+  readonly icon?: string;
+  readonly color?: string;
+
+  constructor(params: {
+    name: string;
+    description?: string | null;
+    icon?: string;
+    color?: string;
+  }) {
+    this.name = params.name;
+    this.description = params.description ?? null;
+    this.icon = params.icon;
+    this.color = params.color;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/create-workspace/create-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/create-workspace/create-workspace.use-case.spec.ts
@@ -1,0 +1,157 @@
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { AddFavoriteUseCase } from 'src/domain/favorites/application/use-cases/add-favorite/add-favorite.use-case';
+import { FavoriteReferenceType } from 'src/domain/favorites/domain/value-objects/favorite-reference-type.enum';
+import {
+  InvalidWorkspaceAppearanceError,
+  InvalidWorkspaceDescriptionError,
+  InvalidWorkspaceNameError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import {
+  WORKSPACE_DESCRIPTION_MAX_LENGTH,
+  WORKSPACE_NAME_MAX_LENGTH,
+} from 'src/domain/workspaces/domain/workspaces.constants';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import {
+  createMockContextService,
+  createMockWorkspacesRepository,
+  TEST_ORG_ID,
+  TEST_USER_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { CreateWorkspaceCommand } from './create-workspace.command';
+import { CreateWorkspaceUseCase } from './create-workspace.use-case';
+
+describe('CreateWorkspaceUseCase', () => {
+  let useCase: CreateWorkspaceUseCase;
+  let repository: jest.Mocked<WorkspacesRepository>;
+  let addFavoriteUseCase: { execute: jest.Mock };
+
+  async function setup(contextService = createMockContextService()) {
+    repository = createMockWorkspacesRepository();
+    addFavoriteUseCase = { execute: jest.fn().mockResolvedValue(undefined) };
+    const module = await Test.createTestingModule({
+      providers: [
+        CreateWorkspaceUseCase,
+        { provide: WorkspacesRepository, useValue: repository },
+        { provide: AddFavoriteUseCase, useValue: addFavoriteUseCase },
+        { provide: ContextService, useValue: contextService },
+      ],
+    }).compile();
+    useCase = module.get(CreateWorkspaceUseCase);
+  }
+
+  beforeAll(() => {
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  beforeEach(async () => {
+    await setup();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a workspace owned by the caller', async () => {
+    const workspace = await useCase.execute(
+      new CreateWorkspaceCommand({ name: 'Bürgeranfragen' }),
+    );
+
+    expect(workspace.userId).toBe(TEST_USER_ID);
+    expect(workspace.orgId).toBe(TEST_ORG_ID);
+    expect(workspace.name).toBe('Bürgeranfragen');
+    expect(repository.save).toHaveBeenCalledWith(workspace);
+  });
+
+  it('favorites a newly created workspace', async () => {
+    const workspace = await useCase.execute(
+      new CreateWorkspaceCommand({ name: 'Gebühren' }),
+    );
+
+    expect(addFavoriteUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: TEST_USER_ID,
+        referenceType: FavoriteReferenceType.Workspace,
+        referenceId: workspace.id,
+      }),
+    );
+  });
+
+  it('applies the requested appearance', async () => {
+    const workspace = await useCase.execute(
+      new CreateWorkspaceCommand({
+        name: 'Feuerwehr',
+        description: 'Einsätze und Fahrzeuge',
+        icon: 'flame',
+        color: '#6b5bd6',
+      }),
+    );
+
+    expect(workspace.icon).toBe('flame');
+    expect(workspace.color).toBe('#6b5bd6');
+    expect(workspace.description).toBe('Einsätze und Fahrzeuge');
+  });
+
+  it('rejects a name that is only whitespace', async () => {
+    await expect(
+      useCase.execute(new CreateWorkspaceCommand({ name: '   ' })),
+    ).rejects.toThrow(InvalidWorkspaceNameError);
+  });
+
+  it('accepts a name at the maximum length', async () => {
+    const workspace = await useCase.execute(
+      new CreateWorkspaceCommand({
+        name: 'a'.repeat(WORKSPACE_NAME_MAX_LENGTH),
+      }),
+    );
+
+    expect(workspace.name).toHaveLength(WORKSPACE_NAME_MAX_LENGTH);
+  });
+
+  it('rejects a name longer than the maximum length', async () => {
+    await expect(
+      useCase.execute(
+        new CreateWorkspaceCommand({
+          name: 'a'.repeat(WORKSPACE_NAME_MAX_LENGTH + 1),
+        }),
+      ),
+    ).rejects.toThrow(InvalidWorkspaceNameError);
+  });
+
+  it('rejects a description longer than the maximum length', async () => {
+    await expect(
+      useCase.execute(
+        new CreateWorkspaceCommand({
+          name: 'Feuerwehr',
+          description: 'a'.repeat(WORKSPACE_DESCRIPTION_MAX_LENGTH + 1),
+        }),
+      ),
+    ).rejects.toThrow(InvalidWorkspaceDescriptionError);
+  });
+
+  it('rejects an icon that is not a catalogue key', async () => {
+    await expect(
+      useCase.execute(
+        new CreateWorkspaceCommand({ name: 'Feuerwehr', icon: 'Flame!' }),
+      ),
+    ).rejects.toThrow(InvalidWorkspaceAppearanceError);
+  });
+
+  it('rejects a colour that is neither palette key nor hex', async () => {
+    await expect(
+      useCase.execute(
+        new CreateWorkspaceCommand({ name: 'Feuerwehr', color: '#12345' }),
+      ),
+    ).rejects.toThrow(InvalidWorkspaceAppearanceError);
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    await setup(createMockContextService({}));
+
+    await expect(
+      useCase.execute(new CreateWorkspaceCommand({ name: 'Bürgeranfragen' })),
+    ).rejects.toThrow(UnauthorizedAccessError);
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/create-workspace/create-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/create-workspace/create-workspace.use-case.ts
@@ -1,0 +1,65 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { AddFavoriteCommand } from 'src/domain/favorites/application/use-cases/add-favorite/add-favorite.command';
+import { AddFavoriteUseCase } from 'src/domain/favorites/application/use-cases/add-favorite/add-favorite.use-case';
+import { FavoriteReferenceType } from 'src/domain/favorites/domain/value-objects/favorite-reference-type.enum';
+import { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { assertValidWorkspaceFields } from '../../util/workspace-fields';
+import { CreateWorkspaceCommand } from './create-workspace.command';
+
+@Injectable()
+export class CreateWorkspaceUseCase {
+  private readonly logger = new Logger(CreateWorkspaceUseCase.name);
+
+  constructor(
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly contextService: ContextService,
+    private readonly addFavoriteUseCase: AddFavoriteUseCase,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(command: CreateWorkspaceCommand): Promise<Workspace> {
+    this.logger.log('Creating workspace');
+
+    assertValidWorkspaceFields({
+      name: command.name,
+      description: command.description ?? null,
+      icon: command.icon,
+      color: command.color,
+    });
+
+    const { userId, orgId } = this.resolveOwner();
+    const workspace = new Workspace({
+      userId,
+      orgId,
+      name: command.name,
+      description: command.description,
+      icon: command.icon,
+      color: command.color,
+    });
+
+    const saved = await this.workspacesRepository.save(workspace);
+    await this.addFavoriteUseCase.execute(
+      new AddFavoriteCommand(
+        saved.userId,
+        FavoriteReferenceType.Workspace,
+        saved.id,
+      ),
+    );
+    return saved;
+  }
+
+  private resolveOwner(): { userId: UUID; orgId: UUID } {
+    const userId = this.contextService.get('userId');
+    const orgId = this.contextService.get('orgId');
+    if (!userId || !orgId) {
+      throw new UnauthorizedAccessError();
+    }
+    return { userId, orgId };
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/delete-workspace/delete-workspace.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/delete-workspace/delete-workspace.command.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class DeleteWorkspaceCommand {
+  constructor(public readonly id: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/delete-workspace/delete-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/delete-workspace/delete-workspace.use-case.spec.ts
@@ -1,0 +1,117 @@
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ContextService } from 'src/common/context/services/context.service';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceDeletionRequestedEvent } from 'src/domain/workspaces/application/events/workspace-deletion-requested.event';
+import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
+import {
+  aWorkspace,
+  createMockContextService,
+  createMockWorkspacesRepository,
+  TEST_ORG_ID,
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { DeleteWorkspaceCommand } from './delete-workspace.command';
+import { DeleteWorkspaceUseCase } from './delete-workspace.use-case';
+
+describe('DeleteWorkspaceUseCase', () => {
+  let useCase: DeleteWorkspaceUseCase;
+  let repository: jest.Mocked<WorkspacesRepository>;
+  let eventEmitter: { emitAsync: jest.Mock };
+
+  beforeAll(() => {
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  beforeEach(async () => {
+    repository = createMockWorkspacesRepository();
+    eventEmitter = { emitAsync: jest.fn().mockResolvedValue([]) };
+    const module = await Test.createTestingModule({
+      providers: [
+        DeleteWorkspaceUseCase,
+        { provide: WorkspacesRepository, useValue: repository },
+        { provide: ContextService, useValue: createMockContextService() },
+        { provide: EventEmitter2, useValue: eventEmitter },
+      ],
+    }).compile();
+    useCase = module.get(DeleteWorkspaceUseCase);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('announces the deletion before removing the row', async () => {
+    repository.findById.mockResolvedValue(aWorkspace());
+    const callOrder: string[] = [];
+    eventEmitter.emitAsync.mockImplementation(() => {
+      callOrder.push('event');
+      return Promise.resolve([]);
+    });
+    repository.delete.mockImplementation(() => {
+      callOrder.push('delete');
+      return Promise.resolve();
+    });
+
+    await useCase.execute(new DeleteWorkspaceCommand(TEST_WORKSPACE_ID));
+
+    expect(callOrder).toEqual(['event', 'delete']);
+    expect(eventEmitter.emitAsync).toHaveBeenCalledWith(
+      WorkspaceDeletionRequestedEvent.EVENT_NAME,
+      expect.objectContaining({
+        workspaceId: TEST_WORKSPACE_ID,
+        userId: TEST_USER_ID,
+        orgId: TEST_ORG_ID,
+      }),
+    );
+  });
+
+  it('runs deferred listener cleanup only after the row delete succeeds', async () => {
+    repository.findById.mockResolvedValue(aWorkspace());
+    const cleanup = jest.fn().mockResolvedValue(undefined);
+    eventEmitter.emitAsync.mockImplementation(
+      (_name: string, event: WorkspaceDeletionRequestedEvent) => {
+        event.deferCleanup('purge thread storage', cleanup);
+        return Promise.resolve([]);
+      },
+    );
+
+    await useCase.execute(new DeleteWorkspaceCommand(TEST_WORKSPACE_ID));
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(repository.delete).toHaveBeenCalledWith(
+      TEST_USER_ID,
+      TEST_WORKSPACE_ID,
+    );
+  });
+
+  it('does not run cleanup when the row delete fails', async () => {
+    repository.findById.mockResolvedValue(aWorkspace());
+    const cleanup = jest.fn().mockResolvedValue(undefined);
+    eventEmitter.emitAsync.mockImplementation(
+      (_name: string, event: WorkspaceDeletionRequestedEvent) => {
+        event.deferCleanup('purge thread storage', cleanup);
+        return Promise.resolve([]);
+      },
+    );
+    repository.delete.mockRejectedValue(new Error('constraint violation'));
+
+    await expect(
+      useCase.execute(new DeleteWorkspaceCommand(TEST_WORKSPACE_ID)),
+    ).rejects.toThrow();
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+
+  it('throws when the workspace does not belong to the caller', async () => {
+    repository.findById.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(new DeleteWorkspaceCommand(TEST_WORKSPACE_ID)),
+    ).rejects.toThrow(WorkspaceNotFoundError);
+    expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
+    expect(repository.delete).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/delete-workspace/delete-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/delete-workspace/delete-workspace.use-case.ts
@@ -1,0 +1,64 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import type { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { runDeferredCleanup } from 'src/common/events/run-deferred-cleanup';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceDeletionRequestedEvent } from 'src/domain/workspaces/application/events/workspace-deletion-requested.event';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceNotFoundError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { DeleteWorkspaceCommand } from './delete-workspace.command';
+
+@Injectable()
+export class DeleteWorkspaceUseCase {
+  private readonly logger = new Logger(DeleteWorkspaceUseCase.name);
+
+  constructor(
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly contextService: ContextService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(command: DeleteWorkspaceCommand): Promise<void> {
+    this.logger.log('Deleting workspace', { workspaceId: command.id });
+
+    const userId = this.resolveUserId();
+    const workspace = await this.workspacesRepository.findById(
+      userId,
+      command.id,
+    );
+    if (!workspace) {
+      throw new WorkspaceNotFoundError(command.id);
+    }
+
+    // Two-phase cleanup: the workspace's threads go by FK cascade, but their
+    // object-storage assets do not. Listeners resolve those while the thread
+    // rows still exist and defer the purge until the delete has succeeded.
+    const event = new WorkspaceDeletionRequestedEvent(
+      workspace.id,
+      workspace.userId,
+      workspace.orgId,
+    );
+    await this.eventEmitter.emitAsync(
+      WorkspaceDeletionRequestedEvent.EVENT_NAME,
+      event,
+    );
+
+    await this.workspacesRepository.delete(userId, command.id);
+
+    await runDeferredCleanup(event.takeCleanupTasks(), this.logger);
+  }
+
+  private resolveUserId(): UUID {
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
+    return userId;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.spec.ts
@@ -1,0 +1,55 @@
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import {
+  aWorkspace,
+  createMockContextService,
+  createMockWorkspacesRepository,
+  TEST_USER_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { FindAllWorkspacesUseCase } from './find-all-workspaces.use-case';
+
+describe('FindAllWorkspacesUseCase', () => {
+  let useCase: FindAllWorkspacesUseCase;
+  let repository: jest.Mocked<WorkspacesRepository>;
+
+  async function setup(contextService = createMockContextService()) {
+    repository = createMockWorkspacesRepository();
+    const module = await Test.createTestingModule({
+      providers: [
+        FindAllWorkspacesUseCase,
+        { provide: WorkspacesRepository, useValue: repository },
+        { provide: ContextService, useValue: contextService },
+      ],
+    }).compile();
+    useCase = module.get(FindAllWorkspacesUseCase);
+  }
+
+  beforeAll(() => {
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  beforeEach(async () => {
+    await setup();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the caller’s workspaces', async () => {
+    const workspaces = [aWorkspace()];
+    repository.findAllByUserId.mockResolvedValue(workspaces);
+
+    await expect(useCase.execute()).resolves.toBe(workspaces);
+    expect(repository.findAllByUserId).toHaveBeenCalledWith(TEST_USER_ID);
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    await setup(createMockContextService({}));
+
+    await expect(useCase.execute()).rejects.toThrow(UnauthorizedAccessError);
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.ts
@@ -1,0 +1,34 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+
+@Injectable()
+export class FindAllWorkspacesUseCase {
+  private readonly logger = new Logger(FindAllWorkspacesUseCase.name);
+
+  constructor(
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(): Promise<Workspace[]> {
+    this.logger.log('Finding all workspaces');
+    return await this.workspacesRepository.findAllByUserId(
+      this.resolveUserId(),
+    );
+  }
+
+  private resolveUserId(): UUID {
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
+    return userId;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspace/find-workspace.query.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspace/find-workspace.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class FindWorkspaceQuery {
+  constructor(public readonly id: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspace/find-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspace/find-workspace.use-case.spec.ts
@@ -1,0 +1,60 @@
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { ContextService } from 'src/common/context/services/context.service';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
+import {
+  aWorkspace,
+  createMockContextService,
+  createMockWorkspacesRepository,
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { FindWorkspaceQuery } from './find-workspace.query';
+import { FindWorkspaceUseCase } from './find-workspace.use-case';
+
+describe('FindWorkspaceUseCase', () => {
+  let useCase: FindWorkspaceUseCase;
+  let repository: jest.Mocked<WorkspacesRepository>;
+
+  beforeAll(() => {
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  beforeEach(async () => {
+    repository = createMockWorkspacesRepository();
+    const module = await Test.createTestingModule({
+      providers: [
+        FindWorkspaceUseCase,
+        { provide: WorkspacesRepository, useValue: repository },
+        { provide: ContextService, useValue: createMockContextService() },
+      ],
+    }).compile();
+    useCase = module.get(FindWorkspaceUseCase);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the workspace scoped to the caller', async () => {
+    const workspace = aWorkspace();
+    repository.findById.mockResolvedValue(workspace);
+
+    await expect(
+      useCase.execute(new FindWorkspaceQuery(TEST_WORKSPACE_ID)),
+    ).resolves.toBe(workspace);
+    expect(repository.findById).toHaveBeenCalledWith(
+      TEST_USER_ID,
+      TEST_WORKSPACE_ID,
+    );
+  });
+
+  it('throws when the workspace does not belong to the caller', async () => {
+    repository.findById.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(new FindWorkspaceQuery(TEST_WORKSPACE_ID)),
+    ).rejects.toThrow(WorkspaceNotFoundError);
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspace/find-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspace/find-workspace.use-case.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceNotFoundError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { FindWorkspaceQuery } from './find-workspace.query';
+
+@Injectable()
+export class FindWorkspaceUseCase {
+  private readonly logger = new Logger(FindWorkspaceUseCase.name);
+
+  constructor(
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(query: FindWorkspaceQuery): Promise<Workspace> {
+    this.logger.log('Finding workspace', { workspaceId: query.id });
+
+    const workspace = await this.workspacesRepository.findById(
+      this.resolveUserId(),
+      query.id,
+    );
+    if (!workspace) {
+      throw new WorkspaceNotFoundError(query.id);
+    }
+    return workspace;
+  }
+
+  private resolveUserId(): UUID {
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
+    return userId;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace/update-workspace.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace/update-workspace.command.ts
@@ -1,0 +1,23 @@
+import type { UUID } from 'crypto';
+
+export class UpdateWorkspaceCommand {
+  readonly id: UUID;
+  readonly name?: string;
+  readonly description?: string | null;
+  readonly icon?: string;
+  readonly color?: string;
+
+  constructor(params: {
+    id: UUID;
+    name?: string;
+    description?: string | null;
+    icon?: string;
+    color?: string;
+  }) {
+    this.id = params.id;
+    this.name = params.name;
+    this.description = params.description;
+    this.icon = params.icon;
+    this.color = params.color;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace/update-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace/update-workspace.use-case.spec.ts
@@ -1,0 +1,149 @@
+import { Test } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { ContextService } from 'src/common/context/services/context.service';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
+import {
+  InvalidWorkspaceAppearanceError,
+  InvalidWorkspaceDescriptionError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { WORKSPACE_DESCRIPTION_MAX_LENGTH } from 'src/domain/workspaces/domain/workspaces.constants';
+import {
+  aWorkspace,
+  createMockContextService,
+  createMockWorkspacesRepository,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { UpdateWorkspaceCommand } from './update-workspace.command';
+import { UpdateWorkspaceUseCase } from './update-workspace.use-case';
+
+describe('UpdateWorkspaceUseCase', () => {
+  let useCase: UpdateWorkspaceUseCase;
+  let repository: jest.Mocked<WorkspacesRepository>;
+
+  beforeAll(() => {
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  beforeEach(async () => {
+    repository = createMockWorkspacesRepository();
+    const module = await Test.createTestingModule({
+      providers: [
+        UpdateWorkspaceUseCase,
+        { provide: WorkspacesRepository, useValue: repository },
+        { provide: ContextService, useValue: createMockContextService() },
+      ],
+    }).compile();
+    useCase = module.get(UpdateWorkspaceUseCase);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('applies only the fields that were sent', async () => {
+    repository.findById.mockResolvedValue(
+      aWorkspace({ name: 'Alt', description: 'Beschreibung', icon: 'folder' }),
+    );
+
+    const updated = await useCase.execute(
+      new UpdateWorkspaceCommand({
+        id: TEST_WORKSPACE_ID,
+        name: 'Neu',
+        color: '#112233',
+      }),
+    );
+
+    expect(updated.name).toBe('Neu');
+    expect(updated.color).toBe('#112233');
+    expect(updated.description).toBe('Beschreibung');
+    expect(updated.icon).toBe('folder');
+  });
+
+  it('clears the description when null is sent', async () => {
+    repository.findById.mockResolvedValue(
+      aWorkspace({ description: 'Beschreibung' }),
+    );
+
+    const updated = await useCase.execute(
+      new UpdateWorkspaceCommand({
+        id: TEST_WORKSPACE_ID,
+        description: null,
+      }),
+    );
+
+    expect(updated.description).toBeNull();
+  });
+
+  it('rejects a description longer than the maximum length', async () => {
+    repository.findById.mockResolvedValue(aWorkspace());
+
+    await expect(
+      useCase.execute(
+        new UpdateWorkspaceCommand({
+          id: TEST_WORKSPACE_ID,
+          description: 'a'.repeat(WORKSPACE_DESCRIPTION_MAX_LENGTH + 1),
+        }),
+      ),
+    ).rejects.toThrow(InvalidWorkspaceDescriptionError);
+  });
+
+  it('rejects an icon that is not a catalogue key', async () => {
+    repository.findById.mockResolvedValue(aWorkspace());
+
+    await expect(
+      useCase.execute(
+        new UpdateWorkspaceCommand({ id: TEST_WORKSPACE_ID, icon: 'Flame!' }),
+      ),
+    ).rejects.toThrow(InvalidWorkspaceAppearanceError);
+  });
+
+  it('rejects a colour that is neither palette key nor hex', async () => {
+    repository.findById.mockResolvedValue(aWorkspace());
+
+    await expect(
+      useCase.execute(
+        new UpdateWorkspaceCommand({ id: TEST_WORKSPACE_ID, color: 'Rot 5' }),
+      ),
+    ).rejects.toThrow(InvalidWorkspaceAppearanceError);
+  });
+
+  it('bumps updatedAt so the edit moves in the "last updated" sort', async () => {
+    const before = new Date('2026-08-02T10:00:00.000Z');
+    repository.findById.mockResolvedValue(aWorkspace({ updatedAt: before }));
+
+    const updated = await useCase.execute(
+      new UpdateWorkspaceCommand({
+        id: TEST_WORKSPACE_ID,
+        name: 'Neu',
+      }),
+    );
+
+    expect(updated.updatedAt.getTime()).toBeGreaterThan(before.getTime());
+  });
+
+  it('leaves updatedAt alone when nothing was actually sent', async () => {
+    const before = new Date('2026-08-02T10:00:00.000Z');
+    repository.findById.mockResolvedValue(aWorkspace({ updatedAt: before }));
+
+    const updated = await useCase.execute(
+      new UpdateWorkspaceCommand({ id: TEST_WORKSPACE_ID }),
+    );
+
+    expect(updated.updatedAt).toEqual(before);
+  });
+
+  it('throws when the workspace does not belong to the caller', async () => {
+    repository.findById.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute(
+        new UpdateWorkspaceCommand({
+          id: TEST_WORKSPACE_ID,
+          name: 'Neu',
+        }),
+      ),
+    ).rejects.toThrow(WorkspaceNotFoundError);
+    expect(repository.save).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace/update-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace/update-workspace.use-case.ts
@@ -1,0 +1,58 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceNotFoundError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { assertValidWorkspaceFields } from '../../util/workspace-fields';
+import { UpdateWorkspaceCommand } from './update-workspace.command';
+
+@Injectable()
+export class UpdateWorkspaceUseCase {
+  private readonly logger = new Logger(UpdateWorkspaceUseCase.name);
+
+  constructor(
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(command: UpdateWorkspaceCommand): Promise<Workspace> {
+    this.logger.log('Updating workspace', { workspaceId: command.id });
+
+    const workspace = await this.workspacesRepository.findById(
+      this.resolveUserId(),
+      command.id,
+    );
+    if (!workspace) {
+      throw new WorkspaceNotFoundError(command.id);
+    }
+
+    assertValidWorkspaceFields(command);
+
+    if (command.name !== undefined) {
+      workspace.rename(command.name);
+    }
+    if (command.description !== undefined) {
+      workspace.describe(command.description);
+    }
+    if (command.icon !== undefined || command.color !== undefined) {
+      workspace.restyle({ icon: command.icon, color: command.color });
+    }
+
+    return await this.workspacesRepository.save(workspace);
+  }
+
+  private resolveUserId(): UUID {
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
+    return userId;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/util/workspace-fields.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/util/workspace-fields.spec.ts
@@ -1,0 +1,58 @@
+import { assertValidWorkspaceFields } from './workspace-fields';
+import {
+  InvalidWorkspaceAppearanceError,
+  InvalidWorkspaceDescriptionError,
+  InvalidWorkspaceNameError,
+} from '../workspaces.errors';
+
+describe('assertValidWorkspaceFields', () => {
+  it('accepts a fully valid field set', () => {
+    expect(() =>
+      assertValidWorkspaceFields({
+        name: 'Bürgeranfragen',
+        description: null,
+        icon: 'folder',
+        color: 'violet',
+      }),
+    ).not.toThrow();
+  });
+
+  it('skips fields that are not part of the request', () => {
+    expect(() => assertValidWorkspaceFields({})).not.toThrow();
+  });
+
+  it('rejects an empty name', () => {
+    expect(() => assertValidWorkspaceFields({ name: '' })).toThrow(
+      InvalidWorkspaceNameError,
+    );
+  });
+
+  it('rejects an over-long description', () => {
+    expect(() =>
+      assertValidWorkspaceFields({ description: 'x'.repeat(10_001) }),
+    ).toThrow(InvalidWorkspaceDescriptionError);
+  });
+
+  it('rejects an unknown icon and color', () => {
+    expect(() => assertValidWorkspaceFields({ icon: 'not a key!' })).toThrow(
+      InvalidWorkspaceAppearanceError,
+    );
+    expect(() => assertValidWorkspaceFields({ color: 'plaid!' })).toThrow(
+      InvalidWorkspaceAppearanceError,
+    );
+  });
+
+  // @IsOptional() on the update DTO waves null through class-validator, so
+  // the application-layer guard is the last line of defence against it.
+  it('rejects null for the non-nullable fields', () => {
+    expect(() => assertValidWorkspaceFields({ name: null })).toThrow(
+      InvalidWorkspaceNameError,
+    );
+    expect(() => assertValidWorkspaceFields({ icon: null })).toThrow(
+      InvalidWorkspaceAppearanceError,
+    );
+    expect(() => assertValidWorkspaceFields({ color: null })).toThrow(
+      InvalidWorkspaceAppearanceError,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/util/workspace-fields.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/util/workspace-fields.ts
@@ -1,0 +1,71 @@
+import {
+  InvalidWorkspaceAppearanceError,
+  InvalidWorkspaceDescriptionError,
+  InvalidWorkspaceNameError,
+} from '../workspaces.errors';
+import {
+  WORKSPACE_COLOR_PATTERN,
+  WORKSPACE_DESCRIPTION_MAX_LENGTH,
+  WORKSPACE_ICON_PATTERN,
+  WORKSPACE_NAME_MAX_LENGTH,
+} from '../../domain/workspaces.constants';
+
+const CONTROL_CHARS = /\p{Cc}/u;
+
+function isValidWorkspaceName(name: string): boolean {
+  return (
+    name.length > 0 &&
+    name.length <= WORKSPACE_NAME_MAX_LENGTH &&
+    name === name.trim() &&
+    !CONTROL_CHARS.test(name)
+  );
+}
+
+// The `typeof` guards exist because `@IsOptional()` on the update DTO also
+// waves `null` through, and `RegExp.test(null)` stringifies to `"null"` and
+// matches — a provided but non-string value must fail, not silently pass.
+
+function assertName(name: string | null | undefined): void {
+  if (name === undefined) return;
+  if (typeof name !== 'string' || !isValidWorkspaceName(name)) {
+    throw new InvalidWorkspaceNameError(String(name));
+  }
+}
+
+function assertDescription(description: string | null | undefined): void {
+  if (description === undefined || description === null) return;
+  if (
+    typeof description !== 'string' ||
+    description.length > WORKSPACE_DESCRIPTION_MAX_LENGTH
+  ) {
+    throw new InvalidWorkspaceDescriptionError();
+  }
+}
+
+function assertAppearance(
+  value: string | null | undefined,
+  field: 'icon' | 'color',
+  pattern: RegExp,
+): void {
+  if (value === undefined) return;
+  if (typeof value !== 'string' || !pattern.test(value)) {
+    throw new InvalidWorkspaceAppearanceError(field);
+  }
+}
+
+/**
+ * Validates every provided field; `undefined` means "not part of this
+ * request" and is skipped, so the same helper serves create (all fields
+ * present) and partial update.
+ */
+export function assertValidWorkspaceFields(fields: {
+  name?: string | null;
+  description?: string | null;
+  icon?: string | null;
+  color?: string | null;
+}): void {
+  assertName(fields.name);
+  assertDescription(fields.description);
+  assertAppearance(fields.icon, 'icon', WORKSPACE_ICON_PATTERN);
+  assertAppearance(fields.color, 'color', WORKSPACE_COLOR_PATTERN);
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/workspaces.errors.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/workspaces.errors.ts
@@ -1,0 +1,80 @@
+import type { ErrorMetadata } from 'src/common/errors/base.error';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+export enum WorkspaceErrorCode {
+  WORKSPACE_NOT_FOUND = 'WORKSPACE_NOT_FOUND',
+  WORKSPACE_INVALID_NAME = 'WORKSPACE_INVALID_NAME',
+  WORKSPACE_INVALID_DESCRIPTION = 'WORKSPACE_INVALID_DESCRIPTION',
+  WORKSPACE_INVALID_APPEARANCE = 'WORKSPACE_INVALID_APPEARANCE',
+  UNEXPECTED_WORKSPACE_ERROR = 'UNEXPECTED_WORKSPACE_ERROR',
+}
+
+export abstract class WorkspaceError extends ApplicationError {
+  constructor(
+    message: string,
+    code: WorkspaceErrorCode,
+    statusCode: number = 400,
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, code, statusCode, metadata);
+  }
+}
+
+export class WorkspaceNotFoundError extends WorkspaceError {
+  constructor(workspaceId: string, metadata?: ErrorMetadata) {
+    super(
+      `Workspace with ID '${workspaceId}' not found`,
+      WorkspaceErrorCode.WORKSPACE_NOT_FOUND,
+      404,
+      { workspaceId, ...metadata },
+    );
+  }
+}
+
+export class InvalidWorkspaceNameError extends WorkspaceError {
+  constructor(name: string, metadata?: ErrorMetadata) {
+    super(
+      `Invalid workspace name "${name}". Names must not be empty, must not ` +
+        `exceed the maximum length, must not start or end with whitespace, ` +
+        `and must not contain control characters.`,
+      WorkspaceErrorCode.WORKSPACE_INVALID_NAME,
+      400,
+      metadata,
+    );
+  }
+}
+
+export class InvalidWorkspaceDescriptionError extends WorkspaceError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'Invalid workspace description: exceeds the maximum length.',
+      WorkspaceErrorCode.WORKSPACE_INVALID_DESCRIPTION,
+      400,
+      metadata,
+    );
+  }
+}
+
+export class InvalidWorkspaceAppearanceError extends WorkspaceError {
+  constructor(field: 'icon' | 'color', metadata?: ErrorMetadata) {
+    super(
+      `Invalid workspace ${field}: not a valid catalogue key` +
+        (field === 'color' ? ' or #rrggbb value.' : '.'),
+      WorkspaceErrorCode.WORKSPACE_INVALID_APPEARANCE,
+      400,
+      { field, ...metadata },
+    );
+  }
+}
+
+export class UnexpectedWorkspaceError extends WorkspaceError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(
+      'Unexpected workspace error',
+      WorkspaceErrorCode.UNEXPECTED_WORKSPACE_ERROR,
+      500,
+      metadata,
+    );
+    this.cause = error;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/domain/workspace.entity.ts
+++ b/ayunis-core-backend/src/domain/workspaces/domain/workspace.entity.ts
@@ -1,0 +1,65 @@
+import type { UUID } from 'crypto';
+import { randomUUID } from 'crypto';
+import {
+  DEFAULT_WORKSPACE_COLOR,
+  DEFAULT_WORKSPACE_ICON,
+} from './workspaces.constants';
+
+export class Workspace {
+  public readonly id: UUID;
+  public readonly userId: UUID;
+  public readonly orgId: UUID;
+  public readonly createdAt: Date;
+  public name: string;
+  public description: string | null;
+  public icon: string;
+  public color: string;
+  public updatedAt: Date;
+
+  constructor(params: {
+    id?: UUID;
+    userId: UUID;
+    orgId: UUID;
+    name: string;
+    description?: string | null;
+    icon?: string;
+    color?: string;
+    createdAt?: Date;
+    updatedAt?: Date;
+  }) {
+    this.id = params.id ?? randomUUID();
+    this.userId = params.userId;
+    this.orgId = params.orgId;
+    this.name = params.name;
+    this.description = params.description ?? null;
+    this.icon = params.icon ?? DEFAULT_WORKSPACE_ICON;
+    this.color = params.color ?? DEFAULT_WORKSPACE_COLOR;
+    this.createdAt = params.createdAt ?? new Date();
+    this.updatedAt = params.updatedAt ?? new Date();
+  }
+
+  rename(name: string): void {
+    this.name = name;
+    this.touch();
+  }
+
+  describe(description: string | null): void {
+    this.description = description;
+    this.touch();
+  }
+
+  restyle(params: { icon?: string; color?: string }): void {
+    this.icon = params.icon ?? this.icon;
+    this.color = params.color ?? this.color;
+    this.touch();
+  }
+
+  /**
+   * The mapper writes `updatedAt` through to the record, so TypeORM's
+   * @UpdateDateColumn never gets to fill it in — an edit would otherwise keep
+   * its old timestamp and never move in the "last updated" sort.
+   */
+  private touch(): void {
+    this.updatedAt = new Date();
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/domain/workspaces.constants.ts
+++ b/ayunis-core-backend/src/domain/workspaces/domain/workspaces.constants.ts
@@ -1,0 +1,14 @@
+export const WORKSPACE_NAME_MAX_LENGTH = 255;
+export const WORKSPACE_DESCRIPTION_MAX_LENGTH = 1000;
+
+export const DEFAULT_WORKSPACE_ICON = 'folder';
+export const DEFAULT_WORKSPACE_COLOR = 'violet';
+
+/**
+ * Icons and colours are chosen from a catalogue the frontend owns; the backend
+ * stores the opaque key and only guards its shape so the column cannot become a
+ * dumping ground. Colours are either a palette key or a `#rrggbb` literal — the
+ * custom-colour picker produces the latter.
+ */
+export const WORKSPACE_ICON_PATTERN = /^[a-z][a-z0-9-]{0,63}$/;
+export const WORKSPACE_COLOR_PATTERN = /^(?:[a-z]{1,31}|#[0-9a-fA-F]{6})$/;

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces-repository.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces-repository.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WorkspaceRecord } from './schema/workspace.record';
+import { LocalWorkspacesRepository } from './local-workspaces.repository';
+import { WorkspaceMapper } from './mappers/workspace.mapper';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([WorkspaceRecord])],
+  providers: [LocalWorkspacesRepository, WorkspaceMapper],
+  exports: [LocalWorkspacesRepository],
+})
+export class LocalWorkspacesRepositoryModule {}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import type { UUID } from 'crypto';
+import { Repository } from 'typeorm';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
+import { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import { WorkspaceMapper } from './mappers/workspace.mapper';
+import { WorkspaceRecord } from './schema/workspace.record';
+
+@Injectable()
+export class LocalWorkspacesRepository extends WorkspacesRepository {
+  constructor(
+    @InjectRepository(WorkspaceRecord)
+    private readonly repo: Repository<WorkspaceRecord>,
+    private readonly mapper: WorkspaceMapper,
+  ) {
+    super();
+  }
+
+  async findAllByUserId(userId: UUID): Promise<Workspace[]> {
+    const records = await this.repo.find({
+      where: { userId },
+      order: { updatedAt: 'DESC' },
+    });
+    return records.map((record) => this.mapper.toDomain(record));
+  }
+
+  async findById(userId: UUID, id: UUID): Promise<Workspace | null> {
+    const record = await this.repo.findOne({ where: { userId, id } });
+    return record ? this.mapper.toDomain(record) : null;
+  }
+
+  async save(workspace: Workspace): Promise<Workspace> {
+    const saved = await this.repo.save(this.mapper.toRecord(workspace));
+    return this.mapper.toDomain(saved);
+  }
+
+  async delete(userId: UUID, id: UUID): Promise<void> {
+    const result = await this.repo.delete({ userId, id });
+    if (!result.affected) {
+      throw new WorkspaceNotFoundError(id);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace.mapper.spec.ts
@@ -1,0 +1,47 @@
+import { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import { WorkspaceRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace.record';
+import { WorkspaceMapper } from './workspace.mapper';
+import {
+  aWorkspace,
+  TEST_ORG_ID,
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+
+describe('WorkspaceMapper', () => {
+  const mapper = new WorkspaceMapper();
+
+  it('round-trips the core fields', () => {
+    const workspace = aWorkspace({
+      name: 'Feuerwehr',
+      description: 'Einsätze',
+      icon: 'flame',
+      color: '#6b5bd6',
+    });
+
+    const roundTripped = mapper.toDomain(mapper.toRecord(workspace));
+
+    expect(roundTripped).toEqual(workspace);
+  });
+
+  it('maps a record to the domain entity', () => {
+    const record = new WorkspaceRecord();
+    record.id = TEST_WORKSPACE_ID;
+    record.userId = TEST_USER_ID;
+    record.orgId = TEST_ORG_ID;
+    record.name = 'Gebühren';
+    record.description = null;
+    record.icon = 'receipt';
+    record.color = 'amber';
+    record.createdAt = new Date('2026-08-01T10:00:00.000Z');
+    record.updatedAt = new Date('2026-08-02T10:00:00.000Z');
+
+    const workspace = mapper.toDomain(record);
+
+    expect(workspace).toBeInstanceOf(Workspace);
+    expect(workspace.name).toBe('Gebühren');
+    expect(workspace.description).toBeNull();
+    expect(workspace.icon).toBe('receipt');
+    expect(workspace.color).toBe('amber');
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace.mapper.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import { WorkspaceRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace.record';
+
+@Injectable()
+export class WorkspaceMapper {
+  toDomain(record: WorkspaceRecord): Workspace {
+    return new Workspace({
+      id: record.id,
+      userId: record.userId,
+      orgId: record.orgId,
+      name: record.name,
+      description: record.description,
+      icon: record.icon,
+      color: record.color,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    });
+  }
+
+  toRecord(domain: Workspace): WorkspaceRecord {
+    const record = new WorkspaceRecord();
+    record.id = domain.id;
+    record.userId = domain.userId;
+    record.orgId = domain.orgId;
+    record.name = domain.name;
+    record.description = domain.description;
+    record.icon = domain.icon;
+    record.color = domain.color;
+    record.createdAt = domain.createdAt;
+    record.updatedAt = domain.updatedAt;
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace.record.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace.record.ts
@@ -1,0 +1,36 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import type { UUID } from 'crypto';
+import { BaseRecord } from 'src/common/db/base-record';
+import { OrgRecord } from 'src/iam/orgs/infrastructure/repositories/local/schema/org.record';
+import { UserRecord } from 'src/iam/users/infrastructure/repositories/local/schema/user.record';
+
+@Entity({ name: 'workspaces' })
+export class WorkspaceRecord extends BaseRecord {
+  @Column({ type: 'varchar', length: 255 })
+  name: string;
+
+  @Column({ type: 'varchar', length: 1000, nullable: true })
+  description: string | null;
+
+  @Column({ type: 'varchar', length: 64 })
+  icon: string;
+
+  @Column({ type: 'varchar', length: 32 })
+  color: string;
+
+  @Column()
+  @Index()
+  userId: UUID;
+
+  @ManyToOne(() => UserRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: UserRecord;
+
+  @Column()
+  @Index()
+  orgId: UUID;
+
+  @ManyToOne(() => OrgRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'orgId' })
+  org: OrgRecord;
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/create-workspace.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/create-workspace.dto.ts
@@ -1,0 +1,52 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+} from 'class-validator';
+import {
+  WORKSPACE_COLOR_PATTERN,
+  WORKSPACE_DESCRIPTION_MAX_LENGTH,
+  WORKSPACE_ICON_PATTERN,
+  WORKSPACE_NAME_MAX_LENGTH,
+} from 'src/domain/workspaces/domain/workspaces.constants';
+
+export class CreateWorkspaceDto {
+  @ApiProperty({
+    description: 'Name of the workspace',
+    example: 'Bürgeranfragen',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(WORKSPACE_NAME_MAX_LENGTH)
+  name: string;
+
+  @ApiPropertyOptional({
+    description: 'What the workspace is for',
+    example: 'Anfragen von Bürgerinnen und Bürgern bündeln',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(WORKSPACE_DESCRIPTION_MAX_LENGTH)
+  description?: string;
+
+  @ApiPropertyOptional({
+    description: 'Key of the workspace icon from the client icon catalogue',
+    example: 'landmark',
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(WORKSPACE_ICON_PATTERN)
+  icon?: string;
+
+  @ApiPropertyOptional({
+    description: 'Palette key or #rrggbb literal for the workspace colour',
+    example: '#6b5bd6',
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(WORKSPACE_COLOR_PATTERN)
+  color?: string;
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/update-workspace.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/update-workspace.dto.ts
@@ -1,0 +1,58 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+} from 'class-validator';
+import {
+  WORKSPACE_COLOR_PATTERN,
+  WORKSPACE_DESCRIPTION_MAX_LENGTH,
+  WORKSPACE_ICON_PATTERN,
+  WORKSPACE_NAME_MAX_LENGTH,
+} from 'src/domain/workspaces/domain/workspaces.constants';
+
+export class UpdateWorkspaceDto {
+  @ApiPropertyOptional({
+    description: 'Name of the workspace',
+    example: 'Bürgeranfragen',
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(WORKSPACE_NAME_MAX_LENGTH)
+  name?: string;
+
+  // `type: String` is load-bearing: without it Swagger cannot infer a type for
+  // `string | null` and emits an object schema, which generates a useless
+  // `{ [key: string]: unknown } | null` on the client.
+  @ApiPropertyOptional({
+    type: String,
+    description: 'What the workspace is for. Send null to clear it.',
+    example: 'Anfragen von Bürgerinnen und Bürgern bündeln',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(WORKSPACE_DESCRIPTION_MAX_LENGTH)
+  description?: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Key of the workspace icon from the client icon catalogue',
+    example: 'landmark',
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(WORKSPACE_ICON_PATTERN)
+  icon?: string;
+
+  @ApiPropertyOptional({
+    description: 'Palette key or #rrggbb literal for the workspace colour',
+    example: '#6b5bd6',
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(WORKSPACE_COLOR_PATTERN)
+  color?: string;
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-response.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-response.dto.ts
@@ -1,0 +1,47 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class WorkspaceResponseDto {
+  @ApiProperty({
+    description: 'Unique identifier of the workspace',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Name of the workspace',
+    example: 'Bürgeranfragen',
+  })
+  name: string;
+
+  @ApiProperty({
+    type: String,
+    description: 'What the workspace is for',
+    example: 'Anfragen von Bürgerinnen und Bürgern bündeln',
+    nullable: true,
+  })
+  description: string | null;
+
+  @ApiProperty({
+    description: 'Key of the workspace icon from the client icon catalogue',
+    example: 'landmark',
+  })
+  icon: string;
+
+  @ApiProperty({
+    description: 'Palette key or #rrggbb literal for the workspace colour',
+    example: '#6b5bd6',
+  })
+  color: string;
+
+  @ApiProperty({
+    description: 'When the workspace was created',
+    example: '2026-08-11T10:00:00.000Z',
+  })
+  createdAt: string;
+
+  @ApiProperty({
+    description: 'When the workspace was last updated',
+    example: '2026-08-11T10:30:00.000Z',
+  })
+  updatedAt: string;
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import { WorkspaceResponseDto } from 'src/domain/workspaces/presenters/http/dtos/workspace-response.dto';
+
+@Injectable()
+export class WorkspaceDtoMapper {
+  toDto(workspace: Workspace): WorkspaceResponseDto {
+    const dto = new WorkspaceResponseDto();
+    dto.id = workspace.id;
+    dto.name = workspace.name;
+    dto.description = workspace.description;
+    dto.icon = workspace.icon;
+    dto.color = workspace.color;
+    dto.createdAt = workspace.createdAt.toISOString();
+    dto.updatedAt = workspace.updatedAt.toISOString();
+    return dto;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/workspaces.controller.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/workspaces.controller.ts
@@ -1,0 +1,156 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { RequireFeature } from 'src/common/guards/feature.guard';
+import { FeatureFlag } from 'src/config/features.config';
+import { CreateWorkspaceUseCase } from 'src/domain/workspaces/application/use-cases/create-workspace/create-workspace.use-case';
+import { CreateWorkspaceCommand } from 'src/domain/workspaces/application/use-cases/create-workspace/create-workspace.command';
+import { FindAllWorkspacesUseCase } from 'src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case';
+import { FindWorkspaceUseCase } from 'src/domain/workspaces/application/use-cases/find-workspace/find-workspace.use-case';
+import { FindWorkspaceQuery } from 'src/domain/workspaces/application/use-cases/find-workspace/find-workspace.query';
+import { UpdateWorkspaceUseCase } from 'src/domain/workspaces/application/use-cases/update-workspace/update-workspace.use-case';
+import { UpdateWorkspaceCommand } from 'src/domain/workspaces/application/use-cases/update-workspace/update-workspace.command';
+import { DeleteWorkspaceUseCase } from 'src/domain/workspaces/application/use-cases/delete-workspace/delete-workspace.use-case';
+import { DeleteWorkspaceCommand } from 'src/domain/workspaces/application/use-cases/delete-workspace/delete-workspace.command';
+import { CreateWorkspaceDto } from './dtos/create-workspace.dto';
+import { UpdateWorkspaceDto } from './dtos/update-workspace.dto';
+import { WorkspaceResponseDto } from './dtos/workspace-response.dto';
+import { WorkspaceDtoMapper } from './mappers/workspace-dto.mapper';
+
+@ApiTags('workspaces')
+@Controller('workspaces')
+@RequireFeature(FeatureFlag.Workspaces)
+export class WorkspacesController {
+  private readonly logger = new Logger(WorkspacesController.name);
+
+  constructor(
+    private readonly createWorkspaceUseCase: CreateWorkspaceUseCase,
+    private readonly findAllWorkspacesUseCase: FindAllWorkspacesUseCase,
+    private readonly findWorkspaceUseCase: FindWorkspaceUseCase,
+    private readonly updateWorkspaceUseCase: UpdateWorkspaceUseCase,
+    private readonly deleteWorkspaceUseCase: DeleteWorkspaceUseCase,
+    private readonly workspaceDtoMapper: WorkspaceDtoMapper,
+  ) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create a workspace' })
+  @ApiResponse({
+    status: 201,
+    description: 'The created workspace',
+    type: WorkspaceResponseDto,
+  })
+  async create(@Body() dto: CreateWorkspaceDto): Promise<WorkspaceResponseDto> {
+    this.logger.log('create');
+    const workspace = await this.createWorkspaceUseCase.execute(
+      new CreateWorkspaceCommand({
+        name: dto.name,
+        description: dto.description,
+        icon: dto.icon,
+        color: dto.color,
+      }),
+    );
+    return this.workspaceDtoMapper.toDto(workspace);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List the current user’s workspaces' })
+  @ApiResponse({
+    status: 200,
+    description: 'The workspaces ordered by most recent update',
+    type: [WorkspaceResponseDto],
+  })
+  async findAll(): Promise<WorkspaceResponseDto[]> {
+    this.logger.log('findAll');
+    const workspaces = await this.findAllWorkspacesUseCase.execute();
+    return workspaces.map((workspace) =>
+      this.workspaceDtoMapper.toDto(workspace),
+    );
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a workspace' })
+  @ApiParam({
+    name: 'id',
+    description: 'The UUID of the workspace',
+    type: 'string',
+    format: 'uuid',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The workspace',
+    type: WorkspaceResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Workspace not found' })
+  async findOne(
+    @Param('id', ParseUUIDPipe) id: UUID,
+  ): Promise<WorkspaceResponseDto> {
+    this.logger.log('findOne', { id });
+    const workspace = await this.findWorkspaceUseCase.execute(
+      new FindWorkspaceQuery(id),
+    );
+    return this.workspaceDtoMapper.toDto(workspace);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update a workspace' })
+  @ApiParam({
+    name: 'id',
+    description: 'The UUID of the workspace',
+    type: 'string',
+    format: 'uuid',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'The updated workspace',
+    type: WorkspaceResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Workspace not found' })
+  async update(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Body() dto: UpdateWorkspaceDto,
+  ): Promise<WorkspaceResponseDto> {
+    this.logger.log('update', { id });
+    const workspace = await this.updateWorkspaceUseCase.execute(
+      new UpdateWorkspaceCommand({
+        id,
+        name: dto.name,
+        description: dto.description,
+        icon: dto.icon,
+        color: dto.color,
+      }),
+    );
+    return this.workspaceDtoMapper.toDto(workspace);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    // True one stack-branch up, where the threads FK cascade lands; kept
+    // stable here so the generated OpenAPI client does not churn mid-stack.
+    summary: 'Delete a workspace and every chat inside it',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'The UUID of the workspace',
+    type: 'string',
+    format: 'uuid',
+  })
+  @ApiResponse({ status: 204, description: 'The workspace was deleted' })
+  @ApiResponse({ status: 404, description: 'Workspace not found' })
+  async remove(@Param('id', ParseUUIDPipe) id: UUID): Promise<void> {
+    this.logger.log('remove', { id });
+    await this.deleteWorkspaceUseCase.execute(new DeleteWorkspaceCommand(id));
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
@@ -1,0 +1,37 @@
+import { Module } from '@nestjs/common';
+import { FavoritesModule } from 'src/domain/favorites/favorites.module';
+import { WorkspacesRepository } from './application/ports/workspaces-repository.port';
+import { LocalWorkspacesRepositoryModule } from './infrastructure/persistence/local/local-workspaces-repository.module';
+import { LocalWorkspacesRepository } from './infrastructure/persistence/local/local-workspaces.repository';
+import { CreateWorkspaceUseCase } from './application/use-cases/create-workspace/create-workspace.use-case';
+import { FindAllWorkspacesUseCase } from './application/use-cases/find-all-workspaces/find-all-workspaces.use-case';
+import { FindWorkspaceUseCase } from './application/use-cases/find-workspace/find-workspace.use-case';
+import { UpdateWorkspaceUseCase } from './application/use-cases/update-workspace/update-workspace.use-case';
+import { DeleteWorkspaceUseCase } from './application/use-cases/delete-workspace/delete-workspace.use-case';
+import { WorkspacesController } from './presenters/http/workspaces.controller';
+import { WorkspaceDtoMapper } from './presenters/http/mappers/workspace-dto.mapper';
+
+@Module({
+  imports: [LocalWorkspacesRepositoryModule, FavoritesModule],
+  controllers: [WorkspacesController],
+  providers: [
+    {
+      provide: WorkspacesRepository,
+      useExisting: LocalWorkspacesRepository,
+    },
+    CreateWorkspaceUseCase,
+    FindAllWorkspacesUseCase,
+    FindWorkspaceUseCase,
+    UpdateWorkspaceUseCase,
+    DeleteWorkspaceUseCase,
+    WorkspaceDtoMapper,
+  ],
+  exports: [
+    CreateWorkspaceUseCase,
+    FindAllWorkspacesUseCase,
+    FindWorkspaceUseCase,
+    UpdateWorkspaceUseCase,
+    DeleteWorkspaceUseCase,
+  ],
+})
+export class WorkspacesModule {}

--- a/ayunis-core-frontend/src/features/feature-toggles/index.ts
+++ b/ayunis-core-frontend/src/features/feature-toggles/index.ts
@@ -4,4 +4,5 @@ export {
   useIsKnowledgeBasesEnabled,
   useIsLetterheadsEnabled,
   useIsSkillsEnabled,
+  useIsWorkspacesEnabled,
 } from './useIsFeatureEnabled';

--- a/ayunis-core-frontend/src/features/feature-toggles/useFeatureToggles.ts
+++ b/ayunis-core-frontend/src/features/feature-toggles/useFeatureToggles.ts
@@ -8,6 +8,7 @@ export function useFeatureToggles(): FeatureTogglesResponseDto {
     knowledgeBasesEnabled: data?.knowledgeBasesEnabled ?? true,
     letterheadsEnabled: data?.letterheadsEnabled ?? false,
     skillsEnabled: data?.skillsEnabled ?? false,
+    workspacesEnabled: data?.workspacesEnabled ?? false,
     agentRuntimeEnabled: data?.agentRuntimeEnabled ?? false,
   };
 }

--- a/ayunis-core-frontend/src/features/feature-toggles/useIsFeatureEnabled.ts
+++ b/ayunis-core-frontend/src/features/feature-toggles/useIsFeatureEnabled.ts
@@ -19,3 +19,7 @@ export function useIsLetterheadsEnabled(): boolean {
 export function useIsSkillsEnabled(): boolean {
   return useIsFeatureEnabled('skillsEnabled');
 }
+
+export function useIsWorkspacesEnabled(): boolean {
+  return useIsFeatureEnabled('workspacesEnabled');
+}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -19,6 +19,8 @@ export interface FeatureTogglesResponseDto {
   letterheadsEnabled: boolean;
   /** Whether the skills feature is enabled */
   skillsEnabled: boolean;
+  /** Whether the workspaces feature is enabled */
+  workspacesEnabled: boolean;
   /** Whether runs use the independent agent runtime */
   agentRuntimeEnabled: boolean;
 }
@@ -4706,6 +4708,51 @@ export interface UpdateQuizQuestionRequestDto {
    * @maxItems 6
    */
   options: QuizAnswerOptionRequestDto[];
+}
+
+export interface CreateWorkspaceDto {
+  /** Name of the workspace */
+  name: string;
+  /** What the workspace is for */
+  description?: string;
+  /** Key of the workspace icon from the client icon catalogue */
+  icon?: string;
+  /** Palette key or #rrggbb literal for the workspace colour */
+  color?: string;
+}
+
+export interface WorkspaceResponseDto {
+  /** Unique identifier of the workspace */
+  id: string;
+  /** Name of the workspace */
+  name: string;
+  /**
+   * What the workspace is for
+   * @nullable
+   */
+  description: string | null;
+  /** Key of the workspace icon from the client icon catalogue */
+  icon: string;
+  /** Palette key or #rrggbb literal for the workspace colour */
+  color: string;
+  /** When the workspace was created */
+  createdAt: string;
+  /** When the workspace was last updated */
+  updatedAt: string;
+}
+
+export interface UpdateWorkspaceDto {
+  /** Name of the workspace */
+  name?: string;
+  /**
+   * What the workspace is for. Send null to clear it.
+   * @nullable
+   */
+  description?: string | null;
+  /** Key of the workspace icon from the client icon catalogue */
+  icon?: string;
+  /** Palette key or #rrggbb literal for the workspace colour */
+  color?: string;
 }
 
 export interface ChatCompletionRequestDto { [key: string]: unknown }

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -79,6 +79,7 @@ import type {
   CreateThreadDto,
   CreateTrialRequestDto,
   CreateUserDto,
+  CreateWorkspaceDto,
   CreditUsageResponseDto,
   CreditsPerEuroResponseDto,
   DeleteAllPendingInvitesResponseDto,
@@ -241,6 +242,7 @@ import type {
   UpdateTrialRequestDto,
   UpdateUserNameDto,
   UpdateUserRoleDto,
+  UpdateWorkspaceDto,
   UpsertOrgAcademyAccessSettingsDto,
   UpsertOrgChatSettingsDto,
   UpsertOrgSystemPromptDto,
@@ -260,7 +262,8 @@ import type {
   UserResponseDto,
   UserSystemPromptResponseDto,
   UserUsageResponseDto,
-  ValidationResponseDto
+  ValidationResponseDto,
+  WorkspaceResponseDto
 } from './ayunisCoreAPI.schemas';
 
 import { customAxiosInstance } from '../client';
@@ -19493,6 +19496,384 @@ export const useSuperAdminAcademyQuizQuestionsControllerDeleteQuizQuestion = <TE
       > => {
 
       const mutationOptions = getSuperAdminAcademyQuizQuestionsControllerDeleteQuizQuestionMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Create a workspace
+ */
+export const workspacesControllerCreate = (
+    createWorkspaceDto: CreateWorkspaceDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<WorkspaceResponseDto>(
+      {url: `/workspaces`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: createWorkspaceDto, signal
+    },
+      );
+    }
+  
+
+
+export const getWorkspacesControllerCreateMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspacesControllerCreate>>, TError,{data: CreateWorkspaceDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspacesControllerCreate>>, TError,{data: CreateWorkspaceDto}, TContext> => {
+
+const mutationKey = ['workspacesControllerCreate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspacesControllerCreate>>, {data: CreateWorkspaceDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  workspacesControllerCreate(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspacesControllerCreateMutationResult = NonNullable<Awaited<ReturnType<typeof workspacesControllerCreate>>>
+    export type WorkspacesControllerCreateMutationBody = CreateWorkspaceDto
+    export type WorkspacesControllerCreateMutationError = unknown
+
+    /**
+ * @summary Create a workspace
+ */
+export const useWorkspacesControllerCreate = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspacesControllerCreate>>, TError,{data: CreateWorkspaceDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspacesControllerCreate>>,
+        TError,
+        {data: CreateWorkspaceDto},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspacesControllerCreateMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary List the current user’s workspaces
+ */
+export const workspacesControllerFindAll = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<WorkspaceResponseDto[]>(
+      {url: `/workspaces`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getWorkspacesControllerFindAllQueryKey = () => {
+    return [
+    `/workspaces`
+    ] as const;
+    }
+
+    
+export const getWorkspacesControllerFindAllQueryOptions = <TData = Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError = unknown>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getWorkspacesControllerFindAllQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof workspacesControllerFindAll>>> = ({ signal }) => workspacesControllerFindAll(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type WorkspacesControllerFindAllQueryResult = NonNullable<Awaited<ReturnType<typeof workspacesControllerFindAll>>>
+export type WorkspacesControllerFindAllQueryError = unknown
+
+
+export function useWorkspacesControllerFindAll<TData = Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError = unknown>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspacesControllerFindAll>>,
+          TError,
+          Awaited<ReturnType<typeof workspacesControllerFindAll>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspacesControllerFindAll<TData = Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspacesControllerFindAll>>,
+          TError,
+          Awaited<ReturnType<typeof workspacesControllerFindAll>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspacesControllerFindAll<TData = Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary List the current user’s workspaces
+ */
+
+export function useWorkspacesControllerFindAll<TData = Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getWorkspacesControllerFindAllQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Get a workspace
+ */
+export const workspacesControllerFindOne = (
+    id: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<WorkspaceResponseDto>(
+      {url: `/workspaces/${id}`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getWorkspacesControllerFindOneQueryKey = (id?: string,) => {
+    return [
+    `/workspaces/${id}`
+    ] as const;
+    }
+
+    
+export const getWorkspacesControllerFindOneQueryOptions = <TData = Awaited<ReturnType<typeof workspacesControllerFindOne>>, TError = void>(id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindOne>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getWorkspacesControllerFindOneQueryKey(id);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof workspacesControllerFindOne>>> = ({ signal }) => workspacesControllerFindOne(id, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindOne>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type WorkspacesControllerFindOneQueryResult = NonNullable<Awaited<ReturnType<typeof workspacesControllerFindOne>>>
+export type WorkspacesControllerFindOneQueryError = void
+
+
+export function useWorkspacesControllerFindOne<TData = Awaited<ReturnType<typeof workspacesControllerFindOne>>, TError = void>(
+ id: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindOne>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspacesControllerFindOne>>,
+          TError,
+          Awaited<ReturnType<typeof workspacesControllerFindOne>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspacesControllerFindOne<TData = Awaited<ReturnType<typeof workspacesControllerFindOne>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindOne>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspacesControllerFindOne>>,
+          TError,
+          Awaited<ReturnType<typeof workspacesControllerFindOne>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspacesControllerFindOne<TData = Awaited<ReturnType<typeof workspacesControllerFindOne>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindOne>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get a workspace
+ */
+
+export function useWorkspacesControllerFindOne<TData = Awaited<ReturnType<typeof workspacesControllerFindOne>>, TError = void>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindOne>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getWorkspacesControllerFindOneQueryOptions(id,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Update a workspace
+ */
+export const workspacesControllerUpdate = (
+    id: string,
+    updateWorkspaceDto: UpdateWorkspaceDto,
+ ) => {
+      
+      
+      return customAxiosInstance<WorkspaceResponseDto>(
+      {url: `/workspaces/${id}`, method: 'PATCH',
+      headers: {'Content-Type': 'application/json', },
+      data: updateWorkspaceDto
+    },
+      );
+    }
+  
+
+
+export const getWorkspacesControllerUpdateMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspacesControllerUpdate>>, TError,{id: string;data: UpdateWorkspaceDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspacesControllerUpdate>>, TError,{id: string;data: UpdateWorkspaceDto}, TContext> => {
+
+const mutationKey = ['workspacesControllerUpdate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspacesControllerUpdate>>, {id: string;data: UpdateWorkspaceDto}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  workspacesControllerUpdate(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspacesControllerUpdateMutationResult = NonNullable<Awaited<ReturnType<typeof workspacesControllerUpdate>>>
+    export type WorkspacesControllerUpdateMutationBody = UpdateWorkspaceDto
+    export type WorkspacesControllerUpdateMutationError = void
+
+    /**
+ * @summary Update a workspace
+ */
+export const useWorkspacesControllerUpdate = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspacesControllerUpdate>>, TError,{id: string;data: UpdateWorkspaceDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspacesControllerUpdate>>,
+        TError,
+        {id: string;data: UpdateWorkspaceDto},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspacesControllerUpdateMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Delete a workspace and every chat inside it
+ */
+export const workspacesControllerRemove = (
+    id: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspaces/${id}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getWorkspacesControllerRemoveMutationOptions = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspacesControllerRemove>>, TError,{id: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspacesControllerRemove>>, TError,{id: string}, TContext> => {
+
+const mutationKey = ['workspacesControllerRemove'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspacesControllerRemove>>, {id: string}> = (props) => {
+          const {id} = props ?? {};
+
+          return  workspacesControllerRemove(id,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspacesControllerRemoveMutationResult = NonNullable<Awaited<ReturnType<typeof workspacesControllerRemove>>>
+    
+    export type WorkspacesControllerRemoveMutationError = void
+
+    /**
+ * @summary Delete a workspace and every chat inside it
+ */
+export const useWorkspacesControllerRemove = <TError = void,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspacesControllerRemove>>, TError,{id: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspacesControllerRemove>>,
+        TError,
+        {id: string},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspacesControllerRemoveMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -9435,6 +9435,158 @@
         "tags": ["Super Admin Academy"]
       }
     },
+    "/workspaces": {
+      "post": {
+        "operationId": "WorkspacesController_create",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWorkspaceDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The created workspace",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Create a workspace",
+        "tags": ["workspaces"]
+      },
+      "get": {
+        "operationId": "WorkspacesController_findAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The workspaces ordered by most recent update",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkspaceResponseDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "List the current user’s workspaces",
+        "tags": ["workspaces"]
+      }
+    },
+    "/workspaces/{id}": {
+      "get": {
+        "operationId": "WorkspacesController_findOne",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The UUID of the workspace",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The workspace",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workspace not found"
+          }
+        },
+        "summary": "Get a workspace",
+        "tags": ["workspaces"]
+      },
+      "patch": {
+        "operationId": "WorkspacesController_update",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The UUID of the workspace",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWorkspaceDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The updated workspace",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workspace not found"
+          }
+        },
+        "summary": "Update a workspace",
+        "tags": ["workspaces"]
+      },
+      "delete": {
+        "operationId": "WorkspacesController_remove",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "The UUID of the workspace",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The workspace was deleted"
+          },
+          "404": {
+            "description": "Workspace not found"
+          }
+        },
+        "summary": "Delete a workspace and every chat inside it",
+        "tags": ["workspaces"]
+      }
+    },
     "/openai-compat/v1/chat/completions": {
       "post": {
         "operationId": "ChatCompletionsController_create",
@@ -10678,6 +10830,11 @@
             "description": "Whether the skills feature is enabled",
             "example": false
           },
+          "workspacesEnabled": {
+            "type": "boolean",
+            "description": "Whether the workspaces feature is enabled",
+            "example": false
+          },
           "agentRuntimeEnabled": {
             "type": "boolean",
             "description": "Whether runs use the independent agent runtime",
@@ -10688,6 +10845,7 @@
           "knowledgeBasesEnabled",
           "letterheadsEnabled",
           "skillsEnabled",
+          "workspacesEnabled",
           "agentRuntimeEnabled"
         ]
       },
@@ -17880,6 +18038,108 @@
           }
         },
         "required": ["text", "options"]
+      },
+      "CreateWorkspaceDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the workspace",
+            "example": "Bürgeranfragen"
+          },
+          "description": {
+            "type": "string",
+            "description": "What the workspace is for",
+            "example": "Anfragen von Bürgerinnen und Bürgern bündeln"
+          },
+          "icon": {
+            "type": "string",
+            "description": "Key of the workspace icon from the client icon catalogue",
+            "example": "landmark"
+          },
+          "color": {
+            "type": "string",
+            "description": "Palette key or #rrggbb literal for the workspace colour",
+            "example": "#6b5bd6"
+          }
+        },
+        "required": ["name"]
+      },
+      "WorkspaceResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the workspace",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the workspace",
+            "example": "Bürgeranfragen"
+          },
+          "description": {
+            "type": "string",
+            "description": "What the workspace is for",
+            "example": "Anfragen von Bürgerinnen und Bürgern bündeln",
+            "nullable": true
+          },
+          "icon": {
+            "type": "string",
+            "description": "Key of the workspace icon from the client icon catalogue",
+            "example": "landmark"
+          },
+          "color": {
+            "type": "string",
+            "description": "Palette key or #rrggbb literal for the workspace colour",
+            "example": "#6b5bd6"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "When the workspace was created",
+            "example": "2026-08-11T10:00:00.000Z"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "When the workspace was last updated",
+            "example": "2026-08-11T10:30:00.000Z"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "icon",
+          "color",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "UpdateWorkspaceDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the workspace",
+            "example": "Bürgeranfragen"
+          },
+          "description": {
+            "type": "string",
+            "description": "What the workspace is for. Send null to clear it.",
+            "example": "Anfragen von Bürgerinnen und Bürgern bündeln",
+            "nullable": true
+          },
+          "icon": {
+            "type": "string",
+            "description": "Key of the workspace icon from the client icon catalogue",
+            "example": "landmark"
+          },
+          "color": {
+            "type": "string",
+            "description": "Palette key or #rrggbb literal for the workspace colour",
+            "example": "#6b5bd6"
+          }
+        }
       },
       "ChatCompletionRequestDto": {
         "type": "object",


### PR DESCRIPTION
Iteration 1 of the Workspaces/Projects plan ([AYC-700](https://linear.app/ayunis/issue/AYC-700)), PR 1 of 5. Backend only — nothing is reachable yet.

Adds a `workspaces` domain module: personal folders that will group a user's chats. A workspace carries a name, an optional description and an appearance (icon key + colour), can be pinned to the sidebar, and holds a manual position in that list.

**User-facing copy says "Projekte"; the code, tables and routes say `workspace`.** The German wording is still open (CS/GTM are being looped in per the ticket comments), so it lives purely in locale files and can change without a migration.

## What's here

- `src/domain/workspaces/` — entity, errors, repository port, 7 use cases, local TypeORM adapter, controller + DTOs. Structure follows `letterheads`; use cases follow the current `@HandleUnexpectedErrors` style rather than letterheads' older hand-written try/catch.
- `CreateWorkspacesTable` migration (generated, not hand-written; drift check is clean).
- `FEATURE_WORKSPACES_ENABLED`, **off by default**, applied at the controller via `@RequireFeature`. Lets iterations 2–6 land on main progressively.

| Method | Route |
| --- | --- |
| POST | `/workspaces` |
| GET | `/workspaces` |
| GET | `/workspaces/:id` |
| PATCH | `/workspaces/reorder` |
| PATCH | `/workspaces/:id` |
| PATCH | `/workspaces/:id/toggle-pinned` |
| DELETE | `/workspaces/:id` |

## Two decisions worth a look

**Pinning and reordering bypass `save()`.** Both go through single-statement SQL in the repository instead of a read-modify-write on the entity. That is deliberate: `updatedAt` is an `@UpdateDateColumn`, and the list page sorts by it — so pinning a workspace or dragging it in the sidebar would otherwise shove it to the top of "Zuletzt aktualisiert". `updateSortOrders` uses `unnest(...) WITH ORDINALITY` so the new order is never partially visible.

**Deletion is announced before it happens.** `DeleteWorkspaceUseCase` emits `WorkspaceDeletionRequestedEvent` *before* the row delete and drains deferred cleanup only after it succeeds — the same two-phase contract as `UserDeletionRequestedEvent`. Nothing listens yet; PR 2 adds the threads listener that purges MinIO blobs, which the FK cascade cannot reach. This also keeps the module dependency one-directional (threads → workspaces), so `madge` and dependency-cruiser stay green.

`PATCH /workspaces/reorder` is declared before `PATCH /workspaces/:id` — reversing them makes `reorder` a 400 from `ParseUUIDPipe`.

## Verification

`tsc --noEmit`, `eslint`, `deps:check`, and 27 new unit tests pass. Migration applied against a local database; re-running `migration:generate` afterwards reports `No changes in database schema were found`.

Refs: AYC-700

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persisted domain, migration, and cross-module delete/event wiring; endpoints are off by default but deletion semantics will matter once threads attach to workspaces.
> 
> **Overview**
> Introduces **workspaces** as per-user, org-scoped folders (name, description, icon/color) ahead of chat grouping in later iterations. The capability is gated by **`FEATURE_WORKSPACES_ENABLED`** / `workspacesEnabled` (default **off**), exposed on `GET /feature-toggles`, and enforced on `/workspaces` via `@RequireFeature`.
> 
> A new **`workspaces` domain module** adds a `workspaces` table migration, TypeORM persistence, five use cases (create, list, get, update, delete), validation for appearance keys, and HTTP CRUD. **Create** persists the row then calls **`AddFavoriteUseCase`** so new workspaces show up in the favorites/sidebar model (pin/order stay in **favorites**, not on the workspace row). **Delete** emits **`WorkspaceDeletionRequestedEvent`** before removing the row and runs listener **deferred cleanup** only after delete succeeds; **favorites** registers a listener to drop workspace favorite references (thread/MinIO cleanup is left for a follow-up).
> 
> The frontend picks up **`workspacesEnabled`** (`useIsWorkspacesEnabled`) and regenerated OpenAPI clients for the new workspace DTOs and routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e30de96b31fe1c5cc05ad096c5c503bbfa3759d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->