### PR TITLE
chore(agent-skills): update skills AYC-000

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -29,30 +29,42 @@ ayunis-core/
 
 Do NOT trust your own assessment of code correctness. Verify through observable behavior — lint, type-check, tests, and runtime. See the development skills below for specific validation sequences.
 
-### 2. Incremental Progress
+### 2. Evidence Before Diagnosis
+
+Principle 1 governs code you wrote. This one governs everything you *assert*: root causes, config values, provider behavior, "this is already fixed", "this should work".
+
+- **Reproduce before diagnosing.** A "likely root cause" derived from reading code and config is not an answer. Run the stack, trigger the failure, then explain it. Passing unit tests are not a substitute for one live request against the actual configured environment.
+- **Never recommend a config value you haven't verified.** An example value found in the repo (an API version, endpoint, model id) is not "the fix". Check it against current provider documentation and the deployed environment, or label it explicitly as unverified.
+- **Name the environment.** Staging and production run different config and different model deployments. State which environment/app your evidence came from before drawing a conclusion; evidence from the wrong environment invalidates the whole analysis.
+- **Report only failure modes the evidence supports.** Do not append extra suspected bugs or "regressions" inferred from general model knowledge to an incident report. If you have a hypothesis, label it as one to check — an unsupported claim presented alongside real findings costs more trust than it buys.
+- **Check what the code does today before proposing a design.** When assessing a ticket in a known repo, read the current implementation and say what it actually does now, rather than reasoning from the ticket's description of intended behavior.
+
+When an access path or tool fails, report the blocker immediately. Do not keep silently probing alternate routes — a named blocker is useful, a long invisible search is not.
+
+### 3. Incremental Progress
 
 - Make one change at a time
 - Validate after each change
 - Commit after each validated change
 - Never batch multiple logical changes
 
-### 3. Respect Boundaries
+### 4. Respect Boundaries
 
 - Read the target module's SUMMARY.md before making changes
 - Respect module boundaries — the `ayunis-core-backend` skill documents how cross-module work is done (application-layer code uses exported use cases from the target module, not ports/adapters; TypeORM schema records may reference records in other modules to declare foreign-key relations — see the `typeorm-migrations` skill)
 - Never edit generated code (e.g., the frontend API client)
 
-### 4. No Useless Comments
+### 5. No Useless Comments
 
 Only write a comment when it states something the code cannot: a non-obvious constraint, ordering requirement, or "why" (e.g., why an event fires *before* a delete). Never write comments that restate the name or body of the thing they annotate ("Returns the ids of every thread owned by a user" on `findAllIdsByUserId`, "// Delete the thread" above `threadsRepository.delete(...)`), narrate what the next line does, or summarize a well-named class a reader can grasp at a glance. If a comment would just paraphrase the code, improve the naming instead and write nothing.
 
-### 5. Simplest Sufficient Solution
+### 6. Simplest Sufficient Solution
 
 Lead with the solution a senior engineer would reach for, not the first mechanism that occurs to you. Before building bespoke machinery, ask whether this is a standard, already-solved problem — reach for the library/pattern/config that solves it directly.
 
 Watch for complexity creep. When a fix keeps growing — extra parameters, a watchdog, a budget, stall-reason plumbing — stop and name the tradeoff: *is the added complexity justified, or is a plainer approach enough?* Surface that question proactively rather than accreting machinery across iterations and waiting for the user to ask "is this worth it?". Often the right move is to challenge the constraint itself (e.g. "does a 300s ceiling even matter here?") instead of engineering around it.
 
-### 6. A Submitted PR Is Not Complete
+### 7. A Submitted PR Is Not Complete
 
 When work creates or updates a PR, submitting it is an intermediate step. Immediately load `finish-pr` and keep ownership until CI and Cursor Bugbot are clean on the latest submitted revision. Fix actionable findings, amend and resubmit, then repeat the verification loop. Never report PR work as complete while checks are pending or failing, Bugbot has not finished, or actionable findings remain. If verification is prevented by an external condition or the same finding survives three fix attempts, report the work as blocked with evidence instead of calling it done.
 

--- a/.claude/skills/appsignal-logs/SKILL.md
+++ b/.claude/skills/appsignal-logs/SKILL.md
@@ -1,58 +1,107 @@
 ---
 name: appsignal-logs
-description: Query Ayunis backend logs in AppSignal to inspect structured attributes (user.id, org.id, nestjs.context, custom metadata). Use when investigating production/staging log data or diagnosing an AppSignal incident — NOT for local dev logs (see backend-debugging).
+description: Query Ayunis deployed-environment telemetry in AppSignal — incidents, occurrence counts and error traces via the `appsignal-cli` binary; structured log attributes (user.id, org.id, nestjs.context, custom metadata) via the v2 logs API. Use when investigating a production/staging incident or log data — NOT for local dev logs (see backend-debugging).
 ---
 
-# AppSignal Logs
+# AppSignal
 
-Ayunis ships backend logs to AppSignal. When you need to inspect what a log line
-actually carried in production/staging — structured attributes like `user.id`,
-`org.id`, `nestjs.context`, or custom metadata — query AppSignal's **v2 logs API
-directly**. Do not rely on `appsignal-cli`.
+Ayunis ships backend logs and errors to AppSignal. There are **two** access paths
+and they answer different questions. Pick by the question, don't default to one.
 
-## The `appsignal-cli` trap — it hides structured attributes
+## Pick the tool by the question
+
+| Question | Tool |
+| --- | --- |
+| Is this incident still happening? How often, first/last seen? | `appsignal-cli` |
+| Which exception, what stack trace, which deploy? | `appsignal-cli` |
+| What did this log line actually carry — `user.id`, `org.id`, `nestjs.context`, custom metadata? | v2 logs API |
+
+**Incident-shaped ticket questions are answered from incident data, not from
+reading code.** "Is this fix realistic?", "how often does this happen?", "is this
+still occurring after the last deploy?", "is this already fixed?" — all of these
+need `appsignal-cli` before you form an opinion. A full PR was once built and then
+closed as a duplicate because an earlier ticket had already suppressed the error in
+a deployed revision and nobody checked the live incident first.
+
+## `appsignal-cli`
+
+**The binary is `appsignal-cli`, not `appsignal`.** `command -v appsignal`
+returning nothing does not mean the CLI is absent — check `appsignal-cli`.
+
+It is **already authenticated**: the CLI holds its own OAuth token in its config
+file (`~/Library/Application Support/appsignal/config.toml` on macOS). Nothing
+needs to be fetched from Bitwarden to use the CLI.
+
+```bash
+appsignal-cli --help                 # discover the current command surface
+appsignal-cli <subcommand> --help    # flags change between versions — check, don't guess
+appsignal-cli apps list              # app ids + environments
+```
+
+The CLI covers apps, incidents (occurrence counts, first/last seen), error traces,
+log search/sources, and deploy markers. Read `--help` rather than guessing flags.
+
+### Always name the environment
+
+Ayunis runs different config and different model deployments per environment.
+Before drawing any conclusion, confirm **which app/environment** you queried and
+say so in your report. A confident diagnosis built on production data presented as
+staging (or vice versa) is worse than no diagnosis — it has happened, and the
+whole analysis had to be thrown away.
+
+## The CLI's one blind spot — structured attributes
 
 `appsignal-cli` renders only AppSignal's **legacy `attributes` field**, which
 AppSignal is phasing out. Modern structured attributes are emitted under a separate
 **`json` field** that the CLI does not display — so the CLI shows `attributes: null`
 (or an empty object) even when the line is rich with structured data.
 
-**Consequence:** trusting the CLI produces a false-negative "the logs have no
-metadata / dotted keys are being dropped" diagnosis. That exact wrong conclusion has
-been reached twice from the CLI before the v2 API revealed the attributes were there
-all along. If a logging investigation hinges on "are attributes present?", query the
-API — never answer from the CLI.
+**Consequence:** trusting the CLI for *attribute presence* produces a false-negative
+"the logs have no metadata / dotted keys are being dropped" diagnosis. That exact
+wrong conclusion has been reached twice. If a logging investigation hinges on "are
+attributes present?", query the v2 API — never answer that question from the CLI.
 
-## Query the v2 logs API instead
+This is a narrow blind spot, not a reason to avoid the CLI for everything else.
 
-Structured attributes live in the `.json` field of each returned line:
+## Query the v2 logs API for attributes
+
+Structured attributes live in the `.json` field of each returned line. The request
+shape below is the one that currently works — `source_ids` is an **array**, and a
+`pagination` object is **required**:
 
 ```bash
-# APPSIGNAL_API_TOKEN — a personal/organization API token from Bitwarden
-# (search AppSignal). Pass it in via env; never inline the secret.
-curl -s -X POST "https://appsignal.com/api/v2/logs/lines?token=${APPSIGNAL_API_TOKEN}" \
+# TOKEN: the appsignal-cli OAuth token from its config.toml (see above), or an
+# AppSignal API token from Bitwarden (search AppSignal). Pass via env; never inline.
+curl -sS -X POST 'https://appsignal.com/api/v2/logs/lines' \
+  -H "Authorization: Bearer ${TOKEN}" \
   -H 'Content-Type: application/json' \
   -d '{
-        "site_id":  "<app/site id>",
-        "source_id":"<log source id>",
-        "query":    "",
-        "limit":    100
+        "from":       "2026-08-06T08:30:00Z",
+        "to":         "2026-08-06T08:55:00Z",
+        "source_ids": ["<log source id>"],
+        "query":      "message:\"Thread deleted successfully\"",
+        "pagination":  {"per_page": 100, "order": "ASC", "cursor": {"time": null}}
       }' \
 | jq '.[] | {timestamp, message, json}'   # <-- .json holds the real attributes
 ```
 
+- Auth is the **`Authorization: Bearer` header**. The old `?token=` query parameter
+  and the `site_id` / `source_id` / `limit` body fields no longer work.
 - The **`.json`** field is where `user.id`, `org.id`, `nestjs.context` and custom
   metadata appear. `.attributes` is the legacy field the CLI reads — expect it empty.
-- Get `site_id` (the AppSignal app) and `source_id` (the log source) from the AppSignal
-  UI URL for the logs view, or from `GET /api/v2/apps` with the same token.
-- Adjust `query`/time window to scope the search; `limit` defaults low, so set it.
+- Get the log `source_id` from `appsignal-cli` (log sources) or the AppSignal UI URL
+  for the logs view.
+- Scope with `from`/`to` and `query`; set `per_page` explicitly.
+
+If the API rejects a request, check AppSignal's current API docs before
+reverse-engineering — the schema has changed at least once.
 
 ## Secrets
 
-The API token is a Bitwarden item (AppSignal). Per skill conventions, this SKILL.md
-names the secret; the agent fetches it (`get-secret`) and exports it as
-`APPSIGNAL_API_TOKEN` before running the curl. Scripts must never call Bitwarden
-internally.
+For the v2 API you can reuse the CLI's own token or fetch the AppSignal API token
+from Bitwarden. Per skill conventions, this SKILL.md names the secret; the agent
+fetches it (`get-secret`) and exports it before running the curl. Scripts must
+never call Bitwarden internally.
 
 ## Scope
 

--- a/.claude/skills/ayunis-core-frontend-dev/SKILL.md
+++ b/.claude/skills/ayunis-core-frontend-dev/SKILL.md
@@ -58,6 +58,7 @@ Framework-level primitives live in the repository-root `packages/ui/` workspace 
 - Run shadcn registry commands from `packages/ui/`, whose `components.json` owns the aliases and registry configuration: `cd ../packages/ui && pnpm dlx shadcn@latest add <component>`.
 - Do not patch `packages/ui/src/components/` for a feature-specific use case. Wrap or compose the primitive in the relevant frontend `ui/` directory or `src/shared/ui/` instead.
 - Changes inside `packages/ui/` must remain application-independent and be intentional design-system work. If a primitive genuinely needs a new generic capability, confirm that scope with the user before changing it.
+- Every newly introduced `packages/ui/src/components/<name>.tsx` component must include a colocated `<name>.stories.tsx`. Cover its representative default state and meaningful generic variants, states, or interactions; compound components should be demonstrated as a usable composition.
 - Import primitives from their public subpaths, such as `@ayunis/ui/components/button`, and `cn` from `@ayunis/ui/lib/cn`. Do not reach into `packages/ui/src/` from the frontend.
 
 ### Reach for existing primitives and tokens
@@ -109,4 +110,5 @@ Use your harness's browser tooling to check the page renders and the console is 
 - [ ] No `any` types introduced
 - [ ] Import rules respected (no upward imports)
 - [ ] UI primitives use public `@ayunis/ui` subpaths
+- [ ] New `packages/ui` components include representative Storybook stories
 - [ ] No feature-specific behavior added to `packages/ui/`

--- a/.claude/skills/finish-pr/SKILL.md
+++ b/.claude/skills/finish-pr/SKILL.md
@@ -29,6 +29,35 @@ gh pr checks <pr-number> --watch --interval 30
 
 If no checks are visible immediately after submission, wait 30 seconds and query again. Do not interpret absent checks as success.
 
+### Zero runs created — check the platform before the repo
+
+If **no workflow runs exist at all** for the new head SHA after a couple of minutes, the cause is far more often platform-side than repo-side. Check that first, before diagnosing workflow triggers, branch filters, or re-pushing:
+
+```bash
+curl -s https://www.githubstatus.com/api/v2/summary.json \
+  | jq '.components[] | select(.name == "Actions") | {name, status}'
+gh run list --limit 10   # repo-wide: are other branches stuck too?
+```
+
+If Actions reports `degraded_performance` or `major_outage`, stop diagnosing the PR — go to the outage rule below. Runs that GitHub never created during an incident do not appear later on their own; they need a re-trigger *after* recovery.
+
+## 2b. External platform outage — report blocked, do not camp on it
+
+A confirmed platform incident is an **external condition**, which §5 already classifies as blocked. Blocked means hand back, not poll harder.
+
+- **Do not** sit in escalating in-session sleep loops, background watchers, or self-scheduled wake-ups waiting for a provider to recover. Sessions have burned 2–6 hours this way, across multiple PRs on the same day, while the answer was always "GitHub is down."
+- **Within ~1 hour** of confirming the incident, report the PR as blocked with the incident status and the exact SHA awaiting verification, and stop. Let the user decide whether to wait.
+- **Never push a no-op or empty commit** to force a `synchronize` event. It pollutes the branch history with meaningless SHAs and discards any Bugbot pass already earned on the real head.
+- **After recovery**, re-trigger with a same-SHA method so existing check results stay valid:
+
+  ```bash
+  gh pr close <pr-number> && gh pr reopen <pr-number>   # same SHA, re-fires triggers
+  ```
+
+  Do this **once**, and say in the report that you did it — closing and reopening is a visible mutation of PR state, not a silent recovery step. If it does not produce runs, report blocked rather than repeating it.
+
+The same applies to any external provider the loop depends on (Bugbot, the registry, Linear). Verify the incident is real before invoking this rule — a single failed check is not an outage.
+
 After the watch completes, inspect the final state explicitly:
 
 ```bash
@@ -75,7 +104,9 @@ Do not declare the task complete until all of these are true for every submitted
 - All Bugbot comments across the submitted stack were triaged and no actionable finding remains.
 - The local worktree is clean and the submitted branches contain every fix.
 
-A polling timeout is not success. Continue waiting and provide occasional progress updates. Report **blocked**, never **done**, when authentication, infrastructure, or another external condition prevents verification.
+A polling timeout is not success. Report **blocked**, never **done**, when authentication, infrastructure, or another external condition prevents verification.
+
+"Keep waiting" applies to checks that are *running* — queued jobs, a slow test suite, a Bugbot pass in flight. It does **not** license open-ended polling when nothing is running because the platform is down: that is the blocked case, and §2b governs it. If you have polled the same unchanged external condition more than a few times, you are no longer verifying — report and hand back.
 
 If the same CI failure or Bugbot finding survives three fix attempts, stop and escalate with the attempts and evidence. New findings on successive revisions are progress and restart the count for those findings.
 

--- a/.claude/skills/nestjs-hexagonal-backend/SKILL.md
+++ b/.claude/skills/nestjs-hexagonal-backend/SKILL.md
@@ -99,6 +99,26 @@ Every domain module ships a `SUMMARY.md`. Read it first when editing an existing
 └── [module].module.ts   # NestJS wiring
 ```
 
+### Extract module services by responsibility
+
+Keep each class focused on one cohesive responsibility. When a change introduces substantial state, lifecycle management, policy, coordination, caching, pooling, retrying, throttling, or other independently testable behavior, extract it into a dedicated injectable service in the same module instead of growing the existing use case or adapter.
+
+Use cases orchestrate reusable application services. Infrastructure adapters stay focused on translating between an application port and an external technology.
+
+Place the extracted service according to what it owns:
+
+- **`application/services/`** — reusable application or domain policy consumed by use cases.
+- **`infrastructure/.../*.service.ts`** — technical behavior tied to an SDK, transport, process lifecycle, cache, pool, queue, or another external mechanism. Application code depends on an application port rather than importing the concrete infrastructure service directly.
+
+Before extending an existing class, ask:
+
+1. Does the new behavior have a separate reason to change?
+2. Does it own independent state or lifecycle?
+3. Can it be named and tested independently?
+4. Could more than one operation or use case need it?
+
+If any answer is yes, prefer a dedicated module service, test it directly, and register it with the NestJS module. Keep a small behavior inline only when it is inseparable from the class's primary responsibility.
+
 ### File & class naming
 
 Suffixes carry structural meaning — the wrong one silently breaks the layer contract readers rely on and triggers review churn. **Before naming a new file, grep how the suffix is already used** (`find src -name "*.<suffix>.ts"`) and match that role.
@@ -153,6 +173,7 @@ For schema changes, use the `typeorm-migrations` skill. Never write migrations b
 - [ ] DTOs have validation decorators
 - [ ] New entities have proper mappers
 - [ ] New module has a `SUMMARY.md` at its root (the repo convention; missing files are flagged by Bugbot)
+- [ ] New stateful or reusable responsibilities are extracted into dedicated module services
 
 ## Anti-Patterns
 

--- a/.claude/skills/ui-storybook/SKILL.md
+++ b/.claude/skills/ui-storybook/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: ui-storybook
+description: Start, inspect, and stop the @ayunis/ui Storybook for Ayunis Core. Use when reviewing UI package components or stories in a browser.
+---
+
+# UI Storybook
+
+Run all commands from the Ayunis Core repository root.
+
+## Start
+
+```bash
+./storybook up
+```
+
+Storybook starts in a checkout-specific tmux session and is available at `http://localhost:6006`. The command waits until the server is ready.
+
+If port 6006 is occupied, do not stop the process using it. Choose another port:
+
+```bash
+STORYBOOK_PORT=6016 ./storybook up
+```
+
+Use the same `STORYBOOK_PORT` value for subsequent status, log, and shutdown commands.
+
+## Inspect
+
+```bash
+./storybook status
+./storybook logs
+TAIL=200 ./storybook logs
+```
+
+## Stop
+
+```bash
+./storybook down
+```
+
+Always stop Storybook through this command. It sends Ctrl-C only to the checkout-specific tmux session created by `./storybook up`; never kill a process by PID.
+
+## Validate stories
+
+```bash
+cd packages/ui
+pnpm typecheck
+pnpm lint
+pnpm deps:check
+pnpm storybook:build
+```

--- a/.claude/skills/use-case-reference/SKILL.md
+++ b/.claude/skills/use-case-reference/SKILL.md
@@ -31,7 +31,7 @@ export class DoSomethingUseCase {
 
   constructor(
     private readonly entityRepository: EntityRepository,
-    // ... other dependencies (other use cases, infra services, etc.)
+    // ... other dependencies (other use cases, application services, ports)
   ) {}
 
   // Error handling — REQUIRED on every execute(), see Rule 1
@@ -39,7 +39,7 @@ export class DoSomethingUseCase {
   async execute(command: DoSomethingCommand): Promise<Entity> {
     this.logger.log('Doing something', { entityId: command.entityId });
 
-    // 1. Auth context — handling varies by project, see Rule 5 below
+    // 1. Auth context — handling varies by project, see Rule 6 below
 
     // 2. Precondition checks (existence, permissions, business rules)
     // (multi-tenant projects typically pass userId here for tenant isolation)
@@ -93,7 +93,22 @@ Use cases throw `ApplicationError` subclasses. The global exception filter conve
 
 A use case is a single business operation. Don't bundle multiple operations into one class with `execute1()` / `execute2()`. If you need two operations, write two use cases.
 
-### 4. Inject repositories via the repository class — never database clients directly
+### 4. Extract broader responsibilities into application services
+
+A use case represents one operation; it must not become the home for a broader capability. Extract cohesive policy, coordination, caching, batching, throttling, lifecycle management, or other independently testable and reusable behavior into a dedicated injectable service in the module.
+
+Place reusable application behavior in `application/services/` and inject that service into each consuming use case. If the behavior is a technical mechanism tied to infrastructure, define an application port and keep the concrete service in infrastructure; use cases must not import concrete adapters.
+
+Extract the responsibility when it has its own reason to change, owns state or lifecycle, can be named and tested independently, or could serve more than one operation. Keep code inline only when it is inseparable from that single use case.
+
+```typescript
+constructor(
+  private readonly policyService: EntityPolicyService,
+  private readonly externalCapability: ExternalCapabilityPort,
+) {}
+```
+
+### 5. Inject repositories via the repository class — never database clients directly
 
 Use cases depend on a repository class. They MUST NOT import a database client (TypeORM, Drizzle, raw `pg`, etc.) directly. This keeps the use case testable without a real database.
 
@@ -105,7 +120,7 @@ constructor(
 
 Whether `EntityRepository` is an **abstract class** with a separate concrete implementation bound via `{ provide: EntityRepository, useClass: ConcreteRepository }` (port/adapter pattern), or a **single concrete class** registered directly in `providers: [EntityRepository]`, is a project-level decision — see your project's structural conventions skill. In both cases the use case constructor looks the same: TypeScript reflection picks up the class as the DI token, so **no `@Inject()` decorator is needed**.
 
-### 5. Auth context — varies by project
+### 6. Auth context — varies by project
 
 Auth handling is a project-level convention. Common patterns:
 
@@ -121,7 +136,7 @@ Auth handling is a project-level convention. Common patterns:
 
 Whichever pattern your project uses, apply it consistently inside `execute()`. **Never** accept `userId` ad-hoc in some use cases and not others.
 
-### 6. Validate preconditions before mutating
+### 7. Validate preconditions before mutating
 
 Always check existence and permissions before performing writes:
 
@@ -134,7 +149,7 @@ if (!entity) {
 // Only then proceed with mutation
 ```
 
-### 7. Each module has its own errors file
+### 8. Each module has its own errors file
 
 Errors live in a module-specific errors file (e.g. `application/<module>.errors.ts`):
 
@@ -171,7 +186,7 @@ export class UnexpectedEntityError extends EntityError {
 
 Every module MUST have an `Unexpected*Error` class for the `@HandleUnexpectedErrors` decorator.
 
-### 8. Logger — use the class name, log entry
+### 9. Logger — use the class name, log entry
 
 ```typescript
 private readonly logger = new Logger(MyUseCase.name);
@@ -189,8 +204,10 @@ When creating or modifying a use case, verify:
 - [ ] `execute()` is decorated with `@HandleUnexpectedErrors(Unexpected*Error)`
 - [ ] No hand-written try/catch error boundary in `execute()`
 - [ ] No HTTP exceptions (`NotFoundException`, `UnauthorizedException`, etc.)
-- [ ] Auth context handled per the project's convention (Rule 5)
+- [ ] Auth context handled per the project's convention (Rule 6)
 - [ ] Preconditions checked before mutations (entity exists, permissions valid)
 - [ ] Repositories injected via DI token (interface), not concrete class
+- [ ] Broader reusable responsibilities are delegated to application services or ports
+- [ ] Use cases do not import concrete infrastructure services or adapters
 - [ ] Module has an `Unexpected*Error` class in its errors file
 - [ ] Logger uses class name, logs entry point (error logging is the decorator's job)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes to Claude agent skills and guidelines; no runtime, auth, or data-path code is modified.
> 
> **Overview**
> Updates Claude agent skills and core guidelines to prevent recurring investigation and architecture mistakes. No application code changes.
> 
> Adds an **Evidence Before Diagnosis** principle in `CLAUDE.md`: reproduce failures live, verify config against the named environment, and avoid unsupported claims.
> 
> Reworks `appsignal-logs` to prefer `appsignal-cli` for incident frequency/traces, keep the v2 logs API only for structured attributes, and document the current Bearer + `source_ids`/`pagination` request shape.
> 
> Adds a `ui-storybook` skill and requires colocated Storybook stories for new `packages/ui` components. Extends `finish-pr` with GitHub Actions outage handling (check status, report blocked, re-trigger via close/reopen). Backend skills now require extracting reusable/stateful behavior into dedicated application or infrastructure services instead of growing use cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 088747e71d3fbc869a3e992f800738508c8c5c1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->