### PR TITLE
fix(marketplace): classify expected installation outages (AYC-720)

### DIFF
--- a/ayunis-core-backend/appsignal-hooks.cjs
+++ b/ayunis-core-backend/appsignal-hooks.cjs
@@ -111,6 +111,17 @@ const SUPPRESSIONS = [
     match: isCrawlerRequest,
   },
   {
+    id: 'marketplace-unavailable',
+    lever: 'ignoreErrors',
+    ticket: 'AYC-720',
+    reason:
+      'Marketplace fetch failures are an expected external-dependency outcome ' +
+      'surfaced to the user as an actionable 503 and retained as a structured ' +
+      'warning. A single occurrence is not actionable operational signal, so ' +
+      'the deliberate protocol error must not open a first-occurrence incident.',
+    exceptionType: 'MARKETPLACE_UNAVAILABLE',
+  },
+  {
     id: 'abort-signal-cancellation',
     lever: 'ignoreErrors',
     ticket: 'AYC-651',

--- a/ayunis-core-backend/src/common/util/appsignal-hooks.spec.ts
+++ b/ayunis-core-backend/src/common/util/appsignal-hooks.spec.ts
@@ -3,6 +3,7 @@
 import createHttpError from 'http-errors';
 import { errors as undiciErrors } from 'undici';
 import { JobRetryScheduledError } from '../../domain/sources/infrastructure/queue/bullmq-job.helpers';
+import { MarketplaceUnavailableError } from '../../domain/marketplace/application/marketplace.errors';
 
 type UndiciRequest = {
   method?: string;
@@ -159,6 +160,7 @@ const ERROR_SAMPLES: Record<string, () => Error> = {
     new DOMException('This operation was aborted', 'AbortError'),
   'bullmq-retry-scheduled': () =>
     new JobRetryScheduledError(new Error('upstream failed')),
+  'marketplace-unavailable': () => new MarketplaceUnavailableError(),
   'oversized-request-body': () =>
     createHttpError(413, 'request entity too large', {
       type: 'entity.too.large',

--- a/ayunis-core-backend/src/domain/marketplace/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/marketplace/SUMMARY.md
@@ -33,7 +33,7 @@ The marketplace module provides integration with the external Ayunis Marketplace
 
 - `MarketplaceSkillNotFoundError` — Skill with given identifier not found (404)
 - `MarketplaceIntegrationNotFoundError` — Integration with given identifier not found (404)
-- `MarketplaceUnavailableError` — Marketplace service is unavailable (503)
+- `MarketplaceUnavailableError` — Marketplace service is unavailable (503); returns safe retry guidance to clients and is classified as an expected dependency failure rather than a first-occurrence AppSignal incident
 
 **Module Dependencies:**
 

--- a/ayunis-core-backend/src/domain/marketplace/application/marketplace.errors.spec.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/marketplace.errors.spec.ts
@@ -1,0 +1,14 @@
+import { MarketplaceUnavailableError } from './marketplace.errors';
+
+describe('MarketplaceUnavailableError', () => {
+  it('returns an actionable 503 response that is safe to show clients', () => {
+    const error = new MarketplaceUnavailableError();
+
+    expect(error.statusCode).toBe(503);
+    expect(error.toClientResponse()).toEqual({
+      code: 'MARKETPLACE_UNAVAILABLE',
+      message:
+        'Marketplace service is currently unavailable. Please try again later.',
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/marketplace/application/marketplace.errors.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/marketplace.errors.ts
@@ -23,9 +23,13 @@ export class MarketplaceIntegrationNotFoundError extends ApplicationError {
 export class MarketplaceUnavailableError extends ApplicationError {
   constructor() {
     super(
-      'Marketplace service is currently unavailable',
+      'Marketplace service is currently unavailable. Please try again later.',
       'MARKETPLACE_UNAVAILABLE',
       503,
     );
+  }
+
+  override toClientResponse() {
+    return { code: this.code, message: this.message };
   }
 }

--- a/ayunis-core-backend/src/domain/marketplace/infrastructure/http/marketplace-http-client.spec.ts
+++ b/ayunis-core-backend/src/domain/marketplace/infrastructure/http/marketplace-http-client.spec.ts
@@ -1,0 +1,31 @@
+import { MarketplaceUnavailableError } from '../../application/marketplace.errors';
+import { MarketplaceHttpError } from 'src/common/clients/marketplace/client';
+import { getAyunisMarketplaceAPI } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI';
+import { MarketplaceHttpClient } from './marketplace-http-client';
+
+jest.mock(
+  'src/common/clients/marketplace/generated/ayunisMarketplaceAPI',
+  () => ({ getAyunisMarketplaceAPI: jest.fn() }),
+);
+
+describe('MarketplaceHttpClient', () => {
+  const getIntegrationByIdentifier = jest.fn();
+
+  beforeEach(() => {
+    jest.mocked(getAyunisMarketplaceAPI).mockReturnValue({
+      publicIntegrationsControllerGetByIdentifier: getIntegrationByIdentifier,
+    } as unknown as ReturnType<typeof getAyunisMarketplaceAPI>);
+    getIntegrationByIdentifier.mockReset();
+  });
+
+  it('classifies marketplace dependency failures as unavailable', async () => {
+    getIntegrationByIdentifier.mockRejectedValue(
+      new MarketplaceHttpError('Request failed with status code 502', 502),
+    );
+    const client = new MarketplaceHttpClient();
+
+    await expect(
+      client.getIntegrationByIdentifier('oparl-council-data'),
+    ).rejects.toThrow(MarketplaceUnavailableError);
+  });
+});

--- a/ayunis-core-backend/src/domain/marketplace/infrastructure/http/marketplace-http-client.ts
+++ b/ayunis-core-backend/src/domain/marketplace/infrastructure/http/marketplace-http-client.ts
@@ -7,6 +7,7 @@ import {
   SkillResponseDto,
 } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
 import { MarketplaceHttpError } from 'src/common/clients/marketplace/client';
+import { MarketplaceUnavailableError } from '../../application/marketplace.errors';
 
 @Injectable()
 export class MarketplaceHttpClient extends MarketplaceClient {
@@ -64,7 +65,7 @@ export class MarketplaceHttpClient extends MarketplaceClient {
         status:
           error instanceof MarketplaceHttpError ? error.status : undefined,
       });
-      throw error;
+      throw new MarketplaceUnavailableError();
     }
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
@@ -18,7 +18,10 @@ import {
   McpMissingRequiredConfigError,
   DuplicateMarketplaceMcpIntegrationError,
 } from '../../mcp.errors';
-import { MarketplaceIntegrationNotFoundError } from 'src/domain/marketplace/application/marketplace.errors';
+import {
+  MarketplaceIntegrationNotFoundError,
+  MarketplaceUnavailableError,
+} from 'src/domain/marketplace/application/marketplace.errors';
 import type { IntegrationResponseDto } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
 import type { UUID } from 'crypto';
 
@@ -367,6 +370,21 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
         }),
       ),
     ).rejects.toThrow(DuplicateMarketplaceMcpIntegrationError);
+  });
+
+  it('does not persist anything when the marketplace is unavailable', async () => {
+    getMarketplaceIntegrationUseCase.execute.mockRejectedValue(
+      new MarketplaceUnavailableError(),
+    );
+
+    await expect(
+      useCase.execute(
+        new InstallMarketplaceIntegrationCommand('oparl-council-data', {}),
+      ),
+    ).rejects.toThrow(MarketplaceUnavailableError);
+
+    expect(repository.save).not.toHaveBeenCalled();
+    expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
   });
 
   it('should propagate MarketplaceIntegrationNotFoundError when integration is not found', async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes marketplace error classification and AppSignal suppression for dependency outages, which affects client-facing 503 responses and operational visibility if mis-scoped.
> 
> **Overview**
> **Marketplace integration outages** are now treated as expected dependency failures instead of raw upstream errors or first-occurrence AppSignal incidents.
> 
> `MarketplaceHttpClient.getIntegrationByIdentifier` maps non-404 fetch failures to `MarketplaceUnavailableError`. That error now returns an actionable 503 client message (`Please try again later`) instead of the generic internal-server mask, and AppSignal ignores `MARKETPLACE_UNAVAILABLE` so a single outage does not open an incident.
> 
> Tests cover the client classification, safe client response, AppSignal sample match, and that install does not persist when the marketplace is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c43076b7388a3f56f710002a6ef7bb0743df69a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->