### PR TITLE
wip(logging): migrate common and integrations to pino (AYC-745)

### DIFF
--- a/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case.spec.ts
+++ b/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { AnonymizeTextUseCase } from './anonymize-text.use-case';
 import { AnonymizeTextCommand } from './anonymize-text.command';
 import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
@@ -8,11 +8,12 @@ import { PiiWhitelistEntry } from 'src/common/anonymization/domain/pii-whitelist
 describe('AnonymizeTextUseCase', () => {
   let useCase: AnonymizeTextUseCase;
   let detect: jest.Mock;
+  const logger = createPinoLoggerMock();
 
   beforeEach(() => {
     detect = jest.fn();
-    useCase = new AnonymizeTextUseCase({ detect });
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    logger.info.mockReset();
+    useCase = new AnonymizeTextUseCase(logger, { detect });
   });
 
   const text = 'Ich bin der Dani, erreichbar unter amt32@stadt-marl.de';

--- a/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case.ts
+++ b/ayunis-core-backend/src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   AnonymizationPort,
   AnonymizationResult,
@@ -12,16 +13,21 @@ import { PiiMask } from 'src/common/anonymization/domain/pii-mask';
 
 @Injectable()
 export class AnonymizeTextUseCase {
-  private readonly logger = new Logger(AnonymizeTextUseCase.name);
-
-  constructor(private readonly anonymizationPort: AnonymizationPort) {}
+  constructor(
+    @InjectPinoLogger(AnonymizeTextUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly anonymizationPort: AnonymizationPort,
+  ) {}
 
   async execute(command: AnonymizeTextCommand): Promise<AnonymizationResult> {
-    this.logger.log('Executing anonymize text', {
-      textLength: command.text.length,
-      entities: command.entities,
-      whitelistSize: command.whitelist?.length ?? 0,
-    });
+    this.logger.info(
+      {
+        textLength: command.text.length,
+        entities: command.entities,
+        whitelistSize: command.whitelist?.length ?? 0,
+      },
+      'Executing anonymize text',
+    );
 
     const detections = await this.anonymizationPort.detect(
       command.text,

--- a/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.spec.ts
+++ b/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { PresidioAnonymizationProvider } from './presidio-anonymization.provider';
 import { PiiCategory } from '../../domain/pii-category.enum';
 import { AnonymizationFailedError } from '../../application/anonymization.errors';
@@ -16,12 +16,11 @@ jest.mock(
 
 describe('PresidioAnonymizationProvider', () => {
   let provider: PresidioAnonymizationProvider;
+  const logger = createPinoLoggerMock();
 
   beforeEach(() => {
-    provider = new PresidioAnonymizationProvider();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    jest.clearAllMocks();
+    provider = new PresidioAnonymizationProvider(logger);
     mockAnalyzeTextAnalyzePost.mockReset();
   });
 
@@ -110,7 +109,6 @@ describe('PresidioAnonymizationProvider', () => {
   });
 
   it('logs payload size and total client duration after detection', async () => {
-    const log = jest.spyOn(Logger.prototype, 'log');
     jest
       .spyOn(performance, 'now')
       .mockReturnValueOnce(100)
@@ -119,11 +117,10 @@ describe('PresidioAnonymizationProvider', () => {
 
     await provider.detect('Der Wetterbericht sagt Regen voraus');
 
-    expect(log).toHaveBeenCalledWith('PII detection complete', {
-      textLength: 35,
-      detectionCount: 0,
-      durationMs: 356.78,
-    });
+    expect(logger.info).toHaveBeenCalledWith(
+      { textLength: 35, detectionCount: 0, durationMs: 356.78 },
+      'PII detection complete',
+    );
   });
 
   it('returns no detections when the service finds no entities', async () => {

--- a/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.ts
+++ b/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { AnonymizationPort } from '../../application/ports/anonymization.port';
 import {
   AnonymizationFailedError,
@@ -26,7 +27,12 @@ function countCodePoints(text: string): number {
 
 @Injectable()
 export class PresidioAnonymizationProvider extends AnonymizationPort {
-  private readonly logger = new Logger(PresidioAnonymizationProvider.name);
+  constructor(
+    @InjectPinoLogger(PresidioAnonymizationProvider.name)
+    private readonly logger: PinoLogger,
+  ) {
+    super();
+  }
 
   async detect(text: string, entities?: string[]): Promise<PiiDetection[]> {
     const textLength = countCodePoints(text);
@@ -37,10 +43,7 @@ export class PresidioAnonymizationProvider extends AnonymizationPort {
       );
     }
 
-    this.logger.debug('Detecting PII', {
-      textLength,
-      entities,
-    });
+    this.logger.debug({ textLength, entities }, 'Detecting PII');
     const startedAt = performance.now();
 
     try {
@@ -58,19 +61,11 @@ export class PresidioAnonymizationProvider extends AnonymizationPort {
         this.toDetection(text, result),
       );
 
-      this.logger.log('PII detection complete', {
-        textLength,
-        detectionCount: detections.length,
-        durationMs: Math.round((performance.now() - startedAt) * 100) / 100,
-      });
+      this.logDetectionComplete(textLength, detections.length, startedAt);
 
       return detections;
     } catch (error: unknown) {
-      this.logger.error('PII detection failed', {
-        textLength,
-        durationMs: Math.round((performance.now() - startedAt) * 100) / 100,
-        error: error as Error,
-      });
+      this.logDetectionFailure(textLength, startedAt, error);
       // Every caller treats a service-call pipeline failure as fatal and
       // fail-closed (the user's message is blocked rather than sent unmasked),
       // so this catch is their single classification point. Transport failures
@@ -88,6 +83,36 @@ export class PresidioAnonymizationProvider extends AnonymizationPort {
         { error: error as Error },
       );
     }
+  }
+
+  private logDetectionComplete(
+    textLength: number,
+    detectionCount: number,
+    startedAt: number,
+  ): void {
+    this.logger.info(
+      {
+        textLength,
+        detectionCount,
+        durationMs: Math.round((performance.now() - startedAt) * 100) / 100,
+      },
+      'PII detection complete',
+    );
+  }
+
+  private logDetectionFailure(
+    textLength: number,
+    startedAt: number,
+    error: unknown,
+  ): void {
+    this.logger.error(
+      {
+        textLength,
+        durationMs: Math.round((performance.now() - startedAt) * 100) / 100,
+        err: error,
+      },
+      'PII detection failed',
+    );
   }
 
   private toDetection(text: string, result: RecognizerResult): PiiDetection {

--- a/ayunis-core-backend/src/common/clients/anonymize/client.ts
+++ b/ayunis-core-backend/src/common/clients/anonymize/client.ts
@@ -1,8 +1,10 @@
-import { Logger } from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
 import axios, { isAxiosError } from 'axios';
 import type { AxiosRequestConfig } from 'axios';
+import { createPinoLoggerConfig } from '../../logger/pino-logger.config';
 
-const logger = new Logger('AnonymizeClient');
+const logger = new PinoLogger(createPinoLoggerConfig());
+logger.setContext('AnonymizeClient');
 
 interface AnonymizeTimingMetadata {
   requestDurationMs: number;
@@ -103,12 +105,12 @@ anonymizeAxios.interceptors.response.use(
   (response) => {
     const startedAt = requestStartedAt.get(response.config);
     if (startedAt !== undefined) {
-      logger.log(
-        'Anonymize request complete',
+      logger.info(
         parseAnonymizeTimingMetadata(
           response.headers,
           Math.round((performance.now() - startedAt) * 100) / 100,
         ),
+        'Anonymize request complete',
       );
     }
     return response;
@@ -116,7 +118,7 @@ anonymizeAxios.interceptors.response.use(
   (error: unknown) => {
     if (isAxiosError(error) && error.response?.status === 500) {
       const data: unknown = error.response.data;
-      logger.error('Anonymize service error', { data });
+      logger.error({ response: data }, 'Anonymize service error');
     }
     return Promise.reject(toSlimTransportError(error));
   },

--- a/ayunis-core-backend/src/common/clients/locaboo/infrastructure/locaboo3/locaboo3.repository.ts
+++ b/ayunis-core-backend/src/common/clients/locaboo/infrastructure/locaboo3/locaboo3.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import {
   CreateBookingParams,
@@ -25,8 +26,9 @@ import { GetCustomerGroupsResponseMapper } from './mappers/getCustomerGroupsResp
 
 @Injectable()
 export class Locaboo3Repository extends LocabooDataRepository {
-  private readonly logger = new Logger(Locaboo3Repository.name);
   constructor(
+    @InjectPinoLogger(Locaboo3Repository.name)
+    private readonly logger: PinoLogger,
     private readonly configService: ConfigService,
     private readonly getBookingsResponseMapper: GetBookingsResponseMapper,
     private readonly getResourcesResponseMapper: GetResourcesResponseMapper,
@@ -41,20 +43,17 @@ export class Locaboo3Repository extends LocabooDataRepository {
     endpoint: string,
     options: RequestInit = {},
   ): Promise<T> {
-    this.logger.log('fetch', {
-      endpoint,
-    });
+    this.logger.info({ endpointPath: endpoint.split('?')[0] }, 'fetch');
     const url = `${this.configService.get<string>('locaboo3.baseUrl')}${endpoint}`;
     const response = await fetch(url, options);
     if (!response.ok) {
       const responseText = await response.text();
       this.logger.error(
-        'Failed to fetch data from Locaboo API',
         {
           errorCode: response.status,
-          ...JSON.parse(responseText),
+          response: JSON.parse(responseText) as unknown,
         },
-        responseText,
+        'Failed to fetch data from Locaboo API',
       );
 
       throw new Error(responseText);
@@ -128,43 +127,39 @@ export class Locaboo3Repository extends LocabooDataRepository {
     );
     return this.getInvoiceRowsResponseMapper
       .toInvoiceRows(response)
-      .filter((row) => {
-        let matches = true;
-        if (params.bookingIds && params.bookingIds.length > 0) {
-          if (row.bookingId) {
-            matches = params.bookingIds.includes(row.bookingId);
-          } else {
-            matches = false;
-          }
-        }
-        if (
-          params.inventoryOrServiceIds &&
-          params.inventoryOrServiceIds.length > 0
-        ) {
-          if (row.inventoryId) {
-            matches = params.inventoryOrServiceIds.includes(row.inventoryId);
-          } else if (row.serviceId) {
-            matches = params.inventoryOrServiceIds.includes(row.serviceId);
-          } else {
-            matches = false;
-          }
-        }
-        if (params.resourceIds && params.resourceIds.length > 0) {
-          if (row.resourceId) {
-            matches = params.resourceIds.includes(row.resourceId);
-          } else {
-            matches = false;
-          }
-        }
-        if (params.resourceNames && params.resourceNames.length > 0) {
-          if (row.resourceName) {
-            matches = params.resourceNames.includes(row.resourceName);
-          } else {
-            matches = false;
-          }
-        }
-        return matches;
-      });
+      .filter((row) => this.matchesInvoiceRow(row, params));
+  }
+
+  private matchesInvoiceRow(
+    row: InvoiceRow,
+    params: GetInvoiceRowsParams,
+  ): boolean {
+    if (params.resourceNames.length > 0) {
+      return this.matchesAny(params.resourceNames, row.resourceName);
+    }
+    if (params.resourceIds.length > 0) {
+      return this.matchesAny(params.resourceIds, row.resourceId);
+    }
+    if (params.inventoryOrServiceIds.length > 0) {
+      return this.matchesAny(
+        params.inventoryOrServiceIds,
+        row.inventoryId,
+        row.serviceId,
+      );
+    }
+    if (params.bookingIds.length > 0) {
+      return this.matchesAny(params.bookingIds, row.bookingId);
+    }
+    return true;
+  }
+
+  private matchesAny(
+    permittedValues: string[],
+    ...actualValues: (string | undefined)[]
+  ): boolean {
+    return actualValues.some(
+      (value) => value !== undefined && permittedValues.includes(value),
+    );
   }
 
   async getCustomerGroups(apiKey: string): Promise<CustomerGroup[]> {

--- a/ayunis-core-backend/src/common/decorators/handle-unexpected-errors.decorator.spec.ts
+++ b/ayunis-core-backend/src/common/decorators/handle-unexpected-errors.decorator.spec.ts
@@ -1,4 +1,5 @@
-import { HttpException, Logger } from '@nestjs/common';
+import { HttpException } from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from '../errors/base.error';
 import { HandleUnexpectedErrors } from './handle-unexpected-errors.decorator';
 
@@ -68,20 +69,22 @@ describe('HandleUnexpectedErrors', () => {
   });
 
   it('logs under the class name and maps unknown errors', async () => {
-    const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    const errorSpy = jest
+      .spyOn(PinoLogger.prototype, 'error')
+      .mockImplementation();
 
     await expect(
       new ExampleUseCase().execute('unexpected-error'),
     ).rejects.toBeInstanceOf(ExampleUnexpectedError);
 
     expect(errorSpy).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
       'Unexpected use-case error',
-      expect.any(String),
     );
   });
 
   it('maps non-Error rejections to the unexpected error', async () => {
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    jest.spyOn(PinoLogger.prototype, 'error').mockImplementation();
     // Third-party libraries sometimes reject with plain strings
     const useCase = new ExampleUseCaseWithDependency({
       load: jest.fn().mockRejectedValue('Rejected as string'),

--- a/ayunis-core-backend/src/common/decorators/handle-unexpected-errors.decorator.ts
+++ b/ayunis-core-backend/src/common/decorators/handle-unexpected-errors.decorator.ts
@@ -1,5 +1,7 @@
-import { HttpException, Logger } from '@nestjs/common';
+import { HttpException } from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from '../errors/base.error';
+import { createPinoLoggerConfig } from '../logger/pino-logger.config';
 
 type UnexpectedErrorClass = new (error: Error) => ApplicationError;
 
@@ -16,7 +18,7 @@ export function HandleUnexpectedErrors(UnexpectedError: UnexpectedErrorClass) {
       return;
     }
 
-    const logger = new Logger(target.constructor.name);
+    const logger = createDecoratorLogger(target.constructor.name);
 
     descriptor.value = async function (
       this: unknown,
@@ -30,7 +32,7 @@ export function HandleUnexpectedErrors(UnexpectedError: UnexpectedErrorClass) {
         }
 
         const error = toError(cause);
-        logger.error('Unexpected use-case error', error.stack);
+        logger.error({ err: error }, 'Unexpected use-case error');
         throw new UnexpectedError(error);
       }
     };
@@ -42,6 +44,12 @@ function isExpectedError(
   error: unknown,
 ): error is ApplicationError | HttpException {
   return error instanceof ApplicationError || error instanceof HttpException;
+}
+
+function createDecoratorLogger(context: string): PinoLogger {
+  const logger = new PinoLogger(createPinoLoggerConfig());
+  logger.setContext(context);
+  return logger;
 }
 
 function toError(cause: unknown): Error {

--- a/ayunis-core-backend/src/common/events/deferred-cleanup.event.spec.ts
+++ b/ayunis-core-backend/src/common/events/deferred-cleanup.event.spec.ts
@@ -1,4 +1,5 @@
-import { Logger } from '@nestjs/common';
+import type { PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerMock } from '../testing/pino-logger.mock';
 import { DeferredCleanupEvent } from './deferred-cleanup.event';
 import { runDeferredCleanup } from './run-deferred-cleanup';
 
@@ -25,11 +26,10 @@ describe('DeferredCleanupEvent', () => {
 });
 
 describe('runDeferredCleanup', () => {
-  let logger: Logger;
+  let logger: jest.Mocked<PinoLogger>;
 
   beforeEach(() => {
-    logger = new Logger('test');
-    jest.spyOn(logger, 'error').mockImplementation();
+    logger = createPinoLoggerMock();
   });
 
   it('runs all tasks in order', async () => {
@@ -66,9 +66,9 @@ describe('runDeferredCleanup', () => {
     ).resolves.toBeUndefined();
 
     expect(second).toHaveBeenCalled();
-    expect(logger.error).toHaveBeenCalledWith('Deferred cleanup task failed', {
-      label: 'failing',
-      error: 'boom',
-    });
+    expect(logger.error).toHaveBeenCalledWith(
+      { label: 'failing', error: 'boom' },
+      'Deferred cleanup task failed',
+    );
   });
 });

--- a/ayunis-core-backend/src/common/events/run-deferred-cleanup.ts
+++ b/ayunis-core-backend/src/common/events/run-deferred-cleanup.ts
@@ -1,5 +1,8 @@
-import type { Logger } from '@nestjs/common';
 import type { DeferredCleanupTask } from './deferred-cleanup.event';
+
+interface StructuredErrorLogger {
+  error(metadata: object, message: string): void;
+}
 
 /**
  * Runs deferred cleanup tasks after a successful row delete. Each task is
@@ -8,16 +11,19 @@ import type { DeferredCleanupTask } from './deferred-cleanup.event';
  */
 export async function runDeferredCleanup(
   tasks: DeferredCleanupTask[],
-  logger: Logger,
+  logger: StructuredErrorLogger,
 ): Promise<void> {
   for (const task of tasks) {
     try {
       await task.run();
     } catch (error) {
-      logger.error('Deferred cleanup task failed', {
-        label: task.label,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      logger.error(
+        {
+          label: task.label,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Deferred cleanup task failed',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/common/guards/rate-limit.guard.spec.ts
+++ b/ayunis-core-backend/src/common/guards/rate-limit.guard.spec.ts
@@ -1,5 +1,5 @@
-import { Logger } from '@nestjs/common';
 import type { ExecutionContext } from '@nestjs/common';
+import { createPinoLoggerMock } from '../testing/pino-logger.mock';
 import type { Reflector } from '@nestjs/core';
 import type { ConfigService } from '@nestjs/config';
 import { RateLimitGuard } from './rate-limit.guard';
@@ -10,6 +10,7 @@ describe('RateLimitGuard', () => {
   let guard: RateLimitGuard;
   let reflector: jest.Mocked<Reflector>;
   let configService: jest.Mocked<ConfigService>;
+  const logger = createPinoLoggerMock();
 
   const clientIp = '203.0.113.7';
 
@@ -30,10 +31,7 @@ describe('RateLimitGuard', () => {
       get: jest.fn(),
     } as unknown as jest.Mocked<ConfigService>;
 
-    guard = new RateLimitGuard(reflector, configService);
-
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    guard = new RateLimitGuard(logger, reflector, configService);
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/common/guards/rate-limit.guard.ts
+++ b/ayunis-core-backend/src/common/guards/rate-limit.guard.ts
@@ -1,9 +1,5 @@
-import {
-  CanActivate,
-  ExecutionContext,
-  Injectable,
-  Logger,
-} from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
 import { ConfigService } from '@nestjs/config';
@@ -21,11 +17,12 @@ interface RateLimitRecord {
 
 @Injectable()
 export class RateLimitGuard implements CanActivate {
-  private readonly logger = new Logger(RateLimitGuard.name);
   private readonly store = new Map<string, RateLimitRecord>();
   private cleanupCounter = 0;
 
   constructor(
+    @InjectPinoLogger(RateLimitGuard.name)
+    private readonly logger: PinoLogger,
     private readonly reflector: Reflector,
     private readonly configService: ConfigService,
   ) {}
@@ -82,13 +79,16 @@ export class RateLimitGuard implements CanActivate {
       };
       this.store.set(key, record);
 
-      this.logger.debug('Rate limit: new window started', {
-        clientIp,
-        key,
-        count: record.count,
-        limit: rateLimitOptions.limit,
-        resetTime: new Date(record.resetTime).toISOString(),
-      });
+      this.logger.debug(
+        {
+          clientIp,
+          key,
+          count: record.count,
+          limit: rateLimitOptions.limit,
+          resetTime: new Date(record.resetTime).toISOString(),
+        },
+        'Rate limit: new window started',
+      );
 
       return true;
     }
@@ -100,13 +100,16 @@ export class RateLimitGuard implements CanActivate {
       this.throwLimitExceeded(key, clientIp, rateLimitOptions, record, now);
     }
 
-    this.logger.debug('Rate limit: request allowed', {
-      clientIp,
-      key,
-      count: record.count,
-      limit: rateLimitOptions.limit,
-      remaining: rateLimitOptions.limit - record.count,
-    });
+    this.logger.debug(
+      {
+        clientIp,
+        key,
+        count: record.count,
+        limit: rateLimitOptions.limit,
+        remaining: rateLimitOptions.limit - record.count,
+      },
+      'Rate limit: request allowed',
+    );
 
     return true;
   }
@@ -120,13 +123,16 @@ export class RateLimitGuard implements CanActivate {
   ): never {
     const timeToReset = record.resetTime - now;
 
-    this.logger.warn('Rate limit exceeded', {
-      clientIp,
-      key,
-      count: record.count,
-      limit: rateLimitOptions.limit,
-      timeToResetMs: timeToReset,
-    });
+    this.logger.warn(
+      {
+        clientIp,
+        key,
+        count: record.count,
+        limit: rateLimitOptions.limit,
+        timeToResetMs: timeToReset,
+      },
+      'Rate limit exceeded',
+    );
 
     throw new RateLimitExceededError(
       rateLimitOptions.message ||

--- a/ayunis-core-backend/src/common/middleware/cookie-parser.middleware.ts
+++ b/ayunis-core-backend/src/common/middleware/cookie-parser.middleware.ts
@@ -1,14 +1,18 @@
-import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Request, Response, NextFunction, RequestHandler } from 'express';
 import { ConfigService } from '@nestjs/config';
 import cookieParser from 'cookie-parser';
 
 @Injectable()
 export class CookieParserMiddleware implements NestMiddleware {
-  private readonly logger = new Logger(CookieParserMiddleware.name);
   private cookieParserMiddleware: RequestHandler;
 
-  constructor(private configService: ConfigService) {
+  constructor(
+    @InjectPinoLogger(CookieParserMiddleware.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {
     const cookieSecret = this.configService.get<string>('auth.cookie.secret');
 
     if (!cookieSecret) {
@@ -17,7 +21,7 @@ export class CookieParserMiddleware implements NestMiddleware {
       );
       this.cookieParserMiddleware = cookieParser();
     } else {
-      this.logger.log('Initializing cookie parser with signing');
+      this.logger.info('Initializing cookie parser with signing');
       this.cookieParserMiddleware = cookieParser(cookieSecret);
     }
   }

--- a/ayunis-core-backend/src/common/middleware/security-headers.middleware.ts
+++ b/ayunis-core-backend/src/common/middleware/security-headers.middleware.ts
@@ -1,10 +1,10 @@
-import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Request, Response, NextFunction } from 'express';
 import helmet from 'helmet';
 
 @Injectable()
 export class SecurityHeadersMiddleware implements NestMiddleware {
-  private readonly logger = new Logger(SecurityHeadersMiddleware.name);
   private helmetMiddleware = helmet({
     crossOriginEmbedderPolicy: false,
     ...(process.env.NODE_ENV !== 'production' && {
@@ -21,8 +21,11 @@ export class SecurityHeadersMiddleware implements NestMiddleware {
     },
   });
 
-  constructor() {
-    this.logger.log(
+  constructor(
+    @InjectPinoLogger(SecurityHeadersMiddleware.name)
+    private readonly logger: PinoLogger,
+  ) {
+    this.logger.info(
       'Security headers middleware initialized with cookie-friendly settings',
     );
   }

--- a/ayunis-core-backend/src/common/process/process-crash-handlers.spec.ts
+++ b/ayunis-core-backend/src/common/process/process-crash-handlers.spec.ts
@@ -1,5 +1,5 @@
-import { Logger } from '@nestjs/common';
 import { Appsignal, sendError } from '@appsignal/nodejs';
+import { createPinoLoggerMock } from '../testing/pino-logger.mock';
 import { ProcessCrashHandlers } from './process-crash-handlers';
 
 jest.mock('@appsignal/nodejs', () => ({
@@ -13,20 +13,19 @@ const stopMock = Appsignal.client.stop as jest.Mock;
 
 describe('ProcessCrashHandlers', () => {
   let handlers: ProcessCrashHandlers;
-  let loggerErrorSpy: jest.SpyInstance;
+  const logger = createPinoLoggerMock();
   let exitSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    handlers = new ProcessCrashHandlers();
-    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    handlers = new ProcessCrashHandlers(logger);
+    logger.error.mockReset();
     exitSpy = jest
       .spyOn(process, 'exit')
       .mockImplementation(() => undefined as never);
   });
 
   afterEach(() => {
-    loggerErrorSpy.mockRestore();
     exitSpy.mockRestore();
   });
 
@@ -36,9 +35,9 @@ describe('ProcessCrashHandlers', () => {
 
       handlers.handleUnhandledRejection(error);
 
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
-        'Unhandled promise rejection: db write failed',
-        error.stack,
+      expect(logger.error).toHaveBeenCalledWith(
+        { err: error },
+        'Unhandled promise rejection',
       );
       expect(sendError).toHaveBeenCalledWith(error);
       expect(exitSpy).not.toHaveBeenCalled();
@@ -62,7 +61,7 @@ describe('ProcessCrashHandlers', () => {
     });
 
     it('still reports to AppSignal when logging fails', () => {
-      loggerErrorSpy.mockImplementationOnce(() => {
+      logger.error.mockImplementationOnce(() => {
         throw new Error('logger transport broken');
       });
       const error = new Error('boom');
@@ -92,9 +91,9 @@ describe('ProcessCrashHandlers', () => {
       handlers.handleUncaughtException(error);
       await new Promise(process.nextTick);
 
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
-        'Uncaught exception: socket write after close',
-        error.stack,
+      expect(logger.error).toHaveBeenCalledWith(
+        { err: error },
+        'Uncaught exception',
       );
       expect(sendError).toHaveBeenCalledWith(error);
       expect(stopMock).toHaveBeenCalled();
@@ -107,9 +106,9 @@ describe('ProcessCrashHandlers', () => {
       handlers.handleUncaughtException(new Error('boom'));
       await new Promise(process.nextTick);
 
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
-        'Failed to stop AppSignal before shutdown: stop timeout',
-        expect.any(String),
+      expect(logger.error).toHaveBeenCalledWith(
+        { err: expect.any(Error) },
+        'Failed to stop AppSignal before shutdown',
       );
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
@@ -129,9 +128,9 @@ describe('ProcessCrashHandlers', () => {
       handlers.handleUncaughtException(null);
       await new Promise(process.nextTick);
 
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
-        'Uncaught exception: null',
-        expect.any(String),
+      expect(logger.error).toHaveBeenCalledWith(
+        { err: expect.any(Error) },
+        'Uncaught exception',
       );
       expect(sendError).toHaveBeenCalledWith(
         expect.objectContaining({ message: 'null' }),

--- a/ayunis-core-backend/src/common/process/process-crash-handlers.ts
+++ b/ayunis-core-backend/src/common/process/process-crash-handlers.ts
@@ -1,5 +1,6 @@
-import { Logger } from '@nestjs/common';
 import { Appsignal, sendError } from '@appsignal/nodejs';
+import { PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerConfig } from '../logger/pino-logger.config';
 
 const APPSIGNAL_STOP_TIMEOUT_MS = 2_000;
 const FAILURE_EXIT_CODE = 1;
@@ -26,9 +27,9 @@ function stringifyRejectionReason(reason: unknown): string {
 }
 
 export class ProcessCrashHandlers {
-  private readonly logger = new Logger(ProcessCrashHandlers.name);
-
   private fatalShutdownStarted = false;
+
+  constructor(private readonly logger: PinoLogger = createCrashLogger()) {}
 
   register(): void {
     process.on('unhandledRejection', this.handleUnhandledRejection);
@@ -62,7 +63,7 @@ export class ProcessCrashHandlers {
 
   private reportError(message: string, error: Error): void {
     try {
-      this.logger.error(`${message}: ${error.message}`, error.stack);
+      this.logger.error({ err: error }, message);
     } catch {
       // There is no safer logging channel left.
     }
@@ -90,8 +91,8 @@ export class ProcessCrashHandlers {
       const error = normalizeError(reason);
 
       this.logger.error(
-        `Failed to stop AppSignal before shutdown: ${error.message}`,
-        error.stack,
+        { err: error },
+        'Failed to stop AppSignal before shutdown',
       );
     } finally {
       this.exitProcess();
@@ -113,4 +114,10 @@ export class ProcessCrashHandlers {
  */
 if (process.env.NODE_ENV !== 'test') {
   new ProcessCrashHandlers().register();
+}
+
+function createCrashLogger(): PinoLogger {
+  const logger = new PinoLogger(createPinoLoggerConfig());
+  logger.setContext(ProcessCrashHandlers.name);
+  return logger;
 }

--- a/ayunis-core-backend/src/common/puppeteer/lazy-chromium-browser.ts
+++ b/ayunis-core-backend/src/common/puppeteer/lazy-chromium-browser.ts
@@ -1,6 +1,7 @@
-import { Logger } from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
 import puppeteer, { type Browser } from 'puppeteer-core';
 import { existsSync } from 'fs';
+import { createPinoLoggerConfig } from '../logger/pino-logger.config';
 
 /**
  * Lazily launched, shared headless-Chromium instance for PDF rendering.
@@ -8,9 +9,10 @@ import { existsSync } from 'fs';
  * (typically from the owning service's `onModuleDestroy`).
  */
 export class LazyChromiumBrowser {
-  private readonly logger = new Logger(LazyChromiumBrowser.name);
   private browser: Browser | null = null;
   private launchPromise: Promise<void> | null = null;
+
+  constructor(private readonly logger: PinoLogger = createBrowserLogger()) {}
 
   async get(): Promise<Browser> {
     if (this.browser?.connected) {
@@ -18,7 +20,7 @@ export class LazyChromiumBrowser {
     }
 
     if (!this.launchPromise) {
-      this.logger.log('Launching Puppeteer browser (lazy init)');
+      this.logger.info('Launching Puppeteer browser (lazy init)');
       this.launchPromise = this.launch().finally(() => {
         this.launchPromise = null;
       });
@@ -35,7 +37,7 @@ export class LazyChromiumBrowser {
     if (this.browser) {
       await this.browser.close();
       this.browser = null;
-      this.logger.log('Puppeteer browser closed');
+      this.logger.info('Puppeteer browser closed');
     }
   }
 
@@ -46,7 +48,7 @@ export class LazyChromiumBrowser {
       executablePath,
       args: ['--no-sandbox', '--disable-setuid-sandbox'],
     });
-    this.logger.log(`Puppeteer browser launched (${executablePath})`);
+    this.logger.info({ executablePath }, 'Puppeteer browser launched');
   }
 
   private resolveChromePath(): string {
@@ -71,4 +73,10 @@ export class LazyChromiumBrowser {
       'No Chrome/Chromium executable found. Set PUPPETEER_EXECUTABLE_PATH.',
     );
   }
+}
+
+function createBrowserLogger(): PinoLogger {
+  const logger = new PinoLogger(createPinoLoggerConfig());
+  logger.setContext(LazyChromiumBrowser.name);
+  return logger;
 }

--- a/ayunis-core-backend/src/common/token-counter/application/token-counter.registry.ts
+++ b/ayunis-core-backend/src/common/token-counter/application/token-counter.registry.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   TokenCounterHandler,
   TokenCounterType,
@@ -10,15 +11,19 @@ import {
 
 @Injectable()
 export class TokenCounterRegistry {
-  private readonly logger = new Logger(TokenCounterRegistry.name);
   private readonly handlers = new Map<TokenCounterType, TokenCounterHandler>();
+
+  constructor(
+    @InjectPinoLogger(TokenCounterRegistry.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   registerHandler(handler: TokenCounterHandler): void {
     this.handlers.set(handler.type, handler);
   }
 
   getHandler(type: TokenCounterType): TokenCounterHandler {
-    this.logger.debug('getHandler', { type });
+    this.logger.debug({ type }, 'getHandler');
     const handler = this.handlers.get(type);
 
     if (!handler) {

--- a/ayunis-core-backend/src/common/token-counter/application/use-cases/count-tokens/count-tokens.use-case.ts
+++ b/ayunis-core-backend/src/common/token-counter/application/use-cases/count-tokens/count-tokens.use-case.ts
@@ -1,15 +1,18 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TokenCounterRegistry } from '../../token-counter.registry';
 import { CountTokensCommand } from './count-tokens.command';
 
 @Injectable()
 export class CountTokensUseCase {
-  private readonly logger = new Logger(CountTokensUseCase.name);
-
-  constructor(private readonly registry: TokenCounterRegistry) {}
+  constructor(
+    @InjectPinoLogger(CountTokensUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly registry: TokenCounterRegistry,
+  ) {}
 
   execute(command: CountTokensCommand): number {
-    this.logger.debug('execute', { textLength: command.text.length });
+    this.logger.debug({ textLength: command.text.length }, 'execute');
 
     const handler = command.counterType
       ? this.registry.getHandler(command.counterType)

--- a/ayunis-core-backend/src/common/token-counter/infrastructure/handlers/tiktoken.handler.ts
+++ b/ayunis-core-backend/src/common/token-counter/infrastructure/handlers/tiktoken.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Tiktoken, get_encoding } from 'tiktoken';
 import {
   TokenCounterHandler,
@@ -10,9 +11,15 @@ export class TiktokenHandler
   extends TokenCounterHandler
   implements OnModuleDestroy
 {
-  private readonly logger = new Logger(TiktokenHandler.name);
   readonly type = TokenCounterType.TIKTOKEN;
   private encoder: Tiktoken | null = null;
+
+  constructor(
+    @InjectPinoLogger(TiktokenHandler.name)
+    private readonly logger: PinoLogger,
+  ) {
+    super();
+  }
 
   isAvailable(): boolean {
     return true;

--- a/ayunis-core-backend/src/common/token-counter/token-counter.module.ts
+++ b/ayunis-core-backend/src/common/token-counter/token-counter.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { getLoggerToken, type PinoLogger } from 'nestjs-pino';
 import { TokenCounterRegistry } from './application/token-counter.registry';
 import { CountTokensUseCase } from './application/use-cases/count-tokens/count-tokens.use-case';
 import { TiktokenHandler } from './infrastructure/handlers/tiktoken.handler';
@@ -9,15 +10,20 @@ import { SimpleHandler } from './infrastructure/handlers/simple.handler';
     {
       provide: TokenCounterRegistry,
       useFactory: (
+        logger: PinoLogger,
         tiktokenHandler: TiktokenHandler,
         simpleHandler: SimpleHandler,
       ) => {
-        const registry = new TokenCounterRegistry();
+        const registry = new TokenCounterRegistry(logger);
         registry.registerHandler(tiktokenHandler);
         registry.registerHandler(simpleHandler);
         return registry;
       },
-      inject: [TiktokenHandler, SimpleHandler],
+      inject: [
+        getLoggerToken(TokenCounterRegistry.name),
+        TiktokenHandler,
+        SimpleHandler,
+      ],
     },
     CountTokensUseCase,
     TiktokenHandler,

--- a/ayunis-core-backend/src/common/util/access-denied-audit.util.ts
+++ b/ayunis-core-backend/src/common/util/access-denied-audit.util.ts
@@ -12,7 +12,7 @@ export interface AuditPrincipal {
 
 /**
  * Structured audit context describing who was denied access and where.
- * Emitted as a `Logger.warn` payload whenever a guard rejects a request
+ * Emitted as structured warning metadata whenever a guard rejects a request
  * with a 403 (wrong role or IP allowlist), so that silent denials become
  * auditable.
  */

--- a/ayunis-core-backend/src/common/util/cookie.util.ts
+++ b/ayunis-core-backend/src/common/util/cookie.util.ts
@@ -2,9 +2,11 @@ import type { Response } from 'express';
 import type { ConfigService } from '@nestjs/config';
 import { getMillisecondsFromJwtExpiry } from './jwt.util';
 import type { AuthTokens } from 'src/iam/authentication/domain/auth-tokens.entity';
-import { Logger } from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerConfig } from '../logger/pino-logger.config';
 
-const logger = new Logger('CookieUtil');
+const logger = new PinoLogger(createPinoLoggerConfig());
+logger.setContext('CookieUtil');
 
 interface CookieOptions {
   httpOnly: boolean;
@@ -58,14 +60,17 @@ export function setCookies(
   const baseOptions = buildCookieOptions(configService);
   const { accessTokenName, refreshTokenName } = getCookieNames(configService);
 
-  logger.debug('Setting cookies with options:', {
-    accessTokenName,
-    domain: baseOptions.domain ?? 'undefined (browser default)',
-    secure: baseOptions.secure,
-    sameSite: baseOptions.sameSite,
-    httpOnly: baseOptions.httpOnly,
-    includeRefreshToken,
-  });
+  logger.debug(
+    {
+      accessTokenName,
+      domain: baseOptions.domain ?? 'undefined (browser default)',
+      secure: baseOptions.secure,
+      sameSite: baseOptions.sameSite,
+      httpOnly: baseOptions.httpOnly,
+      includeRefreshToken,
+    },
+    'Setting cookies with options',
+  );
 
   response.cookie(accessTokenName, tokens.access_token, {
     ...baseOptions,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { Logger, UnauthorizedException } from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
 import { randomUUID } from 'crypto';
 import { DeleteMcpIntegrationUseCase } from './delete-mcp-integration.use-case';
 import { DeleteMcpIntegrationCommand } from './delete-mcp-integration.command';
@@ -29,6 +30,7 @@ describe('DeleteMcpIntegrationUseCase', () => {
   >;
   let loggerLogSpy: jest.SpyInstance;
   let loggerErrorSpy: jest.SpyInstance;
+  let decoratorErrorSpy: jest.SpyInstance;
 
   const mockOrgId = randomUUID();
   const mockIntegrationId = randomUUID();
@@ -102,6 +104,9 @@ describe('DeleteMcpIntegrationUseCase', () => {
     // Spy on logger methods
     loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
     loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    decoratorErrorSpy = jest
+      .spyOn(PinoLogger.prototype, 'error')
+      .mockImplementation();
   });
 
   afterEach(() => {
@@ -261,9 +266,9 @@ describe('DeleteMcpIntegrationUseCase', () => {
       await expect(useCase.execute(command)).rejects.toThrow(
         UnexpectedMcpError,
       );
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect(decoratorErrorSpy).toHaveBeenCalledWith(
+        { err: unexpectedError },
         'Unexpected use-case error',
-        expect.any(String),
       );
     });
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { Logger, UnauthorizedException } from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
 import { randomUUID } from 'crypto';
 import { DiscoverMcpCapabilitiesUseCase } from './discover-mcp-capabilities.use-case';
 import { DiscoverMcpCapabilitiesQuery } from './discover-mcp-capabilities.query';
@@ -30,6 +31,7 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
   let capabilityCache: McpCapabilityCacheService;
   let loggerLogSpy: jest.SpyInstance;
   let loggerErrorSpy: jest.SpyInstance;
+  let decoratorErrorSpy: jest.SpyInstance;
 
   const mockOrgId = randomUUID();
   const mockUserId = randomUUID();
@@ -120,6 +122,9 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
     loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
     jest.spyOn(Logger.prototype, 'warn').mockImplementation();
     loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    decoratorErrorSpy = jest
+      .spyOn(PinoLogger.prototype, 'error')
+      .mockImplementation();
   });
 
   afterEach(() => {
@@ -412,9 +417,9 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
       );
       expect((rejection as UnexpectedMcpError).cause).toBe(unexpectedError);
       expect((rejection as UnexpectedMcpError).metadata).toBeUndefined();
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect(decoratorErrorSpy).toHaveBeenCalledWith(
+        { err: unexpectedError },
         'Unexpected use-case error',
-        expect.any(String),
       );
     });
   });

--- a/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.spec.ts
+++ b/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.spec.ts
@@ -1,4 +1,5 @@
 import type { UUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { PrometheusMetricsListener } from './prometheus-metrics.listener';
 import { UserCreatedEvent } from 'src/iam/users/application/events/user-created.event';
 import { UserMessageCreatedEvent } from 'src/domain/messages/application/events/user-message-created.event';
@@ -42,6 +43,7 @@ function mockHistogram() {
 }
 
 describe('PrometheusMetricsListener', () => {
+  const logger = createPinoLoggerMock();
   let listener: PrometheusMetricsListener;
   let userCreationsCounter: ReturnType<typeof mockCounter>;
   let messagesCounter: ReturnType<typeof mockCounter>;
@@ -65,6 +67,7 @@ describe('PrometheusMetricsListener', () => {
     marketplaceInstallsCounter = mockCounter();
 
     listener = new PrometheusMetricsListener(
+      logger,
       userCreationsCounter as never,
       messagesCounter as never,
       userActivityCounter as never,

--- a/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.ts
+++ b/ayunis-core-backend/src/integrations/metrics/listeners/prometheus-metrics.listener.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OnEvent } from '@nestjs/event-emitter';
 import { InjectMetric } from '@willsoto/nestjs-prometheus';
 import { Counter, Histogram } from 'prom-client';
@@ -33,9 +34,9 @@ import { classifyInferenceError } from '../classify-inference-error.helper';
  */
 @Injectable()
 export class PrometheusMetricsListener {
-  private readonly logger = new Logger(PrometheusMetricsListener.name);
-
   constructor(
+    @InjectPinoLogger(PrometheusMetricsListener.name)
+    private readonly logger: PinoLogger,
     @InjectMetric(AYUNIS_USER_CREATIONS_TOTAL)
     private readonly userCreationsCounter: Counter<string>,
     @InjectMetric(AYUNIS_MESSAGES_TOTAL)

--- a/ayunis-core-backend/src/integrations/metrics/metrics-auth.middleware.spec.ts
+++ b/ayunis-core-backend/src/integrations/metrics/metrics-auth.middleware.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { MetricsAuthMiddleware } from './metrics-auth.middleware';
 import type { ConfigService } from '@nestjs/config';
 import type { Request, Response, NextFunction } from 'express';
@@ -25,6 +26,7 @@ function basicAuth(user: string, password: string): string {
 }
 
 describe('MetricsAuthMiddleware', () => {
+  const logger = createPinoLoggerMock();
   let next: NextFunction;
   let res: Response;
 
@@ -36,6 +38,7 @@ describe('MetricsAuthMiddleware', () => {
   describe('when credentials are not configured', () => {
     it('should pass through without authentication', () => {
       const middleware = new MetricsAuthMiddleware(
+        logger,
         createConfigService(undefined, undefined),
       );
 
@@ -49,6 +52,7 @@ describe('MetricsAuthMiddleware', () => {
   describe('when only user is configured', () => {
     it('should reject all requests with 401', () => {
       const middleware = new MetricsAuthMiddleware(
+        logger,
         createConfigService('admin', undefined),
       );
 
@@ -66,6 +70,7 @@ describe('MetricsAuthMiddleware', () => {
   describe('when only password is configured', () => {
     it('should reject all requests with 401', () => {
       const middleware = new MetricsAuthMiddleware(
+        logger,
         createConfigService(undefined, 'secret'),
       );
 
@@ -85,6 +90,7 @@ describe('MetricsAuthMiddleware', () => {
 
     beforeEach(() => {
       middleware = new MetricsAuthMiddleware(
+        logger,
         createConfigService('prometheus', 's3cret!'),
       );
     });
@@ -146,6 +152,7 @@ describe('MetricsAuthMiddleware', () => {
 
     it('should handle passwords containing colons', () => {
       const mw = new MetricsAuthMiddleware(
+        logger,
         createConfigService('prometheus', 'pass:with:colons'),
       );
 

--- a/ayunis-core-backend/src/integrations/metrics/metrics-auth.middleware.ts
+++ b/ayunis-core-backend/src/integrations/metrics/metrics-auth.middleware.ts
@@ -1,4 +1,5 @@
-import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { timingSafeEqual } from 'crypto';
 import type { Request, Response, NextFunction } from 'express';
@@ -6,12 +7,15 @@ import type { MetricsConfig } from '../../config/metrics.config';
 
 @Injectable()
 export class MetricsAuthMiddleware implements NestMiddleware {
-  private readonly logger = new Logger(MetricsAuthMiddleware.name);
   private readonly user: string | undefined;
   private readonly password: string | undefined;
   private readonly authEnabled: boolean;
 
-  constructor(configService: ConfigService) {
+  constructor(
+    @InjectPinoLogger(MetricsAuthMiddleware.name)
+    private readonly logger: PinoLogger,
+    configService: ConfigService,
+  ) {
     const config = configService.get<MetricsConfig>('metrics')!;
     this.user = config.user;
     this.password = config.password;

--- a/ayunis-core-backend/src/integrations/metrics/metrics.utils.spec.ts
+++ b/ayunis-core-backend/src/integrations/metrics/metrics.utils.spec.ts
@@ -1,11 +1,11 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { safeMetric } from './metrics.utils';
 
 describe('safeMetric', () => {
-  const logger = new Logger('TestLogger');
+  const logger = createPinoLoggerMock();
 
   beforeEach(() => {
-    jest.spyOn(logger, 'warn').mockImplementation();
+    logger.warn.mockReset();
   });
 
   it('should execute the metric function', () => {
@@ -19,8 +19,9 @@ describe('safeMetric', () => {
       throw new Error('metric boom');
     });
     expect(() => safeMetric(logger, fn)).not.toThrow();
-    expect(logger.warn).toHaveBeenCalledWith('Metric recording failed', {
-      error: expect.any(Error),
-    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      'Metric recording failed',
+    );
   });
 });

--- a/ayunis-core-backend/src/integrations/metrics/metrics.utils.ts
+++ b/ayunis-core-backend/src/integrations/metrics/metrics.utils.ts
@@ -1,13 +1,13 @@
-import type { Logger } from '@nestjs/common';
+import type { PinoLogger } from 'nestjs-pino';
 
 /**
  * Wraps a metric operation in a try/catch so that metric failures
  * never crash the main business flow. Logs a warning on failure.
  */
-export function safeMetric(logger: Logger, fn: () => void): void {
+export function safeMetric(logger: PinoLogger, fn: () => void): void {
   try {
     fn();
   } catch (error) {
-    logger.warn('Metric recording failed', { error: error as Error });
+    logger.warn({ err: error }, 'Metric recording failed');
   }
 }

--- a/ayunis-core-backend/src/integrations/webhooks/application/use-cases/send-webhook/send-webhook.use-case.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/application/use-cases/send-webhook/send-webhook.use-case.ts
@@ -1,33 +1,34 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SendWebhookCommand } from './send-webhook.command';
 import { WebhookHandler } from '../../ports/webhook.handler';
 
 @Injectable()
 export class SendWebhookUseCase {
-  private readonly logger = new Logger(SendWebhookUseCase.name);
-
-  constructor(private readonly webhookHandler: WebhookHandler) {}
+  constructor(
+    @InjectPinoLogger(SendWebhookUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly webhookHandler: WebhookHandler,
+  ) {}
 
   async execute(command: SendWebhookCommand): Promise<void> {
-    this.logger.log('Sending webhook', {
-      eventType: command.event.eventType,
-    });
+    this.logger.info({ eventType: command.event.eventType }, 'Sending webhook');
 
     try {
       await this.webhookHandler.sendWebhook(command.event);
-      this.logger.debug('Webhook sent successfully', {
-        eventId: command.event.id,
-        eventType: command.event.eventType,
-      });
+      this.logger.debug(
+        { eventId: command.event.id, eventType: command.event.eventType },
+        'Webhook sent successfully',
+      );
     } catch (error) {
       // Log error but don't fail the main operation
       this.logger.warn(
-        'Webhook delivery failed, continuing with main operation',
         {
           eventId: command.event.id,
           eventType: command.event.eventType,
           error: error instanceof Error ? error.message : 'Unknown error',
         },
+        'Webhook delivery failed, continuing with main operation',
       );
       // We intentionally don't rethrow the error to avoid failing the main business operation
     }

--- a/ayunis-core-backend/src/integrations/webhooks/infrastructure/http/http-webhook.handler.spec.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/infrastructure/http/http-webhook.handler.spec.ts
@@ -1,4 +1,5 @@
 import { createHmac, randomBytes } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { ConfigService } from '@nestjs/config';
 import { HttpWebhookHandler } from './http-webhook.handler';
 import { WebhookEvent } from '../../domain/webhook-event.entity';
@@ -46,6 +47,7 @@ function installFetchMock(): {
 }
 
 describe('HttpWebhookHandler signing', () => {
+  const logger = createPinoLoggerMock();
   const webhookUrl = 'https://example.com/hook';
   let fetchMock: ReturnType<typeof installFetchMock>;
 
@@ -61,6 +63,7 @@ describe('HttpWebhookHandler signing', () => {
   it('signs the body with HMAC-SHA256 when a secret is configured', async () => {
     const secret = randomBytes(32).toString('hex');
     const handler = new HttpWebhookHandler(
+      logger,
       makeConfigService({
         'app.orgEventsWebhookUrl': webhookUrl,
         'app.webhookSigningSecret': secret,
@@ -91,6 +94,7 @@ describe('HttpWebhookHandler signing', () => {
 
   it('omits the signature header when no secret is configured', async () => {
     const handler = new HttpWebhookHandler(
+      logger,
       makeConfigService({
         'app.orgEventsWebhookUrl': webhookUrl,
         'app.webhookSigningSecret': undefined,
@@ -110,6 +114,7 @@ describe('HttpWebhookHandler signing', () => {
   it('signs the exact bytes that are sent in the body', async () => {
     const secret = randomBytes(32).toString('hex');
     const handler = new HttpWebhookHandler(
+      logger,
       makeConfigService({
         'app.orgEventsWebhookUrl': webhookUrl,
         'app.webhookSigningSecret': secret,
@@ -139,6 +144,7 @@ describe('HttpWebhookHandler signing', () => {
 
   it('does nothing when no webhook URL is configured', async () => {
     const handler = new HttpWebhookHandler(
+      logger,
       makeConfigService({
         'app.orgEventsWebhookUrl': undefined,
         'app.webhookSigningSecret': randomBytes(16).toString('hex'),

--- a/ayunis-core-backend/src/integrations/webhooks/infrastructure/http/http-webhook.handler.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/infrastructure/http/http-webhook.handler.ts
@@ -1,5 +1,6 @@
 import { createHmac } from 'crypto';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { WebhookHandler } from '../../application/ports/webhook.handler';
 import { WebhookEvent } from '../../domain/webhook-event.entity';
@@ -10,12 +11,15 @@ import {
 
 @Injectable()
 export class HttpWebhookHandler extends WebhookHandler {
-  private readonly logger = new Logger(HttpWebhookHandler.name);
   private readonly maxRetries = 3;
   private readonly timeoutMs = 10000; // 10 seconds
   private readonly baseBackoffMs = 1000; // 1 second
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    @InjectPinoLogger(HttpWebhookHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {
     super();
   }
 
@@ -26,59 +30,63 @@ export class HttpWebhookHandler extends WebhookHandler {
 
     if (!webhookUrl) {
       this.logger.debug(
+        { eventType: event.eventType, eventId: event.id },
         'Webhook URL not configured, skipping webhook delivery',
-        {
-          eventType: event.eventType,
-          eventId: event.id,
-        },
       );
       return;
     }
 
-    this.logger.log('Attempting webhook delivery', {
-      eventType: event.eventType,
-      eventId: event.id,
-      webhookUrl,
-    });
+    this.logger.info(
+      { eventType: event.eventType, eventId: event.id, url: webhookUrl },
+      'Attempting webhook delivery',
+    );
 
     for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
       try {
         await this.deliverWebhook(event, webhookUrl);
-        this.logger.debug('Webhook delivered successfully', {
-          eventType: event.eventType,
-          eventId: event.id,
-          attempt,
-        });
+        this.logger.debug(
+          { eventType: event.eventType, eventId: event.id, attempt },
+          'Webhook delivered successfully',
+        );
         return; // Success
       } catch (error) {
-        const isLastAttempt = attempt === this.maxRetries;
-        const errorMessage =
-          error instanceof Error ? error.message : 'Unknown error';
-
-        if (isLastAttempt) {
-          this.logger.error('Webhook delivery failed after all retries', {
-            eventType: event.eventType,
-            eventId: event.id,
-            attempts: this.maxRetries,
-            error: errorMessage,
-          });
-          throw new WebhookDeliveryFailedError(event.eventType, errorMessage);
-        }
-
-        const delay = this.baseBackoffMs * Math.pow(2, attempt - 1);
-        this.logger.warn(
-          `Webhook delivery attempt ${attempt} failed, retrying in ${delay}ms`,
-          {
-            eventType: event.eventType,
-            eventId: event.id,
-            error: errorMessage,
-            nextRetryIn: delay,
-          },
-        );
-
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await this.handleDeliveryFailure(event, error, attempt);
       }
     }
+  }
+
+  private async handleDeliveryFailure(
+    event: WebhookEvent,
+    error: unknown,
+    attempt: number,
+  ): Promise<void> {
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unknown error';
+    if (attempt === this.maxRetries) {
+      this.logger.error(
+        {
+          eventType: event.eventType,
+          eventId: event.id,
+          attempts: this.maxRetries,
+          error: errorMessage,
+        },
+        'Webhook delivery failed after all retries',
+      );
+      throw new WebhookDeliveryFailedError(event.eventType, errorMessage);
+    }
+
+    const delay = this.baseBackoffMs * Math.pow(2, attempt - 1);
+    this.logger.warn(
+      {
+        eventType: event.eventType,
+        eventId: event.id,
+        attempt,
+        error: errorMessage,
+        nextRetryIn: delay,
+      },
+      'Webhook delivery attempt failed, retrying',
+    );
+    await new Promise((resolve) => setTimeout(resolve, delay));
   }
 
   private async deliverWebhook(
@@ -96,18 +104,7 @@ export class HttpWebhookHandler extends WebhookHandler {
     // over the same bytes that are sent on the wire.
     const body = JSON.stringify(payload);
 
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-      'User-Agent': 'Ayunis-Core-Webhook/1.0',
-      'X-Webhook-Event-Id': event.id,
-      'X-Webhook-Event-Type': event.eventType,
-      'X-Webhook-Timestamp': event.timestamp.toISOString(),
-    };
-
-    const signature = this.signBody(body);
-    if (signature) {
-      headers['X-Webhook-Signature'] = signature;
-    }
+    const headers = this.buildHeaders(event, body);
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => {
@@ -126,11 +123,14 @@ export class HttpWebhookHandler extends WebhookHandler {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
 
-      this.logger.debug('Webhook HTTP request completed successfully', {
-        eventId: event.id,
-        responseStatus: response.status,
-        responseStatusText: response.statusText,
-      });
+      this.logger.debug(
+        {
+          eventId: event.id,
+          responseStatus: response.status,
+          responseStatusText: response.statusText,
+        },
+        'Webhook HTTP request completed successfully',
+      );
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
         throw new WebhookTimeoutError(event.eventType, this.timeoutMs);
@@ -139,6 +139,24 @@ export class HttpWebhookHandler extends WebhookHandler {
     } finally {
       clearTimeout(timeoutId);
     }
+  }
+
+  private buildHeaders(
+    event: WebhookEvent,
+    body: string,
+  ): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'User-Agent': 'Ayunis-Core-Webhook/1.0',
+      'X-Webhook-Event-Id': event.id,
+      'X-Webhook-Event-Type': event.eventType,
+      'X-Webhook-Timestamp': event.timestamp.toISOString(),
+    };
+    const signature = this.signBody(body);
+    if (signature) {
+      headers['X-Webhook-Signature'] = signature;
+    }
+    return headers;
   }
 
   /**

--- a/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.spec.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.spec.ts
@@ -1,4 +1,5 @@
 import type { UUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { WebhookDispatchListener } from './webhook-dispatch.listener';
 import { UserCreatedEvent } from 'src/iam/users/application/events/user-created.event';
 import { UserUpdatedEvent } from 'src/iam/users/application/events/user-updated.event';
@@ -79,6 +80,7 @@ function makeSeatBasedPayload(): SeatBasedSubscriptionEventData {
 }
 
 describe('WebhookDispatchListener', () => {
+  const logger = createPinoLoggerMock();
   let listener: WebhookDispatchListener;
   let sendWebhookUseCase: jest.Mocked<SendWebhookUseCase>;
   let findUserByIdUseCase: jest.Mocked<FindUserByIdUseCase>;
@@ -100,6 +102,7 @@ describe('WebhookDispatchListener', () => {
     } as unknown as jest.Mocked<ConfigService>;
 
     listener = new WebhookDispatchListener(
+      logger,
       sendWebhookUseCase,
       findUserByIdUseCase,
       findOrgByIdUseCase,

--- a/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/listeners/webhook-dispatch.listener.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { OnEvent } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
@@ -54,9 +55,9 @@ import { IntegrationInstalledWebhookEvent } from '../domain/webhook-events/integ
  */
 @Injectable()
 export class WebhookDispatchListener {
-  private readonly logger = new Logger(WebhookDispatchListener.name);
-
   constructor(
+    @InjectPinoLogger(WebhookDispatchListener.name)
+    private readonly logger: PinoLogger,
     private readonly sendWebhookUseCase: SendWebhookUseCase,
     private readonly findUserByIdUseCase: FindUserByIdUseCase,
     private readonly findOrgByIdUseCase: FindOrgByIdUseCase,
@@ -289,10 +290,13 @@ export class WebhookDispatchListener {
         new FindUserByIdQuery(userId),
       );
     } catch (error) {
-      this.logger.error('Failed to resolve user for webhook enrichment', {
-        userId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          userId,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Failed to resolve user for webhook enrichment',
+      );
       return null;
     }
   }
@@ -309,10 +313,13 @@ export class WebhookDispatchListener {
       );
       return org.name;
     } catch (error) {
-      this.logger.error('Failed to resolve org for webhook enrichment', {
-        orgId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          orgId,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Failed to resolve org for webhook enrichment',
+      );
       return undefined;
     }
   }
@@ -323,10 +330,13 @@ export class WebhookDispatchListener {
         new SendWebhookCommand(webhookEvent),
       );
     } catch (error) {
-      this.logger.error('Webhook dispatch failed', {
-        eventType: webhookEvent.eventType,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          eventType: webhookEvent.eventType,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Webhook dispatch failed',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/integrations/webhooks/webhooks.module.ts
+++ b/ayunis-core-backend/src/integrations/webhooks/webhooks.module.ts
@@ -1,4 +1,5 @@
-import { Logger, Module, type OnModuleInit } from '@nestjs/common';
+import { Module, type OnModuleInit } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { UsersModule } from 'src/iam/users/users.module';
 import { OrgsModule } from 'src/iam/orgs/orgs.module';
@@ -19,9 +20,11 @@ import { WebhookDispatchListener } from './listeners/webhook-dispatch.listener';
   ],
 })
 export class WebhooksModule implements OnModuleInit {
-  private readonly logger = new Logger(WebhooksModule.name);
-
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    @InjectPinoLogger(WebhooksModule.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {}
 
   /**
    * Fail loud at boot if webhook delivery is configured without a signing


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broad constructor/DI changes and log shape shifts affect observability and could break wiring if any provider omits a logger token; Locaboo invoice filtering priority may differ from the previous AND-style inline filter when multiple params are set.
> 
> **Overview**
> **Migrates `common` and `integrations` off Nest’s `Logger` onto `nestjs-pino` (`PinoLogger`)**, using structured calls (`logger.info({ … }, 'message')`, `{ err }` for errors) and `@InjectPinoLogger` on injectables. Standalone code paths (anonymize axios client, cookie util, crash handlers, Puppeteer, `HandleUnexpectedErrors`) build loggers via `createPinoLoggerConfig()` and `setContext`.
> 
> **Tests** swap `Logger.prototype` spies for `createPinoLoggerMock()` and assert Pino-style arguments; MCP specs spy `PinoLogger.prototype.error` for the unexpected-error decorator.
> 
> **Non-logging tweaks:** `Locaboo3Repository` refactors invoice-row filtering into `matchesInvoiceRow` / `matchesAny` (priority: resource names → resource IDs → inventory/service → booking IDs). `HttpWebhookHandler` extracts delivery-failure logging and header building without changing delivery semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74a0ba49df269ca133a9b206d48e86191daf1c34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->