### PR TITLE
fix(chat): preserve new chat layout with reduced motion (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/widgets/chat-input/ui/chat-input-glow.css
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/chat-input-glow.css
@@ -107,27 +107,16 @@
   .chat-input-shell__textarea--animate,
   .chat-input-shell__card .chat-input-body,
   .chat-input-expandable,
-  .new-chat-compose,
-  .new-chat-compose--idle,
   .new-chat-compose--settling,
   .new-chat-compose--settling .new-chat-compose__content,
   .new-chat-greeting,
-  .new-chat-greeting--exit,
-  .new-chat-dock-extras,
-  .new-chat-dock-extras--collapsed {
+  .new-chat-disclaimer,
+  .new-chat-dock-extras {
     transition: none;
-    transform: none;
-    gap: 1rem;
-    opacity: 1;
-    max-height: none;
-    margin-top: 1rem;
   }
 
   .new-chat-disclaimer--visible {
-    transition: none;
     transition-delay: 0ms;
-    transform: none;
-    opacity: 1;
   }
 }
 

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/chat-input-glow.test.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/chat-input-glow.test.ts
@@ -1,0 +1,30 @@
+// @ts-expect-error Node types are intentionally excluded from the browser app.
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const styles = readFileSync(
+  'src/widgets/chat-input/ui/chat-input-glow.css',
+  'utf8',
+) as string;
+
+describe('reduced motion chat input styles', () => {
+  it('preserves the new-chat compose position and visibility states', () => {
+    const mediaQueryStart = styles.indexOf(
+      '@media (prefers-reduced-motion: reduce)',
+    );
+    const chatInputShellStart = styles.indexOf(
+      '.chat-input-shell {',
+      mediaQueryStart,
+    );
+    const reducedMotionStyles = styles.slice(
+      mediaQueryStart,
+      chatInputShellStart,
+    );
+
+    expect(mediaQueryStart).toBeGreaterThanOrEqual(0);
+    expect(chatInputShellStart).toBeGreaterThan(mediaQueryStart);
+    expect(reducedMotionStyles).not.toMatch(
+      /\b(transform|gap|opacity|max-height|margin-top)\s*:/,
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CSS-only accessibility tweak plus a static stylesheet test; no auth, data, or runtime logic changes.
> 
> **Overview**
> **Fixes broken new-chat layout when `prefers-reduced-motion: reduce` is enabled** by narrowing what the first reduced-motion block overrides in `chat-input-glow.css`.
> 
> Previously that block reset **transform, gap, opacity, max-height, and margin-top** (and related selectors) to “visible” static values while disabling motion. That fought the normal idle/settling/greeting/dock state classes and mis-positioned or hid parts of the compose UI. The change **only turns off transitions** (and clears disclaimer fade delay) for the listed chat-input / new-chat elements, so layout and visibility still come from the existing state classes.
> 
> Adds **`chat-input-glow.test.ts`**, which asserts the reduced-motion section before `.chat-input-shell` does not declare those layout properties, so the regression is caught in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1abf6ce9880b0681e28c4d7bd7be46a1bce0d99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->