### PR TITLE
test(frontend): add e2e test ids (AYC-0000)

### DIFF
--- a/ayunis-core-frontend/src/pages/auth/forgot-password/ui/ForgotPasswordPage.tsx
+++ b/ayunis-core-frontend/src/pages/auth/forgot-password/ui/ForgotPasswordPage.tsx
@@ -48,6 +48,7 @@ export function ForgotPasswordPage() {
                 <FormLabel>{t('forgotPassword.email')}</FormLabel>
                 <FormControl>
                   <Input
+                    data-testid="forgot-email"
                     placeholder={t('forgotPassword.emailPlaceholder')}
                     type="email"
                     {...field}
@@ -57,7 +58,12 @@ export function ForgotPasswordPage() {
               </FormItem>
             )}
           />
-          <Button type="submit" className="w-full" disabled={isLoading}>
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={isLoading}
+            data-testid="forgot-submit"
+          >
             {isLoading
               ? t('forgotPassword.sending')
               : t('forgotPassword.sendResetLink')}

--- a/ayunis-core-frontend/src/pages/auth/invite-accept/ui/InviteAcceptPage.tsx
+++ b/ayunis-core-frontend/src/pages/auth/invite-accept/ui/InviteAcceptPage.tsx
@@ -69,6 +69,7 @@ export default function InviteAcceptPage({
                 <FormLabel>{t('inviteAccept.name')}</FormLabel>
                 <FormControl>
                   <Input
+                    data-testid="invite-accept-name"
                     placeholder={t('inviteAccept.namePlaceholder')}
                     {...field}
                   />
@@ -85,6 +86,7 @@ export default function InviteAcceptPage({
                 <FormLabel>{t('inviteAccept.password')}</FormLabel>
                 <FormControl>
                   <PasswordInput
+                    data-testid="invite-accept-password"
                     placeholder={t('inviteAccept.passwordPlaceholder')}
                     {...field}
                   />
@@ -125,7 +127,12 @@ export default function InviteAcceptPage({
               )}
             />
           )}
-          <Button type="submit" className="w-full" disabled={isLoading}>
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={isLoading}
+            data-testid="invite-accept-submit"
+          >
             {isLoading
               ? t('inviteAccept.acceptingInvitation')
               : t('inviteAccept.acceptInvitationButton')}

--- a/ayunis-core-frontend/src/pages/auth/register/ui/RegisterPage.tsx
+++ b/ayunis-core-frontend/src/pages/auth/register/ui/RegisterPage.tsx
@@ -107,6 +107,7 @@ export function RegisterPage({
                 <FormControl>
                   <Input
                     required
+                    data-testid="register-email"
                     placeholder={t('register.emailPlaceholder')}
                     type="email"
                     {...field}
@@ -125,6 +126,7 @@ export function RegisterPage({
                 <FormControl>
                   <Input
                     required
+                    data-testid="register-user-name"
                     placeholder={t('register.userNamePlaceholder')}
                     {...field}
                   />
@@ -142,6 +144,7 @@ export function RegisterPage({
                 <FormControl>
                   <Input
                     required
+                    data-testid="register-org-name"
                     placeholder={t('register.orgNamePlaceholder')}
                     {...field}
                   />
@@ -166,6 +169,7 @@ export function RegisterPage({
                 <FormControl>
                   <PasswordInput
                     required
+                    data-testid="register-password"
                     placeholder={t('register.passwordPlaceholder')}
                     {...field}
                   />
@@ -247,7 +251,12 @@ export function RegisterPage({
               )}
             />
           )}
-          <Button type="submit" className="w-full" disabled={isLoading}>
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={isLoading}
+            data-testid="register-submit"
+          >
             {isLoading
               ? t('register.creatingAccount')
               : t('register.createAccountButton')}

--- a/ayunis-core-frontend/src/pages/auth/reset-password/ui/ResetPasswordPage.tsx
+++ b/ayunis-core-frontend/src/pages/auth/reset-password/ui/ResetPasswordPage.tsx
@@ -55,6 +55,7 @@ export function ResetPasswordPage({ token, mode }: Readonly<Props>) {
                 <FormLabel>{t(`${prefix}.password`)}</FormLabel>
                 <FormControl>
                   <PasswordInput
+                    data-testid="reset-new-password"
                     placeholder={t(`${prefix}.passwordPlaceholder`)}
                     {...field}
                   />
@@ -71,6 +72,7 @@ export function ResetPasswordPage({ token, mode }: Readonly<Props>) {
                 <FormLabel>{t(`${prefix}.confirmPassword`)}</FormLabel>
                 <FormControl>
                   <PasswordInput
+                    data-testid="reset-confirm-password"
                     placeholder={t(`${prefix}.confirmPasswordPlaceholder`)}
                     {...field}
                   />
@@ -79,7 +81,12 @@ export function ResetPasswordPage({ token, mode }: Readonly<Props>) {
               </FormItem>
             )}
           />
-          <Button type="submit" className="w-full" disabled={isLoading}>
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={isLoading}
+            data-testid="reset-submit"
+          >
             {isLoading ? t(`${prefix}.resetting`) : t(`${prefix}.submitButton`)}
           </Button>
         </form>

--- a/ayunis-core-frontend/src/widgets/confirmation-modal/ui/ConfirmationModal.tsx
+++ b/ayunis-core-frontend/src/widgets/confirmation-modal/ui/ConfirmationModal.tsx
@@ -51,6 +51,7 @@ export default function ConfirmationModal() {
               variant="outline"
               onClick={handleCancel}
               disabled={isLoading}
+              data-testid="confirmation-cancel"
             >
               {options.cancelText ?? 'Cancel'}
             </Button>
@@ -58,6 +59,7 @@ export default function ConfirmationModal() {
               variant={isDangerous ? 'destructive' : 'default'}
               onClick={() => void handleConfirm()}
               disabled={isLoading}
+              data-testid="confirmation-confirm"
             >
               {isLoading ? 'Loading...' : (options.confirmText ?? 'Confirm')}
             </Button>

--- a/ayunis-core-frontend/src/widgets/rename-thread-dialog/ui/RenameThreadDialog.tsx
+++ b/ayunis-core-frontend/src/widgets/rename-thread-dialog/ui/RenameThreadDialog.tsx
@@ -117,6 +117,7 @@ export function RenameThreadDialog({
               <Input
                 ref={inputRef}
                 id="title"
+                data-testid="rename-input"
                 value={title}
                 onChange={handleTitleChange}
                 placeholder={t('sidebar.renameThreadPlaceholder')}
@@ -140,6 +141,7 @@ export function RenameThreadDialog({
             </Button>
             <Button
               type="submit"
+              data-testid="rename-submit"
               disabled={
                 isRenaming ||
                 !title.trim() ||

--- a/ayunis-core-frontend/src/widgets/settings-sidebar/ui/SettingsSidebarWidget.tsx
+++ b/ayunis-core-frontend/src/widgets/settings-sidebar/ui/SettingsSidebarWidget.tsx
@@ -67,7 +67,7 @@ export function SettingsSidebarWidget({
   ];
 
   return (
-    <Sidebar collapsible="icon" variant="inset">
+    <Sidebar collapsible="icon" variant="inset" data-testid="settings-sidebar">
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only DOM attributes with no runtime behavior, routing, or auth logic changes.
> 
> **Overview**
> Adds **`data-testid`** hooks on key auth and settings UI so e2e tests can target stable selectors without relying on labels or DOM structure.
> 
> **Auth onboarding:** forgot password (`forgot-email`, `forgot-submit`), register (email, user/org name, password, submit), invite accept (name, password, submit), and reset/activation password flows (`reset-new-password`, `reset-confirm-password`, `reset-submit`).
> 
> **Shared widgets:** confirmation modal cancel/confirm buttons, rename-thread dialog input and submit, and the settings sidebar root (`settings-sidebar`). Submit buttons are reformatted to multi-line props only where needed to attach test ids; no logic or styling changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 283a6e14d11622123e230ed1ad00a90d71b1f0fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->