### PR TITLE
wip(workspaces): add project context backend api (AYC-701)

### DIFF
--- a/ayunis-core-backend/src/common/http/document-upload.ts
+++ b/ayunis-core-backend/src/common/http/document-upload.ts
@@ -1,0 +1,68 @@
+import { BadRequestException } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import * as fs from 'fs';
+import {
+  detectFileType,
+  getCanonicalMimeType,
+  isDocumentSourceFile,
+} from 'src/common/util/file-type';
+import {
+  SOURCE_FILE_UPLOAD_OPTIONS,
+  type UploadedSourceFile,
+} from 'src/common/util/source-file-upload';
+
+export type UploadedDocument = UploadedSourceFile;
+
+export function createDocumentUploadInterceptor(maxFileSizeBytes: number) {
+  return FileInterceptor('file', {
+    ...SOURCE_FILE_UPLOAD_OPTIONS,
+    limits: { fileSize: maxFileSizeBytes },
+  });
+}
+
+interface UploadCleanupLogger {
+  warn(obj: unknown, msg?: string, ...args: unknown[]): void;
+}
+
+export async function cleanupTempUploadFile(
+  filePath: string,
+  logger: UploadCleanupLogger,
+): Promise<void> {
+  try {
+    await fs.promises.unlink(filePath);
+  } catch (error) {
+    logger.warn(
+      { filePath, error: error as Error },
+      'Failed to clean up temp file',
+    );
+  }
+}
+
+type DocumentUploadMimeTypeErrorReason = 'unsupported' | 'missing-mime';
+
+export function resolveDocumentUploadMimeType(params: {
+  file: UploadedDocument;
+  errorMessage: (
+    reason: DocumentUploadMimeTypeErrorReason,
+    detectedType: string | null,
+  ) => string;
+}): string {
+  const detectedType = detectFileType(
+    params.file.mimetype,
+    params.file.originalname,
+  );
+  if (!isDocumentSourceFile(detectedType)) {
+    throw new BadRequestException(
+      params.errorMessage('unsupported', detectedType),
+    );
+  }
+
+  const canonicalMimeType = getCanonicalMimeType(detectedType);
+  if (!canonicalMimeType) {
+    throw new BadRequestException(
+      params.errorMessage('missing-mime', detectedType),
+    );
+  }
+
+  return canonicalMimeType;
+}

--- a/ayunis-core-backend/src/common/util/source-file-upload.ts
+++ b/ayunis-core-backend/src/common/util/source-file-upload.ts
@@ -3,6 +3,7 @@ import { diskStorage } from 'multer';
 import { extname } from 'path';
 import { randomUUID } from 'crypto';
 import * as fs from 'fs';
+import * as path from 'path';
 
 export const MAX_SOURCE_FILE_SIZE_BYTES = 25 * 1024 * 1024; // 25 MB
 
@@ -37,7 +38,12 @@ export function removeUploadedFile(path: string): void {
 export const SOURCE_FILE_UPLOAD_OPTIONS: MulterOptions = {
   // eslint-disable-next-line sonarjs/content-length -- multer file size limit, not HTTP Content-Length
   storage: diskStorage({
-    destination: './uploads',
+    destination: (_req, _file, cb) => {
+      const uploadsPath = path.resolve('./uploads');
+      fs.mkdir(uploadsPath, { recursive: true }, (error) => {
+        cb(error, uploadsPath);
+      });
+    },
     filename: (req, file, cb) => {
       cb(null, `${randomUUID()}${extname(file.originalname)}`);
     },

--- a/ayunis-core-backend/src/db/migrations/1786649398174-AddWorkspaceContextAssignments.ts
+++ b/ayunis-core-backend/src/db/migrations/1786649398174-AddWorkspaceContextAssignments.ts
@@ -1,0 +1,101 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddWorkspaceContextAssignments1786649398174 implements MigrationInterface {
+  name = 'AddWorkspaceContextAssignments1786649398174';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "workspace_source_assignments" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "workspaceId" character varying NOT NULL, "sourceId" character varying NOT NULL, CONSTRAINT "UQ_e6ea90491e8e2c3081c9e02ef99" UNIQUE ("workspaceId", "sourceId"), CONSTRAINT "PK_9dfa799d1b5b4cc0bde7d966c2c" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_e602a51a07600b9fe15184672c" ON "workspace_source_assignments" ("workspaceId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_10545836d90a5593b3bed3896f" ON "workspace_source_assignments" ("sourceId") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "workspace_skill_assignments" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "workspaceId" character varying NOT NULL, "skillId" character varying NOT NULL, CONSTRAINT "UQ_9fadba3515e9dcbf90515eacc25" UNIQUE ("workspaceId", "skillId"), CONSTRAINT "PK_489894de8d18c08c99f5130a605" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_1916a377d1de896630e305779a" ON "workspace_skill_assignments" ("workspaceId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_741632413d27ff112b7776b3f8" ON "workspace_skill_assignments" ("skillId") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "workspace_knowledge_base_assignments" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "workspaceId" character varying NOT NULL, "knowledgeBaseId" character varying NOT NULL, CONSTRAINT "UQ_c63cf835205cea3dddefc1bb52a" UNIQUE ("workspaceId", "knowledgeBaseId"), CONSTRAINT "PK_02ed08a684c925d5d886e83d1ea" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_d8e63bf51231a234484d61b401" ON "workspace_knowledge_base_assignments" ("workspaceId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c372faa720d58488c12396afbb" ON "workspace_knowledge_base_assignments" ("knowledgeBaseId") `,
+    );
+    await queryRunner.query(`ALTER TABLE "workspaces" ADD "instruction" text`);
+    await queryRunner.query(
+      `ALTER TABLE "workspace_source_assignments" ADD CONSTRAINT "FK_e602a51a07600b9fe15184672c3" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspace_source_assignments" ADD CONSTRAINT "FK_10545836d90a5593b3bed3896fd" FOREIGN KEY ("sourceId") REFERENCES "sources"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspace_skill_assignments" ADD CONSTRAINT "FK_1916a377d1de896630e305779aa" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspace_skill_assignments" ADD CONSTRAINT "FK_741632413d27ff112b7776b3f8d" FOREIGN KEY ("skillId") REFERENCES "skills"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspace_knowledge_base_assignments" ADD CONSTRAINT "FK_d8e63bf51231a234484d61b4015" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspace_knowledge_base_assignments" ADD CONSTRAINT "FK_c372faa720d58488c12396afbb1" FOREIGN KEY ("knowledgeBaseId") REFERENCES "knowledge_bases"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "workspace_knowledge_base_assignments" DROP CONSTRAINT "FK_c372faa720d58488c12396afbb1"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspace_knowledge_base_assignments" DROP CONSTRAINT "FK_d8e63bf51231a234484d61b4015"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspace_skill_assignments" DROP CONSTRAINT "FK_741632413d27ff112b7776b3f8d"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspace_skill_assignments" DROP CONSTRAINT "FK_1916a377d1de896630e305779aa"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspace_source_assignments" DROP CONSTRAINT "FK_10545836d90a5593b3bed3896fd"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspace_source_assignments" DROP CONSTRAINT "FK_e602a51a07600b9fe15184672c3"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "workspaces" DROP COLUMN "instruction"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_c372faa720d58488c12396afbb"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_d8e63bf51231a234484d61b401"`,
+    );
+    await queryRunner.query(
+      `DROP TABLE "workspace_knowledge_base_assignments"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_741632413d27ff112b7776b3f8"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_1916a377d1de896630e305779a"`,
+    );
+    await queryRunner.query(`DROP TABLE "workspace_skill_assignments"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_10545836d90a5593b3bed3896f"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_e602a51a07600b9fe15184672c"`,
+    );
+    await queryRunner.query(`DROP TABLE "workspace_source_assignments"`);
+  }
+}

--- a/ayunis-core-backend/src/db/migrations/1787146452562-AddIndexOnSourceKnowledgeBaseId.ts
+++ b/ayunis-core-backend/src/db/migrations/1787146452562-AddIndexOnSourceKnowledgeBaseId.ts
@@ -1,0 +1,17 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddIndexOnSourceKnowledgeBaseId1787146452562 implements MigrationInterface {
+  name = 'AddIndexOnSourceKnowledgeBaseId1787146452562';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IDX_16ddae600230efe98552376f4c" ON "sources" ("knowledgeBaseId") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_16ddae600230efe98552376f4c"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/ports/knowledge-base.repository.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/ports/knowledge-base.repository.ts
@@ -1,11 +1,24 @@
 import type { UUID } from 'crypto';
-import type { KnowledgeBase } from '../../domain/knowledge-base.entity';
+import type { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
 import type { Source } from 'src/domain/sources/domain/source.entity';
+import type { Paginated } from 'src/common/pagination/paginated.entity';
+
+export interface KnowledgeBaseListOptions {
+  search?: string;
+  limit: number;
+  offset: number;
+}
 
 export abstract class KnowledgeBaseRepository {
   abstract findById(id: UUID): Promise<KnowledgeBase | null>;
   abstract findByIds(ids: UUID[]): Promise<KnowledgeBase[]>;
   abstract findAllByUserId(userId: UUID): Promise<KnowledgeBase[]>;
+  abstract findPaginatedAccessible(
+    userId: UUID,
+    workspaceId: UUID | undefined,
+    sharedKnowledgeBaseIds: UUID[],
+    options: KnowledgeBaseListOptions,
+  ): Promise<Paginated<KnowledgeBase>>;
   abstract save(knowledgeBase: KnowledgeBase): Promise<KnowledgeBase>;
   abstract delete(knowledgeBase: KnowledgeBase): Promise<void>;
   abstract assignSourceToKnowledgeBase(
@@ -18,6 +31,9 @@ export abstract class KnowledgeBaseRepository {
   abstract countSourcesByKnowledgeBaseId(
     knowledgeBaseId: UUID,
   ): Promise<number>;
+  abstract countSourcesByKnowledgeBaseIds(
+    knowledgeBaseIds: UUID[],
+  ): Promise<Map<UUID, number>>;
   abstract findSourceByIdAndKnowledgeBaseId(
     sourceId: UUID,
     knowledgeBaseId: UUID,

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.spec.ts
@@ -4,16 +4,18 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 
 import { KnowledgeBaseAccessService } from './knowledge-base-access.service';
-import { KnowledgeBaseRepository } from '../ports/knowledge-base.repository';
+import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
 import { FindShareByEntityUseCase } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case';
 import { FindSharesByScopeUseCase } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.use-case';
 import { CheckKnowledgeBaseSkillShareAccessUseCase } from 'src/domain/skills/application/use-cases/check-knowledge-base-skill-share-access/check-knowledge-base-skill-share-access.use-case';
+import { FindKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase } from 'src/domain/skills/application/use-cases/find-knowledge-base-ids-accessible-via-shared-skills/find-knowledge-base-ids-accessible-via-shared-skills.use-case';
 import { ContextService } from 'src/common/context/services/context.service';
-import { KnowledgeBase } from '../../domain/knowledge-base.entity';
-import { KnowledgeBaseNotFoundError } from '../knowledge-bases.errors';
+import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
+import { KnowledgeBaseNotFoundError } from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import type { Share } from 'src/domain/shares/domain/share.entity';
 import type { UUID } from 'crypto';
+import { Paginated } from 'src/common/pagination/paginated.entity';
 
 describe('KnowledgeBaseAccessService', () => {
   let service: KnowledgeBaseAccessService;
@@ -21,6 +23,7 @@ describe('KnowledgeBaseAccessService', () => {
   let findShareByEntityUseCase: jest.Mocked<FindShareByEntityUseCase>;
   let findSharesByScopeUseCase: jest.Mocked<FindSharesByScopeUseCase>;
   let checkKnowledgeBaseSkillShareAccessUseCase: jest.Mocked<CheckKnowledgeBaseSkillShareAccessUseCase>;
+  let findKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase: jest.Mocked<FindKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase>;
   let contextService: jest.Mocked<ContextService>;
 
   const userId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
@@ -51,10 +54,12 @@ describe('KnowledgeBaseAccessService', () => {
             findById: jest.fn(),
             findByIds: jest.fn(),
             findAllByUserId: jest.fn(),
+            findPaginatedAccessible: jest.fn(),
             save: jest.fn(),
             delete: jest.fn(),
             assignSourceToKnowledgeBase: jest.fn(),
             findSourcesByKnowledgeBaseId: jest.fn(),
+            countSourcesByKnowledgeBaseIds: jest.fn(),
             findSourceByIdAndKnowledgeBaseId: jest.fn(),
           },
         },
@@ -69,6 +74,10 @@ describe('KnowledgeBaseAccessService', () => {
         {
           provide: CheckKnowledgeBaseSkillShareAccessUseCase,
           useValue: { execute: jest.fn() },
+        },
+        {
+          provide: FindKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase,
+          useValue: { execute: jest.fn().mockResolvedValue([]) },
         },
         {
           provide: ContextService,
@@ -89,10 +98,102 @@ describe('KnowledgeBaseAccessService', () => {
     checkKnowledgeBaseSkillShareAccessUseCase = module.get(
       CheckKnowledgeBaseSkillShareAccessUseCase,
     );
+    findKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase = module.get(
+      FindKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase,
+    );
     contextService = module.get(ContextService);
   });
 
   afterEach(() => jest.clearAllMocks());
+
+  describe('countSourcesByKnowledgeBaseIds', () => {
+    it('returns the repository counts for every requested knowledge base', async () => {
+      const secondKbId = '650e8400-e29b-41d4-a716-446655440001' as UUID;
+      const counts = new Map<UUID, number>([
+        [kbId, 3],
+        [secondKbId, 0],
+      ]);
+      knowledgeBaseRepository.countSourcesByKnowledgeBaseIds.mockResolvedValue(
+        counts,
+      );
+
+      const result = await service.countSourcesByKnowledgeBaseIds([
+        kbId,
+        secondKbId,
+      ]);
+
+      expect(result).toEqual(counts);
+      expect(
+        knowledgeBaseRepository.countSourcesByKnowledgeBaseIds,
+      ).toHaveBeenCalledWith([kbId, secondKbId]);
+    });
+  });
+
+  describe('findAllAccessiblePaginated', () => {
+    it('returns only the requested page with shared status', async () => {
+      const sharedKbId = '650e8400-e29b-41d4-a716-446655440001' as UUID;
+      const sharedKb = makeKb(sharedKbId, otherUserId);
+      const page = new Paginated<KnowledgeBase>({
+        data: [sharedKb],
+        limit: 2,
+        offset: 4,
+        total: 5,
+      });
+      knowledgeBaseRepository.findPaginatedAccessible.mockResolvedValue(page);
+      findSharesByScopeUseCase.execute.mockResolvedValue([
+        { entityId: sharedKbId } as never,
+      ]);
+
+      const result = await service.findAllAccessiblePaginated(kbId, {
+        search: 'citizen',
+        limit: 2,
+        offset: 4,
+      });
+
+      expect(result.data).toEqual([
+        { knowledgeBase: sharedKb, isShared: true },
+      ]);
+      expect(result.total).toBe(5);
+      expect(
+        knowledgeBaseRepository.findPaginatedAccessible,
+      ).toHaveBeenCalledWith(userId, kbId, [sharedKbId], {
+        search: 'citizen',
+        limit: 2,
+        offset: 4,
+      });
+    });
+
+    it('includes knowledge bases linked to shared skills', async () => {
+      const sharedKbId = '650e8400-e29b-41d4-a716-446655440001' as UUID;
+      const sharedKb = makeKb(sharedKbId, otherUserId);
+      const page = new Paginated<KnowledgeBase>({
+        data: [sharedKb],
+        limit: 20,
+        offset: 0,
+        total: 1,
+      });
+      knowledgeBaseRepository.findPaginatedAccessible.mockResolvedValue(page);
+      findSharesByScopeUseCase.execute.mockResolvedValue([]);
+      findKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase.execute.mockResolvedValue(
+        [sharedKbId],
+      );
+
+      const result = await service.findAllAccessiblePaginated(undefined, {
+        limit: 20,
+        offset: 0,
+      });
+
+      expect(result.data).toEqual([
+        { knowledgeBase: sharedKb, isShared: true },
+      ]);
+      expect(
+        knowledgeBaseRepository.findPaginatedAccessible,
+      ).toHaveBeenCalledWith(userId, undefined, [sharedKbId], {
+        limit: 20,
+        offset: 0,
+      });
+    });
+  });
 
   describe('findAccessibleKnowledgeBase', () => {
     it('should return owned KB without checking shares', async () => {
@@ -310,6 +411,25 @@ describe('KnowledgeBaseAccessService', () => {
       expect(result[0].isShared).toBe(false);
       expect(result[1].knowledgeBase).toBe(sharedKb);
       expect(result[1].isShared).toBe(true);
+    });
+
+    it('should return KBs linked to shared skills with isShared=true', async () => {
+      const sharedKbId = '660e8400-e29b-41d4-a716-446655440001' as UUID;
+      const sharedKb = makeKb(sharedKbId, otherUserId);
+
+      knowledgeBaseRepository.findAllByUserId.mockResolvedValue([]);
+      findSharesByScopeUseCase.execute.mockResolvedValue([]);
+      findKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase.execute.mockResolvedValue(
+        [sharedKbId],
+      );
+      knowledgeBaseRepository.findByIds.mockResolvedValue([sharedKb]);
+
+      const result = await service.findAllAccessible();
+
+      expect(result).toEqual([{ knowledgeBase: sharedKb, isShared: true }]);
+      expect(knowledgeBaseRepository.findByIds).toHaveBeenCalledWith([
+        sharedKbId,
+      ]);
     });
 
     it('should throw UnauthorizedAccessError when no user in context', async () => {

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.ts
@@ -1,18 +1,23 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
-import { KnowledgeBaseRepository } from '../ports/knowledge-base.repository';
+import {
+  KnowledgeBaseRepository,
+  type KnowledgeBaseListOptions,
+} from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
 import { FindShareByEntityUseCase } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case';
 import { FindShareByEntityQuery } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.query';
 import { FindSharesByScopeUseCase } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.use-case';
 import { FindSharesByScopeQuery } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.query';
 import { CheckKnowledgeBaseSkillShareAccessUseCase } from 'src/domain/skills/application/use-cases/check-knowledge-base-skill-share-access/check-knowledge-base-skill-share-access.use-case';
 import { CheckKnowledgeBaseSkillShareAccessQuery } from 'src/domain/skills/application/use-cases/check-knowledge-base-skill-share-access/check-knowledge-base-skill-share-access.query';
+import { FindKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase } from 'src/domain/skills/application/use-cases/find-knowledge-base-ids-accessible-via-shared-skills/find-knowledge-base-ids-accessible-via-shared-skills.use-case';
 import { SharedEntityType } from 'src/domain/shares/domain/value-objects/shared-entity-type.enum';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
-import { KnowledgeBaseNotFoundError } from '../knowledge-bases.errors';
-import type { KnowledgeBase } from '../../domain/knowledge-base.entity';
+import { KnowledgeBaseNotFoundError } from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
+import type { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
+import { Paginated } from 'src/common/pagination/paginated.entity';
 
 export interface KnowledgeBaseWithShareStatus {
   knowledgeBase: KnowledgeBase;
@@ -28,6 +33,7 @@ export class KnowledgeBaseAccessService {
     private readonly findShareByEntityUseCase: FindShareByEntityUseCase,
     private readonly findSharesByScopeUseCase: FindSharesByScopeUseCase,
     private readonly checkKnowledgeBaseSkillShareAccessUseCase: CheckKnowledgeBaseSkillShareAccessUseCase,
+    private readonly findKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase: FindKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase,
     private readonly contextService: ContextService,
   ) {}
 
@@ -106,9 +112,19 @@ export class KnowledgeBaseAccessService {
   }
 
   /**
-   * Resolves whether a knowledge base is shared with the given user.
-   * Returns false for KB owners, even if the KB has been shared.
+   * Counts sources for multiple knowledge bases in one repository operation.
    */
+  async countSourcesByKnowledgeBaseIds(
+    knowledgeBaseIds: UUID[],
+  ): Promise<Map<UUID, number>> {
+    if (knowledgeBaseIds.length === 0) {
+      return new Map();
+    }
+    return this.knowledgeBaseRepository.countSourcesByKnowledgeBaseIds(
+      knowledgeBaseIds,
+    );
+  }
+
   async resolveIsShared(kbId: UUID, userId: UUID): Promise<boolean> {
     const kb = await this.knowledgeBaseRepository.findById(kbId);
     if (kb?.userId === userId) {
@@ -132,11 +148,9 @@ export class KnowledgeBaseAccessService {
     }
 
     // 1. Fetch owned KBs and shares in parallel
-    const [ownedKbs, shares] = await Promise.all([
+    const [ownedKbs, sharedKnowledgeBaseIds] = await Promise.all([
       this.knowledgeBaseRepository.findAllByUserId(userId),
-      this.findSharesByScopeUseCase.execute(
-        new FindSharesByScopeQuery(SharedEntityType.KNOWLEDGE_BASE),
-      ),
+      this.findAccessibleSharedKnowledgeBaseIds(),
     ]);
 
     const ownedKbIds = new Set(ownedKbs.map((kb) => kb.id));
@@ -149,9 +163,9 @@ export class KnowledgeBaseAccessService {
     );
 
     // 2. Extract shared KB IDs and deduplicate against owned
-    const sharedKbIds = shares
-      .map((s) => s.entityId)
-      .filter((id) => !ownedKbIds.has(id));
+    const sharedKbIds = sharedKnowledgeBaseIds.filter(
+      (id) => !ownedKbIds.has(id),
+    );
 
     this.logger.debug(
       {
@@ -182,5 +196,51 @@ export class KnowledgeBaseAccessService {
     );
 
     return [...ownedResults, ...sharedResults];
+  }
+
+  async findAllAccessiblePaginated(
+    workspaceId: UUID | undefined,
+    options: KnowledgeBaseListOptions,
+  ): Promise<Paginated<KnowledgeBaseWithShareStatus>> {
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    const sharedIds = await this.findAccessibleSharedKnowledgeBaseIds();
+    const page = await this.knowledgeBaseRepository.findPaginatedAccessible(
+      userId,
+      workspaceId,
+      sharedIds,
+      options,
+    );
+    const sharedIdSet = new Set(sharedIds);
+
+    return new Paginated({
+      data: page.data.map((knowledgeBase) => ({
+        knowledgeBase,
+        isShared:
+          knowledgeBase.userId !== userId && sharedIdSet.has(knowledgeBase.id),
+      })),
+      limit: page.limit,
+      offset: page.offset,
+      total: page.total,
+    });
+  }
+
+  private async findAccessibleSharedKnowledgeBaseIds(): Promise<UUID[]> {
+    const [directShares, skillSharedIds] = await Promise.all([
+      this.findSharesByScopeUseCase.execute(
+        new FindSharesByScopeQuery(SharedEntityType.KNOWLEDGE_BASE),
+      ),
+      this.findKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase.execute(),
+    ]);
+
+    return [
+      ...new Set([
+        ...directShares.map((share) => share.entityId),
+        ...skillSharedIds,
+      ]),
+    ];
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.spec.ts
@@ -6,9 +6,9 @@ import type { UUID } from 'crypto';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { AddDocumentToKnowledgeBaseUseCase } from './add-document-to-knowledge-base.use-case';
 import { AddDocumentToKnowledgeBaseCommand } from './add-document-to-knowledge-base.command';
-import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
+import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
-import { KnowledgeBaseNotFoundError } from '../../knowledge-bases.errors';
+import { KnowledgeBaseNotFoundError } from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
 import { StartDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case';
 import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
 import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
@@ -47,6 +47,8 @@ describe('AddDocumentToKnowledgeBaseUseCase', () => {
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
       countSourcesByKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseIds: jest.fn(),
+      findPaginatedAccessible: jest.fn(),
     };
 
     mockStartDocumentProcessingUseCase = {

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.spec.ts
@@ -6,13 +6,13 @@ import { TransactionHost } from '@nestjs-cls/transactional';
 import type { UUID } from 'crypto';
 import { AddUrlToKnowledgeBaseUseCase } from './add-url-to-knowledge-base.use-case';
 import { AddUrlToKnowledgeBaseCommand } from './add-url-to-knowledge-base.command';
-import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
+import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
 import {
   KnowledgeBaseNotFoundError,
   KnowledgeBaseSourceLimitExceededError,
   UnexpectedKnowledgeBaseError,
-} from '../../knowledge-bases.errors';
+} from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
 import { KnowledgeBasesConstants } from 'src/domain/knowledge-bases/domain/knowledge-bases.constants';
 import { StartUrlCrawlUseCase } from 'src/domain/sources/application/use-cases/start-url-crawl/start-url-crawl.use-case';
 import { UrlSource } from 'src/domain/sources/domain/sources/text-source.entity';
@@ -63,6 +63,8 @@ describe('AddUrlToKnowledgeBaseUseCase', () => {
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
       countSourcesByKnowledgeBaseId: jest.fn().mockResolvedValue(0),
+      countSourcesByKnowledgeBaseIds: jest.fn(),
+      findPaginatedAccessible: jest.fn(),
     };
 
     mockStartUrlCrawlUseCase = {

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/create-knowledge-base/create-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/create-knowledge-base/create-knowledge-base.use-case.spec.ts
@@ -4,9 +4,9 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { CreateKnowledgeBaseUseCase } from './create-knowledge-base.use-case';
 import { CreateKnowledgeBaseCommand } from './create-knowledge-base.command';
-import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
+import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
-import { UnexpectedKnowledgeBaseError } from '../../knowledge-bases.errors';
+import { UnexpectedKnowledgeBaseError } from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
 import type { UUID } from 'crypto';
 
 describe('CreateKnowledgeBaseUseCase', () => {
@@ -27,6 +27,8 @@ describe('CreateKnowledgeBaseUseCase', () => {
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
       countSourcesByKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseIds: jest.fn(),
+      findPaginatedAccessible: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case.spec.ts
@@ -13,7 +13,7 @@ jest.mock('@nestjs-cls/transactional', () => ({
 
 import { DeleteKnowledgeBaseUseCase } from './delete-knowledge-base.use-case';
 import { DeleteKnowledgeBaseCommand } from './delete-knowledge-base.command';
-import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
+import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
 import { DeleteSourcesUseCase } from 'src/domain/sources/application/use-cases/delete-sources/delete-sources.use-case';
 import { GetSourcesByKnowledgeBaseIdUseCase } from 'src/domain/sources/application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.use-case';
 import { DeleteSourcesCommand } from 'src/domain/sources/application/use-cases/delete-sources/delete-sources.command';
@@ -21,7 +21,7 @@ import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.
 import {
   KnowledgeBaseNotFoundError,
   UnexpectedKnowledgeBaseError,
-} from '../../knowledge-bases.errors';
+} from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
 import { UrlSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { TextType } from 'src/domain/sources/domain/source-type.enum';
 import type { UUID } from 'crypto';
@@ -49,6 +49,8 @@ describe('DeleteKnowledgeBaseUseCase', () => {
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
       countSourcesByKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseIds: jest.fn(),
+      findPaginatedAccessible: jest.fn(),
     };
 
     mockGetSourcesByKbId = {

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/find-knowledge-base/find-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/find-knowledge-base/find-knowledge-base.use-case.spec.ts
@@ -4,12 +4,12 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { FindKnowledgeBaseUseCase } from './find-knowledge-base.use-case';
 import { FindKnowledgeBaseQuery } from './find-knowledge-base.query';
-import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
+import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
 import {
   KnowledgeBaseNotFoundError,
   UnexpectedKnowledgeBaseError,
-} from '../../knowledge-bases.errors';
+} from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
 import type { UUID } from 'crypto';
 
 describe('FindKnowledgeBaseUseCase', () => {
@@ -31,6 +31,8 @@ describe('FindKnowledgeBaseUseCase', () => {
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
       countSourcesByKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseIds: jest.fn(),
+      findPaginatedAccessible: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-base-document-text/get-knowledge-base-document-text.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-base-document-text/get-knowledge-base-document-text.use-case.spec.ts
@@ -3,17 +3,17 @@ import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetKnowledgeBaseDocumentTextUseCase } from './get-knowledge-base-document-text.use-case';
-import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
+import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
 import { GetKnowledgeBaseDocumentTextQuery } from './get-knowledge-base-document-text.query';
 import {
   KnowledgeBaseNotFoundError,
   DocumentNotInKnowledgeBaseError,
-} from '../../knowledge-bases.errors';
+} from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
 import { randomUUID } from 'crypto';
 import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { FileType, TextType } from 'src/domain/sources/domain/source-type.enum';
-import { KnowledgeBaseAccessService } from '../../services/knowledge-base-access.service';
+import { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
 
 describe('GetKnowledgeBaseDocumentTextUseCase', () => {
   let useCase: GetKnowledgeBaseDocumentTextUseCase;
@@ -30,6 +30,7 @@ describe('GetKnowledgeBaseDocumentTextUseCase', () => {
       findById: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
       countSourcesByKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseIds: jest.fn(),
     } as unknown as jest.Mocked<KnowledgeBaseRepository>;
 
     mockAccessService = {

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.spec.ts
@@ -5,9 +5,9 @@ import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
 import { ListKnowledgeBaseDocumentsUseCase } from './list-knowledge-base-documents.use-case';
 import { ListKnowledgeBaseDocumentsQuery } from './list-knowledge-base-documents.query';
-import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
+import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
-import { KnowledgeBaseNotFoundError } from '../../knowledge-bases.errors';
+import { KnowledgeBaseNotFoundError } from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
 import { UrlSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { TextType } from 'src/domain/sources/domain/source-type.enum';
 
@@ -30,6 +30,8 @@ describe('ListKnowledgeBaseDocumentsUseCase', () => {
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
       countSourcesByKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseIds: jest.fn(),
+      findPaginatedAccessible: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-bases/list-knowledge-bases.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-bases/list-knowledge-bases.use-case.spec.ts
@@ -4,9 +4,9 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ListKnowledgeBasesUseCase } from './list-knowledge-bases.use-case';
 import { ListKnowledgeBasesQuery } from './list-knowledge-bases.query';
-import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
+import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
-import { UnexpectedKnowledgeBaseError } from '../../knowledge-bases.errors';
+import { UnexpectedKnowledgeBaseError } from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
 import type { UUID } from 'crypto';
 
 describe('ListKnowledgeBasesUseCase', () => {
@@ -27,6 +27,8 @@ describe('ListKnowledgeBasesUseCase', () => {
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
       countSourcesByKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseIds: jest.fn(),
+      findPaginatedAccessible: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.spec.ts
@@ -4,19 +4,19 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { QueryKnowledgeBaseUseCase } from './query-knowledge-base.use-case';
 import { QueryKnowledgeBaseQuery } from './query-knowledge-base.query';
-import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
+import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
 import {
   KnowledgeBaseNotFoundError,
   UnexpectedKnowledgeBaseError,
-} from '../../knowledge-bases.errors';
+} from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
 import { SearchContentUseCase } from 'src/domain/rag/indexers/application/use-cases/search-content/search-content.use-case';
 import { IndexEntry } from 'src/domain/rag/indexers/domain/index-entry.entity';
 import { TextSourceContentChunk } from 'src/domain/sources/domain/source-content-chunk.entity';
 import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { FileType, TextType } from 'src/domain/sources/domain/source-type.enum';
 import { ContextService } from 'src/common/context/services/context.service';
-import { KnowledgeBaseAccessService } from '../../services/knowledge-base-access.service';
+import { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
 import { FindContentChunksByIdsUseCase } from 'src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.use-case';
 import type { UUID } from 'crypto';
 
@@ -45,6 +45,8 @@ describe('QueryKnowledgeBaseUseCase', () => {
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
       countSourcesByKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseIds: jest.fn(),
+      findPaginatedAccessible: jest.fn(),
     };
 
     mockFindChunks = {

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case.spec.ts
@@ -12,12 +12,12 @@ import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
 import { RemoveDocumentFromKnowledgeBaseUseCase } from './remove-document-from-knowledge-base.use-case';
 import { RemoveDocumentFromKnowledgeBaseCommand } from './remove-document-from-knowledge-base.command';
-import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
+import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
 import {
   KnowledgeBaseNotFoundError,
   DocumentNotInKnowledgeBaseError,
-} from '../../knowledge-bases.errors';
+} from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
 import { DeleteSourceUseCase } from 'src/domain/sources/application/use-cases/delete-source/delete-source.use-case';
 import { UrlSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { TextType } from 'src/domain/sources/domain/source-type.enum';
@@ -43,6 +43,8 @@ describe('RemoveDocumentFromKnowledgeBaseUseCase', () => {
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
       countSourcesByKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseIds: jest.fn(),
+      findPaginatedAccessible: jest.fn(),
     };
 
     mockDeleteSourceUseCase = {

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/update-knowledge-base/update-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/update-knowledge-base/update-knowledge-base.use-case.spec.ts
@@ -13,12 +13,12 @@ jest.mock('@nestjs-cls/transactional', () => ({
 
 import { UpdateKnowledgeBaseUseCase } from './update-knowledge-base.use-case';
 import { UpdateKnowledgeBaseCommand } from './update-knowledge-base.command';
-import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
+import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
 import {
   KnowledgeBaseNotFoundError,
   UnexpectedKnowledgeBaseError,
-} from '../../knowledge-bases.errors';
+} from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
 import type { UUID } from 'crypto';
 
 describe('UpdateKnowledgeBaseUseCase', () => {
@@ -40,6 +40,8 @@ describe('UpdateKnowledgeBaseUseCase', () => {
       findSourcesByKnowledgeBaseId: jest.fn(),
       findSourceByIdAndKnowledgeBaseId: jest.fn(),
       countSourcesByKnowledgeBaseId: jest.fn(),
+      countSourcesByKnowledgeBaseIds: jest.fn(),
+      findPaginatedAccessible: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/ayunis-core-backend/src/domain/knowledge-bases/infrastructure/persistence/local/local-knowledge-base.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/infrastructure/persistence/local/local-knowledge-base.repository.spec.ts
@@ -1,0 +1,126 @@
+import type { UUID } from 'crypto';
+import type { Repository } from 'typeorm';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import type { KnowledgeBaseMapper } from './mappers/knowledge-base.mapper';
+import type { KnowledgeBaseRecord } from './schema/knowledge-base.record';
+import type { SourceMapper } from 'src/domain/sources/infrastructure/persistence/local/mappers/source.mapper';
+import type { SourceRecord } from 'src/domain/sources/infrastructure/persistence/local/schema/source.record';
+import { LocalKnowledgeBaseRepository } from './local-knowledge-base.repository';
+
+describe('LocalKnowledgeBaseRepository', () => {
+  const firstKnowledgeBaseId = '550e8400-e29b-41d4-a716-446655440000' as UUID;
+  const secondKnowledgeBaseId = '650e8400-e29b-41d4-a716-446655440001' as UUID;
+
+  it('returns a database-paginated page of accessible knowledge bases', async () => {
+    const userId = '750e8400-e29b-41d4-a716-446655440002' as UUID;
+    const workspaceId = '850e8400-e29b-41d4-a716-446655440003' as UUID;
+    const records = [
+      { id: firstKnowledgeBaseId, name: 'Citizen requests' },
+      { id: secondKnowledgeBaseId, name: 'Budget planning' },
+    ] as KnowledgeBaseRecord[];
+    const queryBuilder = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([records, 9]),
+    };
+    const knowledgeBaseRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    } as unknown as jest.Mocked<Repository<KnowledgeBaseRecord>>;
+    const mapper = {
+      toDomain: jest.fn((record: KnowledgeBaseRecord) => record),
+    } as unknown as KnowledgeBaseMapper;
+    const repository = new LocalKnowledgeBaseRepository(
+      createPinoLoggerMock(),
+      knowledgeBaseRepository,
+      {} as Repository<SourceRecord>,
+      mapper,
+      {} as SourceMapper,
+    );
+
+    const result = await repository.findPaginatedAccessible(
+      userId,
+      workspaceId,
+      [secondKnowledgeBaseId],
+      {
+        search: 'citizen',
+        limit: 2,
+        offset: 4,
+      },
+    );
+
+    expect(result.data).toEqual(records);
+    expect(result.total).toBe(9);
+    expect(result.limit).toBe(2);
+    expect(result.offset).toBe(4);
+    expect(queryBuilder.skip).toHaveBeenCalledWith(4);
+    expect(queryBuilder.take).toHaveBeenCalledWith(2);
+    expect(queryBuilder.getManyAndCount).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns grouped source counts and zeroes for knowledge bases without sources', async () => {
+    const queryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      getRawMany: jest
+        .fn()
+        .mockResolvedValue([
+          { knowledgeBaseId: firstKnowledgeBaseId, count: '3' },
+        ]),
+    };
+    const sourceRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    } as unknown as jest.Mocked<
+      Pick<Repository<SourceRecord>, 'createQueryBuilder'>
+    >;
+    const repository = new LocalKnowledgeBaseRepository(
+      createPinoLoggerMock(),
+      {} as Repository<KnowledgeBaseRecord>,
+      sourceRepository as unknown as Repository<SourceRecord>,
+      {} as KnowledgeBaseMapper,
+      {} as SourceMapper,
+    );
+
+    const result = await repository.countSourcesByKnowledgeBaseIds([
+      firstKnowledgeBaseId,
+      secondKnowledgeBaseId,
+    ]);
+
+    expect(result).toEqual(
+      new Map<UUID, number>([
+        [firstKnowledgeBaseId, 3],
+        [secondKnowledgeBaseId, 0],
+      ]),
+    );
+    expect(sourceRepository.createQueryBuilder).toHaveBeenCalledTimes(1);
+    expect(queryBuilder.where).toHaveBeenCalledWith(
+      'source.knowledgeBaseId IN (:...knowledgeBaseIds)',
+      { knowledgeBaseIds: [firstKnowledgeBaseId, secondKnowledgeBaseId] },
+    );
+  });
+
+  it('does not query when no knowledge base ids are provided', async () => {
+    const sourceRepository = {
+      createQueryBuilder: jest.fn(),
+    } as unknown as jest.Mocked<
+      Pick<Repository<SourceRecord>, 'createQueryBuilder'>
+    >;
+    const repository = new LocalKnowledgeBaseRepository(
+      createPinoLoggerMock(),
+      {} as Repository<KnowledgeBaseRecord>,
+      sourceRepository as unknown as Repository<SourceRecord>,
+      {} as KnowledgeBaseMapper,
+      {} as SourceMapper,
+    );
+
+    const result = await repository.countSourcesByKnowledgeBaseIds([]);
+
+    expect(result).toEqual(new Map());
+    expect(sourceRepository.createQueryBuilder).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/knowledge-bases/infrastructure/persistence/local/local-knowledge-base.repository.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/infrastructure/persistence/local/local-knowledge-base.repository.ts
@@ -1,15 +1,19 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Brackets, Repository, SelectQueryBuilder } from 'typeorm';
 import type { UUID } from 'crypto';
-import { KnowledgeBaseRepository } from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
+import {
+  KnowledgeBaseRepository,
+  type KnowledgeBaseListOptions,
+} from 'src/domain/knowledge-bases/application/ports/knowledge-base.repository';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
 import { KnowledgeBaseRecord } from './schema/knowledge-base.record';
 import { KnowledgeBaseMapper } from './mappers/knowledge-base.mapper';
 import { SourceRecord } from 'src/domain/sources/infrastructure/persistence/local/schema/source.record';
 import type { Source } from 'src/domain/sources/domain/source.entity';
 import { SourceMapper } from 'src/domain/sources/infrastructure/persistence/local/mappers/source.mapper';
+import { Paginated } from 'src/common/pagination/paginated.entity';
 
 @Injectable()
 export class LocalKnowledgeBaseRepository extends KnowledgeBaseRepository {
@@ -55,6 +59,84 @@ export class LocalKnowledgeBaseRepository extends KnowledgeBaseRepository {
     return records.map((record) => this.mapper.toDomain(record));
   }
 
+  async findPaginatedAccessible(
+    userId: UUID,
+    workspaceId: UUID | undefined,
+    sharedKnowledgeBaseIds: UUID[],
+    options: KnowledgeBaseListOptions,
+  ): Promise<Paginated<KnowledgeBase>> {
+    this.logger.debug(
+      {
+        userId,
+        workspaceId,
+        search: options.search,
+        limit: options.limit,
+        offset: options.offset,
+      },
+      'findPaginatedAccessible',
+    );
+
+    const [records, total] = await this.buildAccessibleKnowledgeBasesQuery(
+      userId,
+      workspaceId,
+      sharedKnowledgeBaseIds,
+      options,
+    )
+      .orderBy('LOWER(knowledgeBase.name)', 'ASC')
+      .addOrderBy('knowledgeBase.id', 'ASC')
+      .skip(options.offset)
+      .take(options.limit)
+      .getManyAndCount();
+
+    return new Paginated({
+      data: records.map((record) => this.mapper.toDomain(record)),
+      limit: options.limit,
+      offset: options.offset,
+      total,
+    });
+  }
+
+  private buildAccessibleKnowledgeBasesQuery(
+    userId: UUID,
+    workspaceId: UUID | undefined,
+    sharedKnowledgeBaseIds: UUID[],
+    options: KnowledgeBaseListOptions,
+  ): SelectQueryBuilder<KnowledgeBaseRecord> {
+    const queryBuilder = this.repository
+      .createQueryBuilder('knowledgeBase')
+      .where(
+        new Brackets((accessQuery) => {
+          accessQuery.where('knowledgeBase.userId = :userId', { userId });
+          if (sharedKnowledgeBaseIds.length > 0) {
+            accessQuery.orWhere(
+              'knowledgeBase.id IN (:...sharedKnowledgeBaseIds)',
+              { sharedKnowledgeBaseIds },
+            );
+          }
+        }),
+      );
+
+    if (workspaceId) {
+      queryBuilder.andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM workspace_knowledge_base_assignments assignment
+          WHERE assignment."workspaceId" = :workspaceId
+            AND assignment."knowledgeBaseId" = knowledgeBase.id
+        )`,
+        { workspaceId },
+      );
+    }
+
+    if (options.search) {
+      queryBuilder.andWhere('knowledgeBase.name ILIKE :search', {
+        search: `%${options.search}%`,
+      });
+    }
+
+    return queryBuilder;
+  }
+
   async save(knowledgeBase: KnowledgeBase): Promise<KnowledgeBase> {
     this.logger.debug({ id: knowledgeBase.id }, 'save');
     const record = this.mapper.toRecord(knowledgeBase);
@@ -91,6 +173,36 @@ export class LocalKnowledgeBaseRepository extends KnowledgeBaseRepository {
   async countSourcesByKnowledgeBaseId(knowledgeBaseId: UUID): Promise<number> {
     this.logger.debug({ knowledgeBaseId }, 'countSourcesByKnowledgeBaseId');
     return this.sourceRepository.count({ where: { knowledgeBaseId } });
+  }
+
+  async countSourcesByKnowledgeBaseIds(
+    knowledgeBaseIds: UUID[],
+  ): Promise<Map<UUID, number>> {
+    if (knowledgeBaseIds.length === 0) {
+      return new Map();
+    }
+
+    this.logger.debug(
+      { count: knowledgeBaseIds.length },
+      'countSourcesByKnowledgeBaseIds',
+    );
+    const rows = await this.sourceRepository
+      .createQueryBuilder('source')
+      .select('source.knowledgeBaseId', 'knowledgeBaseId')
+      .addSelect('COUNT(source.id)', 'count')
+      .where('source.knowledgeBaseId IN (:...knowledgeBaseIds)', {
+        knowledgeBaseIds,
+      })
+      .groupBy('source.knowledgeBaseId')
+      .getRawMany<{ knowledgeBaseId: UUID; count: string }>();
+
+    const counts = new Map<UUID, number>(
+      knowledgeBaseIds.map((knowledgeBaseId) => [knowledgeBaseId, 0]),
+    );
+    for (const row of rows) {
+      counts.set(row.knowledgeBaseId, Number(row.count));
+    }
+    return counts;
   }
 
   async findSourceByIdAndKnowledgeBaseId(

--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.spec.ts
@@ -1,0 +1,42 @@
+import { BadRequestException } from '@nestjs/common';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { UUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import type { UploadedDocument } from 'src/common/http/document-upload';
+import { KnowledgeBasesController } from './knowledge-bases.controller';
+
+describe('KnowledgeBasesController', () => {
+  it('cleans up an uploaded file when MIME validation rejects it', async () => {
+    const userId: UUID = '123e4567-e89b-12d3-a456-426614174000';
+    const knowledgeBaseId: UUID = '223e4567-e89b-12d3-a456-426614174001';
+    const file: UploadedDocument = {
+      fieldname: 'file',
+      originalname: 'unsupported.exe',
+      encoding: '7bit',
+      mimetype: 'application/octet-stream',
+      size: 128,
+      path: path.join(process.cwd(), 'uploads', 'unsupported-upload.exe'),
+    };
+    const unlink = jest.spyOn(fs.promises, 'unlink').mockResolvedValue();
+    const controller = new KnowledgeBasesController(
+      createPinoLoggerMock(),
+      null as never,
+      null as never,
+      null as never,
+      null as never,
+      null as never,
+      null as never,
+      null as never,
+      null as never,
+      null as never,
+    );
+
+    await expect(
+      controller.addDocument(userId, knowledgeBaseId, file),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(unlink).toHaveBeenCalledWith(file.path);
+    unlink.mockRestore();
+  });
+});

--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
@@ -11,7 +11,6 @@ import {
   HttpStatus,
   UseInterceptors,
   UploadedFile,
-  BadRequestException,
 } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
@@ -25,40 +24,36 @@ import {
   ApiBodyOptions,
   ApiParamOptions,
 } from '@nestjs/swagger';
-import { FileInterceptor } from '@nestjs/platform-express';
-import { diskStorage } from 'multer';
-import { extname, resolve } from 'path';
-import { randomUUID } from 'crypto';
 import * as fs from 'fs';
-
-const UPLOADS_DIR = './uploads';
-fs.mkdirSync(resolve(UPLOADS_DIR), { recursive: true });
 import {
   CurrentUser,
   UserProperty,
 } from 'src/iam/authentication/application/decorators/current-user.decorator';
 import {
-  detectFileType,
-  isDocumentSourceFile,
-  getCanonicalMimeType,
-} from 'src/common/util/file-type';
+  cleanupTempUploadFile,
+  createDocumentUploadInterceptor,
+  resolveDocumentUploadMimeType,
+  type UploadedDocument,
+} from 'src/common/http/document-upload';
 
-import { CreateKnowledgeBaseUseCase } from '../../application/use-cases/create-knowledge-base/create-knowledge-base.use-case';
-import { UpdateKnowledgeBaseUseCase } from '../../application/use-cases/update-knowledge-base/update-knowledge-base.use-case';
-import { DeleteKnowledgeBaseUseCase } from '../../application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case';
-import { AddDocumentToKnowledgeBaseUseCase } from '../../application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case';
-import { AddUrlToKnowledgeBaseUseCase } from '../../application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case';
-import { RemoveDocumentFromKnowledgeBaseUseCase } from '../../application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case';
-import { ListKnowledgeBaseDocumentsUseCase } from '../../application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case';
-import { KnowledgeBaseAccessService } from '../../application/services/knowledge-base-access.service';
+import { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
+import { CreateKnowledgeBaseUseCase } from 'src/domain/knowledge-bases/application/use-cases/create-knowledge-base/create-knowledge-base.use-case';
+import { CreateKnowledgeBaseCommand } from 'src/domain/knowledge-bases/application/use-cases/create-knowledge-base/create-knowledge-base.command';
+import { UpdateKnowledgeBaseUseCase } from 'src/domain/knowledge-bases/application/use-cases/update-knowledge-base/update-knowledge-base.use-case';
+import { UpdateKnowledgeBaseCommand } from 'src/domain/knowledge-bases/application/use-cases/update-knowledge-base/update-knowledge-base.command';
+import { DeleteKnowledgeBaseUseCase } from 'src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case';
+import { DeleteKnowledgeBaseCommand } from 'src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.command';
+import { AddDocumentToKnowledgeBaseUseCase } from 'src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case';
+import { AddDocumentToKnowledgeBaseCommand } from 'src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.command';
+import { AddUrlToKnowledgeBaseUseCase } from 'src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case';
+import { AddUrlToKnowledgeBaseCommand } from 'src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.command';
+import { RemoveDocumentFromKnowledgeBaseUseCase } from 'src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case';
+import { RemoveDocumentFromKnowledgeBaseCommand } from 'src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.command';
+import { ListKnowledgeBaseDocumentsUseCase } from 'src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case';
+import { ListKnowledgeBaseDocumentsQuery } from 'src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.query';
+import { MissingFileError } from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
+import { KnowledgeBasesConstants } from 'src/domain/knowledge-bases/domain/knowledge-bases.constants';
 
-import { CreateKnowledgeBaseCommand } from '../../application/use-cases/create-knowledge-base/create-knowledge-base.command';
-import { UpdateKnowledgeBaseCommand } from '../../application/use-cases/update-knowledge-base/update-knowledge-base.command';
-import { DeleteKnowledgeBaseCommand } from '../../application/use-cases/delete-knowledge-base/delete-knowledge-base.command';
-import { AddDocumentToKnowledgeBaseCommand } from '../../application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.command';
-import { AddUrlToKnowledgeBaseCommand } from '../../application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.command';
-import { RemoveDocumentFromKnowledgeBaseCommand } from '../../application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.command';
-import { ListKnowledgeBaseDocumentsQuery } from '../../application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.query';
 import { CreateKnowledgeBaseDto } from './dto/create-knowledge-base.dto';
 import { UpdateKnowledgeBaseDto } from './dto/update-knowledge-base.dto';
 import { AddUrlToKnowledgeBaseDto } from './dto/add-url-to-knowledge-base.dto';
@@ -70,23 +65,11 @@ import {
   KnowledgeBaseDocumentResponseDto,
   KnowledgeBaseDocumentListResponseDto,
 } from './dto/knowledge-base-document-response.dto';
-import { MissingFileError } from '../../application/knowledge-bases.errors';
-import { KnowledgeBasesConstants } from '../../domain/knowledge-bases.constants';
 import { KnowledgeBaseDtoMapper } from './mappers/knowledge-base-dto.mapper';
 import { RequireFeature } from 'src/common/guards/feature.guard';
 import { FeatureFlag } from 'src/config/features.config';
 import { RequirePermission } from 'src/iam/authorization/application/decorators/permissions.decorator';
 import { Permission } from 'src/iam/permissions/domain/value-objects/permission.enum';
-
-interface UploadedDocument {
-  fieldname: string;
-  originalname: string;
-  encoding: string;
-  mimetype: string;
-  size: number;
-  buffer: Buffer;
-  path: string;
-}
 
 const KB_ID_PARAM: ApiParamOptions = {
   name: 'id',
@@ -109,20 +92,9 @@ const DOCUMENT_UPLOAD_API_BODY: ApiBodyOptions = {
   },
 };
 
-/* eslint-disable sonarjs/content-length -- multer file size limit, not HTTP Content-Length */
-const DocumentUploadInterceptor = FileInterceptor('file', {
-  storage: diskStorage({
-    destination: UPLOADS_DIR,
-    filename: (_req, file, cb) => {
-      cb(null, `${randomUUID()}${extname(file.originalname)}`);
-    },
-  }),
-  limits: { fileSize: KnowledgeBasesConstants.MAX_FILE_SIZE_BYTES },
-  // Browsers send the multipart filename as raw UTF-8 bytes; busboy defaults to
-  // latin1, which garbles umlauts and other non-ASCII characters into mojibake.
-  defParamCharset: 'utf8',
-});
-/* eslint-enable sonarjs/content-length */
+const DocumentUploadInterceptor = createDocumentUploadInterceptor(
+  KnowledgeBasesConstants.MAX_FILE_SIZE_BYTES,
+);
 
 @ApiTags('knowledge-bases')
 @RequireFeature(FeatureFlag.KnowledgeBases)
@@ -340,9 +312,8 @@ export class KnowledgeBasesController {
       },
       'addDocument',
     );
-    const canonicalMimeType = await this.resolveDocumentMimeType(file);
-
     try {
+      const canonicalMimeType = this.resolveDocumentMimeType(file);
       return await this.processDocumentUpload(
         userId,
         id,
@@ -373,26 +344,14 @@ export class KnowledgeBasesController {
     return this.knowledgeBaseDtoMapper.toDocumentDto(source);
   }
 
-  private async resolveDocumentMimeType(
-    file: UploadedDocument,
-  ): Promise<string> {
-    const detectedType = detectFileType(file.mimetype, file.originalname);
-    if (!isDocumentSourceFile(detectedType)) {
-      await this.cleanupTempFile(file.path);
-      throw new BadRequestException(
-        `Unsupported file type: ${file.originalname}. Knowledge bases only support PDF, DOCX, PPTX, TXT, EML, and audio files (MP3, M4A, WAV, WebM).`,
-      );
-    }
-
-    const canonicalMimeType = getCanonicalMimeType(detectedType);
-    if (!canonicalMimeType) {
-      await this.cleanupTempFile(file.path);
-      throw new BadRequestException(
-        `Unable to determine MIME type for detected file type: ${detectedType}`,
-      );
-    }
-
-    return canonicalMimeType;
+  private resolveDocumentMimeType(file: UploadedDocument): string {
+    return resolveDocumentUploadMimeType({
+      file,
+      errorMessage: (reason, detectedType) =>
+        reason === 'missing-mime'
+          ? `Unable to determine MIME type for detected file type: ${detectedType}`
+          : `Unsupported file type: ${file.originalname}. Knowledge bases only support PDF, DOCX, PPTX, TXT, EML, and audio files (MP3, M4A, WAV, WebM).`,
+    });
   }
 
   @RequirePermission(Permission.MANAGE_KNOWLEDGE_BASES)
@@ -485,16 +444,6 @@ export class KnowledgeBasesController {
   }
 
   private async cleanupTempFile(filePath: string): Promise<void> {
-    try {
-      await fs.promises.unlink(filePath);
-    } catch (error) {
-      this.logger.warn(
-        {
-          fileName: filePath,
-          err: error as Error,
-        },
-        'Failed to clean up temp file',
-      );
-    }
+    await cleanupTempUploadFile(filePath, this.logger);
   }
 }

--- a/ayunis-core-backend/src/domain/skills/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/skills/SUMMARY.md
@@ -52,6 +52,7 @@ skills/
 │       ├── unassign-knowledge-base-from-skill/
 │       ├── list-skill-knowledge-bases/
 │       ├── check-knowledge-base-skill-share-access/  # KB reachable via a shared skill of the KB owner? (exported, used by knowledge-bases)
+│       ├── find-knowledge-base-ids-accessible-via-shared-skills/  # bulk KB access projection for shared-skill lists (exported, used by knowledge-bases)
 │       └── install-skill-from-marketplace/
 ├── infrastructure/
 │   └── persistence/local/

--- a/ayunis-core-backend/src/domain/skills/application/ports/skill.repository.ts
+++ b/ayunis-core-backend/src/domain/skills/application/ports/skill.repository.ts
@@ -1,5 +1,12 @@
 import type { UUID } from 'crypto';
-import type { Skill } from '../../domain/skill.entity';
+import type { Skill } from 'src/domain/skills/domain/skill.entity';
+import type { Paginated } from 'src/common/pagination/paginated.entity';
+
+export interface SkillListOptions {
+  search?: string;
+  limit: number;
+  offset: number;
+}
 
 export abstract class SkillRepository {
   abstract create(skill: Skill): Promise<Skill>;
@@ -7,6 +14,12 @@ export abstract class SkillRepository {
   abstract delete(skillId: UUID, userId: UUID): Promise<void>;
   abstract findOne(id: UUID, userId: UUID): Promise<Skill | null>;
   abstract findAllByOwner(userId: UUID): Promise<Skill[]>;
+  abstract findPaginatedAccessible(
+    userId: UUID,
+    workspaceId: UUID | undefined,
+    sharedSkillIds: UUID[],
+    options: SkillListOptions,
+  ): Promise<Paginated<Skill>>;
   abstract findActiveByOwner(userId: UUID): Promise<Skill[]>;
   abstract findByNameAndOwner(
     name: string,
@@ -34,6 +47,7 @@ export abstract class SkillRepository {
     knowledgeBaseId: UUID,
     ownerIds: UUID[],
   ): Promise<Skill[]>;
+  abstract findKnowledgeBaseIdsBySkillIds(skillIds: UUID[]): Promise<UUID[]>;
   abstract removeKnowledgeBaseFromSkills(
     knowledgeBaseId: UUID,
     skillIds: UUID[],

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/find-knowledge-base-ids-accessible-via-shared-skills/find-knowledge-base-ids-accessible-via-shared-skills.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/find-knowledge-base-ids-accessible-via-shared-skills/find-knowledge-base-ids-accessible-via-shared-skills.use-case.spec.ts
@@ -1,0 +1,36 @@
+import type { UUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import type { FindSharesByScopeUseCase } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.use-case';
+import type { SkillRepository } from 'src/domain/skills/application/ports/skill.repository';
+import { FindKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase } from './find-knowledge-base-ids-accessible-via-shared-skills.use-case';
+
+describe('FindKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase', () => {
+  const sharedSkillId = '660e8400-e29b-41d4-a716-446655440001' as UUID;
+  const knowledgeBaseId = '550e8400-e29b-41d4-a716-446655440000' as UUID;
+  const repository = {
+    findKnowledgeBaseIdsBySkillIds: jest.fn(),
+  } as unknown as jest.Mocked<SkillRepository>;
+  const findSharesByScopeUseCase = {
+    execute: jest.fn(),
+  } as unknown as jest.Mocked<FindSharesByScopeUseCase>;
+
+  it('returns knowledge bases linked to skills shared with the current user', async () => {
+    findSharesByScopeUseCase.execute.mockResolvedValue([
+      { entityId: sharedSkillId } as never,
+      { entityId: sharedSkillId } as never,
+    ]);
+    repository.findKnowledgeBaseIdsBySkillIds.mockResolvedValue([
+      knowledgeBaseId,
+    ]);
+    const useCase = new FindKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase(
+      createPinoLoggerMock(),
+      repository,
+      findSharesByScopeUseCase,
+    );
+
+    await expect(useCase.execute()).resolves.toEqual([knowledgeBaseId]);
+    expect(repository.findKnowledgeBaseIdsBySkillIds).toHaveBeenCalledWith([
+      sharedSkillId,
+    ]);
+  });
+});

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/find-knowledge-base-ids-accessible-via-shared-skills/find-knowledge-base-ids-accessible-via-shared-skills.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/find-knowledge-base-ids-accessible-via-shared-skills/find-knowledge-base-ids-accessible-via-shared-skills.use-case.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import type { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { FindSharesByScopeUseCase } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.use-case';
+import { FindSharesByScopeQuery } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.query';
+import { SharedEntityType } from 'src/domain/shares/domain/value-objects/shared-entity-type.enum';
+import { SkillRepository } from 'src/domain/skills/application/ports/skill.repository';
+import { UnexpectedSkillError } from 'src/domain/skills/application/skills.errors';
+
+@Injectable()
+export class FindKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase {
+  constructor(
+    @InjectPinoLogger(FindKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly skillRepository: SkillRepository,
+    private readonly findSharesByScopeUseCase: FindSharesByScopeUseCase,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedSkillError)
+  async execute(): Promise<UUID[]> {
+    const shares = await this.findSharesByScopeUseCase.execute(
+      new FindSharesByScopeQuery(SharedEntityType.SKILL),
+    );
+    const skillIds = [...new Set(shares.map((share) => share.entityId))];
+
+    this.logger.info(
+      { sharedSkillCount: skillIds.length },
+      'findKnowledgeBaseIdsAccessibleViaSharedSkills',
+    );
+
+    if (skillIds.length === 0) {
+      return [];
+    }
+
+    return this.skillRepository.findKnowledgeBaseIdsBySkillIds(skillIds);
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.query.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.query.ts
@@ -1,0 +1,18 @@
+import type { UUID } from 'crypto';
+import { PaginatedQuery } from 'src/common/pagination/paginated.query';
+
+export class ListAccessibleSkillsQuery extends PaginatedQuery {
+  public readonly search?: string;
+  public readonly workspaceId?: UUID;
+
+  constructor(params: {
+    search?: string;
+    workspaceId?: UUID;
+    limit: number;
+    offset: number;
+  }) {
+    super({ limit: params.limit, offset: params.offset });
+    this.search = params.search?.trim() || undefined;
+    this.workspaceId = params.workspaceId;
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.use-case.spec.ts
@@ -1,0 +1,64 @@
+import type { UUID } from 'crypto';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import type { ContextService } from 'src/common/context/services/context.service';
+import type { FindSharesByScopeUseCase } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.use-case';
+import type { SkillRepository } from 'src/domain/skills/application/ports/skill.repository';
+import type { Skill } from 'src/domain/skills/domain/skill.entity';
+import { ListAccessibleSkillsUseCase } from './list-accessible-skills.use-case';
+import { ListAccessibleSkillsQuery } from './list-accessible-skills.query';
+
+describe('ListAccessibleSkillsUseCase', () => {
+  const userId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+  const workspaceId = '223e4567-e89b-12d3-a456-426614174001' as UUID;
+  const sharedSkillId = '323e4567-e89b-12d3-a456-426614174002' as UUID;
+  const repository = {
+    findPaginatedAccessible: jest.fn(),
+  } as unknown as jest.Mocked<SkillRepository>;
+  const findSharesByScopeUseCase = {
+    execute: jest.fn(),
+  } as unknown as jest.Mocked<FindSharesByScopeUseCase>;
+  const contextService = {
+    get: jest.fn().mockReturnValue(userId),
+  } as unknown as jest.Mocked<ContextService>;
+
+  it('returns the requested accessible skill page', async () => {
+    const page = new Paginated<Skill>({
+      data: [],
+      limit: 2,
+      offset: 4,
+      total: 8,
+    });
+    repository.findPaginatedAccessible.mockResolvedValue(page);
+    findSharesByScopeUseCase.execute.mockResolvedValue([
+      { entityId: sharedSkillId } as never,
+    ]);
+    const useCase = new ListAccessibleSkillsUseCase(
+      createPinoLoggerMock(),
+      repository,
+      findSharesByScopeUseCase,
+      contextService,
+    );
+
+    const result = await useCase.execute(
+      new ListAccessibleSkillsQuery({
+        search: 'citizen',
+        workspaceId,
+        limit: 2,
+        offset: 4,
+      }),
+    );
+
+    expect(result).toBe(page);
+    expect(repository.findPaginatedAccessible).toHaveBeenCalledWith(
+      userId,
+      workspaceId,
+      [sharedSkillId],
+      {
+        search: 'citizen',
+        limit: 2,
+        offset: 4,
+      },
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.use-case.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import { FindSharesByScopeUseCase } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.use-case';
+import { FindSharesByScopeQuery } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.query';
+import { SharedEntityType } from 'src/domain/shares/domain/value-objects/shared-entity-type.enum';
+import type { Skill } from 'src/domain/skills/domain/skill.entity';
+import { SkillRepository } from 'src/domain/skills/application/ports/skill.repository';
+import { UnexpectedSkillError } from 'src/domain/skills/application/skills.errors';
+import { ListAccessibleSkillsQuery } from './list-accessible-skills.query';
+
+@Injectable()
+export class ListAccessibleSkillsUseCase {
+  constructor(
+    @InjectPinoLogger(ListAccessibleSkillsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly skillRepository: SkillRepository,
+    private readonly findSharesByScopeUseCase: FindSharesByScopeUseCase,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedSkillError)
+  async execute(query: ListAccessibleSkillsQuery): Promise<Paginated<Skill>> {
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+
+    this.logger.info(
+      {
+        userId,
+        workspaceId: query.workspaceId,
+        search: query.search,
+        limit: query.limit,
+        offset: query.offset,
+      },
+      'listAccessibleSkills',
+    );
+
+    const shares = await this.findSharesByScopeUseCase.execute(
+      new FindSharesByScopeQuery(SharedEntityType.SKILL),
+    );
+    return this.skillRepository.findPaginatedAccessible(
+      userId,
+      query.workspaceId,
+      shares.map((share) => share.entityId),
+      {
+        search: query.search,
+        limit: query.limit,
+        offset: query.offset,
+      },
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-mcp-integrations/list-skill-mcp-integrations.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-mcp-integrations/list-skill-mcp-integrations.use-case.spec.ts
@@ -5,13 +5,16 @@ import { Test } from '@nestjs/testing';
 import { UnauthorizedException } from '@nestjs/common';
 import { ListSkillMcpIntegrationsUseCase } from './list-skill-mcp-integrations.use-case';
 import { ListSkillMcpIntegrationsQuery } from './list-skill-mcp-integrations.query';
-import { SkillRepository } from '../../ports/skill.repository';
+import { SkillRepository } from 'src/domain/skills/application/ports/skill.repository';
 import { GetMcpIntegrationsByIdsUseCase } from 'src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.use-case';
 import { ContextService } from 'src/common/context/services/context.service';
 import { FindShareByEntityUseCase } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case';
 import { SharedEntityType } from 'src/domain/shares/domain/value-objects/shared-entity-type.enum';
 import { Skill } from 'src/domain/skills/domain/skill.entity';
-import { SkillNotFoundError, UnexpectedSkillError } from '../../skills.errors';
+import {
+  SkillNotFoundError,
+  UnexpectedSkillError,
+} from 'src/domain/skills/application/skills.errors';
 import type { UUID } from 'crypto';
 import { PredefinedMcpIntegration } from 'src/domain/mcp/domain/integrations/predefined-mcp-integration.entity';
 import { PredefinedMcpIntegrationSlug } from 'src/domain/mcp/domain/value-objects/predefined-mcp-integration-slug.enum';
@@ -51,7 +54,9 @@ describe('ListSkillMcpIntegrationsUseCase', () => {
       pinSkill: jest.fn(),
       getPinnedSkillIds: jest.fn(),
       findSkillsByKnowledgeBaseAndOwners: jest.fn(),
+      findKnowledgeBaseIdsBySkillIds: jest.fn(),
       removeKnowledgeBaseFromSkills: jest.fn(),
+      findPaginatedAccessible: jest.fn(),
     } as jest.Mocked<SkillRepository>;
 
     const mockGetMcpIntegrationsByIdsUseCase = {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-sources/list-skill-sources.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-sources/list-skill-sources.use-case.spec.ts
@@ -5,13 +5,16 @@ import { Test } from '@nestjs/testing';
 import { UnauthorizedException } from '@nestjs/common';
 import { ListSkillSourcesUseCase } from './list-skill-sources.use-case';
 import { ListSkillSourcesQuery } from './list-skill-sources.query';
-import { SkillRepository } from '../../ports/skill.repository';
+import { SkillRepository } from 'src/domain/skills/application/ports/skill.repository';
 import { GetSourcesByIdsUseCase } from 'src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case';
 import { ContextService } from 'src/common/context/services/context.service';
 import { FindShareByEntityUseCase } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case';
 import { SharedEntityType } from 'src/domain/shares/domain/value-objects/shared-entity-type.enum';
 import { Skill } from 'src/domain/skills/domain/skill.entity';
-import { SkillNotFoundError, UnexpectedSkillError } from '../../skills.errors';
+import {
+  SkillNotFoundError,
+  UnexpectedSkillError,
+} from 'src/domain/skills/application/skills.errors';
 import type { UUID } from 'crypto';
 import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { TextType, FileType } from 'src/domain/sources/domain/source-type.enum';
@@ -49,7 +52,9 @@ describe('ListSkillSourcesUseCase', () => {
       pinSkill: jest.fn(),
       getPinnedSkillIds: jest.fn(),
       findSkillsByKnowledgeBaseAndOwners: jest.fn(),
+      findKnowledgeBaseIdsBySkillIds: jest.fn(),
       removeKnowledgeBaseFromSkills: jest.fn(),
+      findPaginatedAccessible: jest.fn(),
     } as jest.Mocked<SkillRepository>;
 
     const mockGetSourcesByIdsUseCase = {

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill-accessible-page.finder.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill-accessible-page.finder.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Brackets, Repository, SelectQueryBuilder } from 'typeorm';
+import type { UUID } from 'crypto';
+import type { SkillListOptions } from 'src/domain/skills/application/ports/skill.repository';
+import { SkillRecord } from './schema/skill.record';
+
+@Injectable()
+export class LocalSkillAccessiblePageFinder {
+  constructor(
+    @InjectRepository(SkillRecord)
+    private readonly skillRepository: Repository<SkillRecord>,
+  ) {}
+
+  buildQuery(
+    userId: UUID,
+    workspaceId: UUID | undefined,
+    sharedSkillIds: UUID[],
+    options: SkillListOptions,
+  ): SelectQueryBuilder<SkillRecord> {
+    const queryBuilder = this.skillRepository.createQueryBuilder('skill').where(
+      new Brackets((accessQuery) => {
+        accessQuery.where('skill.userId = :userId', { userId });
+        if (sharedSkillIds.length > 0) {
+          accessQuery.orWhere('skill.id IN (:...sharedSkillIds)', {
+            sharedSkillIds,
+          });
+        }
+      }),
+    );
+
+    if (workspaceId) {
+      queryBuilder.andWhere(
+        `EXISTS (
+          SELECT 1
+          FROM workspace_skill_assignments assignment
+          WHERE assignment."workspaceId" = :workspaceId
+            AND assignment."skillId" = skill.id
+        )`,
+        { workspaceId },
+      );
+    }
+
+    if (options.search) {
+      queryBuilder.andWhere('skill.name ILIKE :search', {
+        search: `%${options.search}%`,
+      });
+    }
+
+    return queryBuilder;
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill-knowledge-base-ids.finder.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill-knowledge-base-ids.finder.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import type { EntityManager } from 'typeorm';
+
+@Injectable()
+export class LocalSkillKnowledgeBaseIdsFinder {
+  async findKnowledgeBaseIdsBySkillIds(
+    skillIds: UUID[],
+    manager: EntityManager,
+  ): Promise<UUID[]> {
+    if (skillIds.length === 0) return [];
+
+    const rows = await manager
+      .createQueryBuilder()
+      .select('skb."knowledgeBasesId"', 'knowledgeBaseId')
+      .from('skill_knowledge_bases', 'skb')
+      .innerJoin('skills', 'skill', 'skill.id = skb."skillsId"')
+      .innerJoin(
+        'knowledge_bases',
+        'knowledgeBase',
+        'knowledgeBase.id = skb."knowledgeBasesId"',
+      )
+      .where('skill.id IN (:...skillIds)', { skillIds })
+      .andWhere('knowledgeBase."userId" = skill."userId"')
+      .distinct(true)
+      .getRawMany<{ knowledgeBaseId: UUID }>();
+
+    return rows.map((row) => row.knowledgeBaseId);
+  }
+}

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill-repository.module.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill-repository.module.ts
@@ -4,10 +4,22 @@ import { LocalSkillRepository } from './local-skill.repository';
 import { SkillRecord } from './schema/skill.record';
 import { SkillActivationRecord } from './schema/skill-activation.record';
 import { SkillMapper } from './mappers/skill.mapper';
+import { LocalSkillAccessiblePageFinder } from './local-skill-accessible-page.finder';
+import { LocalSkillKnowledgeBaseIdsFinder } from './local-skill-knowledge-base-ids.finder';
 
 @Module({
   imports: [TypeOrmModule.forFeature([SkillRecord, SkillActivationRecord])],
-  providers: [SkillMapper, LocalSkillRepository],
-  exports: [LocalSkillRepository, SkillMapper],
+  providers: [
+    SkillMapper,
+    LocalSkillAccessiblePageFinder,
+    LocalSkillKnowledgeBaseIdsFinder,
+    LocalSkillRepository,
+  ],
+  exports: [
+    LocalSkillRepository,
+    SkillMapper,
+    LocalSkillAccessiblePageFinder,
+    LocalSkillKnowledgeBaseIdsFinder,
+  ],
 })
 export class LocalSkillRepositoryModule {}

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill.repository.spec.ts
@@ -5,6 +5,8 @@ import type { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adap
 import { randomUUID } from 'crypto';
 
 import { LocalSkillRepository } from './local-skill.repository';
+import { LocalSkillAccessiblePageFinder } from './local-skill-accessible-page.finder';
+import { LocalSkillKnowledgeBaseIdsFinder } from './local-skill-knowledge-base-ids.finder';
 import type { SkillRecord } from './schema/skill.record';
 import { SkillActivationRecord } from './schema/skill-activation.record';
 import type { SkillMapper } from './mappers/skill.mapper';
@@ -61,6 +63,8 @@ describe('LocalSkillRepository', () => {
       skillRepo,
       activationRepo,
       mapper,
+      {} as LocalSkillAccessiblePageFinder,
+      new LocalSkillKnowledgeBaseIdsFinder(),
       txHost,
     );
   });
@@ -93,6 +97,86 @@ describe('LocalSkillRepository', () => {
         SkillNotActiveError,
       );
     });
+  });
+
+  it('returns a database-paginated page of accessible skills', async () => {
+    const sharedSkillId = randomUUID();
+    const workspaceId = randomUUID();
+    const records = [
+      { id: randomUUID(), name: 'Citizen requests' } as SkillRecord,
+      { id: randomUUID(), name: 'Budget planning' } as SkillRecord,
+    ];
+    const queryBuilder = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([records, 7]),
+    };
+    const skillRepository = {
+      manager: {} as EntityManager,
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    } as unknown as jest.Mocked<Repository<SkillRecord>>;
+    const mapper = {
+      toDomain: jest.fn((record: SkillRecord) => record),
+    } as unknown as SkillMapper;
+    const repository = new LocalSkillRepository(
+      createPinoLoggerMock(),
+      skillRepository,
+      activationRepo,
+      mapper,
+      new LocalSkillAccessiblePageFinder(skillRepository),
+      new LocalSkillKnowledgeBaseIdsFinder(),
+      {
+        tx: mockManager,
+      } as unknown as TransactionHost<TransactionalAdapterTypeOrm>,
+    );
+
+    const result = await repository.findPaginatedAccessible(
+      userId,
+      workspaceId,
+      [sharedSkillId],
+      {
+        search: 'citizen',
+        limit: 2,
+        offset: 4,
+      },
+    );
+
+    expect(result.data).toEqual(records);
+    expect(result.total).toBe(7);
+    expect(result.limit).toBe(2);
+    expect(result.offset).toBe(4);
+    expect(queryBuilder.skip).toHaveBeenCalledWith(4);
+    expect(queryBuilder.take).toHaveBeenCalledWith(2);
+    expect(queryBuilder.getManyAndCount).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns knowledge-base IDs linked to the supplied skills', async () => {
+    const linkedKnowledgeBaseIds = [randomUUID(), randomUUID()];
+    const queryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      from: jest.fn().mockReturnThis(),
+      innerJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      distinct: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue(
+        linkedKnowledgeBaseIds.map((knowledgeBaseId) => ({
+          knowledgeBaseId,
+        })),
+      ),
+    };
+    mockManager.createQueryBuilder.mockReturnValue(queryBuilder);
+
+    await expect(
+      repository.findKnowledgeBaseIdsBySkillIds([skillId]),
+    ).resolves.toEqual(linkedKnowledgeBaseIds);
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'knowledgeBase."userId" = skill."userId"',
+    );
   });
 
   describe('toggleSkillPinned', () => {

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill.repository.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill.repository.ts
@@ -6,15 +6,21 @@ import { randomUUID, UUID } from 'crypto';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
 
-import { SkillRepository } from '../../../application/ports/skill.repository';
-import { Skill } from '../../../domain/skill.entity';
+import {
+  SkillRepository,
+  type SkillListOptions,
+} from 'src/domain/skills/application/ports/skill.repository';
+import { Skill } from 'src/domain/skills/domain/skill.entity';
 import { SkillRecord } from './schema/skill.record';
 import { SkillActivationRecord } from './schema/skill-activation.record';
 import { SkillMapper } from './mappers/skill.mapper';
+import { LocalSkillAccessiblePageFinder } from './local-skill-accessible-page.finder';
+import { LocalSkillKnowledgeBaseIdsFinder } from './local-skill-knowledge-base-ids.finder';
+import { Paginated } from 'src/common/pagination/paginated.entity';
 import {
   SkillNotActiveError,
   SkillNotFoundError,
-} from '../../../application/skills.errors';
+} from 'src/domain/skills/application/skills.errors';
 
 const SKILL_RELATIONS = [
   'sources',
@@ -32,6 +38,8 @@ export class LocalSkillRepository implements SkillRepository {
     @InjectRepository(SkillActivationRecord)
     private readonly activationRepository: Repository<SkillActivationRecord>,
     private readonly skillMapper: SkillMapper,
+    private readonly accessiblePageFinder: LocalSkillAccessiblePageFinder,
+    private readonly knowledgeBaseIdsFinder: LocalSkillKnowledgeBaseIdsFinder,
     private readonly txHost: TransactionHost<TransactionalAdapterTypeOrm>,
   ) {}
 
@@ -195,6 +203,39 @@ export class LocalSkillRepository implements SkillRepository {
     });
 
     return records.map((r) => this.skillMapper.toDomain(r));
+  }
+
+  async findPaginatedAccessible(
+    userId: UUID,
+    workspaceId: UUID | undefined,
+    sharedSkillIds: UUID[],
+    options: SkillListOptions,
+  ): Promise<Paginated<Skill>> {
+    this.logger.info(
+      {
+        userId,
+        workspaceId,
+        search: options.search,
+        limit: options.limit,
+        offset: options.offset,
+      },
+      'findPaginatedAccessible',
+    );
+
+    const [records, total] = await this.accessiblePageFinder
+      .buildQuery(userId, workspaceId, sharedSkillIds, options)
+      .orderBy('LOWER(skill.name)', 'ASC')
+      .addOrderBy('skill.id', 'ASC')
+      .skip(options.offset)
+      .take(options.limit)
+      .getManyAndCount();
+
+    return new Paginated({
+      data: records.map((record) => this.skillMapper.toDomain(record)),
+      limit: options.limit,
+      offset: options.offset,
+      total,
+    });
   }
 
   async findActiveByOwner(userId: UUID): Promise<Skill[]> {
@@ -420,6 +461,17 @@ export class LocalSkillRepository implements SkillRepository {
       .getMany();
 
     return records.map((r) => this.skillMapper.toDomain(r));
+  }
+
+  async findKnowledgeBaseIdsBySkillIds(skillIds: UUID[]): Promise<UUID[]> {
+    this.logger.info(
+      { skillCount: skillIds.length },
+      'findKnowledgeBaseIdsBySkillIds',
+    );
+    return this.knowledgeBaseIdsFinder.findKnowledgeBaseIdsBySkillIds(
+      skillIds,
+      this.getManager(),
+    );
   }
 
   async removeKnowledgeBaseFromSkills(

--- a/ayunis-core-backend/src/domain/skills/skills.module.ts
+++ b/ayunis-core-backend/src/domain/skills/skills.module.ts
@@ -1,16 +1,16 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { SourcesModule } from '../sources/sources.module';
-import { McpModule } from '../mcp/mcp.module';
-import { MarketplaceModule } from '../marketplace/marketplace.module';
+import { SourcesModule } from 'src/domain/sources/sources.module';
+import { McpModule } from 'src/domain/mcp/mcp.module';
+import { MarketplaceModule } from 'src/domain/marketplace/marketplace.module';
 import { LocalSkillRepositoryModule } from './infrastructure/persistence/local/local-skill-repository.module';
 import { LocalSkillRepository } from './infrastructure/persistence/local/local-skill.repository';
 import { SkillRepository } from './application/ports/skill.repository';
 import { SkillRecord } from './infrastructure/persistence/local/schema/skill.record';
 import { SkillActivationRecord } from './infrastructure/persistence/local/schema/skill-activation.record';
-import { McpIntegrationRecord } from '../mcp/infrastructure/persistence/postgres/schema/mcp-integration.record';
-import { KnowledgeBaseRecord } from '../knowledge-bases/infrastructure/persistence/local/schema/knowledge-base.record';
-import { KnowledgeBasesModule } from '../knowledge-bases/knowledge-bases.module';
+import { McpIntegrationRecord } from 'src/domain/mcp/infrastructure/persistence/postgres/schema/mcp-integration.record';
+import { KnowledgeBaseRecord } from 'src/domain/knowledge-bases/infrastructure/persistence/local/schema/knowledge-base.record';
+import { KnowledgeBasesModule } from 'src/domain/knowledge-bases/knowledge-bases.module';
 
 // Use Cases
 import { CreateSkillUseCase } from './application/use-cases/create-skill/create-skill.use-case';
@@ -18,6 +18,7 @@ import { UpdateSkillUseCase } from './application/use-cases/update-skill/update-
 import { DeleteSkillUseCase } from './application/use-cases/delete-skill/delete-skill.use-case';
 import { FindOneSkillUseCase } from './application/use-cases/find-one-skill/find-one-skill.use-case';
 import { FindAllSkillsUseCase } from './application/use-cases/find-all-skills/find-all-skills.use-case';
+import { ListAccessibleSkillsUseCase } from './application/use-cases/list-accessible-skills/list-accessible-skills.use-case';
 import { ToggleSkillActiveUseCase } from './application/use-cases/toggle-skill-active/toggle-skill-active.use-case';
 import { ToggleSkillPinnedUseCase } from './application/use-cases/toggle-skill-pinned/toggle-skill-pinned.use-case';
 import { FindActiveSkillsUseCase } from './application/use-cases/find-active-skills/find-active-skills.use-case';
@@ -35,6 +36,7 @@ import { FindSkillByNameUseCase } from './application/use-cases/find-skill-by-na
 import { InstallSkillFromMarketplaceUseCase } from './application/use-cases/install-skill-from-marketplace/install-skill-from-marketplace.use-case';
 import { CreateSkillWithUniqueNameUseCase } from './application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case';
 import { CheckKnowledgeBaseSkillShareAccessUseCase } from './application/use-cases/check-knowledge-base-skill-share-access/check-knowledge-base-skill-share-access.use-case';
+import { FindKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase } from './application/use-cases/find-knowledge-base-ids-accessible-via-shared-skills/find-knowledge-base-ids-accessible-via-shared-skills.use-case';
 
 // Services
 import { MarketplaceSkillInstallationService } from './application/services/marketplace-skill-installation.service';
@@ -48,13 +50,13 @@ import { UserCreatedListener } from './application/listeners/user-created.listen
 
 // Strategies
 import { SkillShareAuthorizationStrategy } from './application/strategies/skill-share-authorization.strategy';
-import { getShareAuthStrategyToken } from '../shares/application/factories/share-authorization.factory';
-import { SharedEntityType } from '../shares/domain/value-objects/shared-entity-type.enum';
+import { getShareAuthStrategyToken } from 'src/domain/shares/application/factories/share-authorization.factory';
+import { SharedEntityType } from 'src/domain/shares/domain/value-objects/shared-entity-type.enum';
 
 // Shares
-import { SharesModule } from '../shares/shares.module';
+import { SharesModule } from 'src/domain/shares/shares.module';
 
-import { ThreadsModule } from '../threads/threads.module';
+import { ThreadsModule } from 'src/domain/threads/threads.module';
 import { UsersModule } from 'src/iam/users/users.module';
 
 // Presenters
@@ -63,8 +65,8 @@ import { SkillSourcesController } from './presenters/http/skill-sources.controll
 import { SkillMcpIntegrationsController } from './presenters/http/skill-mcp-integrations.controller';
 import { SkillKnowledgeBasesController } from './presenters/http/skill-knowledge-bases.controller';
 import { SkillDtoMapper } from './presenters/http/mappers/skill.mapper';
-import { McpIntegrationDtoMapper } from '../mcp/presenters/http/mappers/mcp-integration-dto.mapper';
-import { KnowledgeBaseDtoMapper } from '../knowledge-bases/presenters/http/mappers/knowledge-base-dto.mapper';
+import { McpIntegrationDtoMapper } from 'src/domain/mcp/presenters/http/mappers/mcp-integration-dto.mapper';
+import { KnowledgeBaseDtoMapper } from 'src/domain/knowledge-bases/presenters/http/mappers/knowledge-base-dto.mapper';
 
 @Module({
   imports: [
@@ -99,6 +101,7 @@ import { KnowledgeBaseDtoMapper } from '../knowledge-bases/presenters/http/mappe
     DeleteSkillUseCase,
     FindOneSkillUseCase,
     FindAllSkillsUseCase,
+    ListAccessibleSkillsUseCase,
     ToggleSkillActiveUseCase,
     ToggleSkillPinnedUseCase,
     FindActiveSkillsUseCase,
@@ -116,6 +119,7 @@ import { KnowledgeBaseDtoMapper } from '../knowledge-bases/presenters/http/mappe
     InstallSkillFromMarketplaceUseCase,
     CreateSkillWithUniqueNameUseCase,
     CheckKnowledgeBaseSkillShareAccessUseCase,
+    FindKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase,
 
     // Services
     MarketplaceSkillInstallationService,
@@ -145,6 +149,8 @@ import { KnowledgeBaseDtoMapper } from '../knowledge-bases/presenters/http/mappe
   exports: [
     SkillRepository,
     FindActiveSkillsUseCase,
+    FindAllSkillsUseCase,
+    ListAccessibleSkillsUseCase,
     FindOneSkillUseCase,
     AddSourceToSkillUseCase,
     FindSkillByNameUseCase,
@@ -154,6 +160,7 @@ import { KnowledgeBaseDtoMapper } from '../knowledge-bases/presenters/http/mappe
     getShareAuthStrategyToken(SharedEntityType.SKILL),
     CreateSkillWithUniqueNameUseCase,
     CheckKnowledgeBaseSkillShareAccessUseCase,
+    FindKnowledgeBaseIdsAccessibleViaSharedSkillsUseCase,
   ],
 })
 export class SkillsModule {}

--- a/ayunis-core-backend/src/domain/sources/application/ports/source.repository.ts
+++ b/ayunis-core-backend/src/domain/sources/application/ports/source.repository.ts
@@ -1,13 +1,24 @@
 import type { UUID } from 'crypto';
-import type { TextSource } from '../../domain/sources/text-source.entity';
-import type { DataSource } from '../../domain/sources/data-source.entity';
-import type { Source } from '../../domain/source.entity';
-import type { TextSourceContentChunk } from '../../domain/source-content-chunk.entity';
-import type { SourceStatus } from '../../domain/source-status.enum';
+import type { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
+import type { DataSource } from 'src/domain/sources/domain/sources/data-source.entity';
+import type { Source } from 'src/domain/sources/domain/source.entity';
+import type { TextSourceContentChunk } from 'src/domain/sources/domain/source-content-chunk.entity';
+import type { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
+import type { Paginated } from 'src/common/pagination/paginated.entity';
+
+export interface WorkspaceSourceListOptions {
+  workspaceId: UUID;
+  search?: string;
+  limit: number;
+  offset: number;
+}
 
 export abstract class SourceRepository {
   abstract findById(id: UUID): Promise<TextSource | DataSource | null>;
   abstract findByIds(ids: UUID[]): Promise<Source[]>;
+  abstract findPaginatedByWorkspaceId(
+    options: WorkspaceSourceListOptions,
+  ): Promise<Paginated<Source>>;
   abstract findByKnowledgeBaseId(knowledgeBaseId: UUID): Promise<Source[]>;
   abstract saveTextSource(
     source: TextSource,

--- a/ayunis-core-backend/src/domain/sources/application/testing/source.fixtures.ts
+++ b/ayunis-core-backend/src/domain/sources/application/testing/source.fixtures.ts
@@ -1,6 +1,6 @@
-import type { SourceRepository } from '../ports/source.repository';
-import type { Source } from '../../domain/source.entity';
-import type { TextSource } from '../../domain/sources/text-source.entity';
+import type { SourceRepository } from 'src/domain/sources/application/ports/source.repository';
+import type { Source } from 'src/domain/sources/domain/source.entity';
+import type { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
 
 // Port mock factory — defaults model the "empty" state: finders resolve to
 // null/[], save echoes its argument, deletes resolve, guarded UPDATEs report
@@ -25,5 +25,11 @@ export function createMockSourceRepository(): jest.Mocked<SourceRepository> {
     delete: jest.fn().mockResolvedValue(undefined),
     deleteMany: jest.fn().mockResolvedValue(undefined),
     findUnreferencedIds: jest.fn().mockResolvedValue([]),
+    findPaginatedByWorkspaceId: jest.fn().mockResolvedValue({
+      data: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+    }),
   };
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/list-sources-by-workspace/list-sources-by-workspace.query.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/list-sources-by-workspace/list-sources-by-workspace.query.ts
@@ -1,0 +1,18 @@
+import type { UUID } from 'crypto';
+import { PaginatedQuery } from 'src/common/pagination/paginated.query';
+
+export class ListSourcesByWorkspaceQuery extends PaginatedQuery {
+  public readonly workspaceId: UUID;
+  public readonly search?: string;
+
+  constructor(params: {
+    workspaceId: UUID;
+    search?: string;
+    limit: number;
+    offset: number;
+  }) {
+    super({ limit: params.limit, offset: params.offset });
+    this.workspaceId = params.workspaceId;
+    this.search = params.search?.trim() || undefined;
+  }
+}

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/list-sources-by-workspace/list-sources-by-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/list-sources-by-workspace/list-sources-by-workspace.use-case.spec.ts
@@ -1,0 +1,43 @@
+import type { UUID } from 'crypto';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import type { Source } from 'src/domain/sources/domain/source.entity';
+import type { SourceRepository } from 'src/domain/sources/application/ports/source.repository';
+import { ListSourcesByWorkspaceUseCase } from './list-sources-by-workspace.use-case';
+import { ListSourcesByWorkspaceQuery } from './list-sources-by-workspace.query';
+
+describe('ListSourcesByWorkspaceUseCase', () => {
+  it('returns the requested workspace source page', async () => {
+    const workspaceId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+    const page = new Paginated<Source>({
+      data: [],
+      limit: 2,
+      offset: 4,
+      total: 7,
+    });
+    const repository = {
+      findPaginatedByWorkspaceId: jest.fn().mockResolvedValue(page),
+    } as unknown as jest.Mocked<SourceRepository>;
+    const useCase = new ListSourcesByWorkspaceUseCase(
+      createPinoLoggerMock(),
+      repository,
+    );
+
+    const result = await useCase.execute(
+      new ListSourcesByWorkspaceQuery({
+        workspaceId,
+        search: 'budget',
+        limit: 2,
+        offset: 4,
+      }),
+    );
+
+    expect(result).toBe(page);
+    expect(repository.findPaginatedByWorkspaceId).toHaveBeenCalledWith({
+      workspaceId,
+      search: 'budget',
+      limit: 2,
+      offset: 4,
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/list-sources-by-workspace/list-sources-by-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/list-sources-by-workspace/list-sources-by-workspace.use-case.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import type { Source } from 'src/domain/sources/domain/source.entity';
+import { SourceRepository } from 'src/domain/sources/application/ports/source.repository';
+import { UnexpectedSourceError } from 'src/domain/sources/application/sources.errors';
+import { ListSourcesByWorkspaceQuery } from './list-sources-by-workspace.query';
+
+@Injectable()
+export class ListSourcesByWorkspaceUseCase {
+  constructor(
+    @InjectPinoLogger(ListSourcesByWorkspaceUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly sourceRepository: SourceRepository,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedSourceError)
+  async execute(
+    query: ListSourcesByWorkspaceQuery,
+  ): Promise<Paginated<Source>> {
+    this.logger.info(
+      {
+        workspaceId: query.workspaceId,
+        search: query.search,
+        limit: query.limit,
+        offset: query.offset,
+      },
+      'listSourcesByWorkspace',
+    );
+    return this.sourceRepository.findPaginatedByWorkspaceId({
+      workspaceId: query.workspaceId,
+      search: query.search,
+      limit: query.limit,
+      offset: query.offset,
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/local-source.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/local-source.repository.spec.ts
@@ -1,0 +1,60 @@
+import type { UUID } from 'crypto';
+import type { Repository } from 'typeorm';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import type { Source } from 'src/domain/sources/domain/source.entity';
+import { LocalSourceRepository } from './local-source.repository';
+import type { SourceRecord } from './schema/source.record';
+import type { TextSourceDetailsRecord } from './schema/text-source-details.record';
+import type { DataSourceDetailsRecord } from './schema/data-source-details.record';
+import type { SourceContentChunkRecord } from './schema/source-content-chunk.record';
+import type { SourceMapper } from './mappers/source.mapper';
+import type { SourceContentChunkMapper } from './mappers/source-content-chunk.mapper';
+
+describe('LocalSourceRepository', () => {
+  it('returns a database-paginated page of workspace sources', async () => {
+    const workspaceId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+    const records = [
+      { id: '223e4567-e89b-12d3-a456-426614174001', name: 'Budget.pdf' },
+    ] as unknown as SourceRecord[];
+    const queryBuilder = {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([records, 3]),
+    };
+    const sourceRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    } as unknown as jest.Mocked<Repository<SourceRecord>>;
+    const mapper = {
+      toDomain: jest.fn((record: SourceRecord) => record as unknown as Source),
+    } as unknown as SourceMapper;
+    const repository = new LocalSourceRepository(
+      createPinoLoggerMock(),
+      sourceRepository,
+      {} as Repository<TextSourceDetailsRecord>,
+      {} as Repository<DataSourceDetailsRecord>,
+      {} as Repository<SourceContentChunkRecord>,
+      mapper,
+      {} as SourceContentChunkMapper,
+    );
+
+    const result = await repository.findPaginatedByWorkspaceId({
+      workspaceId,
+      search: 'budget',
+      limit: 1,
+      offset: 2,
+    });
+
+    expect(result.data).toEqual(records);
+    expect(result.total).toBe(3);
+    expect(result.limit).toBe(1);
+    expect(result.offset).toBe(2);
+    expect(queryBuilder.skip).toHaveBeenCalledWith(2);
+    expect(queryBuilder.take).toHaveBeenCalledWith(1);
+    expect(queryBuilder.getManyAndCount).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/local-source.repository.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/local-source.repository.ts
@@ -6,7 +6,10 @@ import type { UUID } from 'crypto';
 import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
 import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { DataSource } from 'src/domain/sources/domain/sources/data-source.entity';
-import { SourceRepository } from 'src/domain/sources/application/ports/source.repository';
+import {
+  SourceRepository,
+  type WorkspaceSourceListOptions,
+} from 'src/domain/sources/application/ports/source.repository';
 import { SourceMapper } from './mappers/source.mapper';
 import { TextSourceDetailsRecord } from './schema/text-source-details.record';
 import {
@@ -22,6 +25,7 @@ import { Source } from 'src/domain/sources/domain/source.entity';
 import { SourceContentChunkRecord } from './schema/source-content-chunk.record';
 import type { TextSourceContentChunk } from 'src/domain/sources/domain/source-content-chunk.entity';
 import { SourceContentChunkMapper } from './mappers/source-content-chunk.mapper';
+import { Paginated } from 'src/common/pagination/paginated.entity';
 
 @Injectable()
 export class LocalSourceRepository extends SourceRepository {
@@ -95,6 +99,58 @@ export class LocalSourceRepository extends SourceRepository {
       .where('source.id IN (:...ids)', { ids })
       .getMany();
     return records.map((record) => this.mapper.toDomain(record));
+  }
+
+  async findPaginatedByWorkspaceId(
+    options: WorkspaceSourceListOptions,
+  ): Promise<Paginated<Source>> {
+    this.logger.info(
+      {
+        workspaceId: options.workspaceId,
+        search: options.search,
+        limit: options.limit,
+        offset: options.offset,
+      },
+      'findPaginatedByWorkspaceId',
+    );
+
+    const queryBuilder = this.sourceRepository
+      .createQueryBuilder('source')
+      .leftJoinAndSelect(
+        'source.dataSourceDetails',
+        'dataSourceDetails',
+        'source.type = :dataType',
+        { dataType: 'data' },
+      )
+      .where(
+        `EXISTS (
+          SELECT 1
+          FROM workspace_source_assignments assignment
+          WHERE assignment."workspaceId" = :workspaceId
+            AND assignment."sourceId" = source.id
+        )`,
+        { workspaceId: options.workspaceId },
+      );
+
+    if (options.search) {
+      queryBuilder.andWhere('source.name ILIKE :search', {
+        search: `%${options.search}%`,
+      });
+    }
+
+    const [records, total] = await queryBuilder
+      .orderBy('LOWER(source.name)', 'ASC')
+      .addOrderBy('source.id', 'ASC')
+      .skip(options.offset)
+      .take(options.limit)
+      .getManyAndCount();
+
+    return new Paginated({
+      data: records.map((record) => this.mapper.toDomain(record)),
+      limit: options.limit,
+      offset: options.offset,
+      total,
+    });
   }
 
   async findByKnowledgeBaseId(knowledgeBaseId: UUID): Promise<Source[]> {
@@ -335,6 +391,9 @@ export class LocalSourceRepository extends SourceRepository {
       )
       .andWhere(
         `NOT EXISTS (SELECT 1 FROM agent_source_assignments asa WHERE asa."sourceId" = s.id)`,
+      )
+      .andWhere(
+        `NOT EXISTS (SELECT 1 FROM workspace_source_assignments wsa WHERE wsa."sourceId" = s.id)`,
       )
       .getRawMany<{ id: UUID }>();
 

--- a/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/schema/source.record.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/schema/source.record.ts
@@ -2,6 +2,7 @@ import {
   ChildEntity,
   Column,
   Entity,
+  Index,
   JoinColumn,
   ManyToOne,
   OneToOne,
@@ -47,6 +48,7 @@ export abstract class SourceRecord extends BaseRecord {
   @Column({ type: 'timestamp', nullable: true })
   processingStartedAt: Date | null;
 
+  @Index()
   @Column({ nullable: true })
   knowledgeBaseId: UUID | null;
 

--- a/ayunis-core-backend/src/domain/sources/sources.module.ts
+++ b/ayunis-core-backend/src/domain/sources/sources.module.ts
@@ -1,10 +1,10 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { LocalSourceRepositoryModule } from './infrastructure/persistence/local/local-source-repository.module';
-import { ModelsModule } from '../models/models.module';
-import { SplitterModule } from '../rag/splitters/splitter.module';
-import { RetrieverModule } from '../retrievers/retriever.module';
-import { IndexersModule } from '../rag/indexers/indexers.module';
-import { StorageModule } from '../storage/storage.module';
+import { ModelsModule } from 'src/domain/models/models.module';
+import { SplitterModule } from 'src/domain/rag/splitters/splitter.module';
+import { RetrieverModule } from 'src/domain/retrievers/retriever.module';
+import { IndexersModule } from 'src/domain/rag/indexers/indexers.module';
+import { StorageModule } from 'src/domain/storage/storage.module';
 import { DocumentProcessingModule } from './infrastructure/queue/document-processing.module';
 import { DataSourceProcessingModule } from './infrastructure/queue/data-source-processing.module';
 import { UrlCrawlModule } from './infrastructure/queue/url-crawl.module';
@@ -33,6 +33,7 @@ import { FindUnreferencedSourceIdsUseCase } from './application/use-cases/find-u
 import { CreateProcessingUrlSourceUseCase } from './application/use-cases/create-processing-url-source/create-processing-url-source.use-case';
 import { EnqueueUrlCrawlUseCase } from './application/use-cases/enqueue-url-crawl/enqueue-url-crawl.use-case';
 import { StartUrlCrawlUseCase } from './application/use-cases/start-url-crawl/start-url-crawl.use-case';
+import { ListSourcesByWorkspaceUseCase } from './application/use-cases/list-sources-by-workspace/list-sources-by-workspace.use-case';
 
 @Module({
   imports: [
@@ -70,6 +71,7 @@ import { StartUrlCrawlUseCase } from './application/use-cases/start-url-crawl/st
     CreateProcessingUrlSourceUseCase,
     EnqueueUrlCrawlUseCase,
     StartUrlCrawlUseCase,
+    ListSourcesByWorkspaceUseCase,
   ],
   exports: [
     LocalSourceRepositoryModule,
@@ -98,6 +100,7 @@ import { StartUrlCrawlUseCase } from './application/use-cases/start-url-crawl/st
     CreateProcessingUrlSourceUseCase,
     EnqueueUrlCrawlUseCase,
     StartUrlCrawlUseCase,
+    ListSourcesByWorkspaceUseCase,
   ],
 })
 export class SourcesModule {}

--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -8,8 +8,9 @@ favorites and their order are owned by the `favorites` module.
 
 User-facing copy calls them "Projekte"; the code, tables and routes say
 `workspace` throughout. See AYC-700 (iteration 1 of the Workspaces/Projects
-plan) — sharing, skills, knowledge and retention settings arrive in later
-iterations.
+plan). Workspaces are not shareable yet, but they can carry a private
+instruction and attached skills, knowledge bases and documents for their
+owner's chats.
 
 The whole module sits behind the `workspacesEnabled` feature flag
 (`FEATURE_WORKSPACES_ENABLED`, off by default), applied at the controller.
@@ -49,6 +50,19 @@ workspaces/
 │   ├── testing/workspace.fixtures.ts
 │   └── use-cases/
 │       ├── create-workspace/
+│       ├── attach-skill-to-workspace/
+│       ├── detach-skill-from-workspace/
+│       ├── attach-knowledge-base-to-workspace/
+│       ├── detach-knowledge-base-from-workspace/
+│       ├── add-document-to-workspace/
+│       ├── remove-document-from-workspace/
+│       ├── update-workspace-instruction/
+│       ├── build-workspace-run-context/
+│       ├── list-workspace-skill-candidates/
+│       ├── list-workspace-knowledge-base-candidates/
+│       ├── list-workspace-skills/
+│       ├── list-workspace-knowledge-bases/
+│       ├── list-workspace-documents/
 │       ├── find-all-workspaces/
 │       ├── find-workspaces-by-ids/
 │       ├── find-workspace/
@@ -75,6 +89,17 @@ workspaces/
 | GET | `/workspaces/:id` | Read one |
 | PATCH | `/workspaces/:id` | Update name / description / icon / colour |
 | DELETE | `/workspaces/:id` | Delete the workspace and its chats |
+| GET | `/workspaces/:id/context` | Read the full runtime context |
+| GET | `/workspaces/:id/context/skill-candidates` | List accessible skills with attachment state |
+| GET | `/workspaces/:id/context/knowledge-base-candidates` | List accessible knowledge bases with attachment state |
+| GET | `/workspaces/:id/context/skills` | List attached skills |
+| GET | `/workspaces/:id/context/knowledge-bases` | List attached knowledge bases |
+| GET | `/workspaces/:id/context/documents` | List attached documents |
+| POST / DELETE | `/workspaces/:id/context/skills/:skillId` | Attach or detach a skill |
+| POST / DELETE | `/workspaces/:id/context/knowledge-bases/:knowledgeBaseId` | Attach or detach a knowledge base |
+| POST | `/workspaces/:id/context/documents` | Upload and attach a document |
+| DELETE | `/workspaces/:id/context/documents/:documentId` | Remove an attached document |
+| PATCH | `/workspaces/:id/context/instruction` | Update the workspace instruction |
 
 ## Cross-Module Boundaries
 
@@ -88,5 +113,17 @@ repository reads the `threads` table directly (raw SQL) to derive per-workspace
 chat counts and last activity. Favorites resolves workspace
 metadata through the exported, user-scoped `FindWorkspacesByIdsUseCase`.
 
+Workspace context use cases consume exported skills, knowledge-bases and
+sources application use cases/services for access checks, candidate lists and
+document processing. The workspace repository owns only the assignment rows;
+the referenced entity modules remain responsible for entity access and
+processing.
+
 The repository port is deliberately not exported — cross-module access goes
 through the exported use cases.
+
+Workspace context list endpoints use dedicated paginated use cases. Candidate
+and attached lists apply search, access checks, workspace assignments, ordering,
+offset, limit, and total-count queries in the database. The full `/context`
+endpoint remains the unpaginated runtime-context projection used when starting
+or running a workspace chat.

--- a/ayunis-core-backend/src/domain/workspaces/application/ports/workspaces-repository.port.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/ports/workspaces-repository.port.ts
@@ -1,14 +1,40 @@
 import type { UUID } from 'crypto';
 import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import type { Paginated } from 'src/common/pagination/paginated.entity';
+
+export type WorkspaceSortKey = 'updatedAt' | 'createdAt' | 'name';
+
+export interface WorkspaceListOptions {
+  search?: string;
+  sort: WorkspaceSortKey;
+  limit: number;
+  offset: number;
+}
 
 export interface WorkspaceThreadStats {
   chatCount: number;
   lastActivityAt: Date | null;
 }
 
+export interface WorkspaceKnowledgeBaseRef {
+  id: UUID;
+  name: string;
+  description: string | null;
+  documentCount: number;
+}
+
+export interface WorkspaceContextRefs {
+  skillIds: UUID[];
+  knowledgeBases: WorkspaceKnowledgeBaseRef[];
+  sourceIds: UUID[];
+}
+
 export abstract class WorkspacesRepository {
   /** Ordered by the workspace's last update, newest first. */
-  abstract findAllByUserId(userId: UUID): Promise<Workspace[]>;
+  abstract findAllByUserId(
+    userId: UUID,
+    query: WorkspaceListOptions,
+  ): Promise<Paginated<Workspace>>;
   abstract findAllByIds(userId: UUID, ids: UUID[]): Promise<Workspace[]>;
 
   /**
@@ -20,6 +46,18 @@ export abstract class WorkspacesRepository {
   ): Promise<Map<UUID, WorkspaceThreadStats>>;
   abstract findById(userId: UUID, id: UUID): Promise<Workspace | null>;
   abstract save(workspace: Workspace): Promise<Workspace>;
+  abstract attachSkill(workspaceId: UUID, skillId: UUID): Promise<void>;
+  abstract detachSkill(workspaceId: UUID, skillId: UUID): Promise<void>;
+  abstract attachKnowledgeBase(
+    workspaceId: UUID,
+    knowledgeBaseId: UUID,
+  ): Promise<void>;
+  abstract detachKnowledgeBase(
+    workspaceId: UUID,
+    knowledgeBaseId: UUID,
+  ): Promise<void>;
+  abstract attachSource(workspaceId: UUID, sourceId: UUID): Promise<void>;
+  abstract getContextRefs(workspaceId: UUID): Promise<WorkspaceContextRefs>;
   /** Throws `WorkspaceNotFoundError` when the user owns no such workspace. */
-  abstract delete(userId: UUID, id: UUID): Promise<void>;
+  abstract delete(userId: UUID, id: UUID): Promise<UUID[]>;
 }

--- a/ayunis-core-backend/src/domain/workspaces/application/testing/workspace.fixtures.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/testing/workspace.fixtures.ts
@@ -39,9 +39,19 @@ export function createMockWorkspacesRepository(): jest.Mocked<WorkspacesReposito
     findAllByIds: jest.fn().mockResolvedValue([]),
     getThreadStats: jest.fn().mockResolvedValue(new Map()),
     findById: jest.fn().mockResolvedValue(null),
+    attachSkill: jest.fn().mockResolvedValue(undefined),
+    detachSkill: jest.fn().mockResolvedValue(undefined),
+    attachKnowledgeBase: jest.fn().mockResolvedValue(undefined),
+    detachKnowledgeBase: jest.fn().mockResolvedValue(undefined),
+    attachSource: jest.fn().mockResolvedValue(undefined),
+    getContextRefs: jest.fn().mockResolvedValue({
+      skillIds: [],
+      knowledgeBases: [],
+      sourceIds: [],
+    }),
     save: jest
       .fn()
       .mockImplementation((workspace: Workspace) => Promise.resolve(workspace)),
-    delete: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockResolvedValue([]),
   };
 }

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/add-document-to-workspace/add-document-to-workspace.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/add-document-to-workspace/add-document-to-workspace.command.ts
@@ -1,0 +1,10 @@
+import type { UUID } from 'crypto';
+
+export class AddDocumentToWorkspaceCommand {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly fileData: Buffer,
+    public readonly fileName: string,
+    public readonly fileType: string,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/add-document-to-workspace/add-document-to-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/add-document-to-workspace/add-document-to-workspace.use-case.ts
@@ -1,0 +1,79 @@
+import type { UUID } from 'crypto';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { DeleteSourceCommand } from 'src/domain/sources/application/use-cases/delete-source/delete-source.command';
+import { DeleteSourceUseCase } from 'src/domain/sources/application/use-cases/delete-source/delete-source.use-case';
+import { StartDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case';
+import { StartDocumentProcessingCommand } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.command';
+import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
+import { WORKSPACE_MAX_SOURCES } from 'src/domain/workspaces/domain/workspaces.constants';
+import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceNotFoundError,
+  WorkspaceSourceLimitExceededError,
+} from '../../workspaces.errors';
+import { AddDocumentToWorkspaceCommand } from './add-document-to-workspace.command';
+
+@Injectable()
+export class AddDocumentToWorkspaceUseCase {
+  constructor(
+    @InjectPinoLogger(AddDocumentToWorkspaceUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly startDocumentProcessingUseCase: StartDocumentProcessingUseCase,
+    private readonly deleteSourceUseCase: DeleteSourceUseCase,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(command: AddDocumentToWorkspaceCommand): Promise<FileSource> {
+    this.logger.info(
+      {
+        workspaceId: command.workspaceId,
+        fileName: command.fileName,
+      },
+      'addDocumentToWorkspace',
+    );
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+
+    const workspace = await this.workspacesRepository.findById(
+      userId,
+      command.workspaceId,
+    );
+    if (!workspace) throw new WorkspaceNotFoundError(command.workspaceId);
+
+    await this.assertSourceCapacity(command.workspaceId);
+
+    const source = await this.startDocumentProcessingUseCase.execute(
+      new StartDocumentProcessingCommand({
+        fileData: command.fileData,
+        fileName: command.fileName,
+        fileType: command.fileType,
+      }),
+    );
+    try {
+      await this.workspacesRepository.attachSource(
+        command.workspaceId,
+        source.id,
+      );
+      return source;
+    } catch (error) {
+      await this.deleteSourceUseCase.execute(
+        new DeleteSourceCommand(source.id, workspace.orgId),
+      );
+      throw error;
+    }
+  }
+
+  private async assertSourceCapacity(workspaceId: UUID): Promise<void> {
+    const refs = await this.workspacesRepository.getContextRefs(workspaceId);
+    if (refs.sourceIds.length >= WORKSPACE_MAX_SOURCES) {
+      throw new WorkspaceSourceLimitExceededError(WORKSPACE_MAX_SOURCES);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/attach-knowledge-base-to-workspace/attach-knowledge-base-to-workspace.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/attach-knowledge-base-to-workspace/attach-knowledge-base-to-workspace.command.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class AttachKnowledgeBaseToWorkspaceCommand {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly knowledgeBaseId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/attach-knowledge-base-to-workspace/attach-knowledge-base-to-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/attach-knowledge-base-to-workspace/attach-knowledge-base-to-workspace.use-case.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
+import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceNotFoundError,
+} from '../../workspaces.errors';
+import { AttachKnowledgeBaseToWorkspaceCommand } from './attach-knowledge-base-to-workspace.command';
+
+@Injectable()
+export class AttachKnowledgeBaseToWorkspaceUseCase {
+  constructor(
+    @InjectPinoLogger(AttachKnowledgeBaseToWorkspaceUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly knowledgeBaseAccessService: KnowledgeBaseAccessService,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(command: AttachKnowledgeBaseToWorkspaceCommand): Promise<void> {
+    this.logger.info(
+      {
+        workspaceId: command.workspaceId,
+        knowledgeBaseId: command.knowledgeBaseId,
+      },
+      'attachKnowledgeBaseToWorkspace',
+    );
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+
+    const workspace = await this.workspacesRepository.findById(
+      userId,
+      command.workspaceId,
+    );
+    if (!workspace) throw new WorkspaceNotFoundError(command.workspaceId);
+
+    await this.knowledgeBaseAccessService.findAccessibleKnowledgeBase(
+      command.knowledgeBaseId,
+    );
+    await this.workspacesRepository.attachKnowledgeBase(
+      command.workspaceId,
+      command.knowledgeBaseId,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/attach-skill-to-workspace/attach-skill-to-workspace.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/attach-skill-to-workspace/attach-skill-to-workspace.command.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class AttachSkillToWorkspaceCommand {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly skillId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/attach-skill-to-workspace/attach-skill-to-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/attach-skill-to-workspace/attach-skill-to-workspace.use-case.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
+import {
+  WorkspaceNotFoundError,
+  UnexpectedWorkspaceError,
+} from '../../workspaces.errors';
+import { SkillAccessService } from 'src/domain/skills/application/services/skill-access.service';
+import { AttachSkillToWorkspaceCommand } from './attach-skill-to-workspace.command';
+
+@Injectable()
+export class AttachSkillToWorkspaceUseCase {
+  constructor(
+    @InjectPinoLogger(AttachSkillToWorkspaceUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly skillAccessService: SkillAccessService,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(command: AttachSkillToWorkspaceCommand): Promise<void> {
+    this.logger.info(
+      {
+        workspaceId: command.workspaceId,
+        skillId: command.skillId,
+      },
+      'attachSkillToWorkspace',
+    );
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+
+    const workspace = await this.workspacesRepository.findById(
+      userId,
+      command.workspaceId,
+    );
+    if (!workspace) throw new WorkspaceNotFoundError(command.workspaceId);
+
+    await this.skillAccessService.findAccessibleSkill(command.skillId);
+    await this.workspacesRepository.attachSkill(
+      command.workspaceId,
+      command.skillId,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/build-workspace-run-context/build-workspace-run-context.query.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/build-workspace-run-context/build-workspace-run-context.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class BuildWorkspaceRunContextQuery {
+  constructor(public readonly workspaceId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/build-workspace-run-context/build-workspace-run-context.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/build-workspace-run-context/build-workspace-run-context.use-case.spec.ts
@@ -1,0 +1,207 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { randomUUID } from 'crypto';
+import { Skill } from 'src/domain/skills/domain/skill.entity';
+import { SkillNotFoundError } from 'src/domain/skills/application/skills.errors';
+import { KnowledgeBaseNotFoundError } from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
+import type { FindOneSkillUseCase } from 'src/domain/skills/application/use-cases/find-one-skill/find-one-skill.use-case';
+import type { GetKnowledgeBasesByIdsUseCase } from 'src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.use-case';
+import type { GetSourcesByIdsUseCase } from 'src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case';
+import type { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
+import {
+  createMockContextService,
+  createMockWorkspacesRepository,
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+  aWorkspace,
+} from '../../testing/workspace.fixtures';
+import { BuildWorkspaceRunContextQuery } from './build-workspace-run-context.query';
+import { BuildWorkspaceRunContextUseCase } from './build-workspace-run-context.use-case';
+
+describe('BuildWorkspaceRunContextUseCase', () => {
+  it('resolves assigned skills, knowledge bases, documents and instruction', async () => {
+    const skillId = randomUUID();
+    const sourceId = randomUUID();
+    const knowledgeBaseId = randomUUID();
+    const mcpIntegrationId = randomUUID();
+    const repository = createMockWorkspacesRepository();
+    repository.findById.mockResolvedValue(
+      aWorkspace({ instruction: 'Use building department wording.' }),
+    );
+    repository.getContextRefs.mockResolvedValue({
+      skillIds: [skillId],
+      knowledgeBases: [
+        {
+          id: knowledgeBaseId,
+          name: 'Building Code',
+          description: 'Rules for building permits',
+          documentCount: 3,
+        },
+      ],
+      sourceIds: [sourceId],
+    });
+    const skill = new Skill({
+      id: skillId,
+      name: 'Permit Check',
+      shortDescription: 'Checks permit applications',
+      instructions: 'Check every permit application for missing parcel IDs.',
+      mcpIntegrationIds: [mcpIntegrationId],
+      userId: TEST_USER_ID,
+    });
+    const findOneSkillUseCase = {
+      execute: jest.fn().mockResolvedValue({
+        skill,
+        isActive: false,
+        isShared: false,
+        isPinned: false,
+      }),
+    } as unknown as jest.Mocked<FindOneSkillUseCase>;
+    const source = { id: sourceId, name: 'Setback rules.pdf' };
+    const getSourcesByIdsUseCase = {
+      execute: jest.fn().mockResolvedValue([source]),
+    } as unknown as jest.Mocked<GetSourcesByIdsUseCase>;
+    const getKnowledgeBasesByIdsUseCase = {
+      execute: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<GetKnowledgeBasesByIdsUseCase>;
+    const knowledgeBaseAccessService = {
+      findAccessibleKnowledgeBase: jest.fn().mockResolvedValue({}),
+      countSourcesByKnowledgeBaseIds: jest.fn().mockResolvedValue(new Map()),
+    } as unknown as jest.Mocked<KnowledgeBaseAccessService>;
+    const useCase = new BuildWorkspaceRunContextUseCase(
+      createPinoLoggerMock(),
+      repository,
+      findOneSkillUseCase,
+      getSourcesByIdsUseCase,
+      getKnowledgeBasesByIdsUseCase,
+      knowledgeBaseAccessService,
+      createMockContextService(),
+    );
+
+    const result = await useCase.execute(
+      new BuildWorkspaceRunContextQuery(TEST_WORKSPACE_ID),
+    );
+
+    expect(result.instruction).toBe('Use building department wording.');
+    expect(result.skills).toEqual([skill]);
+    expect(result.knowledgeBases).toHaveLength(1);
+    expect(result.sources).toEqual([source]);
+    expect(result.mcpIntegrationIds).toEqual([mcpIntegrationId]);
+  });
+
+  it('skips assigned skills that are no longer accessible', async () => {
+    const accessibleSkillId = randomUUID();
+    const revokedSkillId = randomUUID();
+    const repository = createMockWorkspacesRepository();
+    repository.getContextRefs.mockResolvedValue({
+      skillIds: [accessibleSkillId, revokedSkillId],
+      knowledgeBases: [],
+      sourceIds: [],
+    });
+    repository.findById.mockResolvedValue(aWorkspace());
+    const accessibleSkill = new Skill({
+      id: accessibleSkillId,
+      name: 'Accessible Skill',
+      shortDescription: 'Still shared',
+      instructions: 'Use accessible skill instructions.',
+      userId: TEST_USER_ID,
+    });
+    const findOneSkillUseCase = {
+      execute: jest
+        .fn()
+        .mockResolvedValueOnce({
+          skill: accessibleSkill,
+          isActive: false,
+          isShared: true,
+          isPinned: false,
+        })
+        .mockRejectedValueOnce(new SkillNotFoundError(revokedSkillId)),
+    } as unknown as jest.Mocked<FindOneSkillUseCase>;
+    const getSourcesByIdsUseCase = {
+      execute: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<GetSourcesByIdsUseCase>;
+    const getKnowledgeBasesByIdsUseCase = {
+      execute: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<GetKnowledgeBasesByIdsUseCase>;
+    const knowledgeBaseAccessService = {
+      findAccessibleKnowledgeBase: jest.fn().mockResolvedValue({}),
+      countSourcesByKnowledgeBaseIds: jest.fn().mockResolvedValue(new Map()),
+    } as unknown as jest.Mocked<KnowledgeBaseAccessService>;
+    const useCase = new BuildWorkspaceRunContextUseCase(
+      createPinoLoggerMock(),
+      repository,
+      findOneSkillUseCase,
+      getSourcesByIdsUseCase,
+      getKnowledgeBasesByIdsUseCase,
+      knowledgeBaseAccessService,
+      createMockContextService(),
+    );
+
+    const result = await useCase.execute(
+      new BuildWorkspaceRunContextQuery(TEST_WORKSPACE_ID),
+    );
+
+    expect(result.skills).toEqual([accessibleSkill]);
+  });
+
+  it('skips assigned knowledge bases that are no longer accessible', async () => {
+    const accessibleKnowledgeBaseId = randomUUID();
+    const revokedKnowledgeBaseId = randomUUID();
+    const repository = createMockWorkspacesRepository();
+    repository.findById.mockResolvedValue(aWorkspace());
+    repository.getContextRefs.mockResolvedValue({
+      skillIds: [],
+      knowledgeBases: [
+        {
+          id: accessibleKnowledgeBaseId,
+          name: 'Accessible KB',
+          description: null,
+          documentCount: 1,
+        },
+        {
+          id: revokedKnowledgeBaseId,
+          name: 'Revoked KB',
+          description: null,
+          documentCount: 1,
+        },
+      ],
+      sourceIds: [],
+    });
+    const findOneSkillUseCase = {
+      execute: jest.fn(),
+    } as unknown as jest.Mocked<FindOneSkillUseCase>;
+    const getSourcesByIdsUseCase = {
+      execute: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<GetSourcesByIdsUseCase>;
+    const getKnowledgeBasesByIdsUseCase = {
+      execute: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<GetKnowledgeBasesByIdsUseCase>;
+    const knowledgeBaseAccessService = {
+      findAccessibleKnowledgeBase: jest
+        .fn()
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(
+          new KnowledgeBaseNotFoundError(revokedKnowledgeBaseId),
+        ),
+      countSourcesByKnowledgeBaseIds: jest.fn().mockResolvedValue(new Map()),
+    } as unknown as jest.Mocked<KnowledgeBaseAccessService>;
+    const useCase = new BuildWorkspaceRunContextUseCase(
+      createPinoLoggerMock(),
+      repository,
+      findOneSkillUseCase,
+      getSourcesByIdsUseCase,
+      getKnowledgeBasesByIdsUseCase,
+      knowledgeBaseAccessService,
+      createMockContextService(),
+    );
+
+    const result = await useCase.execute(
+      new BuildWorkspaceRunContextQuery(TEST_WORKSPACE_ID),
+    );
+
+    expect(result.knowledgeBases.map((kb) => kb.id)).toEqual([
+      accessibleKnowledgeBaseId,
+    ]);
+    expect(result.runtimeKnowledgeBases.map((kb) => kb.id)).toEqual([
+      accessibleKnowledgeBaseId,
+    ]);
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/build-workspace-run-context/build-workspace-run-context.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/build-workspace-run-context/build-workspace-run-context.use-case.ts
@@ -1,0 +1,203 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import type { UUID } from 'crypto';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { FindOneSkillUseCase } from 'src/domain/skills/application/use-cases/find-one-skill/find-one-skill.use-case';
+import { FindOneSkillQuery } from 'src/domain/skills/application/use-cases/find-one-skill/find-one-skill.query';
+import { GetKnowledgeBasesByIdsUseCase } from 'src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.use-case';
+import { GetKnowledgeBasesByIdsQuery } from 'src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.query';
+import { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
+import { KnowledgeBaseNotFoundError } from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
+import { GetSourcesByIdsUseCase } from 'src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case';
+import { GetSourcesByIdsQuery } from 'src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.query';
+import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
+import type { Skill } from 'src/domain/skills/domain/skill.entity';
+import { SkillNotFoundError } from 'src/domain/skills/application/skills.errors';
+import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import type {
+  WorkspaceKnowledgeBaseContext,
+  WorkspaceRunContext,
+} from 'src/domain/workspaces/domain/workspace-run-context.entity';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceNotFoundError,
+} from '../../workspaces.errors';
+import { BuildWorkspaceRunContextQuery } from './build-workspace-run-context.query';
+
+@Injectable()
+export class BuildWorkspaceRunContextUseCase {
+  constructor(
+    @InjectPinoLogger(BuildWorkspaceRunContextUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly findOneSkillUseCase: FindOneSkillUseCase,
+    private readonly getSourcesByIdsUseCase: GetSourcesByIdsUseCase,
+    private readonly getKnowledgeBasesByIdsUseCase: GetKnowledgeBasesByIdsUseCase,
+    private readonly knowledgeBaseAccessService: KnowledgeBaseAccessService,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(
+    query: BuildWorkspaceRunContextQuery,
+  ): Promise<WorkspaceRunContext> {
+    this.logger.info(
+      { workspaceId: query.workspaceId },
+      'buildWorkspaceRunContext',
+    );
+    const workspace = await this.findWorkspace(query.workspaceId);
+
+    const refs = await this.workspacesRepository.getContextRefs(
+      query.workspaceId,
+    );
+    const [skills, knowledgeBases] = await Promise.all([
+      this.findAssignedSkills(refs.skillIds),
+      this.findAssignedKnowledgeBases(refs.knowledgeBases),
+    ]);
+    const sourceIds = this.collectRuntimeSourceIds(refs.sourceIds, skills);
+    const [runtimeSources, skillKnowledgeBases] = await Promise.all([
+      this.getSourcesByIdsUseCase.execute(new GetSourcesByIdsQuery(sourceIds)),
+      this.getSkillKnowledgeBases(skills),
+    ]);
+    const workspaceSourceIds = new Set(refs.sourceIds);
+    const workspaceSources = runtimeSources.filter((source) =>
+      workspaceSourceIds.has(source.id),
+    );
+    const runtimeKnowledgeBases = this.mergeKnowledgeBases(
+      knowledgeBases,
+      skillKnowledgeBases,
+    );
+
+    return {
+      instruction: workspace.instruction,
+      skills,
+      knowledgeBases,
+      sources: workspaceSources,
+      runtimeKnowledgeBases,
+      runtimeSources,
+      mcpIntegrationIds: this.unique(
+        skills.flatMap((skill) => skill.mcpIntegrationIds),
+      ),
+    };
+  }
+
+  private async findWorkspace(workspaceId: UUID): Promise<Workspace> {
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+
+    const workspace = await this.workspacesRepository.findById(
+      userId,
+      workspaceId,
+    );
+    if (!workspace) throw new WorkspaceNotFoundError(workspaceId);
+    return workspace;
+  }
+
+  private collectRuntimeSourceIds(sourceIds: UUID[], skills: Skill[]): UUID[] {
+    return this.unique([
+      ...sourceIds,
+      ...skills.flatMap((skill) => skill.sourceIds),
+    ]);
+  }
+
+  private async findAssignedSkills(skillIds: UUID[]): Promise<Skill[]> {
+    const skillResults = await Promise.all(
+      skillIds.map((skillId) => this.findAssignedSkill(skillId)),
+    );
+    return skillResults.filter((skill): skill is Skill => skill !== null);
+  }
+
+  private async findAssignedSkill(skillId: UUID): Promise<Skill | null> {
+    try {
+      const result = await this.findOneSkillUseCase.execute(
+        new FindOneSkillQuery(skillId),
+      );
+      return result.skill;
+    } catch (error) {
+      if (!(error instanceof SkillNotFoundError)) throw error;
+      this.logger.warn('Skipping inaccessible workspace skill assignment', {
+        skillId,
+      });
+      return null;
+    }
+  }
+
+  private async findAssignedKnowledgeBases(
+    knowledgeBases: WorkspaceKnowledgeBaseContext[],
+  ): Promise<WorkspaceKnowledgeBaseContext[]> {
+    const results = await Promise.all(
+      knowledgeBases.map((knowledgeBase) =>
+        this.findAssignedKnowledgeBase(knowledgeBase),
+      ),
+    );
+    const accessibleKnowledgeBases = results.filter(
+      (knowledgeBase): knowledgeBase is WorkspaceKnowledgeBaseContext =>
+        knowledgeBase !== null,
+    );
+    return this.withDocumentCounts(accessibleKnowledgeBases);
+  }
+
+  private async findAssignedKnowledgeBase(
+    knowledgeBase: WorkspaceKnowledgeBaseContext,
+  ): Promise<WorkspaceKnowledgeBaseContext | null> {
+    try {
+      await this.knowledgeBaseAccessService.findAccessibleKnowledgeBase(
+        knowledgeBase.id,
+      );
+      return knowledgeBase;
+    } catch (error) {
+      if (!(error instanceof KnowledgeBaseNotFoundError)) throw error;
+      this.logger.warn('Skipping inaccessible workspace knowledge base', {
+        knowledgeBaseId: knowledgeBase.id,
+      });
+      return null;
+    }
+  }
+
+  private async withDocumentCounts(
+    knowledgeBases: WorkspaceKnowledgeBaseContext[],
+  ): Promise<WorkspaceKnowledgeBaseContext[]> {
+    const documentCounts =
+      await this.knowledgeBaseAccessService.countSourcesByKnowledgeBaseIds(
+        knowledgeBases.map((knowledgeBase) => knowledgeBase.id),
+      );
+    return knowledgeBases.map((knowledgeBase) => ({
+      ...knowledgeBase,
+      documentCount: documentCounts.get(knowledgeBase.id) ?? 0,
+    }));
+  }
+
+  private async getSkillKnowledgeBases(
+    skills: Skill[],
+  ): Promise<WorkspaceKnowledgeBaseContext[]> {
+    const knowledgeBaseIds = this.unique(
+      skills.flatMap((skill) => skill.knowledgeBaseIds),
+    );
+    const knowledgeBases = await this.getKnowledgeBasesByIdsUseCase.execute(
+      new GetKnowledgeBasesByIdsQuery(knowledgeBaseIds),
+    );
+    return knowledgeBases.map((kb) => ({
+      id: kb.id,
+      name: kb.name,
+      description: kb.description,
+      documentCount: 0,
+    }));
+  }
+
+  private mergeKnowledgeBases(
+    workspaceKnowledgeBases: WorkspaceKnowledgeBaseContext[],
+    skillKnowledgeBases: WorkspaceKnowledgeBaseContext[],
+  ): WorkspaceKnowledgeBaseContext[] {
+    const seen = new Set(workspaceKnowledgeBases.map((kb) => kb.id));
+    return [
+      ...workspaceKnowledgeBases,
+      ...skillKnowledgeBases.filter((kb) => !seen.has(kb.id)),
+    ];
+  }
+
+  private unique(ids: UUID[]): UUID[] {
+    return [...new Set(ids)];
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/delete-workspace/delete-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/delete-workspace/delete-workspace.use-case.spec.ts
@@ -1,9 +1,11 @@
+import type { UUID } from 'crypto';
 import { Test } from '@nestjs/testing';
 import { getLoggerToken } from 'nestjs-pino';
 import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ContextService } from 'src/common/context/services/context.service';
 import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { DeleteSourceUseCase } from 'src/domain/sources/application/use-cases/delete-source/delete-source.use-case';
 import { WorkspaceDeletionRequestedEvent } from 'src/domain/workspaces/application/events/workspace-deletion-requested.event';
 import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
 import {
@@ -17,13 +19,17 @@ import {
 import { DeleteWorkspaceCommand } from './delete-workspace.command';
 import { DeleteWorkspaceUseCase } from './delete-workspace.use-case';
 
+const TEST_SOURCE_ID = '44444444-4444-4444-8444-444444444444' as UUID;
+
 describe('DeleteWorkspaceUseCase', () => {
   let useCase: DeleteWorkspaceUseCase;
   let repository: jest.Mocked<WorkspacesRepository>;
+  let deleteSourceUseCase: { execute: jest.Mock };
   let eventEmitter: { emitAsync: jest.Mock };
 
   beforeEach(async () => {
     repository = createMockWorkspacesRepository();
+    deleteSourceUseCase = { execute: jest.fn().mockResolvedValue(undefined) };
     eventEmitter = { emitAsync: jest.fn().mockResolvedValue([]) };
     const module = await Test.createTestingModule({
       providers: [
@@ -33,6 +39,7 @@ describe('DeleteWorkspaceUseCase', () => {
           useValue: createPinoLoggerMock(),
         },
         { provide: WorkspacesRepository, useValue: repository },
+        { provide: DeleteSourceUseCase, useValue: deleteSourceUseCase },
         { provide: ContextService, useValue: createMockContextService() },
         { provide: EventEmitter2, useValue: eventEmitter },
       ],
@@ -53,7 +60,7 @@ describe('DeleteWorkspaceUseCase', () => {
     });
     repository.delete.mockImplementation(() => {
       callOrder.push('delete');
-      return Promise.resolve();
+      return Promise.resolve([]);
     });
 
     await useCase.execute(new DeleteWorkspaceCommand(TEST_WORKSPACE_ID));
@@ -64,6 +71,29 @@ describe('DeleteWorkspaceUseCase', () => {
       expect.objectContaining({
         workspaceId: TEST_WORKSPACE_ID,
         userId: TEST_USER_ID,
+        orgId: TEST_ORG_ID,
+      }),
+    );
+  });
+
+  it('deletes direct workspace documents after deleting the row', async () => {
+    repository.findById.mockResolvedValue(aWorkspace());
+    const callOrder: string[] = [];
+    deleteSourceUseCase.execute.mockImplementation(() => {
+      callOrder.push('source');
+      return Promise.resolve();
+    });
+    repository.delete.mockImplementation(() => {
+      callOrder.push('delete');
+      return Promise.resolve([TEST_SOURCE_ID]);
+    });
+
+    await useCase.execute(new DeleteWorkspaceCommand(TEST_WORKSPACE_ID));
+
+    expect(callOrder).toEqual(['delete', 'source']);
+    expect(deleteSourceUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceId: TEST_SOURCE_ID,
         orgId: TEST_ORG_ID,
       }),
     );

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/delete-workspace/delete-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/delete-workspace/delete-workspace.use-case.ts
@@ -6,6 +6,8 @@ import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { runDeferredCleanup } from 'src/common/events/run-deferred-cleanup';
+import { DeleteSourceCommand } from 'src/domain/sources/application/use-cases/delete-source/delete-source.command';
+import { DeleteSourceUseCase } from 'src/domain/sources/application/use-cases/delete-source/delete-source.use-case';
 import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
 import { WorkspaceDeletionRequestedEvent } from 'src/domain/workspaces/application/events/workspace-deletion-requested.event';
 import {
@@ -20,6 +22,7 @@ export class DeleteWorkspaceUseCase {
     @InjectPinoLogger(DeleteWorkspaceUseCase.name)
     private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
+    private readonly deleteSourceUseCase: DeleteSourceUseCase,
     private readonly contextService: ContextService,
     private readonly eventEmitter: EventEmitter2,
   ) {}
@@ -50,9 +53,27 @@ export class DeleteWorkspaceUseCase {
       event,
     );
 
-    await this.workspacesRepository.delete(userId, command.id);
+    const sourceIds = await this.workspacesRepository.delete(
+      userId,
+      command.id,
+    );
+    this.deferWorkspaceSourceDeletion(event, sourceIds, workspace.orgId);
 
     await runDeferredCleanup(event.takeCleanupTasks(), this.logger);
+  }
+
+  private deferWorkspaceSourceDeletion(
+    event: WorkspaceDeletionRequestedEvent,
+    sourceIds: UUID[],
+    orgId: UUID,
+  ): void {
+    for (const sourceId of sourceIds) {
+      event.deferCleanup(`workspace-source:${sourceId}`, () =>
+        this.deleteSourceUseCase.execute(
+          new DeleteSourceCommand(sourceId, orgId),
+        ),
+      );
+    }
   }
 
   private resolveUserId(): UUID {

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/detach-knowledge-base-from-workspace/detach-knowledge-base-from-workspace.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/detach-knowledge-base-from-workspace/detach-knowledge-base-from-workspace.command.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class DetachKnowledgeBaseFromWorkspaceCommand {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly knowledgeBaseId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/detach-knowledge-base-from-workspace/detach-knowledge-base-from-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/detach-knowledge-base-from-workspace/detach-knowledge-base-from-workspace.use-case.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceNotFoundError,
+} from '../../workspaces.errors';
+import { DetachKnowledgeBaseFromWorkspaceCommand } from './detach-knowledge-base-from-workspace.command';
+
+@Injectable()
+export class DetachKnowledgeBaseFromWorkspaceUseCase {
+  constructor(
+    @InjectPinoLogger(DetachKnowledgeBaseFromWorkspaceUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(
+    command: DetachKnowledgeBaseFromWorkspaceCommand,
+  ): Promise<void> {
+    this.logger.info(
+      {
+        workspaceId: command.workspaceId,
+        knowledgeBaseId: command.knowledgeBaseId,
+      },
+      'detachKnowledgeBaseFromWorkspace',
+    );
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+
+    const workspace = await this.workspacesRepository.findById(
+      userId,
+      command.workspaceId,
+    );
+    if (!workspace) throw new WorkspaceNotFoundError(command.workspaceId);
+
+    await this.workspacesRepository.detachKnowledgeBase(
+      command.workspaceId,
+      command.knowledgeBaseId,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/detach-skill-from-workspace/detach-skill-from-workspace.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/detach-skill-from-workspace/detach-skill-from-workspace.command.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class DetachSkillFromWorkspaceCommand {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly skillId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/detach-skill-from-workspace/detach-skill-from-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/detach-skill-from-workspace/detach-skill-from-workspace.use-case.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceNotFoundError,
+} from '../../workspaces.errors';
+import { DetachSkillFromWorkspaceCommand } from './detach-skill-from-workspace.command';
+
+@Injectable()
+export class DetachSkillFromWorkspaceUseCase {
+  constructor(
+    @InjectPinoLogger(DetachSkillFromWorkspaceUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(command: DetachSkillFromWorkspaceCommand): Promise<void> {
+    this.logger.info(
+      {
+        workspaceId: command.workspaceId,
+        skillId: command.skillId,
+      },
+      'detachSkillFromWorkspace',
+    );
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+
+    const workspace = await this.workspacesRepository.findById(
+      userId,
+      command.workspaceId,
+    );
+    if (!workspace) throw new WorkspaceNotFoundError(command.workspaceId);
+
+    await this.workspacesRepository.detachSkill(
+      command.workspaceId,
+      command.skillId,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.query.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.query.ts
@@ -1,0 +1,34 @@
+import { PaginatedQuery } from 'src/common/pagination/paginated.query';
+import {
+  WORKSPACE_DEFAULT_LIST_LIMIT,
+  WORKSPACE_MAX_LIST_LIMIT,
+} from 'src/domain/workspaces/domain/workspaces.constants';
+import type {
+  WorkspaceListOptions,
+  WorkspaceSortKey,
+} from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+
+export class FindAllWorkspacesQuery
+  extends PaginatedQuery
+  implements WorkspaceListOptions
+{
+  public readonly search?: string;
+  public readonly sort: WorkspaceSortKey;
+
+  constructor(params?: {
+    search?: string;
+    sort?: WorkspaceSortKey;
+    limit?: number;
+    offset?: number;
+  }) {
+    super({
+      limit: Math.min(
+        params?.limit ?? WORKSPACE_DEFAULT_LIST_LIMIT,
+        WORKSPACE_MAX_LIST_LIMIT,
+      ),
+      offset: params?.offset ?? 0,
+    });
+    this.search = params?.search?.trim() || undefined;
+    this.sort = params?.sort ?? 'updatedAt';
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.spec.ts
@@ -11,6 +11,8 @@ import {
   TEST_USER_ID,
 } from 'src/domain/workspaces/application/testing/workspace.fixtures';
 import { FindAllWorkspacesUseCase } from './find-all-workspaces.use-case';
+import { FindAllWorkspacesQuery } from './find-all-workspaces.query';
+import { Paginated } from 'src/common/pagination/paginated.entity';
 
 describe('FindAllWorkspacesUseCase', () => {
   let useCase: FindAllWorkspacesUseCase;
@@ -42,22 +44,37 @@ describe('FindAllWorkspacesUseCase', () => {
 
   it('returns the caller’s workspaces with their chat stats', async () => {
     const workspace = aWorkspace();
-    repository.findAllByUserId.mockResolvedValue([workspace]);
+    repository.findAllByUserId.mockResolvedValue(
+      new Paginated({ data: [workspace], limit: 20, offset: 0, total: 1 }),
+    );
     repository.getThreadStats.mockResolvedValue(
       new Map([[workspace.id, { chatCount: 3, lastActivityAt: null }]]),
     );
 
-    await expect(useCase.execute()).resolves.toEqual([
-      { workspace, chatCount: 3, lastActivityAt: workspace.updatedAt },
-    ]);
-    expect(repository.findAllByUserId).toHaveBeenCalledWith(TEST_USER_ID);
+    await expect(useCase.execute()).resolves.toEqual(
+      new Paginated({
+        data: [
+          { workspace, chatCount: 3, lastActivityAt: workspace.updatedAt },
+        ],
+        limit: 20,
+        offset: 0,
+        total: 1,
+      }),
+    );
+    expect(repository.findAllByUserId).toHaveBeenCalledWith(
+      TEST_USER_ID,
+      expect.objectContaining({ limit: 20, offset: 0, sort: 'updatedAt' }),
+    );
   });
 
   it('reports zero chats for a workspace without stats', async () => {
     const workspace = aWorkspace();
-    repository.findAllByUserId.mockResolvedValue([workspace]);
+    repository.findAllByUserId.mockResolvedValue(
+      new Paginated({ data: [workspace], limit: 20, offset: 0, total: 1 }),
+    );
 
-    const [item] = await useCase.execute();
+    const { data } = await useCase.execute();
+    const [item] = data;
 
     expect(item.chatCount).toBe(0);
     expect(item.lastActivityAt).toEqual(workspace.updatedAt);
@@ -68,12 +85,15 @@ describe('FindAllWorkspacesUseCase', () => {
       updatedAt: new Date('2026-08-02T10:00:00.000Z'),
     });
     const chatActivity = new Date('2026-08-05T10:00:00.000Z');
-    repository.findAllByUserId.mockResolvedValue([workspace]);
+    repository.findAllByUserId.mockResolvedValue(
+      new Paginated({ data: [workspace], limit: 20, offset: 0, total: 1 }),
+    );
     repository.getThreadStats.mockResolvedValue(
       new Map([[workspace.id, { chatCount: 1, lastActivityAt: chatActivity }]]),
     );
 
-    const [item] = await useCase.execute();
+    const { data } = await useCase.execute();
+    const [item] = data;
 
     expect(item.lastActivityAt).toEqual(chatActivity);
   });
@@ -82,7 +102,9 @@ describe('FindAllWorkspacesUseCase', () => {
     const workspace = aWorkspace({
       updatedAt: new Date('2026-08-09T10:00:00.000Z'),
     });
-    repository.findAllByUserId.mockResolvedValue([workspace]);
+    repository.findAllByUserId.mockResolvedValue(
+      new Paginated({ data: [workspace], limit: 20, offset: 0, total: 1 }),
+    );
     repository.getThreadStats.mockResolvedValue(
       new Map([
         [
@@ -95,7 +117,8 @@ describe('FindAllWorkspacesUseCase', () => {
       ]),
     );
 
-    const [item] = await useCase.execute();
+    const { data } = await useCase.execute();
+    const [item] = data;
 
     expect(item.lastActivityAt).toEqual(workspace.updatedAt);
   });
@@ -103,6 +126,8 @@ describe('FindAllWorkspacesUseCase', () => {
   it('rejects an unauthenticated caller', async () => {
     await setup(createMockContextService({}));
 
-    await expect(useCase.execute()).rejects.toThrow(UnauthorizedAccessError);
+    await expect(useCase.execute(new FindAllWorkspacesQuery())).rejects.toThrow(
+      UnauthorizedAccessError,
+    );
   });
 });

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.ts
@@ -7,6 +7,8 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
 import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import { FindAllWorkspacesQuery } from './find-all-workspaces.query';
 
 export interface WorkspaceListItem {
   workspace: Workspace;
@@ -25,17 +27,20 @@ export class FindAllWorkspacesUseCase {
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
-  async execute(): Promise<WorkspaceListItem[]> {
+  async execute(
+    query: FindAllWorkspacesQuery = new FindAllWorkspacesQuery(),
+  ): Promise<Paginated<WorkspaceListItem>> {
     this.logger.info('Finding all workspaces');
 
     const workspaces = await this.workspacesRepository.findAllByUserId(
       this.resolveUserId(),
+      query,
     );
     const stats = await this.workspacesRepository.getThreadStats(
-      workspaces.map((workspace) => workspace.id),
+      workspaces.data.map((workspace) => workspace.id),
     );
 
-    return workspaces.map((workspace) => {
+    const data = workspaces.data.map((workspace) => {
       const threadStats = stats.get(workspace.id);
       const chatActivity = threadStats?.lastActivityAt;
       return {
@@ -46,6 +51,13 @@ export class FindAllWorkspacesUseCase {
             ? chatActivity
             : workspace.updatedAt,
       };
+    });
+
+    return new Paginated({
+      data,
+      limit: workspaces.limit,
+      offset: workspaces.offset,
+      total: workspaces.total,
     });
   }
 

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-documents/list-workspace-documents.query.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-documents/list-workspace-documents.query.ts
@@ -1,0 +1,18 @@
+import type { UUID } from 'crypto';
+import { PaginatedQuery } from 'src/common/pagination/paginated.query';
+
+export class ListWorkspaceDocumentsQuery extends PaginatedQuery {
+  public readonly workspaceId: UUID;
+  public readonly search?: string;
+
+  constructor(params: {
+    workspaceId: UUID;
+    search?: string;
+    limit: number;
+    offset: number;
+  }) {
+    super({ limit: params.limit, offset: params.offset });
+    this.workspaceId = params.workspaceId;
+    this.search = params.search?.trim() || undefined;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-documents/list-workspace-documents.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-documents/list-workspace-documents.use-case.spec.ts
@@ -1,0 +1,55 @@
+import type { UUID } from 'crypto';
+import type { ContextService } from 'src/common/context/services/context.service';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import type { ListSourcesByWorkspaceUseCase } from 'src/domain/sources/application/use-cases/list-sources-by-workspace/list-sources-by-workspace.use-case';
+import type { Source } from 'src/domain/sources/domain/source.entity';
+import type { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { ListWorkspaceDocumentsUseCase } from './list-workspace-documents.use-case';
+import { ListWorkspaceDocumentsQuery } from './list-workspace-documents.query';
+
+describe('ListWorkspaceDocumentsUseCase', () => {
+  it('returns the paginated documents attached to a workspace', async () => {
+    const workspaceId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+    const page = new Paginated<Source>({
+      data: [],
+      limit: 2,
+      offset: 4,
+      total: 5,
+    });
+    const workspacesRepository = {
+      findById: jest.fn().mockResolvedValue({}),
+    } as unknown as jest.Mocked<WorkspacesRepository>;
+    const listSourcesByWorkspaceUseCase = {
+      execute: jest.fn().mockResolvedValue(page),
+    } as unknown as jest.Mocked<ListSourcesByWorkspaceUseCase>;
+    const contextService = {
+      get: jest.fn().mockReturnValue('223e4567-e89b-12d3-a456-426614174001'),
+    } as unknown as jest.Mocked<ContextService>;
+    const useCase = new ListWorkspaceDocumentsUseCase(
+      createPinoLoggerMock(),
+      workspacesRepository,
+      listSourcesByWorkspaceUseCase,
+      contextService,
+    );
+
+    const result = await useCase.execute(
+      new ListWorkspaceDocumentsQuery({
+        workspaceId,
+        search: 'budget',
+        limit: 2,
+        offset: 4,
+      }),
+    );
+
+    expect(result).toBe(page);
+    expect(listSourcesByWorkspaceUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId,
+        search: 'budget',
+        limit: 2,
+        offset: 4,
+      }),
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-documents/list-workspace-documents.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-documents/list-workspace-documents.use-case.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import { ListSourcesByWorkspaceUseCase } from 'src/domain/sources/application/use-cases/list-sources-by-workspace/list-sources-by-workspace.use-case';
+import { ListSourcesByWorkspaceQuery } from 'src/domain/sources/application/use-cases/list-sources-by-workspace/list-sources-by-workspace.query';
+import type { Source } from 'src/domain/sources/domain/source.entity';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceNotFoundError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { ListWorkspaceDocumentsQuery } from './list-workspace-documents.query';
+
+@Injectable()
+export class ListWorkspaceDocumentsUseCase {
+  constructor(
+    @InjectPinoLogger(ListWorkspaceDocumentsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly listSourcesByWorkspaceUseCase: ListSourcesByWorkspaceUseCase,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(
+    query: ListWorkspaceDocumentsQuery,
+  ): Promise<Paginated<Source>> {
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+
+    this.logger.info(
+      { workspaceId: query.workspaceId },
+      'listWorkspaceDocuments',
+    );
+    const workspace = await this.workspacesRepository.findById(
+      userId,
+      query.workspaceId,
+    );
+    if (!workspace) throw new WorkspaceNotFoundError(query.workspaceId);
+
+    return this.listSourcesByWorkspaceUseCase.execute(
+      new ListSourcesByWorkspaceQuery({
+        workspaceId: query.workspaceId,
+        search: query.search,
+        limit: query.limit,
+        offset: query.offset,
+      }),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-base-candidates/list-workspace-knowledge-base-candidates.query.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-base-candidates/list-workspace-knowledge-base-candidates.query.ts
@@ -1,0 +1,18 @@
+import type { UUID } from 'crypto';
+import { PaginatedQuery } from 'src/common/pagination/paginated.query';
+
+export class ListWorkspaceKnowledgeBaseCandidatesQuery extends PaginatedQuery {
+  public readonly workspaceId: UUID;
+  public readonly search?: string;
+
+  constructor(params: {
+    workspaceId: UUID;
+    search?: string;
+    limit: number;
+    offset: number;
+  }) {
+    super({ limit: params.limit, offset: params.offset });
+    this.workspaceId = params.workspaceId;
+    this.search = params.search?.trim() || undefined;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-base-candidates/list-workspace-knowledge-base-candidates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-base-candidates/list-workspace-knowledge-base-candidates.use-case.spec.ts
@@ -1,0 +1,80 @@
+import type { UUID } from 'crypto';
+import type { ContextService } from 'src/common/context/services/context.service';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import type { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
+import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
+import type { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { ListWorkspaceKnowledgeBaseCandidatesUseCase } from './list-workspace-knowledge-base-candidates.use-case';
+import { ListWorkspaceKnowledgeBaseCandidatesQuery } from './list-workspace-knowledge-base-candidates.query';
+
+describe('ListWorkspaceKnowledgeBaseCandidatesUseCase', () => {
+  it('returns a paginated candidate page with attachment state', async () => {
+    const workspaceId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+    const knowledgeBaseId = '223e4567-e89b-12d3-a456-426614174001' as UUID;
+    const knowledgeBase = new KnowledgeBase({
+      id: knowledgeBaseId,
+      name: 'Citizen requests',
+      description: 'Citizen request documents',
+      orgId: '323e4567-e89b-12d3-a456-426614174002',
+      userId: '423e4567-e89b-12d3-a456-426614174003',
+    });
+    const page = new Paginated({
+      data: [{ knowledgeBase, isShared: false }],
+      limit: 2,
+      offset: 4,
+      total: 5,
+    });
+    const workspacesRepository = {
+      findById: jest.fn().mockResolvedValue({}),
+      getContextRefs: jest.fn().mockResolvedValue({
+        skillIds: [],
+        knowledgeBases: [
+          {
+            id: knowledgeBaseId,
+            name: knowledgeBase.name,
+            description: knowledgeBase.description,
+            documentCount: 0,
+          },
+        ],
+        sourceIds: [],
+      }),
+    } as unknown as jest.Mocked<WorkspacesRepository>;
+    const knowledgeBaseAccessService = {
+      findAllAccessiblePaginated: jest.fn().mockResolvedValue(page),
+      countSourcesByKnowledgeBaseIds: jest
+        .fn()
+        .mockResolvedValue(new Map([[knowledgeBaseId, 0]])),
+    } as unknown as jest.Mocked<KnowledgeBaseAccessService>;
+    const contextService = {
+      get: jest.fn().mockReturnValue('523e4567-e89b-12d3-a456-426614174004'),
+    } as unknown as jest.Mocked<ContextService>;
+    const useCase = new ListWorkspaceKnowledgeBaseCandidatesUseCase(
+      createPinoLoggerMock(),
+      workspacesRepository,
+      knowledgeBaseAccessService,
+      contextService,
+    );
+
+    const result = await useCase.execute(
+      new ListWorkspaceKnowledgeBaseCandidatesQuery({
+        workspaceId,
+        search: 'citizen',
+        limit: 2,
+        offset: 4,
+      }),
+    );
+
+    expect(result.data).toEqual([
+      { knowledgeBase, documentCount: 0, isAttached: true },
+    ]);
+    expect(result.total).toBe(5);
+    expect(
+      knowledgeBaseAccessService.findAllAccessiblePaginated,
+    ).toHaveBeenCalledWith(undefined, {
+      search: 'citizen',
+      limit: 2,
+      offset: 4,
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-base-candidates/list-workspace-knowledge-base-candidates.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-base-candidates/list-workspace-knowledge-base-candidates.use-case.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
+import type { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceNotFoundError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { ListWorkspaceKnowledgeBaseCandidatesQuery } from './list-workspace-knowledge-base-candidates.query';
+
+export interface WorkspaceKnowledgeBaseCandidate {
+  knowledgeBase: KnowledgeBase;
+  documentCount: number;
+  isAttached: boolean;
+}
+
+@Injectable()
+export class ListWorkspaceKnowledgeBaseCandidatesUseCase {
+  constructor(
+    @InjectPinoLogger(ListWorkspaceKnowledgeBaseCandidatesUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly knowledgeBaseAccessService: KnowledgeBaseAccessService,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(
+    query: ListWorkspaceKnowledgeBaseCandidatesQuery,
+  ): Promise<Paginated<WorkspaceKnowledgeBaseCandidate>> {
+    this.logger.info(
+      {
+        workspaceId: query.workspaceId,
+      },
+      'listWorkspaceKnowledgeBaseCandidates',
+    );
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+
+    const workspace = await this.workspacesRepository.findById(
+      userId,
+      query.workspaceId,
+    );
+    if (!workspace) throw new WorkspaceNotFoundError(query.workspaceId);
+
+    const [accessible, refs] = await Promise.all([
+      this.knowledgeBaseAccessService.findAllAccessiblePaginated(undefined, {
+        search: query.search,
+        limit: query.limit,
+        offset: query.offset,
+      }),
+      this.workspacesRepository.getContextRefs(query.workspaceId),
+    ]);
+    const documentCounts =
+      await this.knowledgeBaseAccessService.countSourcesByKnowledgeBaseIds(
+        accessible.data.map(({ knowledgeBase }) => knowledgeBase.id),
+      );
+    const attachedIds = new Set(refs.knowledgeBases.map(({ id }) => id));
+    return new Paginated({
+      data: accessible.data.map(({ knowledgeBase }) => ({
+        knowledgeBase,
+        documentCount: documentCounts.get(knowledgeBase.id) ?? 0,
+        isAttached: attachedIds.has(knowledgeBase.id),
+      })),
+      limit: accessible.limit,
+      offset: accessible.offset,
+      total: accessible.total,
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-bases/list-workspace-knowledge-bases.query.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-bases/list-workspace-knowledge-bases.query.ts
@@ -1,0 +1,18 @@
+import type { UUID } from 'crypto';
+import { PaginatedQuery } from 'src/common/pagination/paginated.query';
+
+export class ListWorkspaceKnowledgeBasesQuery extends PaginatedQuery {
+  public readonly workspaceId: UUID;
+  public readonly search?: string;
+
+  constructor(params: {
+    workspaceId: UUID;
+    search?: string;
+    limit: number;
+    offset: number;
+  }) {
+    super({ limit: params.limit, offset: params.offset });
+    this.workspaceId = params.workspaceId;
+    this.search = params.search?.trim() || undefined;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-bases/list-workspace-knowledge-bases.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-bases/list-workspace-knowledge-bases.use-case.spec.ts
@@ -1,0 +1,72 @@
+import type { UUID } from 'crypto';
+import type { ContextService } from 'src/common/context/services/context.service';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import type { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
+import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
+import type { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { ListWorkspaceKnowledgeBasesUseCase } from './list-workspace-knowledge-bases.use-case';
+import { ListWorkspaceKnowledgeBasesQuery } from './list-workspace-knowledge-bases.query';
+
+describe('ListWorkspaceKnowledgeBasesUseCase', () => {
+  it('returns the paginated knowledge bases attached to a workspace', async () => {
+    const workspaceId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+    const knowledgeBase = new KnowledgeBase({
+      id: '223e4567-e89b-12d3-a456-426614174001',
+      name: 'Citizen requests',
+      description: 'Citizen request documents',
+      orgId: '323e4567-e89b-12d3-a456-426614174002',
+      userId: '423e4567-e89b-12d3-a456-426614174003',
+    });
+    const page = new Paginated({
+      data: [{ knowledgeBase, isShared: false }],
+      limit: 2,
+      offset: 4,
+      total: 5,
+    });
+    const workspacesRepository = {
+      findById: jest.fn().mockResolvedValue({}),
+    } as unknown as jest.Mocked<WorkspacesRepository>;
+    const knowledgeBaseAccessService = {
+      findAllAccessiblePaginated: jest.fn().mockResolvedValue(page),
+      countSourcesByKnowledgeBaseIds: jest
+        .fn()
+        .mockResolvedValue(new Map([[knowledgeBase.id, 3]])),
+    } as unknown as jest.Mocked<KnowledgeBaseAccessService>;
+    const contextService = {
+      get: jest.fn().mockReturnValue('523e4567-e89b-12d3-a456-426614174004'),
+    } as unknown as jest.Mocked<ContextService>;
+    const useCase = new ListWorkspaceKnowledgeBasesUseCase(
+      createPinoLoggerMock(),
+      workspacesRepository,
+      knowledgeBaseAccessService,
+      contextService,
+    );
+
+    const result = await useCase.execute(
+      new ListWorkspaceKnowledgeBasesQuery({
+        workspaceId,
+        search: 'citizen',
+        limit: 2,
+        offset: 4,
+      }),
+    );
+
+    expect(result.data).toEqual([
+      {
+        id: knowledgeBase.id,
+        name: knowledgeBase.name,
+        description: knowledgeBase.description,
+        documentCount: 3,
+      },
+    ]);
+    expect(result.total).toBe(5);
+    expect(
+      knowledgeBaseAccessService.findAllAccessiblePaginated,
+    ).toHaveBeenCalledWith(workspaceId, {
+      search: 'citizen',
+      limit: 2,
+      offset: 4,
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-bases/list-workspace-knowledge-bases.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-bases/list-workspace-knowledge-bases.use-case.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
+import type { WorkspaceKnowledgeBaseContext } from 'src/domain/workspaces/domain/workspace-run-context.entity';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceNotFoundError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { ListWorkspaceKnowledgeBasesQuery } from './list-workspace-knowledge-bases.query';
+
+@Injectable()
+export class ListWorkspaceKnowledgeBasesUseCase {
+  constructor(
+    @InjectPinoLogger(ListWorkspaceKnowledgeBasesUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly knowledgeBaseAccessService: KnowledgeBaseAccessService,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(
+    query: ListWorkspaceKnowledgeBasesQuery,
+  ): Promise<Paginated<WorkspaceKnowledgeBaseContext>> {
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+
+    this.logger.info(
+      { workspaceId: query.workspaceId },
+      'listWorkspaceKnowledgeBases',
+    );
+    const workspace = await this.workspacesRepository.findById(
+      userId,
+      query.workspaceId,
+    );
+    if (!workspace) throw new WorkspaceNotFoundError(query.workspaceId);
+
+    const page =
+      await this.knowledgeBaseAccessService.findAllAccessiblePaginated(
+        query.workspaceId,
+        {
+          search: query.search,
+          limit: query.limit,
+          offset: query.offset,
+        },
+      );
+    const counts =
+      await this.knowledgeBaseAccessService.countSourcesByKnowledgeBaseIds(
+        page.data.map(({ knowledgeBase }) => knowledgeBase.id),
+      );
+
+    return new Paginated({
+      data: page.data.map(({ knowledgeBase }) => ({
+        id: knowledgeBase.id,
+        name: knowledgeBase.name,
+        description: knowledgeBase.description,
+        documentCount: counts.get(knowledgeBase.id) ?? 0,
+      })),
+      limit: page.limit,
+      offset: page.offset,
+      total: page.total,
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skill-candidates/list-workspace-skill-candidates.query.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skill-candidates/list-workspace-skill-candidates.query.ts
@@ -1,0 +1,18 @@
+import type { UUID } from 'crypto';
+import { PaginatedQuery } from 'src/common/pagination/paginated.query';
+
+export class ListWorkspaceSkillCandidatesQuery extends PaginatedQuery {
+  public readonly workspaceId: UUID;
+  public readonly search?: string;
+
+  constructor(params: {
+    workspaceId: UUID;
+    search?: string;
+    limit: number;
+    offset: number;
+  }) {
+    super({ limit: params.limit, offset: params.offset });
+    this.workspaceId = params.workspaceId;
+    this.search = params.search?.trim() || undefined;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skill-candidates/list-workspace-skill-candidates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skill-candidates/list-workspace-skill-candidates.use-case.spec.ts
@@ -1,0 +1,68 @@
+import type { UUID } from 'crypto';
+import type { ContextService } from 'src/common/context/services/context.service';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import type { ListAccessibleSkillsUseCase } from 'src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.use-case';
+import { Skill } from 'src/domain/skills/domain/skill.entity';
+import type { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { ListWorkspaceSkillCandidatesUseCase } from './list-workspace-skill-candidates.use-case';
+import { ListWorkspaceSkillCandidatesQuery } from './list-workspace-skill-candidates.query';
+
+describe('ListWorkspaceSkillCandidatesUseCase', () => {
+  it('returns a paginated candidate page with attachment state', async () => {
+    const workspaceId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+    const skillId = '223e4567-e89b-12d3-a456-426614174001' as UUID;
+    const skill = new Skill({
+      id: skillId,
+      name: 'Citizen requests',
+      shortDescription: 'Handles citizen requests',
+      instructions: 'Use the request workflow',
+      userId: '323e4567-e89b-12d3-a456-426614174002',
+    });
+    const page = new Paginated({
+      data: [skill],
+      limit: 2,
+      offset: 4,
+      total: 5,
+    });
+    const workspacesRepository = {
+      findById: jest.fn().mockResolvedValue({}),
+      getContextRefs: jest.fn().mockResolvedValue({
+        skillIds: [skillId],
+        knowledgeBases: [],
+        sourceIds: [],
+      }),
+    } as unknown as jest.Mocked<WorkspacesRepository>;
+    const listAccessibleSkillsUseCase = {
+      execute: jest.fn().mockResolvedValue(page),
+    } as unknown as jest.Mocked<ListAccessibleSkillsUseCase>;
+    const contextService = {
+      get: jest.fn().mockReturnValue('423e4567-e89b-12d3-a456-426614174003'),
+    } as unknown as jest.Mocked<ContextService>;
+    const useCase = new ListWorkspaceSkillCandidatesUseCase(
+      createPinoLoggerMock(),
+      workspacesRepository,
+      listAccessibleSkillsUseCase,
+      contextService,
+    );
+
+    const result = await useCase.execute(
+      new ListWorkspaceSkillCandidatesQuery({
+        workspaceId,
+        search: 'citizen',
+        limit: 2,
+        offset: 4,
+      }),
+    );
+
+    expect(result.data).toEqual([{ skill, isAttached: true }]);
+    expect(result.total).toBe(5);
+    expect(listAccessibleSkillsUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: 'citizen',
+        limit: 2,
+        offset: 4,
+      }),
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skill-candidates/list-workspace-skill-candidates.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skill-candidates/list-workspace-skill-candidates.use-case.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { ListAccessibleSkillsUseCase } from 'src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.use-case';
+import { ListAccessibleSkillsQuery } from 'src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.query';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import type { Skill } from 'src/domain/skills/domain/skill.entity';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceNotFoundError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { ListWorkspaceSkillCandidatesQuery } from './list-workspace-skill-candidates.query';
+
+export interface WorkspaceSkillCandidate {
+  skill: Skill;
+  isAttached: boolean;
+}
+
+@Injectable()
+export class ListWorkspaceSkillCandidatesUseCase {
+  constructor(
+    @InjectPinoLogger(ListWorkspaceSkillCandidatesUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly listAccessibleSkillsUseCase: ListAccessibleSkillsUseCase,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(
+    query: ListWorkspaceSkillCandidatesQuery,
+  ): Promise<Paginated<WorkspaceSkillCandidate>> {
+    this.logger.info(
+      {
+        workspaceId: query.workspaceId,
+      },
+      'listWorkspaceSkillCandidates',
+    );
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+
+    const workspace = await this.workspacesRepository.findById(
+      userId,
+      query.workspaceId,
+    );
+    if (!workspace) throw new WorkspaceNotFoundError(query.workspaceId);
+
+    const [skills, refs] = await Promise.all([
+      this.listAccessibleSkillsUseCase.execute(
+        new ListAccessibleSkillsQuery({
+          search: query.search,
+          limit: query.limit,
+          offset: query.offset,
+        }),
+      ),
+      this.workspacesRepository.getContextRefs(query.workspaceId),
+    ]);
+    const attachedIds = new Set(refs.skillIds);
+    return new Paginated({
+      data: skills.data.map((skill) => ({
+        skill,
+        isAttached: attachedIds.has(skill.id),
+      })),
+      limit: skills.limit,
+      offset: skills.offset,
+      total: skills.total,
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skills/list-workspace-skills.query.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skills/list-workspace-skills.query.ts
@@ -1,0 +1,18 @@
+import type { UUID } from 'crypto';
+import { PaginatedQuery } from 'src/common/pagination/paginated.query';
+
+export class ListWorkspaceSkillsQuery extends PaginatedQuery {
+  public readonly workspaceId: UUID;
+  public readonly search?: string;
+
+  constructor(params: {
+    workspaceId: UUID;
+    search?: string;
+    limit: number;
+    offset: number;
+  }) {
+    super({ limit: params.limit, offset: params.offset });
+    this.workspaceId = params.workspaceId;
+    this.search = params.search?.trim() || undefined;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skills/list-workspace-skills.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skills/list-workspace-skills.use-case.spec.ts
@@ -1,0 +1,62 @@
+import type { UUID } from 'crypto';
+import type { ContextService } from 'src/common/context/services/context.service';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import type { ListAccessibleSkillsUseCase } from 'src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.use-case';
+import { Skill } from 'src/domain/skills/domain/skill.entity';
+import type { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { ListWorkspaceSkillsUseCase } from './list-workspace-skills.use-case';
+import { ListWorkspaceSkillsQuery } from './list-workspace-skills.query';
+
+describe('ListWorkspaceSkillsUseCase', () => {
+  it('returns the paginated skills attached to a workspace', async () => {
+    const workspaceId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+    const skill = new Skill({
+      id: '223e4567-e89b-12d3-a456-426614174001',
+      name: 'Citizen requests',
+      shortDescription: 'Handles citizen requests',
+      instructions: 'Use the request workflow',
+      userId: '323e4567-e89b-12d3-a456-426614174002',
+    });
+    const page = new Paginated({
+      data: [skill],
+      limit: 2,
+      offset: 4,
+      total: 5,
+    });
+    const workspacesRepository = {
+      findById: jest.fn().mockResolvedValue({}),
+    } as unknown as jest.Mocked<WorkspacesRepository>;
+    const listAccessibleSkillsUseCase = {
+      execute: jest.fn().mockResolvedValue(page),
+    } as unknown as jest.Mocked<ListAccessibleSkillsUseCase>;
+    const contextService = {
+      get: jest.fn().mockReturnValue('423e4567-e89b-12d3-a456-426614174003'),
+    } as unknown as jest.Mocked<ContextService>;
+    const useCase = new ListWorkspaceSkillsUseCase(
+      createPinoLoggerMock(),
+      workspacesRepository,
+      listAccessibleSkillsUseCase,
+      contextService,
+    );
+
+    const result = await useCase.execute(
+      new ListWorkspaceSkillsQuery({
+        workspaceId,
+        search: 'citizen',
+        limit: 2,
+        offset: 4,
+      }),
+    );
+
+    expect(result).toBe(page);
+    expect(listAccessibleSkillsUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: 'citizen',
+        workspaceId,
+        limit: 2,
+        offset: 4,
+      }),
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skills/list-workspace-skills.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skills/list-workspace-skills.use-case.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import { ListAccessibleSkillsUseCase } from 'src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.use-case';
+import { ListAccessibleSkillsQuery } from 'src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.query';
+import type { Skill } from 'src/domain/skills/domain/skill.entity';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceNotFoundError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { ListWorkspaceSkillsQuery } from './list-workspace-skills.query';
+
+@Injectable()
+export class ListWorkspaceSkillsUseCase {
+  constructor(
+    @InjectPinoLogger(ListWorkspaceSkillsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly listAccessibleSkillsUseCase: ListAccessibleSkillsUseCase,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(query: ListWorkspaceSkillsQuery): Promise<Paginated<Skill>> {
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+
+    this.logger.info({ workspaceId: query.workspaceId }, 'listWorkspaceSkills');
+    const workspace = await this.workspacesRepository.findById(
+      userId,
+      query.workspaceId,
+    );
+    if (!workspace) throw new WorkspaceNotFoundError(query.workspaceId);
+
+    return this.listAccessibleSkillsUseCase.execute(
+      new ListAccessibleSkillsQuery({
+        workspaceId: query.workspaceId,
+        search: query.search,
+        limit: query.limit,
+        offset: query.offset,
+      }),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-document-from-workspace/remove-document-from-workspace.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-document-from-workspace/remove-document-from-workspace.command.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class RemoveDocumentFromWorkspaceCommand {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly sourceId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-document-from-workspace/remove-document-from-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-document-from-workspace/remove-document-from-workspace.use-case.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { DeleteSourceCommand } from 'src/domain/sources/application/use-cases/delete-source/delete-source.command';
+import { DeleteSourceUseCase } from 'src/domain/sources/application/use-cases/delete-source/delete-source.use-case';
+import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceNotFoundError,
+} from '../../workspaces.errors';
+import { RemoveDocumentFromWorkspaceCommand } from './remove-document-from-workspace.command';
+
+@Injectable()
+export class RemoveDocumentFromWorkspaceUseCase {
+  constructor(
+    @InjectPinoLogger(RemoveDocumentFromWorkspaceUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly deleteSourceUseCase: DeleteSourceUseCase,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(command: RemoveDocumentFromWorkspaceCommand): Promise<void> {
+    this.logger.info(
+      {
+        workspaceId: command.workspaceId,
+        sourceId: command.sourceId,
+      },
+      'removeDocumentFromWorkspace',
+    );
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+
+    const workspace = await this.workspacesRepository.findById(
+      userId,
+      command.workspaceId,
+    );
+    if (!workspace) throw new WorkspaceNotFoundError(command.workspaceId);
+
+    const refs = await this.workspacesRepository.getContextRefs(
+      command.workspaceId,
+    );
+    if (!refs.sourceIds.includes(command.sourceId)) return;
+
+    await this.deleteSourceUseCase.execute(
+      new DeleteSourceCommand(command.sourceId, workspace.orgId),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-instruction/update-workspace-instruction.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-instruction/update-workspace-instruction.command.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class UpdateWorkspaceInstructionCommand {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly instruction: string | null,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-instruction/update-workspace-instruction.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-instruction/update-workspace-instruction.use-case.spec.ts
@@ -1,0 +1,53 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import {
+  createMockContextService,
+  createMockWorkspacesRepository,
+  TEST_WORKSPACE_ID,
+  aWorkspace,
+} from '../../testing/workspace.fixtures';
+import { UpdateWorkspaceInstructionCommand } from './update-workspace-instruction.command';
+import { UpdateWorkspaceInstructionUseCase } from './update-workspace-instruction.use-case';
+
+describe('UpdateWorkspaceInstructionUseCase', () => {
+  it('stores trimmed project instructions', async () => {
+    const repository = createMockWorkspacesRepository();
+    repository.findById.mockResolvedValue(aWorkspace());
+    const useCase = new UpdateWorkspaceInstructionUseCase(
+      createPinoLoggerMock(),
+      repository,
+      createMockContextService(),
+    );
+
+    const result = await useCase.execute(
+      new UpdateWorkspaceInstructionCommand(
+        TEST_WORKSPACE_ID,
+        '  Use building department wording.  ',
+      ),
+    );
+
+    expect(result.instruction).toBe('Use building department wording.');
+    expect(repository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instruction: 'Use building department wording.',
+      }),
+    );
+  });
+
+  it('clears blank project instructions', async () => {
+    const repository = createMockWorkspacesRepository();
+    repository.findById.mockResolvedValue(
+      aWorkspace({ instruction: 'Use building department wording.' }),
+    );
+    const useCase = new UpdateWorkspaceInstructionUseCase(
+      createPinoLoggerMock(),
+      repository,
+      createMockContextService(),
+    );
+
+    const result = await useCase.execute(
+      new UpdateWorkspaceInstructionCommand(TEST_WORKSPACE_ID, '   '),
+    );
+
+    expect(result.instruction).toBeNull();
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-instruction/update-workspace-instruction.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-instruction/update-workspace-instruction.use-case.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceNotFoundError,
+} from '../../workspaces.errors';
+import { UpdateWorkspaceInstructionCommand } from './update-workspace-instruction.command';
+
+@Injectable()
+export class UpdateWorkspaceInstructionUseCase {
+  constructor(
+    @InjectPinoLogger(UpdateWorkspaceInstructionUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(
+    command: UpdateWorkspaceInstructionCommand,
+  ): Promise<Workspace> {
+    this.logger.info(
+      {
+        workspaceId: command.workspaceId,
+      },
+      'updateWorkspaceInstruction',
+    );
+    const userId = this.contextService.get('userId');
+    if (!userId) throw new UnauthorizedAccessError();
+
+    const workspace = await this.workspacesRepository.findById(
+      userId,
+      command.workspaceId,
+    );
+    if (!workspace) throw new WorkspaceNotFoundError(command.workspaceId);
+
+    workspace.instruct(command.instruction?.trim() || null);
+    return this.workspacesRepository.save(workspace);
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/workspaces.errors.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/workspaces.errors.ts
@@ -6,6 +6,8 @@ export enum WorkspaceErrorCode {
   WORKSPACE_INVALID_NAME = 'WORKSPACE_INVALID_NAME',
   WORKSPACE_INVALID_DESCRIPTION = 'WORKSPACE_INVALID_DESCRIPTION',
   WORKSPACE_INVALID_APPEARANCE = 'WORKSPACE_INVALID_APPEARANCE',
+  MISSING_FILE = 'MISSING_FILE',
+  WORKSPACE_SOURCE_LIMIT_EXCEEDED = 'WORKSPACE_SOURCE_LIMIT_EXCEEDED',
   UNEXPECTED_WORKSPACE_ERROR = 'UNEXPECTED_WORKSPACE_ERROR',
 }
 
@@ -63,6 +65,28 @@ export class InvalidWorkspaceAppearanceError extends WorkspaceError {
       WorkspaceErrorCode.WORKSPACE_INVALID_APPEARANCE,
       400,
       { field, ...metadata },
+    );
+  }
+}
+
+export class MissingWorkspaceDocumentFileError extends WorkspaceError {
+  constructor(metadata?: ErrorMetadata) {
+    super(
+      'No file was provided in the request',
+      WorkspaceErrorCode.MISSING_FILE,
+      400,
+      metadata,
+    );
+  }
+}
+
+export class WorkspaceSourceLimitExceededError extends WorkspaceError {
+  constructor(maxSources: number, metadata?: ErrorMetadata) {
+    super(
+      `Workspace cannot have more than ${maxSources} sources`,
+      WorkspaceErrorCode.WORKSPACE_SOURCE_LIMIT_EXCEEDED,
+      400,
+      { maxSources, ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/workspaces/domain/workspace-run-context.entity.ts
+++ b/ayunis-core-backend/src/domain/workspaces/domain/workspace-run-context.entity.ts
@@ -1,0 +1,19 @@
+import type { UUID } from 'crypto';
+import type { Skill } from 'src/domain/skills/domain/skill.entity';
+import type { Source } from 'src/domain/sources/domain/source.entity';
+import type { KnowledgeBaseSummary } from 'src/domain/knowledge-bases/domain/knowledge-base-summary';
+
+export interface WorkspaceKnowledgeBaseContext extends KnowledgeBaseSummary {
+  description: string | null;
+  documentCount: number;
+}
+
+export interface WorkspaceRunContext {
+  instruction: string | null;
+  skills: Skill[];
+  knowledgeBases: WorkspaceKnowledgeBaseContext[];
+  sources: Source[];
+  runtimeKnowledgeBases: WorkspaceKnowledgeBaseContext[];
+  runtimeSources: Source[];
+  mcpIntegrationIds: UUID[];
+}

--- a/ayunis-core-backend/src/domain/workspaces/domain/workspace.entity.ts
+++ b/ayunis-core-backend/src/domain/workspaces/domain/workspace.entity.ts
@@ -12,6 +12,7 @@ export class Workspace {
   public readonly createdAt: Date;
   public name: string;
   public description: string | null;
+  public instruction: string | null;
   public icon: string;
   public color: string;
   public updatedAt: Date;
@@ -22,6 +23,7 @@ export class Workspace {
     orgId: UUID;
     name: string;
     description?: string | null;
+    instruction?: string | null;
     icon?: string;
     color?: string;
     createdAt?: Date;
@@ -32,6 +34,7 @@ export class Workspace {
     this.orgId = params.orgId;
     this.name = params.name;
     this.description = params.description ?? null;
+    this.instruction = params.instruction ?? null;
     this.icon = params.icon ?? DEFAULT_WORKSPACE_ICON;
     this.color = params.color ?? DEFAULT_WORKSPACE_COLOR;
     this.createdAt = params.createdAt ?? new Date();
@@ -45,6 +48,11 @@ export class Workspace {
 
   describe(description: string | null): void {
     this.description = description;
+    this.touch();
+  }
+
+  instruct(instruction: string | null): void {
+    this.instruction = instruction;
     this.touch();
   }
 

--- a/ayunis-core-backend/src/domain/workspaces/domain/workspaces.constants.ts
+++ b/ayunis-core-backend/src/domain/workspaces/domain/workspaces.constants.ts
@@ -3,6 +3,11 @@ export const WORKSPACE_DESCRIPTION_MAX_LENGTH = 1000;
 
 export const DEFAULT_WORKSPACE_ICON = 'folder';
 export const DEFAULT_WORKSPACE_COLOR = 'violet';
+export const WORKSPACE_MAX_SOURCES = 500;
+export const WORKSPACE_DEFAULT_LIST_LIMIT = 20;
+export const WORKSPACE_MAX_LIST_LIMIT = 100;
+export const WORKSPACE_CONTEXT_DEFAULT_LIST_LIMIT = 20;
+export const WORKSPACE_CONTEXT_MAX_LIST_LIMIT = 100;
 
 /**
  * Icons and colours are chosen from a catalogue the frontend owns; the backend

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces-repository.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces-repository.module.ts
@@ -1,11 +1,21 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { WorkspaceRecord } from './schema/workspace.record';
+import { WorkspaceSkillAssignmentRecord } from './schema/workspace-skill-assignment.record';
+import { WorkspaceKnowledgeBaseAssignmentRecord } from './schema/workspace-knowledge-base-assignment.record';
+import { WorkspaceSourceAssignmentRecord } from './schema/workspace-source-assignment.record';
 import { LocalWorkspacesRepository } from './local-workspaces.repository';
 import { WorkspaceMapper } from './mappers/workspace.mapper';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([WorkspaceRecord])],
+  imports: [
+    TypeOrmModule.forFeature([
+      WorkspaceRecord,
+      WorkspaceSkillAssignmentRecord,
+      WorkspaceKnowledgeBaseAssignmentRecord,
+      WorkspaceSourceAssignmentRecord,
+    ]),
+  ],
   providers: [LocalWorkspacesRepository, WorkspaceMapper],
   exports: [LocalWorkspacesRepository],
 })

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.spec.ts
@@ -1,0 +1,57 @@
+import { randomUUID } from 'crypto';
+import type { Repository } from 'typeorm';
+import { LocalWorkspacesRepository } from './local-workspaces.repository';
+import type { WorkspaceMapper } from './mappers/workspace.mapper';
+import type { WorkspaceRecord } from './schema/workspace.record';
+import type { WorkspaceSkillAssignmentRecord } from './schema/workspace-skill-assignment.record';
+import type { WorkspaceKnowledgeBaseAssignmentRecord } from './schema/workspace-knowledge-base-assignment.record';
+import type { WorkspaceSourceAssignmentRecord } from './schema/workspace-source-assignment.record';
+
+describe('LocalWorkspacesRepository', () => {
+  it('quotes the computed activity alias for PostgreSQL ordering', async () => {
+    const countQuery = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getCount: jest.fn().mockResolvedValue(0),
+    };
+    const listQuery = {
+      leftJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      addGroupBy: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue([]),
+    };
+    const workspaceRepository = {
+      createQueryBuilder: jest
+        .fn()
+        .mockReturnValueOnce(countQuery)
+        .mockReturnValueOnce(listQuery),
+    } as unknown as Repository<WorkspaceRecord>;
+    const mapper = {
+      toDomain: jest.fn(),
+    } as unknown as WorkspaceMapper;
+    const repository = new LocalWorkspacesRepository(
+      workspaceRepository,
+      {} as Repository<WorkspaceSkillAssignmentRecord>,
+      {} as Repository<WorkspaceKnowledgeBaseAssignmentRecord>,
+      {} as Repository<WorkspaceSourceAssignmentRecord>,
+      mapper,
+    );
+
+    await repository.findAllByUserId(randomUUID(), {
+      sort: 'updatedAt',
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(listQuery.orderBy).toHaveBeenCalledWith(
+      '"effectiveActivityAt"',
+      'DESC',
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.ts
@@ -1,32 +1,126 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import type { UUID } from 'crypto';
+import { randomUUID, type UUID } from 'crypto';
 import {
   WorkspacesRepository,
+  type WorkspaceContextRefs,
   type WorkspaceThreadStats,
 } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
-import { In, Repository } from 'typeorm';
+import { In, Repository, SelectQueryBuilder } from 'typeorm';
 import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
 import { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import { WorkspaceMapper } from './mappers/workspace.mapper';
 import { WorkspaceRecord } from './schema/workspace.record';
+import { WorkspaceSkillAssignmentRecord } from './schema/workspace-skill-assignment.record';
+import { WorkspaceKnowledgeBaseAssignmentRecord } from './schema/workspace-knowledge-base-assignment.record';
+import { WorkspaceSourceAssignmentRecord } from './schema/workspace-source-assignment.record';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import type {
+  WorkspaceListOptions,
+  WorkspaceSortKey,
+} from 'src/domain/workspaces/application/ports/workspaces-repository.port';
 
 @Injectable()
 export class LocalWorkspacesRepository extends WorkspacesRepository {
   constructor(
     @InjectRepository(WorkspaceRecord)
     private readonly repo: Repository<WorkspaceRecord>,
+    @InjectRepository(WorkspaceSkillAssignmentRecord)
+    private readonly skillAssignmentsRepo: Repository<WorkspaceSkillAssignmentRecord>,
+    @InjectRepository(WorkspaceKnowledgeBaseAssignmentRecord)
+    private readonly knowledgeBaseAssignmentsRepo: Repository<WorkspaceKnowledgeBaseAssignmentRecord>,
+    @InjectRepository(WorkspaceSourceAssignmentRecord)
+    private readonly sourceAssignmentsRepo: Repository<WorkspaceSourceAssignmentRecord>,
     private readonly mapper: WorkspaceMapper,
   ) {
     super();
   }
 
-  async findAllByUserId(userId: UUID): Promise<Workspace[]> {
-    const records = await this.repo.find({
-      where: { userId },
-      order: { updatedAt: 'DESC' },
+  async findAllByUserId(
+    userId: UUID,
+    query: WorkspaceListOptions,
+  ): Promise<Paginated<Workspace>> {
+    const countQuery = this.createWorkspaceCountQuery(userId, query);
+    const listQuery = this.createWorkspaceListQuery(userId, query);
+
+    const [records, total] = await Promise.all([
+      listQuery
+        .addOrderBy('workspace.id', 'ASC')
+        .skip(query.offset)
+        .take(query.limit)
+        .getMany(),
+      countQuery.getCount(),
+    ]);
+
+    return new Paginated({
+      data: records.map((record) => this.mapper.toDomain(record)),
+      limit: query.limit,
+      offset: query.offset,
+      total,
     });
-    return records.map((record) => this.mapper.toDomain(record));
+  }
+
+  private createWorkspaceCountQuery(
+    userId: UUID,
+    query: Pick<WorkspaceListOptions, 'search'>,
+  ): SelectQueryBuilder<WorkspaceRecord> {
+    const countQuery = this.repo
+      .createQueryBuilder('workspace')
+      .where('workspace.userId = :userId', { userId });
+    this.applyWorkspaceSearch(countQuery, query.search);
+    return countQuery;
+  }
+
+  private createWorkspaceListQuery(
+    userId: UUID,
+    query: Pick<WorkspaceListOptions, 'search' | 'sort'>,
+  ): SelectQueryBuilder<WorkspaceRecord> {
+    const listQuery = this.repo
+      .createQueryBuilder('workspace')
+      .leftJoin('threads', 'thread', 'thread."workspaceId" = workspace.id')
+      .where('workspace.userId = :userId', { userId })
+      .addGroupBy('workspace.id');
+
+    this.applyWorkspaceSearch(listQuery, query.search);
+    this.applyWorkspaceSort(listQuery, query.sort);
+    return listQuery;
+  }
+
+  private applyWorkspaceSearch(
+    query: SelectQueryBuilder<WorkspaceRecord>,
+    search?: string,
+  ): void {
+    if (search) {
+      query.andWhere('workspace.name ILIKE :search', {
+        search: `%${search}%`,
+      });
+    }
+  }
+
+  private applyWorkspaceSort(
+    query: SelectQueryBuilder<WorkspaceRecord>,
+    sort: WorkspaceSortKey,
+  ): void {
+    if (sort === 'name') {
+      query.orderBy('LOWER(workspace.name)', 'ASC');
+      return;
+    }
+    if (sort === 'createdAt') {
+      query.orderBy('workspace.createdAt', 'DESC');
+      return;
+    }
+    query
+      .addSelect(
+        `GREATEST(
+           workspace."updatedAt",
+           COALESCE(
+             MAX(COALESCE(thread."lastActivityAt", thread."createdAt")),
+             workspace."updatedAt"
+           )
+         )`,
+        'effectiveActivityAt',
+      )
+      .orderBy('"effectiveActivityAt"', 'DESC');
   }
 
   async findAllByIds(userId: UUID, ids: UUID[]): Promise<Workspace[]> {
@@ -75,10 +169,89 @@ export class LocalWorkspacesRepository extends WorkspacesRepository {
     return this.mapper.toDomain(saved);
   }
 
-  async delete(userId: UUID, id: UUID): Promise<void> {
-    const result = await this.repo.delete({ userId, id });
-    if (!result.affected) {
-      throw new WorkspaceNotFoundError(id);
-    }
+  async attachSkill(workspaceId: UUID, skillId: UUID): Promise<void> {
+    await this.skillAssignmentsRepo
+      .createQueryBuilder()
+      .insert()
+      .values({ id: randomUUID(), workspaceId, skillId })
+      .orIgnore()
+      .execute();
+  }
+
+  async detachSkill(workspaceId: UUID, skillId: UUID): Promise<void> {
+    await this.skillAssignmentsRepo.delete({ workspaceId, skillId });
+  }
+
+  async attachKnowledgeBase(
+    workspaceId: UUID,
+    knowledgeBaseId: UUID,
+  ): Promise<void> {
+    await this.knowledgeBaseAssignmentsRepo
+      .createQueryBuilder()
+      .insert()
+      .values({ id: randomUUID(), workspaceId, knowledgeBaseId })
+      .orIgnore()
+      .execute();
+  }
+
+  async detachKnowledgeBase(
+    workspaceId: UUID,
+    knowledgeBaseId: UUID,
+  ): Promise<void> {
+    await this.knowledgeBaseAssignmentsRepo.delete({
+      workspaceId,
+      knowledgeBaseId,
+    });
+  }
+
+  async attachSource(workspaceId: UUID, sourceId: UUID): Promise<void> {
+    await this.sourceAssignmentsRepo
+      .createQueryBuilder()
+      .insert()
+      .values({ id: randomUUID(), workspaceId, sourceId })
+      .orIgnore()
+      .execute();
+  }
+
+  async getContextRefs(workspaceId: UUID): Promise<WorkspaceContextRefs> {
+    const [skillAssignments, knowledgeBaseAssignments, sourceAssignments] =
+      await Promise.all([
+        this.skillAssignmentsRepo.find({ where: { workspaceId } }),
+        this.knowledgeBaseAssignmentsRepo.find({
+          where: { workspaceId },
+          relations: { knowledgeBase: true },
+        }),
+        this.sourceAssignmentsRepo.find({ where: { workspaceId } }),
+      ]);
+
+    return {
+      skillIds: skillAssignments.map((assignment) => assignment.skillId),
+      knowledgeBases: knowledgeBaseAssignments.map((assignment) => ({
+        id: assignment.knowledgeBaseId,
+        name: assignment.knowledgeBase.name,
+        description: assignment.knowledgeBase.description,
+        documentCount: 0,
+      })),
+      sourceIds: sourceAssignments.map((assignment) => assignment.sourceId),
+    };
+  }
+
+  async delete(userId: UUID, id: UUID): Promise<UUID[]> {
+    return this.repo.manager.transaction(async (manager) => {
+      const workspaces: Array<{ id: UUID }> = await manager.query(
+        `SELECT id FROM workspaces WHERE id = $1 AND "userId" = $2 FOR UPDATE`,
+        [id, userId],
+      );
+      if (workspaces.length === 0) throw new WorkspaceNotFoundError(id);
+
+      const sourceRows: Array<{ sourceId: UUID }> = await manager.query(
+        `DELETE FROM workspace_source_assignments
+         WHERE "workspaceId" = $1
+         RETURNING "sourceId"`,
+        [id],
+      );
+      await manager.delete(WorkspaceRecord, { id });
+      return sourceRows.map((row) => row.sourceId);
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace.mapper.ts
@@ -11,6 +11,7 @@ export class WorkspaceMapper {
       orgId: record.orgId,
       name: record.name,
       description: record.description,
+      instruction: record.instruction,
       icon: record.icon,
       color: record.color,
       createdAt: record.createdAt,
@@ -25,6 +26,7 @@ export class WorkspaceMapper {
     record.orgId = domain.orgId;
     record.name = domain.name;
     record.description = domain.description;
+    record.instruction = domain.instruction;
     record.icon = domain.icon;
     record.color = domain.color;
     record.createdAt = domain.createdAt;

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace-knowledge-base-assignment.record.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace-knowledge-base-assignment.record.ts
@@ -1,0 +1,28 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne, Unique } from 'typeorm';
+import type { UUID } from 'crypto';
+import { BaseRecord } from 'src/common/db/base-record';
+import { KnowledgeBaseRecord } from 'src/domain/knowledge-bases/infrastructure/persistence/local/schema/knowledge-base.record';
+import { WorkspaceRecord } from './workspace.record';
+
+@Entity({ name: 'workspace_knowledge_base_assignments' })
+@Unique(['workspaceId', 'knowledgeBaseId'])
+export class WorkspaceKnowledgeBaseAssignmentRecord extends BaseRecord {
+  @Column()
+  @Index()
+  workspaceId: UUID;
+
+  @ManyToOne(() => WorkspaceRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'workspaceId' })
+  workspace: WorkspaceRecord;
+
+  @Column()
+  @Index()
+  knowledgeBaseId: UUID;
+
+  @ManyToOne(() => KnowledgeBaseRecord, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'knowledgeBaseId' })
+  knowledgeBase: KnowledgeBaseRecord;
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace-skill-assignment.record.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace-skill-assignment.record.ts
@@ -1,0 +1,25 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne, Unique } from 'typeorm';
+import type { UUID } from 'crypto';
+import { BaseRecord } from 'src/common/db/base-record';
+import { SkillRecord } from 'src/domain/skills/infrastructure/persistence/local/schema/skill.record';
+import { WorkspaceRecord } from './workspace.record';
+
+@Entity({ name: 'workspace_skill_assignments' })
+@Unique(['workspaceId', 'skillId'])
+export class WorkspaceSkillAssignmentRecord extends BaseRecord {
+  @Column()
+  @Index()
+  workspaceId: UUID;
+
+  @ManyToOne(() => WorkspaceRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'workspaceId' })
+  workspace: WorkspaceRecord;
+
+  @Column()
+  @Index()
+  skillId: UUID;
+
+  @ManyToOne(() => SkillRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'skillId' })
+  skill: SkillRecord;
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace-source-assignment.record.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace-source-assignment.record.ts
@@ -1,0 +1,25 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne, Unique } from 'typeorm';
+import type { UUID } from 'crypto';
+import { BaseRecord } from 'src/common/db/base-record';
+import { SourceRecord } from 'src/domain/sources/infrastructure/persistence/local/schema/source.record';
+import { WorkspaceRecord } from './workspace.record';
+
+@Entity({ name: 'workspace_source_assignments' })
+@Unique(['workspaceId', 'sourceId'])
+export class WorkspaceSourceAssignmentRecord extends BaseRecord {
+  @Column()
+  @Index()
+  workspaceId: UUID;
+
+  @ManyToOne(() => WorkspaceRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'workspaceId' })
+  workspace: WorkspaceRecord;
+
+  @Column()
+  @Index()
+  sourceId: UUID;
+
+  @ManyToOne(() => SourceRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'sourceId' })
+  source: SourceRecord;
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace.record.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace.record.ts
@@ -12,6 +12,9 @@ export class WorkspaceRecord extends BaseRecord {
   @Column({ type: 'varchar', length: 1000, nullable: true })
   description: string | null;
 
+  @Column({ type: 'text', nullable: true })
+  instruction: string | null;
+
   @Column({ type: 'varchar', length: 64 })
   icon: string;
 

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/find-all-workspaces-query-params.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/find-all-workspaces-query-params.dto.ts
@@ -1,0 +1,25 @@
+import { Type } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, IsString, Min } from 'class-validator';
+import type { WorkspaceSortKey } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+
+export class FindAllWorkspacesQueryParamsDto {
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @IsIn(['updatedAt', 'createdAt', 'name'])
+  sort?: WorkspaceSortKey;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  limit?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Type(() => Number)
+  offset?: number;
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/update-workspace-instruction.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/update-workspace-instruction.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDefined, IsString, MaxLength, ValidateIf } from 'class-validator';
+
+export class UpdateWorkspaceInstructionDto {
+  @ApiProperty({
+    type: String,
+    description: 'Instructions that apply to every chat in the workspace',
+    nullable: true,
+    maxLength: 10000,
+  })
+  @IsDefined()
+  @ValidateIf((dto: UpdateWorkspaceInstructionDto) => dto.instruction !== null)
+  @IsString()
+  @MaxLength(10000)
+  instruction: string | null;
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-context-list-query.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-context-list-query.dto.ts
@@ -1,0 +1,35 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Min } from 'class-validator';
+import {
+  WORKSPACE_CONTEXT_DEFAULT_LIST_LIMIT,
+  WORKSPACE_CONTEXT_MAX_LIST_LIMIT,
+} from 'src/domain/workspaces/domain/workspaces.constants';
+
+export class WorkspaceContextListQueryDto {
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  limit?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Type(() => Number)
+  offset?: number;
+
+  toQuery() {
+    return {
+      search: this.search,
+      limit: Math.min(
+        this.limit ?? WORKSPACE_CONTEXT_DEFAULT_LIST_LIMIT,
+        WORKSPACE_CONTEXT_MAX_LIST_LIMIT,
+      ),
+      offset: this.offset ?? 0,
+    };
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-context-response.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-context-response.dto.ts
@@ -1,0 +1,129 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
+import {
+  SourceType,
+  TextType,
+} from 'src/domain/sources/domain/source-type.enum';
+import { SourceCreator } from 'src/domain/sources/domain/source-creator.enum';
+import { PaginationDto } from 'src/common/pagination/pagination.dto';
+
+export class WorkspaceSkillResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  shortDescription: string;
+}
+
+export class WorkspaceSkillCandidateResponseDto extends WorkspaceSkillResponseDto {
+  @ApiProperty()
+  isAttached: boolean;
+}
+
+export class WorkspaceKnowledgeBaseResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty({ type: String, nullable: true })
+  description: string | null;
+
+  @ApiProperty()
+  documentCount: number;
+}
+
+export class WorkspaceKnowledgeBaseCandidateResponseDto extends WorkspaceKnowledgeBaseResponseDto {
+  @ApiProperty()
+  isAttached: boolean;
+}
+
+export class WorkspaceDocumentResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty({ enum: SourceType })
+  type: SourceType;
+
+  @ApiProperty({ enum: SourceCreator })
+  createdBy: SourceCreator;
+
+  @ApiProperty({ enum: SourceStatus })
+  status: SourceStatus;
+
+  @ApiProperty({ type: String, nullable: true })
+  processingError?: string | null;
+
+  @ApiProperty({ enum: TextType, required: false })
+  textType?: TextType;
+
+  @ApiProperty({ required: false })
+  url?: string;
+
+  @ApiProperty()
+  createdAt: string;
+
+  @ApiProperty()
+  updatedAt: string;
+}
+
+export class WorkspaceContextResponseDto {
+  @ApiProperty({ type: String, nullable: true })
+  instruction: string | null;
+
+  @ApiProperty({ type: [WorkspaceSkillResponseDto] })
+  skills: WorkspaceSkillResponseDto[];
+
+  @ApiProperty({ type: [WorkspaceKnowledgeBaseResponseDto] })
+  knowledgeBases: WorkspaceKnowledgeBaseResponseDto[];
+
+  @ApiProperty({ type: [WorkspaceDocumentResponseDto] })
+  documents: WorkspaceDocumentResponseDto[];
+}
+
+export class WorkspaceSkillListResponseDto {
+  @ApiProperty({ type: [WorkspaceSkillResponseDto] })
+  data: WorkspaceSkillResponseDto[];
+
+  @ApiProperty({ type: PaginationDto })
+  pagination: PaginationDto;
+}
+
+export class WorkspaceKnowledgeBaseListResponseDto {
+  @ApiProperty({ type: [WorkspaceKnowledgeBaseResponseDto] })
+  data: WorkspaceKnowledgeBaseResponseDto[];
+
+  @ApiProperty({ type: PaginationDto })
+  pagination: PaginationDto;
+}
+
+export class WorkspaceDocumentListResponseDto {
+  @ApiProperty({ type: [WorkspaceDocumentResponseDto] })
+  data: WorkspaceDocumentResponseDto[];
+
+  @ApiProperty({ type: PaginationDto })
+  pagination: PaginationDto;
+}
+
+export class WorkspaceSkillCandidateListResponseDto {
+  @ApiProperty({ type: [WorkspaceSkillCandidateResponseDto] })
+  data: WorkspaceSkillCandidateResponseDto[];
+
+  @ApiProperty({ type: PaginationDto })
+  pagination: PaginationDto;
+}
+
+export class WorkspaceKnowledgeBaseCandidateListResponseDto {
+  @ApiProperty({ type: [WorkspaceKnowledgeBaseCandidateResponseDto] })
+  data: WorkspaceKnowledgeBaseCandidateResponseDto[];
+
+  @ApiProperty({ type: PaginationDto })
+  pagination: PaginationDto;
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-list-response.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-list-response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PaginationDto } from 'src/common/pagination/pagination.dto';
+import { WorkspaceResponseDto } from './workspace-response.dto';
+
+export class WorkspaceListResponseDto {
+  @ApiProperty({ type: [WorkspaceResponseDto] })
+  data: WorkspaceResponseDto[];
+
+  @ApiProperty({ type: PaginationDto })
+  pagination: PaginationDto;
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-response.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-response.dto.ts
@@ -22,6 +22,14 @@ export class WorkspaceResponseDto {
   description: string | null;
 
   @ApiProperty({
+    type: String,
+    description: 'Instructions that apply to every chat in the workspace',
+    example: 'Answer with the tone and policies of the building department.',
+    nullable: true,
+  })
+  instruction: string | null;
+
+  @ApiProperty({
     description: 'Key of the workspace icon from the client icon catalogue',
     example: 'landmark',
   })

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-context-dto.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-context-dto.mapper.spec.ts
@@ -1,0 +1,84 @@
+import type { UUID } from 'crypto';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import type { WorkspaceKnowledgeBaseCandidate } from 'src/domain/workspaces/application/use-cases/list-workspace-knowledge-base-candidates/list-workspace-knowledge-base-candidates.use-case';
+import type { WorkspaceSkillCandidate } from 'src/domain/workspaces/application/use-cases/list-workspace-skill-candidates/list-workspace-skill-candidates.use-case';
+import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
+import { Skill } from 'src/domain/skills/domain/skill.entity';
+import { WorkspaceContextDtoMapper } from './workspace-context-dto.mapper';
+
+describe('WorkspaceContextDtoMapper', () => {
+  const mapper = new WorkspaceContextDtoMapper();
+  const userId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+  const skill = new Skill({
+    id: '223e4567-e89b-12d3-a456-426614174000',
+    name: 'Legal Research',
+    shortDescription: 'Research legal topics',
+    instructions: 'Research legal topics carefully.',
+    userId,
+  });
+  const knowledgeBase = new KnowledgeBase({
+    id: '323e4567-e89b-12d3-a456-426614174000',
+    name: 'Council Documents',
+    description: 'Municipal council documents',
+    orgId: userId,
+    userId,
+  });
+
+  it('maps a paginated skill candidate page', () => {
+    const candidate: WorkspaceSkillCandidate = {
+      skill,
+      isAttached: true,
+    };
+
+    const result = mapper.toSkillCandidateListDto(
+      new Paginated({
+        data: [candidate],
+        limit: 20,
+        offset: 0,
+        total: 1,
+      }),
+    );
+
+    expect(result).toEqual({
+      data: [
+        {
+          id: skill.id,
+          name: skill.name,
+          shortDescription: skill.shortDescription,
+          isAttached: true,
+        },
+      ],
+      pagination: { limit: 20, offset: 0, total: 1 },
+    });
+  });
+
+  it('maps a paginated knowledge-base candidate page', () => {
+    const candidate: WorkspaceKnowledgeBaseCandidate = {
+      knowledgeBase,
+      documentCount: 12,
+      isAttached: false,
+    };
+
+    const result = mapper.toKnowledgeBaseCandidateListDto(
+      new Paginated({
+        data: [candidate],
+        limit: 20,
+        offset: 20,
+        total: 32,
+      }),
+    );
+
+    expect(result).toEqual({
+      data: [
+        {
+          id: knowledgeBase.id,
+          name: knowledgeBase.name,
+          description: knowledgeBase.description,
+          documentCount: 12,
+          isAttached: false,
+        },
+      ],
+      pagination: { limit: 20, offset: 20, total: 32 },
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-context-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-context-dto.mapper.ts
@@ -1,0 +1,165 @@
+import { Injectable } from '@nestjs/common';
+import type { Paginated } from 'src/common/pagination/paginated.entity';
+import type { PaginationDto } from 'src/common/pagination/pagination.dto';
+import type { WorkspaceSkillCandidate } from 'src/domain/workspaces/application/use-cases/list-workspace-skill-candidates/list-workspace-skill-candidates.use-case';
+import type { WorkspaceKnowledgeBaseCandidate } from 'src/domain/workspaces/application/use-cases/list-workspace-knowledge-base-candidates/list-workspace-knowledge-base-candidates.use-case';
+import type { Skill } from 'src/domain/skills/domain/skill.entity';
+import type { Source } from 'src/domain/sources/domain/source.entity';
+import {
+  TextSource,
+  UrlSource,
+} from 'src/domain/sources/domain/sources/text-source.entity';
+import type {
+  WorkspaceKnowledgeBaseContext,
+  WorkspaceRunContext,
+} from 'src/domain/workspaces/domain/workspace-run-context.entity';
+import {
+  WorkspaceContextResponseDto,
+  WorkspaceDocumentListResponseDto,
+  WorkspaceDocumentResponseDto,
+  WorkspaceKnowledgeBaseCandidateListResponseDto,
+  WorkspaceKnowledgeBaseCandidateResponseDto,
+  WorkspaceKnowledgeBaseListResponseDto,
+  WorkspaceKnowledgeBaseResponseDto,
+  WorkspaceSkillCandidateListResponseDto,
+  WorkspaceSkillCandidateResponseDto,
+  WorkspaceSkillListResponseDto,
+  WorkspaceSkillResponseDto,
+} from 'src/domain/workspaces/presenters/http/dtos/workspace-context-response.dto';
+
+@Injectable()
+export class WorkspaceContextDtoMapper {
+  toContextDto(context: WorkspaceRunContext): WorkspaceContextResponseDto {
+    const dto = new WorkspaceContextResponseDto();
+    dto.instruction = context.instruction;
+    dto.skills = context.skills.map((skill) => this.toSkillDto(skill));
+    dto.knowledgeBases = context.knowledgeBases.map((knowledgeBase) =>
+      this.toKnowledgeBaseDto(knowledgeBase),
+    );
+    dto.documents = context.sources.map((source) => this.toDocumentDto(source));
+    return dto;
+  }
+
+  toSkillDto(skill: Skill): WorkspaceSkillResponseDto {
+    const dto = new WorkspaceSkillResponseDto();
+    dto.id = skill.id;
+    dto.name = skill.name;
+    dto.shortDescription = skill.shortDescription;
+    return dto;
+  }
+
+  toSkillCandidateDto(
+    candidate: WorkspaceSkillCandidate,
+  ): WorkspaceSkillCandidateResponseDto {
+    return {
+      ...this.toSkillDto(candidate.skill),
+      isAttached: candidate.isAttached,
+    };
+  }
+
+  toKnowledgeBaseDto(
+    knowledgeBase: WorkspaceKnowledgeBaseContext,
+  ): WorkspaceKnowledgeBaseResponseDto {
+    return this.toKnowledgeBaseResponseDto(
+      knowledgeBase,
+      knowledgeBase.documentCount,
+    );
+  }
+
+  toKnowledgeBaseCandidateDto(
+    candidate: WorkspaceKnowledgeBaseCandidate,
+  ): WorkspaceKnowledgeBaseCandidateResponseDto {
+    return {
+      ...this.toKnowledgeBaseResponseDto(
+        candidate.knowledgeBase,
+        candidate.documentCount,
+      ),
+      isAttached: candidate.isAttached,
+    };
+  }
+
+  toDocumentDto(source: Source): WorkspaceDocumentResponseDto {
+    const dto = new WorkspaceDocumentResponseDto();
+    dto.id = source.id;
+    dto.name = source.name;
+    dto.type = source.type;
+    dto.createdBy = source.createdBy;
+    dto.status = source.status;
+    dto.processingError = source.processingError;
+    dto.createdAt = source.createdAt.toISOString();
+    dto.updatedAt = source.updatedAt.toISOString();
+    if (source instanceof TextSource) {
+      dto.textType = source.textType;
+      if (source instanceof UrlSource) dto.url = source.url;
+    }
+    return dto;
+  }
+
+  toSkillListDto(page: Paginated<Skill>): WorkspaceSkillListResponseDto {
+    return {
+      data: page.data.map((skill) => this.toSkillDto(skill)),
+      pagination: this.toPaginationDto(page),
+    };
+  }
+
+  toSkillCandidateListDto(
+    page: Paginated<WorkspaceSkillCandidate>,
+  ): WorkspaceSkillCandidateListResponseDto {
+    return {
+      data: page.data.map((candidate) => this.toSkillCandidateDto(candidate)),
+      pagination: this.toPaginationDto(page),
+    };
+  }
+
+  toKnowledgeBaseListDto(
+    page: Paginated<WorkspaceKnowledgeBaseContext>,
+  ): WorkspaceKnowledgeBaseListResponseDto {
+    return {
+      data: page.data.map((knowledgeBase) =>
+        this.toKnowledgeBaseDto(knowledgeBase),
+      ),
+      pagination: this.toPaginationDto(page),
+    };
+  }
+
+  toKnowledgeBaseCandidateListDto(
+    page: Paginated<WorkspaceKnowledgeBaseCandidate>,
+  ): WorkspaceKnowledgeBaseCandidateListResponseDto {
+    return {
+      data: page.data.map((candidate) =>
+        this.toKnowledgeBaseCandidateDto(candidate),
+      ),
+      pagination: this.toPaginationDto(page),
+    };
+  }
+
+  toDocumentListDto(page: Paginated<Source>): WorkspaceDocumentListResponseDto {
+    return {
+      data: page.data.map((source) => this.toDocumentDto(source)),
+      pagination: this.toPaginationDto(page),
+    };
+  }
+
+  private toKnowledgeBaseResponseDto(
+    knowledgeBase: Pick<
+      WorkspaceKnowledgeBaseContext,
+      'id' | 'name' | 'description'
+    >,
+    documentCount: number,
+  ): WorkspaceKnowledgeBaseResponseDto {
+    const dto = new WorkspaceKnowledgeBaseResponseDto();
+    dto.id = knowledgeBase.id;
+    dto.name = knowledgeBase.name;
+    dto.description = knowledgeBase.description;
+    dto.documentCount = documentCount;
+    return dto;
+  }
+
+  private toPaginationDto<T>(page: Paginated<T>): PaginationDto {
+    return {
+      limit: page.limit,
+      offset: page.offset,
+      total: page.total,
+    };
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.spec.ts
@@ -1,0 +1,42 @@
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import { aWorkspace } from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceDtoMapper } from './workspace-dto.mapper';
+
+describe('WorkspaceDtoMapper', () => {
+  const mapper = new WorkspaceDtoMapper();
+
+  it('maps a paginated workspace list with chat activity metadata', () => {
+    const workspace = aWorkspace({
+      name: 'Council Documents',
+      description: 'Municipal documents',
+    });
+    const lastActivityAt = new Date('2026-08-20T10:15:00.000Z');
+
+    const result = mapper.toPaginatedDto(
+      new Paginated({
+        data: [{ workspace, chatCount: 4, lastActivityAt }],
+        limit: 20,
+        offset: 0,
+        total: 1,
+      }),
+    );
+
+    expect(result).toEqual({
+      data: [
+        {
+          id: workspace.id,
+          name: workspace.name,
+          description: workspace.description,
+          instruction: workspace.instruction,
+          icon: workspace.icon,
+          color: workspace.color,
+          createdAt: workspace.createdAt.toISOString(),
+          updatedAt: workspace.updatedAt.toISOString(),
+          chatCount: 4,
+          lastActivityAt: lastActivityAt.toISOString(),
+        },
+      ],
+      pagination: { limit: 20, offset: 0, total: 1 },
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@nestjs/common';
+import type { Paginated } from 'src/common/pagination/paginated.entity';
 import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import type { WorkspaceListItem } from 'src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case';
 import { WorkspaceResponseDto } from 'src/domain/workspaces/presenters/http/dtos/workspace-response.dto';
+import { WorkspaceListResponseDto } from 'src/domain/workspaces/presenters/http/dtos/workspace-list-response.dto';
 
 @Injectable()
 export class WorkspaceDtoMapper {
@@ -10,6 +12,7 @@ export class WorkspaceDtoMapper {
     dto.id = workspace.id;
     dto.name = workspace.name;
     dto.description = workspace.description;
+    dto.instruction = workspace.instruction;
     dto.icon = workspace.icon;
     dto.color = workspace.color;
     dto.createdAt = workspace.createdAt.toISOString();
@@ -22,5 +25,16 @@ export class WorkspaceDtoMapper {
     dto.chatCount = item.chatCount;
     dto.lastActivityAt = item.lastActivityAt.toISOString();
     return dto;
+  }
+
+  toPaginatedDto(page: Paginated<WorkspaceListItem>): WorkspaceListResponseDto {
+    return {
+      data: page.data.map((item) => this.toListItemDto(item)),
+      pagination: {
+        limit: page.limit,
+        offset: page.offset,
+        total: page.total,
+      },
+    };
   }
 }

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/workspace-context.controller.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/workspace-context.controller.ts
@@ -1,0 +1,320 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Body,
+  Query,
+  UploadedFile,
+  UseInterceptors,
+} from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import type { UUID } from 'crypto';
+import * as fs from 'fs';
+import {
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { RequireFeature } from 'src/common/guards/feature.guard';
+import { FeatureFlag } from 'src/config/features.config';
+import {
+  cleanupTempUploadFile,
+  createDocumentUploadInterceptor,
+  resolveDocumentUploadMimeType,
+  type UploadedDocument,
+} from 'src/common/http/document-upload';
+import { MissingWorkspaceDocumentFileError } from 'src/domain/workspaces/application/workspaces.errors';
+import { BuildWorkspaceRunContextUseCase } from 'src/domain/workspaces/application/use-cases/build-workspace-run-context/build-workspace-run-context.use-case';
+import { BuildWorkspaceRunContextQuery } from 'src/domain/workspaces/application/use-cases/build-workspace-run-context/build-workspace-run-context.query';
+import { AttachSkillToWorkspaceUseCase } from 'src/domain/workspaces/application/use-cases/attach-skill-to-workspace/attach-skill-to-workspace.use-case';
+import { AttachSkillToWorkspaceCommand } from 'src/domain/workspaces/application/use-cases/attach-skill-to-workspace/attach-skill-to-workspace.command';
+import { DetachSkillFromWorkspaceUseCase } from 'src/domain/workspaces/application/use-cases/detach-skill-from-workspace/detach-skill-from-workspace.use-case';
+import { DetachSkillFromWorkspaceCommand } from 'src/domain/workspaces/application/use-cases/detach-skill-from-workspace/detach-skill-from-workspace.command';
+import { AttachKnowledgeBaseToWorkspaceUseCase } from 'src/domain/workspaces/application/use-cases/attach-knowledge-base-to-workspace/attach-knowledge-base-to-workspace.use-case';
+import { AttachKnowledgeBaseToWorkspaceCommand } from 'src/domain/workspaces/application/use-cases/attach-knowledge-base-to-workspace/attach-knowledge-base-to-workspace.command';
+import { DetachKnowledgeBaseFromWorkspaceUseCase } from 'src/domain/workspaces/application/use-cases/detach-knowledge-base-from-workspace/detach-knowledge-base-from-workspace.use-case';
+import { DetachKnowledgeBaseFromWorkspaceCommand } from 'src/domain/workspaces/application/use-cases/detach-knowledge-base-from-workspace/detach-knowledge-base-from-workspace.command';
+import { AddDocumentToWorkspaceUseCase } from 'src/domain/workspaces/application/use-cases/add-document-to-workspace/add-document-to-workspace.use-case';
+import { AddDocumentToWorkspaceCommand } from 'src/domain/workspaces/application/use-cases/add-document-to-workspace/add-document-to-workspace.command';
+import { RemoveDocumentFromWorkspaceUseCase } from 'src/domain/workspaces/application/use-cases/remove-document-from-workspace/remove-document-from-workspace.use-case';
+import { RemoveDocumentFromWorkspaceCommand } from 'src/domain/workspaces/application/use-cases/remove-document-from-workspace/remove-document-from-workspace.command';
+import { UpdateWorkspaceInstructionUseCase } from 'src/domain/workspaces/application/use-cases/update-workspace-instruction/update-workspace-instruction.use-case';
+import { UpdateWorkspaceInstructionCommand } from 'src/domain/workspaces/application/use-cases/update-workspace-instruction/update-workspace-instruction.command';
+import { ListWorkspaceSkillCandidatesUseCase } from 'src/domain/workspaces/application/use-cases/list-workspace-skill-candidates/list-workspace-skill-candidates.use-case';
+import { ListWorkspaceSkillCandidatesQuery } from 'src/domain/workspaces/application/use-cases/list-workspace-skill-candidates/list-workspace-skill-candidates.query';
+import { ListWorkspaceKnowledgeBaseCandidatesUseCase } from 'src/domain/workspaces/application/use-cases/list-workspace-knowledge-base-candidates/list-workspace-knowledge-base-candidates.use-case';
+import { ListWorkspaceKnowledgeBaseCandidatesQuery } from 'src/domain/workspaces/application/use-cases/list-workspace-knowledge-base-candidates/list-workspace-knowledge-base-candidates.query';
+import { ListWorkspaceSkillsUseCase } from 'src/domain/workspaces/application/use-cases/list-workspace-skills/list-workspace-skills.use-case';
+import { ListWorkspaceSkillsQuery } from 'src/domain/workspaces/application/use-cases/list-workspace-skills/list-workspace-skills.query';
+import { ListWorkspaceKnowledgeBasesUseCase } from 'src/domain/workspaces/application/use-cases/list-workspace-knowledge-bases/list-workspace-knowledge-bases.use-case';
+import { ListWorkspaceKnowledgeBasesQuery } from 'src/domain/workspaces/application/use-cases/list-workspace-knowledge-bases/list-workspace-knowledge-bases.query';
+import { ListWorkspaceDocumentsUseCase } from 'src/domain/workspaces/application/use-cases/list-workspace-documents/list-workspace-documents.use-case';
+import { ListWorkspaceDocumentsQuery } from 'src/domain/workspaces/application/use-cases/list-workspace-documents/list-workspace-documents.query';
+import { WorkspaceContextDtoMapper } from 'src/domain/workspaces/presenters/http/mappers/workspace-context-dto.mapper';
+import { WorkspaceDtoMapper } from 'src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper';
+import { UpdateWorkspaceInstructionDto } from 'src/domain/workspaces/presenters/http/dtos/update-workspace-instruction.dto';
+import { WorkspaceContextListQueryDto } from 'src/domain/workspaces/presenters/http/dtos/workspace-context-list-query.dto';
+import {
+  WorkspaceContextResponseDto,
+  WorkspaceDocumentListResponseDto,
+  WorkspaceKnowledgeBaseCandidateListResponseDto,
+  WorkspaceKnowledgeBaseListResponseDto,
+  WorkspaceSkillCandidateListResponseDto,
+  WorkspaceSkillListResponseDto,
+  WorkspaceDocumentResponseDto,
+} from 'src/domain/workspaces/presenters/http/dtos/workspace-context-response.dto';
+import { WorkspaceResponseDto } from 'src/domain/workspaces/presenters/http/dtos/workspace-response.dto';
+
+const DocumentUploadInterceptor = createDocumentUploadInterceptor(
+  25 * 1024 * 1024,
+);
+
+@ApiTags('workspaces')
+@Controller('workspaces/:id/context')
+@RequireFeature(FeatureFlag.Workspaces)
+export class WorkspaceContextController {
+  constructor(
+    private readonly buildWorkspaceRunContextUseCase: BuildWorkspaceRunContextUseCase,
+    private readonly attachSkillToWorkspaceUseCase: AttachSkillToWorkspaceUseCase,
+    private readonly detachSkillFromWorkspaceUseCase: DetachSkillFromWorkspaceUseCase,
+    private readonly attachKnowledgeBaseToWorkspaceUseCase: AttachKnowledgeBaseToWorkspaceUseCase,
+    private readonly detachKnowledgeBaseFromWorkspaceUseCase: DetachKnowledgeBaseFromWorkspaceUseCase,
+    private readonly addDocumentToWorkspaceUseCase: AddDocumentToWorkspaceUseCase,
+    private readonly removeDocumentFromWorkspaceUseCase: RemoveDocumentFromWorkspaceUseCase,
+    private readonly updateWorkspaceInstructionUseCase: UpdateWorkspaceInstructionUseCase,
+    private readonly listWorkspaceSkillCandidatesUseCase: ListWorkspaceSkillCandidatesUseCase,
+    private readonly listWorkspaceKnowledgeBaseCandidatesUseCase: ListWorkspaceKnowledgeBaseCandidatesUseCase,
+    private readonly listWorkspaceSkillsUseCase: ListWorkspaceSkillsUseCase,
+    private readonly listWorkspaceKnowledgeBasesUseCase: ListWorkspaceKnowledgeBasesUseCase,
+    private readonly listWorkspaceDocumentsUseCase: ListWorkspaceDocumentsUseCase,
+    private readonly contextDtoMapper: WorkspaceContextDtoMapper,
+    private readonly workspaceDtoMapper: WorkspaceDtoMapper,
+    @InjectPinoLogger(WorkspaceContextController.name)
+    private readonly logger: PinoLogger,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get workspace context' })
+  @ApiResponse({ status: 200, type: WorkspaceContextResponseDto })
+  async findContext(
+    @Param('id', ParseUUIDPipe) id: UUID,
+  ): Promise<WorkspaceContextResponseDto> {
+    const context = await this.buildWorkspaceRunContextUseCase.execute(
+      new BuildWorkspaceRunContextQuery(id),
+    );
+    return this.contextDtoMapper.toContextDto(context);
+  }
+
+  @Get('skill-candidates')
+  @ApiQuery({ name: 'search', required: false, type: String })
+  @ApiQuery({ name: 'limit', required: false, type: Number, default: 20 })
+  @ApiQuery({ name: 'offset', required: false, type: Number, default: 0 })
+  @ApiResponse({ status: 200, type: WorkspaceSkillCandidateListResponseDto })
+  async listSkillCandidates(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Query() queryParams: WorkspaceContextListQueryDto,
+  ): Promise<WorkspaceSkillCandidateListResponseDto> {
+    const page = await this.listWorkspaceSkillCandidatesUseCase.execute(
+      new ListWorkspaceSkillCandidatesQuery({
+        workspaceId: id,
+        ...queryParams.toQuery(),
+      }),
+    );
+    return this.contextDtoMapper.toSkillCandidateListDto(page);
+  }
+
+  @Get('knowledge-base-candidates')
+  @ApiQuery({ name: 'search', required: false, type: String })
+  @ApiQuery({ name: 'limit', required: false, type: Number, default: 20 })
+  @ApiQuery({ name: 'offset', required: false, type: Number, default: 0 })
+  @ApiResponse({
+    status: 200,
+    type: WorkspaceKnowledgeBaseCandidateListResponseDto,
+  })
+  async listKnowledgeBaseCandidates(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Query() queryParams: WorkspaceContextListQueryDto,
+  ): Promise<WorkspaceKnowledgeBaseCandidateListResponseDto> {
+    const page = await this.listWorkspaceKnowledgeBaseCandidatesUseCase.execute(
+      new ListWorkspaceKnowledgeBaseCandidatesQuery({
+        workspaceId: id,
+        ...queryParams.toQuery(),
+      }),
+    );
+    return this.contextDtoMapper.toKnowledgeBaseCandidateListDto(page);
+  }
+
+  @Get('skills')
+  @ApiQuery({ name: 'search', required: false, type: String })
+  @ApiQuery({ name: 'limit', required: false, type: Number, default: 20 })
+  @ApiQuery({ name: 'offset', required: false, type: Number, default: 0 })
+  @ApiResponse({ status: 200, type: WorkspaceSkillListResponseDto })
+  async listSkills(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Query() queryParams: WorkspaceContextListQueryDto,
+  ): Promise<WorkspaceSkillListResponseDto> {
+    const page = await this.listWorkspaceSkillsUseCase.execute(
+      new ListWorkspaceSkillsQuery({
+        workspaceId: id,
+        ...queryParams.toQuery(),
+      }),
+    );
+    return this.contextDtoMapper.toSkillListDto(page);
+  }
+
+  @Get('knowledge-bases')
+  @ApiQuery({ name: 'search', required: false, type: String })
+  @ApiQuery({ name: 'limit', required: false, type: Number, default: 20 })
+  @ApiQuery({ name: 'offset', required: false, type: Number, default: 0 })
+  @ApiResponse({ status: 200, type: WorkspaceKnowledgeBaseListResponseDto })
+  async listKnowledgeBases(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Query() queryParams: WorkspaceContextListQueryDto,
+  ): Promise<WorkspaceKnowledgeBaseListResponseDto> {
+    const page = await this.listWorkspaceKnowledgeBasesUseCase.execute(
+      new ListWorkspaceKnowledgeBasesQuery({
+        workspaceId: id,
+        ...queryParams.toQuery(),
+      }),
+    );
+    return this.contextDtoMapper.toKnowledgeBaseListDto(page);
+  }
+
+  @Get('documents')
+  @ApiQuery({ name: 'search', required: false, type: String })
+  @ApiQuery({ name: 'limit', required: false, type: Number, default: 20 })
+  @ApiQuery({ name: 'offset', required: false, type: Number, default: 0 })
+  @ApiResponse({ status: 200, type: WorkspaceDocumentListResponseDto })
+  async listDocuments(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Query() queryParams: WorkspaceContextListQueryDto,
+  ): Promise<WorkspaceDocumentListResponseDto> {
+    const page = await this.listWorkspaceDocumentsUseCase.execute(
+      new ListWorkspaceDocumentsQuery({
+        workspaceId: id,
+        ...queryParams.toQuery(),
+      }),
+    );
+    return this.contextDtoMapper.toDocumentListDto(page);
+  }
+
+  @Post('skills/:skillId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async attachSkill(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Param('skillId', ParseUUIDPipe) skillId: UUID,
+  ): Promise<void> {
+    await this.attachSkillToWorkspaceUseCase.execute(
+      new AttachSkillToWorkspaceCommand(id, skillId),
+    );
+  }
+
+  @Delete('skills/:skillId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async detachSkill(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Param('skillId', ParseUUIDPipe) skillId: UUID,
+  ): Promise<void> {
+    await this.detachSkillFromWorkspaceUseCase.execute(
+      new DetachSkillFromWorkspaceCommand(id, skillId),
+    );
+  }
+
+  @Post('knowledge-bases/:knowledgeBaseId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async attachKnowledgeBase(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Param('knowledgeBaseId', ParseUUIDPipe) knowledgeBaseId: UUID,
+  ): Promise<void> {
+    await this.attachKnowledgeBaseToWorkspaceUseCase.execute(
+      new AttachKnowledgeBaseToWorkspaceCommand(id, knowledgeBaseId),
+    );
+  }
+
+  @Delete('knowledge-bases/:knowledgeBaseId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async detachKnowledgeBase(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Param('knowledgeBaseId', ParseUUIDPipe) knowledgeBaseId: UUID,
+  ): Promise<void> {
+    await this.detachKnowledgeBaseFromWorkspaceUseCase.execute(
+      new DetachKnowledgeBaseFromWorkspaceCommand(id, knowledgeBaseId),
+    );
+  }
+
+  @Post('documents')
+  @ApiConsumes('multipart/form-data')
+  @ApiResponse({ status: 201, type: WorkspaceDocumentResponseDto })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { file: { type: 'string', format: 'binary' } },
+      required: ['file'],
+    },
+  })
+  @UseInterceptors(DocumentUploadInterceptor)
+  async addDocument(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @UploadedFile() file?: UploadedDocument,
+  ): Promise<WorkspaceDocumentResponseDto> {
+    if (!file) throw new MissingWorkspaceDocumentFileError();
+    try {
+      const fileType = this.resolveDocumentMimeType(file);
+      const fileData = await fs.promises.readFile(file.path);
+      const source = await this.addDocumentToWorkspaceUseCase.execute(
+        new AddDocumentToWorkspaceCommand(
+          id,
+          fileData,
+          file.originalname,
+          fileType,
+        ),
+      );
+      return this.contextDtoMapper.toDocumentDto(source);
+    } finally {
+      await this.cleanupTempFile(file.path);
+    }
+  }
+
+  @Delete('documents/:documentId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async removeDocument(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Param('documentId', ParseUUIDPipe) documentId: UUID,
+  ): Promise<void> {
+    await this.removeDocumentFromWorkspaceUseCase.execute(
+      new RemoveDocumentFromWorkspaceCommand(id, documentId),
+    );
+  }
+
+  @Patch('instruction')
+  @ApiResponse({ status: 200, type: WorkspaceResponseDto })
+  async updateInstruction(
+    @Param('id', ParseUUIDPipe) id: UUID,
+    @Body() dto: UpdateWorkspaceInstructionDto,
+  ): Promise<WorkspaceResponseDto> {
+    const workspace = await this.updateWorkspaceInstructionUseCase.execute(
+      new UpdateWorkspaceInstructionCommand(id, dto.instruction),
+    );
+    return this.workspaceDtoMapper.toDto(workspace);
+  }
+
+  private resolveDocumentMimeType(file: UploadedDocument): string {
+    return resolveDocumentUploadMimeType({
+      file,
+      errorMessage: () => `Unsupported file type: ${file.originalname}`,
+    });
+  }
+
+  private async cleanupTempFile(filePath: string): Promise<void> {
+    await cleanupTempUploadFile(filePath, this.logger);
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/workspaces.controller.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/workspaces.controller.ts
@@ -9,9 +9,16 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Query,
 } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
-import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import type { UUID } from 'crypto';
 import { RequireFeature } from 'src/common/guards/feature.guard';
 import { FeatureFlag } from 'src/config/features.config';
@@ -28,6 +35,9 @@ import { CreateWorkspaceDto } from './dtos/create-workspace.dto';
 import { UpdateWorkspaceDto } from './dtos/update-workspace.dto';
 import { WorkspaceResponseDto } from './dtos/workspace-response.dto';
 import { WorkspaceDtoMapper } from './mappers/workspace-dto.mapper';
+import { FindAllWorkspacesQuery } from 'src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.query';
+import { FindAllWorkspacesQueryParamsDto } from './dtos/find-all-workspaces-query-params.dto';
+import { WorkspaceListResponseDto } from './dtos/workspace-list-response.dto';
 
 @ApiTags('workspaces')
 @Controller('workspaces')
@@ -66,15 +76,27 @@ export class WorkspacesController {
 
   @Get()
   @ApiOperation({ summary: 'List the current user’s workspaces' })
+  @ApiQuery({ name: 'search', required: false, type: String })
+  @ApiQuery({
+    name: 'sort',
+    required: false,
+    enum: ['updatedAt', 'createdAt', 'name'],
+  })
+  @ApiQuery({ name: 'limit', required: false, type: Number, default: 20 })
+  @ApiQuery({ name: 'offset', required: false, type: Number, default: 0 })
   @ApiResponse({
     status: 200,
-    description: 'The workspaces ordered by most recent update',
-    type: [WorkspaceResponseDto],
+    description: 'A page of workspaces ordered by the requested sort',
+    type: WorkspaceListResponseDto,
   })
-  async findAll(): Promise<WorkspaceResponseDto[]> {
+  async findAll(
+    @Query() queryParams: FindAllWorkspacesQueryParamsDto,
+  ): Promise<WorkspaceListResponseDto> {
     this.logger.info('findAll');
-    const items = await this.findAllWorkspacesUseCase.execute();
-    return items.map((item) => this.workspaceDtoMapper.toListItemDto(item));
+    const page = await this.findAllWorkspacesUseCase.execute(
+      new FindAllWorkspacesQuery(queryParams),
+    );
+    return this.workspaceDtoMapper.toPaginatedDto(page);
   }
 
   @Get(':id')

--- a/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
@@ -1,5 +1,8 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { FavoritesModule } from 'src/domain/favorites/favorites.module';
+import { SkillsModule } from 'src/domain/skills/skills.module';
+import { KnowledgeBasesModule } from 'src/domain/knowledge-bases/knowledge-bases.module';
+import { SourcesModule } from 'src/domain/sources/sources.module';
 import { WorkspacesRepository } from './application/ports/workspaces-repository.port';
 import { LocalWorkspacesRepositoryModule } from './infrastructure/persistence/local/local-workspaces-repository.module';
 import { LocalWorkspacesRepository } from './infrastructure/persistence/local/local-workspaces.repository';
@@ -11,10 +14,31 @@ import { DeleteWorkspaceUseCase } from './application/use-cases/delete-workspace
 import { WorkspacesController } from './presenters/http/workspaces.controller';
 import { WorkspaceDtoMapper } from './presenters/http/mappers/workspace-dto.mapper';
 import { FindWorkspacesByIdsUseCase } from './application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case';
+import { WorkspaceContextController } from './presenters/http/workspace-context.controller';
+import { WorkspaceContextDtoMapper } from './presenters/http/mappers/workspace-context-dto.mapper';
+import { AttachSkillToWorkspaceUseCase } from './application/use-cases/attach-skill-to-workspace/attach-skill-to-workspace.use-case';
+import { DetachSkillFromWorkspaceUseCase } from './application/use-cases/detach-skill-from-workspace/detach-skill-from-workspace.use-case';
+import { AttachKnowledgeBaseToWorkspaceUseCase } from './application/use-cases/attach-knowledge-base-to-workspace/attach-knowledge-base-to-workspace.use-case';
+import { DetachKnowledgeBaseFromWorkspaceUseCase } from './application/use-cases/detach-knowledge-base-from-workspace/detach-knowledge-base-from-workspace.use-case';
+import { AddDocumentToWorkspaceUseCase } from './application/use-cases/add-document-to-workspace/add-document-to-workspace.use-case';
+import { RemoveDocumentFromWorkspaceUseCase } from './application/use-cases/remove-document-from-workspace/remove-document-from-workspace.use-case';
+import { UpdateWorkspaceInstructionUseCase } from './application/use-cases/update-workspace-instruction/update-workspace-instruction.use-case';
+import { BuildWorkspaceRunContextUseCase } from './application/use-cases/build-workspace-run-context/build-workspace-run-context.use-case';
+import { ListWorkspaceSkillCandidatesUseCase } from './application/use-cases/list-workspace-skill-candidates/list-workspace-skill-candidates.use-case';
+import { ListWorkspaceKnowledgeBaseCandidatesUseCase } from './application/use-cases/list-workspace-knowledge-base-candidates/list-workspace-knowledge-base-candidates.use-case';
+import { ListWorkspaceSkillsUseCase } from './application/use-cases/list-workspace-skills/list-workspace-skills.use-case';
+import { ListWorkspaceKnowledgeBasesUseCase } from './application/use-cases/list-workspace-knowledge-bases/list-workspace-knowledge-bases.use-case';
+import { ListWorkspaceDocumentsUseCase } from './application/use-cases/list-workspace-documents/list-workspace-documents.use-case';
 
 @Module({
-  imports: [LocalWorkspacesRepositoryModule, forwardRef(() => FavoritesModule)],
-  controllers: [WorkspacesController],
+  imports: [
+    LocalWorkspacesRepositoryModule,
+    forwardRef(() => FavoritesModule),
+    forwardRef(() => SkillsModule),
+    forwardRef(() => KnowledgeBasesModule),
+    SourcesModule,
+  ],
+  controllers: [WorkspacesController, WorkspaceContextController],
   providers: [
     {
       provide: WorkspacesRepository,
@@ -26,7 +50,21 @@ import { FindWorkspacesByIdsUseCase } from './application/use-cases/find-workspa
     FindWorkspacesByIdsUseCase,
     UpdateWorkspaceUseCase,
     DeleteWorkspaceUseCase,
+    AttachSkillToWorkspaceUseCase,
+    DetachSkillFromWorkspaceUseCase,
+    AttachKnowledgeBaseToWorkspaceUseCase,
+    DetachKnowledgeBaseFromWorkspaceUseCase,
+    AddDocumentToWorkspaceUseCase,
+    RemoveDocumentFromWorkspaceUseCase,
+    UpdateWorkspaceInstructionUseCase,
+    BuildWorkspaceRunContextUseCase,
+    ListWorkspaceSkillCandidatesUseCase,
+    ListWorkspaceKnowledgeBaseCandidatesUseCase,
+    ListWorkspaceSkillsUseCase,
+    ListWorkspaceKnowledgeBasesUseCase,
+    ListWorkspaceDocumentsUseCase,
     WorkspaceDtoMapper,
+    WorkspaceContextDtoMapper,
   ],
   exports: [
     CreateWorkspaceUseCase,
@@ -35,6 +73,7 @@ import { FindWorkspacesByIdsUseCase } from './application/use-cases/find-workspa
     FindWorkspacesByIdsUseCase,
     UpdateWorkspaceUseCase,
     DeleteWorkspaceUseCase,
+    BuildWorkspaceRunContextUseCase,
   ],
 })
 export class WorkspacesModule {}

--- a/ayunis-core-frontend/src/app/routes/_authenticated/workspaces.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/workspaces.index.tsx
@@ -17,11 +17,12 @@ export const Route = createFileRoute('/_authenticated/workspaces/')({
     if (!featureToggles.workspacesEnabled) {
       throw redirect({ to: '/chat' });
     }
+    const params = { limit: 100, offset: 0 };
     const workspaces = await queryClient.fetchQuery({
-      queryKey: getWorkspacesControllerFindAllQueryKey(),
-      queryFn: () => workspacesControllerFindAll(),
+      queryKey: getWorkspacesControllerFindAllQueryKey(params),
+      queryFn: () => workspacesControllerFindAll(params),
     });
-    return { workspaces };
+    return { workspaces: workspaces.data };
   },
 });
 

--- a/ayunis-core-frontend/src/features/workspaces/api/useWorkspaces.ts
+++ b/ayunis-core-frontend/src/features/workspaces/api/useWorkspaces.ts
@@ -3,20 +3,21 @@ import {
   getWorkspacesControllerFindAllQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
 import { useIsWorkspacesEnabled } from '@/features/feature-toggles';
-import type { Workspace } from '../model/types';
+import type { Workspace } from '@/features/workspaces/model/types';
 
 export function useWorkspaces() {
   const isEnabled = useIsWorkspacesEnabled();
-  const { data, isLoading, error } = useWorkspacesControllerFindAll({
+  const params = { limit: 100, offset: 0 };
+  const { data, isLoading, error } = useWorkspacesControllerFindAll(params, {
     query: {
-      queryKey: getWorkspacesControllerFindAllQueryKey(),
+      queryKey: getWorkspacesControllerFindAllQueryKey(params),
       // The controller 404s while the feature is off, which would otherwise
       // surface as an error on every page that renders the sidebar.
       enabled: isEnabled,
     },
   });
 
-  const workspaces: Workspace[] = data ?? [];
+  const workspaces: Workspace[] = data?.data ?? [];
 
   return {
     workspaces,

--- a/ayunis-core-frontend/src/pages/workspaces/lib/sortWorkspaces.test.ts
+++ b/ayunis-core-frontend/src/pages/workspaces/lib/sortWorkspaces.test.ts
@@ -7,6 +7,7 @@ function aWorkspace(overrides: Partial<Workspace>): Workspace {
     id: 'id',
     name: 'Workspace',
     description: null,
+    instruction: null,
     icon: 'folder',
     color: 'violet',
     createdAt: '2026-08-01T10:00:00.000Z',

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3496,6 +3496,11 @@ export interface WorkspaceResponseDto {
    * @nullable
    */
   description: string | null;
+  /**
+   * Instructions that apply to every chat in the workspace
+   * @nullable
+   */
+  instruction: string | null;
   /** Key of the workspace icon from the client icon catalogue */
   icon: string;
   /** Palette key or #rrggbb literal for the workspace colour */
@@ -3510,6 +3515,11 @@ export interface WorkspaceResponseDto {
   lastActivityAt?: string;
 }
 
+export interface WorkspaceListResponseDto {
+  data: WorkspaceResponseDto[];
+  pagination: PaginationDto;
+}
+
 export interface UpdateWorkspaceDto {
   /** Name of the workspace */
   name?: string;
@@ -3522,6 +3532,130 @@ export interface UpdateWorkspaceDto {
   icon?: string;
   /** Palette key or #rrggbb literal for the workspace colour */
   color?: string;
+}
+
+export interface WorkspaceSkillResponseDto {
+  id: string;
+  name: string;
+  shortDescription: string;
+}
+
+export interface WorkspaceKnowledgeBaseResponseDto {
+  id: string;
+  name: string;
+  /** @nullable */
+  description: string | null;
+  documentCount: number;
+}
+
+export type WorkspaceDocumentResponseDtoType = typeof WorkspaceDocumentResponseDtoType[keyof typeof WorkspaceDocumentResponseDtoType];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WorkspaceDocumentResponseDtoType = {
+  text: 'text',
+  data: 'data',
+} as const;
+
+export type WorkspaceDocumentResponseDtoCreatedBy = typeof WorkspaceDocumentResponseDtoCreatedBy[keyof typeof WorkspaceDocumentResponseDtoCreatedBy];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WorkspaceDocumentResponseDtoCreatedBy = {
+  user: 'user',
+  llm: 'llm',
+  system: 'system',
+} as const;
+
+export type WorkspaceDocumentResponseDtoStatus = typeof WorkspaceDocumentResponseDtoStatus[keyof typeof WorkspaceDocumentResponseDtoStatus];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WorkspaceDocumentResponseDtoStatus = {
+  processing: 'processing',
+  ready: 'ready',
+  failed: 'failed',
+} as const;
+
+export type WorkspaceDocumentResponseDtoTextType = typeof WorkspaceDocumentResponseDtoTextType[keyof typeof WorkspaceDocumentResponseDtoTextType];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WorkspaceDocumentResponseDtoTextType = {
+  file: 'file',
+  web: 'web',
+} as const;
+
+export interface WorkspaceDocumentResponseDto {
+  id: string;
+  name: string;
+  type: WorkspaceDocumentResponseDtoType;
+  createdBy: WorkspaceDocumentResponseDtoCreatedBy;
+  status: WorkspaceDocumentResponseDtoStatus;
+  /** @nullable */
+  processingError: string | null;
+  textType?: WorkspaceDocumentResponseDtoTextType;
+  url?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkspaceContextResponseDto {
+  /** @nullable */
+  instruction: string | null;
+  skills: WorkspaceSkillResponseDto[];
+  knowledgeBases: WorkspaceKnowledgeBaseResponseDto[];
+  documents: WorkspaceDocumentResponseDto[];
+}
+
+export interface WorkspaceSkillCandidateResponseDto {
+  id: string;
+  name: string;
+  shortDescription: string;
+  isAttached: boolean;
+}
+
+export interface WorkspaceSkillCandidateListResponseDto {
+  data: WorkspaceSkillCandidateResponseDto[];
+  pagination: PaginationDto;
+}
+
+export interface WorkspaceKnowledgeBaseCandidateResponseDto {
+  id: string;
+  name: string;
+  /** @nullable */
+  description: string | null;
+  documentCount: number;
+  isAttached: boolean;
+}
+
+export interface WorkspaceKnowledgeBaseCandidateListResponseDto {
+  data: WorkspaceKnowledgeBaseCandidateResponseDto[];
+  pagination: PaginationDto;
+}
+
+export interface WorkspaceSkillListResponseDto {
+  data: WorkspaceSkillResponseDto[];
+  pagination: PaginationDto;
+}
+
+export interface WorkspaceKnowledgeBaseListResponseDto {
+  data: WorkspaceKnowledgeBaseResponseDto[];
+  pagination: PaginationDto;
+}
+
+export interface WorkspaceDocumentListResponseDto {
+  data: WorkspaceDocumentResponseDto[];
+  pagination: PaginationDto;
+}
+
+export interface UpdateWorkspaceInstructionDto {
+  /**
+   * Instructions that apply to every chat in the workspace
+   * @maxLength 10000
+   * @nullable
+   */
+  instruction: string | null;
 }
 
 export type WorkspaceFavoriteResponseDtoReferenceType = typeof WorkspaceFavoriteResponseDtoReferenceType[keyof typeof WorkspaceFavoriteResponseDtoReferenceType];
@@ -5408,6 +5542,57 @@ export const SharesControllerGetSharesEntityType = {
 
 export type SkillSourcesControllerAddFileSourceBody = {
   /** The file to upload (max 25 MB) */
+  file: Blob;
+};
+
+export type WorkspacesControllerFindAllParams = {
+offset?: number;
+limit?: number;
+sort?: WorkspacesControllerFindAllSort;
+search?: string;
+};
+
+export type WorkspacesControllerFindAllSort = typeof WorkspacesControllerFindAllSort[keyof typeof WorkspacesControllerFindAllSort];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WorkspacesControllerFindAllSort = {
+  updatedAt: 'updatedAt',
+  createdAt: 'createdAt',
+  name: 'name',
+} as const;
+
+export type WorkspaceContextControllerListSkillCandidatesParams = {
+offset?: number;
+limit?: number;
+search?: string;
+};
+
+export type WorkspaceContextControllerListKnowledgeBaseCandidatesParams = {
+offset?: number;
+limit?: number;
+search?: string;
+};
+
+export type WorkspaceContextControllerListSkillsParams = {
+offset?: number;
+limit?: number;
+search?: string;
+};
+
+export type WorkspaceContextControllerListKnowledgeBasesParams = {
+offset?: number;
+limit?: number;
+search?: string;
+};
+
+export type WorkspaceContextControllerListDocumentsParams = {
+offset?: number;
+limit?: number;
+search?: string;
+};
+
+export type WorkspaceContextControllerAddDocumentBody = {
   file: Blob;
 };
 

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -249,6 +249,7 @@ import type {
   UpdateUserNameDto,
   UpdateUserRoleDto,
   UpdateWorkspaceDto,
+  UpdateWorkspaceInstructionDto,
   UpsertOrgAcademyAccessSettingsDto,
   UpsertOrgChatSettingsDto,
   UpsertOrgSystemPromptDto,
@@ -269,7 +270,22 @@ import type {
   UserSystemPromptResponseDto,
   UserUsageResponseDto,
   ValidationResponseDto,
-  WorkspaceResponseDto
+  WorkspaceContextControllerAddDocumentBody,
+  WorkspaceContextControllerListDocumentsParams,
+  WorkspaceContextControllerListKnowledgeBaseCandidatesParams,
+  WorkspaceContextControllerListKnowledgeBasesParams,
+  WorkspaceContextControllerListSkillCandidatesParams,
+  WorkspaceContextControllerListSkillsParams,
+  WorkspaceContextResponseDto,
+  WorkspaceDocumentListResponseDto,
+  WorkspaceDocumentResponseDto,
+  WorkspaceKnowledgeBaseCandidateListResponseDto,
+  WorkspaceKnowledgeBaseListResponseDto,
+  WorkspaceListResponseDto,
+  WorkspaceResponseDto,
+  WorkspaceSkillCandidateListResponseDto,
+  WorkspaceSkillListResponseDto,
+  WorkspacesControllerFindAllParams
 } from './ayunisCoreAPI.schemas';
 
 import { customAxiosInstance } from '../client';
@@ -13271,13 +13287,14 @@ export const useWorkspacesControllerCreate = <TError = unknown,
  * @summary List the current user’s workspaces
  */
 export const workspacesControllerFindAll = (
-    
+    params?: WorkspacesControllerFindAllParams,
  signal?: AbortSignal
 ) => {
       
       
-      return customAxiosInstance<WorkspaceResponseDto[]>(
-      {url: `/workspaces`, method: 'GET', signal
+      return customAxiosInstance<WorkspaceListResponseDto>(
+      {url: `/workspaces`, method: 'GET',
+        params, signal
     },
       );
     }
@@ -13285,23 +13302,23 @@ export const workspacesControllerFindAll = (
 
 
 
-export const getWorkspacesControllerFindAllQueryKey = () => {
+export const getWorkspacesControllerFindAllQueryKey = (params?: WorkspacesControllerFindAllParams,) => {
     return [
-    `/workspaces`
+    `/workspaces`, ...(params ? [params]: [])
     ] as const;
     }
 
     
-export const getWorkspacesControllerFindAllQueryOptions = <TData = Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError = unknown>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError, TData>>, }
+export const getWorkspacesControllerFindAllQueryOptions = <TData = Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError = unknown>(params?: WorkspacesControllerFindAllParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError, TData>>, }
 ) => {
 
 const {query: queryOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getWorkspacesControllerFindAllQueryKey();
+  const queryKey =  queryOptions?.queryKey ?? getWorkspacesControllerFindAllQueryKey(params);
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof workspacesControllerFindAll>>> = ({ signal }) => workspacesControllerFindAll(signal);
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof workspacesControllerFindAll>>> = ({ signal }) => workspacesControllerFindAll(params, signal);
 
       
 
@@ -13315,7 +13332,7 @@ export type WorkspacesControllerFindAllQueryError = unknown
 
 
 export function useWorkspacesControllerFindAll<TData = Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError = unknown>(
-  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError, TData>> & Pick<
+ params: undefined |  WorkspacesControllerFindAllParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError, TData>> & Pick<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof workspacesControllerFindAll>>,
           TError,
@@ -13325,7 +13342,7 @@ export function useWorkspacesControllerFindAll<TData = Awaited<ReturnType<typeof
  , queryClient?: QueryClient
   ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useWorkspacesControllerFindAll<TData = Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError = unknown>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError, TData>> & Pick<
+ params?: WorkspacesControllerFindAllParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError, TData>> & Pick<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof workspacesControllerFindAll>>,
           TError,
@@ -13335,7 +13352,7 @@ export function useWorkspacesControllerFindAll<TData = Awaited<ReturnType<typeof
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useWorkspacesControllerFindAll<TData = Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError = unknown>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError, TData>>, }
+ params?: WorkspacesControllerFindAllParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError, TData>>, }
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
@@ -13343,11 +13360,11 @@ export function useWorkspacesControllerFindAll<TData = Awaited<ReturnType<typeof
  */
 
 export function useWorkspacesControllerFindAll<TData = Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError = unknown>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError, TData>>, }
+ params?: WorkspacesControllerFindAllParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspacesControllerFindAll>>, TError, TData>>, }
  , queryClient?: QueryClient 
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
-  const queryOptions = getWorkspacesControllerFindAllQueryOptions(options)
+  const queryOptions = getWorkspacesControllerFindAllQueryOptions(params,options)
 
   const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 
@@ -13576,6 +13593,982 @@ export const useWorkspacesControllerRemove = <TError = void,
       > => {
 
       const mutationOptions = getWorkspacesControllerRemoveMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Get workspace context
+ */
+export const workspaceContextControllerFindContext = (
+    id: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<WorkspaceContextResponseDto>(
+      {url: `/workspaces/${id}/context`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getWorkspaceContextControllerFindContextQueryKey = (id?: string,) => {
+    return [
+    `/workspaces/${id}/context`
+    ] as const;
+    }
+
+    
+export const getWorkspaceContextControllerFindContextQueryOptions = <TData = Awaited<ReturnType<typeof workspaceContextControllerFindContext>>, TError = unknown>(id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerFindContext>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getWorkspaceContextControllerFindContextQueryKey(id);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof workspaceContextControllerFindContext>>> = ({ signal }) => workspaceContextControllerFindContext(id, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerFindContext>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type WorkspaceContextControllerFindContextQueryResult = NonNullable<Awaited<ReturnType<typeof workspaceContextControllerFindContext>>>
+export type WorkspaceContextControllerFindContextQueryError = unknown
+
+
+export function useWorkspaceContextControllerFindContext<TData = Awaited<ReturnType<typeof workspaceContextControllerFindContext>>, TError = unknown>(
+ id: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerFindContext>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceContextControllerFindContext>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceContextControllerFindContext>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceContextControllerFindContext<TData = Awaited<ReturnType<typeof workspaceContextControllerFindContext>>, TError = unknown>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerFindContext>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceContextControllerFindContext>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceContextControllerFindContext>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceContextControllerFindContext<TData = Awaited<ReturnType<typeof workspaceContextControllerFindContext>>, TError = unknown>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerFindContext>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get workspace context
+ */
+
+export function useWorkspaceContextControllerFindContext<TData = Awaited<ReturnType<typeof workspaceContextControllerFindContext>>, TError = unknown>(
+ id: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerFindContext>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getWorkspaceContextControllerFindContextQueryOptions(id,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+export const workspaceContextControllerListSkillCandidates = (
+    id: string,
+    params?: WorkspaceContextControllerListSkillCandidatesParams,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<WorkspaceSkillCandidateListResponseDto>(
+      {url: `/workspaces/${id}/context/skill-candidates`, method: 'GET',
+        params, signal
+    },
+      );
+    }
+  
+
+
+
+export const getWorkspaceContextControllerListSkillCandidatesQueryKey = (id?: string,
+    params?: WorkspaceContextControllerListSkillCandidatesParams,) => {
+    return [
+    `/workspaces/${id}/context/skill-candidates`, ...(params ? [params]: [])
+    ] as const;
+    }
+
+    
+export const getWorkspaceContextControllerListSkillCandidatesQueryOptions = <TData = Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>, TError = unknown>(id: string,
+    params?: WorkspaceContextControllerListSkillCandidatesParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getWorkspaceContextControllerListSkillCandidatesQueryKey(id,params);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>> = ({ signal }) => workspaceContextControllerListSkillCandidates(id,params, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type WorkspaceContextControllerListSkillCandidatesQueryResult = NonNullable<Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>>
+export type WorkspaceContextControllerListSkillCandidatesQueryError = unknown
+
+
+export function useWorkspaceContextControllerListSkillCandidates<TData = Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>, TError = unknown>(
+ id: string,
+    params: undefined |  WorkspaceContextControllerListSkillCandidatesParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceContextControllerListSkillCandidates<TData = Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>, TError = unknown>(
+ id: string,
+    params?: WorkspaceContextControllerListSkillCandidatesParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceContextControllerListSkillCandidates<TData = Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>, TError = unknown>(
+ id: string,
+    params?: WorkspaceContextControllerListSkillCandidatesParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+export function useWorkspaceContextControllerListSkillCandidates<TData = Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>, TError = unknown>(
+ id: string,
+    params?: WorkspaceContextControllerListSkillCandidatesParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListSkillCandidates>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getWorkspaceContextControllerListSkillCandidatesQueryOptions(id,params,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+export const workspaceContextControllerListKnowledgeBaseCandidates = (
+    id: string,
+    params?: WorkspaceContextControllerListKnowledgeBaseCandidatesParams,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<WorkspaceKnowledgeBaseCandidateListResponseDto>(
+      {url: `/workspaces/${id}/context/knowledge-base-candidates`, method: 'GET',
+        params, signal
+    },
+      );
+    }
+  
+
+
+
+export const getWorkspaceContextControllerListKnowledgeBaseCandidatesQueryKey = (id?: string,
+    params?: WorkspaceContextControllerListKnowledgeBaseCandidatesParams,) => {
+    return [
+    `/workspaces/${id}/context/knowledge-base-candidates`, ...(params ? [params]: [])
+    ] as const;
+    }
+
+    
+export const getWorkspaceContextControllerListKnowledgeBaseCandidatesQueryOptions = <TData = Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>, TError = unknown>(id: string,
+    params?: WorkspaceContextControllerListKnowledgeBaseCandidatesParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getWorkspaceContextControllerListKnowledgeBaseCandidatesQueryKey(id,params);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>> = ({ signal }) => workspaceContextControllerListKnowledgeBaseCandidates(id,params, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type WorkspaceContextControllerListKnowledgeBaseCandidatesQueryResult = NonNullable<Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>>
+export type WorkspaceContextControllerListKnowledgeBaseCandidatesQueryError = unknown
+
+
+export function useWorkspaceContextControllerListKnowledgeBaseCandidates<TData = Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>, TError = unknown>(
+ id: string,
+    params: undefined |  WorkspaceContextControllerListKnowledgeBaseCandidatesParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceContextControllerListKnowledgeBaseCandidates<TData = Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>, TError = unknown>(
+ id: string,
+    params?: WorkspaceContextControllerListKnowledgeBaseCandidatesParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceContextControllerListKnowledgeBaseCandidates<TData = Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>, TError = unknown>(
+ id: string,
+    params?: WorkspaceContextControllerListKnowledgeBaseCandidatesParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+export function useWorkspaceContextControllerListKnowledgeBaseCandidates<TData = Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>, TError = unknown>(
+ id: string,
+    params?: WorkspaceContextControllerListKnowledgeBaseCandidatesParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBaseCandidates>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getWorkspaceContextControllerListKnowledgeBaseCandidatesQueryOptions(id,params,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+export const workspaceContextControllerListSkills = (
+    id: string,
+    params?: WorkspaceContextControllerListSkillsParams,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<WorkspaceSkillListResponseDto>(
+      {url: `/workspaces/${id}/context/skills`, method: 'GET',
+        params, signal
+    },
+      );
+    }
+  
+
+
+
+export const getWorkspaceContextControllerListSkillsQueryKey = (id?: string,
+    params?: WorkspaceContextControllerListSkillsParams,) => {
+    return [
+    `/workspaces/${id}/context/skills`, ...(params ? [params]: [])
+    ] as const;
+    }
+
+    
+export const getWorkspaceContextControllerListSkillsQueryOptions = <TData = Awaited<ReturnType<typeof workspaceContextControllerListSkills>>, TError = unknown>(id: string,
+    params?: WorkspaceContextControllerListSkillsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListSkills>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getWorkspaceContextControllerListSkillsQueryKey(id,params);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof workspaceContextControllerListSkills>>> = ({ signal }) => workspaceContextControllerListSkills(id,params, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListSkills>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type WorkspaceContextControllerListSkillsQueryResult = NonNullable<Awaited<ReturnType<typeof workspaceContextControllerListSkills>>>
+export type WorkspaceContextControllerListSkillsQueryError = unknown
+
+
+export function useWorkspaceContextControllerListSkills<TData = Awaited<ReturnType<typeof workspaceContextControllerListSkills>>, TError = unknown>(
+ id: string,
+    params: undefined |  WorkspaceContextControllerListSkillsParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListSkills>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceContextControllerListSkills>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceContextControllerListSkills>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceContextControllerListSkills<TData = Awaited<ReturnType<typeof workspaceContextControllerListSkills>>, TError = unknown>(
+ id: string,
+    params?: WorkspaceContextControllerListSkillsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListSkills>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceContextControllerListSkills>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceContextControllerListSkills>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceContextControllerListSkills<TData = Awaited<ReturnType<typeof workspaceContextControllerListSkills>>, TError = unknown>(
+ id: string,
+    params?: WorkspaceContextControllerListSkillsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListSkills>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+export function useWorkspaceContextControllerListSkills<TData = Awaited<ReturnType<typeof workspaceContextControllerListSkills>>, TError = unknown>(
+ id: string,
+    params?: WorkspaceContextControllerListSkillsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListSkills>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getWorkspaceContextControllerListSkillsQueryOptions(id,params,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+export const workspaceContextControllerListKnowledgeBases = (
+    id: string,
+    params?: WorkspaceContextControllerListKnowledgeBasesParams,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<WorkspaceKnowledgeBaseListResponseDto>(
+      {url: `/workspaces/${id}/context/knowledge-bases`, method: 'GET',
+        params, signal
+    },
+      );
+    }
+  
+
+
+
+export const getWorkspaceContextControllerListKnowledgeBasesQueryKey = (id?: string,
+    params?: WorkspaceContextControllerListKnowledgeBasesParams,) => {
+    return [
+    `/workspaces/${id}/context/knowledge-bases`, ...(params ? [params]: [])
+    ] as const;
+    }
+
+    
+export const getWorkspaceContextControllerListKnowledgeBasesQueryOptions = <TData = Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>, TError = unknown>(id: string,
+    params?: WorkspaceContextControllerListKnowledgeBasesParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getWorkspaceContextControllerListKnowledgeBasesQueryKey(id,params);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>> = ({ signal }) => workspaceContextControllerListKnowledgeBases(id,params, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type WorkspaceContextControllerListKnowledgeBasesQueryResult = NonNullable<Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>>
+export type WorkspaceContextControllerListKnowledgeBasesQueryError = unknown
+
+
+export function useWorkspaceContextControllerListKnowledgeBases<TData = Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>, TError = unknown>(
+ id: string,
+    params: undefined |  WorkspaceContextControllerListKnowledgeBasesParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceContextControllerListKnowledgeBases<TData = Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>, TError = unknown>(
+ id: string,
+    params?: WorkspaceContextControllerListKnowledgeBasesParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceContextControllerListKnowledgeBases<TData = Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>, TError = unknown>(
+ id: string,
+    params?: WorkspaceContextControllerListKnowledgeBasesParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+export function useWorkspaceContextControllerListKnowledgeBases<TData = Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>, TError = unknown>(
+ id: string,
+    params?: WorkspaceContextControllerListKnowledgeBasesParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListKnowledgeBases>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getWorkspaceContextControllerListKnowledgeBasesQueryOptions(id,params,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+export const workspaceContextControllerListDocuments = (
+    id: string,
+    params?: WorkspaceContextControllerListDocumentsParams,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<WorkspaceDocumentListResponseDto>(
+      {url: `/workspaces/${id}/context/documents`, method: 'GET',
+        params, signal
+    },
+      );
+    }
+  
+
+
+
+export const getWorkspaceContextControllerListDocumentsQueryKey = (id?: string,
+    params?: WorkspaceContextControllerListDocumentsParams,) => {
+    return [
+    `/workspaces/${id}/context/documents`, ...(params ? [params]: [])
+    ] as const;
+    }
+
+    
+export const getWorkspaceContextControllerListDocumentsQueryOptions = <TData = Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>, TError = unknown>(id: string,
+    params?: WorkspaceContextControllerListDocumentsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getWorkspaceContextControllerListDocumentsQueryKey(id,params);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>> = ({ signal }) => workspaceContextControllerListDocuments(id,params, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type WorkspaceContextControllerListDocumentsQueryResult = NonNullable<Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>>
+export type WorkspaceContextControllerListDocumentsQueryError = unknown
+
+
+export function useWorkspaceContextControllerListDocuments<TData = Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>, TError = unknown>(
+ id: string,
+    params: undefined |  WorkspaceContextControllerListDocumentsParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceContextControllerListDocuments<TData = Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>, TError = unknown>(
+ id: string,
+    params?: WorkspaceContextControllerListDocumentsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceContextControllerListDocuments<TData = Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>, TError = unknown>(
+ id: string,
+    params?: WorkspaceContextControllerListDocumentsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+
+export function useWorkspaceContextControllerListDocuments<TData = Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>, TError = unknown>(
+ id: string,
+    params?: WorkspaceContextControllerListDocumentsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceContextControllerListDocuments>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getWorkspaceContextControllerListDocumentsQueryOptions(id,params,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+export const workspaceContextControllerAddDocument = (
+    id: string,
+    workspaceContextControllerAddDocumentBody: WorkspaceContextControllerAddDocumentBody,
+ signal?: AbortSignal
+) => {
+      
+      const formData = new FormData();
+formData.append(`file`, workspaceContextControllerAddDocumentBody.file)
+
+      return customAxiosInstance<WorkspaceDocumentResponseDto>(
+      {url: `/workspaces/${id}/context/documents`, method: 'POST',
+      headers: {'Content-Type': 'multipart/form-data', },
+       data: formData, signal
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceContextControllerAddDocumentMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerAddDocument>>, TError,{id: string;data: WorkspaceContextControllerAddDocumentBody}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerAddDocument>>, TError,{id: string;data: WorkspaceContextControllerAddDocumentBody}, TContext> => {
+
+const mutationKey = ['workspaceContextControllerAddDocument'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceContextControllerAddDocument>>, {id: string;data: WorkspaceContextControllerAddDocumentBody}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  workspaceContextControllerAddDocument(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceContextControllerAddDocumentMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceContextControllerAddDocument>>>
+    export type WorkspaceContextControllerAddDocumentMutationBody = WorkspaceContextControllerAddDocumentBody
+    export type WorkspaceContextControllerAddDocumentMutationError = unknown
+
+    export const useWorkspaceContextControllerAddDocument = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerAddDocument>>, TError,{id: string;data: WorkspaceContextControllerAddDocumentBody}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceContextControllerAddDocument>>,
+        TError,
+        {id: string;data: WorkspaceContextControllerAddDocumentBody},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceContextControllerAddDocumentMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+export const workspaceContextControllerAttachSkill = (
+    id: string,
+    skillId: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspaces/${id}/context/skills/${skillId}`, method: 'POST', signal
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceContextControllerAttachSkillMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerAttachSkill>>, TError,{id: string;skillId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerAttachSkill>>, TError,{id: string;skillId: string}, TContext> => {
+
+const mutationKey = ['workspaceContextControllerAttachSkill'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceContextControllerAttachSkill>>, {id: string;skillId: string}> = (props) => {
+          const {id,skillId} = props ?? {};
+
+          return  workspaceContextControllerAttachSkill(id,skillId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceContextControllerAttachSkillMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceContextControllerAttachSkill>>>
+    
+    export type WorkspaceContextControllerAttachSkillMutationError = unknown
+
+    export const useWorkspaceContextControllerAttachSkill = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerAttachSkill>>, TError,{id: string;skillId: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceContextControllerAttachSkill>>,
+        TError,
+        {id: string;skillId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceContextControllerAttachSkillMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+export const workspaceContextControllerDetachSkill = (
+    id: string,
+    skillId: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspaces/${id}/context/skills/${skillId}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceContextControllerDetachSkillMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerDetachSkill>>, TError,{id: string;skillId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerDetachSkill>>, TError,{id: string;skillId: string}, TContext> => {
+
+const mutationKey = ['workspaceContextControllerDetachSkill'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceContextControllerDetachSkill>>, {id: string;skillId: string}> = (props) => {
+          const {id,skillId} = props ?? {};
+
+          return  workspaceContextControllerDetachSkill(id,skillId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceContextControllerDetachSkillMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceContextControllerDetachSkill>>>
+    
+    export type WorkspaceContextControllerDetachSkillMutationError = unknown
+
+    export const useWorkspaceContextControllerDetachSkill = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerDetachSkill>>, TError,{id: string;skillId: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceContextControllerDetachSkill>>,
+        TError,
+        {id: string;skillId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceContextControllerDetachSkillMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+export const workspaceContextControllerAttachKnowledgeBase = (
+    id: string,
+    knowledgeBaseId: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspaces/${id}/context/knowledge-bases/${knowledgeBaseId}`, method: 'POST', signal
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceContextControllerAttachKnowledgeBaseMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerAttachKnowledgeBase>>, TError,{id: string;knowledgeBaseId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerAttachKnowledgeBase>>, TError,{id: string;knowledgeBaseId: string}, TContext> => {
+
+const mutationKey = ['workspaceContextControllerAttachKnowledgeBase'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceContextControllerAttachKnowledgeBase>>, {id: string;knowledgeBaseId: string}> = (props) => {
+          const {id,knowledgeBaseId} = props ?? {};
+
+          return  workspaceContextControllerAttachKnowledgeBase(id,knowledgeBaseId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceContextControllerAttachKnowledgeBaseMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceContextControllerAttachKnowledgeBase>>>
+    
+    export type WorkspaceContextControllerAttachKnowledgeBaseMutationError = unknown
+
+    export const useWorkspaceContextControllerAttachKnowledgeBase = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerAttachKnowledgeBase>>, TError,{id: string;knowledgeBaseId: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceContextControllerAttachKnowledgeBase>>,
+        TError,
+        {id: string;knowledgeBaseId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceContextControllerAttachKnowledgeBaseMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+export const workspaceContextControllerDetachKnowledgeBase = (
+    id: string,
+    knowledgeBaseId: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspaces/${id}/context/knowledge-bases/${knowledgeBaseId}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceContextControllerDetachKnowledgeBaseMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerDetachKnowledgeBase>>, TError,{id: string;knowledgeBaseId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerDetachKnowledgeBase>>, TError,{id: string;knowledgeBaseId: string}, TContext> => {
+
+const mutationKey = ['workspaceContextControllerDetachKnowledgeBase'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceContextControllerDetachKnowledgeBase>>, {id: string;knowledgeBaseId: string}> = (props) => {
+          const {id,knowledgeBaseId} = props ?? {};
+
+          return  workspaceContextControllerDetachKnowledgeBase(id,knowledgeBaseId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceContextControllerDetachKnowledgeBaseMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceContextControllerDetachKnowledgeBase>>>
+    
+    export type WorkspaceContextControllerDetachKnowledgeBaseMutationError = unknown
+
+    export const useWorkspaceContextControllerDetachKnowledgeBase = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerDetachKnowledgeBase>>, TError,{id: string;knowledgeBaseId: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceContextControllerDetachKnowledgeBase>>,
+        TError,
+        {id: string;knowledgeBaseId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceContextControllerDetachKnowledgeBaseMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+export const workspaceContextControllerRemoveDocument = (
+    id: string,
+    documentId: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspaces/${id}/context/documents/${documentId}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceContextControllerRemoveDocumentMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerRemoveDocument>>, TError,{id: string;documentId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerRemoveDocument>>, TError,{id: string;documentId: string}, TContext> => {
+
+const mutationKey = ['workspaceContextControllerRemoveDocument'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceContextControllerRemoveDocument>>, {id: string;documentId: string}> = (props) => {
+          const {id,documentId} = props ?? {};
+
+          return  workspaceContextControllerRemoveDocument(id,documentId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceContextControllerRemoveDocumentMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceContextControllerRemoveDocument>>>
+    
+    export type WorkspaceContextControllerRemoveDocumentMutationError = unknown
+
+    export const useWorkspaceContextControllerRemoveDocument = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerRemoveDocument>>, TError,{id: string;documentId: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceContextControllerRemoveDocument>>,
+        TError,
+        {id: string;documentId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceContextControllerRemoveDocumentMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+export const workspaceContextControllerUpdateInstruction = (
+    id: string,
+    updateWorkspaceInstructionDto: UpdateWorkspaceInstructionDto,
+ ) => {
+      
+      
+      return customAxiosInstance<WorkspaceResponseDto>(
+      {url: `/workspaces/${id}/context/instruction`, method: 'PATCH',
+      headers: {'Content-Type': 'application/json', },
+      data: updateWorkspaceInstructionDto
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceContextControllerUpdateInstructionMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerUpdateInstruction>>, TError,{id: string;data: UpdateWorkspaceInstructionDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerUpdateInstruction>>, TError,{id: string;data: UpdateWorkspaceInstructionDto}, TContext> => {
+
+const mutationKey = ['workspaceContextControllerUpdateInstruction'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceContextControllerUpdateInstruction>>, {id: string;data: UpdateWorkspaceInstructionDto}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  workspaceContextControllerUpdateInstruction(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceContextControllerUpdateInstructionMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceContextControllerUpdateInstruction>>>
+    export type WorkspaceContextControllerUpdateInstructionMutationBody = UpdateWorkspaceInstructionDto
+    export type WorkspaceContextControllerUpdateInstructionMutationError = unknown
+
+    export const useWorkspaceContextControllerUpdateInstruction = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceContextControllerUpdateInstruction>>, TError,{id: string;data: UpdateWorkspaceInstructionDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceContextControllerUpdateInstruction>>,
+        TError,
+        {id: string;data: UpdateWorkspaceInstructionDto},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceContextControllerUpdateInstructionMutationOptions(options);
 
       return useMutation(mutationOptions, queryClient);
     }

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -6521,17 +6521,50 @@
       },
       "get": {
         "operationId": "WorkspacesController_findAll",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "sort",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "enum": ["updatedAt", "createdAt", "name"],
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "The workspaces ordered by most recent update",
+            "description": "A page of workspaces ordered by the requested sort",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/WorkspaceResponseDto"
-                  }
+                  "$ref": "#/components/schemas/WorkspaceListResponseDto"
                 }
               }
             }
@@ -6639,6 +6672,527 @@
           }
         },
         "summary": "Delete a workspace and every chat inside it",
+        "tags": ["workspaces"]
+      }
+    },
+    "/workspaces/{id}/context": {
+      "get": {
+        "operationId": "WorkspaceContextController_findContext",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceContextResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get workspace context",
+        "tags": ["workspaces"]
+      }
+    },
+    "/workspaces/{id}/context/skill-candidates": {
+      "get": {
+        "operationId": "WorkspaceContextController_listSkillCandidates",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceSkillCandidateListResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["workspaces"]
+      }
+    },
+    "/workspaces/{id}/context/knowledge-base-candidates": {
+      "get": {
+        "operationId": "WorkspaceContextController_listKnowledgeBaseCandidates",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceKnowledgeBaseCandidateListResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["workspaces"]
+      }
+    },
+    "/workspaces/{id}/context/skills": {
+      "get": {
+        "operationId": "WorkspaceContextController_listSkills",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceSkillListResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["workspaces"]
+      }
+    },
+    "/workspaces/{id}/context/knowledge-bases": {
+      "get": {
+        "operationId": "WorkspaceContextController_listKnowledgeBases",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceKnowledgeBaseListResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["workspaces"]
+      }
+    },
+    "/workspaces/{id}/context/documents": {
+      "get": {
+        "operationId": "WorkspaceContextController_listDocuments",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "type": "number"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "number"
+            }
+          },
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceDocumentListResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["workspaces"]
+      },
+      "post": {
+        "operationId": "WorkspaceContextController_addDocument",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                },
+                "required": ["file"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceDocumentResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["workspaces"]
+      }
+    },
+    "/workspaces/{id}/context/skills/{skillId}": {
+      "post": {
+        "operationId": "WorkspaceContextController_attachSkill",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "skillId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "tags": ["workspaces"]
+      },
+      "delete": {
+        "operationId": "WorkspaceContextController_detachSkill",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "skillId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "tags": ["workspaces"]
+      }
+    },
+    "/workspaces/{id}/context/knowledge-bases/{knowledgeBaseId}": {
+      "post": {
+        "operationId": "WorkspaceContextController_attachKnowledgeBase",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "knowledgeBaseId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "tags": ["workspaces"]
+      },
+      "delete": {
+        "operationId": "WorkspaceContextController_detachKnowledgeBase",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "knowledgeBaseId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "tags": ["workspaces"]
+      }
+    },
+    "/workspaces/{id}/context/documents/{documentId}": {
+      "delete": {
+        "operationId": "WorkspaceContextController_removeDocument",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "documentId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "tags": ["workspaces"]
+      }
+    },
+    "/workspaces/{id}/context/instruction": {
+      "patch": {
+        "operationId": "WorkspaceContextController_updateInstruction",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWorkspaceInstructionDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceResponseDto"
+                }
+              }
+            }
+          }
+        },
         "tags": ["workspaces"]
       }
     },
@@ -16061,6 +16615,12 @@
             "example": "Anfragen von Bürgerinnen und Bürgern bündeln",
             "nullable": true
           },
+          "instruction": {
+            "type": "string",
+            "description": "Instructions that apply to every chat in the workspace",
+            "example": "Answer with the tone and policies of the building department.",
+            "nullable": true
+          },
           "icon": {
             "type": "string",
             "description": "Key of the workspace icon from the client icon catalogue",
@@ -16096,11 +16656,27 @@
           "id",
           "name",
           "description",
+          "instruction",
           "icon",
           "color",
           "createdAt",
           "updatedAt"
         ]
+      },
+      "WorkspaceListResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceResponseDto"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationDto"
+          }
+        },
+        "required": ["data", "pagination"]
       },
       "UpdateWorkspaceDto": {
         "type": "object",
@@ -16127,6 +16703,245 @@
             "example": "#6b5bd6"
           }
         }
+      },
+      "WorkspaceSkillResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "shortDescription": {
+            "type": "string"
+          }
+        },
+        "required": ["id", "name", "shortDescription"]
+      },
+      "WorkspaceKnowledgeBaseResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "documentCount": {
+            "type": "number"
+          }
+        },
+        "required": ["id", "name", "description", "documentCount"]
+      },
+      "WorkspaceDocumentResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["text", "data"]
+          },
+          "createdBy": {
+            "type": "string",
+            "enum": ["user", "llm", "system"]
+          },
+          "status": {
+            "type": "string",
+            "enum": ["processing", "ready", "failed"]
+          },
+          "processingError": {
+            "type": "string",
+            "nullable": true
+          },
+          "textType": {
+            "type": "string",
+            "enum": ["file", "web"]
+          },
+          "url": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type",
+          "createdBy",
+          "status",
+          "processingError",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "WorkspaceContextResponseDto": {
+        "type": "object",
+        "properties": {
+          "instruction": {
+            "type": "string",
+            "nullable": true
+          },
+          "skills": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceSkillResponseDto"
+            }
+          },
+          "knowledgeBases": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceKnowledgeBaseResponseDto"
+            }
+          },
+          "documents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceDocumentResponseDto"
+            }
+          }
+        },
+        "required": ["instruction", "skills", "knowledgeBases", "documents"]
+      },
+      "WorkspaceSkillCandidateResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "shortDescription": {
+            "type": "string"
+          },
+          "isAttached": {
+            "type": "boolean"
+          }
+        },
+        "required": ["id", "name", "shortDescription", "isAttached"]
+      },
+      "WorkspaceSkillCandidateListResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceSkillCandidateResponseDto"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationDto"
+          }
+        },
+        "required": ["data", "pagination"]
+      },
+      "WorkspaceKnowledgeBaseCandidateResponseDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "documentCount": {
+            "type": "number"
+          },
+          "isAttached": {
+            "type": "boolean"
+          }
+        },
+        "required": ["id", "name", "description", "documentCount", "isAttached"]
+      },
+      "WorkspaceKnowledgeBaseCandidateListResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceKnowledgeBaseCandidateResponseDto"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationDto"
+          }
+        },
+        "required": ["data", "pagination"]
+      },
+      "WorkspaceSkillListResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceSkillResponseDto"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationDto"
+          }
+        },
+        "required": ["data", "pagination"]
+      },
+      "WorkspaceKnowledgeBaseListResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceKnowledgeBaseResponseDto"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationDto"
+          }
+        },
+        "required": ["data", "pagination"]
+      },
+      "WorkspaceDocumentListResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceDocumentResponseDto"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationDto"
+          }
+        },
+        "required": ["data", "pagination"]
+      },
+      "UpdateWorkspaceInstructionDto": {
+        "type": "object",
+        "properties": {
+          "instruction": {
+            "type": "string",
+            "description": "Instructions that apply to every chat in the workspace",
+            "nullable": true,
+            "maxLength": 10000
+          }
+        },
+        "required": ["instruction"]
       },
       "WorkspaceFavoriteResponseDto": {
         "type": "object",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches chat runtime context assembly, file uploads, and cascade deletion of workspace-owned sources, but access checks reuse existing skill/KB services and changes are mostly additive behind the workspaces feature flag.
> 
> **Overview**
> Adds **workspace project context** so an owner can attach a private instruction, skills, knowledge bases, and uploaded documents, and expose that through `/workspaces/:id/context` for chat runtime.
> 
> Persistence adds assignment join tables plus `workspaces.instruction`, with use cases to attach/detach entities, upload/remove workspace documents (with source limits and rollback on failed attach), update instruction, and **`BuildWorkspaceRunContextUseCase`** to resolve accessible assignments into a merged run payload (including skill-linked KBs/sources and MCP IDs, skipping revoked shares). Workspace deletion now returns attached source IDs and defers source cleanup after the row delete.
> 
> **Paginated, DB-backed listing** is wired through skills, knowledge bases, and sources: accessible skills/KBs can be filtered by workspace assignment; workspace document lists use `ListSourcesByWorkspace`; workspace and context UI lists use search/limit/offset with candidate pages marked `isAttached`. Workspace index listing gains search, sort, and pagination.
> 
> Shared **`document-upload`** helpers centralize multer setup, MIME validation, and temp-file cleanup; knowledge-base uploads adopt them, and disk upload destination now ensures `./uploads` exists. An index on `sources.knowledgeBaseId` and an unreferenced-source guard excluding workspace assignments reduce orphan/lifecycle edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be554af67f7210f91d426d135c3bf7dee15a4d1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->