### PR TITLE
feat(auth): manage SSO connections in Superadmin (AYC-640)

### DIFF
--- a/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.orgs.$id.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.orgs.$id.tsx
@@ -25,6 +25,7 @@ const searchSchema = z.object({
       'usage',
       'crawl-domains',
       'addons',
+      'sso',
     ])
     .optional(),
   usersSearch: z.string().optional(),

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/ssoMutationError.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/ssoMutationError.ts
@@ -1,0 +1,18 @@
+import extractErrorData from '@/shared/api/extract-error-data';
+
+const SSO_ERROR_KEYS: Record<string, string> = {
+  SSO_CONNECTION_CONFLICT: 'sso.errors.conflict',
+  SSO_CONNECTION_MUST_BE_DISABLED: 'sso.errors.mustDisable',
+  SSO_CONNECTION_CHANGED: 'sso.errors.changed',
+  SSO_CONNECTION_NOT_FOUND: 'sso.errors.notFound',
+  SSO_INVALID_CONFIGURATION: 'sso.errors.invalid',
+};
+
+export function getSsoErrorKey(error: unknown): string {
+  try {
+    const { code } = extractErrorData(error);
+    return SSO_ERROR_KEYS[code] ?? 'sso.errors.unexpected';
+  } catch {
+    return 'sso.errors.unexpected';
+  }
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useConfigureSuperAdminSso.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useConfigureSuperAdminSso.ts
@@ -1,0 +1,45 @@
+import { getSsoErrorKey } from '@/pages/super-admin-settings/org/api/ssoMutationError';
+import type { SsoConnectionFormFields } from '@/pages/super-admin-settings/org/model/types';
+import {
+  getSuperAdminSsoConnectionsControllerGetQueryKey,
+  useSuperAdminSsoConnectionsControllerConfigure,
+} from '@/shared/api';
+import extractErrorData from '@/shared/api/extract-error-data';
+import { setValidationErrors } from '@/shared/lib/set-validation-errors';
+import { showError, showSuccess } from '@/shared/lib/toast';
+import { useQueryClient } from '@tanstack/react-query';
+import type { UseFormReturn } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+export function useConfigureSuperAdminSso(
+  orgId: string,
+  form: UseFormReturn<SsoConnectionFormFields>,
+) {
+  const { t } = useTranslation('super-admin-settings-org');
+  const queryClient = useQueryClient();
+  const mutation = useSuperAdminSsoConnectionsControllerConfigure({
+    mutation: {
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: getSuperAdminSsoConnectionsControllerGetQueryKey(orgId),
+        });
+        showSuccess(t('sso.configure.success'));
+      },
+      onError: (error) => {
+        try {
+          const { code, errors } = extractErrorData(error);
+          if (code === 'VALIDATION_ERROR' && errors) {
+            setValidationErrors(form, errors, t, 'sso.validation');
+            return;
+          }
+        } catch {
+          showError(t('sso.errors.unexpected'));
+          return;
+        }
+        showError(t(getSsoErrorKey(error)));
+      },
+    },
+  });
+
+  return { configure: mutation.mutate, isPending: mutation.isPending };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSetSuperAdminSsoEnabled.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSetSuperAdminSsoEnabled.ts
@@ -1,0 +1,31 @@
+import { getSsoErrorKey } from '@/pages/super-admin-settings/org/api/ssoMutationError';
+import {
+  getSuperAdminSsoConnectionsControllerGetQueryKey,
+  useSuperAdminSsoConnectionsControllerSetEnabled,
+} from '@/shared/api';
+import { showError, showSuccess } from '@/shared/lib/toast';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+
+export function useSetSuperAdminSsoEnabled(orgId: string) {
+  const { t } = useTranslation('super-admin-settings-org');
+  const queryClient = useQueryClient();
+
+  return useSuperAdminSsoConnectionsControllerSetEnabled({
+    mutation: {
+      onSuccess: (_data, variables) => {
+        void queryClient.invalidateQueries({
+          queryKey: getSuperAdminSsoConnectionsControllerGetQueryKey(orgId),
+        });
+        showSuccess(
+          t(
+            variables.data.enabled
+              ? 'sso.enable.success'
+              : 'sso.disable.success',
+          ),
+        );
+      },
+      onError: (error) => showError(t(getSsoErrorKey(error))),
+    },
+  });
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSetSuperAdminSsoJit.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSetSuperAdminSsoJit.ts
@@ -1,0 +1,25 @@
+import { getSsoErrorKey } from '@/pages/super-admin-settings/org/api/ssoMutationError';
+import {
+  getSuperAdminSsoConnectionsControllerGetQueryKey,
+  useSuperAdminSsoConnectionsControllerSetJitProvisioning,
+} from '@/shared/api';
+import { showError, showSuccess } from '@/shared/lib/toast';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+
+export function useSetSuperAdminSsoJit(orgId: string) {
+  const { t } = useTranslation('super-admin-settings-org');
+  const queryClient = useQueryClient();
+
+  return useSuperAdminSsoConnectionsControllerSetJitProvisioning({
+    mutation: {
+      onSuccess: () => {
+        void queryClient.invalidateQueries({
+          queryKey: getSuperAdminSsoConnectionsControllerGetQueryKey(orgId),
+        });
+        showSuccess(t('sso.jit.success'));
+      },
+      onError: (error) => showError(t(getSsoErrorKey(error))),
+    },
+  });
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminSsoConnection.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/api/useSuperAdminSsoConnection.ts
@@ -1,0 +1,11 @@
+import { useSuperAdminSsoConnectionsControllerGet } from '@/shared/api';
+
+export function useSuperAdminSsoConnection(orgId: string) {
+  const query = useSuperAdminSsoConnectionsControllerGet(orgId);
+
+  return {
+    connection: query.data?.connection ?? null,
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/model/types.ts
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/model/types.ts
@@ -1,3 +1,9 @@
 export interface UpdateSubscriptionStartDateFormData {
   startsAt: string;
 }
+
+export interface SsoConnectionFormFields {
+  emailDomain: string;
+  zitadelOrgId: string;
+  domainVerified: boolean;
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/EnableSsoDialog.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/EnableSsoDialog.tsx
@@ -1,0 +1,93 @@
+import type { useSetSuperAdminSsoEnabled } from '@/pages/super-admin-settings/org/api/useSetSuperAdminSsoEnabled';
+import type { OrgSsoConnectionResponseDto } from '@/shared/api';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@ayunis/ui/components/alert-dialog';
+import { Button } from '@ayunis/ui/components/button';
+import { Checkbox } from '@ayunis/ui/components/checkbox';
+import { Label } from '@ayunis/ui/components/label';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface EnableSsoDialogProps {
+  orgId: string;
+  connection: OrgSsoConnectionResponseDto;
+  // Owned by the parent so its busy state also covers an in-flight enable.
+  mutation: ReturnType<typeof useSetSuperAdminSsoEnabled>;
+  disabled?: boolean;
+}
+
+export default function EnableSsoDialog({
+  orgId,
+  connection,
+  mutation,
+  disabled = false,
+}: Readonly<EnableSsoDialogProps>) {
+  const { t } = useTranslation('super-admin-settings-org');
+  const [reviewed, setReviewed] = useState(false);
+
+  function enable() {
+    mutation.mutate({
+      orgId,
+      data: {
+        enabled: true,
+        confirmed: true,
+        reviewedEmailDomain: connection.emailDomain,
+        reviewedZitadelOrgId: connection.zitadelOrgId ?? undefined,
+      },
+    });
+  }
+
+  return (
+    <AlertDialog onOpenChange={(open) => !open && setReviewed(false)}>
+      <AlertDialogTrigger asChild>
+        <Button disabled={disabled}>{t('sso.enable.button')}</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t('sso.enable.title')}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t('sso.enable.description')}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <dl className="grid gap-3 rounded-lg border p-4 text-sm">
+          <div>
+            <dt className="text-muted-foreground">{t('sso.emailDomain')}</dt>
+            <dd className="font-medium">{connection.emailDomain}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">{t('sso.zitadelOrgId')}</dt>
+            <dd className="font-mono text-xs">{connection.zitadelOrgId}</dd>
+          </div>
+        </dl>
+        <div className="flex items-start gap-2">
+          <Checkbox
+            id="confirm-sso-mapping"
+            checked={reviewed}
+            onCheckedChange={(value) => setReviewed(value === true)}
+          />
+          <Label htmlFor="confirm-sso-mapping" className="font-normal">
+            {t('sso.enable.confirm')}
+          </Label>
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{t('sso.cancel')}</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={!reviewed || mutation.isPending}
+            onClick={enable}
+          >
+            {t('sso.enable.confirmButton')}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/Page.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/Page.tsx
@@ -25,6 +25,7 @@ import AddonsSection from './AddonsSection';
 import TrialSection from './TrialSection';
 import NoTrialSection from './NoTrialSection';
 import UsageTab from './UsageTab';
+import SsoSection from './SsoSection';
 import {
   Tabs,
   TabsList,
@@ -51,7 +52,8 @@ interface SuperAdminSettingsOrgPageProps {
     | 'trials'
     | 'usage'
     | 'crawl-domains'
-    | 'addons';
+    | 'addons'
+    | 'sso';
 }
 export default function SuperAdminSettingsOrgPage({
   org,
@@ -84,7 +86,8 @@ export default function SuperAdminSettingsOrgPage({
             | 'trials'
             | 'usage'
             | 'crawl-domains'
-            | 'addons',
+            | 'addons'
+            | 'sso',
         },
       });
     },
@@ -103,20 +106,23 @@ export default function SuperAdminSettingsOrgPage({
         onValueChange={handleTabChange}
         className="w-full"
       >
-        <TabsList>
-          <TabsTrigger value="org">{t('tabs.org')}</TabsTrigger>
-          <TabsTrigger value="users">{t('tabs.users')}</TabsTrigger>
-          <TabsTrigger value="subscriptions">
-            {t('tabs.subscriptions')}
-          </TabsTrigger>
-          <TabsTrigger value="trials">{t('tabs.trials')}</TabsTrigger>
-          <TabsTrigger value="models">{t('tabs.models')}</TabsTrigger>
-          <TabsTrigger value="crawl-domains">
-            {t('tabs.crawlDomains')}
-          </TabsTrigger>
-          <TabsTrigger value="addons">{t('tabs.addons')}</TabsTrigger>
-          <TabsTrigger value="usage">{t('tabs.usage')}</TabsTrigger>
-        </TabsList>
+        <div className="overflow-x-auto">
+          <TabsList>
+            <TabsTrigger value="org">{t('tabs.org')}</TabsTrigger>
+            <TabsTrigger value="users">{t('tabs.users')}</TabsTrigger>
+            <TabsTrigger value="subscriptions">
+              {t('tabs.subscriptions')}
+            </TabsTrigger>
+            <TabsTrigger value="trials">{t('tabs.trials')}</TabsTrigger>
+            <TabsTrigger value="models">{t('tabs.models')}</TabsTrigger>
+            <TabsTrigger value="crawl-domains">
+              {t('tabs.crawlDomains')}
+            </TabsTrigger>
+            <TabsTrigger value="addons">{t('tabs.addons')}</TabsTrigger>
+            <TabsTrigger value="usage">{t('tabs.usage')}</TabsTrigger>
+            <TabsTrigger value="sso">{t('tabs.sso')}</TabsTrigger>
+          </TabsList>
+        </div>
         <TabsContent value="org" className="mt-4">
           <OrgDetails org={org} />
         </TabsContent>
@@ -198,6 +204,9 @@ export default function SuperAdminSettingsOrgPage({
         </TabsContent>
         <TabsContent value="usage" className="mt-4">
           <UsageTab orgId={org.id} />
+        </TabsContent>
+        <TabsContent value="sso" className="mt-4">
+          <SsoSection orgId={org.id} />
         </TabsContent>
       </Tabs>
     </SuperAdminSettingsLayout>

--- a/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/SsoSection.tsx
+++ b/ayunis-core-frontend/src/pages/super-admin-settings/org/ui/SsoSection.tsx
@@ -1,0 +1,242 @@
+import { useConfigureSuperAdminSso } from '@/pages/super-admin-settings/org/api/useConfigureSuperAdminSso';
+import { useSetSuperAdminSsoEnabled } from '@/pages/super-admin-settings/org/api/useSetSuperAdminSsoEnabled';
+import { useSetSuperAdminSsoJit } from '@/pages/super-admin-settings/org/api/useSetSuperAdminSsoJit';
+import { useSuperAdminSsoConnection } from '@/pages/super-admin-settings/org/api/useSuperAdminSsoConnection';
+import type { SsoConnectionFormFields } from '@/pages/super-admin-settings/org/model/types';
+import { Alert, AlertDescription } from '@ayunis/ui/components/alert';
+import { Badge } from '@ayunis/ui/components/badge';
+import { Button } from '@ayunis/ui/components/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@ayunis/ui/components/card';
+import { Checkbox } from '@ayunis/ui/components/checkbox';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@ayunis/ui/components/form';
+import { Input } from '@ayunis/ui/components/input';
+import { Label } from '@ayunis/ui/components/label';
+import { Skeleton } from '@ayunis/ui/components/skeleton';
+import { Switch } from '@ayunis/ui/components/switch';
+import { InfoIcon } from 'lucide-react';
+import { useEffect } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import EnableSsoDialog from '@/pages/super-admin-settings/org/ui/EnableSsoDialog';
+
+interface SsoSectionProps {
+  orgId: string;
+}
+
+function connectionStatusKey(
+  connection: ReturnType<typeof useSuperAdminSsoConnection>['connection'],
+) {
+  if (!connection) return 'sso.status.notConfigured';
+  return connection.enabled ? 'sso.status.enabled' : 'sso.status.disabled';
+}
+
+export default function SsoSection({ orgId }: Readonly<SsoSectionProps>) {
+  const { t } = useTranslation('super-admin-settings-org');
+  const { connection, isLoading, isError } = useSuperAdminSsoConnection(orgId);
+  const form = useForm<SsoConnectionFormFields>({
+    defaultValues: { emailDomain: '', zitadelOrgId: '', domainVerified: false },
+  });
+  const configure = useConfigureSuperAdminSso(orgId, form);
+  const setEnabled = useSetSuperAdminSsoEnabled(orgId);
+  const setJit = useSetSuperAdminSsoJit(orgId);
+  const domainVerified = useWatch({
+    control: form.control,
+    name: 'domainVerified',
+  });
+
+  // Keyed on the saved values rather than the connection object, so a JIT
+  // refetch does not reset the form under an operator who is still typing.
+  // `savedEnabled` is included because enabling locks the fields: without it a
+  // locked form could display unsaved edits instead of the activated mapping.
+  const savedEmailDomain = connection?.emailDomain ?? '';
+  const savedZitadelOrgId = connection?.zitadelOrgId ?? '';
+  const savedEnabled = connection?.enabled ?? false;
+
+  useEffect(() => {
+    form.reset({
+      emailDomain: savedEmailDomain,
+      zitadelOrgId: savedZitadelOrgId,
+      domainVerified: false,
+    });
+  }, [savedEmailDomain, savedZitadelOrgId, savedEnabled, form]);
+
+  if (isLoading) return <Skeleton className="h-80 w-full" />;
+  if (isError) {
+    return <p className="text-destructive text-sm">{t('sso.loadError')}</p>;
+  }
+
+  const busy = configure.isPending || setEnabled.isPending || setJit.isPending;
+  const mappingLocked = connection?.enabled === true;
+
+  function submit(values: SsoConnectionFormFields) {
+    configure.configure({
+      orgId,
+      data: {
+        emailDomain: values.emailDomain.trim(),
+        zitadelOrgId: values.zitadelOrgId.trim(),
+        domainVerified: values.domainVerified,
+      },
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <CardTitle>{t('sso.title')}</CardTitle>
+              <CardDescription>{t('sso.description')}</CardDescription>
+            </div>
+            <Badge variant={connection?.enabled ? 'default' : 'secondary'}>
+              {t(connectionStatusKey(connection))}
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {mappingLocked && (
+            <Alert className="mb-4">
+              <InfoIcon className="h-4 w-4" />
+              <AlertDescription>{t('sso.mappingLocked')}</AlertDescription>
+            </Alert>
+          )}
+          <Form {...form}>
+            <form
+              className="space-y-4"
+              onSubmit={(event) => void form.handleSubmit(submit)(event)}
+            >
+              <div className="grid gap-4 md:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="emailDomain"
+                  rules={{ required: t('sso.validation.emailDomain.required') }}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t('sso.emailDomain')}</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="stadt.example"
+                          disabled={mappingLocked || busy}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="zitadelOrgId"
+                  rules={{
+                    required: t('sso.validation.zitadelOrgId.required'),
+                  }}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t('sso.zitadelOrgId')}</FormLabel>
+                      <FormControl>
+                        <Input disabled={mappingLocked || busy} {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <FormField
+                control={form.control}
+                name="domainVerified"
+                rules={{
+                  required: t('sso.validation.domainVerified.required'),
+                }}
+                render={({ field }) => (
+                  <FormItem>
+                    <div className="flex items-start gap-2">
+                      <FormControl>
+                        <Checkbox
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                          disabled={mappingLocked || busy}
+                        />
+                      </FormControl>
+                      <FormLabel className="font-normal">
+                        {t('sso.domainVerified')}
+                      </FormLabel>
+                    </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex justify-end">
+                <Button
+                  type="submit"
+                  disabled={mappingLocked || busy || !domainVerified}
+                >
+                  {t('sso.configure.save')}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+
+      {connection && (
+        <Card>
+          <CardHeader>
+            <CardTitle>{t('sso.access.title')}</CardTitle>
+            <CardDescription>{t('sso.access.description')}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <Label htmlFor="sso-jit">{t('sso.jit.label')}</Label>
+                <p className="text-muted-foreground text-sm">
+                  {t('sso.jit.description')}
+                </p>
+              </div>
+              <Switch
+                id="sso-jit"
+                checked={connection.jitProvisioningEnabled}
+                disabled={busy}
+                onCheckedChange={(enabled) =>
+                  setJit.mutate({ orgId, data: { enabled } })
+                }
+              />
+            </div>
+            <div className="flex justify-end">
+              {connection.enabled ? (
+                <Button
+                  variant="destructive"
+                  disabled={busy}
+                  onClick={() =>
+                    setEnabled.mutate({ orgId, data: { enabled: false } })
+                  }
+                >
+                  {t('sso.disable.button')}
+                </Button>
+              ) : (
+                <EnableSsoDialog
+                  orgId={orgId}
+                  connection={connection}
+                  mutation={setEnabled}
+                  disabled={busy}
+                />
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-org.json
+++ b/ayunis-core-frontend/src/shared/locales/de/super-admin-settings-org.json
@@ -273,7 +273,74 @@
     "models": "Modelle",
     "usage": "Nutzung",
     "crawlDomains": "Crawl-Domains",
-    "addons": "Add-ons"
+    "addons": "Add-ons",
+    "sso": "SSO"
+  },
+  "sso": {
+    "title": "Single Sign-on",
+    "description": "Verbinden Sie diese Organisation mit ihrer verifizierten Zitadel-Broker-Organisation.",
+    "emailDomain": "Verifizierte E-Mail-Domain",
+    "zitadelOrgId": "Zitadel-Organisations-ID",
+    "domainVerified": "Ich habe die Domain-Inhaberschaft verifiziert und die Zitadel-Einrichtung abgeschlossen.",
+    "mappingLocked": "Deaktivieren Sie SSO, bevor Sie die Domain oder Zitadel-Organisationszuordnung ändern.",
+    "loadError": "Die SSO-Verbindung konnte nicht geladen werden.",
+    "cancel": "Abbrechen",
+    "status": {
+      "enabled": "Aktiviert",
+      "disabled": "Deaktiviert",
+      "notConfigured": "Nicht konfiguriert"
+    },
+    "configure": {
+      "save": "Verbindung speichern",
+      "success": "SSO-Verbindung gespeichert. Sie bleibt deaktiviert, bis sie ausdrücklich aktiviert wird."
+    },
+    "access": {
+      "title": "Zugriff und Bereitstellung",
+      "description": "Steuern Sie Anmeldung und JIT-Benutzeranlage unabhängig. Einladungen bleiben verfügbar."
+    },
+    "jit": {
+      "label": "JIT-Bereitstellung",
+      "description": "Beim ersten gültigen kommunalen SSO-Login einen Ayunis-Benutzer erstellen.",
+      "success": "JIT-Bereitstellung aktualisiert."
+    },
+    "enable": {
+      "button": "SSO aktivieren",
+      "title": "Diese SSO-Verbindung aktivieren?",
+      "description": "Prüfen Sie die genaue Routing-Zuordnung, die aktiviert wird.",
+      "confirm": "Ich habe diese Domain- und Zitadel-Organisationszuordnung geprüft.",
+      "confirmButton": "SSO aktivieren",
+      "success": "SSO aktiviert."
+    },
+    "disable": {
+      "button": "SSO deaktivieren",
+      "success": "SSO deaktiviert. Die lokale Anmeldung bleibt verfügbar."
+    },
+    "validation": {
+      "emailDomain": {
+        "required": "Geben Sie die verifizierte E-Mail-Domain ein.",
+        "matches": "Geben Sie eine gültige E-Mail-Domain ein.",
+        "invalid": "Geben Sie eine gültige E-Mail-Domain ein."
+      },
+      "zitadelOrgId": {
+        "required": "Geben Sie die Zitadel-Organisations-ID ein.",
+        "isNotEmpty": "Geben Sie die Zitadel-Organisations-ID ein.",
+        "maxLength": "Die Zitadel-Organisations-ID ist zu lang.",
+        "matches": "Die Zitadel-Organisations-ID darf keine Leerzeichen enthalten.",
+        "invalid": "Geben Sie eine gültige Zitadel-Organisations-ID ein."
+      },
+      "domainVerified": {
+        "required": "Bestätigen Sie Domain-Inhaberschaft und Zitadel-Einrichtung."
+      },
+      "invalid": "Prüfen Sie die eingegebene SSO-Verbindung."
+    },
+    "errors": {
+      "conflict": "Diese Domain oder Zitadel-Organisation ist bereits einer anderen Organisation zugeordnet.",
+      "mustDisable": "Deaktivieren Sie SSO, bevor Sie die Routing-Zuordnung ändern.",
+      "changed": "Die Verbindung wurde während der Prüfung geändert. Laden Sie neu und versuchen Sie es erneut.",
+      "notFound": "Für diese Organisation ist keine SSO-Verbindung vorhanden.",
+      "invalid": "Die SSO-Verbindung ist unvollständig oder ungültig.",
+      "unexpected": "Die SSO-Verbindung konnte nicht aktualisiert werden."
+    }
   },
   "addons": {
     "title": "Add-ons",

--- a/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-org.json
+++ b/ayunis-core-frontend/src/shared/locales/en/super-admin-settings-org.json
@@ -273,7 +273,74 @@
     "models": "Models",
     "usage": "Usage",
     "crawlDomains": "Crawl Domains",
-    "addons": "Add-ons"
+    "addons": "Add-ons",
+    "sso": "SSO"
+  },
+  "sso": {
+    "title": "Single sign-on",
+    "description": "Connect this organization to its verified Zitadel broker organization.",
+    "emailDomain": "Verified email domain",
+    "zitadelOrgId": "Zitadel organization ID",
+    "domainVerified": "I verified ownership of this domain and completed the Zitadel setup.",
+    "mappingLocked": "Disable SSO before changing the domain or Zitadel organization mapping.",
+    "loadError": "The SSO connection could not be loaded.",
+    "cancel": "Cancel",
+    "status": {
+      "enabled": "Enabled",
+      "disabled": "Disabled",
+      "notConfigured": "Not configured"
+    },
+    "configure": {
+      "save": "Save connection",
+      "success": "SSO connection saved. It remains disabled until explicitly enabled."
+    },
+    "access": {
+      "title": "Access and provisioning",
+      "description": "Control runtime login and JIT account creation independently. Invitations remain available."
+    },
+    "jit": {
+      "label": "JIT provisioning",
+      "description": "Create an Ayunis user on the first valid municipal SSO login.",
+      "success": "JIT provisioning updated."
+    },
+    "enable": {
+      "button": "Enable SSO",
+      "title": "Enable this SSO connection?",
+      "description": "Review the exact routing mapping that will become active.",
+      "confirm": "I reviewed this domain and Zitadel organization mapping.",
+      "confirmButton": "Enable SSO",
+      "success": "SSO enabled."
+    },
+    "disable": {
+      "button": "Disable SSO",
+      "success": "SSO disabled. Local login remains available."
+    },
+    "validation": {
+      "emailDomain": {
+        "required": "Enter the verified email domain.",
+        "matches": "Enter a valid email domain.",
+        "invalid": "Enter a valid email domain."
+      },
+      "zitadelOrgId": {
+        "required": "Enter the Zitadel organization ID.",
+        "isNotEmpty": "Enter the Zitadel organization ID.",
+        "maxLength": "The Zitadel organization ID is too long.",
+        "matches": "The Zitadel organization ID cannot contain whitespace.",
+        "invalid": "Enter a valid Zitadel organization ID."
+      },
+      "domainVerified": {
+        "required": "Confirm domain ownership and the Zitadel setup."
+      },
+      "invalid": "Review the entered SSO connection."
+    },
+    "errors": {
+      "conflict": "This domain or Zitadel organization is already assigned to another organization.",
+      "mustDisable": "Disable SSO before changing its routing mapping.",
+      "changed": "The connection changed while you were reviewing it. Reload and try again.",
+      "notFound": "No SSO connection exists for this organization.",
+      "invalid": "The SSO connection is incomplete or invalid.",
+      "unexpected": "The SSO connection could not be updated."
+    }
   },
   "addons": {
     "title": "Add-ons",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes govern how organizations authenticate via SSO routing and JIT provisioning; mistakes could misroute logins, though the UI adds verification and enable-time confirmation gates.
> 
> **Overview**
> Adds a **SSO** tab on super-admin organization settings so operators can manage per-org Zitadel SSO without leaving the org detail page. The route search schema and tab navigation now accept `sso`, and the tab list scrolls horizontally on narrow viewports.
> 
> The new **SSO** section loads the org connection, lets super-admins save **verified email domain** + **Zitadel org ID** (with a domain-verification attestation), and blocks mapping edits while SSO is enabled. After a connection exists, they can toggle **JIT provisioning**, **disable** SSO in one click, or **enable** it through a confirmation dialog that shows the mapping and requires an explicit review checkbox before sending `confirmed` plus the reviewed domain/org IDs to the API.
> 
> Supporting hooks wrap the generated super-admin SSO endpoints (get, configure, set enabled, set JIT), map API error codes to translated messages, and invalidate the connection query on success. English and German copy covers validation, toasts, and SSO-specific errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac8e63b4ea9af8d4d1bc95794b0fd33f45db15f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Screenshots / demo

#### Superadmin SSO tab — enable is gated on explicit confirmation

| Unconfirmed save blocked | Saved, still disabled |
| --- | --- |
| ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-640/docs/pr-media/ayc-640/03-unverified-blocked.png) | ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-640/docs/pr-media/ayc-640/05-saved-disabled.png) |

#### End-to-end interaction

![demo](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-640/docs/pr-media/ayc-640/demo.gif)

#### Persistence across reload

![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-640/docs/pr-media/ayc-640/06-persisted-after-reload.png)

#### Responsive — 0px horizontal overflow at every breakpoint

| Mobile 375px | Tablet 768px | Desktop 1280px |
| --- | --- | --- |
| ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-640/docs/pr-media/ayc-640/resp-mobile.png) | ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-640/docs/pr-media/ayc-640/resp-tablet.png) | ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-640/docs/pr-media/ayc-640/resp-desktop.png) |

> Media hosted on the `pr-media/ayc-640` branch (not part of this PR's diff); safe to delete after merge.
