### PR TITLE
wip(auth): add organization-pinned SSO orchestration (AYC-644)

### DIFF
--- a/ayunis-core-backend/src/iam/sso/SUMMARY.md
+++ b/ayunis-core-backend/src/iam/sso/SUMMARY.md
@@ -9,6 +9,8 @@ Federated identities use the exact validated OIDC issuer and subject as their du
 
 `SsoLoginTransaction` stores a state hash, browser-binding hash, fixed post-login path, encrypted PKCE verifier and nonce, pinned Ayunis and Zitadel organization IDs, and a ten-minute expiry. `SsoLoginTransactionsRepository` provides atomic one-time consumption, `SsoLoginTransactionEncryptionPort` protects the verifier and nonce at rest, and `SsoLoginTransactionCleanupTask` removes expired records. Broker tokens are never persisted.
 
+The login orchestration use cases discover an enabled connection from a validated email domain, start an organization-pinned broker authorization request, and complete only a matching one-time callback whose verified email domain and Zitadel organization match that connection. Public HTTP adapters are added separately from user admission and Core session issuance.
+
 `OrgSsoConnection` owns normalized connection state, while `OrgSsoConnectionsRepository` defines lookups, persistence, and conditional updates for routing and runtime flags. The Postgres adapter reports database constraint violations without deciding application conflicts and uses conditional writes to prevent stale operator changes from overwriting newer state.
 
 For V1, reusable application use cases read and configure a verified domain and its Zitadel organization mapping. New mappings are disabled by default, repeated configuration is idempotent, and an enabled mapping must be disabled before its routing identifiers can change. Separate use cases control runtime enablement and JIT provisioning so Superadmin HTTP adapters and later automation can reuse the same boundary.

--- a/ayunis-core-backend/src/iam/sso/application/sso.errors.ts
+++ b/ayunis-core-backend/src/iam/sso/application/sso.errors.ts
@@ -12,6 +12,10 @@ export enum SsoErrorCode {
   CONNECTION_CHANGED = 'SSO_CONNECTION_CHANGED',
   BROKER_NOT_CONFIGURED = 'SSO_BROKER_NOT_CONFIGURED',
   BROKER_RESPONSE_INVALID = 'SSO_BROKER_RESPONSE_INVALID',
+  DISCOVERY_EMAIL_INVALID = 'SSO_DISCOVERY_EMAIL_INVALID',
+  CONNECTION_NOT_AVAILABLE = 'SSO_CONNECTION_NOT_AVAILABLE',
+  LOGIN_TRANSACTION_INVALID = 'SSO_LOGIN_TRANSACTION_INVALID',
+  ORGANIZATION_MISMATCH = 'SSO_ORGANIZATION_MISMATCH',
   UNEXPECTED = 'SSO_UNEXPECTED_ERROR',
 }
 
@@ -100,6 +104,47 @@ export class InvalidSsoBrokerResponseError extends SsoError {
       SsoErrorCode.BROKER_RESPONSE_INVALID,
       401,
       { field },
+    );
+  }
+}
+
+export class InvalidSsoDiscoveryEmailError extends SsoError {
+  constructor() {
+    super(
+      'Enter a valid work email address',
+      SsoErrorCode.DISCOVERY_EMAIL_INVALID,
+      400,
+      { field: 'email' },
+    );
+  }
+}
+
+export class SsoConnectionNotAvailableError extends SsoError {
+  constructor() {
+    super(
+      'SSO is not available for this organization',
+      SsoErrorCode.CONNECTION_NOT_AVAILABLE,
+      404,
+    );
+  }
+}
+
+export class InvalidSsoLoginTransactionError extends SsoError {
+  constructor() {
+    super(
+      'SSO login transaction is invalid or expired',
+      SsoErrorCode.LOGIN_TRANSACTION_INVALID,
+      401,
+    );
+  }
+}
+
+export class SsoOrganizationMismatchError extends SsoError {
+  constructor() {
+    super(
+      'The authenticated identity does not belong to the requested organization',
+      SsoErrorCode.ORGANIZATION_MISMATCH,
+      401,
     );
   }
 }

--- a/ayunis-core-backend/src/iam/sso/application/testing/sso-login.fixtures.ts
+++ b/ayunis-core-backend/src/iam/sso/application/testing/sso-login.fixtures.ts
@@ -1,0 +1,19 @@
+import type { UUID } from 'crypto';
+import { OrgSsoConnection } from 'src/iam/sso/domain/org-sso-connection.entity';
+
+export const SSO_TEST_ORG_ID =
+  'f4fcdc42-176e-4d32-bd5b-6dad8d2426b4' as UUID;
+export const SSO_TEST_ZITADEL_ORG_ID = '385820595704561666';
+
+export function anEnabledSsoConnection(
+  overrides: Partial<OrgSsoConnection> = {},
+): OrgSsoConnection {
+  return new OrgSsoConnection({
+    orgId: SSO_TEST_ORG_ID,
+    emailDomain: 'demo.com',
+    domainVerifiedAt: new Date('2026-08-12T09:00:00.000Z'),
+    zitadelOrgId: SSO_TEST_ZITADEL_ORG_ID,
+    enabled: true,
+    ...overrides,
+  });
+}

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/complete-org-sso-login/complete-org-sso-login.command.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/complete-org-sso-login/complete-org-sso-login.command.ts
@@ -1,0 +1,6 @@
+export class CompleteOrgSsoLoginCommand {
+  constructor(
+    readonly callbackParameters: URLSearchParams,
+    readonly browserBinding: string | undefined,
+  ) {}
+}

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/complete-org-sso-login/complete-org-sso-login.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/complete-org-sso-login/complete-org-sso-login.use-case.spec.ts
@@ -1,0 +1,295 @@
+import { createHash } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { CompleteOrgSsoLoginCommand } from 'src/iam/sso/application/use-cases/complete-org-sso-login/complete-org-sso-login.command';
+import { CompleteOrgSsoLoginUseCase } from 'src/iam/sso/application/use-cases/complete-org-sso-login/complete-org-sso-login.use-case';
+import { SsoLoginTransaction } from 'src/iam/sso/domain/sso-login-transaction.entity';
+import {
+  anEnabledSsoConnection,
+  SSO_TEST_ORG_ID,
+  SSO_TEST_ZITADEL_ORG_ID,
+} from 'src/iam/sso/application/testing/sso-login.fixtures';
+
+const TEST_STATE = 'oauth-state';
+const TEST_BROWSER_BINDING = 'browser-binding';
+
+describe(CompleteOrgSsoLoginUseCase.name, () => {
+  const callbackParameters = new URLSearchParams({
+    code: 'authorization-code',
+    state: TEST_STATE,
+  });
+
+  it('returns a validated identity when the callback matches the pinned organizations', async () => {
+    const transaction = pendingTransaction();
+    const transactions = {
+      save: jest.fn(),
+      consume: jest.fn().mockResolvedValue(transaction),
+      deleteExpired: jest.fn(),
+    };
+    const broker = {
+      createAuthorizationRequest: jest.fn(),
+      validateCallback: jest.fn().mockResolvedValue({
+        issuer: 'https://sso.ayunis.de',
+        subject: 'zitadel-user',
+        email: 'staff@demo.com',
+        emailVerified: true,
+        zitadelOrgId: SSO_TEST_ZITADEL_ORG_ID,
+      }),
+    };
+    const useCase = new CompleteOrgSsoLoginUseCase(
+      createPinoLoggerMock(),
+      transactions,
+      broker,
+      {
+        encrypt: jest.fn(),
+        decrypt: jest
+          .fn()
+          .mockReturnValueOnce('pkce-verifier')
+          .mockReturnValueOnce('oidc-nonce'),
+      },
+      connectionRepository(),
+    );
+
+    await expect(
+      useCase.execute(
+        new CompleteOrgSsoLoginCommand(
+          callbackParameters,
+          TEST_BROWSER_BINDING,
+        ),
+      ),
+    ).resolves.toMatchObject({
+      orgId: SSO_TEST_ORG_ID,
+      subject: 'zitadel-user',
+      zitadelOrgId: SSO_TEST_ZITADEL_ORG_ID,
+      postLoginPath: '/',
+    });
+    expect(transactions.consume).toHaveBeenCalledWith(
+      createHash('sha256').update(TEST_STATE).digest('hex'),
+      createHash('sha256').update(TEST_BROWSER_BINDING).digest('hex'),
+      expect.any(Date),
+    );
+  });
+
+  it('rejects a callback without a single state value', async () => {
+    const useCase = new CompleteOrgSsoLoginUseCase(
+      createPinoLoggerMock(),
+      {
+        save: jest.fn(),
+        consume: jest.fn(),
+        deleteExpired: jest.fn(),
+      },
+      { createAuthorizationRequest: jest.fn(), validateCallback: jest.fn() },
+      { encrypt: jest.fn(), decrypt: jest.fn() },
+      connectionRepository(),
+    );
+
+    await expect(
+      useCase.execute(
+        new CompleteOrgSsoLoginCommand(
+          new URLSearchParams('code=authorization-code'),
+          TEST_BROWSER_BINDING,
+        ),
+      ),
+    ).rejects.toMatchObject({ code: 'SSO_LOGIN_TRANSACTION_INVALID' });
+  });
+
+  it('rejects a replayed or expired transaction', async () => {
+    const useCase = new CompleteOrgSsoLoginUseCase(
+      createPinoLoggerMock(),
+      {
+        save: jest.fn(),
+        consume: jest.fn().mockResolvedValue(null),
+        deleteExpired: jest.fn(),
+      },
+      { createAuthorizationRequest: jest.fn(), validateCallback: jest.fn() },
+      { encrypt: jest.fn(), decrypt: jest.fn() },
+      connectionRepository(),
+    );
+
+    await expect(
+      useCase.execute(
+        new CompleteOrgSsoLoginCommand(
+          callbackParameters,
+          TEST_BROWSER_BINDING,
+        ),
+      ),
+    ).rejects.toMatchObject({ code: 'SSO_LOGIN_TRANSACTION_INVALID' });
+  });
+
+  it('rejects a broker organization that differs from the pinned organization', async () => {
+    const broker = {
+      createAuthorizationRequest: jest.fn(),
+      validateCallback: jest.fn().mockResolvedValue({
+        issuer: 'https://sso.ayunis.de',
+        subject: 'zitadel-user',
+        email: 'staff@other.example',
+        emailVerified: true,
+        zitadelOrgId: 'different-zitadel-org',
+      }),
+    };
+    const useCase = new CompleteOrgSsoLoginUseCase(
+      createPinoLoggerMock(),
+      {
+        save: jest.fn(),
+        consume: jest.fn().mockResolvedValue(pendingTransaction()),
+        deleteExpired: jest.fn(),
+      },
+      broker,
+      {
+        encrypt: jest.fn(),
+        decrypt: jest
+          .fn()
+          .mockReturnValueOnce('pkce-verifier')
+          .mockReturnValueOnce('oidc-nonce'),
+      },
+      connectionRepository(),
+    );
+
+    await expect(
+      useCase.execute(
+        new CompleteOrgSsoLoginCommand(
+          callbackParameters,
+          TEST_BROWSER_BINDING,
+        ),
+      ),
+    ).rejects.toMatchObject({ code: 'SSO_ORGANIZATION_MISMATCH' });
+  });
+
+  it('rejects an unverified broker email', async () => {
+    const useCase = useCaseWithIdentity({ emailVerified: false });
+
+    await expect(
+      useCase.execute(
+        new CompleteOrgSsoLoginCommand(
+          callbackParameters,
+          TEST_BROWSER_BINDING,
+        ),
+      ),
+    ).rejects.toMatchObject({
+      code: 'SSO_BROKER_RESPONSE_INVALID',
+      metadata: { field: 'email_verified' },
+    });
+  });
+
+  it('rejects a verified broker email outside the configured domain', async () => {
+    const useCase = useCaseWithIdentity({
+      email: 'staff@other.example',
+    });
+
+    await expect(
+      useCase.execute(
+        new CompleteOrgSsoLoginCommand(
+          callbackParameters,
+          TEST_BROWSER_BINDING,
+        ),
+      ),
+    ).rejects.toMatchObject({ code: 'SSO_ORGANIZATION_MISMATCH' });
+  });
+
+  it.each([
+    ['disabled', anEnabledSsoConnection({ enabled: false })],
+    [
+      'remapped',
+      anEnabledSsoConnection({ zitadelOrgId: '385820595704561999' }),
+    ],
+  ])(
+    'rejects a callback when the connection was %s',
+    async (_case, mapping) => {
+      const useCase = useCaseWithIdentity({}, mapping);
+
+      await expect(
+        useCase.execute(
+          new CompleteOrgSsoLoginCommand(
+            callbackParameters,
+            TEST_BROWSER_BINDING,
+          ),
+        ),
+      ).rejects.toMatchObject({ code: 'SSO_CONNECTION_NOT_AVAILABLE' });
+    },
+  );
+
+  it('rejects a callback from a different browser before broker exchange', async () => {
+    const broker = {
+      createAuthorizationRequest: jest.fn(),
+      validateCallback: jest.fn(),
+    };
+    const useCase = new CompleteOrgSsoLoginUseCase(
+      createPinoLoggerMock(),
+      {
+        save: jest.fn(),
+        consume: jest.fn().mockResolvedValue(null),
+        deleteExpired: jest.fn(),
+      },
+      broker,
+      { encrypt: jest.fn(), decrypt: jest.fn() },
+      connectionRepository(),
+    );
+
+    await expect(
+      useCase.execute(
+        new CompleteOrgSsoLoginCommand(callbackParameters, 'other-browser'),
+      ),
+    ).rejects.toMatchObject({ code: 'SSO_LOGIN_TRANSACTION_INVALID' });
+    expect(broker.validateCallback).not.toHaveBeenCalled();
+  });
+});
+
+function pendingTransaction(): SsoLoginTransaction {
+  return new SsoLoginTransaction({
+    stateHash: createHash('sha256').update(TEST_STATE).digest('hex'),
+    browserBindingHash: createHash('sha256')
+      .update(TEST_BROWSER_BINDING)
+      .digest('hex'),
+    postLoginPath: '/',
+    encryptedCodeVerifier: 'encrypted-verifier',
+    encryptedNonce: 'encrypted-nonce',
+    orgId: SSO_TEST_ORG_ID,
+    zitadelOrgId: SSO_TEST_ZITADEL_ORG_ID,
+    expiresAt: new Date(Date.now() + 5 * 60 * 1000),
+  });
+}
+
+function connectionRepository(connection = anEnabledSsoConnection()) {
+  return {
+    findByOrgId: jest.fn().mockResolvedValue(connection),
+    findByEmailDomain: jest.fn(),
+    findByZitadelOrgId: jest.fn(),
+    save: jest.fn(),
+    updateConfigurationIfDisabled: jest.fn(),
+    setEnabled: jest.fn(),
+    setJitProvisioningEnabled: jest.fn(),
+    setJitProvisioningEnabledIfMappingMatches: jest.fn(),
+  };
+}
+
+function useCaseWithIdentity(
+  identityOverrides: Record<string, unknown>,
+  connection = anEnabledSsoConnection(),
+): CompleteOrgSsoLoginUseCase {
+  return new CompleteOrgSsoLoginUseCase(
+    createPinoLoggerMock(),
+    {
+      save: jest.fn(),
+      consume: jest.fn().mockResolvedValue(pendingTransaction()),
+      deleteExpired: jest.fn(),
+    },
+    {
+      createAuthorizationRequest: jest.fn(),
+      validateCallback: jest.fn().mockResolvedValue({
+        issuer: 'https://sso.ayunis.de',
+        subject: 'zitadel-user',
+        email: 'staff@demo.com',
+        emailVerified: true,
+        zitadelOrgId: SSO_TEST_ZITADEL_ORG_ID,
+        ...identityOverrides,
+      }),
+    },
+    {
+      encrypt: jest.fn(),
+      decrypt: jest
+        .fn()
+        .mockReturnValueOnce('pkce-verifier')
+        .mockReturnValueOnce('oidc-nonce'),
+    },
+    connectionRepository(connection),
+  );
+}

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/complete-org-sso-login/complete-org-sso-login.use-case.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/complete-org-sso-login/complete-org-sso-login.use-case.ts
@@ -1,0 +1,101 @@
+import { Injectable } from '@nestjs/common';
+import { createHash } from 'crypto';
+import type { UUID } from 'crypto';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import {
+  OidcBrokerClient,
+  type ValidatedOidcIdentity,
+} from 'src/iam/sso/application/ports/oidc-broker.client';
+import { SsoLoginTransactionEncryptionPort } from 'src/iam/sso/application/ports/sso-login-transaction-encryption.port';
+import { SsoLoginTransactionsRepository } from 'src/iam/sso/application/ports/sso-login-transactions.repository';
+import { OrgSsoConnectionsRepository } from 'src/iam/sso/application/ports/org-sso-connections.repository';
+import {
+  InvalidSsoBrokerResponseError,
+  InvalidSsoLoginTransactionError,
+  SsoConnectionNotAvailableError,
+  SsoOrganizationMismatchError,
+  UnexpectedSsoError,
+} from 'src/iam/sso/application/sso.errors';
+import { CompleteOrgSsoLoginCommand } from 'src/iam/sso/application/use-cases/complete-org-sso-login/complete-org-sso-login.command';
+import { emailDomainFromAddress } from 'src/iam/sso/domain/sso-connection-values';
+
+export interface CompletedOrgSsoLogin extends ValidatedOidcIdentity {
+  orgId: UUID;
+  postLoginPath: string;
+}
+
+@Injectable()
+export class CompleteOrgSsoLoginUseCase {
+  constructor(
+    @InjectPinoLogger(CompleteOrgSsoLoginUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly transactions: SsoLoginTransactionsRepository,
+    private readonly broker: OidcBrokerClient,
+    private readonly encryption: SsoLoginTransactionEncryptionPort,
+    private readonly connections: OrgSsoConnectionsRepository,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedSsoError)
+  async execute(
+    command: CompleteOrgSsoLoginCommand,
+  ): Promise<CompletedOrgSsoLogin> {
+    this.logger.info('Completing organization SSO login');
+    const state = this.singleState(command.callbackParameters);
+    const browserBindingHash = this.browserBindingHash(command.browserBinding);
+    const transaction = await this.transactions.consume(
+      createHash('sha256').update(state).digest('hex'),
+      browserBindingHash,
+      new Date(),
+    );
+    if (!transaction) {
+      throw new InvalidSsoLoginTransactionError();
+    }
+    const connection = await this.connections.findByOrgId(transaction.orgId);
+    if (
+      !connection?.enabled ||
+      connection.zitadelOrgId !== transaction.zitadelOrgId
+    ) {
+      throw new SsoConnectionNotAvailableError();
+    }
+    const identity = await this.broker.validateCallback({
+      callbackParameters: command.callbackParameters,
+      codeVerifier: this.encryption.decrypt(transaction.encryptedCodeVerifier),
+      expectedState: state,
+      expectedNonce: this.encryption.decrypt(transaction.encryptedNonce),
+    });
+    if (identity.zitadelOrgId !== transaction.zitadelOrgId) {
+      throw new SsoOrganizationMismatchError();
+    }
+    if (!identity.emailVerified) {
+      throw new InvalidSsoBrokerResponseError('email_verified');
+    }
+    const identityEmailDomain = emailDomainFromAddress(identity.email);
+    if (!identityEmailDomain) {
+      throw new InvalidSsoBrokerResponseError('email');
+    }
+    if (identityEmailDomain !== connection.emailDomain) {
+      throw new SsoOrganizationMismatchError();
+    }
+    return {
+      ...identity,
+      orgId: transaction.orgId,
+      postLoginPath: transaction.postLoginPath,
+    };
+  }
+
+  private singleState(parameters: URLSearchParams): string {
+    const values = parameters.getAll('state');
+    if (values.length !== 1 || values[0].length === 0) {
+      throw new InvalidSsoLoginTransactionError();
+    }
+    return values[0];
+  }
+
+  private browserBindingHash(binding: string | undefined): string {
+    if (!binding) {
+      throw new InvalidSsoLoginTransactionError();
+    }
+    return createHash('sha256').update(binding).digest('hex');
+  }
+}

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/discover-org-sso/discover-org-sso.query.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/discover-org-sso/discover-org-sso.query.ts
@@ -1,0 +1,3 @@
+export class DiscoverOrgSsoQuery {
+  constructor(readonly email: string) {}
+}

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/discover-org-sso/discover-org-sso.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/discover-org-sso/discover-org-sso.use-case.spec.ts
@@ -1,0 +1,55 @@
+import { InvalidSsoDiscoveryEmailError } from 'src/iam/sso/application/sso.errors';
+import { DiscoverOrgSsoQuery } from 'src/iam/sso/application/use-cases/discover-org-sso/discover-org-sso.query';
+import { DiscoverOrgSsoUseCase } from 'src/iam/sso/application/use-cases/discover-org-sso/discover-org-sso.use-case';
+import { createMockOrgSsoConnectionsRepository } from 'src/iam/sso/application/testing/org-sso-connection.fixtures';
+import { anEnabledSsoConnection } from 'src/iam/sso/application/testing/sso-login.fixtures';
+
+describe(DiscoverOrgSsoUseCase.name, () => {
+  it('returns only the non-secret routing identifier for an enabled connection', async () => {
+    const repository = createMockOrgSsoConnectionsRepository();
+    repository.findByEmailDomain.mockResolvedValue(anEnabledSsoConnection());
+    const useCase = new DiscoverOrgSsoUseCase(
+      createPinoLoggerMock(),
+      repository,
+    );
+
+    await expect(
+      useCase.execute(new DiscoverOrgSsoQuery('Staff@Demo.com')),
+    ).resolves.toEqual({
+      available: true,
+      orgId: 'f4fcdc42-176e-4d32-bd5b-6dad8d2426b4',
+    });
+    expect(repository.findByEmailDomain).toHaveBeenCalledWith('demo.com');
+  });
+
+  it.each([
+    ['unknown', null],
+    ['disabled', anEnabledSsoConnection({ enabled: false })],
+  ])('does not discover an %s connection', async (_case, connection) => {
+    const repository = createMockOrgSsoConnectionsRepository();
+    repository.findByEmailDomain.mockResolvedValue(connection);
+    const useCase = new DiscoverOrgSsoUseCase(
+      createPinoLoggerMock(),
+      repository,
+    );
+
+    await expect(
+      useCase.execute(new DiscoverOrgSsoQuery('staff@unknown.example')),
+    ).resolves.toEqual({ available: false });
+  });
+
+  it.each(['not-an-email', 'staff@invalid_domain', 'staff@dept@demo.com'])(
+    'rejects malformed email routing input %s',
+    async (email) => {
+      const useCase = new DiscoverOrgSsoUseCase(
+        createPinoLoggerMock(),
+        createMockOrgSsoConnectionsRepository(),
+      );
+
+      await expect(
+        useCase.execute(new DiscoverOrgSsoQuery(email)),
+      ).rejects.toBeInstanceOf(InvalidSsoDiscoveryEmailError);
+    },
+  );
+});
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/discover-org-sso/discover-org-sso.use-case.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/discover-org-sso/discover-org-sso.use-case.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { OrgSsoConnectionsRepository } from 'src/iam/sso/application/ports/org-sso-connections.repository';
+import {
+  InvalidSsoDiscoveryEmailError,
+  UnexpectedSsoError,
+} from 'src/iam/sso/application/sso.errors';
+import { DiscoverOrgSsoQuery } from 'src/iam/sso/application/use-cases/discover-org-sso/discover-org-sso.query';
+import { emailDomainFromAddress } from 'src/iam/sso/domain/sso-connection-values';
+
+export type SsoDiscoveryResult =
+  { available: false } | { available: true; orgId: string };
+
+@Injectable()
+export class DiscoverOrgSsoUseCase {
+  constructor(
+    @InjectPinoLogger(DiscoverOrgSsoUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly connections: OrgSsoConnectionsRepository,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedSsoError)
+  async execute(query: DiscoverOrgSsoQuery): Promise<SsoDiscoveryResult> {
+    this.logger.info('Discovering organization SSO connection');
+    const domain = this.emailDomain(query.email);
+    const connection = await this.connections.findByEmailDomain(domain);
+    if (!connection?.enabled || !connection.zitadelOrgId) {
+      return { available: false };
+    }
+    return { available: true, orgId: connection.orgId };
+  }
+
+  private emailDomain(email: string): string {
+    const domain = emailDomainFromAddress(email);
+    if (!domain) {
+      throw new InvalidSsoDiscoveryEmailError();
+    }
+    return domain;
+  }
+}

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/start-org-sso-login/start-org-sso-login.command.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/start-org-sso-login/start-org-sso-login.command.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class StartOrgSsoLoginCommand {
+  constructor(readonly orgId: UUID) {}
+}

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/start-org-sso-login/start-org-sso-login.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/start-org-sso-login/start-org-sso-login.use-case.spec.ts
@@ -1,0 +1,91 @@
+import { createHash } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { StartOrgSsoLoginCommand } from 'src/iam/sso/application/use-cases/start-org-sso-login/start-org-sso-login.command';
+import { StartOrgSsoLoginUseCase } from 'src/iam/sso/application/use-cases/start-org-sso-login/start-org-sso-login.use-case';
+import { createMockOrgSsoConnectionsRepository } from 'src/iam/sso/application/testing/org-sso-connection.fixtures';
+import {
+  anEnabledSsoConnection,
+  SSO_TEST_ORG_ID,
+} from 'src/iam/sso/application/testing/sso-login.fixtures';
+
+describe(StartOrgSsoLoginUseCase.name, () => {
+  it('stores only hashed state and encrypted secrets before redirecting', async () => {
+    const repository = createMockOrgSsoConnectionsRepository();
+    repository.findByOrgId.mockResolvedValue(anEnabledSsoConnection());
+    const transactions = {
+      save: jest.fn().mockImplementation(async (transaction) => transaction),
+      consume: jest.fn(),
+      deleteExpired: jest.fn(),
+    };
+    const broker = {
+      createAuthorizationRequest: jest.fn().mockResolvedValue({
+        authorizationUrl: 'https://sso.ayunis.de/oauth/v2/authorize',
+        state: 'oauth-state',
+        nonce: 'oidc-nonce',
+        codeVerifier: 'pkce-verifier',
+      }),
+      validateCallback: jest.fn(),
+    };
+    const encryption = {
+      encrypt: jest.fn((value: string) => `encrypted:${value}`),
+      decrypt: jest.fn(),
+    };
+    const useCase = new StartOrgSsoLoginUseCase(
+      createPinoLoggerMock(),
+      repository,
+      transactions,
+      broker,
+      encryption,
+    );
+
+    const result = await useCase.execute(
+      new StartOrgSsoLoginCommand(SSO_TEST_ORG_ID),
+    );
+    expect(result).toEqual({
+      authorizationUrl: 'https://sso.ayunis.de/oauth/v2/authorize',
+      browserBinding: expect.any(String),
+    });
+    expect(transactions.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgId: SSO_TEST_ORG_ID,
+        stateHash: createHash('sha256').update('oauth-state').digest('hex'),
+        browserBindingHash: createHash('sha256')
+          .update(result.browserBinding)
+          .digest('hex'),
+        postLoginPath: '/',
+        encryptedCodeVerifier: 'encrypted:pkce-verifier',
+        encryptedNonce: 'encrypted:oidc-nonce',
+      }),
+    );
+    expect(JSON.stringify(transactions.save.mock.calls)).not.toContain(
+      'oauth-state',
+    );
+    expect(JSON.stringify(transactions.save.mock.calls)).not.toContain(
+      result.browserBinding,
+    );
+  });
+
+  it.each([
+    ['missing', null],
+    ['disabled', anEnabledSsoConnection({ enabled: false })],
+    ['unmapped', anEnabledSsoConnection({ zitadelOrgId: null })],
+  ])('refuses a %s connection', async (_case, connection) => {
+    const repository = createMockOrgSsoConnectionsRepository();
+    repository.findByOrgId.mockResolvedValue(connection);
+    const useCase = new StartOrgSsoLoginUseCase(
+      createPinoLoggerMock(),
+      repository,
+      {
+        save: jest.fn(),
+        consume: jest.fn(),
+        deleteExpired: jest.fn(),
+      },
+      { createAuthorizationRequest: jest.fn(), validateCallback: jest.fn() },
+      { encrypt: jest.fn(), decrypt: jest.fn() },
+    );
+
+    await expect(
+      useCase.execute(new StartOrgSsoLoginCommand(SSO_TEST_ORG_ID)),
+    ).rejects.toMatchObject({ code: 'SSO_CONNECTION_NOT_AVAILABLE' });
+  });
+});

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/start-org-sso-login/start-org-sso-login.use-case.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/start-org-sso-login/start-org-sso-login.use-case.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@nestjs/common';
+import { createHash, randomBytes } from 'crypto';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { OidcBrokerClient } from 'src/iam/sso/application/ports/oidc-broker.client';
+import { OrgSsoConnectionsRepository } from 'src/iam/sso/application/ports/org-sso-connections.repository';
+import { SsoLoginTransactionEncryptionPort } from 'src/iam/sso/application/ports/sso-login-transaction-encryption.port';
+import { SsoLoginTransactionsRepository } from 'src/iam/sso/application/ports/sso-login-transactions.repository';
+import {
+  SsoConnectionNotAvailableError,
+  UnexpectedSsoError,
+} from 'src/iam/sso/application/sso.errors';
+import { StartOrgSsoLoginCommand } from 'src/iam/sso/application/use-cases/start-org-sso-login/start-org-sso-login.command';
+import { SsoLoginTransaction } from 'src/iam/sso/domain/sso-login-transaction.entity';
+
+const POST_LOGIN_PATH = '/';
+const LOGIN_TRANSACTION_TTL_MS = 10 * 60 * 1000;
+
+@Injectable()
+export class StartOrgSsoLoginUseCase {
+  constructor(
+    @InjectPinoLogger(StartOrgSsoLoginUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly connections: OrgSsoConnectionsRepository,
+    private readonly transactions: SsoLoginTransactionsRepository,
+    private readonly broker: OidcBrokerClient,
+    private readonly encryption: SsoLoginTransactionEncryptionPort,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedSsoError)
+  async execute(
+    command: StartOrgSsoLoginCommand,
+  ): Promise<{ authorizationUrl: string; browserBinding: string }> {
+    this.logger.info(
+      { orgId: command.orgId },
+      'Starting organization SSO login',
+    );
+    const connection = await this.connections.findByOrgId(command.orgId);
+    if (!connection?.enabled || !connection.zitadelOrgId) {
+      throw new SsoConnectionNotAvailableError();
+    }
+    const request = await this.broker.createAuthorizationRequest({
+      zitadelOrgId: connection.zitadelOrgId,
+    });
+    const browserBinding = randomBytes(32).toString('base64url');
+    await this.transactions.save(
+      new SsoLoginTransaction({
+        stateHash: createHash('sha256').update(request.state).digest('hex'),
+        browserBindingHash: createHash('sha256')
+          .update(browserBinding)
+          .digest('hex'),
+        postLoginPath: POST_LOGIN_PATH,
+        encryptedCodeVerifier: this.encryption.encrypt(request.codeVerifier),
+        encryptedNonce: this.encryption.encrypt(request.nonce),
+        orgId: connection.orgId,
+        zitadelOrgId: connection.zitadelOrgId,
+        expiresAt: new Date(Date.now() + LOGIN_TRANSACTION_TTL_MS),
+      }),
+    );
+    return { authorizationUrl: request.authorizationUrl, browserBinding };
+  }
+}

--- a/ayunis-core-backend/src/iam/sso/domain/sso-connection-values.ts
+++ b/ayunis-core-backend/src/iam/sso/domain/sso-connection-values.ts
@@ -4,6 +4,7 @@ export const EMAIL_DOMAIN_PATTERN =
   '^([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9])([.]([a-z0-9]|[a-z0-9][a-z0-9-]{0,61}[a-z0-9]))+$';
 
 const emailDomainRegex = new RegExp(EMAIL_DOMAIN_PATTERN);
+const invalidEmailLocalPartPattern = /[\p{White_Space}\p{Cc}]/u;
 const invalidZitadelOrgIdPattern = /[\p{White_Space}\p{Cc}]/u;
 
 export function normalizeEmailDomain(value: string): string {
@@ -12,6 +13,26 @@ export function normalizeEmailDomain(value: string): string {
     throw new InvalidSsoConnectionValueError('emailDomain');
   }
   return normalized;
+}
+
+export function emailDomainFromAddress(value: string): string | null {
+  const normalized = value.trim().toLowerCase();
+  const separator = normalized.indexOf('@');
+  if (
+    separator <= 0 ||
+    separator !== normalized.lastIndexOf('@') ||
+    invalidEmailLocalPartPattern.test(normalized.slice(0, separator))
+  ) {
+    return null;
+  }
+  try {
+    return normalizeEmailDomain(normalized.slice(separator + 1));
+  } catch (error) {
+    if (error instanceof InvalidSsoConnectionValueError) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 export function normalizeZitadelOrgId(value: string): string {

--- a/ayunis-core-backend/src/iam/sso/sso.module.ts
+++ b/ayunis-core-backend/src/iam/sso/sso.module.ts
@@ -5,10 +5,13 @@ import { OidcBrokerClient } from 'src/iam/sso/application/ports/oidc-broker.clie
 import { OrgSsoConnectionsRepository } from 'src/iam/sso/application/ports/org-sso-connections.repository';
 import { SsoLoginTransactionEncryptionPort } from 'src/iam/sso/application/ports/sso-login-transaction-encryption.port';
 import { SsoLoginTransactionsRepository } from 'src/iam/sso/application/ports/sso-login-transactions.repository';
+import { CompleteOrgSsoLoginUseCase } from 'src/iam/sso/application/use-cases/complete-org-sso-login/complete-org-sso-login.use-case';
 import { ConfigureOrgSsoConnectionUseCase } from 'src/iam/sso/application/use-cases/configure-org-sso-connection/configure-org-sso-connection.use-case';
+import { DiscoverOrgSsoUseCase } from 'src/iam/sso/application/use-cases/discover-org-sso/discover-org-sso.use-case';
 import { GetOrgSsoConnectionUseCase } from 'src/iam/sso/application/use-cases/get-org-sso-connection/get-org-sso-connection.use-case';
 import { SetOrgSsoEnabledUseCase } from 'src/iam/sso/application/use-cases/set-org-sso-enabled/set-org-sso-enabled.use-case';
 import { SetOrgSsoJitProvisioningUseCase } from 'src/iam/sso/application/use-cases/set-org-sso-jit-provisioning/set-org-sso-jit-provisioning.use-case';
+import { StartOrgSsoLoginUseCase } from 'src/iam/sso/application/use-cases/start-org-sso-login/start-org-sso-login.use-case';
 import { SsoLoginTransactionEncryptionService } from 'src/iam/sso/infrastructure/encryption/sso-login-transaction-encryption.service';
 import { ZitadelOidcBrokerClient } from 'src/iam/sso/infrastructure/oidc/zitadel-oidc-broker.client';
 import { OrgSsoConnectionMapper } from 'src/iam/sso/infrastructure/persistence/postgres/mappers/org-sso-connection.mapper';
@@ -54,6 +57,9 @@ import { SuperAdminSsoConnectionsController } from 'src/iam/sso/presenters/http/
     SetOrgSsoEnabledUseCase,
     SetOrgSsoJitProvisioningUseCase,
     GetOrgSsoConnectionUseCase,
+    DiscoverOrgSsoUseCase,
+    StartOrgSsoLoginUseCase,
+    CompleteOrgSsoLoginUseCase,
     SsoLoginTransactionCleanupTask,
   ],
   exports: [
@@ -61,6 +67,9 @@ import { SuperAdminSsoConnectionsController } from 'src/iam/sso/presenters/http/
     SetOrgSsoEnabledUseCase,
     SetOrgSsoJitProvisioningUseCase,
     GetOrgSsoConnectionUseCase,
+    DiscoverOrgSsoUseCase,
+    StartOrgSsoLoginUseCase,
+    CompleteOrgSsoLoginUseCase,
   ],
 })
 export class SsoModule {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches authentication orchestration, OIDC callback validation, and org/domain pinning; mistakes could allow cross-org login or accept replayed callbacks despite transaction checks.
> 
> **Overview**
> Adds **application-layer** org SSO login flow: **discover** by email domain, **start** a Zitadel-pinned authorization redirect, and **complete** the OIDC callback—without public HTTP endpoints or session issuance in this change.
> 
> **Discover** normalizes the email domain, looks up an enabled connection with a broker mapping, and returns only `{ available, orgId? }` (no secrets). **Start** refuses missing/disabled/unmapped connections, creates a broker auth request, persists a short-lived login transaction with hashed `state`/browser binding and encrypted PKCE verifier and nonce, and returns the authorization URL plus a browser binding token. **Complete** atomically consumes the transaction (state + browser binding), re-checks the connection is still enabled and pinned to the same Zitadel org, validates the callback via the broker, and enforces verified email, matching Zitadel org, and email domain before returning identity plus `orgId` and `postLoginPath`.
> 
> New errors cover unavailable connections, invalid/expired login transactions, and organization mismatch. Domain parsing gains `emailDomainFromAddress` for routing and callback checks. The three use cases are registered and exported from `SsoModule`; `SUMMARY.md` notes HTTP adapters and user admission remain separate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0eddb7f938f74fe37b831f2289ae66d0adfe84f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->