### PR TITLE
fix(mistral): accept string reference ids in streams (AYC-718)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.spec.ts
@@ -527,6 +527,38 @@ describe('StreamingInferenceService.executeStreamingInference — tool-call inte
     expect(execute).toHaveBeenCalledTimes(1);
   });
 
+  it('persists only completed text when a controlled inference error interrupts the stream', async () => {
+    const interruptedStream = new Observable<StreamInferenceResponseChunk>(
+      (subscriber) => {
+        subscriber.next(
+          StreamInferenceResponseChunk.text('Die verfügbaren Quellen sind '),
+        );
+        subscriber.next(
+          toolCallChunk({
+            id: 'call_1',
+            name: 'internet_search',
+            argumentsDelta: '{"query":"Bürgerbüro Öffnungszeiten"}',
+          }),
+        );
+        const timer = setTimeout(
+          () =>
+            subscriber.error(
+              new InferenceFailedError('Provider inference failed'),
+            ),
+          20,
+        );
+        return () => clearTimeout(timer);
+      },
+    );
+    const execute = jest.fn().mockReturnValue(interruptedStream);
+    const { service, savedMessages } = buildServiceWithStream(execute);
+
+    await expect(consume(service)).rejects.toBeInstanceOf(InferenceFailedError);
+    expect(savedMessages[0].content).toEqual([
+      expect.objectContaining({ text: 'Die verfügbaren Quellen sind ' }),
+    ]);
+  });
+
   it('treats a tool call that streamed no arguments as an empty object', async () => {
     const { service, savedMessages } = buildService([
       toolCallChunk({ id: 'call_1', name: 'list_letterheads' }),

--- a/packages/provider-mistral/package.json
+++ b/packages/provider-mistral/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@ayunis/inference": "workspace:*",
-    "@mistralai/mistralai": "^1.14.0"
+    "@mistralai/mistralai": "^2.4.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",

--- a/packages/provider-mistral/src/convert-chunk.spec.ts
+++ b/packages/provider-mistral/src/convert-chunk.spec.ts
@@ -1,4 +1,8 @@
-import type { CompletionEvent } from '@mistralai/mistralai/models/components';
+import {
+  CompletionEvent$inboundSchema,
+  ReferenceChunk$inboundSchema,
+  type CompletionEvent,
+} from '@mistralai/mistralai/models/components';
 import { describe, expect, it } from 'vitest';
 
 import { ToolNameCodec } from '@ayunis/inference';
@@ -37,6 +41,40 @@ describe('convertChunk', () => {
         }),
       ),
     ).toEqual({ textDelta: 'Hello' });
+  });
+
+  it('accepts streamed reference blocks with string-valued reference_ids', () => {
+    const parsed = CompletionEvent$inboundSchema.parse({
+      data: JSON.stringify({
+        id: 'chatcmpl-reference',
+        model: 'mistral-large-latest',
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: [
+                {
+                  type: 'reference',
+                  reference_ids: ['source-7f3b1a'],
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      }),
+    });
+
+    expect(convertChunk(parsed)).toBeNull();
+  });
+
+  it('rejects non-scalar reference_ids', () => {
+    expect(() =>
+      ReferenceChunk$inboundSchema.parse({
+        type: 'reference',
+        reference_ids: [{ source: 'municipal-website' }],
+      }),
+    ).toThrow();
   });
 
   it('converts tool_call deltas, carrying id, name and arguments', () => {

--- a/packages/provider-mistral/src/convert-request.ts
+++ b/packages/provider-mistral/src/convert-request.ts
@@ -1,10 +1,9 @@
 import type {
+  ChatCompletionStreamRequestMessage,
+  ChatCompletionStreamRequestTool,
+  ChatCompletionStreamRequestToolChoice,
   ContentChunk,
-  Messages,
-  Tool,
   ToolCall,
-  ToolChoice as MistralToolChoice,
-  ToolChoiceEnum,
 } from '@mistralai/mistralai/models/components';
 
 import type {
@@ -17,7 +16,10 @@ import type {
 
 import { normalizeSchemaForMistral } from './normalize-schema';
 
-export const convertTool = (tool: ToolSchema, codec: ToolNameCodec): Tool => ({
+export const convertTool = (
+  tool: ToolSchema,
+  codec: ToolNameCodec,
+): Extract<ChatCompletionStreamRequestTool, { type: 'function' }> => ({
   type: 'function',
   function: {
     name: codec.encode(tool.name),
@@ -32,7 +34,7 @@ export const convertTool = (tool: ToolSchema, codec: ToolNameCodec): Tool => ({
 export const convertToolChoice = (
   toolChoice: ToolChoice,
   codec: ToolNameCodec,
-): MistralToolChoice | ToolChoiceEnum => {
+): ChatCompletionStreamRequestToolChoice => {
   if (toolChoice === 'auto') {
     return 'auto';
   }
@@ -57,8 +59,8 @@ export const convertMessages = (
   instructions: string,
   messages: readonly Message[],
   codec: ToolNameCodec,
-): Messages[] => {
-  const converted: Messages[] = [];
+): ChatCompletionStreamRequestMessage[] => {
+  const converted: ChatCompletionStreamRequestMessage[] = [];
   if (instructions) {
     converted.push({ role: 'system', content: instructions });
   }
@@ -89,7 +91,7 @@ export const convertMessages = (
  */
 const convertUser = (
   content: readonly MessageContent[],
-): Messages & { role: 'user' } => {
+): Extract<ChatCompletionStreamRequestMessage, { role: 'user' }> => {
   const hasImage = content.some((c) => c.type === 'image');
   if (!hasImage) {
     return { role: 'user', content: joinText(content) };
@@ -115,7 +117,7 @@ const convertUser = (
 const convertAssistant = (
   content: readonly MessageContent[],
   codec: ToolNameCodec,
-): Messages & { role: 'assistant' } => {
+): Extract<ChatCompletionStreamRequestMessage, { role: 'assistant' }> => {
   const toolCalls = content
     .filter((c): c is Extract<MessageContent, { type: 'tool_use' }> => {
       return c.type === 'tool_use';
@@ -129,7 +131,10 @@ const convertAssistant = (
       },
     }));
   const text = joinText(content);
-  const message: Messages & { role: 'assistant' } = {
+  const message: Extract<
+    ChatCompletionStreamRequestMessage,
+    { role: 'assistant' }
+  > = {
     role: 'assistant',
     content: text || undefined,
   };
@@ -139,7 +144,9 @@ const convertAssistant = (
   return message;
 };
 
-const convertToolResults = (content: readonly MessageContent[]): Messages[] =>
+const convertToolResults = (
+  content: readonly MessageContent[],
+): ChatCompletionStreamRequestMessage[] =>
   content
     .filter((c): c is Extract<MessageContent, { type: 'tool_result' }> => {
       return c.type === 'tool_result';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -845,8 +845,8 @@ importers:
         specifier: workspace:*
         version: link:../inference
       '@mistralai/mistralai':
-        specifier: ^1.14.0
-        version: 1.15.1
+        specifier: ^2.4.1
+        version: 2.5.0(@opentelemetry/api@1.9.1)
     devDependencies:
       '@eslint/js':
         specifier: ^9.18.0
@@ -2654,9 +2654,6 @@ packages:
 
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
-
-  '@mistralai/mistralai@1.15.1':
-    resolution: {integrity: sha512-fb995eiz3r0KsBGtRjFV+/iLbX+UpfalxpF+YitT3R6ukrPD4PN+FGwwmYcRFhNAzVzDUtTVxQYnjQWEnwV5nw==}
 
   '@mistralai/mistralai@2.5.0':
     resolution: {integrity: sha512-S/r6tkiUHblaDJGsb84WS0ePTF2YHVta2EoTi1NJqHNt5mfRRS2uE4v7hCYV134+an+fk6WgG3+aFfinJbQBjQ==}
@@ -14749,15 +14746,6 @@ snapshots:
       '@chevrotain/types': 11.1.2
 
   '@microsoft/tsdoc@0.16.0': {}
-
-  '@mistralai/mistralai@1.15.1':
-    dependencies:
-      ws: 8.21.0
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   '@mistralai/mistralai@2.5.0(@opentelemetry/api@1.9.1)':
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Major Mistral SDK major-version bump affects provider request/response typing and stream parsing. Behavior change is narrowly scoped to accepting reference chunks and related persistence coverage.
> 
> **Overview**
> Upgrades `@mistralai/mistralai` from **v1 to v2** so streamed `reference` content blocks with **string** `reference_ids` parse successfully instead of failing the inbound schema.
> 
> Request conversion types are updated to the v2 stream request shapes (`ChatCompletionStreamRequestMessage` / `Tool` / `ToolChoice`). Adds coverage that reference chunks convert to `null` (ignored) and that interrupted streams still persist only completed text, not in-flight tool calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fee5b1a90bf0663ac281b1b6c82b1a09c496067. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->