### PR TITLE
fix(chat): keep tool activity open until assistant responds (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimeline.test.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimeline.test.tsx
@@ -246,6 +246,52 @@ describe('AgentRunTimeline', () => {
     );
   });
 
+  it('keeps completed activity expanded until assistant text arrives', () => {
+    const activityBlock = {
+      kind: 'activity' as const,
+      key: 'completed-activity',
+      steps: [
+        {
+          kind: 'tool' as const,
+          key: 'completed-tool',
+          status: 'done' as const,
+          toolUse: {
+            type: 'tool_use' as const,
+            id: 'completed-tool',
+            name: 'internet_search',
+            params: {},
+          },
+        },
+      ],
+    };
+    const { rerender } = render(
+      <AgentRunTimeline
+        unit={{ ...unit, blocks: [activityBlock], isStreaming: true }}
+      />,
+    );
+
+    expect(screen.getByTestId('step-completed-tool')).toBeTruthy();
+
+    rerender(
+      <AgentRunTimeline
+        unit={{
+          ...unit,
+          blocks: [
+            activityBlock,
+            {
+              kind: 'text',
+              key: 'assistant-answer',
+              content: { type: 'text', text: 'answer' },
+            },
+          ],
+          isStreaming: true,
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId('step-completed-tool')).toBeNull();
+  });
+
   it('does not render the response-start orb after timeline content exists', () => {
     render(<AgentRunTimeline unit={{ ...unit, isStreaming: true }} />);
 

--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimeline.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimeline.tsx
@@ -47,6 +47,9 @@ export default function AgentRunTimeline({
           key={block.key}
           block={block}
           index={index}
+          hasFollowingText={unit.blocks
+            .slice(index + 1)
+            .some((candidate) => candidate.kind === 'text')}
           threadId={threadId}
           onOpenArtifact={onOpenArtifact}
         />
@@ -66,6 +69,7 @@ function hasInProgressStep(block: AgentRunBlock): boolean {
 interface RunBlockProps {
   block: AgentRunBlock;
   index: number;
+  hasFollowingText: boolean;
   threadId?: string;
   onOpenArtifact?: (artifactId: string) => void;
 }
@@ -73,11 +77,12 @@ interface RunBlockProps {
 function RunBlock({
   block,
   index,
+  hasFollowingText,
   threadId,
   onOpenArtifact,
 }: Readonly<RunBlockProps>) {
   if (block.kind === 'activity') {
-    return <ActivityBlock block={block} />;
+    return <ActivityBlock block={block} hasFollowingText={hasFollowingText} />;
   }
   if (block.kind === 'rich-tool' || block.kind === 'pending-tool') {
     return (
@@ -96,16 +101,20 @@ function RunBlock({
   );
 }
 
-function ActivityBlock({ block }: Readonly<{ block: ActivityRunBlock }>) {
+function ActivityBlock({
+  block,
+  hasFollowingText,
+}: Readonly<{ block: ActivityRunBlock; hasFollowingText: boolean }>) {
   const { t } = useTranslation('chat');
   const isActive = block.steps.some((step) => step.status === 'in_progress');
   const [userOpen, setUserOpen] = useState<boolean | null>(null);
-  const [lastActive, setLastActive] = useState(isActive);
-  if (lastActive !== isActive) {
-    setLastActive(isActive);
+  const [previousHasFollowingText, setPreviousHasFollowingText] =
+    useState(hasFollowingText);
+  if (previousHasFollowingText !== hasFollowingText) {
+    setPreviousHasFollowingText(hasFollowingText);
     setUserOpen(null);
   }
-  const open = userOpen ?? isActive;
+  const open = userOpen ?? !hasFollowingText;
   const headerLabel = isActive
     ? t('chat.timeline.working')
     : t('chat.timeline.summary', { count: block.steps.length });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only collapsible state change in the chat timeline with no auth, data, or API impact. Covered by a focused unit test.
> 
> **Overview**
> Keeps completed tool **activity** sections expanded in the chat timeline until the assistant’s text reply appears, instead of collapsing as soon as tools finish.
> 
> `ActivityBlock` now defaults open based on whether a later `text` block exists (`hasFollowingText`), and resets manual open/close when that flag changes. Adds a regression test covering the expand-until-answer behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55f3f3a0b7a1412428300628094804f841f9136b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->