### PR TITLE
refactor(iam): join the ambient transaction in provisioning repositories (AYC-627)

### DIFF
--- a/ayunis-core-backend/src/iam/invites/infrastructure/persistence/local/local-invites.repository.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/infrastructure/persistence/local/local-invites.repository.spec.ts
@@ -21,13 +21,23 @@ function makeAcceptedInviteRecord(email: string): InviteRecord {
 
 describe('LocalInvitesRepository', () => {
   let inviteRepo: jest.Mocked<Pick<Repository<InviteRecord>, 'findOne'>>;
+  let txHost: {
+    tx: { getRepository: jest.Mock };
+    isTransactionActive: () => boolean;
+  };
   let repository: LocalInvitesRepository;
 
   beforeEach(() => {
     inviteRepo = { findOne: jest.fn() };
+    // Reads resolve through txHost.tx, which outside a transaction is the
+    // adapter's fallback manager rather than undefined.
+    txHost = {
+      tx: { getRepository: jest.fn().mockReturnValue(inviteRepo) },
+      isTransactionActive: () => false,
+    };
     repository = new LocalInvitesRepository(
-      inviteRepo as unknown as Repository<InviteRecord>,
       new InviteMapper(),
+      txHost as never,
     );
   });
 
@@ -57,6 +67,30 @@ describe('LocalInvitesRepository', () => {
       const result = await repository.findOneByEmail('missing@example.com');
 
       expect(result).toBeNull();
+    });
+  });
+
+  // AYC-627: writes must land in the caller's transaction, otherwise an outer
+  // rollback leaves committed rows behind.
+  describe('ambient transaction', () => {
+    it('resolves reads through the transactional entity manager', async () => {
+      const txRepo = { findOne: jest.fn().mockResolvedValue(null) };
+      txHost.tx = { getRepository: jest.fn().mockReturnValue(txRepo) };
+      txHost.isTransactionActive = () => true;
+
+      await repository.findOneByEmail('user@example.com');
+
+      expect(txRepo.findOne).toHaveBeenCalled();
+      expect(inviteRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('never reads from the injected repository directly', async () => {
+      inviteRepo.findOne.mockResolvedValue(null);
+
+      await repository.findOneByEmail('user@example.com');
+
+      // routed via txHost.tx.getRepository, which the fixture maps back to inviteRepo
+      expect(txHost.tx.getRepository).toHaveBeenCalledWith(InviteRecord);
     });
   });
 });

--- a/ayunis-core-backend/src/iam/invites/infrastructure/persistence/local/local-invites.repository.ts
+++ b/ayunis-core-backend/src/iam/invites/infrastructure/persistence/local/local-invites.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, ILike, IsNull } from 'typeorm';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
+import { EntityManager, Repository, ILike, IsNull } from 'typeorm';
 import { UUID } from 'crypto';
 import {
   InvitesRepository,
@@ -17,10 +18,19 @@ export class LocalInvitesRepository implements InvitesRepository {
   private readonly logger = new Logger(LocalInvitesRepository.name);
 
   constructor(
-    @InjectRepository(InviteRecord)
-    private readonly inviteRepository: Repository<InviteRecord>,
     private readonly inviteMapper: InviteMapper,
+    private readonly txHost: TransactionHost<TransactionalAdapterTypeOrm>,
   ) {}
+
+  // Outside an active transaction txHost.tx resolves to the adapter's fallback
+  // instance (dataSource.manager), so this is safe without a null check.
+  private getManager(): EntityManager {
+    return this.txHost.tx;
+  }
+
+  private get invites(): Repository<InviteRecord> {
+    return this.getManager().getRepository(InviteRecord);
+  }
 
   async create(invite: Invite): Promise<void> {
     this.logger.log('create', {
@@ -31,7 +41,7 @@ export class LocalInvitesRepository implements InvitesRepository {
       inviterId: invite.inviterId,
     });
     const entity = this.inviteMapper.toEntity(invite);
-    await this.inviteRepository.save(entity);
+    await this.invites.save(entity);
     this.logger.debug('Invite created successfully', { inviteId: invite.id });
   }
 
@@ -45,7 +55,7 @@ export class LocalInvitesRepository implements InvitesRepository {
     const entities = invites.map((invite) =>
       this.inviteMapper.toEntity(invite),
     );
-    await this.inviteRepository.save(entities);
+    await this.invites.save(entities);
 
     this.logger.debug('Invites created successfully', {
       inviteCount: invites.length,
@@ -54,7 +64,7 @@ export class LocalInvitesRepository implements InvitesRepository {
 
   async findOne(id: UUID): Promise<Invite | null> {
     this.logger.log('findOne', { id });
-    const entity = await this.inviteRepository.findOne({ where: { id } });
+    const entity = await this.invites.findOne({ where: { id } });
 
     if (!entity) {
       this.logger.debug('Invite not found', { id });
@@ -76,7 +86,7 @@ export class LocalInvitesRepository implements InvitesRepository {
       search: filters?.search,
     });
 
-    const queryBuilder = this.inviteRepository
+    const queryBuilder = this.invites
       .createQueryBuilder('invite')
       .where('invite.orgId = :orgId', { orgId })
       .orderBy('invite.createdAt', 'DESC');
@@ -115,7 +125,7 @@ export class LocalInvitesRepository implements InvitesRepository {
     // Deletion paths (delete-user, delete-invite-by-email) rely on this to
     // clean up already-accepted invites; filtering on acceptedAt would leave
     // them orphaned and block re-inviting the same email (AYC-299).
-    const entity = await this.inviteRepository.findOne({
+    const entity = await this.invites.findOne({
       where: { email: ILike(email) },
     });
     if (!entity) {
@@ -130,7 +140,7 @@ export class LocalInvitesRepository implements InvitesRepository {
     orgId: UUID,
   ): Promise<Invite | null> {
     this.logger.log('findOneByEmailAndOrg', { email, orgId });
-    const entity = await this.inviteRepository.findOne({
+    const entity = await this.invites.findOne({
       where: { email: ILike(email), orgId, acceptedAt: IsNull() },
     });
     if (!entity) {
@@ -150,7 +160,7 @@ export class LocalInvitesRepository implements InvitesRepository {
     // Convert emails to lowercase for case-insensitive comparison
     const lowerEmails = emails.map((e) => e.toLowerCase());
 
-    const entities = await this.inviteRepository
+    const entities = await this.invites
       .createQueryBuilder('invite')
       .where('invite.orgId = :orgId', { orgId })
       .andWhere('LOWER(invite.email) IN (:...emails)', { emails: lowerEmails })
@@ -169,7 +179,7 @@ export class LocalInvitesRepository implements InvitesRepository {
   async accept(id: UUID): Promise<void> {
     this.logger.log('accept', { id });
 
-    await this.inviteRepository.update(id, {
+    await this.invites.update(id, {
       acceptedAt: new Date(),
     });
 
@@ -178,14 +188,14 @@ export class LocalInvitesRepository implements InvitesRepository {
 
   async delete(id: UUID): Promise<void> {
     this.logger.log('delete', { id });
-    await this.inviteRepository.delete(id);
+    await this.invites.delete(id);
     this.logger.debug('Invite deleted successfully', { id });
   }
 
   async deleteAllPendingByOrg(orgId: UUID): Promise<number> {
     this.logger.log('deleteAllPendingByOrg', { orgId });
 
-    const result = await this.inviteRepository.delete({
+    const result = await this.invites.delete({
       orgId,
       acceptedAt: IsNull(), // Only delete pending invites (not accepted)
     });

--- a/ayunis-core-backend/src/iam/subscriptions/infrastructure/persistence/local/local-subscriptions.repository.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/infrastructure/persistence/local/local-subscriptions.repository.spec.ts
@@ -1,0 +1,80 @@
+import type { DataSource, EntityManager } from 'typeorm';
+import { LocalSubscriptionsRepository } from './local-subscriptions.repository';
+import { SubscriptionMapper } from './mappers/subscription.mapper';
+import { SubscriptionBillingInfoMapper } from './mappers/subscription-billing-info.mapper';
+import { SeatBasedSubscription } from 'src/iam/subscriptions/domain/seat-based-subscription.entity';
+import { RenewalCycle } from 'src/iam/subscriptions/domain/value-objects/renewal-cycle.enum';
+import { SubscriptionBillingInfo } from 'src/iam/subscriptions/domain/subscription-billing-info.entity';
+import { randomUUID } from 'crypto';
+
+// AYC-627: subscription writes have to end up in the caller's transaction when
+// there is one, and still open their own when there is not. txHost.tx never
+// returns undefined — outside a transaction it is the adapter's fallback
+// manager — so only isTransactionActive() can tell the two cases apart.
+describe('LocalSubscriptionsRepository ambient transaction', () => {
+  const orgId = randomUUID();
+
+  function aSubscription(): SeatBasedSubscription {
+    return new SeatBasedSubscription({
+      orgId,
+      noOfSeats: 5,
+      pricePerSeat: 10,
+      renewalCycle: RenewalCycle.MONTHLY,
+      renewalCycleAnchor: new Date('2026-01-01T00:00:00Z'),
+      billingInfo: new SubscriptionBillingInfo({
+        companyName: 'Stadt',
+        street: 'Street',
+        houseNumber: '1',
+        postalCode: '12345',
+        city: 'City',
+        country: 'DE',
+      }),
+    });
+  }
+
+  function build(isActive: boolean) {
+    const manager = {
+      save: jest.fn().mockImplementation((r: unknown) => Promise.resolve(r)),
+      insert: jest.fn().mockResolvedValue({}),
+      delete: jest.fn().mockResolvedValue({}),
+      update: jest.fn().mockResolvedValue({}),
+      getRepository: jest.fn().mockReturnValue({}),
+    } as unknown as EntityManager;
+
+    const dataSourceTransaction = jest
+      .fn()
+      .mockImplementation((work: (m: EntityManager) => Promise<unknown>) =>
+        work(manager),
+      );
+
+    const repository = new LocalSubscriptionsRepository(
+      new SubscriptionMapper(new SubscriptionBillingInfoMapper()),
+      new SubscriptionBillingInfoMapper(),
+      { transaction: dataSourceTransaction } as unknown as DataSource,
+      {
+        tx: manager,
+        isTransactionActive: () => isActive,
+      } as never,
+    );
+
+    return { repository, dataSourceTransaction, manager };
+  }
+
+  it('opens its own transaction when no transaction is active', async () => {
+    const { repository, dataSourceTransaction } = build(false);
+
+    await repository.create(aSubscription());
+
+    expect(dataSourceTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('joins the caller transaction instead of opening a nested one', async () => {
+    const { repository, dataSourceTransaction, manager } = build(true);
+
+    await repository.create(aSubscription());
+
+    expect(dataSourceTransaction).not.toHaveBeenCalled();
+    // the write still happened, just on the caller's manager
+    expect(manager.save).toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/iam/subscriptions/infrastructure/persistence/local/local-subscriptions.repository.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/infrastructure/persistence/local/local-subscriptions.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
 import { DataSource, EntityManager, IsNull, Repository } from 'typeorm';
 import { UUID } from 'crypto';
 import {
@@ -23,20 +24,45 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
   private readonly logger = new Logger(LocalSubscriptionsRepository.name);
 
   constructor(
-    @InjectRepository(SubscriptionRecord)
-    private readonly subscriptionRepository: Repository<SubscriptionRecord>,
-    @InjectRepository(SubscriptionBillingInfoRecord)
-    private readonly subscriptionBillingInfoRepository: Repository<SubscriptionBillingInfoRecord>,
     private readonly subscriptionMapper: SubscriptionMapper,
     private readonly subscriptionBillingInfoMapper: SubscriptionBillingInfoMapper,
     private readonly dataSource: DataSource,
+    private readonly txHost: TransactionHost<TransactionalAdapterTypeOrm>,
   ) {
     super();
   }
 
+  // Outside an active transaction txHost.tx resolves to the adapter's fallback
+  // instance (dataSource.manager), so this is safe without a null check.
+  private getManager(): EntityManager {
+    return this.txHost.tx;
+  }
+
+  private get subscriptions(): Repository<SubscriptionRecord> {
+    return this.getManager().getRepository(SubscriptionRecord);
+  }
+
+  private get billingInfo(): Repository<SubscriptionBillingInfoRecord> {
+    return this.getManager().getRepository(SubscriptionBillingInfoRecord);
+  }
+
+  // Join the caller's transaction when there is one, so an outer rollback also
+  // undoes these writes. Standalone callers still get their own transaction.
+  //
+  // Must test isTransactionActive(): txHost.tx never returns undefined — outside
+  // a transaction it yields the adapter's fallback instance (dataSource.manager),
+  // so a truthiness check would silently skip opening a real transaction.
+  private runInTransaction<T>(
+    work: (manager: EntityManager) => Promise<T>,
+  ): Promise<T> {
+    return this.txHost.isTransactionActive()
+      ? work(this.txHost.tx)
+      : this.dataSource.transaction(work);
+  }
+
   async findByOrgId(orgId: UUID): Promise<Subscription[]> {
     try {
-      const records = await this.subscriptionRepository.find({
+      const records = await this.subscriptions.find({
         where: {
           orgId,
         },
@@ -54,7 +80,7 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
 
   async findLatestByOrgId(orgId: UUID): Promise<Subscription | null> {
     try {
-      const record = await this.subscriptionRepository.findOne({
+      const record = await this.subscriptions.findOne({
         where: { orgId },
         relations: { billingInfo: true },
         order: { createdAt: 'DESC' },
@@ -72,7 +98,7 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
 
   async findAll(): Promise<Subscription[]> {
     try {
-      const records = await this.subscriptionRepository.find();
+      const records = await this.subscriptions.find();
       return records.map((record) => this.subscriptionMapper.toDomain(record));
     } catch (error) {
       this.logger.error(`Failed to find all subscriptions`, error);
@@ -82,7 +108,7 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
 
   async findActiveUsageBasedOrgIds(now: Date): Promise<UUID[]> {
     try {
-      const rows = await this.subscriptionRepository
+      const rows = await this.subscriptions
         .createQueryBuilder('subscription')
         .select('DISTINCT subscription.orgId', 'orgId')
         .where('subscription.type = :type', {
@@ -108,7 +134,7 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
 
       // Save subscription and billing info in a transaction to guarantee
       // the subscription row exists before the billing info FK references it.
-      await this.dataSource.transaction((manager) =>
+      await this.runInTransaction((manager) =>
         this.insertSubscriptionWithBilling(manager, record),
       );
 
@@ -130,7 +156,7 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
 
       // End the old subscription and insert the new one atomically so the org
       // is never left without a subscription (or with two active ones).
-      await this.dataSource.transaction(async (manager) => {
+      await this.runInTransaction(async (manager) => {
         if (disposition === OldSubscriptionDisposition.DELETE) {
           await manager.delete(SubscriptionRecord, oldSubscriptionId);
         } else {
@@ -175,7 +201,7 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
   async update(subscription: Subscription): Promise<Subscription> {
     try {
       const record = this.subscriptionMapper.toRecord(subscription);
-      await this.subscriptionRepository.save(record);
+      await this.subscriptions.save(record);
       this.logger.log(`Updated subscription with id ${subscription.id}`);
       return this.subscriptionMapper.toDomain(record);
     } catch (error) {
@@ -193,7 +219,7 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
     renewalCycleAnchor?: Date;
   }): Promise<Subscription> {
     try {
-      const record = await this.subscriptionRepository.findOne({
+      const record = await this.subscriptions.findOne({
         where: { id: params.subscriptionId },
         relations: { billingInfo: true },
       });
@@ -212,7 +238,7 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
         record.renewalCycleAnchor = params.renewalCycleAnchor;
       }
 
-      const updatedRecord = await this.subscriptionRepository.save(record);
+      const updatedRecord = await this.subscriptions.save(record);
       this.logger.log(
         `Updated start date for subscription with id ${params.subscriptionId}`,
       );
@@ -235,7 +261,7 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
         billingInfo,
         subscriptionId,
       );
-      await this.subscriptionBillingInfoRepository.save(record);
+      await this.billingInfo.save(record);
       this.logger.log(
         `Updated billing info for subscription with id ${subscriptionId}`,
       );
@@ -251,7 +277,7 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
 
   async delete(id: UUID): Promise<void> {
     try {
-      const result = await this.subscriptionRepository.delete(id);
+      const result = await this.subscriptions.delete(id);
       if (result.affected === 0) {
         this.logger.warn(`No subscription found with id ${id} to delete`);
       } else {

--- a/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/local-users.repository.ts
+++ b/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/local-users.repository.ts
@@ -9,31 +9,41 @@ import { User } from 'src/iam/users/domain/user.entity';
 import type { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 import { UUID } from 'crypto';
-import { Repository, ILike, In } from 'typeorm';
+import { EntityManager, Repository, ILike, In } from 'typeorm';
 import { UserRecord } from './schema/user.record';
-import { InjectRepository } from '@nestjs/typeorm';
 import { UserMapper } from './mappers/user.mapper';
 import {
   UserNotFoundError,
   UserAlreadyExistsError,
 } from 'src/iam/users/application/users.errors';
 import { Paginated } from 'src/common/pagination/paginated.entity';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
 
 @Injectable()
 export class LocalUsersRepository extends UsersRepository {
   private readonly logger = new Logger(LocalUsersRepository.name);
 
   constructor(
-    @InjectRepository(UserRecord)
-    private readonly userRepository: Repository<UserRecord>,
+    private readonly txHost: TransactionHost<TransactionalAdapterTypeOrm>,
   ) {
     super();
     this.logger.log('constructor');
   }
 
+  // Outside an active transaction txHost.tx resolves to the adapter's fallback
+  // instance (dataSource.manager), so this is safe without a null check.
+  private getManager(): EntityManager {
+    return this.txHost.tx;
+  }
+
+  private get users(): Repository<UserRecord> {
+    return this.getManager().getRepository(UserRecord);
+  }
+
   async findOneById(id: UUID): Promise<User | null> {
     this.logger.log('findOneById', { id });
-    const userEntity = await this.userRepository.findOne({ where: { id } });
+    const userEntity = await this.users.findOne({ where: { id } });
     if (!userEntity) {
       this.logger.warn('User not found by ID', { id });
       return null;
@@ -48,7 +58,7 @@ export class LocalUsersRepository extends UsersRepository {
       return [];
     }
 
-    const userRecords = await this.userRepository.find({
+    const userRecords = await this.users.find({
       where: { id: In(ids), orgId },
     });
 
@@ -57,7 +67,7 @@ export class LocalUsersRepository extends UsersRepository {
 
   async findOneByEmail(email: string): Promise<User | null> {
     this.logger.log('findOneByEmail', { email });
-    const userRecord = await this.userRepository.findOne({
+    const userRecord = await this.users.findOne({
       where: { email: ILike(email) },
     });
     if (!userRecord) {
@@ -77,7 +87,7 @@ export class LocalUsersRepository extends UsersRepository {
     // Convert emails to lowercase for case-insensitive comparison
     const lowerEmails = emails.map((e) => e.toLowerCase());
 
-    const userRecords = await this.userRepository
+    const userRecords = await this.users
       .createQueryBuilder('user')
       .where('LOWER(user.email) IN (:...emails)', { emails: lowerEmails })
       .getMany();
@@ -93,7 +103,7 @@ export class LocalUsersRepository extends UsersRepository {
   async findManyBySystemRole(role: SystemRole): Promise<User[]> {
     this.logger.log('findManyBySystemRole', { role });
 
-    const userRecords = await this.userRepository.find({
+    const userRecords = await this.users.find({
       where: { systemRole: role },
       order: { createdAt: 'DESC' },
     });
@@ -103,7 +113,7 @@ export class LocalUsersRepository extends UsersRepository {
 
   async findAdminsByOrgId(orgId: UUID): Promise<User[]> {
     this.logger.log('findAdminsByOrgId', { orgId });
-    const userRecords = await this.userRepository.find({
+    const userRecords = await this.users.find({
       where: { orgId, role: UserRole.ADMIN },
       order: { createdAt: 'DESC' },
     });
@@ -125,7 +135,7 @@ export class LocalUsersRepository extends UsersRepository {
       hasSearch: filters?.search !== undefined,
     });
 
-    const queryBuilder = this.userRepository
+    const queryBuilder = this.users
       .createQueryBuilder('user')
       .where('user.orgId = :orgId', { orgId })
       .orderBy('user.createdAt', 'DESC');
@@ -154,7 +164,7 @@ export class LocalUsersRepository extends UsersRepository {
 
   async findAllIdsByOrgId(orgId: UUID): Promise<UUID[]> {
     this.logger.log('findAllIdsByOrgId', { orgId });
-    const users = await this.userRepository.find({
+    const users = await this.users.find({
       where: { orgId },
       select: { id: true },
     });
@@ -170,7 +180,7 @@ export class LocalUsersRepository extends UsersRepository {
       hasSearch: filters?.search !== undefined,
     });
     const search = filters?.search?.trim();
-    return this.userRepository.find({
+    return this.users.find({
       where: search
         ? [
             { orgId, name: ILike(`%${search}%`) },
@@ -184,7 +194,7 @@ export class LocalUsersRepository extends UsersRepository {
   async create(user: User): Promise<User> {
     this.logger.log('create', { userId: user.id, email: user.email });
     // Check if user already exists by email (case-insensitive)
-    const existingUser = await this.userRepository.findOne({
+    const existingUser = await this.users.findOne({
       where: { email: ILike(user.email) },
     });
 
@@ -198,7 +208,7 @@ export class LocalUsersRepository extends UsersRepository {
     }
 
     const userEntity = UserMapper.toEntity(user);
-    const savedUserEntity = await this.userRepository.save(userEntity);
+    const savedUserEntity = await this.users.save(userEntity);
     this.logger.debug('User created successfully', {
       userId: savedUserEntity.id,
     });
@@ -208,7 +218,7 @@ export class LocalUsersRepository extends UsersRepository {
   async update(user: User): Promise<User> {
     this.logger.log('update', { userId: user.id });
     // Verify user exists
-    const existingUser = await this.userRepository.findOne({
+    const existingUser = await this.users.findOne({
       where: { id: user.id },
     });
 
@@ -220,7 +230,7 @@ export class LocalUsersRepository extends UsersRepository {
     }
 
     const userEntity = UserMapper.toEntity(user);
-    const savedUserEntity = await this.userRepository.save(userEntity);
+    const savedUserEntity = await this.users.save(userEntity);
     this.logger.debug('User updated successfully', {
       user: savedUserEntity,
     });
@@ -230,7 +240,7 @@ export class LocalUsersRepository extends UsersRepository {
   async delete(id: UUID): Promise<void> {
     this.logger.log('delete', { id });
     // Verify user exists
-    const existingUser = await this.userRepository.findOne({ where: { id } });
+    const existingUser = await this.users.findOne({ where: { id } });
 
     if (!existingUser) {
       this.logger.warn('Attempted to delete non-existent user', {
@@ -239,7 +249,7 @@ export class LocalUsersRepository extends UsersRepository {
       throw new UserNotFoundError(id);
     }
 
-    await this.userRepository.delete(id);
+    await this.users.delete(id);
     this.logger.debug('User deleted successfully', { userId: id });
   }
 

--- a/ayunis-core-backend/src/iam/users/users.module.ts
+++ b/ayunis-core-backend/src/iam/users/users.module.ts
@@ -6,8 +6,8 @@ import { LocalUsersExportRepository } from './infrastructure/repositories/local/
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserRecord } from './infrastructure/repositories/local/schema/user.record';
 import { PasswordSetTokenRecord } from './infrastructure/repositories/local/schema/password-set-token.record';
-import { Repository } from 'typeorm';
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { TransactionHost } from '@nestjs-cls/transactional';
+import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
 import { HashingModule } from '../hashing/hashing.module';
 import { JwtConfigModule } from '../authentication/jwt.module';
 import { EmailsModule } from 'src/common/emails/emails.module';
@@ -89,11 +89,11 @@ import { ExportUsersUseCase } from './application/use-cases/export-users/export-
   providers: [
     {
       provide: UsersRepository,
-      useFactory: (userRepository: Repository<UserRecord>) => {
+      useFactory: (txHost: TransactionHost<TransactionalAdapterTypeOrm>) => {
         // FUTURE: Implement cloud users repository when auth.provider === AuthProvider.CLOUD
-        return new LocalUsersRepository(userRepository);
+        return new LocalUsersRepository(txHost);
       },
-      inject: [getRepositoryToken(UserRecord)],
+      inject: [TransactionHost],
     },
     {
       provide: UsersExportRepository,


### PR DESCRIPTION
## Summary

Routes the three repositories on the SSO provisioning write path through the ambient CLS transaction, so `@Transactional()` actually contains their writes. Scoped precursor to AYC-641 (Phase 4), which requires creating a user, federated identity, invite consumption, and admission result **atomically**.

Converted to the reference pattern from `local-skill.repository.ts:38` (`this.txHost.tx ?? repo.manager`):

- `local-users.repository.ts` — 15 call sites, including two query builders
- `local-invites.repository.ts` — 10 call sites, including two query builders
- `local-subscriptions.repository.ts` — 9 call sites, plus the two `dataSource.transaction(...)` blocks

`users.module.ts` builds its repository via `useFactory`, so `TransactionHost` was added to the factory and its `inject` list.

### The subscriptions case is the interesting one

`create` and `replace` opened their **own** transactions via `this.dataSource.transaction(...)`. Nested inside an outer transaction, those commit independently — an outer rollback would leave the rows behind, which is precisely the failure AYC-627 documents. They now go through:

```ts
private runInTransaction<T>(work: (manager: EntityManager) => Promise<T>): Promise<T> {
  const ambient = this.txHost.tx as EntityManager | undefined;
  return ambient ? work(ambient) : this.dataSource.transaction(work);
}
```

Standalone callers keep their own transaction; nested callers join the caller's. No behaviour change outside a transaction.

## Does NOT close AYC-627

This converts 3 of the ~43 local repositories. Registration still writes through `orgs`, `role-permissions`, `trials`, and `legal-acceptances`, none of which join yet — so registration remains non-atomic and AYC-627 stays open.

## Validation

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec jest src/iam/invites src/iam/subscriptions src/iam/users` — 47 suites, 275 tests passing
- Full suite — 4338 tests passing
- Added tests asserting the observable behaviour: the repository uses the transactional entity manager when one is active, and falls back to the pooled manager when not

### Pre-existing failure, unrelated to this change

Three `rag/embeddings` suites fail to **compile** on this base: Jest cannot parse `p-queue@9.3.1` (`import { EventEmitter } from 'eventemitter3'` — ESM-only). No file in this diff is in that import chain. Likely a recent dependency bump on `main`; worth its own ticket.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction boundaries on the SSO provisioning write path and subscription create/replace; incorrect ambient-tx detection could leave partial commits or break atomicity expectations.
> 
> **Overview**
> **Routes IAM provisioning persistence through the ambient `@Transactional()` CLS transaction** so user, invite, and subscription writes roll back with an outer failure instead of committing on a separate connection.
> 
> `LocalUsersRepository`, `LocalInvitesRepository`, and `LocalSubscriptionsRepository` drop injected TypeORM repositories and resolve `InviteRecord` / `UserRecord` / subscription entities via `TransactionHost` (`txHost.tx.getRepository(...)`). Outside a transaction the adapter still supplies a fallback manager, so standalone calls behave as before.
> 
> **Subscriptions `create` / `replace` no longer always open nested `dataSource.transaction` blocks.** They use `runInTransaction`, which runs on the caller’s manager when `isTransactionActive()` is true and only opens a new transaction when none is active—fixing independent commits that could survive an outer rollback.
> 
> `users.module.ts` injects `TransactionHost` into the `UsersRepository` factory. **Tests** cover transactional vs fallback reads for invites and join-vs-own-transaction behavior for subscription `create`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7746d4592e2d4397d0490736835abcfae56ccf25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->