### PR TITLE
fix(invites): prevent global invite conflicts from causing bulk invite 500s

### DIFF
--- a/ayunis-core-backend/src/iam/invites/application/ports/invites.repository.ts
+++ b/ayunis-core-backend/src/iam/invites/application/ports/invites.repository.ts
@@ -28,10 +28,7 @@ export abstract class InvitesRepository {
     email: string,
     orgId: UUID,
   ): Promise<Invite | null>;
-  abstract findByEmailsAndOrg(
-    emails: string[],
-    orgId: string,
-  ): Promise<Invite[]>;
+  abstract findByEmails(emails: string[]): Promise<Invite[]>;
   abstract accept(id: UUID): Promise<boolean>;
   abstract delete(id: UUID): Promise<void>;
   abstract deleteAllPendingByOrg(orgId: UUID): Promise<number>;

--- a/ayunis-core-backend/src/iam/invites/application/services/bulk-invite-validator.service.ts
+++ b/ayunis-core-backend/src/iam/invites/application/services/bulk-invite-validator.service.ts
@@ -26,10 +26,7 @@ export class BulkInviteValidatorService {
     const occurrences = emailOccurrences(command);
     const duplicateErrors = duplicateEmailErrors(occurrences);
     const uniqueEmails = [...occurrences.keys()];
-    const invites = await this.invites.findByEmailsAndOrg(
-      uniqueEmails,
-      command.orgId,
-    );
+    const invites = await this.invites.findByEmails(uniqueEmails);
     const users = await this.findUsersByEmails.execute(
       new FindUsersByEmailsQuery(uniqueEmails),
     );
@@ -114,7 +111,7 @@ function rowError(
       row,
       originalEmail,
       'EMAIL_ALREADY_INVITED',
-      'Email already has a pending invite',
+      'Email already has an invite',
     );
   }
   if (userEmails.has(email)) {

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/create-bulk-invites/create-bulk-invites.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/create-bulk-invites/create-bulk-invites.use-case.spec.ts
@@ -54,7 +54,7 @@ describe('CreateBulkInvitesUseCase', () => {
     const mockInvitesRepository = {
       create: jest.fn(),
       createMany: jest.fn(),
-      findByEmailsAndOrg: jest.fn(),
+      findByEmails: jest.fn(),
       deleteAllPendingByOrg: jest.fn(),
       delete: jest.fn(),
     };
@@ -188,7 +188,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks();
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
       inviteJwtService.generateInviteToken.mockReturnValue('mock-token');
 
@@ -218,7 +218,7 @@ describe('CreateBulkInvitesUseCase', () => {
         userId: mockUserId,
       });
       setupDefaultConfigMocks();
-      invitesRepository.findByEmailsAndOrg.mockReturnValue(
+      invitesRepository.findByEmails.mockReturnValue(
         new Promise((resolve) => {
           resolveInvites = resolve;
         }),
@@ -229,7 +229,7 @@ describe('CreateBulkInvitesUseCase', () => {
       const creation = useCase.execute(command);
       await new Promise((resolve) => setImmediate(resolve));
 
-      expect(invitesRepository.findByEmailsAndOrg).toHaveBeenCalledTimes(1);
+      expect(invitesRepository.findByEmails).toHaveBeenCalledTimes(1);
       expect(usersRepository.findManyByEmails).not.toHaveBeenCalled();
 
       resolveInvites([]);
@@ -245,7 +245,7 @@ describe('CreateBulkInvitesUseCase', () => {
         userId: mockUserId,
       });
       setupDefaultConfigMocks({ hasEmailConfig: true });
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
       inviteJwtService.generateInviteToken.mockReturnValue('mock-token');
       invitesRepository.createMany.mockImplementation(async () => {
@@ -268,7 +268,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks({ hasEmailConfig: false });
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
       inviteJwtService.generateInviteToken.mockReturnValue('mock-token');
 
@@ -288,7 +288,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks({ hasEmailConfig: true });
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
       inviteJwtService.generateInviteToken.mockReturnValue('mock-token');
 
@@ -306,7 +306,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks({ hasEmailConfig: true });
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
       inviteJwtService.generateInviteToken.mockReturnValue('mock-token');
       sendInvitationEmailUseCase.execute.mockRejectedValue(
@@ -330,7 +330,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks();
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
       inviteJwtService.generateInviteToken.mockImplementation(() => {
         throw new Error('JWT generation failed');
@@ -354,7 +354,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks({ hasEmailConfig: true });
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
       inviteJwtService.generateInviteToken.mockReturnValue('mock-token');
 
@@ -386,7 +386,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks();
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
 
       await expect(useCase.execute(command)).rejects.toThrow(
@@ -403,7 +403,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks({ emailProviderBlacklist: ['gmail'] });
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
 
       await expect(useCase.execute(command)).rejects.toThrow(
@@ -425,12 +425,94 @@ describe('CreateBulkInvitesUseCase', () => {
         role: UserRole.USER,
         expiresAt: new Date(Date.now() + 86400000),
       });
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([existingInvite]);
+      invitesRepository.findByEmails.mockResolvedValue([existingInvite]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
 
       await expect(useCase.execute(command)).rejects.toThrow(
         BulkInviteValidationFailedError,
       );
+    });
+
+    // Regression for AYC-735: invites.email is globally unique, so an invite
+    // row for a requested email in ANOTHER org previously passed the org-scoped
+    // validation and only blew up on createMany with a DB unique violation
+    // (converted to a 500). It must be reported as EMAIL_ALREADY_INVITED and no
+    // rows must be inserted.
+    it('should report EMAIL_ALREADY_INVITED when an invite exists in another org', async () => {
+      const command = new CreateBulkInvitesCommand({
+        invites: [{ email: 'existing@example.com', role: UserRole.USER }],
+        orgId: mockOrgId,
+        userId: mockUserId,
+      });
+
+      setupDefaultConfigMocks();
+      const otherOrgId =
+        '123e4567-e89b-12d3-a456-426614174999' as typeof mockOrgId;
+      const inviteInOtherOrg = new Invite({
+        email: 'existing@example.com',
+        orgId: otherOrgId,
+        role: UserRole.USER,
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+      invitesRepository.findByEmails.mockResolvedValue([inviteInOtherOrg]);
+      usersRepository.findManyByEmails.mockResolvedValue([]);
+
+      try {
+        await useCase.execute(command);
+        fail('Expected BulkInviteValidationFailedError to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BulkInviteValidationFailedError);
+        const bulkError = error as BulkInviteValidationFailedError;
+        expect(bulkError.metadata?.errors).toEqual([
+          expect.objectContaining({
+            row: 1,
+            email: 'existing@example.com',
+            errorCode: 'EMAIL_ALREADY_INVITED',
+          }),
+        ]);
+      }
+      expect(invitesRepository.findByEmails).toHaveBeenCalledWith([
+        'existing@example.com',
+      ]);
+      expect(invitesRepository.createMany).not.toHaveBeenCalled();
+    });
+
+    // Regression for AYC-735: an accepted/orphaned invite row also holds the
+    // globally unique email and must block re-inviting via the bulk flow with a
+    // validation error rather than a 500.
+    it('should report EMAIL_ALREADY_INVITED when an accepted/orphaned invite row exists', async () => {
+      const command = new CreateBulkInvitesCommand({
+        invites: [{ email: 'accepted@example.com', role: UserRole.USER }],
+        orgId: mockOrgId,
+        userId: mockUserId,
+      });
+
+      setupDefaultConfigMocks();
+      const acceptedInvite = new Invite({
+        email: 'accepted@example.com',
+        orgId: mockOrgId,
+        role: UserRole.USER,
+        acceptedAt: new Date(Date.now() - 86400000),
+        expiresAt: new Date(Date.now() + 86400000),
+      });
+      invitesRepository.findByEmails.mockResolvedValue([acceptedInvite]);
+      usersRepository.findManyByEmails.mockResolvedValue([]);
+
+      try {
+        await useCase.execute(command);
+        fail('Expected BulkInviteValidationFailedError to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(BulkInviteValidationFailedError);
+        const bulkError = error as BulkInviteValidationFailedError;
+        expect(bulkError.metadata?.errors).toEqual([
+          expect.objectContaining({
+            row: 1,
+            email: 'accepted@example.com',
+            errorCode: 'EMAIL_ALREADY_INVITED',
+          }),
+        ]);
+      }
+      expect(invitesRepository.createMany).not.toHaveBeenCalled();
     });
 
     it('should throw BulkInviteValidationFailedError when email is already a user', async () => {
@@ -441,7 +523,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks();
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       const existingUser = new User({
         id: 'user-id' as any,
         email: 'user@example.com',
@@ -471,7 +553,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks({ emailProviderBlacklist: ['gmail'] });
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
 
       try {
@@ -540,7 +622,7 @@ describe('CreateBulkInvitesUseCase', () => {
       };
 
       setupDefaultConfigMocks({ isCloudHosted: true });
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
       inviteJwtService.generateInviteToken.mockReturnValue('mock-token');
       getActiveSubscriptionUseCase.execute.mockResolvedValue(
@@ -563,7 +645,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks({ isCloudHosted: false });
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
       inviteJwtService.generateInviteToken.mockReturnValue('mock-token');
 
@@ -583,7 +665,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks({ isCloudHosted: true });
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
       inviteJwtService.generateInviteToken.mockReturnValue('mock-token');
       getActiveSubscriptionUseCase.execute.mockResolvedValue(
@@ -608,7 +690,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks({ isCloudHosted: true });
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
       inviteJwtService.generateInviteToken.mockReturnValue('mock-token');
       getActiveSubscriptionUseCase.execute.mockResolvedValue(
@@ -634,7 +716,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks({ isCloudHosted: true });
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
       inviteJwtService.generateInviteToken.mockReturnValue('mock-token');
       getActiveSubscriptionUseCase.execute.mockRejectedValue(
@@ -655,7 +737,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks({ isCloudHosted: true });
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
       getActiveSubscriptionUseCase.execute.mockResolvedValue(
         createMockSubscription(-1, 10),
@@ -675,7 +757,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks();
-      invitesRepository.findByEmailsAndOrg.mockRejectedValue(
+      invitesRepository.findByEmails.mockRejectedValue(
         new Error('Database connection failed'),
       );
 
@@ -695,7 +777,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks();
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
       invitesRepository.createMany.mockRejectedValue(
         new Error('Database error'),
@@ -714,7 +796,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks({ isCloudHosted: true });
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
       getActiveSubscriptionUseCase.execute.mockRejectedValue(
         new Error('Unexpected subscription error'),
@@ -735,7 +817,7 @@ describe('CreateBulkInvitesUseCase', () => {
       });
 
       setupDefaultConfigMocks({ inviteExpiresIn: '24h' });
-      invitesRepository.findByEmailsAndOrg.mockResolvedValue([]);
+      invitesRepository.findByEmails.mockResolvedValue([]);
       usersRepository.findManyByEmails.mockResolvedValue([]);
       inviteJwtService.generateInviteToken.mockReturnValue('mock-token');
 

--- a/ayunis-core-backend/src/iam/invites/infrastructure/persistence/local/local-invites.repository.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/infrastructure/persistence/local/local-invites.repository.spec.ts
@@ -22,7 +22,7 @@ function makeAcceptedInviteRecord(email: string): InviteRecord {
 
 describe('LocalInvitesRepository', () => {
   let inviteRepo: jest.Mocked<
-    Pick<Repository<InviteRecord>, 'findOne' | 'update'>
+    Pick<Repository<InviteRecord>, 'findOne' | 'update' | 'createQueryBuilder'>
   >;
   let txHost: {
     tx: { getRepository: jest.Mock };
@@ -31,7 +31,11 @@ describe('LocalInvitesRepository', () => {
   let repository: LocalInvitesRepository;
 
   beforeEach(() => {
-    inviteRepo = { findOne: jest.fn(), update: jest.fn() };
+    inviteRepo = {
+      findOne: jest.fn(),
+      update: jest.fn(),
+      createQueryBuilder: jest.fn(),
+    };
     // Reads resolve through txHost.tx, which outside a transaction is the
     // adapter's fallback manager rather than undefined.
     txHost = {
@@ -150,6 +154,51 @@ describe('LocalInvitesRepository', () => {
 
       // routed via txHost.tx.getRepository, which the fixture maps back to inviteRepo
       expect(txHost.tx.getRepository).toHaveBeenCalledWith(InviteRecord);
+    });
+  });
+
+  describe('findByEmails', () => {
+    // Regression test for AYC-735: invites.email is globally unique, so bulk
+    // validation must look up invites globally — case-insensitively and
+    // regardless of organization or acceptance status — otherwise a conflicting
+    // row (in another org, or accepted/orphaned) slips past validation and
+    // fails the batch insert with a DB unique violation surfaced as a 500.
+    it('queries globally and case-insensitively with no org/acceptance filter', async () => {
+      const accepted = makeAcceptedInviteRecord('user@example.com');
+      const where = jest.fn().mockReturnThis();
+      const andWhere = jest.fn().mockReturnThis();
+      const getMany = jest.fn().mockResolvedValue([accepted]);
+      inviteRepo.createQueryBuilder.mockReturnValue({
+        where,
+        andWhere,
+        getMany,
+      } as never);
+
+      const result = await repository.findByEmails([
+        'User@Example.com',
+        'Second@Example.com',
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(accepted.id);
+
+      // Only a single, global WHERE on lowercased emails — no org or
+      // acceptedAt constraints.
+      expect(where).toHaveBeenCalledTimes(1);
+      expect(where).toHaveBeenCalledWith(
+        'LOWER(invite.email) IN (:...emails)',
+        {
+          emails: ['user@example.com', 'second@example.com'],
+        },
+      );
+      expect(andWhere).not.toHaveBeenCalled();
+    });
+
+    it('returns an empty array without querying when no emails are given', async () => {
+      const result = await repository.findByEmails([]);
+
+      expect(result).toEqual([]);
+      expect(inviteRepo.createQueryBuilder).not.toHaveBeenCalled();
     });
   });
 });

--- a/ayunis-core-backend/src/iam/invites/infrastructure/persistence/local/local-invites.repository.ts
+++ b/ayunis-core-backend/src/iam/invites/infrastructure/persistence/local/local-invites.repository.ts
@@ -161,33 +161,33 @@ export class LocalInvitesRepository implements InvitesRepository {
     return this.inviteMapper.toDomain(entity);
   }
 
-  async findByEmailsAndOrg(emails: string[], orgId: string): Promise<Invite[]> {
-    this.logger.info(
-      { emailCount: emails.length, orgId },
-      'findByEmailsAndOrg',
-    );
+  async findByEmails(emails: string[]): Promise<Invite[]> {
+    this.logger.info({ emailCount: emails.length }, 'findByEmails');
 
     if (emails.length === 0) {
       return [];
     }
 
-    // Convert emails to lowercase for case-insensitive comparison
+    // invites.email carries a GLOBAL unique constraint, so at most one invite
+    // row can exist per email across all orgs. Look invites up globally,
+    // case-insensitively, and regardless of organization or acceptance status:
+    // a pending invite in another org or an orphaned accepted invite is
+    // invisible to an org-scoped lookup yet still makes the batch insert fail
+    // with a DB unique violation, surfacing as a generic 500 instead of a
+    // clear validation error (AYC-735).
     const lowerEmails = emails.map((e) => e.toLowerCase());
 
     const entities = await this.invites
       .createQueryBuilder('invite')
-      .where('invite.orgId = :orgId', { orgId })
-      .andWhere('LOWER(invite.email) IN (:...emails)', { emails: lowerEmails })
-      .andWhere('invite.acceptedAt IS NULL') // Only pending invites
+      .where('LOWER(invite.email) IN (:...emails)', { emails: lowerEmails })
       .getMany();
 
     this.logger.debug(
       {
-        orgId,
         requestedCount: emails.length,
         foundCount: entities.length,
       },
-      'Found invites by emails and org',
+      'Found invites by emails',
     );
 
     return entities.map((entity) => this.inviteMapper.toDomain(entity));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`CreateBulkInvitesUseCase.validateAllInvites` checked existing invites with `findByEmailsAndOrg`, which only returns **pending invites in the target organization**. But `invites.email` has a **global** unique constraint.

An invite row for a requested email in another organization, or an accepted/orphaned invite row, passed validation. `createMany` then hit the DB unique constraint, and the use case converted the failure into `UnexpectedInviteError` (HTTP 500) — failing the whole bulk request instead of returning a validation error.

This is the bulk-invite equivalent of the single-invite bug fixed in [AYC-734](https://linear.app/ayunis/issue/AYC-734) / [PR #1383](https://github.com/ayunis-core/ayunis-core/pull/1383).

Refs [AYC-735](https://linear.app/ayunis/issue/AYC-735).

## Changes

- Added a global, case-insensitive `findByEmails(emails)` to `InvitesRepository` (and its local implementation) that ignores organization and acceptance status, and removed the now-unused org-scoped `findByEmailsAndOrg`.
- `validateAllInvites` now looks invites up globally, so every requested email that already has an invite row is reported as `EMAIL_ALREADY_INVITED` via the existing `BulkInviteValidationFailedError` response. No invite rows are inserted when a conflict is found.
- Decomposed the touched use case into focused helpers, extracting the pure request-validation logic into `create-bulk-invites.validation.ts`. This keeps the file within the complexity, file-size and duplication gates that run on any changed file. **Behaviour is unchanged.**

## Acceptance criteria

- [x] Bulk validation looks up existing invite rows globally, case-insensitively, regardless of organization or acceptance status.
- [x] Every requested email that already has an invite row is reported as `EMAIL_ALREADY_INVITED` through `BulkInviteValidationFailedError` instead of causing a 500 during `createMany`.
- [x] No invite rows are inserted when global invite conflicts are found during validation.
- [x] Regression tests cover an existing invite in another organization and an accepted/orphaned invite row.

## Testing

- `jest src/iam/invites` — 55 tests pass (including the two new use-case regression tests and two new repository tests for `findByEmails`).
- Backend ESLint, Prettier, TypeScript typecheck, complexity gate, dependency-cruiser, jscpd duplication and file-size checks all pass (pre-commit).

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-735](https://linear.app/ayunis/issue/AYC-735/prevent-global-invite-conflicts-from-causing-bulk-invite-500s)

<div><a href="https://cursor.com/agents/bc-2e73a336-1798-48ab-a0b3-0424fc016fb8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e73a336-1798-48ab-a0b3-0424fc016fb8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

