### PR TITLE
chore(dev): make anonymisation service opt-in (AYC-000)

### DIFF
--- a/.claude/skills/dev-environment/SKILL.md
+++ b/.claude/skills/dev-environment/SKILL.md
@@ -7,19 +7,27 @@ description: Start, stop, and manage the local dev stack (Docker infra, backend,
 
 ## Starting the Stack
 
-The `./dev` script manages the full local development stack. It works from any checkout — worktree or main repo.
+The `./dev` script manages the local development stack. It works from any checkout — worktree or main repo.
+
+By default, `./dev up` omits the slow anonymisation service. Use this for routine backend, frontend, migration, and QA work:
 
 ```bash
-# Start everything (requires a slot number on first run)
+# Requires a slot number on first run
 ./dev up --slot 2
 
 # Subsequent runs remember the slot
 ./dev up
 ```
 
+Before starting the stack, decide whether the task actually exercises anonymisation. Only include the service when the task tests or changes anonymisation behavior:
+
+```bash
+./dev up --slot 2 --with-anonymisation
+```
+
 ### What `./dev up` does
 
-1. Starts Docker infrastructure (postgres, minio, mailcatcher, code-execution, anonymize)
+1. Starts Docker infrastructure (postgres, minio, mailcatcher, code-execution, redis, gotenberg, plus anonymize only when `--with-anonymisation` is set)
 2. Generates `.env.dev` with localhost connection config for the slot
 3. Runs database migrations
 4. Starts the backend natively (`nest start --watch`)
@@ -56,7 +64,7 @@ The backend runs `nest start --watch` — it auto-reloads on code changes. If it
 ```bash
 ./dev logs backend    # Check what went wrong
 ./dev down
-./dev up              # Slot is remembered
+./dev up              # Slot is remembered; add --with-anonymisation only if needed
 ```
 
 ## Stopping

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ port, it exits with an actionable error instead of terminating that process.
 
 ```bash
 # Start or converge a slot to a healthy stack. The slot is remembered.
+# Anonymisation is omitted by default; add --with-anonymisation when needed.
 ./dev up --slot 2
 
 # Check process/session state and backend/frontend HTTP readiness.

--- a/ayunis-core-backend/README.md
+++ b/ayunis-core-backend/README.md
@@ -61,6 +61,9 @@ From the **repository root**:
 ./dev down          # Stop everything
 ```
 
+Anonymisation is omitted by default to speed up startup. Add
+`--with-anonymisation` to `./dev up` when working on anonymisation behavior.
+
 Use `./dev up --slot 1` to run a second instance in parallel (e.g. for another worktree).
 
 Environment precedence and the `DEV_PORT_OFFSET` slot derivation are

--- a/dev
+++ b/dev
@@ -3,8 +3,9 @@
 # dev — manage a per-worktree development stack for ayunis-core
 #
 # Usage:
-#   ./dev up   [--slot N]   Start infra (Docker) + backend + frontend in background
-#   ./dev down [--slot N]   Stop everything
+#   ./dev up   [--slot N] [--with-anonymisation]
+#                              Start infra (Docker) + backend + frontend in background
+#   ./dev down [--slot N]      Stop everything
 #   ./dev status [--slot N] Show what's running and on which ports
 #   ./dev logs [--slot N] [--tail N] [backend|frontend|infra|all]
 #                           Print recent logs (default: all, last 80 lines)
@@ -26,15 +27,21 @@ warn() { echo "⚠️  $*" >&2; }
 # ── Parse arguments ────────────────────────────────────────────────────────
 
 SLOT=""
+WITH_ANONYMISATION=false
 COMMAND="${1:-help}"
 shift || true
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --slot) SLOT="${2:?--slot requires a number}"; shift 2 ;;
-    *)      break ;;
+    --with-anonymisation) WITH_ANONYMISATION=true; shift ;;
+    *) break ;;
   esac
 done
+
+if $WITH_ANONYMISATION && [ "$COMMAND" != "up" ]; then
+  die "--with-anonymisation is only supported by ./dev up"
+fi
 
 # ── Resolve slot: explicit flag > saved file > error ──────────────────────
 
@@ -78,6 +85,19 @@ STATE_DIR="$REPO_DIR/.dev/slot-${SLOT}"
 CHECKOUT_ID="$(printf '%s' "$REPO_DIR" | cksum | cut -d' ' -f1)"
 BACKEND_SESSION="${PROJECT_NAME}-${CHECKOUT_ID}-backend"
 FRONTEND_SESSION="${PROJECT_NAME}-${CHECKOUT_ID}-frontend"
+
+INFRA_SERVICES=(
+  postgres
+  minio
+  mailcatcher
+  docker-socket-proxy
+  code-execution
+  redis
+  gotenberg
+)
+if $WITH_ANONYMISATION; then
+  INFRA_SERVICES+=(anonymize)
+fi
 
 # ── Docker compose wrapper ─────────────────────────────────────────────────
 
@@ -259,7 +279,7 @@ cmd_up() {
 
     # -- 1. Docker infrastructure -----------------------------------------
     info "Starting Docker infrastructure …"
-    dc up -d --build --wait 2>&1 | tail -5
+    dc up -d --build --wait "${INFRA_SERVICES[@]}" 2>&1 | tail -5
   fi
 
   # -- 2. Generate .env.dev for backend ------------------------------------
@@ -501,8 +521,7 @@ _sync_dependencies() {
 
 _infra_healthy() {
   local expected_services service status_line state health
-  expected_services="$(dc config --services 2>/dev/null)" || return 1
-  [ -n "$expected_services" ] || return 1
+  expected_services="$(printf '%s\n' "${INFRA_SERVICES[@]}")"
 
   local service_status
   service_status="$(dc ps --format '{{.Service}}|{{.State}}|{{.Health}}' 2>/dev/null)" || return 1
@@ -551,7 +570,11 @@ _print_ready_summary() {
   echo "  MinIO:        localhost:$MINIO_HOST_PORT  (console: $MINIO_CONSOLE_HOST_PORT)"
   echo "  Mailcatcher:  smtp :$MAILCATCHER_SMTP_HOST_PORT  web :$MAILCATCHER_WEB_HOST_PORT"
   echo "  Code exec:    localhost:$CODE_EXEC_HOST_PORT"
-  echo "  Anonymize:    localhost:$ANONYMIZE_HOST_PORT"
+  if $WITH_ANONYMISATION; then
+    echo "  Anonymize:    localhost:$ANONYMIZE_HOST_PORT"
+  else
+    echo "  Anonymize:    disabled"
+  fi
   echo "  Gotenberg:    localhost:$GOTENBERG_HOST_PORT"
 }
 
@@ -668,7 +691,7 @@ case "$COMMAND" in
     echo "Usage: ./dev <up|down|status|logs> [--slot N] [logs options]"
     echo ""
     echo "Commands:"
-    echo "  up     --slot N                            Start the full dev stack in background"
+    echo "  up     --slot N [--with-anonymisation]     Start the dev stack in background"
     echo "  down   [--slot N]                          Stop everything"
     echo "  status [--slot N]                          Show what's running"
     echo "  logs   [--slot N] [--tail N] [backend|frontend|infra|all]"

--- a/scripts/dev-status.test.sh
+++ b/scripts/dev-status.test.sh
@@ -212,12 +212,14 @@ chmod +x \
   "$TEST_DIR/bin/openssl" \
   "$TEST_DIR/bin/sleep"
 
+: > "$TEST_DIR/default-docker-calls"
 set +e
 output="$(
   PATH="$TEST_DIR/bin:$PATH" \
     AYUNIS_NO_INFISICAL=1 \
     FAKE_BACKEND_SESSION=1 \
     FAKE_BACKEND_READY="$TEST_DIR/backend-ready" \
+    FAKE_DOCKER_CALLS="$TEST_DIR/default-docker-calls" \
     FAKE_PNPM_CALLS="$TEST_DIR/pnpm-calls" \
     FAKE_TMUX_CALLS="$TEST_DIR/tmux-calls" \
     "$UP_DIR/dev" up 2>&1
@@ -239,6 +241,11 @@ fi
 
 if ! grep -Fq -- 'install --frozen-lockfile' "$TEST_DIR/pnpm-calls" 2>/dev/null; then
   printf 'Expected dev up to synchronize workspace dependencies with a frozen-lockfile install.\n' >&2
+  failures=$((failures + 1))
+fi
+
+if grep -F -- ' up -d --build --wait ' "$TEST_DIR/default-docker-calls" | grep -Fq -- ' anonymize'; then
+  printf 'Expected dev up to omit anonymize by default.\n' >&2
   failures=$((failures + 1))
 fi
 
@@ -403,6 +410,38 @@ set -e
 
 if [[ $status -eq 0 || "$output" != *"pnpm install --frozen-lockfile"* ]]; then
   printf 'Expected dependency repair failures to include the exact recovery command.\n%s\n' "$output" >&2
+  failures=$((failures + 1))
+fi
+
+WITH_ANONYMISATION_DIR="$TEST_DIR/with-anonymisation"
+mkdir -p \
+  "$WITH_ANONYMISATION_DIR/.dev" \
+  "$WITH_ANONYMISATION_DIR/ayunis-core-backend" \
+  "$WITH_ANONYMISATION_DIR/ayunis-core-frontend" \
+  "$WITH_ANONYMISATION_DIR/ayunis-core-code-execution/sandbox"
+cp "$REPO_DIR/dev" "$WITH_ANONYMISATION_DIR/dev"
+chmod +x "$WITH_ANONYMISATION_DIR/dev"
+printf '97\n' > "$WITH_ANONYMISATION_DIR/.dev/slot"
+: > "$TEST_DIR/with-anonymisation-docker-calls"
+rm -f "$TEST_DIR/with-anonymisation-ready" "$TEST_DIR/with-anonymisation-ready.frontend"
+
+set +e
+output="$(
+  PATH="$TEST_DIR/bin:$PATH" \
+    AYUNIS_NO_INFISICAL=1 \
+    FAKE_BACKEND_READY="$TEST_DIR/with-anonymisation-ready" \
+    FAKE_DOCKER_CALLS="$TEST_DIR/with-anonymisation-docker-calls" \
+    "$WITH_ANONYMISATION_DIR/dev" up --with-anonymisation 2>&1
+)"
+status=$?
+set -e
+
+compose_up_call="$(grep -F -- ' up -d --build --wait ' "$TEST_DIR/with-anonymisation-docker-calls" || true)"
+if [[ $status -ne 0 \
+  || "$compose_up_call" != *" postgres "* \
+  || "$compose_up_call" != *" anonymize"* ]]; then
+  printf 'Expected --with-anonymisation to include anonymize.\n%s\nDocker calls:\n%s\n' \
+    "$output" "$(cat "$TEST_DIR/with-anonymisation-docker-calls")" >&2
   failures=$((failures + 1))
 fi
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Local dev tooling and documentation only; no production or application runtime behavior changes.
> 
> **Overview**
> **Faster default dev startup** by not bringing up the slow anonymisation Docker service unless you ask for it.
> 
> `./dev up` now starts a fixed infra set (postgres, minio, mailcatcher, docker-socket-proxy, code-execution, redis, gotenberg) and passes only those services to `docker compose up`. **`--with-anonymisation`** (valid only on `up`) appends `anonymize` to that list. Infra health checks use the same explicit list instead of every service in the compose file, and the ready summary shows **Anonymize: disabled** unless the flag was used.
> 
> README, backend README, and the dev-environment skill document the new default and flag. **`scripts/dev-status.test.sh`** asserts default `up` omits `anonymize` from compose and that `--with-anonymisation` includes it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe1323886e93a5b3169216fd6d809e8cd16afa8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->