### PR TITLE
wip(workspaces): add batch lookup and list API enhancements (AYC-700)

### DIFF
--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -50,6 +50,7 @@ workspaces/
 │   └── use-cases/
 │       ├── create-workspace/
 │       ├── find-all-workspaces/
+│       ├── find-workspaces-by-ids/
 │       ├── find-workspace/
 │       ├── update-workspace/
 │       └── delete-workspace/
@@ -81,7 +82,11 @@ workspaces/
 On deletion, the module emits `WorkspaceDeletionRequestedEvent` without
 importing favorites; `FavoritesModule` listens to clean up references.
 `ThreadsModule` depends on workspaces to validate a thread's `workspaceId`
-and listen for `WorkspaceDeletionRequestedEvent`.
+and listen for `WorkspaceDeletionRequestedEvent`. In the other direction the
+coupling is schema-level, not module-level: `getThreadStats` in the local
+repository reads the `threads` table directly (raw SQL) to derive per-workspace
+chat counts and last activity. Favorites resolves workspace
+metadata through the exported, user-scoped `FindWorkspacesByIdsUseCase`.
 
 The repository port is deliberately not exported — cross-module access goes
 through the exported use cases.

--- a/ayunis-core-backend/src/domain/workspaces/application/ports/workspaces-repository.port.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/ports/workspaces-repository.port.ts
@@ -1,9 +1,23 @@
 import type { UUID } from 'crypto';
 import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 
+export interface WorkspaceThreadStats {
+  chatCount: number;
+  lastActivityAt: Date | null;
+}
+
 export abstract class WorkspacesRepository {
   /** Ordered by the workspace's last update, newest first. */
   abstract findAllByUserId(userId: UUID): Promise<Workspace[]>;
+  abstract findAllByIds(userId: UUID, ids: UUID[]): Promise<Workspace[]>;
+
+  /**
+   * Chat count and latest chat activity per workspace, for the list page.
+   * Missing entries mean "no chats".
+   */
+  abstract getThreadStats(
+    workspaceIds: UUID[],
+  ): Promise<Map<UUID, WorkspaceThreadStats>>;
   abstract findById(userId: UUID, id: UUID): Promise<Workspace | null>;
   abstract save(workspace: Workspace): Promise<Workspace>;
   /** Throws `WorkspaceNotFoundError` when the user owns no such workspace. */

--- a/ayunis-core-backend/src/domain/workspaces/application/testing/workspace.fixtures.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/testing/workspace.fixtures.ts
@@ -36,6 +36,8 @@ export function createMockContextService(
 export function createMockWorkspacesRepository(): jest.Mocked<WorkspacesRepository> {
   return {
     findAllByUserId: jest.fn().mockResolvedValue([]),
+    findAllByIds: jest.fn().mockResolvedValue([]),
+    getThreadStats: jest.fn().mockResolvedValue(new Map()),
     findById: jest.fn().mockResolvedValue(null),
     save: jest
       .fn()

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.spec.ts
@@ -39,12 +39,64 @@ describe('FindAllWorkspacesUseCase', () => {
     jest.clearAllMocks();
   });
 
-  it('returns the caller’s workspaces', async () => {
-    const workspaces = [aWorkspace()];
-    repository.findAllByUserId.mockResolvedValue(workspaces);
+  it('returns the caller’s workspaces with their chat stats', async () => {
+    const workspace = aWorkspace();
+    repository.findAllByUserId.mockResolvedValue([workspace]);
+    repository.getThreadStats.mockResolvedValue(
+      new Map([[workspace.id, { chatCount: 3, lastActivityAt: null }]]),
+    );
 
-    await expect(useCase.execute()).resolves.toBe(workspaces);
+    await expect(useCase.execute()).resolves.toEqual([
+      { workspace, chatCount: 3, lastActivityAt: workspace.updatedAt },
+    ]);
     expect(repository.findAllByUserId).toHaveBeenCalledWith(TEST_USER_ID);
+  });
+
+  it('reports zero chats for a workspace without stats', async () => {
+    const workspace = aWorkspace();
+    repository.findAllByUserId.mockResolvedValue([workspace]);
+
+    const [item] = await useCase.execute();
+
+    expect(item.chatCount).toBe(0);
+    expect(item.lastActivityAt).toEqual(workspace.updatedAt);
+  });
+
+  it('surfaces chat activity newer than the last edit', async () => {
+    const workspace = aWorkspace({
+      updatedAt: new Date('2026-08-02T10:00:00.000Z'),
+    });
+    const chatActivity = new Date('2026-08-05T10:00:00.000Z');
+    repository.findAllByUserId.mockResolvedValue([workspace]);
+    repository.getThreadStats.mockResolvedValue(
+      new Map([[workspace.id, { chatCount: 1, lastActivityAt: chatActivity }]]),
+    );
+
+    const [item] = await useCase.execute();
+
+    expect(item.lastActivityAt).toEqual(chatActivity);
+  });
+
+  it('keeps the edit timestamp when it is newer than chat activity', async () => {
+    const workspace = aWorkspace({
+      updatedAt: new Date('2026-08-09T10:00:00.000Z'),
+    });
+    repository.findAllByUserId.mockResolvedValue([workspace]);
+    repository.getThreadStats.mockResolvedValue(
+      new Map([
+        [
+          workspace.id,
+          {
+            chatCount: 1,
+            lastActivityAt: new Date('2026-08-05T10:00:00.000Z'),
+          },
+        ],
+      ]),
+    );
+
+    const [item] = await useCase.execute();
+
+    expect(item.lastActivityAt).toEqual(workspace.updatedAt);
   });
 
   it('rejects an unauthenticated caller', async () => {

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.ts
@@ -7,6 +7,13 @@ import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
 import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
 
+export interface WorkspaceListItem {
+  workspace: Workspace;
+  chatCount: number;
+  /** Later of the workspace's own edit and its most recent chat activity. */
+  lastActivityAt: Date;
+}
+
 @Injectable()
 export class FindAllWorkspacesUseCase {
   private readonly logger = new Logger(FindAllWorkspacesUseCase.name);
@@ -17,11 +24,28 @@ export class FindAllWorkspacesUseCase {
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
-  async execute(): Promise<Workspace[]> {
+  async execute(): Promise<WorkspaceListItem[]> {
     this.logger.log('Finding all workspaces');
-    return await this.workspacesRepository.findAllByUserId(
+
+    const workspaces = await this.workspacesRepository.findAllByUserId(
       this.resolveUserId(),
     );
+    const stats = await this.workspacesRepository.getThreadStats(
+      workspaces.map((workspace) => workspace.id),
+    );
+
+    return workspaces.map((workspace) => {
+      const threadStats = stats.get(workspace.id);
+      const chatActivity = threadStats?.lastActivityAt;
+      return {
+        workspace,
+        chatCount: threadStats?.chatCount ?? 0,
+        lastActivityAt:
+          chatActivity && chatActivity > workspace.updatedAt
+            ? chatActivity
+            : workspace.updatedAt,
+      };
+    });
   }
 
   private resolveUserId(): UUID {

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.query.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.query.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class FindWorkspacesByIdsQuery {
+  constructor(
+    public readonly userId: UUID,
+    public readonly ids: UUID[],
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case.spec.ts
@@ -1,0 +1,24 @@
+import type { UUID } from 'crypto';
+import type { WorkspacesRepository } from '../../ports/workspaces-repository.port';
+import { FindWorkspacesByIdsQuery } from './find-workspaces-by-ids.query';
+import { FindWorkspacesByIdsUseCase } from './find-workspaces-by-ids.use-case';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111' as UUID;
+const WORKSPACE_ID = '22222222-2222-4222-8222-222222222222' as UUID;
+
+describe('FindWorkspacesByIdsUseCase', () => {
+  it('returns only workspaces owned by the requested user', async () => {
+    const workspaces = [{ id: WORKSPACE_ID }];
+    const repository = {
+      findAllByIds: jest.fn().mockResolvedValue(workspaces),
+    } as unknown as WorkspacesRepository;
+    const useCase = new FindWorkspacesByIdsUseCase(repository);
+
+    await expect(
+      useCase.execute(new FindWorkspacesByIdsQuery(USER_ID, [WORKSPACE_ID])),
+    ).resolves.toBe(workspaces);
+    expect(repository.findAllByIds).toHaveBeenCalledWith(USER_ID, [
+      WORKSPACE_ID,
+    ]);
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case.ts
@@ -1,0 +1,22 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import type { Workspace } from '../../../domain/workspace.entity';
+import { UnexpectedWorkspaceError } from '../../workspaces.errors';
+import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
+import type { FindWorkspacesByIdsQuery } from './find-workspaces-by-ids.query';
+
+@Injectable()
+export class FindWorkspacesByIdsUseCase {
+  private readonly logger = new Logger(FindWorkspacesByIdsUseCase.name);
+
+  constructor(private readonly workspacesRepository: WorkspacesRepository) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(query: FindWorkspacesByIdsQuery): Promise<Workspace[]> {
+    this.logger.debug('Finding workspaces by ids', {
+      userId: query.userId,
+      count: query.ids.length,
+    });
+    return this.workspacesRepository.findAllByIds(query.userId, query.ids);
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.ts
@@ -1,8 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import type { UUID } from 'crypto';
-import { Repository } from 'typeorm';
-import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import {
+  WorkspacesRepository,
+  type WorkspaceThreadStats,
+} from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { In, Repository } from 'typeorm';
 import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
 import { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import { WorkspaceMapper } from './mappers/workspace.mapper';
@@ -24,6 +27,42 @@ export class LocalWorkspacesRepository extends WorkspacesRepository {
       order: { updatedAt: 'DESC' },
     });
     return records.map((record) => this.mapper.toDomain(record));
+  }
+
+  async findAllByIds(userId: UUID, ids: UUID[]): Promise<Workspace[]> {
+    if (ids.length === 0) return [];
+    const records = await this.repo.find({ where: { userId, id: In(ids) } });
+    return records.map((record) => this.mapper.toDomain(record));
+  }
+
+  // Read-only seam onto the threads table by name. Importing the threads
+  // module here would reverse the threads → workspaces dependency and close a
+  // cycle, so this aggregate query stays raw SQL instead.
+  async getThreadStats(
+    workspaceIds: UUID[],
+  ): Promise<Map<UUID, WorkspaceThreadStats>> {
+    if (workspaceIds.length === 0) {
+      return new Map();
+    }
+    const rows: Array<{
+      workspaceId: UUID;
+      chatCount: number;
+      lastActivityAt: Date | null;
+    }> = await this.repo.manager.query(
+      `SELECT "workspaceId",
+              COUNT(*)::int AS "chatCount",
+              MAX(COALESCE("lastActivityAt", "createdAt")) AS "lastActivityAt"
+       FROM threads
+       WHERE "workspaceId" = ANY($1)
+       GROUP BY "workspaceId"`,
+      [workspaceIds],
+    );
+    return new Map(
+      rows.map((row) => [
+        row.workspaceId,
+        { chatCount: row.chatCount, lastActivityAt: row.lastActivityAt },
+      ]),
+    );
   }
 
   async findById(userId: UUID, id: UUID): Promise<Workspace | null> {

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-response.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-response.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class WorkspaceResponseDto {
   @ApiProperty({
@@ -44,4 +44,18 @@ export class WorkspaceResponseDto {
     example: '2026-08-11T10:30:00.000Z',
   })
   updatedAt: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Number of chats filed under the workspace (list responses only)',
+    example: 3,
+  })
+  chatCount?: number;
+
+  @ApiPropertyOptional({
+    description:
+      'Later of the last edit and the most recent chat activity (list responses only)',
+    example: '2026-08-11T10:30:00.000Z',
+  })
+  lastActivityAt?: string;
 }

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import type { WorkspaceListItem } from 'src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case';
 import { WorkspaceResponseDto } from 'src/domain/workspaces/presenters/http/dtos/workspace-response.dto';
 
 @Injectable()
@@ -13,6 +14,13 @@ export class WorkspaceDtoMapper {
     dto.color = workspace.color;
     dto.createdAt = workspace.createdAt.toISOString();
     dto.updatedAt = workspace.updatedAt.toISOString();
+    return dto;
+  }
+
+  toListItemDto(item: WorkspaceListItem): WorkspaceResponseDto {
+    const dto = this.toDto(item.workspace);
+    dto.chatCount = item.chatCount;
+    dto.lastActivityAt = item.lastActivityAt.toISOString();
     return dto;
   }
 }

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/workspaces.controller.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/workspaces.controller.ts
@@ -73,10 +73,8 @@ export class WorkspacesController {
   })
   async findAll(): Promise<WorkspaceResponseDto[]> {
     this.logger.log('findAll');
-    const workspaces = await this.findAllWorkspacesUseCase.execute();
-    return workspaces.map((workspace) =>
-      this.workspaceDtoMapper.toDto(workspace),
-    );
+    const items = await this.findAllWorkspacesUseCase.execute();
+    return items.map((item) => this.workspaceDtoMapper.toListItemDto(item));
   }
 
   @Get(':id')

--- a/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
@@ -10,6 +10,7 @@ import { UpdateWorkspaceUseCase } from './application/use-cases/update-workspace
 import { DeleteWorkspaceUseCase } from './application/use-cases/delete-workspace/delete-workspace.use-case';
 import { WorkspacesController } from './presenters/http/workspaces.controller';
 import { WorkspaceDtoMapper } from './presenters/http/mappers/workspace-dto.mapper';
+import { FindWorkspacesByIdsUseCase } from './application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case';
 
 @Module({
   imports: [LocalWorkspacesRepositoryModule, FavoritesModule],
@@ -22,6 +23,7 @@ import { WorkspaceDtoMapper } from './presenters/http/mappers/workspace-dto.mapp
     CreateWorkspaceUseCase,
     FindAllWorkspacesUseCase,
     FindWorkspaceUseCase,
+    FindWorkspacesByIdsUseCase,
     UpdateWorkspaceUseCase,
     DeleteWorkspaceUseCase,
     WorkspaceDtoMapper,
@@ -30,6 +32,7 @@ import { WorkspaceDtoMapper } from './presenters/http/mappers/workspace-dto.mapp
     CreateWorkspaceUseCase,
     FindAllWorkspacesUseCase,
     FindWorkspaceUseCase,
+    FindWorkspacesByIdsUseCase,
     UpdateWorkspaceUseCase,
     DeleteWorkspaceUseCase,
   ],

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3462,6 +3462,10 @@ export interface WorkspaceResponseDto {
   createdAt: string;
   /** When the workspace was last updated */
   updatedAt: string;
+  /** Number of chats filed under the workspace (list responses only) */
+  chatCount?: number;
+  /** Later of the last edit and the most recent chat activity (list responses only) */
+  lastActivityAt?: string;
 }
 
 export interface UpdateWorkspaceDto {

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -15861,6 +15861,16 @@
             "type": "string",
             "description": "When the workspace was last updated",
             "example": "2026-08-11T10:30:00.000Z"
+          },
+          "chatCount": {
+            "type": "number",
+            "description": "Number of chats filed under the workspace (list responses only)",
+            "example": 3
+          },
+          "lastActivityAt": {
+            "type": "string",
+            "description": "Later of the last edit and the most recent chat activity (list responses only)",
+            "example": "2026-08-11T10:30:00.000Z"
           }
         },
         "required": [


### PR DESCRIPTION
Include OpenAPI sync for list-only workspace response fields.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> List endpoint shape changes (additive fields) and raw SQL reads on `threads` bypass the threads module; scope stays user-scoped with tests, but cross-table coupling is worth a careful look.
> 
> **Overview**
> **GET `/workspaces`** now returns list-only **`chatCount`** and **`lastActivityAt`**, where activity is the later of the workspace’s `updatedAt` and the newest thread activity (via a new **`getThreadStats`** aggregate on the `threads` table). Single-workspace responses are unchanged.
> 
> Adds **`FindWorkspacesByIdsUseCase`** (user-scoped batch fetch) and repository **`findAllByIds`**, exported for favorites and other modules. OpenAPI and generated frontend types include the optional list fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2537ebd737e50d99c0302891ab2f8117dff587b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->