### PR TITLE
wip(favorites): add favorites HTTP API and reference resolver (AYC-700)

### DIFF
--- a/ayunis-core-backend/src/domain/favorites/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/favorites/SUMMARY.md
@@ -11,7 +11,7 @@ rendered; the current sidebar may call the interaction “pinning”.
 Each `Favorite` contains a strict `FavoriteReferenceType`, a UUID
 `referenceId`, its owning user, and a non-negative position. The closed enum
 currently supports workspaces and threads. Adding another target requires an
-enum value plus resolver support in a later layer.
+enum value plus resolver support in this module.
 
 The database intentionally has no foreign key from `referenceId`: one column
 can reference multiple target tables. A user/reference uniqueness constraint
@@ -30,10 +30,19 @@ prevents duplicate favorites, and a user/position constraint protects order.
 
 - **`AddFavoriteUseCase`** — Appends a favorite for a user; adding an existing
   reference is a no-op. Callers own access checks.
+- **`FindFavoritesUseCase`** — Reads the caller's favorites and resolves each
+  reference into display metadata.
+- **`ToggleFavoriteUseCase`** — Favorites or unfavorites an owned target;
+  unfavoriting compacts order.
 - **`ReorderFavoritesUseCase`** — Reorders the caller's favorites; unknown ids
   are ignored and omitted favorites keep their relative order at the end.
 - **`RemoveFavoriteReferenceUseCase`** — Deletes every favorite row matching a
   reference type/id (used when a target is deleted).
+
+## Application Services
+
+- **`FavoriteReferenceResolver`** — Validates ownership and maps favorites to
+  workspace or thread display fields.
 
 ## Event Listeners
 
@@ -53,7 +62,27 @@ prevents duplicate favorites, and a user/position constraint protects order.
   uniqueness; `@Check` enforces non-negative positions.
 - **`FavoriteMapper`** — Domain ↔ Record conversion.
 
+## HTTP API
+
+`FavoritesController` — base path `/favorites`, tag `favorites`. Gated with
+`@RequireFeature(FeatureFlag.Workspaces)` like the workspaces API, since
+favorites currently only surface workspace/thread pinning.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/favorites` | Read resolved favorites in personal order |
+| PATCH | `/favorites/toggle` | Favorite or unfavorite an owned target |
+| PATCH | `/favorites/reorder` | Reorder the caller's favorites |
+
+The response is discriminated by `referenceType`. Workspace favorites include
+name, icon, and color; thread favorites include their nullable name.
+
 ## Exports
 
-- `AddFavoriteUseCase`, `ReorderFavoritesUseCase`,
-  `RemoveFavoriteReferenceUseCase`
+- `AddFavoriteUseCase`, `FindFavoritesUseCase`, `ToggleFavoriteUseCase`,
+  `ReorderFavoritesUseCase`, `RemoveFavoriteReferenceUseCase`
+
+## Dependencies
+
+- **workspaces** — ownership checks and workspace display metadata.
+- **threads** — ownership checks and thread display metadata.

--- a/ayunis-core-backend/src/domain/favorites/application/services/favorite-reference-resolver.service.spec.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/services/favorite-reference-resolver.service.spec.ts
@@ -1,0 +1,102 @@
+import type { UUID } from 'crypto';
+import type { FindThreadsByIdsUseCase } from 'src/domain/threads/application/use-cases/find-threads-by-ids/find-threads-by-ids.use-case';
+import { ThreadNotFoundError } from 'src/domain/threads/application/threads.errors';
+import type { FindWorkspacesByIdsUseCase } from 'src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case';
+import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
+import { FavoriteReferenceType } from '../../domain/value-objects/favorite-reference-type.enum';
+import { Favorite } from '../../domain/favorite.entity';
+import { FavoriteReferenceResolver } from './favorite-reference-resolver.service';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111' as UUID;
+const WORKSPACE_ID = '22222222-2222-4222-8222-222222222222' as UUID;
+const THREAD_ID = '33333333-3333-4333-8333-333333333333' as UUID;
+
+describe('FavoriteReferenceResolver', () => {
+  it('resolves ordered workspace and thread metadata as a discriminated result', async () => {
+    const resolver = createResolver({
+      workspaces: [
+        {
+          id: WORKSPACE_ID,
+          name: 'Project Alpha',
+          icon: 'folder',
+          color: 'blue',
+        },
+      ],
+      threads: [{ id: THREAD_ID, title: null }],
+    });
+    const favorites = [
+      favorite(FavoriteReferenceType.Workspace, WORKSPACE_ID, 0),
+      favorite(FavoriteReferenceType.Thread, THREAD_ID, 1),
+    ];
+
+    await expect(resolver.resolveAll(favorites, USER_ID)).resolves.toEqual([
+      {
+        id: favorites[0].id,
+        position: 0,
+        referenceType: FavoriteReferenceType.Workspace,
+        referenceId: WORKSPACE_ID,
+        name: 'Project Alpha',
+        icon: 'folder',
+        color: 'blue',
+      },
+      {
+        id: favorites[1].id,
+        position: 1,
+        referenceType: FavoriteReferenceType.Thread,
+        referenceId: THREAD_ID,
+        name: null,
+      },
+    ]);
+  });
+
+  it('rejects a thread reference the user does not own', async () => {
+    const resolver = createResolver({ threads: [] });
+
+    await expect(
+      resolver.assertAccessible(
+        FavoriteReferenceType.Thread,
+        THREAD_ID,
+        USER_ID,
+      ),
+    ).rejects.toBeInstanceOf(ThreadNotFoundError);
+  });
+
+  it('rejects a workspace reference the user does not own', async () => {
+    const resolver = createResolver({ workspaces: [] });
+
+    await expect(
+      resolver.assertAccessible(
+        FavoriteReferenceType.Workspace,
+        WORKSPACE_ID,
+        USER_ID,
+      ),
+    ).rejects.toBeInstanceOf(WorkspaceNotFoundError);
+  });
+});
+
+function createResolver(params: {
+  workspaces?: unknown[];
+  threads?: unknown[];
+}): FavoriteReferenceResolver {
+  return new FavoriteReferenceResolver(
+    {
+      execute: jest.fn().mockResolvedValue(params.workspaces ?? []),
+    } as unknown as FindWorkspacesByIdsUseCase,
+    {
+      execute: jest.fn().mockResolvedValue(params.threads ?? []),
+    } as unknown as FindThreadsByIdsUseCase,
+  );
+}
+
+function favorite(
+  referenceType: FavoriteReferenceType,
+  referenceId: UUID,
+  position: number,
+): Favorite {
+  return new Favorite({
+    userId: USER_ID,
+    referenceType,
+    referenceId,
+    position,
+  });
+}

--- a/ayunis-core-backend/src/domain/favorites/application/services/favorite-reference-resolver.service.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/services/favorite-reference-resolver.service.ts
@@ -1,0 +1,121 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { ThreadNotFoundError } from 'src/domain/threads/application/threads.errors';
+import { FindThreadsByIdsQuery } from 'src/domain/threads/application/use-cases/find-threads-by-ids/find-threads-by-ids.query';
+import { FindThreadsByIdsUseCase } from 'src/domain/threads/application/use-cases/find-threads-by-ids/find-threads-by-ids.use-case';
+import { FindWorkspacesByIdsQuery } from 'src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.query';
+import { FindWorkspacesByIdsUseCase } from 'src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case';
+import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
+import type { Thread } from 'src/domain/threads/domain/thread.entity';
+import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import { FavoriteReferenceType } from '../../domain/value-objects/favorite-reference-type.enum';
+import type { Favorite } from '../../domain/favorite.entity';
+import type { FavoriteResult } from '../use-cases/find-favorites/favorite.result';
+
+@Injectable()
+export class FavoriteReferenceResolver {
+  private readonly logger = new Logger(FavoriteReferenceResolver.name);
+
+  constructor(
+    private readonly findWorkspacesByIdsUseCase: FindWorkspacesByIdsUseCase,
+    private readonly findThreadsByIdsUseCase: FindThreadsByIdsUseCase,
+  ) {}
+
+  async resolveAll(
+    favorites: Favorite[],
+    userId: UUID,
+  ): Promise<FavoriteResult[]> {
+    const [workspaces, threads] = await Promise.all([
+      this.findWorkspacesByIdsUseCase.execute(
+        new FindWorkspacesByIdsQuery(
+          userId,
+          this.referenceIds(favorites, FavoriteReferenceType.Workspace),
+        ),
+      ),
+      this.findThreadsByIdsUseCase.execute(
+        new FindThreadsByIdsQuery(
+          userId,
+          this.referenceIds(favorites, FavoriteReferenceType.Thread),
+        ),
+      ),
+    ]);
+    const workspacesById = new Map(
+      workspaces.map((workspace) => [workspace.id, workspace]),
+    );
+    const threadsById = new Map(threads.map((thread) => [thread.id, thread]));
+
+    return favorites.flatMap((favorite) => {
+      const result = this.resolve(favorite, workspacesById, threadsById);
+      if (!result) {
+        this.logger.warn('Ignoring stale favorite reference', {
+          favoriteId: favorite.id,
+          referenceType: favorite.referenceType,
+          referenceId: favorite.referenceId,
+        });
+      }
+      return result ? [result] : [];
+    });
+  }
+
+  async assertAccessible(
+    referenceType: FavoriteReferenceType,
+    referenceId: UUID,
+    userId: UUID,
+  ): Promise<void> {
+    if (referenceType === FavoriteReferenceType.Workspace) {
+      const workspaces = await this.findWorkspacesByIdsUseCase.execute(
+        new FindWorkspacesByIdsQuery(userId, [referenceId]),
+      );
+      if (workspaces.length === 0) {
+        throw new WorkspaceNotFoundError(referenceId);
+      }
+      return;
+    }
+    const threads = await this.findThreadsByIdsUseCase.execute(
+      new FindThreadsByIdsQuery(userId, [referenceId]),
+    );
+    if (threads.length === 0) {
+      throw new ThreadNotFoundError(referenceId, userId);
+    }
+  }
+
+  private referenceIds(
+    favorites: Favorite[],
+    referenceType: FavoriteReferenceType,
+  ): UUID[] {
+    return favorites
+      .filter((favorite) => favorite.referenceType === referenceType)
+      .map((favorite) => favorite.referenceId);
+  }
+
+  private resolve(
+    favorite: Favorite,
+    workspacesById: Map<UUID, Workspace>,
+    threadsById: Map<UUID, Thread>,
+  ): FavoriteResult | null {
+    if (favorite.referenceType === FavoriteReferenceType.Workspace) {
+      const workspace = workspacesById.get(favorite.referenceId);
+      return workspace
+        ? {
+            id: favorite.id,
+            position: favorite.position,
+            referenceType: FavoriteReferenceType.Workspace,
+            referenceId: favorite.referenceId,
+            name: workspace.name,
+            icon: workspace.icon,
+            color: workspace.color,
+          }
+        : null;
+    }
+    const thread = threadsById.get(favorite.referenceId);
+    return thread
+      ? {
+          id: favorite.id,
+          position: favorite.position,
+          referenceType: FavoriteReferenceType.Thread,
+          referenceId: favorite.referenceId,
+          name: thread.title ?? null,
+        }
+      : null;
+  }
+}

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/find-favorites/favorite.result.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/find-favorites/favorite.result.ts
@@ -1,0 +1,22 @@
+import type { UUID } from 'crypto';
+import type { FavoriteReferenceType } from '../../../domain/value-objects/favorite-reference-type.enum';
+
+interface FavoriteResultBase {
+  id: UUID;
+  position: number;
+  referenceId: UUID;
+}
+
+export interface WorkspaceFavoriteResult extends FavoriteResultBase {
+  referenceType: FavoriteReferenceType.Workspace;
+  name: string;
+  icon: string;
+  color: string;
+}
+
+export interface ThreadFavoriteResult extends FavoriteResultBase {
+  referenceType: FavoriteReferenceType.Thread;
+  name: string | null;
+}
+
+export type FavoriteResult = WorkspaceFavoriteResult | ThreadFavoriteResult;

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/find-favorites/find-favorites.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/find-favorites/find-favorites.use-case.spec.ts
@@ -1,0 +1,35 @@
+import type { UUID } from 'crypto';
+import type { ContextService } from 'src/common/context/services/context.service';
+import type { FavoriteReferenceResolver } from '../../services/favorite-reference-resolver.service';
+import type { FavoritesRepository } from '../../ports/favorites-repository.port';
+import { FavoriteReferenceType } from '../../../domain/value-objects/favorite-reference-type.enum';
+import { Favorite } from '../../../domain/favorite.entity';
+import { FindFavoritesUseCase } from './find-favorites.use-case';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111' as UUID;
+const WORKSPACE_ID = '22222222-2222-4222-8222-222222222222' as UUID;
+
+describe('FindFavoritesUseCase', () => {
+  it('loads and resolves the current user favorites', async () => {
+    const favorite = new Favorite({
+      userId: USER_ID,
+      referenceType: FavoriteReferenceType.Workspace,
+      referenceId: WORKSPACE_ID,
+      position: 0,
+    });
+    const repository = {
+      findAllByUserId: jest.fn().mockResolvedValue([favorite]),
+    } as unknown as FavoritesRepository;
+    const resolved = [{ id: favorite.id, name: 'Project Alpha' }];
+    const resolver = {
+      resolveAll: jest.fn().mockResolvedValue(resolved),
+    } as unknown as FavoriteReferenceResolver;
+    const context = {
+      get: jest.fn().mockReturnValue(USER_ID),
+    } as unknown as ContextService;
+    const useCase = new FindFavoritesUseCase(repository, resolver, context);
+
+    await expect(useCase.execute()).resolves.toBe(resolved);
+    expect(resolver.resolveAll).toHaveBeenCalledWith([favorite], USER_ID);
+  });
+});

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/find-favorites/find-favorites.use-case.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/find-favorites/find-favorites.use-case.ts
@@ -1,0 +1,34 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { ContextService } from 'src/common/context/services/context.service';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { UnexpectedFavoriteError } from '../../favorites.errors';
+import { FavoritesRepository } from '../../ports/favorites-repository.port';
+import { FavoriteReferenceResolver } from '../../services/favorite-reference-resolver.service';
+import type { FavoriteResult } from './favorite.result';
+
+@Injectable()
+export class FindFavoritesUseCase {
+  private readonly logger = new Logger(FindFavoritesUseCase.name);
+
+  constructor(
+    private readonly favoritesRepository: FavoritesRepository,
+    private readonly favoriteReferenceResolver: FavoriteReferenceResolver,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedFavoriteError)
+  async execute(): Promise<FavoriteResult[]> {
+    this.logger.log('Finding favorites');
+    const userId = this.requireUserId();
+    const favorites = await this.favoritesRepository.findAllByUserId(userId);
+    return this.favoriteReferenceResolver.resolveAll(favorites, userId);
+  }
+
+  private requireUserId(): UUID {
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+    return userId;
+  }
+}

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/toggle-favorite/toggle-favorite.command.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/toggle-favorite/toggle-favorite.command.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+import type { FavoriteReferenceType } from '../../../domain/value-objects/favorite-reference-type.enum';
+
+export class ToggleFavoriteCommand {
+  constructor(
+    public readonly referenceType: FavoriteReferenceType,
+    public readonly referenceId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/toggle-favorite/toggle-favorite.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/toggle-favorite/toggle-favorite.use-case.spec.ts
@@ -1,0 +1,100 @@
+import type { UUID } from 'crypto';
+import type { ContextService } from 'src/common/context/services/context.service';
+import type { FavoriteReferenceResolver } from '../../services/favorite-reference-resolver.service';
+import type { FavoritesRepository } from '../../ports/favorites-repository.port';
+import { FavoriteReferenceType } from '../../../domain/value-objects/favorite-reference-type.enum';
+import { Favorite } from '../../../domain/favorite.entity';
+import { ToggleFavoriteCommand } from './toggle-favorite.command';
+import { ToggleFavoriteUseCase } from './toggle-favorite.use-case';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111' as UUID;
+const WORKSPACE_ID = '22222222-2222-4222-8222-222222222222' as UUID;
+const THREAD_ID = '33333333-3333-4333-8333-333333333333' as UUID;
+
+describe('ToggleFavoriteUseCase', () => {
+  it('validates and appends a new favorite', async () => {
+    const { useCase, repository, resolver } = setup();
+
+    await useCase.execute(
+      command(FavoriteReferenceType.Workspace, WORKSPACE_ID),
+    );
+
+    expect(resolver.assertAccessible).toHaveBeenCalledWith(
+      FavoriteReferenceType.Workspace,
+      WORKSPACE_ID,
+      USER_ID,
+    );
+    expect(repository.append).toHaveBeenCalledWith(
+      USER_ID,
+      FavoriteReferenceType.Workspace,
+      WORKSPACE_ID,
+    );
+  });
+
+  it('removes an existing favorite and compacts the remaining order', async () => {
+    const existing = favorite(FavoriteReferenceType.Thread, THREAD_ID, 0);
+    const remaining = favorite(
+      FavoriteReferenceType.Workspace,
+      WORKSPACE_ID,
+      1,
+    );
+    const { useCase, repository } = setup([existing, remaining]);
+
+    await useCase.execute(command(FavoriteReferenceType.Thread, THREAD_ID));
+
+    expect(repository.remove).toHaveBeenCalledWith(existing);
+    expect(repository.reorder).toHaveBeenCalledWith(USER_ID, [remaining.id]);
+    expect(repository.append).not.toHaveBeenCalled();
+  });
+
+  it('removes a stale favorite without requiring the target to be accessible', async () => {
+    const existing = favorite(FavoriteReferenceType.Thread, THREAD_ID, 0);
+    const { useCase, repository, resolver } = setup([existing]);
+    resolver.assertAccessible.mockRejectedValue(new Error('gone'));
+
+    await useCase.execute(command(FavoriteReferenceType.Thread, THREAD_ID));
+
+    expect(resolver.assertAccessible).not.toHaveBeenCalled();
+    expect(repository.remove).toHaveBeenCalledWith(existing);
+  });
+});
+
+function setup(current: Favorite[] = []) {
+  const repository = {
+    findAllByUserId: jest.fn().mockResolvedValue(current),
+    append: jest.fn(),
+    remove: jest.fn(),
+    reorder: jest.fn(),
+  } as unknown as jest.Mocked<FavoritesRepository>;
+  const resolver = {
+    assertAccessible: jest.fn(),
+  } as unknown as jest.Mocked<FavoriteReferenceResolver>;
+  const context = {
+    get: jest.fn().mockReturnValue(USER_ID),
+  } as unknown as ContextService;
+  return {
+    repository,
+    resolver,
+    useCase: new ToggleFavoriteUseCase(repository, resolver, context),
+  };
+}
+
+function favorite(
+  referenceType: FavoriteReferenceType,
+  referenceId: UUID,
+  position: number,
+): Favorite {
+  return new Favorite({
+    userId: USER_ID,
+    referenceType,
+    referenceId,
+    position,
+  });
+}
+
+function command(
+  referenceType: FavoriteReferenceType,
+  referenceId: UUID,
+): ToggleFavoriteCommand {
+  return new ToggleFavoriteCommand(referenceType, referenceId);
+}

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/toggle-favorite/toggle-favorite.use-case.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/toggle-favorite/toggle-favorite.use-case.ts
@@ -1,0 +1,66 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { ContextService } from 'src/common/context/services/context.service';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { Favorite } from '../../../domain/favorite.entity';
+import { UnexpectedFavoriteError } from '../../favorites.errors';
+import { FavoritesRepository } from '../../ports/favorites-repository.port';
+import { FavoriteReferenceResolver } from '../../services/favorite-reference-resolver.service';
+import { ToggleFavoriteCommand } from './toggle-favorite.command';
+
+@Injectable()
+export class ToggleFavoriteUseCase {
+  private readonly logger = new Logger(ToggleFavoriteUseCase.name);
+
+  constructor(
+    private readonly favoritesRepository: FavoritesRepository,
+    private readonly favoriteReferenceResolver: FavoriteReferenceResolver,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedFavoriteError)
+  async execute(command: ToggleFavoriteCommand): Promise<void> {
+    this.logger.log('Toggling favorite', {
+      referenceType: command.referenceType,
+      referenceId: command.referenceId,
+    });
+    const userId = this.requireUserId();
+    const current = await this.favoritesRepository.findAllByUserId(userId);
+    const existing = current.find(
+      (favorite) =>
+        favorite.referenceType === command.referenceType &&
+        favorite.referenceId === command.referenceId,
+    );
+    if (existing) {
+      // Deliberately no access check: the target may be gone or no longer
+      // owned, and unfavoriting must keep working for such stale rows.
+      await this.remove(existing, current);
+      return;
+    }
+    await this.favoriteReferenceResolver.assertAccessible(
+      command.referenceType,
+      command.referenceId,
+      userId,
+    );
+    await this.favoritesRepository.append(
+      userId,
+      command.referenceType,
+      command.referenceId,
+    );
+  }
+
+  private async remove(existing: Favorite, current: Favorite[]): Promise<void> {
+    await this.favoritesRepository.remove(existing);
+    const remainingIds = current
+      .filter((favorite) => favorite.id !== existing.id)
+      .map((favorite) => favorite.id);
+    await this.favoritesRepository.reorder(existing.userId, remainingIds);
+  }
+
+  private requireUserId(): UUID {
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+    return userId;
+  }
+}

--- a/ayunis-core-backend/src/domain/favorites/favorites.module.ts
+++ b/ayunis-core-backend/src/domain/favorites/favorites.module.ts
@@ -1,22 +1,42 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { AddFavoriteUseCase } from './application/use-cases/add-favorite/add-favorite.use-case';
+import { FindFavoritesUseCase } from './application/use-cases/find-favorites/find-favorites.use-case';
 import { ReorderFavoritesUseCase } from './application/use-cases/reorder-favorites/reorder-favorites.use-case';
 import { RemoveFavoriteReferenceUseCase } from './application/use-cases/remove-favorite-reference/remove-favorite-reference.use-case';
+import { ToggleFavoriteUseCase } from './application/use-cases/toggle-favorite/toggle-favorite.use-case';
 import { LocalFavoritesRepositoryModule } from './infrastructure/persistence/local/local-favorites-repository.module';
-import { FavoriteWorkspaceDeletionRequestedListener } from './application/listeners/workspace-deletion-requested.listener';
 import { FavoriteThreadDeletionRequestedListener } from './application/listeners/thread-deletion-requested.listener';
+import { FavoriteWorkspaceDeletionRequestedListener } from './application/listeners/workspace-deletion-requested.listener';
+import { WorkspacesModule } from '../workspaces/workspaces.module';
+import { ThreadsModule } from '../threads/threads.module';
+import { FavoriteReferenceResolver } from './application/services/favorite-reference-resolver.service';
+import { FavoritesController } from './presenters/http/favorites.controller';
 
+// The reference resolver reads from workspaces and threads while workspaces
+// (auto-favorite on create) and threads (favorite cleanup on cascade delete)
+// call back into favorites, so every module reference on this cycle is a
+// forwardRef — a plain reference would be undefined at import evaluation.
 @Module({
-  imports: [LocalFavoritesRepositoryModule],
+  imports: [
+    LocalFavoritesRepositoryModule,
+    forwardRef(() => WorkspacesModule),
+    forwardRef(() => ThreadsModule),
+  ],
+  controllers: [FavoritesController],
   providers: [
     AddFavoriteUseCase,
+    FindFavoritesUseCase,
+    ToggleFavoriteUseCase,
     ReorderFavoritesUseCase,
     RemoveFavoriteReferenceUseCase,
+    FavoriteReferenceResolver,
     FavoriteWorkspaceDeletionRequestedListener,
     FavoriteThreadDeletionRequestedListener,
   ],
   exports: [
     AddFavoriteUseCase,
+    FindFavoritesUseCase,
+    ToggleFavoriteUseCase,
     ReorderFavoritesUseCase,
     RemoveFavoriteReferenceUseCase,
   ],

--- a/ayunis-core-backend/src/domain/favorites/presenters/http/dtos/favorite-response.dto.ts
+++ b/ayunis-core-backend/src/domain/favorites/presenters/http/dtos/favorite-response.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { FavoriteReferenceType } from '../../../domain/value-objects/favorite-reference-type.enum';
+
+class FavoriteResponseDtoBase {
+  @ApiProperty({ format: 'uuid' })
+  id: UUID;
+
+  @ApiProperty({ minimum: 0 })
+  position: number;
+
+  @ApiProperty({ format: 'uuid' })
+  referenceId: UUID;
+}
+
+export class WorkspaceFavoriteResponseDto extends FavoriteResponseDtoBase {
+  @ApiProperty({ enum: [FavoriteReferenceType.Workspace] })
+  referenceType: FavoriteReferenceType.Workspace;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  icon: string;
+
+  @ApiProperty()
+  color: string;
+}
+
+export class ThreadFavoriteResponseDto extends FavoriteResponseDtoBase {
+  @ApiProperty({ enum: [FavoriteReferenceType.Thread] })
+  referenceType: FavoriteReferenceType.Thread;
+
+  @ApiProperty({ type: String, nullable: true })
+  name: string | null;
+}
+
+export type FavoriteResponseDto =
+  WorkspaceFavoriteResponseDto | ThreadFavoriteResponseDto;

--- a/ayunis-core-backend/src/domain/favorites/presenters/http/dtos/reorder-favorites.dto.ts
+++ b/ayunis-core-backend/src/domain/favorites/presenters/http/dtos/reorder-favorites.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { ArrayUnique, IsArray, IsUUID } from 'class-validator';
+
+export class ReorderFavoritesDto {
+  @ApiProperty({ type: [String], format: 'uuid' })
+  @IsArray()
+  @ArrayUnique()
+  @IsUUID(undefined, { each: true })
+  favoriteIds: UUID[];
+}

--- a/ayunis-core-backend/src/domain/favorites/presenters/http/dtos/toggle-favorite.dto.ts
+++ b/ayunis-core-backend/src/domain/favorites/presenters/http/dtos/toggle-favorite.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { IsEnum, IsUUID } from 'class-validator';
+import { FavoriteReferenceType } from '../../../domain/value-objects/favorite-reference-type.enum';
+
+export class ToggleFavoriteDto {
+  @ApiProperty({ enum: FavoriteReferenceType })
+  @IsEnum(FavoriteReferenceType)
+  referenceType: FavoriteReferenceType;
+
+  @ApiProperty({ format: 'uuid' })
+  @IsUUID()
+  referenceId: UUID;
+}

--- a/ayunis-core-backend/src/domain/favorites/presenters/http/favorites.controller.ts
+++ b/ayunis-core-backend/src/domain/favorites/presenters/http/favorites.controller.ts
@@ -1,0 +1,89 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Patch,
+} from '@nestjs/common';
+import {
+  ApiExtraModels,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import { RequireFeature } from 'src/common/guards/feature.guard';
+import { FeatureFlag } from 'src/config/features.config';
+import { FindFavoritesUseCase } from '../../application/use-cases/find-favorites/find-favorites.use-case';
+import { ReorderFavoritesCommand } from '../../application/use-cases/reorder-favorites/reorder-favorites.command';
+import { ReorderFavoritesUseCase } from '../../application/use-cases/reorder-favorites/reorder-favorites.use-case';
+import { ToggleFavoriteCommand } from '../../application/use-cases/toggle-favorite/toggle-favorite.command';
+import { ToggleFavoriteUseCase } from '../../application/use-cases/toggle-favorite/toggle-favorite.use-case';
+import {
+  ThreadFavoriteResponseDto,
+  type FavoriteResponseDto,
+  WorkspaceFavoriteResponseDto,
+} from './dtos/favorite-response.dto';
+import { ReorderFavoritesDto } from './dtos/reorder-favorites.dto';
+import { ToggleFavoriteDto } from './dtos/toggle-favorite.dto';
+
+// Favorites currently only surface workspace/thread pinning, which ships
+// behind the workspaces flag; the API is gated with it so a disabled feature
+// has no reachable server surface.
+@ApiTags('favorites')
+@ApiExtraModels(WorkspaceFavoriteResponseDto, ThreadFavoriteResponseDto)
+@RequireFeature(FeatureFlag.Workspaces)
+@Controller('favorites')
+export class FavoritesController {
+  private readonly logger = new Logger(FavoritesController.name);
+
+  constructor(
+    private readonly findFavoritesUseCase: FindFavoritesUseCase,
+    private readonly toggleFavoriteUseCase: ToggleFavoriteUseCase,
+    private readonly reorderFavoritesUseCase: ReorderFavoritesUseCase,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get the current user favorites' })
+  @ApiResponse({
+    status: 200,
+    schema: {
+      type: 'array',
+      items: {
+        oneOf: [
+          { $ref: getSchemaPath(WorkspaceFavoriteResponseDto) },
+          { $ref: getSchemaPath(ThreadFavoriteResponseDto) },
+        ],
+        discriminator: { propertyName: 'referenceType' },
+      },
+    },
+  })
+  async findAll(): Promise<FavoriteResponseDto[]> {
+    this.logger.log('findAll');
+    return this.findFavoritesUseCase.execute();
+  }
+
+  @Patch('toggle')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Favorite or unfavorite an authorized reference' })
+  @ApiResponse({ status: 204, description: 'The favorite was toggled' })
+  async toggle(@Body() dto: ToggleFavoriteDto): Promise<void> {
+    this.logger.log('toggle', dto);
+    await this.toggleFavoriteUseCase.execute(
+      new ToggleFavoriteCommand(dto.referenceType, dto.referenceId),
+    );
+  }
+
+  @Patch('reorder')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Reorder the current user favorites' })
+  @ApiResponse({ status: 204, description: 'The favorites were reordered' })
+  async reorder(@Body() dto: ReorderFavoritesDto): Promise<void> {
+    this.logger.log('reorder', { count: dto.favoriteIds.length });
+    await this.reorderFavoritesUseCase.execute(
+      new ReorderFavoritesCommand(dto.favoriteIds),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/threads/threads.module.ts
+++ b/ayunis-core-backend/src/domain/threads/threads.module.ts
@@ -70,8 +70,10 @@ import { McpModule } from '../mcp/mcp.module';
     MessagesModule,
     OrgsModule,
     StorageModule,
-    WorkspacesModule,
-    FavoritesModule,
+    // Both sit on the favorites↔{threads,workspaces} module cycle — see the
+    // note in favorites.module.ts.
+    forwardRef(() => WorkspacesModule),
+    forwardRef(() => FavoritesModule),
     SharesModule,
     ThreadPiiMasksModule,
     McpModule,

--- a/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { FavoritesModule } from 'src/domain/favorites/favorites.module';
 import { WorkspacesRepository } from './application/ports/workspaces-repository.port';
 import { LocalWorkspacesRepositoryModule } from './infrastructure/persistence/local/local-workspaces-repository.module';
@@ -13,7 +13,7 @@ import { WorkspaceDtoMapper } from './presenters/http/mappers/workspace-dto.mapp
 import { FindWorkspacesByIdsUseCase } from './application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case';
 
 @Module({
-  imports: [LocalWorkspacesRepositoryModule, FavoritesModule],
+  imports: [LocalWorkspacesRepositoryModule, forwardRef(() => FavoritesModule)],
   controllers: [WorkspacesController],
   providers: [
     {

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3482,6 +3482,61 @@ export interface UpdateWorkspaceDto {
   color?: string;
 }
 
+export type WorkspaceFavoriteResponseDtoReferenceType = typeof WorkspaceFavoriteResponseDtoReferenceType[keyof typeof WorkspaceFavoriteResponseDtoReferenceType];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WorkspaceFavoriteResponseDtoReferenceType = {
+  workspace: 'workspace',
+} as const;
+
+export interface WorkspaceFavoriteResponseDto {
+  id: string;
+  /** @minimum 0 */
+  position: number;
+  referenceId: string;
+  referenceType: WorkspaceFavoriteResponseDtoReferenceType;
+  name: string;
+  icon: string;
+  color: string;
+}
+
+export type ThreadFavoriteResponseDtoReferenceType = typeof ThreadFavoriteResponseDtoReferenceType[keyof typeof ThreadFavoriteResponseDtoReferenceType];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ThreadFavoriteResponseDtoReferenceType = {
+  thread: 'thread',
+} as const;
+
+export interface ThreadFavoriteResponseDto {
+  id: string;
+  /** @minimum 0 */
+  position: number;
+  referenceId: string;
+  referenceType: ThreadFavoriteResponseDtoReferenceType;
+  /** @nullable */
+  name: string | null;
+}
+
+export type ToggleFavoriteDtoReferenceType = typeof ToggleFavoriteDtoReferenceType[keyof typeof ToggleFavoriteDtoReferenceType];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ToggleFavoriteDtoReferenceType = {
+  workspace: 'workspace',
+  thread: 'thread',
+} as const;
+
+export interface ToggleFavoriteDto {
+  referenceType: ToggleFavoriteDtoReferenceType;
+  referenceId: string;
+}
+
+export interface ReorderFavoritesDto {
+  favoriteIds: string[];
+}
+
 export interface PiiWhitelistEntryDto {
   /** PII category exempt from anonymization */
   category: PiiCategory;
@@ -5296,6 +5351,8 @@ export type SkillSourcesControllerAddFileSourceBody = {
   /** The file to upload (max 25 MB) */
   file: Blob;
 };
+
+export type FavoritesControllerFindAll200Item = WorkspaceFavoriteResponseDto | ThreadFavoriteResponseDto;
 
 export type ArtifactsControllerExportParams = {
 /**

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -88,6 +88,7 @@ import type {
   EmbeddingModelResponseDto,
   ErrorResponseDto,
   FairUseLimitsResponseDto,
+  FavoritesControllerFindAll200Item,
   FeatureTogglesResponseDto,
   ForgotPasswordDto,
   GeneratePersonalizedSystemPromptDto,
@@ -156,6 +157,7 @@ import type {
   RegisterDto,
   ReorderChaptersRequestDto,
   ReorderCourseModulesRequestDto,
+  ReorderFavoritesDto,
   ResendEmailConfirmationDto,
   ResetPasswordDto,
   RetentionPolicyResponseDto,
@@ -211,6 +213,7 @@ import type {
   ThreadSourcesControllerAddFileSourceBody,
   ThreadSourcesControllerGetThreadSources200Item,
   ThreadsControllerFindAllParams,
+  ToggleFavoriteDto,
   TranscriptionResponseDto,
   TranscriptionsControllerTranscribeBody,
   TriggerPasswordResetResponseDto,
@@ -13476,6 +13479,227 @@ export const useWorkspacesControllerRemove = <TError = void,
       > => {
 
       const mutationOptions = getWorkspacesControllerRemoveMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Get the current user favorites
+ */
+export const favoritesControllerFindAll = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<FavoritesControllerFindAll200Item[]>(
+      {url: `/favorites`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getFavoritesControllerFindAllQueryKey = () => {
+    return [
+    `/favorites`
+    ] as const;
+    }
+
+    
+export const getFavoritesControllerFindAllQueryOptions = <TData = Awaited<ReturnType<typeof favoritesControllerFindAll>>, TError = unknown>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof favoritesControllerFindAll>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getFavoritesControllerFindAllQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof favoritesControllerFindAll>>> = ({ signal }) => favoritesControllerFindAll(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof favoritesControllerFindAll>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type FavoritesControllerFindAllQueryResult = NonNullable<Awaited<ReturnType<typeof favoritesControllerFindAll>>>
+export type FavoritesControllerFindAllQueryError = unknown
+
+
+export function useFavoritesControllerFindAll<TData = Awaited<ReturnType<typeof favoritesControllerFindAll>>, TError = unknown>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof favoritesControllerFindAll>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof favoritesControllerFindAll>>,
+          TError,
+          Awaited<ReturnType<typeof favoritesControllerFindAll>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useFavoritesControllerFindAll<TData = Awaited<ReturnType<typeof favoritesControllerFindAll>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof favoritesControllerFindAll>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof favoritesControllerFindAll>>,
+          TError,
+          Awaited<ReturnType<typeof favoritesControllerFindAll>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useFavoritesControllerFindAll<TData = Awaited<ReturnType<typeof favoritesControllerFindAll>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof favoritesControllerFindAll>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get the current user favorites
+ */
+
+export function useFavoritesControllerFindAll<TData = Awaited<ReturnType<typeof favoritesControllerFindAll>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof favoritesControllerFindAll>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getFavoritesControllerFindAllQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Favorite or unfavorite an authorized reference
+ */
+export const favoritesControllerToggle = (
+    toggleFavoriteDto: ToggleFavoriteDto,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/favorites/toggle`, method: 'PATCH',
+      headers: {'Content-Type': 'application/json', },
+      data: toggleFavoriteDto
+    },
+      );
+    }
+  
+
+
+export const getFavoritesControllerToggleMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof favoritesControllerToggle>>, TError,{data: ToggleFavoriteDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof favoritesControllerToggle>>, TError,{data: ToggleFavoriteDto}, TContext> => {
+
+const mutationKey = ['favoritesControllerToggle'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof favoritesControllerToggle>>, {data: ToggleFavoriteDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  favoritesControllerToggle(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type FavoritesControllerToggleMutationResult = NonNullable<Awaited<ReturnType<typeof favoritesControllerToggle>>>
+    export type FavoritesControllerToggleMutationBody = ToggleFavoriteDto
+    export type FavoritesControllerToggleMutationError = unknown
+
+    /**
+ * @summary Favorite or unfavorite an authorized reference
+ */
+export const useFavoritesControllerToggle = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof favoritesControllerToggle>>, TError,{data: ToggleFavoriteDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof favoritesControllerToggle>>,
+        TError,
+        {data: ToggleFavoriteDto},
+        TContext
+      > => {
+
+      const mutationOptions = getFavoritesControllerToggleMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Reorder the current user favorites
+ */
+export const favoritesControllerReorder = (
+    reorderFavoritesDto: ReorderFavoritesDto,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/favorites/reorder`, method: 'PATCH',
+      headers: {'Content-Type': 'application/json', },
+      data: reorderFavoritesDto
+    },
+      );
+    }
+  
+
+
+export const getFavoritesControllerReorderMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof favoritesControllerReorder>>, TError,{data: ReorderFavoritesDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof favoritesControllerReorder>>, TError,{data: ReorderFavoritesDto}, TContext> => {
+
+const mutationKey = ['favoritesControllerReorder'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof favoritesControllerReorder>>, {data: ReorderFavoritesDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  favoritesControllerReorder(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type FavoritesControllerReorderMutationResult = NonNullable<Awaited<ReturnType<typeof favoritesControllerReorder>>>
+    export type FavoritesControllerReorderMutationBody = ReorderFavoritesDto
+    export type FavoritesControllerReorderMutationError = unknown
+
+    /**
+ * @summary Reorder the current user favorites
+ */
+export const useFavoritesControllerReorder = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof favoritesControllerReorder>>, TError,{data: ReorderFavoritesDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof favoritesControllerReorder>>,
+        TError,
+        {data: ReorderFavoritesDto},
+        TContext
+      > => {
+
+      const mutationOptions = getFavoritesControllerReorderMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -6582,6 +6582,85 @@
         "tags": ["workspaces"]
       }
     },
+    "/favorites": {
+      "get": {
+        "operationId": "FavoritesController_findAll",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/WorkspaceFavoriteResponseDto"
+                      },
+                      {
+                        "$ref": "#/components/schemas/ThreadFavoriteResponseDto"
+                      }
+                    ],
+                    "discriminator": {
+                      "propertyName": "referenceType"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get the current user favorites",
+        "tags": ["favorites"]
+      }
+    },
+    "/favorites/toggle": {
+      "patch": {
+        "operationId": "FavoritesController_toggle",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ToggleFavoriteDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "The favorite was toggled"
+          }
+        },
+        "summary": "Favorite or unfavorite an authorized reference",
+        "tags": ["favorites"]
+      }
+    },
+    "/favorites/reorder": {
+      "patch": {
+        "operationId": "FavoritesController_reorder",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReorderFavoritesDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "The favorites were reordered"
+          }
+        },
+        "summary": "Reorder the current user favorites",
+        "tags": ["favorites"]
+      }
+    },
     "/anonymization-settings/pii-whitelist": {
       "get": {
         "operationId": "AnonymizationSettingsController_get",
@@ -15908,6 +15987,98 @@
             "example": "#6b5bd6"
           }
         }
+      },
+      "WorkspaceFavoriteResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "position": {
+            "type": "number",
+            "minimum": 0
+          },
+          "referenceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "referenceType": {
+            "type": "string",
+            "enum": ["workspace"]
+          },
+          "name": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "position",
+          "referenceId",
+          "referenceType",
+          "name",
+          "icon",
+          "color"
+        ]
+      },
+      "ThreadFavoriteResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "position": {
+            "type": "number",
+            "minimum": 0
+          },
+          "referenceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "referenceType": {
+            "type": "string",
+            "enum": ["thread"]
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": ["id", "position", "referenceId", "referenceType", "name"]
+      },
+      "ToggleFavoriteDto": {
+        "type": "object",
+        "properties": {
+          "referenceType": {
+            "type": "string",
+            "enum": ["workspace", "thread"]
+          },
+          "referenceId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": ["referenceType", "referenceId"]
+      },
+      "ReorderFavoritesDto": {
+        "type": "object",
+        "properties": {
+          "favoriteIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        },
+        "required": ["favoriteIds"]
       },
       "PiiWhitelistEntryDto": {
         "type": "object",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New user-facing endpoints with ownership checks and cross-module `forwardRef` cycles; toggle/reorder touch persisted ordering but reuse existing repository behavior.
> 
> **Overview**
> Exposes **workspace/thread pinning** over HTTP so clients can list, toggle, and reorder favorites without going through other domains.
> 
> Adds **`FavoriteReferenceResolver`** to batch-load owned workspaces/threads, map them to discriminated display payloads (workspace name/icon/color vs thread title), verify ownership on **favorite**, and **drop stale rows** on read with a warning. **`FindFavoritesUseCase`** and **`ToggleFavoriteUseCase`** sit on top: toggle **compacts order** after remove and **skips access checks when unfavoriting** so users can clear dead references.
> 
> **`FavoritesController`** (`/favorites`, gated by `FeatureFlag.Workspaces`) wires **GET** list, **PATCH** `/toggle`, and **PATCH** `/reorder`. Module wiring uses **`forwardRef`** with **threads** and **workspaces** to break the favorites cycle. Frontend **OpenAPI** types and React Query hooks are regenerated for the new endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c982694509c1bafb5cb0e284aa4220f6fd56ee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->