### PR TITLE
feat(workspaces): show chat count and activity on the projects list (AYC-700)

### DIFF
--- a/ayunis-core-backend/src/domain/workspaces/application/ports/workspaces-repository.port.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/ports/workspaces-repository.port.ts
@@ -1,6 +1,11 @@
 import type { UUID } from 'crypto';
 import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 
+export interface WorkspaceThreadStats {
+  chatCount: number;
+  lastActivityAt: Date | null;
+}
+
 export abstract class WorkspacesRepository {
   /**
    * Ordered by the caller's `sortOrder` ascending — never-ordered workspaces
@@ -9,6 +14,14 @@ export abstract class WorkspacesRepository {
    * adapters must uphold it.
    */
   abstract findAllByUserId(userId: UUID): Promise<Workspace[]>;
+
+  /**
+   * Chat count and latest chat activity per workspace, for the list page.
+   * Missing entries mean "no chats".
+   */
+  abstract getThreadStats(
+    workspaceIds: UUID[],
+  ): Promise<Map<UUID, WorkspaceThreadStats>>;
   abstract findById(userId: UUID, id: UUID): Promise<Workspace | null>;
   /**
    * Persists the workspace's own fields only. The caller's pin state and

--- a/ayunis-core-backend/src/domain/workspaces/application/testing/workspace.fixtures.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/testing/workspace.fixtures.ts
@@ -38,6 +38,7 @@ export function createMockContextService(
 export function createMockWorkspacesRepository(): jest.Mocked<WorkspacesRepository> {
   return {
     findAllByUserId: jest.fn().mockResolvedValue([]),
+    getThreadStats: jest.fn().mockResolvedValue(new Map()),
     findById: jest.fn().mockResolvedValue(null),
     save: jest
       .fn()

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.spec.ts
@@ -39,12 +39,64 @@ describe('FindAllWorkspacesUseCase', () => {
     jest.clearAllMocks();
   });
 
-  it('returns the caller’s workspaces', async () => {
-    const workspaces = [aWorkspace()];
-    repository.findAllByUserId.mockResolvedValue(workspaces);
+  it('returns the caller’s workspaces with their chat stats', async () => {
+    const workspace = aWorkspace();
+    repository.findAllByUserId.mockResolvedValue([workspace]);
+    repository.getThreadStats.mockResolvedValue(
+      new Map([[workspace.id, { chatCount: 3, lastActivityAt: null }]]),
+    );
 
-    await expect(useCase.execute()).resolves.toBe(workspaces);
+    await expect(useCase.execute()).resolves.toEqual([
+      { workspace, chatCount: 3, lastActivityAt: workspace.updatedAt },
+    ]);
     expect(repository.findAllByUserId).toHaveBeenCalledWith(TEST_USER_ID);
+  });
+
+  it('reports zero chats for a workspace without stats', async () => {
+    const workspace = aWorkspace();
+    repository.findAllByUserId.mockResolvedValue([workspace]);
+
+    const [item] = await useCase.execute();
+
+    expect(item.chatCount).toBe(0);
+    expect(item.lastActivityAt).toEqual(workspace.updatedAt);
+  });
+
+  it('surfaces chat activity newer than the last edit', async () => {
+    const workspace = aWorkspace({
+      updatedAt: new Date('2026-08-02T10:00:00.000Z'),
+    });
+    const chatActivity = new Date('2026-08-05T10:00:00.000Z');
+    repository.findAllByUserId.mockResolvedValue([workspace]);
+    repository.getThreadStats.mockResolvedValue(
+      new Map([[workspace.id, { chatCount: 1, lastActivityAt: chatActivity }]]),
+    );
+
+    const [item] = await useCase.execute();
+
+    expect(item.lastActivityAt).toEqual(chatActivity);
+  });
+
+  it('keeps the edit timestamp when it is newer than chat activity', async () => {
+    const workspace = aWorkspace({
+      updatedAt: new Date('2026-08-09T10:00:00.000Z'),
+    });
+    repository.findAllByUserId.mockResolvedValue([workspace]);
+    repository.getThreadStats.mockResolvedValue(
+      new Map([
+        [
+          workspace.id,
+          {
+            chatCount: 1,
+            lastActivityAt: new Date('2026-08-05T10:00:00.000Z'),
+          },
+        ],
+      ]),
+    );
+
+    const [item] = await useCase.execute();
+
+    expect(item.lastActivityAt).toEqual(workspace.updatedAt);
   });
 
   it('rejects an unauthenticated caller', async () => {

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.ts
@@ -7,6 +7,13 @@ import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
 import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
 
+export interface WorkspaceListItem {
+  workspace: Workspace;
+  chatCount: number;
+  /** Later of the workspace's own edit and its most recent chat activity. */
+  lastActivityAt: Date;
+}
+
 @Injectable()
 export class FindAllWorkspacesUseCase {
   private readonly logger = new Logger(FindAllWorkspacesUseCase.name);
@@ -17,11 +24,28 @@ export class FindAllWorkspacesUseCase {
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
-  async execute(): Promise<Workspace[]> {
+  async execute(): Promise<WorkspaceListItem[]> {
     this.logger.log('Finding all workspaces');
-    return await this.workspacesRepository.findAllByUserId(
+
+    const workspaces = await this.workspacesRepository.findAllByUserId(
       this.resolveUserId(),
     );
+    const stats = await this.workspacesRepository.getThreadStats(
+      workspaces.map((workspace) => workspace.id),
+    );
+
+    return workspaces.map((workspace) => {
+      const threadStats = stats.get(workspace.id);
+      const chatActivity = threadStats?.lastActivityAt;
+      return {
+        workspace,
+        chatCount: threadStats?.chatCount ?? 0,
+        lastActivityAt:
+          chatActivity && chatActivity > workspace.updatedAt
+            ? chatActivity
+            : workspace.updatedAt,
+      };
+    });
   }
 
   private resolveUserId(): UUID {

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.ts
@@ -3,7 +3,10 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { randomUUID } from 'crypto';
 import type { UUID } from 'crypto';
-import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import {
+  WorkspacesRepository,
+  type WorkspaceThreadStats,
+} from 'src/domain/workspaces/application/ports/workspaces-repository.port';
 import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
 import { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import { WorkspaceRecord } from './schema/workspace.record';
@@ -52,6 +55,36 @@ export class LocalWorkspacesRepository extends WorkspacesRepository {
         );
       })
       .map(({ record, settings: row }) => this.mapper.toDomain(record, row));
+  }
+
+  // Read-only seam onto the threads table by name. Importing the threads
+  // module here would reverse the threads → workspaces dependency and close a
+  // cycle, so this aggregate query stays raw SQL instead.
+  async getThreadStats(
+    workspaceIds: UUID[],
+  ): Promise<Map<UUID, WorkspaceThreadStats>> {
+    if (workspaceIds.length === 0) {
+      return new Map();
+    }
+    const rows: Array<{
+      workspaceId: UUID;
+      chatCount: number;
+      lastActivityAt: Date | null;
+    }> = await this.repo.manager.query(
+      `SELECT "workspaceId",
+              COUNT(*)::int AS "chatCount",
+              MAX(COALESCE("lastActivityAt", "createdAt")) AS "lastActivityAt"
+       FROM threads
+       WHERE "workspaceId" = ANY($1)
+       GROUP BY "workspaceId"`,
+      [workspaceIds],
+    );
+    return new Map(
+      rows.map((row) => [
+        row.workspaceId,
+        { chatCount: row.chatCount, lastActivityAt: row.lastActivityAt },
+      ]),
+    );
   }
 
   async findById(userId: UUID, id: UUID): Promise<Workspace | null> {

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-response.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-response.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class WorkspaceResponseDto {
   @ApiProperty({
@@ -56,4 +56,18 @@ export class WorkspaceResponseDto {
     example: '2026-08-11T10:30:00.000Z',
   })
   updatedAt: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Number of chats filed under the workspace (list responses only)',
+    example: 3,
+  })
+  chatCount?: number;
+
+  @ApiPropertyOptional({
+    description:
+      'Later of the last edit and the most recent chat activity (list responses only)',
+    example: '2026-08-11T10:30:00.000Z',
+  })
+  lastActivityAt?: string;
 }

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import type { WorkspaceListItem } from 'src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case';
 import { WorkspaceResponseDto } from 'src/domain/workspaces/presenters/http/dtos/workspace-response.dto';
 
 @Injectable()
@@ -15,6 +16,13 @@ export class WorkspaceDtoMapper {
     dto.sortOrder = workspace.sortOrder;
     dto.createdAt = workspace.createdAt.toISOString();
     dto.updatedAt = workspace.updatedAt.toISOString();
+    return dto;
+  }
+
+  toListItemDto(item: WorkspaceListItem): WorkspaceResponseDto {
+    const dto = this.toDto(item.workspace);
+    dto.chatCount = item.chatCount;
+    dto.lastActivityAt = item.lastActivityAt.toISOString();
     return dto;
   }
 }

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/workspaces.controller.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/workspaces.controller.ts
@@ -80,10 +80,8 @@ export class WorkspacesController {
   })
   async findAll(): Promise<WorkspaceResponseDto[]> {
     this.logger.log('findAll');
-    const workspaces = await this.findAllWorkspacesUseCase.execute();
-    return workspaces.map((workspace) =>
-      this.workspaceDtoMapper.toDto(workspace),
-    );
+    const items = await this.findAllWorkspacesUseCase.execute();
+    return items.map((item) => this.workspaceDtoMapper.toListItemDto(item));
   }
 
   // Declared before `PATCH :id` so `reorder` is not swallowed by the id route.

--- a/ayunis-core-frontend/src/pages/workspaces/lib/sortWorkspaces.test.ts
+++ b/ayunis-core-frontend/src/pages/workspaces/lib/sortWorkspaces.test.ts
@@ -24,6 +24,13 @@ describe('sortWorkspaces', () => {
     createdAt: '2026-08-01T10:00:00.000Z',
     updatedAt: '2026-08-05T10:00:00.000Z',
   });
+  const busy = aWorkspace({
+    id: 'busy',
+    name: 'Zulassung',
+    createdAt: '2026-08-01T09:00:00.000Z',
+    updatedAt: '2026-08-01T09:00:00.000Z',
+    lastActivityAt: '2026-08-09T10:00:00.000Z',
+  });
   const newer = aWorkspace({
     id: 'newer',
     name: 'Bauhof',
@@ -35,6 +42,12 @@ describe('sortWorkspaces', () => {
     expect(
       sortWorkspaces([newer, older], 'updatedAt').map((w) => w.id),
     ).toEqual(['older', 'newer']);
+  });
+
+  it('ranks chat activity as an update', () => {
+    expect(sortWorkspaces([older, busy], 'updatedAt').map((w) => w.id)).toEqual(
+      ['busy', 'older'],
+    );
   });
 
   it('puts the most recently created first', () => {

--- a/ayunis-core-frontend/src/pages/workspaces/lib/sortWorkspaces.ts
+++ b/ayunis-core-frontend/src/pages/workspaces/lib/sortWorkspaces.ts
@@ -19,9 +19,17 @@ export function sortWorkspaces(
       left.name.localeCompare(right.name, locale),
     );
   }
-  // Newest first. ISO-8601 strings compare correctly as strings.
+  if (sortKey === 'createdAt') {
+    // Newest first. ISO-8601 strings compare correctly as strings.
+    return sorted.sort((left, right) =>
+      right.createdAt.localeCompare(left.createdAt),
+    );
+  }
+  // "Last updated" means activity: the later of the workspace's own edit and
+  // its most recent chat activity, so busy workspaces rise even when their
+  // settings were never touched.
   return sorted.sort((left, right) =>
-    right[sortKey].localeCompare(left[sortKey]),
+    effectiveActivity(right).localeCompare(effectiveActivity(left)),
   );
 }
 
@@ -34,4 +42,8 @@ export function filterWorkspaces(
   return workspaces.filter((workspace) =>
     workspace.name.toLowerCase().includes(term),
   );
+}
+
+function effectiveActivity(workspace: Workspace): string {
+  return workspace.lastActivityAt ?? workspace.updatedAt;
 }

--- a/ayunis-core-frontend/src/pages/workspaces/ui/WorkspaceCard.tsx
+++ b/ayunis-core-frontend/src/pages/workspaces/ui/WorkspaceCard.tsx
@@ -1,7 +1,9 @@
 import { Link } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
 import {
   Card,
   CardDescription,
+  CardFooter,
   CardHeader,
   CardTitle,
 } from '@ayunis/ui/components/card';
@@ -14,6 +16,7 @@ interface WorkspaceCardProps {
 }
 
 export function WorkspaceCard({ workspace }: Readonly<WorkspaceCardProps>) {
+  const { t } = useTranslation('workspaces');
   return (
     // The pin button is a sibling of the link, not a descendant: a <button>
     // inside an <a> is invalid HTML and breaks keyboard activation.
@@ -37,6 +40,9 @@ export function WorkspaceCard({ workspace }: Readonly<WorkspaceCardProps>) {
               {workspace.description}
             </CardDescription>
           </CardHeader>
+          <CardFooter className="text-sm text-muted-foreground">
+            {t('page.chatCount', { count: workspace.chatCount ?? 0 })}
+          </CardFooter>
         </Card>
       </Link>
       <div className="absolute top-4 right-4">

--- a/ayunis-core-frontend/src/pages/workspaces/ui/WorkspaceRow.tsx
+++ b/ayunis-core-frontend/src/pages/workspaces/ui/WorkspaceRow.tsx
@@ -1,4 +1,5 @@
 import { Link } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
 import {
   Item,
   ItemActions,
@@ -16,6 +17,7 @@ interface WorkspaceRowProps {
 }
 
 export function WorkspaceRow({ workspace }: Readonly<WorkspaceRowProps>) {
+  const { t } = useTranslation('workspaces');
   return (
     <Item variant="outline" className="relative">
       <ItemMedia>
@@ -37,11 +39,14 @@ export function WorkspaceRow({ workspace }: Readonly<WorkspaceRowProps>) {
             {workspace.name}
           </Link>
         </ItemTitle>
-        {workspace.description && (
-          <ItemDescription className="line-clamp-1">
-            {workspace.description}
-          </ItemDescription>
-        )}
+        <ItemDescription className="line-clamp-1">
+          {[
+            t('page.chatCount', { count: workspace.chatCount ?? 0 }),
+            workspace.description,
+          ]
+            .filter(Boolean)
+            .join(' · ')}
+        </ItemDescription>
       </ItemContent>
       <ItemActions className="relative">
         <WorkspacePinButton

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3474,6 +3474,10 @@ export interface WorkspaceResponseDto {
   createdAt: string;
   /** When the workspace was last updated */
   updatedAt: string;
+  /** Number of chats filed under the workspace (list responses only) */
+  chatCount?: number;
+  /** Later of the last edit and the most recent chat activity (list responses only) */
+  lastActivityAt?: string;
 }
 
 export interface ReorderWorkspacesDto {

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -15773,6 +15773,16 @@
             "type": "string",
             "description": "When the workspace was last updated",
             "example": "2026-08-11T10:30:00.000Z"
+          },
+          "chatCount": {
+            "type": "number",
+            "description": "Number of chats filed under the workspace (list responses only)",
+            "example": 3
+          },
+          "lastActivityAt": {
+            "type": "string",
+            "description": "Later of the last edit and the most recent chat activity (list responses only)",
+            "example": "2026-08-11T10:30:00.000Z"
           }
         },
         "required": [


### PR DESCRIPTION
Completes AYC-700's list-page scope, stacked on #1351. The projects list now shows each workspace's chat count, and "Zuletzt aktualisiert" means *activity*, not just settings edits.

- `GET /workspaces` returns `chatCount` and `lastActivityAt` (the later of the last edit and the newest chat activity) per item. The aggregate is one read-only raw-SQL query against the threads table — importing the threads module would reverse the threads → workspaces dependency and close a cycle, hence the documented seam.
- Cards and rows render the count; the list's default sort uses `lastActivityAt ?? updatedAt`, so a busy project rises without its settings ever being touched, with zero write amplification (no per-message workspace updates).
- Covered by use-case tests (count fallback, activity-newer-than-edit, edit-newer-than-activity) and sort tests.

Refs: AYC-700

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive list API fields and read-only SQL aggregation; single-workspace endpoints unchanged and behavior is covered by use-case and sort tests.
> 
> **Overview**
> **`GET /workspaces`** now returns optional **`chatCount`** and **`lastActivityAt`** on list items only. **`FindAllWorkspacesUseCase`** loads workspaces, batches **`getThreadStats`** per id, and sets **`lastActivityAt`** to the later of workspace **`updatedAt`** and latest thread activity (zero chats when no stats row).
> 
> The local repository implements stats with a **read-only raw SQL** aggregate on **`threads`** (count + **`MAX(COALESCE(lastActivityAt, createdAt))`**) to avoid a modules cycle with threads.
> 
> On the frontend, **cards and rows** show translated chat counts; **“last updated” sort** uses **`lastActivityAt ?? updatedAt`** so active projects rise without metadata edits. OpenAPI/generated client types pick up the new fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 370ec7f1f71904167815c4d6b161133614c5e4a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->