### PR TITLE
wip(favorites): add ordered user favorites (AYC-700)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,6 +50,7 @@ ayunis-core/
 | [academy](ayunis-core-backend/src/domain/academy/SUMMARY.md) | Learning | Academy chapters and lessons managed by super admins |
 | [anonymization-settings](ayunis-core-backend/src/domain/anonymization-settings) | Privacy Config | Org-level PII whitelist for anonymous mode |
 | [thread-pii-masks](ayunis-core-backend/src/domain/thread-pii-masks/SUMMARY.md) | Privacy | Per-thread PII mask dictionary for anonymous mode |
+| [favorites](ayunis-core-backend/src/domain/favorites/SUMMARY.md) | Favorites | User-owned ordered references resolved for navigation |
 
 ### IAM Modules — Identity & Access Management
 

--- a/ayunis-core-backend/src/app/app.module.ts
+++ b/ayunis-core-backend/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { SkillTemplatesModule } from '../domain/skill-templates/skill-templates.
 import { AcademyModule } from '../domain/academy/academy.module';
 import { ArtifactsModule } from '../domain/artifacts/artifacts.module';
 import { LetterheadsModule } from '../domain/letterheads/letterheads.module';
+import { FavoritesModule } from '../domain/favorites/favorites.module';
 import { OpenAICompatModule } from '../domain/openai-compat/openai-compat.module';
 import { IamModule } from '../iam/iam.module';
 
@@ -138,6 +139,7 @@ import { IntegrationsModule } from '../integrations/integrations.module';
     AcademyModule,
     ArtifactsModule,
     LetterheadsModule,
+    FavoritesModule,
     OpenAICompatModule,
     IamModule.register({
       authProvider:

--- a/ayunis-core-backend/src/db/migrations/1786528759738-CreateFavorites.ts
+++ b/ayunis-core-backend/src/db/migrations/1786528759738-CreateFavorites.ts
@@ -1,0 +1,33 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateFavorites1786528759738 implements MigrationInterface {
+  name = 'CreateFavorites1786528759738';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."favorites_referencetype_enum" AS ENUM('workspace', 'thread')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "favorites" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "userId" character varying NOT NULL, "referenceType" "public"."favorites_referencetype_enum" NOT NULL, "referenceId" character varying NOT NULL, "position" integer NOT NULL, CONSTRAINT "UQ_b527413b952a9febee24eb49e9f" UNIQUE ("userId", "position"), CONSTRAINT "UQ_205f0e1f423660b759b3f7dc8e5" UNIQUE ("userId", "referenceType", "referenceId"), CONSTRAINT "CHK_68a1c85789c6e1d0bd42e790f4" CHECK ("position" >= 0), CONSTRAINT "PK_890818d27523748dd36a4d1bdc8" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_e747534006c6e3c2f09939da60" ON "favorites" ("userId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "favorites" ADD CONSTRAINT "FK_e747534006c6e3c2f09939da60f" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "favorites" DROP CONSTRAINT "FK_e747534006c6e3c2f09939da60f"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_e747534006c6e3c2f09939da60"`,
+    );
+    await queryRunner.query(`DROP TABLE "favorites"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."favorites_referencetype_enum"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/favorites/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/favorites/SUMMARY.md
@@ -1,0 +1,49 @@
+# Favorites Module
+
+## Purpose
+
+Favorites are one user-owned, ordered collection of typed references. The
+module keeps persistence and ordering independent of where favorites are
+rendered; the current sidebar may call the interaction “pinning”.
+
+## Domain
+
+Each `Favorite` contains a strict `FavoriteReferenceType`, a UUID
+`referenceId`, its owning user, and a non-negative position. The closed enum
+currently supports workspaces and threads. Adding another target requires an
+enum value plus resolver support in a later layer.
+
+The database intentionally has no foreign key from `referenceId`: one column
+can reference multiple target tables. A user/reference uniqueness constraint
+prevents duplicate favorites, and a user/position constraint protects order.
+
+## Ports
+
+- **`FavoritesRepository`** — `findAllByUserId`, `append`, `remove`,
+  `removeByReference`, `reorder`. `append` assigns the end position atomically
+  inside the insert and treats an already-favorited reference as a no-op;
+  two concurrent appends can still race to the same position, which surfaces
+  as a user/position unique violation and is retried with a bounded number
+  of attempts.
+
+## Use Cases
+
+- **`AddFavoriteUseCase`** — Appends a favorite for a user; adding an existing
+  reference is a no-op. Callers own access checks.
+- **`ReorderFavoritesUseCase`** — Reorders the caller's favorites; unknown ids
+  are ignored and omitted favorites keep their relative order at the end.
+- **`RemoveFavoriteReferenceUseCase`** — Deletes every favorite row matching a
+  reference type/id (used when a target is deleted).
+
+## Infrastructure
+
+- **`LocalFavoritesRepository`** — TypeORM implementation backed by the
+  `favorites` table.
+- **`FavoriteRecord`** — TypeORM entity with user/reference and user/position
+  uniqueness; `@Check` enforces non-negative positions.
+- **`FavoriteMapper`** — Domain ↔ Record conversion.
+
+## Exports
+
+- `AddFavoriteUseCase`, `ReorderFavoritesUseCase`,
+  `RemoveFavoriteReferenceUseCase`

--- a/ayunis-core-backend/src/domain/favorites/application/favorites.errors.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/favorites.errors.ts
@@ -1,0 +1,29 @@
+import type { ErrorMetadata } from 'src/common/errors/base.error';
+import { ApplicationError } from 'src/common/errors/base.error';
+
+export enum FavoriteErrorCode {
+  UNEXPECTED_FAVORITE_ERROR = 'UNEXPECTED_FAVORITE_ERROR',
+}
+
+export abstract class FavoriteError extends ApplicationError {
+  constructor(
+    message: string,
+    code: FavoriteErrorCode,
+    statusCode: number = 400,
+    metadata?: ErrorMetadata,
+  ) {
+    super(message, code, statusCode, metadata);
+  }
+}
+
+export class UnexpectedFavoriteError extends FavoriteError {
+  constructor(error: Error, metadata?: ErrorMetadata) {
+    super(
+      'Unexpected favorite error',
+      FavoriteErrorCode.UNEXPECTED_FAVORITE_ERROR,
+      500,
+      metadata,
+    );
+    this.cause = error;
+  }
+}

--- a/ayunis-core-backend/src/domain/favorites/application/ports/favorites-repository.port.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/ports/favorites-repository.port.ts
@@ -1,0 +1,23 @@
+import type { UUID } from 'crypto';
+import type { Favorite } from '../../domain/favorite.entity';
+import type { FavoriteReferenceType } from '../../domain/value-objects/favorite-reference-type.enum';
+
+export abstract class FavoritesRepository {
+  abstract findAllByUserId(userId: UUID): Promise<Favorite[]>;
+  /**
+   * Appends a favorite at the end of the user's order. Must be atomic and
+   * idempotent: concurrent appends may not fail on the user/position
+   * uniqueness constraint, and re-appending an existing reference is a no-op.
+   */
+  abstract append(
+    userId: UUID,
+    referenceType: FavoriteReferenceType,
+    referenceId: UUID,
+  ): Promise<void>;
+  abstract remove(favorite: Favorite): Promise<void>;
+  abstract removeByReference(
+    referenceType: FavoriteReferenceType,
+    referenceId: UUID,
+  ): Promise<void>;
+  abstract reorder(userId: UUID, favoriteIds: UUID[]): Promise<void>;
+}

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/add-favorite/add-favorite.command.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/add-favorite/add-favorite.command.ts
@@ -1,0 +1,10 @@
+import type { UUID } from 'crypto';
+import type { FavoriteReferenceType } from '../../../domain/value-objects/favorite-reference-type.enum';
+
+export class AddFavoriteCommand {
+  constructor(
+    public readonly userId: UUID,
+    public readonly referenceType: FavoriteReferenceType,
+    public readonly referenceId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/add-favorite/add-favorite.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/add-favorite/add-favorite.use-case.spec.ts
@@ -1,0 +1,39 @@
+import type { UUID } from 'crypto';
+import type { FavoritesRepository } from '../../ports/favorites-repository.port';
+import { FavoriteReferenceType } from '../../../domain/value-objects/favorite-reference-type.enum';
+import { AddFavoriteCommand } from './add-favorite.command';
+import { AddFavoriteUseCase } from './add-favorite.use-case';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111' as UUID;
+const WORKSPACE_ID = '22222222-2222-4222-8222-222222222222' as UUID;
+
+describe('AddFavoriteUseCase', () => {
+  it('appends the reference for the user', async () => {
+    const repository = createRepository();
+    const useCase = new AddFavoriteUseCase(repository);
+
+    await useCase.execute(
+      new AddFavoriteCommand(
+        USER_ID,
+        FavoriteReferenceType.Workspace,
+        WORKSPACE_ID,
+      ),
+    );
+
+    expect(repository.append).toHaveBeenCalledWith(
+      USER_ID,
+      FavoriteReferenceType.Workspace,
+      WORKSPACE_ID,
+    );
+  });
+});
+
+function createRepository(): jest.Mocked<FavoritesRepository> {
+  return {
+    findAllByUserId: jest.fn(),
+    append: jest.fn().mockResolvedValue(undefined),
+    remove: jest.fn(),
+    removeByReference: jest.fn(),
+    reorder: jest.fn(),
+  };
+}

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/add-favorite/add-favorite.use-case.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/add-favorite/add-favorite.use-case.ts
@@ -1,0 +1,27 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnexpectedFavoriteError } from '../../favorites.errors';
+import { FavoritesRepository } from '../../ports/favorites-repository.port';
+import { AddFavoriteCommand } from './add-favorite.command';
+
+@Injectable()
+export class AddFavoriteUseCase {
+  private readonly logger = new Logger(AddFavoriteUseCase.name);
+
+  constructor(private readonly favoritesRepository: FavoritesRepository) {}
+
+  @HandleUnexpectedErrors(UnexpectedFavoriteError)
+  async execute(command: AddFavoriteCommand): Promise<void> {
+    this.logger.log('Adding favorite', {
+      userId: command.userId,
+      referenceType: command.referenceType,
+      referenceId: command.referenceId,
+    });
+
+    await this.favoritesRepository.append(
+      command.userId,
+      command.referenceType,
+      command.referenceId,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/remove-favorite-reference/remove-favorite-reference.command.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/remove-favorite-reference/remove-favorite-reference.command.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+import type { FavoriteReferenceType } from '../../../domain/value-objects/favorite-reference-type.enum';
+
+export class RemoveFavoriteReferenceCommand {
+  constructor(
+    public readonly referenceType: FavoriteReferenceType,
+    public readonly referenceId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/remove-favorite-reference/remove-favorite-reference.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/remove-favorite-reference/remove-favorite-reference.use-case.spec.ts
@@ -1,0 +1,36 @@
+import type { UUID } from 'crypto';
+import type { FavoritesRepository } from '../../ports/favorites-repository.port';
+import { FavoriteReferenceType } from '../../../domain/value-objects/favorite-reference-type.enum';
+import { RemoveFavoriteReferenceCommand } from './remove-favorite-reference.command';
+import { RemoveFavoriteReferenceUseCase } from './remove-favorite-reference.use-case';
+
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111' as UUID;
+
+describe('RemoveFavoriteReferenceUseCase', () => {
+  it('removes the deleted reference from every user favorite list', async () => {
+    const repository = createRepository();
+    const useCase = new RemoveFavoriteReferenceUseCase(repository);
+
+    await useCase.execute(
+      new RemoveFavoriteReferenceCommand(
+        FavoriteReferenceType.Workspace,
+        WORKSPACE_ID,
+      ),
+    );
+
+    expect(repository.removeByReference).toHaveBeenCalledWith(
+      FavoriteReferenceType.Workspace,
+      WORKSPACE_ID,
+    );
+  });
+});
+
+function createRepository(): jest.Mocked<FavoritesRepository> {
+  return {
+    findAllByUserId: jest.fn(),
+    append: jest.fn(),
+    remove: jest.fn(),
+    removeByReference: jest.fn().mockResolvedValue(undefined),
+    reorder: jest.fn(),
+  };
+}

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/remove-favorite-reference/remove-favorite-reference.use-case.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/remove-favorite-reference/remove-favorite-reference.use-case.ts
@@ -1,0 +1,24 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { FavoritesRepository } from '../../ports/favorites-repository.port';
+import { UnexpectedFavoriteError } from '../../favorites.errors';
+import { RemoveFavoriteReferenceCommand } from './remove-favorite-reference.command';
+
+@Injectable()
+export class RemoveFavoriteReferenceUseCase {
+  private readonly logger = new Logger(RemoveFavoriteReferenceUseCase.name);
+
+  constructor(private readonly favoritesRepository: FavoritesRepository) {}
+
+  @HandleUnexpectedErrors(UnexpectedFavoriteError)
+  async execute(command: RemoveFavoriteReferenceCommand): Promise<void> {
+    this.logger.log('Removing favorite reference', {
+      referenceType: command.referenceType,
+      referenceId: command.referenceId,
+    });
+    await this.favoritesRepository.removeByReference(
+      command.referenceType,
+      command.referenceId,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/reorder-favorites/reorder-favorites.command.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/reorder-favorites/reorder-favorites.command.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class ReorderFavoritesCommand {
+  constructor(public readonly favoriteIds: UUID[]) {}
+}

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/reorder-favorites/reorder-favorites.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/reorder-favorites/reorder-favorites.use-case.spec.ts
@@ -1,0 +1,66 @@
+import { randomUUID } from 'crypto';
+import type { UUID } from 'crypto';
+import type { ContextService } from 'src/common/context/services/context.service';
+import type { FavoritesRepository } from '../../ports/favorites-repository.port';
+import { Favorite } from '../../../domain/favorite.entity';
+import { FavoriteReferenceType } from '../../../domain/value-objects/favorite-reference-type.enum';
+import { ReorderFavoritesCommand } from './reorder-favorites.command';
+import { ReorderFavoritesUseCase } from './reorder-favorites.use-case';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111' as UUID;
+const FIRST_FAVORITE_ID = '22222222-2222-4222-8222-222222222222' as UUID;
+const SECOND_FAVORITE_ID = '33333333-3333-4333-8333-333333333333' as UUID;
+
+describe('ReorderFavoritesUseCase', () => {
+  it('places omitted owned favorites after the requested order', async () => {
+    const first = createFavorite(FIRST_FAVORITE_ID, 0);
+    const second = createFavorite(SECOND_FAVORITE_ID, 1);
+    const repository = createRepository([first, second]);
+    const useCase = new ReorderFavoritesUseCase(
+      repository,
+      createContextService(),
+    );
+
+    const result = await useCase.execute(
+      new ReorderFavoritesCommand([SECOND_FAVORITE_ID]),
+    );
+
+    expect(result.map((favorite) => favorite.id)).toEqual([
+      SECOND_FAVORITE_ID,
+      FIRST_FAVORITE_ID,
+    ]);
+    expect(result.map((favorite) => favorite.position)).toEqual([0, 1]);
+    expect(repository.reorder).toHaveBeenCalledWith(USER_ID, [
+      SECOND_FAVORITE_ID,
+      FIRST_FAVORITE_ID,
+    ]);
+  });
+});
+
+function createFavorite(id: UUID, position: number): Favorite {
+  return new Favorite({
+    id,
+    userId: USER_ID,
+    referenceType: FavoriteReferenceType.Thread,
+    referenceId: randomUUID(),
+    position,
+  });
+}
+
+function createRepository(
+  favorites: Favorite[],
+): jest.Mocked<FavoritesRepository> {
+  return {
+    findAllByUserId: jest.fn().mockResolvedValue(favorites),
+    append: jest.fn(),
+    remove: jest.fn(),
+    removeByReference: jest.fn(),
+    reorder: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createContextService(): jest.Mocked<ContextService> {
+  return {
+    get: jest.fn((key: string) => (key === 'userId' ? USER_ID : undefined)),
+  } as unknown as jest.Mocked<ContextService>;
+}

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/reorder-favorites/reorder-favorites.use-case.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/reorder-favorites/reorder-favorites.use-case.ts
@@ -1,0 +1,62 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { ContextService } from 'src/common/context/services/context.service';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import type { Favorite } from '../../../domain/favorite.entity';
+import { FavoritesRepository } from '../../ports/favorites-repository.port';
+import { UnexpectedFavoriteError } from '../../favorites.errors';
+import { ReorderFavoritesCommand } from './reorder-favorites.command';
+
+@Injectable()
+export class ReorderFavoritesUseCase {
+  private readonly logger = new Logger(ReorderFavoritesUseCase.name);
+
+  constructor(
+    private readonly favoritesRepository: FavoritesRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedFavoriteError)
+  async execute(command: ReorderFavoritesCommand): Promise<Favorite[]> {
+    this.logger.log('Reordering favorites', {
+      count: command.favoriteIds.length,
+    });
+    const userId = this.requireUserId();
+    const current = await this.favoritesRepository.findAllByUserId(userId);
+    const currentById = new Map(
+      current.map((favorite) => [favorite.id, favorite]),
+    );
+    const requested = this.resolveRequested(command.favoriteIds, currentById);
+    const requestedIds = new Set(requested.map((favorite) => favorite.id));
+    const ordered = [
+      ...requested,
+      ...current.filter((favorite) => !requestedIds.has(favorite.id)),
+    ];
+
+    await this.favoritesRepository.reorder(
+      userId,
+      ordered.map((favorite) => favorite.id),
+    );
+    return ordered.map((favorite, position) => {
+      favorite.position = position;
+      return favorite;
+    });
+  }
+
+  private resolveRequested(
+    favoriteIds: UUID[],
+    currentById: Map<UUID, Favorite>,
+  ): Favorite[] {
+    return [...new Set(favoriteIds)].flatMap((id) => {
+      const favorite = currentById.get(id);
+      return favorite ? [favorite] : [];
+    });
+  }
+
+  private requireUserId(): UUID {
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+    return userId;
+  }
+}

--- a/ayunis-core-backend/src/domain/favorites/domain/favorite.entity.ts
+++ b/ayunis-core-backend/src/domain/favorites/domain/favorite.entity.ts
@@ -1,0 +1,25 @@
+import { randomUUID } from 'crypto';
+import type { UUID } from 'crypto';
+import type { FavoriteReferenceType } from './value-objects/favorite-reference-type.enum';
+
+export class Favorite {
+  public readonly id: UUID;
+  public readonly userId: UUID;
+  public readonly referenceType: FavoriteReferenceType;
+  public readonly referenceId: UUID;
+  public position: number;
+
+  constructor(params: {
+    id?: UUID;
+    userId: UUID;
+    referenceType: FavoriteReferenceType;
+    referenceId: UUID;
+    position: number;
+  }) {
+    this.id = params.id ?? randomUUID();
+    this.userId = params.userId;
+    this.referenceType = params.referenceType;
+    this.referenceId = params.referenceId;
+    this.position = params.position;
+  }
+}

--- a/ayunis-core-backend/src/domain/favorites/domain/value-objects/favorite-reference-type.enum.ts
+++ b/ayunis-core-backend/src/domain/favorites/domain/value-objects/favorite-reference-type.enum.ts
@@ -1,0 +1,4 @@
+export enum FavoriteReferenceType {
+  Workspace = 'workspace',
+  Thread = 'thread',
+}

--- a/ayunis-core-backend/src/domain/favorites/favorites.module.ts
+++ b/ayunis-core-backend/src/domain/favorites/favorites.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { AddFavoriteUseCase } from './application/use-cases/add-favorite/add-favorite.use-case';
+import { ReorderFavoritesUseCase } from './application/use-cases/reorder-favorites/reorder-favorites.use-case';
+import { RemoveFavoriteReferenceUseCase } from './application/use-cases/remove-favorite-reference/remove-favorite-reference.use-case';
+import { LocalFavoritesRepositoryModule } from './infrastructure/persistence/local/local-favorites-repository.module';
+
+@Module({
+  imports: [LocalFavoritesRepositoryModule],
+  providers: [
+    AddFavoriteUseCase,
+    ReorderFavoritesUseCase,
+    RemoveFavoriteReferenceUseCase,
+  ],
+  exports: [
+    AddFavoriteUseCase,
+    ReorderFavoritesUseCase,
+    RemoveFavoriteReferenceUseCase,
+  ],
+})
+export class FavoritesModule {}

--- a/ayunis-core-backend/src/domain/favorites/infrastructure/persistence/local/local-favorites-repository.module.ts
+++ b/ayunis-core-backend/src/domain/favorites/infrastructure/persistence/local/local-favorites-repository.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FavoritesRepository } from '../../../application/ports/favorites-repository.port';
+import { LocalFavoritesRepository } from './local-favorites.repository';
+import { FavoriteMapper } from './mappers/favorite.mapper';
+import { FavoriteRecord } from './schema/favorite.record';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([FavoriteRecord])],
+  providers: [
+    LocalFavoritesRepository,
+    FavoriteMapper,
+    { provide: FavoritesRepository, useExisting: LocalFavoritesRepository },
+  ],
+  exports: [FavoritesRepository],
+})
+export class LocalFavoritesRepositoryModule {}

--- a/ayunis-core-backend/src/domain/favorites/infrastructure/persistence/local/local-favorites.repository.ts
+++ b/ayunis-core-backend/src/domain/favorites/infrastructure/persistence/local/local-favorites.repository.ts
@@ -1,0 +1,110 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { randomUUID } from 'crypto';
+import type { UUID } from 'crypto';
+import { Repository } from 'typeorm';
+import type { FavoriteReferenceType } from 'src/domain/favorites/domain/value-objects/favorite-reference-type.enum';
+import type { Favorite } from 'src/domain/favorites/domain/favorite.entity';
+import { FavoritesRepository } from 'src/domain/favorites/application/ports/favorites-repository.port';
+import { FavoriteMapper } from './mappers/favorite.mapper';
+import { FavoriteRecord } from './schema/favorite.record';
+
+const PG_UNIQUE_VIOLATION = '23505';
+const MAX_APPEND_ATTEMPTS = 3;
+
+function isUniqueViolation(error: unknown): boolean {
+  if (error === null || typeof error !== 'object') return false;
+  const { code, driverError } = error as {
+    code?: unknown;
+    driverError?: { code?: unknown };
+  };
+  return (
+    code === PG_UNIQUE_VIOLATION || driverError?.code === PG_UNIQUE_VIOLATION
+  );
+}
+
+@Injectable()
+export class LocalFavoritesRepository extends FavoritesRepository {
+  constructor(
+    @InjectRepository(FavoriteRecord)
+    private readonly favorites: Repository<FavoriteRecord>,
+    private readonly mapper: FavoriteMapper,
+  ) {
+    super();
+  }
+
+  async findAllByUserId(userId: UUID): Promise<Favorite[]> {
+    const records = await this.favorites.find({
+      where: { userId },
+      order: { position: 'ASC' },
+    });
+    return records.map((record) => this.mapper.toDomain(record));
+  }
+
+  // The position is computed inside the INSERT so no read-then-write gap
+  // exists, and a duplicate reference no-ops via ON CONFLICT. Two concurrent
+  // appends can still resolve the same position; that surfaces as a
+  // user/position unique violation and is retried. The parameter casts are
+  // required: $2 appears in both the select list and the WHERE clause, and
+  // Postgres otherwise fails to deduce a single type for it.
+  async append(
+    userId: UUID,
+    referenceType: FavoriteReferenceType,
+    referenceId: UUID,
+  ): Promise<void> {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        await this.favorites.manager.query(
+          `INSERT INTO "favorites" ("id", "userId", "referenceType", "referenceId", "position")
+           SELECT $1::character varying, $2::character varying, $3::"public"."favorites_referencetype_enum", $4::character varying,
+                  COALESCE(MAX("position"), -1) + 1
+           FROM "favorites" WHERE "userId" = $2::character varying
+           ON CONFLICT ("userId", "referenceType", "referenceId") DO NOTHING`,
+          [randomUUID(), userId, referenceType, referenceId],
+        );
+        return;
+      } catch (error) {
+        if (!isUniqueViolation(error) || attempt >= MAX_APPEND_ATTEMPTS) {
+          throw error;
+        }
+      }
+    }
+  }
+
+  async remove(favorite: Favorite): Promise<void> {
+    await this.favorites.delete({ id: favorite.id, userId: favorite.userId });
+  }
+
+  async removeByReference(
+    referenceType: FavoriteReferenceType,
+    referenceId: UUID,
+  ): Promise<void> {
+    await this.favorites.delete({ referenceType, referenceId });
+  }
+
+  async reorder(userId: UUID, favoriteIds: UUID[]): Promise<void> {
+    if (favoriteIds.length === 0) return;
+    await this.favorites.manager.transaction(async (manager) => {
+      const [{ maxPosition }] = await manager.query<
+        Array<{ maxPosition: number }>
+      >(
+        `SELECT COALESCE(MAX("position"), -1)::int AS "maxPosition"
+         FROM "favorites" WHERE "userId" = $1`,
+        [userId],
+      );
+      await manager.query(
+        `UPDATE "favorites" SET "position" = "position" + $1
+         WHERE "userId" = $2`,
+        [maxPosition + 1, userId],
+      );
+      await manager.query(
+        `UPDATE "favorites" favorite
+         SET "position" = ordered."position" - 1
+         FROM unnest($1::character varying[]) WITH ORDINALITY
+           AS ordered("id", "position")
+         WHERE favorite."userId" = $2 AND favorite."id" = ordered."id"`,
+        [favoriteIds, userId],
+      );
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/favorites/infrastructure/persistence/local/mappers/favorite.mapper.ts
+++ b/ayunis-core-backend/src/domain/favorites/infrastructure/persistence/local/mappers/favorite.mapper.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { Favorite } from 'src/domain/favorites/domain/favorite.entity';
+import { FavoriteRecord } from '../schema/favorite.record';
+
+@Injectable()
+export class FavoriteMapper {
+  toDomain(record: FavoriteRecord): Favorite {
+    return new Favorite({
+      id: record.id,
+      userId: record.userId,
+      referenceType: record.referenceType,
+      referenceId: record.referenceId,
+      position: record.position,
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/favorites/infrastructure/persistence/local/schema/favorite.record.ts
+++ b/ayunis-core-backend/src/domain/favorites/infrastructure/persistence/local/schema/favorite.record.ts
@@ -1,0 +1,36 @@
+import type { UUID } from 'crypto';
+import {
+  Check,
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  Unique,
+} from 'typeorm';
+import { BaseRecord } from 'src/common/db/base-record';
+import { FavoriteReferenceType } from 'src/domain/favorites/domain/value-objects/favorite-reference-type.enum';
+import { UserRecord } from 'src/iam/users/infrastructure/repositories/local/schema/user.record';
+
+@Entity({ name: 'favorites' })
+@Unique(['userId', 'referenceType', 'referenceId'])
+@Unique(['userId', 'position'])
+@Check('"position" >= 0')
+export class FavoriteRecord extends BaseRecord {
+  @Column({ nullable: false })
+  @Index()
+  userId: UUID;
+
+  @ManyToOne(() => UserRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: UserRecord;
+
+  @Column({ nullable: false, type: 'enum', enum: FavoriteReferenceType })
+  referenceType: FavoriteReferenceType;
+
+  @Column({ nullable: false })
+  referenceId: UUID;
+
+  @Column({ nullable: false, type: 'int' })
+  position: number;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> New isolated table and application module with no auth-sensitive paths in this PR; migration and ordering logic are the main operational considerations until HTTP integration lands.
> 
> **Overview**
> Introduces a new **favorites** backend domain so each user can keep an **ordered list** of typed references (`workspace` or `thread`), intended for sidebar pinning/navigation once wired up.
> 
> Persistence is added via a migration on `favorites` with per-user ordering (`position`), duplicate prevention per reference, and **no FK on `referenceId`** so one column can point at multiple target tables. `LocalFavoritesRepository` implements atomic **append** (idempotent `ON CONFLICT`, retry on position races), transactional **reorder**, and cleanup by reference when targets are deleted.
> 
> Application use cases **`AddFavoriteUseCase`**, **`ReorderFavoritesUseCase`** (current user from context; unknown ids ignored), and **`RemoveFavoriteReferenceUseCase`** are exported through **`FavoritesModule`**, registered in **`AppModule`**. There are **no HTTP presenters** in this diff—callers are expected to enforce access. Docs updated in **`ARCHITECTURE.md`** and module **`SUMMARY.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd65b2736fe658b98d29a3ff5a8a8881b299b69b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->