### PR TITLE
fix(invites): reject globally-existing email invites to prevent 500 (AYC-734)

### DIFF
--- a/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.spec.ts
@@ -105,6 +105,7 @@ describe('CreateInviteUseCase', () => {
 
     // Default: no existing invite
     invitesRepository.findOneByEmailAndOrg.mockResolvedValue(null);
+    invitesRepository.findOneByEmail.mockResolvedValue(null);
 
     // Mock logger
     jest.spyOn(Logger.prototype, 'log').mockImplementation();
@@ -369,9 +370,42 @@ describe('CreateInviteUseCase', () => {
         userId: mockUserId,
       });
 
-      invitesRepository.findOneByEmailAndOrg.mockResolvedValue({
+      findUserByEmailUseCase.execute.mockResolvedValue(null);
+      invitesRepository.findOneByEmail.mockResolvedValue({
         id: 'existing-invite-id',
         email: mockEmail,
+      } as any);
+
+      configService.get.mockReturnValueOnce([]); // auth.emailProviderBlacklist
+
+      // Act & Assert
+      await expect(useCase.execute(command)).rejects.toThrow(
+        EmailNotAvailableError,
+      );
+      expect(invitesRepository.create).not.toHaveBeenCalled();
+    });
+
+    it('should throw EmailNotAvailableError when an invite for the email exists in a different org (global unique constraint) instead of a 500', async () => {
+      // Regression for AYC-734: invites.email is globally unique. A pending
+      // invite for this email in another org is invisible to the org-scoped
+      // lookup, so the insert previously hit a DB unique violation and
+      // surfaced as a generic UnexpectedInviteError (500). It must be rejected
+      // up front with a clear domain error instead.
+      const command = new CreateInviteCommand({
+        email: 'schichler-koep@sveinfo.de',
+        orgId: mockOrgId,
+        role: UserRole.USER,
+        userId: mockUserId,
+      });
+
+      // No user yet and no pending invite in THIS org...
+      findUserByEmailUseCase.execute.mockResolvedValue(null);
+      invitesRepository.findOneByEmailAndOrg.mockResolvedValue(null);
+      // ...but an invite row already exists for this email in another org.
+      invitesRepository.findOneByEmail.mockResolvedValue({
+        id: 'existing-invite-id',
+        email: 'schichler-koep@sveinfo.de',
+        orgId: '123e4567-e89b-12d3-a456-426614174999',
       } as any);
 
       configService.get.mockReturnValueOnce([]); // auth.emailProviderBlacklist

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.ts
@@ -105,24 +105,26 @@ export class CreateInviteUseCase {
     email: string,
     orgId: UUID,
   ): Promise<void> {
-    const existingInvite = await this.invitesRepository.findOneByEmailAndOrg(
-      email,
-      orgId,
-    );
-    if (existingInvite) {
-      throw new EmailNotAvailableError();
-    }
-
     const existingUser = await this.findUserByEmailUseCase.execute(
       new FindUserByEmailQuery(email),
     );
-    if (!existingUser) {
-      return;
+    if (existingUser) {
+      if (existingUser.orgId === orgId) {
+        throw new UserAlreadyExistsError();
+      }
+      throw new EmailNotAvailableError();
     }
-    if (existingUser.orgId === orgId) {
-      throw new UserAlreadyExistsError();
+
+    // invites.email carries a GLOBAL unique constraint, so at most one invite
+    // row can exist per email across all orgs. Any pre-existing invite — a
+    // pending invite in another org, or an orphaned accepted invite — is
+    // invisible to an org-scoped lookup yet still makes the insert fail with a
+    // DB unique violation, surfacing as a generic 500 instead of a clear
+    // error. Check globally and reject up front (AYC-734).
+    const existingInvite = await this.invitesRepository.findOneByEmail(email);
+    if (existingInvite) {
+      throw new EmailNotAvailableError();
     }
-    throw new EmailNotAvailableError();
   }
 
   private async ensureCloudSeatsAvailable(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Stadt Euskirchen (second-largest customer) could not invite `schichler-koep@sveinfo.de`; the admin UI showed the generic error **"Fehler beim Erstellen der Einladung"**.

That message is the frontend's *default* fallback for an unmapped error code — i.e. a 500, not a validation error. The hyphen / unknown domain flagged in the ticket are red herrings (`sveinfo` is not on the provider blacklist and hyphens are valid).

## Root cause

`invites.email` carries a **global** `UNIQUE` constraint (`UQ_08583b1882195ae2674f8391323`, since the initial schema), but `CreateInviteUseCase.ensureEmailAvailable` only guarded against:

1. a **pending invite in the current org** (`findOneByEmailAndOrg`, which also filters `acceptedAt IS NULL`), and
2. an existing **user**.

A pre-existing invite row for the same email that is *not* a same-org pending invite — e.g. a pending invite in **another org**, or an orphaned accepted invite whose user was deleted — slips past both checks. The subsequent `INSERT` then hits the global unique-constraint violation, which is caught as an `UnexpectedInviteError` (500) → generic UI error.

This is the same class of bug previously seen in AYC-299 (orphaned accepted invites blocking re-invite); that fix addressed the *delete* path, this one closes the remaining gap on the *create* path.

## Fix

`ensureEmailAvailable` now checks the users table first (preserving the more specific `USER_ALREADY_EXISTS` message for same-org users), then does a **global** `findOneByEmail` lookup. Any existing invite row for the email is rejected up front with the mapped `EmailNotAvailableError` (frontend: *"Einladung nicht möglich."*) instead of letting the DB throw an unhandled unique violation. Since the column is globally unique there is at most one invite row per email, so the previous org-scoped lookup was strictly redundant and is replaced.

## Tests

- Updated the existing "invite already exists" test to drive the new global lookup.
- Added a regression test: an invite for the email existing **in a different org** now yields `EmailNotAvailableError` and never calls `create` (previously → 500).
- Full `src/iam/invites` suite green (51 tests); backend lint + typecheck clean.

## Known related follow-up (not in this PR)

`CreateBulkInvitesUseCase` has the same gap: `findByEmailsAndOrg` is org-scoped, so a globally-existing invite would fail the whole batch with a 500. Fixing it properly needs a global batch lookup; recommend a separate ticket to keep this fix focused and low-risk.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-734](https://linear.app/ayunis/issue/AYC-734/bug-einladung-kann-nicht-erstellt-werden-stadt-euskirchen)

<div><a href="https://cursor.com/agents/bc-982e4bdd-3471-4197-b538-a539f17c5ad0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-982e4bdd-3471-4197-b538-a539f17c5ad0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

