### PR TITLE
fix(chat): show full tool source text without clipped rounded container (AYC-731)

### DIFF
--- a/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimelineRow.tsx
+++ b/ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimelineRow.tsx
@@ -13,7 +13,6 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@ayunis/ui/components/collapsible';
-import { Badge } from '@ayunis/ui/components/badge';
 import { PiiText } from '@/widgets/markdown';
 import type { TimelineStep, StepStatus } from '../model/types';
 import { getToolActionLabel } from '../lib/get-tool-action-label';
@@ -179,16 +178,9 @@ function getStepView(
           </div>
         )}
         {hasResult && (
-          <Badge
-            variant="outline"
-            className="font-normal whitespace-normal text-left"
-          >
-            <div className="max-h-32 w-full overflow-y-auto">
-              <span className="text-xs text-muted-foreground whitespace-pre-wrap">
-                <PiiText>{step.result ?? ''}</PiiText>
-              </span>
-            </div>
-          </Badge>
+          <div className="text-xs text-muted-foreground whitespace-pre-wrap break-words">
+            <PiiText>{step.result ?? ''}</PiiText>
+          </div>
         )}
       </>
     ),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In the chat agent-run timeline, tool results (e.g. from file/source queries — "Searched files") were rendered inside a rounded `Badge` (outline pill) wrapping a `max-h-32 overflow-y-auto` scroll box. This clipped the source text into a small, rounded preview container, making the content hard to scan quickly (see [AYC-731](https://linear.app/issue/AYC-731)).

## Fix

Render the tool result as plain, full-width text so the entire source text is directly readable:

- Removed the rounded `Badge` wrapper and the `max-h-32 overflow-y-auto` clipping container.
- Kept `whitespace-pre-wrap` for formatting and added `break-words` to keep long tokens from overflowing.
- Removed the now-unused `Badge` import.

This makes the full text visible immediately for better overview, matching how the thinking / skill-instruction transcript details are shown.

## Scope

- `ayunis-core-frontend/src/pages/chat/ui/agent-run-timeline/ui/AgentRunTimelineRow.tsx`

Streamed-arguments and params blocks are intentionally left unchanged since the issue is specifically about the source text result being shown in a rounded, clipped container.

## Verification

- `eslint` on the changed file: passes
- `tsc --noEmit`: passes
- `vitest run` on `agent-run-timeline`: 48 tests pass
- Pre-commit checks (ESLint, Prettier, TypeScript, dependency-cruiser, jscpd, file-size): all pass
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-731](https://linear.app/ayunis/issue/AYC-731/show-full-source-text-without-clipped-rounded-container)

<div><a href="https://cursor.com/agents/bc-8ed528ad-f539-4ec0-99ea-090482de86e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ed528ad-f539-4ec0-99ea-090482de86e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

