### PR TITLE
wip(workspaces): store pinning and manual order per user (AYC-700)

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1786457049763-MoveWorkspacePinningToUserSettings.ts
+++ b/ayunis-core-backend/src/db/migrations/1786457049763-MoveWorkspacePinningToUserSettings.ts
@@ -1,0 +1,64 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MoveWorkspacePinningToUserSettings1786457049763 implements MigrationInterface {
+  name = 'MoveWorkspacePinningToUserSettings1786457049763';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "workspace_user_settings" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "workspaceId" character varying NOT NULL, "userId" character varying NOT NULL, "isPinned" boolean NOT NULL DEFAULT false, "sortOrder" integer, CONSTRAINT "UQ_workspace_user_settings_workspace_user" UNIQUE ("workspaceId", "userId"), CONSTRAINT "PK_132511d23bc2712f120daecd449" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_08575f620f60e21ba0f0b6d6ff" ON "workspace_user_settings" ("workspaceId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_bcd79942ac06e73f60ad84f5a8" ON "workspace_user_settings" ("userId") `,
+    );
+    // Every existing workspace is single-owner, so its pin state and manual
+    // order become the owner's settings row before the columns disappear.
+    // Rows still on the column defaults get no settings row — a missing row
+    // already means "unpinned, never ordered", and only the never-ordered
+    // state keeps such workspaces sorting last as designed.
+    await queryRunner.query(
+      `INSERT INTO "workspace_user_settings" ("id", "workspaceId", "userId", "isPinned", "sortOrder")
+             SELECT (gen_random_uuid())::character varying, w."id", w."userId", w."isPinned", w."sortOrder"
+             FROM "workspaces" w
+             WHERE w."isPinned" OR w."sortOrder" <> 0`,
+    );
+    await queryRunner.query(`ALTER TABLE "workspaces" DROP COLUMN "isPinned"`);
+    await queryRunner.query(`ALTER TABLE "workspaces" DROP COLUMN "sortOrder"`);
+    await queryRunner.query(
+      `ALTER TABLE "workspace_user_settings" ADD CONSTRAINT "FK_08575f620f60e21ba0f0b6d6ff6" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspace_user_settings" ADD CONSTRAINT "FK_bcd79942ac06e73f60ad84f5a88" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "workspace_user_settings" DROP CONSTRAINT "FK_bcd79942ac06e73f60ad84f5a88"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspace_user_settings" DROP CONSTRAINT "FK_08575f620f60e21ba0f0b6d6ff6"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspaces" ADD "sortOrder" integer NOT NULL DEFAULT '0'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspaces" ADD "isPinned" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `UPDATE "workspaces" w
+             SET "isPinned" = s."isPinned", "sortOrder" = COALESCE(s."sortOrder", 0)
+             FROM "workspace_user_settings" s
+             WHERE s."workspaceId" = w."id" AND s."userId" = w."userId"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_bcd79942ac06e73f60ad84f5a8"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_08575f620f60e21ba0f0b6d6ff"`,
+    );
+    await queryRunner.query(`DROP TABLE "workspace_user_settings"`);
+  }
+}

--- a/ayunis-core-backend/src/db/scripts/seed-minimal/seeders/workspace-seeder.ts
+++ b/ayunis-core-backend/src/db/scripts/seed-minimal/seeders/workspace-seeder.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import { WorkspaceRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace.record';
+import { WorkspaceUserSettingsRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace-user-settings.record';
 import { OrgSeeder } from './base-seeder';
 import type { SeedState } from '../seed-state';
 import type { OrgFixture } from '../seed-types';
@@ -21,7 +22,7 @@ export class WorkspaceSeeder extends OrgSeeder {
     const admin = ctx.getAdmin(org.key);
 
     for (const workspace of workspaces) {
-      await this.findOrCreate(
+      const record = await this.findOrCreate(
         this.repo(WorkspaceRecord),
         { orgId, userId: admin.id, name: workspace.name },
         () => ({
@@ -32,10 +33,22 @@ export class WorkspaceSeeder extends OrgSeeder {
           description: workspace.description ?? null,
           icon: workspace.icon,
           color: workspace.color,
+        }),
+        { entity: 'Workspace', name: workspace.name },
+      );
+
+      // Pin state and manual order are per-user rows, owned by the admin here.
+      await this.findOrCreate(
+        this.repo(WorkspaceUserSettingsRecord),
+        { workspaceId: record.id, userId: admin.id },
+        () => ({
+          id: randomUUID(),
+          workspaceId: record.id,
+          userId: admin.id,
           isPinned: workspace.isPinned,
           sortOrder: workspace.sortOrder,
         }),
-        { entity: 'Workspace', name: workspace.name },
+        { entity: 'Workspace settings', name: workspace.name },
       );
     }
   }

--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -16,10 +16,19 @@ The whole module sits behind the `workspacesEnabled` feature flag
 
 ## Domain Concepts
 
-- **Workspace** — owned by exactly one user and scoped to their org. `isPinned`
-  controls sidebar visibility; `sortOrder` is the manual position within it.
-  Both are deliberately kept out of `updatedAt`'s reach so pinning and dragging
-  do not reshuffle the "last updated" sort on the list page.
+- **Workspace** — owned by exactly one user and scoped to their org.
+- **Per-user settings** — `isPinned` (sidebar visibility) and `sortOrder` (the
+  manual position there) are how a user arranges *their* sidebar, so they live
+  on `workspace_user_settings` (one row per workspace × user, the
+  `skill_activations` pattern) rather than on the workspace row. That keeps
+  them out of `updatedAt`'s reach — pinning and dragging never reshuffle the
+  "last updated" sort — and means iteration 4's shared workspaces will not make
+  collaborators fight over one pin state. The domain `Workspace` entity still
+  carries both fields; the repository hydrates them from the caller's settings
+  row (read-only projections — `save` persists the workspace row alone, and
+  settings are written only via `saveSettings` on creation and the atomic
+  `togglePinned` / `updateSortOrders` paths, so a rename can never rewrite the
+  caller's manual order).
 - **Appearance** — `icon` and `color` are opaque keys owned by the frontend
   catalogue. The backend only guards their shape (`WORKSPACE_ICON_PATTERN`,
   `WORKSPACE_COLOR_PATTERN`); `color` is either a palette key or a `#rrggbb`
@@ -54,6 +63,7 @@ workspaces/
 │       └── reorder-workspaces/
 ├── infrastructure/persistence/local/
 │   ├── schema/workspace.record.ts   # table `workspaces`
+│   ├── schema/workspace-user-settings.record.ts # per-user pin + order
 │   ├── mappers/workspace.mapper.ts
 │   ├── local-workspaces.repository.ts
 │   └── local-workspaces-repository.module.ts

--- a/ayunis-core-backend/src/domain/workspaces/application/ports/workspaces-repository.port.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/ports/workspaces-repository.port.ts
@@ -3,24 +3,37 @@ import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 
 export abstract class WorkspacesRepository {
   /**
-   * Ordered by `sortOrder` ascending, ties broken by `updatedAt` descending.
+   * Ordered by the caller's `sortOrder` ascending — never-ordered workspaces
+   * sort last — with ties broken by `updatedAt` descending.
    * `ReorderWorkspacesUseCase` relies on this order when renumbering, so
    * adapters must uphold it.
    */
   abstract findAllByUserId(userId: UUID): Promise<Workspace[]>;
   abstract findById(userId: UUID, id: UUID): Promise<Workspace | null>;
+  /**
+   * Persists the workspace's own fields only. The caller's pin state and
+   * manual order are written by `saveSettings`, `togglePinned` and
+   * `updateSortOrders` — never here, so a plain rename cannot overwrite them.
+   */
   abstract save(workspace: Workspace): Promise<Workspace>;
+  /**
+   * Writes the owner's pin state and manual order for this workspace in one
+   * atomic upsert. Used on creation; later changes go through the dedicated
+   * `togglePinned` / `updateSortOrders` paths.
+   */
+  abstract saveSettings(workspace: Workspace): Promise<void>;
   /** Throws `WorkspaceNotFoundError` when the user owns no such workspace. */
   abstract delete(userId: UUID, id: UUID): Promise<void>;
 
   /**
-   * Flips `isPinned` in a single statement. Pinning is not an edit of the
-   * workspace itself, so it must not bump `updatedAt` — the list page sorts by
-   * it and a pin would otherwise reshuffle "last updated".
+   * Flips the caller's `isPinned` for this workspace. Pin state is per user
+   * (stored on `workspace_user_settings`), and it is not an edit of the
+   * workspace itself, so `updatedAt` stays put — the list page sorts by it
+   * and a pin would otherwise reshuffle "last updated".
    * Throws `WorkspaceNotFoundError` when the user owns no such workspace.
    */
   abstract togglePinned(userId: UUID, id: UUID): Promise<boolean>;
 
-  /** Writes `sortOrder = index` for the given ids. Also leaves `updatedAt` alone. */
+  /** Writes the caller's `sortOrder = index` for the given ids. Also leaves `updatedAt` alone. */
   abstract updateSortOrders(userId: UUID, orderedIds: UUID[]): Promise<void>;
 }

--- a/ayunis-core-backend/src/domain/workspaces/application/testing/workspace.fixtures.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/testing/workspace.fixtures.ts
@@ -42,6 +42,7 @@ export function createMockWorkspacesRepository(): jest.Mocked<WorkspacesReposito
     save: jest
       .fn()
       .mockImplementation((workspace: Workspace) => Promise.resolve(workspace)),
+    saveSettings: jest.fn().mockResolvedValue(undefined),
     delete: jest.fn().mockResolvedValue(undefined),
     togglePinned: jest.fn().mockResolvedValue(true),
     updateSortOrders: jest.fn().mockResolvedValue(undefined),

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/create-workspace/create-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/create-workspace/create-workspace.use-case.spec.ts
@@ -66,6 +66,7 @@ describe('CreateWorkspaceUseCase', () => {
     );
 
     expect(workspace.isPinned).toBe(true);
+    expect(repository.saveSettings).toHaveBeenCalledWith(workspace);
   });
 
   it('places the workspace after the existing ones', async () => {

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/create-workspace/create-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/create-workspace/create-workspace.use-case.ts
@@ -37,7 +37,11 @@ export class CreateWorkspaceUseCase {
       sortOrder: nextSortOrder(existing),
     });
 
-    return await this.workspacesRepository.save(workspace);
+    const saved = await this.workspacesRepository.save(workspace);
+    // The initial pin and slot in the manual order are written separately —
+    // `save` deliberately never touches per-user settings.
+    await this.workspacesRepository.saveSettings(saved);
+    return saved;
   }
 
   private resolveOwner(): { userId: UUID; orgId: UUID } {

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace/update-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace/update-workspace.use-case.spec.ts
@@ -124,6 +124,10 @@ describe('UpdateWorkspaceUseCase', () => {
 
     expect(updated.isPinned).toBe(true);
     expect(updated.sortOrder).toBe(3);
+    // A plain edit must never write the per-user settings row: the mapper
+    // defaults a missing/never-ordered row, and persisting those defaults
+    // would silently rewrite the caller's manual order.
+    expect(repository.saveSettings).not.toHaveBeenCalled();
   });
 
   it('throws when the workspace does not belong to the caller', async () => {

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/foreign-key-violation.util.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/foreign-key-violation.util.ts
@@ -1,0 +1,20 @@
+/**
+ * Checks if an error is a PostgreSQL foreign key violation (error code 23503).
+ * Works with TypeORM's QueryFailedError which wraps the driver error.
+ */
+export function isForeignKeyViolation(error: unknown): boolean {
+  if (error === null || error === undefined || typeof error !== 'object') {
+    return false;
+  }
+
+  const record = error as Record<string, unknown>;
+
+  // TypeORM QueryFailedError exposes driverError with the PG error code
+  if (record.driverError && typeof record.driverError === 'object') {
+    const driverError = record.driverError as Record<string, unknown>;
+    return driverError.code === '23503';
+  }
+
+  // Fallback: check the error itself (e.g. raw pg errors)
+  return record.code === '23503';
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces-repository.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces-repository.module.ts
@@ -1,11 +1,14 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { WorkspaceRecord } from './schema/workspace.record';
+import { WorkspaceUserSettingsRecord } from './schema/workspace-user-settings.record';
 import { LocalWorkspacesRepository } from './local-workspaces.repository';
 import { WorkspaceMapper } from './mappers/workspace.mapper';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([WorkspaceRecord])],
+  imports: [
+    TypeOrmModule.forFeature([WorkspaceRecord, WorkspaceUserSettingsRecord]),
+  ],
   providers: [LocalWorkspacesRepository, WorkspaceMapper],
   exports: [LocalWorkspacesRepository],
 })

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.spec.ts
@@ -1,0 +1,172 @@
+import { randomUUID, type UUID } from 'crypto';
+import { Logger } from '@nestjs/common';
+import type { Repository } from 'typeorm';
+import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
+import { LocalWorkspacesRepository } from './local-workspaces.repository';
+import { WorkspaceRecord } from './schema/workspace.record';
+import type { WorkspaceUserSettingsRecord } from './schema/workspace-user-settings.record';
+import { WorkspaceMapper } from './mappers/workspace.mapper';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111' as UUID;
+
+function aRecord(params: {
+  id?: UUID;
+  name?: string;
+  updatedAt?: string;
+}): WorkspaceRecord {
+  const record = new WorkspaceRecord();
+  record.id = params.id ?? randomUUID();
+  record.userId = USER_ID;
+  record.orgId = randomUUID();
+  record.name = params.name ?? 'Bürgeranfragen';
+  record.description = null;
+  record.icon = 'folder';
+  record.color = 'violet';
+  record.createdAt = new Date('2026-08-01T10:00:00.000Z');
+  record.updatedAt = new Date(params.updatedAt ?? '2026-08-02T10:00:00.000Z');
+  return record;
+}
+
+function aSettingsRow(params: {
+  workspaceId: UUID;
+  isPinned?: boolean;
+  sortOrder?: number | null;
+}): WorkspaceUserSettingsRecord {
+  return {
+    id: randomUUID(),
+    workspaceId: params.workspaceId,
+    userId: USER_ID,
+    isPinned: params.isPinned ?? false,
+    sortOrder: params.sortOrder ?? null,
+  } as WorkspaceUserSettingsRecord;
+}
+
+describe('LocalWorkspacesRepository', () => {
+  let repository: LocalWorkspacesRepository;
+  let repo: jest.Mocked<Pick<Repository<WorkspaceRecord>, 'find' | 'save'>>;
+  let settingsRepo: jest.Mocked<
+    Pick<Repository<WorkspaceUserSettingsRecord>, 'find' | 'findOne'>
+  > & { manager: { query: jest.Mock } };
+
+  beforeAll(() => {
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+  });
+
+  beforeEach(() => {
+    repo = { find: jest.fn(), save: jest.fn() };
+    settingsRepo = {
+      find: jest.fn().mockResolvedValue([]),
+      findOne: jest.fn().mockResolvedValue(null),
+      manager: { query: jest.fn().mockResolvedValue([]) },
+    };
+    repository = new LocalWorkspacesRepository(
+      repo as unknown as Repository<WorkspaceRecord>,
+      settingsRepo as unknown as Repository<WorkspaceUserSettingsRecord>,
+      new WorkspaceMapper(),
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findAllByUserId', () => {
+    it('orders by the manual order, never-ordered last, latest edit breaking ties', async () => {
+      const third = aRecord({ name: 'Explizit 4' });
+      const first = aRecord({ name: 'Explizit 0' });
+      const neverOrderedOld = aRecord({
+        name: 'Nie sortiert, älter',
+        updatedAt: '2026-08-03T10:00:00.000Z',
+      });
+      const neverOrderedNew = aRecord({
+        name: 'Nie sortiert, neuer',
+        updatedAt: '2026-08-05T10:00:00.000Z',
+      });
+      repo.find.mockResolvedValue([
+        neverOrderedOld,
+        third,
+        neverOrderedNew,
+        first,
+      ]);
+      settingsRepo.find.mockResolvedValue([
+        aSettingsRow({ workspaceId: third.id, sortOrder: 4 }),
+        aSettingsRow({ workspaceId: first.id, sortOrder: 0 }),
+        aSettingsRow({ workspaceId: neverOrderedOld.id, sortOrder: null }),
+      ]);
+
+      const result = await repository.findAllByUserId(USER_ID);
+
+      expect(result.map((workspace) => workspace.name)).toEqual([
+        'Explizit 0',
+        'Explizit 4',
+        'Nie sortiert, neuer',
+        'Nie sortiert, älter',
+      ]);
+    });
+
+    it('hydrates pin state from the settings row', async () => {
+      const record = aRecord({});
+      repo.find.mockResolvedValue([record]);
+      settingsRepo.find.mockResolvedValue([
+        aSettingsRow({ workspaceId: record.id, isPinned: true }),
+      ]);
+
+      const [workspace] = await repository.findAllByUserId(USER_ID);
+
+      expect(workspace.isPinned).toBe(true);
+    });
+  });
+
+  describe('save', () => {
+    it('persists the workspace row and leaves the settings row alone', async () => {
+      const record = aRecord({});
+      repo.find.mockResolvedValue([record]);
+      settingsRepo.find.mockResolvedValue([
+        aSettingsRow({ workspaceId: record.id, sortOrder: null }),
+      ]);
+      const [workspace] = await repository.findAllByUserId(USER_ID);
+
+      workspace.rename('Umbenannt');
+      await repository.save(workspace);
+
+      expect(repo.save).toHaveBeenCalled();
+      expect(settingsRepo.manager.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('saveSettings', () => {
+    it('upserts pin state and manual order in one statement', async () => {
+      const record = aRecord({});
+      repo.find.mockResolvedValue([record]);
+      settingsRepo.find.mockResolvedValue([]);
+      const [workspace] = await repository.findAllByUserId(USER_ID);
+
+      await repository.saveSettings(workspace);
+
+      expect(settingsRepo.manager.query).toHaveBeenCalledWith(
+        expect.stringContaining('ON CONFLICT ("workspaceId", "userId")'),
+        [expect.any(String), workspace.id, USER_ID, false, 0],
+      );
+    });
+  });
+
+  describe('togglePinned', () => {
+    it('returns the flipped pin state', async () => {
+      settingsRepo.manager.query.mockResolvedValue([{ isPinned: true }]);
+
+      await expect(
+        repository.togglePinned(USER_ID, randomUUID()),
+      ).resolves.toBe(true);
+    });
+
+    it('reports a vanished workspace as not found instead of a raw FK error', async () => {
+      settingsRepo.manager.query.mockRejectedValue({
+        driverError: { code: '23503' },
+      });
+
+      await expect(
+        repository.togglePinned(USER_ID, randomUUID()),
+      ).rejects.toThrow(WorkspaceNotFoundError);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.ts
@@ -1,12 +1,18 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { randomUUID } from 'crypto';
 import type { UUID } from 'crypto';
 import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
 import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
 import { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import { WorkspaceRecord } from './schema/workspace.record';
+import { WorkspaceUserSettingsRecord } from './schema/workspace-user-settings.record';
 import { WorkspaceMapper } from './mappers/workspace.mapper';
+import { isForeignKeyViolation } from './foreign-key-violation.util';
+
+/** Never-ordered workspaces sort behind every manually placed one. */
+const UNORDERED = Number.MAX_SAFE_INTEGER;
 
 @Injectable()
 export class LocalWorkspacesRepository extends WorkspacesRepository {
@@ -15,27 +21,69 @@ export class LocalWorkspacesRepository extends WorkspacesRepository {
   constructor(
     @InjectRepository(WorkspaceRecord)
     private readonly repo: Repository<WorkspaceRecord>,
+    @InjectRepository(WorkspaceUserSettingsRecord)
+    private readonly settingsRepo: Repository<WorkspaceUserSettingsRecord>,
     private readonly mapper: WorkspaceMapper,
   ) {
     super();
   }
 
   async findAllByUserId(userId: UUID): Promise<Workspace[]> {
-    const records = await this.repo.find({
-      where: { userId },
-      order: { sortOrder: 'ASC', updatedAt: 'DESC' },
-    });
-    return records.map((record) => this.mapper.toDomain(record));
+    const [records, settings] = await Promise.all([
+      this.repo.find({ where: { userId } }),
+      this.settingsRepo.find({ where: { userId } }),
+    ]);
+    const settingsByWorkspace = new Map(
+      settings.map((row) => [row.workspaceId, row]),
+    );
+
+    return records
+      .map((record) => ({
+        record,
+        settings: settingsByWorkspace.get(record.id) ?? null,
+      }))
+      .sort((left, right) => {
+        const order =
+          (left.settings?.sortOrder ?? UNORDERED) -
+          (right.settings?.sortOrder ?? UNORDERED);
+        if (order !== 0) return order;
+        return (
+          right.record.updatedAt.getTime() - left.record.updatedAt.getTime()
+        );
+      })
+      .map(({ record, settings: row }) => this.mapper.toDomain(record, row));
   }
 
   async findById(userId: UUID, id: UUID): Promise<Workspace | null> {
     const record = await this.repo.findOne({ where: { userId, id } });
-    return record ? this.mapper.toDomain(record) : null;
+    if (!record) return null;
+    const settings = await this.settingsRepo.findOne({
+      where: { workspaceId: id, userId },
+    });
+    return this.mapper.toDomain(record, settings);
   }
 
   async save(workspace: Workspace): Promise<Workspace> {
-    const saved = await this.repo.save(this.mapper.toRecord(workspace));
-    return this.mapper.toDomain(saved);
+    await this.repo.save(this.mapper.toRecord(workspace));
+    return workspace;
+  }
+
+  // Single statement, like togglePinned/updateSortOrders: no find-then-save
+  // window, and an existing row keeps its id.
+  async saveSettings(workspace: Workspace): Promise<void> {
+    await this.settingsRepo.manager.query(
+      `INSERT INTO workspace_user_settings ("id", "workspaceId", "userId", "isPinned", "sortOrder")
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT ("workspaceId", "userId")
+       DO UPDATE SET "isPinned" = EXCLUDED."isPinned", "sortOrder" = EXCLUDED."sortOrder"`,
+      [
+        randomUUID(),
+        workspace.id,
+        workspace.userId,
+        workspace.isPinned,
+        workspace.sortOrder,
+      ],
+    );
   }
 
   async delete(userId: UUID, id: UUID): Promise<void> {
@@ -45,20 +93,31 @@ export class LocalWorkspacesRepository extends WorkspacesRepository {
     }
   }
 
+  // Callers verify workspace ownership via findById first; the FK guarantees
+  // the workspace exists. Single statement so concurrent toggles cannot lose
+  // an update, and the workspace row's updatedAt is never touched.
   async togglePinned(userId: UUID, id: UUID): Promise<boolean> {
     this.logger.log('togglePinned', { workspaceId: id });
 
-    const rows: Array<{ isPinned: boolean }> = await this.repo.manager.query(
-      `UPDATE workspaces SET "isPinned" = NOT "isPinned"
-       WHERE "id" = $1 AND "userId" = $2
-       RETURNING "isPinned"`,
-      [id, userId],
-    );
-
-    if (rows.length === 0) {
-      throw new WorkspaceNotFoundError(id);
+    try {
+      const rows: Array<{ isPinned: boolean }> =
+        await this.settingsRepo.manager.query(
+          `INSERT INTO workspace_user_settings ("id", "workspaceId", "userId", "isPinned")
+           VALUES ($1, $2, $3, true)
+           ON CONFLICT ("workspaceId", "userId")
+           DO UPDATE SET "isPinned" = NOT workspace_user_settings."isPinned"
+           RETURNING "isPinned"`,
+          [randomUUID(), id, userId],
+        );
+      return rows[0].isPinned;
+    } catch (error) {
+      // A workspace deleted between the caller's ownership check and this
+      // insert surfaces as an FK violation, not as zero returned rows.
+      if (isForeignKeyViolation(error)) {
+        throw new WorkspaceNotFoundError(id);
+      }
+      throw error;
     }
-    return rows[0].isPinned;
   }
 
   async updateSortOrders(userId: UUID, orderedIds: UUID[]): Promise<void> {
@@ -67,13 +126,14 @@ export class LocalWorkspacesRepository extends WorkspacesRepository {
     }
     this.logger.log('updateSortOrders', { count: orderedIds.length });
 
-    // One statement so the new order is never partially visible, and so
-    // `updatedAt` stays untouched (reordering is not an edit of the workspace).
-    await this.repo.manager.query(
-      `UPDATE workspaces AS w
-       SET "sortOrder" = t.ordinality - 1
-       FROM unnest($1::varchar[]) WITH ORDINALITY AS t(id, ordinality)
-       WHERE w."id" = t.id AND w."userId" = $2`,
+    // One statement so the new order is never partially visible. Rows are
+    // created on demand for workspaces the user never pinned or ordered.
+    await this.settingsRepo.manager.query(
+      `INSERT INTO workspace_user_settings ("id", "workspaceId", "userId", "sortOrder")
+       SELECT (gen_random_uuid())::character varying, t.id, $2, t.ordinality - 1
+       FROM unnest($1::character varying[]) WITH ORDINALITY AS t(id, ordinality)
+       ON CONFLICT ("workspaceId", "userId")
+       DO UPDATE SET "sortOrder" = EXCLUDED."sortOrder"`,
       [orderedIds, userId],
     );
   }

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace.mapper.spec.ts
@@ -1,5 +1,6 @@
 import { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import { WorkspaceRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace.record';
+import { WorkspaceUserSettingsRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace-user-settings.record';
 import { WorkspaceMapper } from './workspace.mapper';
 import {
   aWorkspace,
@@ -11,7 +12,19 @@ import {
 describe('WorkspaceMapper', () => {
   const mapper = new WorkspaceMapper();
 
-  it('round-trips every field', () => {
+  function settingsRow(
+    overrides: Partial<WorkspaceUserSettingsRecord> = {},
+  ): WorkspaceUserSettingsRecord {
+    const row = new WorkspaceUserSettingsRecord();
+    row.workspaceId = TEST_WORKSPACE_ID;
+    row.userId = TEST_USER_ID;
+    row.isPinned = true;
+    row.sortOrder = 7;
+    Object.assign(row, overrides);
+    return row;
+  }
+
+  it('round-trips the core fields', () => {
     const workspace = aWorkspace({
       name: 'Feuerwehr',
       description: 'Einsätze',
@@ -21,9 +34,31 @@ describe('WorkspaceMapper', () => {
       sortOrder: 7,
     });
 
-    const roundTripped = mapper.toDomain(mapper.toRecord(workspace));
+    const roundTripped = mapper.toDomain(
+      mapper.toRecord(workspace),
+      settingsRow(),
+    );
 
     expect(roundTripped).toEqual(workspace);
+  });
+
+  it('hydrates pin state and order from the settings row', () => {
+    const record = mapper.toRecord(aWorkspace());
+
+    const workspace = mapper.toDomain(
+      record,
+      settingsRow({ isPinned: true, sortOrder: 3 }),
+    );
+
+    expect(workspace.isPinned).toBe(true);
+    expect(workspace.sortOrder).toBe(3);
+  });
+
+  it('defaults to unpinned and unordered without a settings row', () => {
+    const workspace = mapper.toDomain(mapper.toRecord(aWorkspace()), null);
+
+    expect(workspace.isPinned).toBe(false);
+    expect(workspace.sortOrder).toBe(0);
   });
 
   it('maps a record to the domain entity', () => {
@@ -35,8 +70,6 @@ describe('WorkspaceMapper', () => {
     record.description = null;
     record.icon = 'receipt';
     record.color = 'amber';
-    record.isPinned = false;
-    record.sortOrder = 2;
     record.createdAt = new Date('2026-08-01T10:00:00.000Z');
     record.updatedAt = new Date('2026-08-02T10:00:00.000Z');
 
@@ -47,7 +80,5 @@ describe('WorkspaceMapper', () => {
     expect(workspace.description).toBeNull();
     expect(workspace.icon).toBe('receipt');
     expect(workspace.color).toBe('amber');
-    expect(workspace.isPinned).toBe(false);
-    expect(workspace.sortOrder).toBe(2);
   });
 });

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace.mapper.ts
@@ -1,10 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import { WorkspaceRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace.record';
+import type { WorkspaceUserSettingsRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace-user-settings.record';
 
 @Injectable()
 export class WorkspaceMapper {
-  toDomain(record: WorkspaceRecord): Workspace {
+  /**
+   * Pin state and manual order live on the caller's settings row, not on the
+   * workspace itself; a missing row means the defaults.
+   */
+  toDomain(
+    record: WorkspaceRecord,
+    settings?: WorkspaceUserSettingsRecord | null,
+  ): Workspace {
     return new Workspace({
       id: record.id,
       userId: record.userId,
@@ -13,8 +21,8 @@ export class WorkspaceMapper {
       description: record.description,
       icon: record.icon,
       color: record.color,
-      isPinned: record.isPinned,
-      sortOrder: record.sortOrder,
+      isPinned: settings?.isPinned ?? false,
+      sortOrder: settings?.sortOrder ?? 0,
       createdAt: record.createdAt,
       updatedAt: record.updatedAt,
     });
@@ -29,8 +37,6 @@ export class WorkspaceMapper {
     record.description = domain.description;
     record.icon = domain.icon;
     record.color = domain.color;
-    record.isPinned = domain.isPinned;
-    record.sortOrder = domain.sortOrder;
     record.createdAt = domain.createdAt;
     record.updatedAt = domain.updatedAt;
     return record;

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace-user-settings.record.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace-user-settings.record.ts
@@ -1,0 +1,39 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne, Unique } from 'typeorm';
+import type { UUID } from 'crypto';
+import { BaseRecord } from 'src/common/db/base-record';
+import { UserRecord } from 'src/iam/users/infrastructure/repositories/local/schema/user.record';
+import { WorkspaceRecord } from './workspace.record';
+
+/**
+ * Per-user workspace preferences. Pinning and manual sidebar order are how a
+ * user arranges *their* sidebar, not properties of the workspace itself — kept
+ * off the workspace row so iteration 4's shared workspaces don't make
+ * collaborators fight over one pin state. Follows the `skill_activations`
+ * per-user-state precedent.
+ */
+@Entity({ name: 'workspace_user_settings' })
+@Unique('UQ_workspace_user_settings_workspace_user', ['workspaceId', 'userId'])
+export class WorkspaceUserSettingsRecord extends BaseRecord {
+  @Column()
+  @Index()
+  workspaceId: UUID;
+
+  @ManyToOne(() => WorkspaceRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'workspaceId' })
+  workspace: WorkspaceRecord;
+
+  @Column()
+  @Index()
+  userId: UUID;
+
+  @ManyToOne(() => UserRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: UserRecord;
+
+  @Column({ default: false })
+  isPinned: boolean;
+
+  /** Position in the user's manual order; null = never ordered, sorts last. */
+  @Column({ type: 'int', nullable: true })
+  sortOrder: number | null;
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace.record.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace.record.ts
@@ -18,12 +18,6 @@ export class WorkspaceRecord extends BaseRecord {
   @Column({ type: 'varchar', length: 32 })
   color: string;
 
-  @Column({ default: false })
-  isPinned: boolean;
-
-  @Column({ type: 'int', default: 0 })
-  sortOrder: number;
-
   @Column()
   @Index()
   userId: UUID;


### PR DESCRIPTION
Part of AYC-700, stacked on #1347. Moves `isPinned` and `sortOrder` off the `workspaces` row into a per-user `workspace_user_settings` table (the `skill_activations` pattern), so iteration 4's shared workspaces won't make collaborators fight over one pin state.

- HTTP contract unchanged — the repository hydrates both fields from the caller's settings row; port signatures, use cases and the frontend are untouched.
- Migration backfills every existing workspace's pin/order into an owner settings row before dropping the columns; rollback restores them. Verified against a live dev DB with both seeded and manually created workspaces.
- Toggle stays a single atomic statement (`INSERT … ON CONFLICT DO UPDATE SET "isPinned" = NOT …`); reorder upserts rows on demand.
- Seeder writes the settings rows alongside the workspaces.

Refs: AYC-700

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema migration drops columns after selective backfill; incorrect migration logic could lose pin/order for default-state workspaces, though HTTP behavior is intended to stay the same.
> 
> **Overview**
> Moves **`isPinned`** and **`sortOrder`** off the **`workspaces`** table into **`workspace_user_settings`** (one row per workspace × user), so sidebar layout can stay per user when shared workspaces land later. The public API is unchanged: the repository still hydrates those fields on **`Workspace`** from the caller’s settings row.
> 
> A migration creates the new table, backfills owner settings only where pin/order differed from defaults, then drops the old columns (rollback restores them). **`save`** now writes workspace fields only; **`saveSettings`** upserts initial pin/order on create, while **`togglePinned`** and **`updateSortOrders`** use atomic **`INSERT … ON CONFLICT`** against the settings table (FK violations map to **`WorkspaceNotFoundError`**). Listing/sorting joins settings in memory (never-ordered workspaces sort last). Seeds and tests were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa0399020b84d154d2159c1ba4c030fd499ac35c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->