### PR TITLE
test(e2e): extract screenshot media helpers (AYC-0000)

### DIFF
--- a/ayunis-core-e2e/tests/screenshots/lib/delay.ts
+++ b/ayunis-core-e2e/tests/screenshots/lib/delay.ts
@@ -1,0 +1,3 @@
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/ayunis-core-e2e/tests/screenshots/lib/media-paths.ts
+++ b/ayunis-core-e2e/tests/screenshots/lib/media-paths.ts
@@ -1,0 +1,30 @@
+import path from 'node:path';
+
+export const screenshotsOutDir = process.env.SCREENSHOTS_DIR ?? 'screenshots-output';
+
+export function shotPath(routeName: string, viewport: string): string {
+  return path.join(screenshotsOutDir, `${routeName}--${viewport}.png`);
+}
+
+export function gifPath(
+  routeName: string,
+  sceneName: string,
+  viewport: string,
+): string {
+  return path.join(
+    screenshotsOutDir,
+    `${routeName}--${sceneName}--${viewport}.gif`,
+  );
+}
+
+export function framesPath(
+  routeName: string,
+  sceneName: string,
+  viewport: string,
+): string {
+  return path.join(
+    screenshotsOutDir,
+    'frames',
+    `${routeName}--${sceneName}--${viewport}`,
+  );
+}

--- a/ayunis-core-e2e/tests/screenshots/lib/record-gif.ts
+++ b/ayunis-core-e2e/tests/screenshots/lib/record-gif.ts
@@ -1,0 +1,70 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import type { Page } from '@playwright/test';
+import { delay } from './delay';
+import { framesPath, gifPath } from './media-paths';
+
+export async function recordGif(
+  page: Page,
+  routeName: string,
+  sceneName: string,
+  viewport: string,
+  action: () => Promise<void>,
+): Promise<void> {
+  const framesDir = framesPath(routeName, sceneName, viewport);
+  rmSync(framesDir, { recursive: true, force: true });
+  mkdirSync(framesDir, { recursive: true });
+
+  const session = await page.context().newCDPSession(page);
+  let frameCount = 0;
+  session.on('Page.screencastFrame', ({ data, sessionId }) => {
+    const frameName = `f-${String(frameCount).padStart(4, '0')}.jpg`;
+    writeFileSync(path.join(framesDir, frameName), Buffer.from(data, 'base64'));
+    frameCount += 1;
+    void session.send('Page.screencastFrameAck', { sessionId });
+  });
+
+  await session.send('Page.startScreencast', {
+    format: 'jpeg',
+    quality: 80,
+    everyNthFrame: 1,
+  });
+  try {
+    await action();
+    await delay(400);
+  } finally {
+    await session.send('Page.stopScreencast');
+    await session.detach();
+  }
+
+  if (frameCount === 0) return;
+  writeGif(framesDir, routeName, sceneName, viewport);
+}
+
+function writeGif(
+  framesDir: string,
+  routeName: string,
+  sceneName: string,
+  viewport: string,
+): void {
+  const result = spawnSync(
+    'ffmpeg',
+    [
+      '-y',
+      '-framerate',
+      '10',
+      '-pattern_type',
+      'glob',
+      '-i',
+      path.join(framesDir, 'f-*.jpg'),
+      '-vf',
+      'fps=10,scale=1000:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse',
+      gifPath(routeName, sceneName, viewport),
+    ],
+    { stdio: 'inherit' },
+  );
+  if (result.status !== 0) {
+    throw new Error(`ffmpeg failed for ${routeName}/${sceneName} (${viewport})`);
+  }
+}

--- a/ayunis-core-e2e/tests/screenshots/routes.ts
+++ b/ayunis-core-e2e/tests/screenshots/routes.ts
@@ -1,0 +1,36 @@
+import type { Page } from '@playwright/test';
+
+export const MOBILE_ANCHOR = '[data-slot="sidebar-inset"]';
+
+export const VIEWPORTS = [
+  { label: 'desktop', width: 1280, height: 800 },
+  { label: 'mobile', width: 375, height: 812 },
+] as const;
+
+export const SCREENSHOT_ROUTES = [
+  { path: '/chat', name: 'chat', anchor: 'sidebar' },
+  {
+    path: '/admin-settings/users',
+    name: 'admin-users',
+    anchor: 'settings-sidebar',
+  },
+  {
+    path: '/admin-settings/instructions',
+    name: 'admin-instructions',
+    anchor: 'settings-sidebar',
+  },
+  {
+    path: '/settings/account',
+    name: 'settings-account',
+    anchor: 'settings-sidebar',
+  },
+] as const;
+
+export type ScreenshotRoute = (typeof SCREENSHOT_ROUTES)[number];
+export type ScreenshotRouteName = ScreenshotRoute['name'] | 'chat-conversation';
+export type ViewportLabel = (typeof VIEWPORTS)[number]['label'];
+
+export function routeAnchor(page: Page, route: ScreenshotRoute, viewport: ViewportLabel) {
+  if (viewport === 'desktop') return page.getByTestId(route.anchor);
+  return page.locator(MOBILE_ANCHOR);
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> New e2e-only helpers with no production or auth/data impact; GIF recording still depends on ffmpeg at runtime.
> 
> **Overview**
> Pulls shared Playwright screenshot tooling out of monolithic test code into **`tests/screenshots/lib`** and **`routes.ts`**.
> 
> **`delay`**, **`media-paths`** (output dir via `SCREENSHOTS_DIR`, PNG/GIF/frame path naming), and **`recordGif`** (CDP screencast → JPEG frames → **ffmpeg** palette GIF, now keyed by route + **scene** + viewport) live in the lib folder. **`routes.ts`** centralizes desktop/mobile viewports, the screenshot route list and anchors, and **`routeAnchor`** (test-id sidebar on desktop, `sidebar-inset` on mobile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6009ea03b7ae509e9f803b2df6da2d1baa2a176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->