### PR TITLE
wip(logging): migrate models and openai compatibility to pino (AYC-746)

### DIFF
--- a/ayunis-core-backend/src/domain/models/application/registry/image-generation-handler.registry.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/registry/image-generation-handler.registry.spec.ts
@@ -1,11 +1,12 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { ConfigService } from '@nestjs/config';
-import { Logger } from '@nestjs/common';
 import { ImageGenerationHandlerRegistry } from './image-generation-handler.registry';
 import { ModelProvider } from '../../domain/value-objects/model-provider.enum';
 import { ModelProviderNotSupportedError } from '../models.errors';
 import type { ImageGenerationHandler } from '../ports/image-generation.handler';
 
 describe('ImageGenerationHandlerRegistry', () => {
+  const logger = createPinoLoggerMock();
   let registry: ImageGenerationHandlerRegistry;
   let configService: jest.Mocked<ConfigService>;
 
@@ -22,10 +23,10 @@ describe('ImageGenerationHandlerRegistry', () => {
       get: jest.fn(),
     } as unknown as jest.Mocked<ConfigService>;
 
-    registry = new ImageGenerationHandlerRegistry(configService);
+    registry = new ImageGenerationHandlerRegistry(logger, configService);
 
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    logger.info.mockImplementation();
+    logger.error.mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/models/application/registry/image-generation-handler.registry.ts
+++ b/ayunis-core-backend/src/domain/models/application/registry/image-generation-handler.registry.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { ModelProvider } from '../../domain/value-objects/model-provider.enum';
 import { ImageGenerationHandler } from '../ports/image-generation.handler';
@@ -6,11 +7,14 @@ import { ModelProviderNotSupportedError } from '../models.errors';
 
 @Injectable()
 export class ImageGenerationHandlerRegistry {
-  private readonly logger = new Logger(ImageGenerationHandlerRegistry.name);
   private readonly handlers = new Map<ModelProvider, ImageGenerationHandler>();
   private mockHandler?: ImageGenerationHandler;
 
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    @InjectPinoLogger(ImageGenerationHandlerRegistry.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {}
 
   register(provider: ModelProvider, handler: ImageGenerationHandler): void {
     this.handlers.set(provider, handler);
@@ -28,12 +32,12 @@ export class ImageGenerationHandlerRegistry {
           'Mock image generation handler not registered. Call registerMockHandler() before using getHandler() in test environment.',
         );
       }
-      this.logger.log('Using mock handler for image generation');
+      this.logger.info('Using mock handler for image generation');
       return this.mockHandler;
     }
     const handler = this.handlers.get(provider);
     if (!handler) {
-      this.logger.error('Image generation handler not found', { provider });
+      this.logger.error({ provider }, 'Image generation handler not found');
       throw new ModelProviderNotSupportedError(provider);
     }
     return handler;

--- a/ayunis-core-backend/src/domain/models/application/registry/inference-handler.registry.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/registry/inference-handler.registry.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
@@ -38,7 +39,10 @@ describe('InferenceHandlerRegistry', () => {
             mistralHandler: MistralInferenceHandler,
             configService: any,
           ) => {
-            const registry = new InferenceHandlerRegistry(configService);
+            const registry = new InferenceHandlerRegistry(
+              createPinoLoggerMock(),
+              configService,
+            );
             registry.register(ModelProvider.MISTRAL, mistralHandler);
             return registry;
           },

--- a/ayunis-core-backend/src/domain/models/application/registry/inference-handler.registry.ts
+++ b/ayunis-core-backend/src/domain/models/application/registry/inference-handler.registry.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ModelProvider } from '../../domain/value-objects/model-provider.enum';
 import { InferenceHandler } from '../ports/inference.handler';
 import { ModelProviderNotSupportedError } from '../models.errors';
@@ -6,12 +7,15 @@ import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class InferenceHandlerRegistry {
-  private readonly logger = new Logger(InferenceHandlerRegistry.name);
   private readonly handlers = new Map<ModelProvider, InferenceHandler>();
   private mockHandler: InferenceHandler;
 
-  constructor(private readonly configService: ConfigService) {
-    this.logger.log(InferenceHandlerRegistry.name);
+  constructor(
+    @InjectPinoLogger(InferenceHandlerRegistry.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {
+    this.logger.info(InferenceHandlerRegistry.name);
     // prebuilt handlers are registered in models.module.ts
   }
 
@@ -36,14 +40,17 @@ export class InferenceHandlerRegistry {
   getHandler(provider: ModelProvider): InferenceHandler {
     const isTest = this.configService.get<boolean>('app.isTest');
     if (isTest) {
-      this.logger.log('Using mock handler for non-streaming');
+      this.logger.info('Using mock handler for non-streaming');
       return this.mockHandler;
     }
     const handler = this.handlers.get(provider);
     if (!handler) {
-      this.logger.error('Handler not found', {
-        provider,
-      });
+      this.logger.error(
+        {
+          provider,
+        },
+        'Handler not found',
+      );
       throw new ModelProviderNotSupportedError(provider);
     }
     return handler;

--- a/ayunis-core-backend/src/domain/models/application/registry/model-provider-info.registry.ts
+++ b/ayunis-core-backend/src/domain/models/application/registry/model-provider-info.registry.ts
@@ -2,7 +2,8 @@ import { ModelProviderInfoEntity } from '../../domain/model-provider-info.entity
 import { ModelProvider } from '../../domain/value-objects/model-provider.enum';
 import { ModelProviderLocation } from '../../domain/value-objects/model-provider-locations.enum';
 import { ModelProviderInfoNotFoundError } from '../models.errors';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 
 /**
  * Extended provider configuration that includes the config key for API key lookup.
@@ -88,7 +89,10 @@ const MODEL_PROVIDER_CONFIGS: ModelProviderConfig[] = [
 
 @Injectable()
 export class ModelProviderInfoRegistry {
-  private readonly logger = new Logger(ModelProviderInfoRegistry.name);
+  constructor(
+    @InjectPinoLogger(ModelProviderInfoRegistry.name)
+    private readonly logger: PinoLogger,
+  ) {}
   private readonly modelProviderConfigs: ModelProviderConfig[] =
     MODEL_PROVIDER_CONFIGS;
 
@@ -100,7 +104,8 @@ export class ModelProviderInfoRegistry {
     );
     if (!modelProviderConfig) {
       this.logger.error(
-        `Model provider info not found for provider: ${provider}`,
+        { provider },
+        'Model provider info not found for provider',
       );
       throw new ModelProviderInfoNotFoundError(provider);
     }

--- a/ayunis-core-backend/src/domain/models/application/registry/stream-inference-handler.registry.ts
+++ b/ayunis-core-backend/src/domain/models/application/registry/stream-inference-handler.registry.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ModelProvider } from '../../domain/value-objects/model-provider.enum';
 import { StreamInferenceHandler } from '../ports/stream-inference.handler';
 import { ModelProviderNotSupportedError } from '../models.errors';
@@ -6,12 +7,15 @@ import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class StreamInferenceHandlerRegistry {
-  private readonly logger = new Logger(StreamInferenceHandlerRegistry.name);
   private readonly handlers = new Map<ModelProvider, StreamInferenceHandler>();
   private mockHandler: StreamInferenceHandler;
 
-  constructor(private readonly configService: ConfigService) {
-    this.logger.log(StreamInferenceHandlerRegistry.name);
+  constructor(
+    @InjectPinoLogger(StreamInferenceHandlerRegistry.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {
+    this.logger.info(StreamInferenceHandlerRegistry.name);
     // prebuilt handlers are registered in models.module.ts
   }
 
@@ -36,7 +40,7 @@ export class StreamInferenceHandlerRegistry {
   getHandler(provider: ModelProvider): StreamInferenceHandler {
     const isTest = this.configService.get<boolean>('app.isTest');
     if (isTest) {
-      this.logger.log('Using mock handler for streaming');
+      this.logger.info('Using mock handler for streaming');
       return this.mockHandler;
     }
     const handler = this.handlers.get(provider);

--- a/ayunis-core-backend/src/domain/models/application/services/model-policy.service.ts
+++ b/ayunis-core-backend/src/domain/models/application/services/model-policy.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { Model } from '../../domain/model.entity';
 import { EmbeddingModel } from '../../domain/models/embedding.model';
 import { ImageGenerationModel } from '../../domain/models/image-generation.model';
@@ -18,9 +19,10 @@ export const SUPPORTED_IMAGE_GENERATION_PROVIDERS: ModelProvider[] = [
 
 @Injectable()
 export class ModelPolicyService {
-  private readonly logger = new Logger(ModelPolicyService.name);
-
   constructor(
+    @InjectPinoLogger(ModelPolicyService.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
   ) {}
 
@@ -33,7 +35,8 @@ export class ModelPolicyService {
   assertSupportedImageGenerationProvider(provider: ModelProvider): void {
     if (!SUPPORTED_IMAGE_GENERATION_PROVIDERS.includes(provider)) {
       this.logger.warn(
-        `Unsupported provider for image generation: ${provider}`,
+        { provider },
+        'Unsupported provider for image generation',
       );
       throw new ImageGenerationModelProviderNotSupportedError(provider);
     }
@@ -66,8 +69,8 @@ export class ModelPolicyService {
       newModelId: candidate.model.id,
     };
     this.logger.error(
-      'Attempt to create a second permitted embedding model for org',
       metadata,
+      'Attempt to create a second permitted embedding model for org',
     );
     throw new MultipleEmbeddingModelsNotAllowedError(metadata);
   }
@@ -92,8 +95,8 @@ export class ModelPolicyService {
       newModelId: candidate.model.id,
     };
     this.logger.error(
-      'Attempt to create a second permitted image-generation model for org',
       metadata,
+      'Attempt to create a second permitted image-generation model for org',
     );
     throw new MultipleImageGenerationModelsNotAllowedError(metadata);
   }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case.spec.ts
@@ -1,6 +1,7 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { ClearDefaultsByCatalogModelIdUseCase } from './clear-defaults-by-catalog-model-id.use-case';
 import { ClearDefaultsByCatalogModelIdCommand } from './clear-defaults-by-catalog-model-id.command';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
@@ -11,6 +12,7 @@ import { ModelProvider } from 'src/domain/models/domain/value-objects/model-prov
 import type { UUID } from 'crypto';
 
 describe('ClearDefaultsByCatalogModelIdUseCase', () => {
+  const logger = createPinoLoggerMock();
   let useCase: ClearDefaultsByCatalogModelIdUseCase;
   let permittedModelsRepository: jest.Mocked<PermittedModelsRepository>;
   let userDefaultModelsRepository: jest.Mocked<UserDefaultModelsRepository>;
@@ -49,6 +51,10 @@ describe('ClearDefaultsByCatalogModelIdUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(ClearDefaultsByCatalogModelIdUseCase.name),
+          useValue: logger,
+        },
         ClearDefaultsByCatalogModelIdUseCase,
         {
           provide: PermittedModelsRepository,
@@ -68,8 +74,8 @@ describe('ClearDefaultsByCatalogModelIdUseCase', () => {
     userDefaultModelsRepository = module.get(UserDefaultModelsRepository);
 
     // Mock logger
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+    logger.info.mockImplementation();
+    logger.debug.mockImplementation();
   });
 
   afterEach(() => {
@@ -215,7 +221,7 @@ describe('ClearDefaultsByCatalogModelIdUseCase', () => {
 
       permittedModelsRepository.findAllByCatalogModelId.mockResolvedValue([]);
 
-      const debugSpy = jest.spyOn(Logger.prototype, 'debug');
+      const debugSpy = logger.debug;
 
       // Act
       await useCase.execute(command);
@@ -231,8 +237,8 @@ describe('ClearDefaultsByCatalogModelIdUseCase', () => {
         permittedModelsRepository.unsetDefaultsByCatalogModelId,
       ).not.toHaveBeenCalled();
       expect(debugSpy).toHaveBeenCalledWith(
-        'No permitted models found for catalog model',
         { catalogModelId: mockCatalogModelId },
+        'No permitted models found for catalog model',
       );
     });
 
@@ -308,30 +314,30 @@ describe('ClearDefaultsByCatalogModelIdUseCase', () => {
       userDefaultModelsRepository.deleteByPermittedModelIds.mockResolvedValue();
       permittedModelsRepository.unsetDefaultsByCatalogModelId.mockResolvedValue();
 
-      const logSpy = jest.spyOn(Logger.prototype, 'log');
-      const debugSpy = jest.spyOn(Logger.prototype, 'debug');
+      const logSpy = logger.info;
+      const debugSpy = logger.debug;
 
       // Act
       await useCase.execute(command);
 
       // Assert
       expect(logSpy).toHaveBeenCalledWith(
-        'Clearing defaults for archived catalog model',
         { catalogModelId: mockCatalogModelId },
+        'Clearing defaults for archived catalog model',
       );
       expect(debugSpy).toHaveBeenCalledWith(
-        'Found permitted models to clear defaults',
         {
           catalogModelId: mockCatalogModelId,
           permittedModelCount: 2,
         },
+        'Found permitted models to clear defaults',
       );
       expect(logSpy).toHaveBeenCalledWith(
-        'Successfully cleared all defaults for archived catalog model',
         {
           catalogModelId: mockCatalogModelId,
           affectedPermittedModels: 2,
         },
+        'Successfully cleared all defaults for archived catalog model',
       );
     });
   });

--- a/ayunis-core-backend/src/domain/models/application/use-cases/clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case.ts
@@ -1,23 +1,26 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ClearDefaultsByCatalogModelIdCommand } from './clear-defaults-by-catalog-model-id.command';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
 
 @Injectable()
 export class ClearDefaultsByCatalogModelIdUseCase {
-  private readonly logger = new Logger(
-    ClearDefaultsByCatalogModelIdUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(ClearDefaultsByCatalogModelIdUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
   ) {}
 
   async execute(command: ClearDefaultsByCatalogModelIdCommand): Promise<void> {
-    this.logger.log('Clearing defaults for archived catalog model', {
-      catalogModelId: command.catalogModelId,
-    });
+    this.logger.info(
+      {
+        catalogModelId: command.catalogModelId,
+      },
+      'Clearing defaults for archived catalog model',
+    );
 
     // 1. Find all permitted models that reference this catalog model
     const permittedModels =
@@ -26,18 +29,24 @@ export class ClearDefaultsByCatalogModelIdUseCase {
       );
 
     if (permittedModels.length === 0) {
-      this.logger.debug('No permitted models found for catalog model', {
-        catalogModelId: command.catalogModelId,
-      });
+      this.logger.debug(
+        {
+          catalogModelId: command.catalogModelId,
+        },
+        'No permitted models found for catalog model',
+      );
       return;
     }
 
     const permittedModelIds = permittedModels.map((pm) => pm.id);
 
-    this.logger.debug('Found permitted models to clear defaults', {
-      catalogModelId: command.catalogModelId,
-      permittedModelCount: permittedModelIds.length,
-    });
+    this.logger.debug(
+      {
+        catalogModelId: command.catalogModelId,
+        permittedModelCount: permittedModelIds.length,
+      },
+      'Found permitted models to clear defaults',
+    );
 
     // 2. Delete all user default models that reference these permitted models
     await this.userDefaultModelsRepository.deleteByPermittedModelIds(
@@ -49,12 +58,12 @@ export class ClearDefaultsByCatalogModelIdUseCase {
       command.catalogModelId,
     );
 
-    this.logger.log(
-      'Successfully cleared all defaults for archived catalog model',
+    this.logger.info(
       {
         catalogModelId: command.catalogModelId,
         affectedPermittedModels: permittedModelIds.length,
       },
+      'Successfully cleared all defaults for archived catalog model',
     );
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-embedding-model/create-embedding-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-embedding-model/create-embedding-model.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { CreateEmbeddingModelUseCase } from './create-embedding-model.use-case';
 import { CreateEmbeddingModelCommand } from './create-embedding-model.command';
 import type { ModelsRepository } from '../../ports/models.repository';
@@ -24,7 +25,10 @@ describe('CreateEmbeddingModelUseCase', () => {
       save: jest.fn(),
       delete: jest.fn(),
     };
-    useCase = new CreateEmbeddingModelUseCase(modelsRepository);
+    useCase = new CreateEmbeddingModelUseCase(
+      createPinoLoggerMock(),
+      modelsRepository,
+    );
   });
 
   const createCommand = (): CreateEmbeddingModelCommand =>

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-embedding-model/create-embedding-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-embedding-model/create-embedding-model.use-case.ts
@@ -5,21 +5,27 @@ import {
   ModelAlreadyExistsError,
   UnexpectedModelError,
 } from '../../models.errors';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 
 @Injectable()
 export class CreateEmbeddingModelUseCase {
-  private readonly logger = new Logger(CreateEmbeddingModelUseCase.name);
-
-  constructor(private readonly modelsRepository: ModelsRepository) {}
+  constructor(
+    @InjectPinoLogger(CreateEmbeddingModelUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly modelsRepository: ModelsRepository,
+  ) {}
 
   @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(command: CreateEmbeddingModelCommand): Promise<EmbeddingModel> {
-    this.logger.log('Creating embedding model', {
-      name: command.name,
-      provider: command.provider,
-    });
+    this.logger.info(
+      {
+        name: command.name,
+        provider: command.provider,
+      },
+      'Creating embedding model',
+    );
 
     const existingModel = await this.modelsRepository.findOne({
       name: command.name,
@@ -27,10 +33,13 @@ export class CreateEmbeddingModelUseCase {
     });
 
     if (existingModel) {
-      this.logger.warn('Embedding model already exists', {
-        name: command.name,
-        provider: command.provider,
-      });
+      this.logger.warn(
+        {
+          name: command.name,
+          provider: command.provider,
+        },
+        'Embedding model already exists',
+      );
       throw new ModelAlreadyExistsError(command.name, command.provider);
     }
 

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-image-generation-model/create-image-generation-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-image-generation-model/create-image-generation-model.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { CreateImageGenerationModelUseCase } from './create-image-generation-model.use-case';
@@ -29,6 +31,14 @@ describe('CreateImageGenerationModelUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(CreateImageGenerationModelUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
+        {
+          provide: getLoggerToken(ModelPolicyService.name),
+          useValue: createPinoLoggerMock(),
+        },
         CreateImageGenerationModelUseCase,
         ModelPolicyService,
         { provide: ModelsRepository, useValue: mockModelsRepository },

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-image-generation-model/create-image-generation-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-image-generation-model/create-image-generation-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ImageGenerationModel } from 'src/domain/models/domain/models/image-generation.model';
 import { ModelsRepository } from '../../ports/models.repository';
@@ -11,9 +12,10 @@ import { CreateImageGenerationModelCommand } from './create-image-generation-mod
 
 @Injectable()
 export class CreateImageGenerationModelUseCase {
-  private readonly logger = new Logger(CreateImageGenerationModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateImageGenerationModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly modelsRepository: ModelsRepository,
     private readonly modelPolicy: ModelPolicyService,
   ) {}
@@ -47,9 +49,12 @@ export class CreateImageGenerationModelUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Unexpected error creating image-generation model', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error creating image-generation model',
+      );
       throw new UnexpectedModelError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-permitted-model/create-permitted-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-permitted-model/create-permitted-model.use-case.spec.ts
@@ -1,6 +1,7 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { CreatePermittedModelUseCase } from './create-permitted-model.use-case';
 import { CreatePermittedModelCommand } from './create-permitted-model.command';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
@@ -28,6 +29,7 @@ import { ContextService } from 'src/common/context/services/context.service';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 
 describe('CreatePermittedModelUseCase', () => {
+  const logger = createPinoLoggerMock();
   let useCase: CreatePermittedModelUseCase;
   let permittedModelsRepository: jest.Mocked<PermittedModelsRepository>;
   let modelsRepository: jest.Mocked<ModelsRepository>;
@@ -64,6 +66,11 @@ describe('CreatePermittedModelUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(CreatePermittedModelUseCase.name),
+          useValue: logger,
+        },
+        { provide: getLoggerToken(ModelPolicyService.name), useValue: logger },
         CreatePermittedModelUseCase,
         ModelPolicyService,
         {
@@ -90,8 +97,8 @@ describe('CreatePermittedModelUseCase', () => {
     });
 
     // Mock logger
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    logger.info.mockImplementation();
+    logger.error.mockImplementation();
   });
 
   afterEach(() => {
@@ -123,7 +130,7 @@ describe('CreatePermittedModelUseCase', () => {
       modelsRepository.findOne.mockResolvedValue(mockModel);
       permittedModelsRepository.create.mockResolvedValue(mockPermittedModel);
 
-      const logSpy = jest.spyOn(Logger.prototype, 'log');
+      const logSpy = logger.info;
 
       // Act
       const result = await useCase.execute(command);
@@ -140,10 +147,10 @@ describe('CreatePermittedModelUseCase', () => {
       );
       expect(result).toBe(mockPermittedModel);
 
-      expect(logSpy).toHaveBeenCalledWith('execute', {
-        modelId: mockModelId,
-        orgId: mockOrgId,
-      });
+      expect(logSpy).toHaveBeenCalledWith(
+        { modelId: mockModelId, orgId: mockOrgId },
+        'execute',
+      );
     });
 
     it('should throw ModelNotFoundError when model is not found', async () => {
@@ -184,7 +191,7 @@ describe('CreatePermittedModelUseCase', () => {
       const repositoryError = new Error('Database constraint violation');
       permittedModelsRepository.create.mockRejectedValue(repositoryError);
 
-      const errorSpy = jest.spyOn(Logger.prototype, 'error');
+      const errorSpy = logger.error;
 
       // Act & Assert
       await expect(useCase.execute(command)).rejects.toThrow(
@@ -192,9 +199,10 @@ describe('CreatePermittedModelUseCase', () => {
       );
 
       expect(permittedModelsRepository.create).toHaveBeenCalled();
-      expect(errorSpy).toHaveBeenCalledWith('Error creating permitted model', {
-        error: repositoryError,
-      });
+      expect(errorSpy).toHaveBeenCalledWith(
+        { err: repositoryError },
+        'Error creating permitted model',
+      );
     });
 
     it('should reject non-Azure image-generation models explicitly', async () => {
@@ -304,7 +312,7 @@ describe('CreatePermittedModelUseCase', () => {
 
       modelsRepository.findOne.mockResolvedValue(undefined);
 
-      const errorSpy = jest.spyOn(Logger.prototype, 'error');
+      const errorSpy = logger.error;
 
       // Act & Assert
       await expect(useCase.execute(command)).rejects.toThrow(

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-permitted-model/create-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-permitted-model/create-permitted-model.use-case.ts
@@ -2,7 +2,8 @@ import { PermittedModel } from 'src/domain/models/domain/permitted-model.entity'
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { ModelsRepository } from '../../ports/models.repository';
 import { CreatePermittedModelCommand } from './create-permitted-model.command';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
@@ -13,8 +14,10 @@ import { ModelPolicyService } from '../../services/model-policy.service';
 
 @Injectable()
 export class CreatePermittedModelUseCase {
-  private readonly logger = new Logger(CreatePermittedModelUseCase.name);
   constructor(
+    @InjectPinoLogger(CreatePermittedModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly modelsRepository: ModelsRepository,
     private readonly contextService: ContextService,
@@ -22,10 +25,13 @@ export class CreatePermittedModelUseCase {
   ) {}
 
   async execute(command: CreatePermittedModelCommand): Promise<PermittedModel> {
-    this.logger.log('execute', {
-      modelId: command.modelId,
-      orgId: command.orgId,
-    });
+    this.logger.info(
+      {
+        modelId: command.modelId,
+        orgId: command.orgId,
+      },
+      'execute',
+    );
     try {
       const orgId = this.contextService.get('orgId');
       const orgRole = this.contextService.get('role');
@@ -55,9 +61,12 @@ export class CreatePermittedModelUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error creating permitted model', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error creating permitted model',
+      );
       throw new UnexpectedModelError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-team-permitted-model/create-team-permitted-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-team-permitted-model/create-team-permitted-model.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { CreateTeamPermittedModelUseCase } from './create-team-permitted-model.use-case';
@@ -80,6 +82,10 @@ describe('CreateTeamPermittedModelUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(CreateTeamPermittedModelUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         CreateTeamPermittedModelUseCase,
         TeamPermittedModelValidator,
         {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/create-team-permitted-model/create-team-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/create-team-permitted-model/create-team-permitted-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { ModelsRepository } from '../../ports/models.repository';
@@ -17,9 +18,10 @@ import { ImageGenerationModel } from 'src/domain/models/domain/models/image-gene
 
 @Injectable()
 export class CreateTeamPermittedModelUseCase {
-  private readonly logger = new Logger(CreateTeamPermittedModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateTeamPermittedModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly modelsRepository: ModelsRepository,
     private readonly validator: TeamPermittedModelValidator,
@@ -29,11 +31,14 @@ export class CreateTeamPermittedModelUseCase {
   async execute(
     command: CreateTeamPermittedModelCommand,
   ): Promise<PermittedModel> {
-    this.logger.log('execute', {
-      modelId: command.modelId,
-      orgId: command.orgId,
-      teamId: command.teamId,
-    });
+    this.logger.info(
+      {
+        modelId: command.modelId,
+        orgId: command.orgId,
+        teamId: command.teamId,
+      },
+      'execute',
+    );
 
     this.validator.validateAdminAccess(command.orgId);
     await this.validator.validateTeamInOrg(command.teamId, command.orgId);

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-model/delete-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-model/delete-model.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import type { ModelsRepository } from '../../ports/models.repository';
 import type { PermittedModelsRepository } from '../../ports/permitted-models.repository';
@@ -51,6 +52,7 @@ describe('DeleteModelUseCase', () => {
     };
     hasUsageForModelUseCase = { execute: jest.fn().mockResolvedValue(false) };
     useCase = new DeleteModelUseCase(
+      createPinoLoggerMock(),
       modelsRepository as unknown as ModelsRepository,
       permittedModelsRepository as unknown as PermittedModelsRepository,
       hasUsageForModelUseCase as unknown as HasUsageForModelUseCase,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-model/delete-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-model/delete-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { HasUsageForModelQuery } from 'src/domain/usage/application/use-cases/has-usage-for-model/has-usage-for-model.query';
 import { HasUsageForModelUseCase } from 'src/domain/usage/application/use-cases/has-usage-for-model/has-usage-for-model.use-case';
@@ -14,9 +15,10 @@ import { DeleteModelCommand } from './delete-model.command';
 
 @Injectable()
 export class DeleteModelUseCase {
-  private readonly logger = new Logger(DeleteModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly modelsRepository: ModelsRepository,
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly hasUsageForModelUseCase: HasUsageForModelUseCase,
@@ -24,7 +26,7 @@ export class DeleteModelUseCase {
 
   @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(command: DeleteModelCommand): Promise<void> {
-    this.logger.log('Deleting catalog model', { modelId: command.id });
+    this.logger.info({ modelId: command.id }, 'Deleting catalog model');
 
     await this.modelsRepository.withCatalogModelLocked(
       command.id,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 // Mock the Transactional decorator
 jest.mock('@nestjs-cls/transactional', () => ({
   Transactional:
@@ -8,7 +10,6 @@ jest.mock('@nestjs-cls/transactional', () => ({
 
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { DeletePermittedModelUseCase } from './delete-permitted-model.use-case';
 import { DeletePermittedModelCommand } from './delete-permitted-model.command';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
@@ -35,6 +36,7 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 import { EmbeddingDimensions } from 'src/domain/models/domain/value-objects/embedding-dimensions.enum';
 
 describe('DeletePermittedModelUseCase', () => {
+  const logger = createPinoLoggerMock();
   let useCase: DeletePermittedModelUseCase;
   let permittedModelsRepository: jest.Mocked<PermittedModelsRepository>;
   let getPermittedModelsUseCase: jest.Mocked<GetPermittedModelsUseCase>;
@@ -74,6 +76,10 @@ describe('DeletePermittedModelUseCase', () => {
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(DeletePermittedModelUseCase.name),
+          useValue: logger,
+        },
         DeletePermittedModelUseCase,
         {
           provide: PermittedModelsRepository,
@@ -127,9 +133,9 @@ describe('DeletePermittedModelUseCase', () => {
     deleteSourcesUseCase = module.get(DeleteSourcesUseCase);
     contextService = module.get(ContextService);
 
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    logger.info.mockImplementation();
+    logger.debug.mockImplementation();
+    logger.error.mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-permitted-model/delete-permitted-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { DeletePermittedModelCommand } from './delete-permitted-model.command';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import {
@@ -33,9 +34,10 @@ import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum'
 
 @Injectable()
 export class DeletePermittedModelUseCase {
-  private readonly logger = new Logger(DeletePermittedModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeletePermittedModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly deleteUserDefaultModelByModelIdUseCase: DeleteUserDefaultModelsByModelIdUseCase,
     private readonly getPermittedModelsUseCase: GetPermittedModelsUseCase,
@@ -47,10 +49,13 @@ export class DeletePermittedModelUseCase {
 
   @Transactional()
   async execute(command: DeletePermittedModelCommand): Promise<void> {
-    this.logger.log('execute', {
-      modelId: command.permittedModelId,
-      orgId: command.orgId,
-    });
+    this.logger.info(
+      {
+        modelId: command.permittedModelId,
+        orgId: command.orgId,
+      },
+      'execute',
+    );
     try {
       const orgId = this.contextService.get('orgId');
       const orgRole = this.contextService.get('role');
@@ -64,10 +69,13 @@ export class DeletePermittedModelUseCase {
         id: command.permittedModelId,
       });
       if (!model) {
-        this.logger.error('Model not found', {
-          modelId: command.permittedModelId,
-          orgId: command.orgId,
-        });
+        this.logger.error(
+          {
+            modelId: command.permittedModelId,
+            orgId: command.orgId,
+          },
+          'Model not found',
+        );
         throw new PermittedModelDeletionFailedError('Model not found', {
           modelId: command.permittedModelId,
         });
@@ -83,7 +91,7 @@ export class DeletePermittedModelUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error deleting permitted model', error);
+      this.logger.error({ err: error }, 'Error deleting permitted model');
       throw new UnexpectedModelError(
         error instanceof Error ? error : new Error('Unknown error'),
       );
@@ -102,11 +110,11 @@ export class DeletePermittedModelUseCase {
       return this.deletePermittedImageGenerationModel(command.orgId, model);
     }
     this.logger.error(
-      'Model is not a language, embedding, or image-generation model',
       {
         modelId: command.permittedModelId,
         orgId: command.orgId,
       },
+      'Model is not a language, embedding, or image-generation model',
     );
     throw new PermittedModelDeletionFailedError(
       'Model is not a language, embedding, or image-generation model',
@@ -140,21 +148,17 @@ export class DeletePermittedModelUseCase {
     if (modelToDelete.isDefault) {
       throw new CannotDeleteDefaultModelError(model.id);
     }
-    this.logger.debug(
-      'Deleting user default models that reference this model',
-      {
-        modelId: model.id,
-      },
-    );
+    this.logLanguageModelCleanup(model.id);
 
     // Delete all user default models that reference this model
     await this.deleteUserDefaultModelByModelIdUseCase.execute(
       new DeleteUserDefaultModelsByModelIdCommand(model.id),
     );
 
-    this.logger.debug('Replacing model in all threads that use it', {
-      modelId: model.id,
-    });
+    this.logger.debug(
+      { modelId: model.id },
+      'Replacing model in all threads that use it',
+    );
 
     // Replace the model in all threads that use it
     // Because the user default model is deleted, this will fall back
@@ -177,6 +181,13 @@ export class DeletePermittedModelUseCase {
       id: model.id,
       orgId: orgId,
     });
+  }
+
+  private logLanguageModelCleanup(modelId: UUID): void {
+    this.logger.debug(
+      { modelId },
+      'Deleting user default models that reference this model',
+    );
   }
 
   private async deletePermittedEmbeddingModel(

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-team-permitted-model/delete-team-permitted-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-team-permitted-model/delete-team-permitted-model.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { DeleteTeamPermittedModelUseCase } from './delete-team-permitted-model.use-case';
@@ -64,6 +66,10 @@ describe('DeleteTeamPermittedModelUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(DeleteTeamPermittedModelUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         DeleteTeamPermittedModelUseCase,
         TeamPermittedModelValidator,
         {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-team-permitted-model/delete-team-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-team-permitted-model/delete-team-permitted-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { DeleteTeamPermittedModelCommand } from './delete-team-permitted-model.command';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -7,19 +8,23 @@ import { TeamPermittedModelValidator } from '../../services/team-permitted-model
 
 @Injectable()
 export class DeleteTeamPermittedModelUseCase {
-  private readonly logger = new Logger(DeleteTeamPermittedModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteTeamPermittedModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly validator: TeamPermittedModelValidator,
   ) {}
 
   async execute(command: DeleteTeamPermittedModelCommand): Promise<void> {
-    this.logger.log('execute', {
-      permittedModelId: command.permittedModelId,
-      orgId: command.orgId,
-      teamId: command.teamId,
-    });
+    this.logger.info(
+      {
+        permittedModelId: command.permittedModelId,
+        orgId: command.orgId,
+        teamId: command.teamId,
+      },
+      'execute',
+    );
 
     try {
       this.validator.validateAdminAccess(command.orgId);
@@ -38,7 +43,7 @@ export class DeleteTeamPermittedModelUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error deleting team permitted model', error);
+      this.logger.error({ err: error }, 'Error deleting team permitted model');
       throw new UnexpectedModelError(
         error instanceof Error ? error : new Error('Unknown error'),
       );

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-user-default-model/delete-user-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-user-default-model/delete-user-default-model.use-case.ts
@@ -1,60 +1,61 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { DeleteUserDefaultModelCommand } from './delete-user-default-model.command';
 import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
 import { ModelError } from '../../models.errors';
 
 @Injectable()
 export class DeleteUserDefaultModelUseCase {
-  private readonly logger = new Logger(DeleteUserDefaultModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteUserDefaultModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
   ) {}
 
   async execute(command: DeleteUserDefaultModelCommand): Promise<void> {
-    this.logger.log('execute', {
-      userId: command.userId,
-    });
-
+    this.logger.info({ userId: command.userId }, 'execute');
     try {
-      // First, find the user's current default model
-      const userDefaultModel =
-        await this.userDefaultModelsRepository.findByUserId(command.userId);
-
-      if (!userDefaultModel) {
-        this.logger.debug('No user default model found to delete', {
-          userId: command.userId,
-        });
-        // Not throwing an error here as it's idempotent - no default model to delete
-        return;
-      }
-
-      this.logger.debug('User default model found, deleting', {
-        userId: command.userId,
-        modelId: userDefaultModel.id,
-        modelName: userDefaultModel.model.name,
-        modelProvider: userDefaultModel.model.provider,
-      });
-
-      // Delete the user's default model
-      await this.userDefaultModelsRepository.delete(
-        userDefaultModel,
-        command.userId,
-      );
-
-      this.logger.debug('User default model deleted successfully', {
-        userId: command.userId,
-        modelId: userDefaultModel.id,
-      });
+      await this.deleteDefault(command);
     } catch (error) {
-      if (error instanceof ModelError) {
-        throw error;
-      }
-      this.logger.error('Failed to delete user default model', {
-        userId: command.userId,
-        error: error instanceof Error ? error : new Error('Unknown error'),
-      });
+      if (error instanceof ModelError) throw error;
+      this.logger.error(
+        {
+          userId: command.userId,
+          err: error instanceof Error ? error : new Error('Unknown error'),
+        },
+        'Failed to delete user default model',
+      );
       throw error;
     }
+  }
+
+  private async deleteDefault(
+    command: DeleteUserDefaultModelCommand,
+  ): Promise<void> {
+    const current = await this.userDefaultModelsRepository.findByUserId(
+      command.userId,
+    );
+    if (!current) {
+      this.logger.debug(
+        { userId: command.userId },
+        'No user default model found to delete',
+      );
+      return;
+    }
+    this.logger.debug(
+      {
+        userId: command.userId,
+        modelId: current.id,
+        modelName: current.model.name,
+        modelProvider: current.model.provider,
+      },
+      'User default model found, deleting',
+    );
+    await this.userDefaultModelsRepository.delete(current, command.userId);
+    this.logger.debug(
+      { userId: command.userId, modelId: current.id },
+      'User default model deleted successfully',
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/delete-user-default-models-by-model-id/delete-user-default-models-by-model-id.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/delete-user-default-models-by-model-id/delete-user-default-models-by-model-id.use-case.ts
@@ -1,23 +1,26 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
 import { DeleteUserDefaultModelsByModelIdCommand } from './delete-user-default-models-by-model-id.command';
 
 @Injectable()
 export class DeleteUserDefaultModelsByModelIdUseCase {
-  private readonly logger = new Logger(
-    DeleteUserDefaultModelsByModelIdUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(DeleteUserDefaultModelsByModelIdUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
   ) {}
 
   async execute(
     command: DeleteUserDefaultModelsByModelIdCommand,
   ): Promise<void> {
-    this.logger.debug('Deleting user default models by model id', {
-      modelId: command.permittedModelId,
-    });
+    this.logger.debug(
+      {
+        modelId: command.permittedModelId,
+      },
+      'Deleting user default models by model id',
+    );
     await this.userDefaultModelsRepository.deleteByModelId(
       command.permittedModelId,
     );

--- a/ayunis-core-backend/src/domain/models/application/use-cases/generate-image/generate-image.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/generate-image/generate-image.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { GenerateImageUseCase } from './generate-image.use-case';
 import { GenerateImageCommand } from './generate-image.command';
 import type { ImageGenerationHandlerRegistry } from '../../registry/image-generation-handler.registry';
@@ -15,6 +15,7 @@ import { ImageGenerationModel } from 'src/domain/models/domain/models/image-gene
 import { ModelProvider } from 'src/domain/models/domain/value-objects/model-provider.enum';
 
 describe('GenerateImageUseCase', () => {
+  const logger = createPinoLoggerMock();
   let useCase: GenerateImageUseCase;
   let registry: jest.Mocked<ImageGenerationHandlerRegistry>;
   let handler: jest.Mocked<ImageGenerationHandler>;
@@ -37,10 +38,10 @@ describe('GenerateImageUseCase', () => {
       registerMockHandler: jest.fn(),
     } as unknown as jest.Mocked<ImageGenerationHandlerRegistry>;
 
-    useCase = new GenerateImageUseCase(registry);
+    useCase = new GenerateImageUseCase(logger, registry);
 
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    logger.info.mockImplementation();
+    logger.error.mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/generate-image/generate-image.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/generate-image/generate-image.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { wrapProviderFailure } from 'src/common/errors/wrap-provider-failure.helper';
 import { ImageGenerationHandlerRegistry } from '../../registry/image-generation-handler.registry';
@@ -11,17 +12,21 @@ import { GenerateImageCommand } from './generate-image.command';
 
 @Injectable()
 export class GenerateImageUseCase {
-  private readonly logger = new Logger(GenerateImageUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GenerateImageUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly imageGenerationHandlerRegistry: ImageGenerationHandlerRegistry,
   ) {}
 
   async execute(command: GenerateImageCommand): Promise<ImageGenerationResult> {
-    this.logger.log('execute', {
-      model: command.model.name,
-      provider: command.model.provider,
-    });
+    this.logger.info(
+      {
+        model: command.model.name,
+        provider: command.model.provider,
+      },
+      'execute',
+    );
 
     try {
       const handler = this.imageGenerationHandlerRegistry.getHandler(
@@ -41,11 +46,14 @@ export class GenerateImageUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Image generation failed', {
-        model: command.model.name,
-        provider: command.model.provider,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          model: command.model.name,
+          provider: command.model.provider,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Image generation failed',
+      );
       const providerError = wrapProviderFailure(error, {
         provider: command.model.provider,
         modelId: command.model.name,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-all-models/get-all-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-all-models/get-all-models.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ModelsRepository } from '../../ports/models.repository';
 import { Model } from 'src/domain/models/domain/model.entity';
@@ -6,13 +7,15 @@ import { UnexpectedModelError } from '../../models.errors';
 
 @Injectable()
 export class GetAllModelsUseCase {
-  private readonly logger = new Logger(GetAllModelsUseCase.name);
-
-  constructor(private readonly modelsRepository: ModelsRepository) {}
+  constructor(
+    @InjectPinoLogger(GetAllModelsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly modelsRepository: ModelsRepository,
+  ) {}
 
   @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(): Promise<Model[]> {
-    this.logger.log('execute');
+    this.logger.info('execute');
 
     return this.modelsRepository.findAll();
   }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-configured-models-by-type/get-configured-models-by-type.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-configured-models-by-type/get-configured-models-by-type.use-case.spec.ts
@@ -1,6 +1,7 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -18,6 +19,7 @@ import { GetConfiguredModelsByTypeQuery } from './get-configured-models-by-type.
 import { GetConfiguredModelsByTypeUseCase } from './get-configured-models-by-type.use-case';
 
 describe('GetConfiguredModelsByTypeUseCase', () => {
+  const logger = createPinoLoggerMock();
   let useCase: GetConfiguredModelsByTypeUseCase;
   let modelsRepository: jest.Mocked<ModelsRepository>;
   let configService: jest.Mocked<ConfigService>;
@@ -68,6 +70,10 @@ describe('GetConfiguredModelsByTypeUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(GetConfiguredModelsByTypeUseCase.name),
+          useValue: logger,
+        },
         GetConfiguredModelsByTypeUseCase,
         { provide: ModelsRepository, useValue: mockModelsRepository },
         { provide: ConfigService, useValue: mockConfigService },
@@ -93,9 +99,9 @@ describe('GetConfiguredModelsByTypeUseCase', () => {
       return null;
     });
 
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    logger.info.mockImplementation();
+    logger.debug.mockImplementation();
+    logger.warn.mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-configured-models-by-type/get-configured-models-by-type.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-configured-models-by-type/get-configured-models-by-type.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -12,9 +13,10 @@ import { GetConfiguredModelsByTypeQuery } from './get-configured-models-by-type.
 
 @Injectable()
 export class GetConfiguredModelsByTypeUseCase {
-  private readonly logger = new Logger(GetConfiguredModelsByTypeUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetConfiguredModelsByTypeUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly modelsRepository: ModelsRepository,
     private readonly contextService: ContextService,
     private readonly configService: ConfigService,
@@ -28,10 +30,13 @@ export class GetConfiguredModelsByTypeUseCase {
       throw new UnauthorizedAccessError();
     }
 
-    this.logger.log('getConfiguredModelsByType', {
-      orgId: query.orgId,
-      type: query.type,
-    });
+    this.logger.info(
+      {
+        orgId: query.orgId,
+        type: query.type,
+      },
+      'getConfiguredModelsByType',
+    );
     const allModels = await this.modelsRepository.findAll();
     const configuredModels = allModels.filter(
       (model) =>
@@ -39,10 +44,13 @@ export class GetConfiguredModelsByTypeUseCase {
         !model.isArchived &&
         this.hasApiKeyForProvider(model.provider),
     );
-    this.logger.debug('Configured models by type', {
-      type: query.type,
-      models: configuredModels,
-    });
+    this.logger.debug(
+      {
+        type: query.type,
+        models: configuredModels,
+      },
+      'Configured models by type',
+    );
     return configuredModels;
   }
 
@@ -56,7 +64,7 @@ export class GetConfiguredModelsByTypeUseCase {
 
     const configKey = this.modelProviderInfoRegistry.getConfigKey(provider);
     if (!configKey) {
-      this.logger.warn(`No config mapping found for provider: ${provider}`);
+      this.logger.warn({ provider }, 'No config mapping found for provider');
       return false;
     }
 

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetDefaultModelUseCase } from './get-default-model.use-case';
@@ -59,6 +61,10 @@ describe('GetDefaultModelUseCase', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(GetDefaultModelUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         GetDefaultModelUseCase,
         {
           provide: PermittedModelsRepository,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-default-model/get-default-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
@@ -14,9 +15,10 @@ import { GetDefaultModelQuery } from './get-default-model.query';
 
 @Injectable()
 export class GetDefaultModelUseCase {
-  private readonly logger = new Logger(GetDefaultModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetDefaultModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
     private readonly getEffectiveLanguageModelsUseCase: GetEffectiveLanguageModelsUseCase,
@@ -24,7 +26,14 @@ export class GetDefaultModelUseCase {
 
   @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(query: GetDefaultModelQuery): Promise<PermittedLanguageModel> {
-    this.logger.log('execute', { query });
+    this.logger.info(
+      {
+        orgId: query.orgId,
+        userId: query.userId,
+        blacklistedModelIds: query.blacklistedModelIds,
+      },
+      'execute',
+    );
     const { models, overrideTeamIds } =
       await this.getEffectiveLanguageModelsUseCase.execute(
         new GetEffectiveLanguageModelsQuery(query.orgId, query.userId),

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetEffectiveLanguageModelsUseCase } from './get-effective-language-models.use-case';
@@ -68,6 +70,10 @@ describe('GetEffectiveLanguageModelsUseCase', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(GetEffectiveLanguageModelsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         GetEffectiveLanguageModelsUseCase,
         {
           provide: PermittedModelsRepository,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-effective-language-models/get-effective-language-models.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -14,9 +15,10 @@ import type { EffectiveLanguageModelsResult } from './effective-language-models-
 
 @Injectable()
 export class GetEffectiveLanguageModelsUseCase {
-  private readonly logger = new Logger(GetEffectiveLanguageModelsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetEffectiveLanguageModelsUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly findTeamsByUserIdUseCase: FindTeamsByUserIdUseCase,
     private readonly contextService: ContextService,
@@ -25,10 +27,13 @@ export class GetEffectiveLanguageModelsUseCase {
   async execute(
     query: GetEffectiveLanguageModelsQuery,
   ): Promise<EffectiveLanguageModelsResult> {
-    this.logger.log('Resolving effective language models', {
-      userId: query.userId,
-      orgId: query.orgId,
-    });
+    this.logger.info(
+      {
+        userId: query.userId,
+        orgId: query.orgId,
+      },
+      'Resolving effective language models',
+    );
 
     try {
       this.validateOrgAccess(query.orgId);
@@ -42,11 +47,14 @@ export class GetEffectiveLanguageModelsUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error resolving effective language models', {
-        userId: query.userId,
-        orgId: query.orgId,
-        error: error instanceof Error ? error : new Error('Unknown error'),
-      });
+      this.logger.error(
+        {
+          userId: query.userId,
+          orgId: query.orgId,
+          err: error instanceof Error ? error : new Error('Unknown error'),
+        },
+        'Error resolving effective language models',
+      );
       throw new UnexpectedModelError(error as Error);
     }
   }
@@ -73,10 +81,13 @@ export class GetEffectiveLanguageModelsUseCase {
     const overrideTeamIds = overrideTeams.map((t) => t.id);
 
     if (overrideTeams.length === 0) {
-      this.logger.debug('No override teams found, returning org-level models', {
-        userId,
-        orgId,
-      });
+      this.logger.debug(
+        {
+          userId,
+          orgId,
+        },
+        'No override teams found, returning org-level models',
+      );
       return this.buildOrgFallback(orgId);
     }
 
@@ -84,8 +95,8 @@ export class GetEffectiveLanguageModelsUseCase {
 
     if (merged.length === 0) {
       this.logger.debug(
-        'Override teams have no configured models, falling back to org-level models',
         { userId, orgId },
+        'Override teams have no configured models, falling back to org-level models',
       );
       return this.buildOrgFallback(orgId);
     }
@@ -119,10 +130,13 @@ export class GetEffectiveLanguageModelsUseCase {
       }
     }
 
-    this.logger.debug('Merged team models', {
-      teamIds,
-      modelCount: modelsByModelId.size,
-    });
+    this.logger.debug(
+      {
+        teamIds,
+        modelCount: modelsByModelId.size,
+      },
+      'Merged team models',
+    );
 
     return Array.from(modelsByModelId.values());
   }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-inference/get-inference.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-inference/get-inference.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { GetInferenceUseCase } from './get-inference.use-case';
 import { GetInferenceCommand } from './get-inference.command';
@@ -45,7 +46,11 @@ function useCaseWithFailingHandler(error: Error): GetInferenceUseCase {
   const contextService = {
     get: () => '123e4567-e89b-12d3-a456-426614174000',
   };
-  return new GetInferenceUseCase(registry as never, contextService as never);
+  return new GetInferenceUseCase(
+    createPinoLoggerMock(),
+    registry as never,
+    contextService as never,
+  );
 }
 
 function useCaseWithResponse(response: InferenceResponse): GetInferenceUseCase {
@@ -55,7 +60,11 @@ function useCaseWithResponse(response: InferenceResponse): GetInferenceUseCase {
   const contextService = {
     get: () => '123e4567-e89b-12d3-a456-426614174000',
   };
-  return new GetInferenceUseCase(registry as never, contextService as never);
+  return new GetInferenceUseCase(
+    createPinoLoggerMock(),
+    registry as never,
+    contextService as never,
+  );
 }
 
 describe('GetInferenceUseCase error mapping', () => {
@@ -199,6 +208,7 @@ describe('GetInferenceUseCase replayed message sanitation', () => {
     };
     const contextService = { get: () => randomUUID() };
     const useCase = new GetInferenceUseCase(
+      createPinoLoggerMock(),
       registry as never,
       contextService as never,
     );

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-inference/get-inference.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-inference/get-inference.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetInferenceCommand } from './get-inference.command';
 import { InferenceHandlerRegistry } from '../../registry/inference-handler.registry';
 import {
@@ -18,21 +19,25 @@ import { ToolUseMessageContent } from 'src/domain/messages/domain/message-conten
 
 @Injectable()
 export class GetInferenceUseCase {
-  private readonly logger = new Logger(GetInferenceUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetInferenceUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly inferenceHandlerRegistry: InferenceHandlerRegistry,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(command: GetInferenceCommand): Promise<InferenceResponse> {
-    this.logger.log('triggerInference', {
-      model: command.model.name,
-      messageCount: command.messages.length,
-      toolCount: command.tools.length,
-      toolChoice: command.toolChoice,
-      hasInstructions: Boolean(command.instructions),
-    });
+    this.logger.info(
+      {
+        model: command.model.name,
+        messageCount: command.messages.length,
+        toolCount: command.tools.length,
+        toolChoice: command.toolChoice,
+        hasInstructions: Boolean(command.instructions),
+      },
+      'triggerInference',
+    );
 
     const orgId = this.contextService.get('orgId');
     if (!orgId) {
@@ -93,22 +98,28 @@ export class GetInferenceUseCase {
       modelId: command.model.name,
     });
     if (providerError) {
-      this.logger.error('Provider unavailable during inference', {
-        code: providerError.code,
-        ...providerError.context,
-      });
+      this.logger.error(
+        {
+          code: providerError.code,
+          ...providerError.context,
+        },
+        'Provider unavailable during inference',
+      );
       throw providerError;
     }
     const status = extractUpstreamStatus(error);
-    this.logger.error('Provider inference failed', {
-      model: command.model.name,
-      provider: command.model.provider,
-      messageCount: command.messages.length,
-      toolCount: command.tools.length,
-      toolChoice: command.toolChoice,
-      errorName: error instanceof Error ? error.name : 'Unknown',
-      status,
-    });
+    this.logger.error(
+      {
+        model: command.model.name,
+        provider: command.model.provider,
+        messageCount: command.messages.length,
+        toolCount: command.tools.length,
+        toolChoice: command.toolChoice,
+        errorName: error instanceof Error ? error.name : 'Unknown',
+        status,
+      },
+      'Provider inference failed',
+    );
     throw new InferenceFailedError('Provider inference failed', { status });
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-model-by-id/get-model-by-id.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-model-by-id/get-model-by-id.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Model } from 'src/domain/models/domain/model.entity';
 import { ModelsRepository } from '../../ports/models.repository';
@@ -10,13 +11,15 @@ import {
 
 @Injectable()
 export class GetModelByIdUseCase {
-  private readonly logger = new Logger(GetModelByIdUseCase.name);
-
-  constructor(private readonly modelsRepository: ModelsRepository) {}
+  constructor(
+    @InjectPinoLogger(GetModelByIdUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly modelsRepository: ModelsRepository,
+  ) {}
 
   @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(query: GetModelByIdQuery): Promise<Model> {
-    this.logger.log('execute', { id: query.id });
+    this.logger.info({ id: query.id }, 'execute');
 
     const model = await this.modelsRepository.findOne({ id: query.id });
     if (!model) {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-model/get-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-model/get-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Model } from 'src/domain/models/domain/model.entity';
 import { ModelsRepository } from '../../ports/models.repository';
@@ -10,13 +11,15 @@ import {
 
 @Injectable()
 export class GetModelUseCase {
-  private readonly logger = new Logger(GetModelUseCase.name);
-
-  constructor(private readonly modelsRepository: ModelsRepository) {}
+  constructor(
+    @InjectPinoLogger(GetModelUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly modelsRepository: ModelsRepository,
+  ) {}
 
   @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(query: GetModelQuery): Promise<Model> {
-    this.logger.log('execute', query);
+    this.logger.info(query, 'execute');
 
     const model = await this.modelsRepository.findOne(query);
     if (!model) {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-org-default-model/get-org-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-org-default-model/get-org-default-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GetOrgDefaultModelQuery } from './get-org-default-model.query';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
@@ -7,9 +8,10 @@ import { UnexpectedModelError } from '../../models.errors';
 
 @Injectable()
 export class GetOrgDefaultModelUseCase {
-  private readonly logger = new Logger(GetOrgDefaultModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetOrgDefaultModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
   ) {}
 
@@ -17,25 +19,34 @@ export class GetOrgDefaultModelUseCase {
   async execute(
     query: GetOrgDefaultModelQuery,
   ): Promise<PermittedLanguageModel | null> {
-    this.logger.log('execute', {
-      orgId: query.orgId,
-    });
+    this.logger.info(
+      {
+        orgId: query.orgId,
+      },
+      'execute',
+    );
 
     // Get only the organization's specific default model
     const orgDefaultModel =
       await this.permittedModelsRepository.findOrgDefaultLanguage(query.orgId);
 
     if (orgDefaultModel) {
-      this.logger.debug('Organization default model found', {
-        orgId: query.orgId,
-        modelId: orgDefaultModel.id,
-        modelName: orgDefaultModel.model.name,
-        modelProvider: orgDefaultModel.model.provider,
-      });
+      this.logger.debug(
+        {
+          orgId: query.orgId,
+          modelId: orgDefaultModel.id,
+          modelName: orgDefaultModel.model.name,
+          modelProvider: orgDefaultModel.model.provider,
+        },
+        'Organization default model found',
+      );
     } else {
-      this.logger.debug('No organization default model found', {
-        orgId: query.orgId,
-      });
+      this.logger.debug(
+        {
+          orgId: query.orgId,
+        },
+        'No organization default model found',
+      );
     }
 
     return orgDefaultModel ?? null;

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case.spec.ts
@@ -1,5 +1,6 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
@@ -22,6 +23,7 @@ import { GetPermittedEmbeddingModelQuery } from './get-permitted-embedding-model
 import { GetPermittedEmbeddingModelUseCase } from './get-permitted-embedding-model.use-case';
 
 describe('GetPermittedEmbeddingModelUseCase', () => {
+  const logger = createPinoLoggerMock();
   const orgId = randomUUID();
   const otherOrgId = randomUUID();
 
@@ -56,6 +58,10 @@ describe('GetPermittedEmbeddingModelUseCase', () => {
 
     const module = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(GetPermittedEmbeddingModelUseCase.name),
+          useValue: logger,
+        },
         GetPermittedEmbeddingModelUseCase,
         {
           provide: PermittedModelsRepository,
@@ -67,8 +73,8 @@ describe('GetPermittedEmbeddingModelUseCase', () => {
 
     useCase = module.get(GetPermittedEmbeddingModelUseCase);
 
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    logger.info.mockImplementation();
+    logger.error.mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-embedding-model/get-permitted-embedding-model.use-case.ts
@@ -6,16 +6,18 @@ import {
   UnexpectedModelError,
 } from '../../models.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 
 @Injectable()
 export class GetPermittedEmbeddingModelUseCase {
-  private readonly logger = new Logger(GetPermittedEmbeddingModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetPermittedEmbeddingModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -23,9 +25,12 @@ export class GetPermittedEmbeddingModelUseCase {
   async execute(
     query: GetPermittedEmbeddingModelQuery,
   ): Promise<PermittedEmbeddingModel> {
-    this.logger.log('execute', {
-      orgId: query.orgId,
-    });
+    this.logger.info(
+      {
+        orgId: query.orgId,
+      },
+      'execute',
+    );
 
     try {
       const orgId = this.contextService.get('orgId');

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-image-generation-model/get-permitted-image-generation-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-image-generation-model/get-permitted-image-generation-model.use-case.spec.ts
@@ -1,5 +1,6 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
@@ -24,6 +25,7 @@ import { FindTeamsByUserIdUseCase } from 'src/iam/teams/application/use-cases/fi
 import { Team } from 'src/iam/teams/domain/team.entity';
 
 describe('GetPermittedImageGenerationModelUseCase', () => {
+  const logger = createPinoLoggerMock();
   const orgId = randomUUID();
   const otherOrgId = randomUUID();
   const userId = randomUUID();
@@ -67,6 +69,14 @@ describe('GetPermittedImageGenerationModelUseCase', () => {
 
     const module = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(ModelPolicyService.name),
+          useValue: createPinoLoggerMock(),
+        },
+        {
+          provide: getLoggerToken(GetPermittedImageGenerationModelUseCase.name),
+          useValue: logger,
+        },
         GetPermittedImageGenerationModelUseCase,
         ModelPolicyService,
         {
@@ -84,8 +94,8 @@ describe('GetPermittedImageGenerationModelUseCase', () => {
     useCase = module.get(GetPermittedImageGenerationModelUseCase);
     modelPolicy = module.get(ModelPolicyService);
 
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    logger.info.mockImplementation();
+    logger.error.mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-image-generation-model/get-permitted-image-generation-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-image-generation-model/get-permitted-image-generation-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -24,11 +25,10 @@ import { GetPermittedImageGenerationModelQuery } from './get-permitted-image-gen
  */
 @Injectable()
 export class GetPermittedImageGenerationModelUseCase {
-  private readonly logger = new Logger(
-    GetPermittedImageGenerationModelUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(GetPermittedImageGenerationModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
     private readonly modelPolicy: ModelPolicyService,
@@ -39,9 +39,12 @@ export class GetPermittedImageGenerationModelUseCase {
   async execute(
     query: GetPermittedImageGenerationModelQuery,
   ): Promise<PermittedImageGenerationModel> {
-    this.logger.log('execute', {
-      orgId: query.orgId,
-    });
+    this.logger.info(
+      {
+        orgId: query.orgId,
+      },
+      'execute',
+    );
 
     this.validateOrgAccess(query.orgId);
 

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-model/get-permitted-language-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-model/get-permitted-language-model.use-case.spec.ts
@@ -1,6 +1,7 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import type { UUID } from 'crypto';
 import { GetPermittedLanguageModelUseCase } from './get-permitted-language-model.use-case';
 import { GetPermittedLanguageModelQuery } from './get-permitted-language-model.query';
@@ -15,6 +16,7 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 import { GetEffectiveLanguageModelsUseCase } from '../get-effective-language-models/get-effective-language-models.use-case';
 
 describe('GetPermittedLanguageModelUseCase', () => {
+  const logger = createPinoLoggerMock();
   let useCase: GetPermittedLanguageModelUseCase;
   let permittedModelsRepository: jest.Mocked<PermittedModelsRepository>;
   let getEffectiveLanguageModelsUseCase: jest.Mocked<GetEffectiveLanguageModelsUseCase>;
@@ -49,6 +51,10 @@ describe('GetPermittedLanguageModelUseCase', () => {
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(GetPermittedLanguageModelUseCase.name),
+          useValue: logger,
+        },
         GetPermittedLanguageModelUseCase,
         {
           provide: PermittedModelsRepository,
@@ -82,8 +88,8 @@ describe('GetPermittedLanguageModelUseCase', () => {
       GetEffectiveLanguageModelsUseCase,
     );
 
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    logger.info.mockImplementation();
+    logger.error.mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-model/get-permitted-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-model/get-permitted-language-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ContextService } from 'src/common/context/services/context.service';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -15,9 +16,10 @@ import { GetPermittedLanguageModelQuery } from './get-permitted-language-model.q
 
 @Injectable()
 export class GetPermittedLanguageModelUseCase {
-  private readonly logger = new Logger(GetPermittedLanguageModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetPermittedLanguageModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly getEffectiveLanguageModelsUseCase: GetEffectiveLanguageModelsUseCase,
     private readonly contextService: ContextService,
@@ -27,7 +29,10 @@ export class GetPermittedLanguageModelUseCase {
   async execute(
     query: GetPermittedLanguageModelQuery,
   ): Promise<PermittedLanguageModel> {
-    this.logger.log('getPermittedLanguageModel', { query });
+    this.logger.info(
+      { permittedModelId: query.id },
+      'getPermittedLanguageModel',
+    );
     const model = await this.permittedModelsRepository.findOneLanguage({
       id: query.id,
     });

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.use-case.ts
@@ -1,7 +1,8 @@
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { GetPermittedLanguageModelsQuery } from './get-permitted-language-models.query';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UnexpectedModelError } from '../../models.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -10,9 +11,10 @@ import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum'
 
 @Injectable()
 export class GetPermittedLanguageModelsUseCase {
-  private readonly logger = new Logger(GetPermittedLanguageModelsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetPermittedLanguageModelsUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -20,9 +22,12 @@ export class GetPermittedLanguageModelsUseCase {
   async execute(
     query: GetPermittedLanguageModelsQuery,
   ): Promise<PermittedLanguageModel[]> {
-    this.logger.log('Executing get permitted language models', {
-      orgId: query.orgId,
-    });
+    this.logger.info(
+      {
+        orgId: query.orgId,
+      },
+      'Executing get permitted language models',
+    );
     try {
       const orgId = this.contextService.get('orgId');
       const systemRole = this.contextService.get('systemRole');
@@ -36,10 +41,13 @@ export class GetPermittedLanguageModelsUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error getting permitted language models', {
-        orgId: query.orgId,
-        error: error instanceof Error ? error : new Error('Unknown error'),
-      });
+      this.logger.error(
+        {
+          orgId: query.orgId,
+          err: error instanceof Error ? error : new Error('Unknown error'),
+        },
+        'Error getting permitted language models',
+      );
       throw new UnexpectedModelError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-model/get-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-model/get-permitted-model.use-case.ts
@@ -5,27 +5,30 @@ import {
   UnexpectedModelError,
 } from '../../models.errors';
 import { GetPermittedModelQuery } from './get-permitted-model.query';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
 
 @Injectable()
 export class GetPermittedModelUseCase {
-  private readonly logger = new Logger(GetPermittedModelUseCase.name);
   constructor(
+    @InjectPinoLogger(GetPermittedModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(query: GetPermittedModelQuery): Promise<PermittedModel> {
     try {
-      this.logger.log('execute', {
-        query,
-      });
-      this.logger.debug('GetPermittedModelByIdQuery', {
-        query,
-      });
+      const metadata = {
+        orgId: query.orgId,
+        permittedModelId: query.permittedModelId,
+      };
+      this.logger.info(metadata, 'execute');
+      this.logger.debug(metadata, 'GetPermittedModelByIdQuery');
       const orgId = this.contextService.get('orgId');
       const systemRole = this.contextService.get('systemRole');
       const model = await this.permittedModelsRepository.findOne({
@@ -37,9 +40,7 @@ export class GetPermittedModelUseCase {
         throw new UnauthorizedAccessError();
       }
       if (!model) {
-        this.logger.error('Permitted model not found', {
-          query,
-        });
+        this.logger.error(metadata, 'Permitted model not found');
         throw new PermittedModelNotFoundError(query.permittedModelId);
       }
       return model;
@@ -47,9 +48,12 @@ export class GetPermittedModelUseCase {
       if (error instanceof PermittedModelNotFoundError) {
         throw error;
       }
-      this.logger.error('Error getting permitted model', {
-        error: error instanceof Error ? error : new Error('Unknown error'),
-      });
+      this.logger.error(
+        {
+          err: error instanceof Error ? error : new Error('Unknown error'),
+        },
+        'Error getting permitted model',
+      );
       throw new UnexpectedModelError(
         error instanceof Error ? error : new Error('Unknown error'),
         {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-models/get-permitted-models.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-models/get-permitted-models.use-case.spec.ts
@@ -1,6 +1,7 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { GetPermittedModelsUseCase } from './get-permitted-models.use-case';
 import { GetPermittedModelsQuery } from './get-permitted-models.query';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
@@ -8,6 +9,7 @@ import type { PermittedModel } from 'src/domain/models/domain/permitted-model.en
 import { ContextService } from 'src/common/context/services/context.service';
 
 describe('GetPermittedModelsUseCase', () => {
+  const logger = createPinoLoggerMock();
   let useCase: GetPermittedModelsUseCase;
   let permittedModelsRepository: jest.Mocked<PermittedModelsRepository>;
   let mockContextService: any;
@@ -28,6 +30,10 @@ describe('GetPermittedModelsUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(GetPermittedModelsUseCase.name),
+          useValue: logger,
+        },
         GetPermittedModelsUseCase,
         {
           provide: PermittedModelsRepository,
@@ -48,8 +54,8 @@ describe('GetPermittedModelsUseCase', () => {
     });
 
     // Mock logger
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    logger.debug.mockImplementation();
+    logger.error.mockImplementation();
   });
 
   afterEach(() => {
@@ -160,16 +166,16 @@ describe('GetPermittedModelsUseCase', () => {
 
       permittedModelsRepository.findAll.mockResolvedValue([]);
 
-      const debugSpy = jest.spyOn(Logger.prototype, 'debug');
+      const debugSpy = logger.debug;
 
       // Act
       await useCase.execute(query);
 
       // Assert
-      expect(debugSpy).toHaveBeenCalledWith('Getting permitted models', {
-        orgId: mockOrgId,
-        filter,
-      });
+      expect(debugSpy).toHaveBeenCalledWith(
+        { orgId: mockOrgId, filter },
+        'Getting permitted models',
+      );
     });
 
     it('should handle repository errors', async () => {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-models/get-permitted-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-permitted-models/get-permitted-models.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetPermittedModelsQuery } from './get-permitted-models.query';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { PermittedModel } from 'src/domain/models/domain/permitted-model.entity';
@@ -8,18 +9,22 @@ import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum'
 
 @Injectable()
 export class GetPermittedModelsUseCase {
-  private readonly logger = new Logger(GetPermittedModelsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetPermittedModelsUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(query: GetPermittedModelsQuery): Promise<PermittedModel[]> {
-    this.logger.debug('Getting permitted models', {
-      orgId: query.orgId,
-      filter: query.filter,
-    });
+    this.logger.debug(
+      {
+        orgId: query.orgId,
+        filter: query.filter,
+      },
+      'Getting permitted models',
+    );
     try {
       const orgId = this.contextService.get('orgId');
       const systemRole = this.contextService.get('systemRole');
@@ -30,9 +35,12 @@ export class GetPermittedModelsUseCase {
       }
       return this.permittedModelsRepository.findAll(query.orgId, query.filter);
     } catch (error) {
-      this.logger.error('Error getting permitted models', {
-        error: error instanceof Error ? error : new Error('Unknown error'),
-      });
+      this.logger.error(
+        {
+          err: error instanceof Error ? error : new Error('Unknown error'),
+        },
+        'Error getting permitted models',
+      );
       throw error;
     }
   }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-team-permitted-image-generation-models/get-team-permitted-image-generation-models.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-team-permitted-image-generation-models/get-team-permitted-image-generation-models.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetTeamPermittedImageGenerationModelsUseCase } from './get-team-permitted-image-generation-models.use-case';
@@ -46,6 +48,12 @@ describe('GetTeamPermittedImageGenerationModelsUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(
+            GetTeamPermittedImageGenerationModelsUseCase.name,
+          ),
+          useValue: createPinoLoggerMock(),
+        },
         GetTeamPermittedImageGenerationModelsUseCase,
         TeamPermittedModelValidator,
         {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-team-permitted-image-generation-models/get-team-permitted-image-generation-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-team-permitted-image-generation-models/get-team-permitted-image-generation-models.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { GetTeamPermittedImageGenerationModelsQuery } from './get-team-permitted-image-generation-models.query';
@@ -8,11 +9,10 @@ import { TeamPermittedModelValidator } from '../../services/team-permitted-model
 
 @Injectable()
 export class GetTeamPermittedImageGenerationModelsUseCase {
-  private readonly logger = new Logger(
-    GetTeamPermittedImageGenerationModelsUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(GetTeamPermittedImageGenerationModelsUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly validator: TeamPermittedModelValidator,
   ) {}
@@ -21,10 +21,13 @@ export class GetTeamPermittedImageGenerationModelsUseCase {
   async execute(
     query: GetTeamPermittedImageGenerationModelsQuery,
   ): Promise<PermittedImageGenerationModel[]> {
-    this.logger.log('execute', {
-      teamId: query.teamId,
-      orgId: query.orgId,
-    });
+    this.logger.info(
+      {
+        teamId: query.teamId,
+        orgId: query.orgId,
+      },
+      'execute',
+    );
 
     this.validator.validateAdminAccess(query.orgId);
     await this.validator.validateTeamInOrg(query.teamId, query.orgId);

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-team-permitted-models/get-team-permitted-models.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-team-permitted-models/get-team-permitted-models.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetTeamPermittedModelsUseCase } from './get-team-permitted-models.use-case';
@@ -46,6 +48,10 @@ describe('GetTeamPermittedModelsUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(GetTeamPermittedModelsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         GetTeamPermittedModelsUseCase,
         TeamPermittedModelValidator,
         {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-team-permitted-models/get-team-permitted-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-team-permitted-models/get-team-permitted-models.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { GetTeamPermittedModelsQuery } from './get-team-permitted-models.query';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
@@ -8,9 +9,10 @@ import { TeamPermittedModelValidator } from '../../services/team-permitted-model
 
 @Injectable()
 export class GetTeamPermittedModelsUseCase {
-  private readonly logger = new Logger(GetTeamPermittedModelsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetTeamPermittedModelsUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly validator: TeamPermittedModelValidator,
   ) {}
@@ -18,10 +20,13 @@ export class GetTeamPermittedModelsUseCase {
   async execute(
     query: GetTeamPermittedModelsQuery,
   ): Promise<PermittedLanguageModel[]> {
-    this.logger.log('execute', {
-      teamId: query.teamId,
-      orgId: query.orgId,
-    });
+    this.logger.info(
+      {
+        teamId: query.teamId,
+        orgId: query.orgId,
+      },
+      'execute',
+    );
 
     try {
       this.validator.validateAdminAccess(query.orgId);
@@ -35,7 +40,7 @@ export class GetTeamPermittedModelsUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error listing team permitted models', error);
+      this.logger.error({ err: error }, 'Error listing team permitted models');
       throw new UnexpectedModelError(
         error instanceof Error ? error : new Error('Unknown error'),
       );

--- a/ayunis-core-backend/src/domain/models/application/use-cases/get-user-default-model/get-user-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/get-user-default-model/get-user-default-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetUserDefaultModelQuery } from './get-user-default-model.query';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
 import { UserDefaultModelsRepository } from '../../ports/user-default-models.repository';
@@ -6,34 +7,44 @@ import { ModelError } from '../../models.errors';
 
 @Injectable()
 export class GetUserDefaultModelUseCase {
-  private readonly logger = new Logger(GetUserDefaultModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetUserDefaultModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
   ) {}
 
   async execute(
     query: GetUserDefaultModelQuery,
   ): Promise<PermittedLanguageModel | null> {
-    this.logger.log('execute', {
-      userId: query.userId,
-    });
+    this.logger.info(
+      {
+        userId: query.userId,
+      },
+      'execute',
+    );
 
     try {
       const userDefaultModel =
         await this.userDefaultModelsRepository.findByUserId(query.userId);
 
       if (userDefaultModel) {
-        this.logger.debug('User default model found', {
-          userId: query.userId,
-          modelId: userDefaultModel.id,
-          modelName: userDefaultModel.model.name,
-          modelProvider: userDefaultModel.model.provider,
-        });
+        this.logger.debug(
+          {
+            userId: query.userId,
+            modelId: userDefaultModel.id,
+            modelName: userDefaultModel.model.name,
+            modelProvider: userDefaultModel.model.provider,
+          },
+          'User default model found',
+        );
       } else {
-        this.logger.debug('No user default model found', {
-          userId: query.userId,
-        });
+        this.logger.debug(
+          {
+            userId: query.userId,
+          },
+          'No user default model found',
+        );
       }
 
       return userDefaultModel;
@@ -41,10 +52,13 @@ export class GetUserDefaultModelUseCase {
       if (error instanceof ModelError) {
         throw error;
       }
-      this.logger.error('Failed to get user default model', {
-        userId: query.userId,
-        error: error instanceof Error ? error : new Error('Unknown error'),
-      });
+      this.logger.error(
+        {
+          userId: query.userId,
+          err: error instanceof Error ? error : new Error('Unknown error'),
+        },
+        'Failed to get user default model',
+      );
       throw error;
     }
   }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/map-messages-to-inference/map-messages-to-inference.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/map-messages-to-inference/map-messages-to-inference.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import type { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 import { ToolUseMessageContent } from 'src/domain/messages/domain/message-contents/tool-use.message-content.entity';
@@ -33,6 +34,7 @@ describe('MapMessagesToInferenceUseCase', () => {
     ]);
     const useCase = new MapMessagesToInferenceUseCase(
       {} as ImageContentService,
+      createPinoLoggerMock(),
     );
 
     const [mapped] = await useCase.execute(command);

--- a/ayunis-core-backend/src/domain/models/application/use-cases/map-messages-to-inference/map-messages-to-inference.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/map-messages-to-inference/map-messages-to-inference.use-case.ts
@@ -1,6 +1,8 @@
 import type { Message as InferenceMessage } from '@ayunis/inference';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { createPinoLoggerConfig } from 'src/common/logger/pino-logger.config';
 import { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 import { stripReplayedToolNulls } from '../../helpers/strip-replayed-tool-nulls.helper';
 import { toInferenceMessages } from '../../mappers/message.mapper';
@@ -15,17 +17,22 @@ import { MapMessagesToInferenceCommand } from './map-messages-to-inference.comma
  */
 @Injectable()
 export class MapMessagesToInferenceUseCase {
-  private readonly logger = new Logger(MapMessagesToInferenceUseCase.name);
-
-  constructor(private readonly imageContentService: ImageContentService) {}
+  constructor(
+    private readonly imageContentService: ImageContentService,
+    @InjectPinoLogger(MapMessagesToInferenceUseCase.name)
+    private readonly logger: PinoLogger = createMapMessagesLogger(),
+  ) {}
 
   @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(
     command: MapMessagesToInferenceCommand,
   ): Promise<InferenceMessage[]> {
-    this.logger.log('Mapping thread messages to inference', {
-      count: command.messages.length,
-    });
+    this.logger.info(
+      {
+        count: command.messages.length,
+      },
+      'Mapping thread messages to inference',
+    );
     const messages = stripReplayedToolNulls(command.messages, command.tools);
     return toInferenceMessages(
       messages,
@@ -33,4 +40,10 @@ export class MapMessagesToInferenceUseCase {
       this.imageContentService,
     );
   }
+}
+
+function createMapMessagesLogger(): PinoLogger {
+  const logger = new PinoLogger(createPinoLoggerConfig());
+  logger.setContext(MapMessagesToInferenceUseCase.name);
+  return logger;
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/resolve-model-provider/resolve-model-provider.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/resolve-model-provider/resolve-model-provider.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { ModelProvider as InferenceModelProvider } from '@ayunis/inference';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
@@ -36,6 +38,10 @@ describe('ResolveModelProviderUseCase', () => {
 
     const moduleRef: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(ResolveModelProviderUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         ResolveModelProviderUseCase,
         { provide: StreamInferenceHandlerRegistry, useValue: registry },
       ],

--- a/ayunis-core-backend/src/domain/models/application/use-cases/resolve-model-provider/resolve-model-provider.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/resolve-model-provider/resolve-model-provider.use-case.ts
@@ -1,5 +1,6 @@
 import type { ModelProvider } from '@ayunis/inference';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { StreamInferenceHandlerRegistry } from '../../registry/stream-inference-handler.registry';
 import { UnexpectedModelError } from '../../models.errors';
@@ -13,18 +14,22 @@ import { ResolveModelProviderQuery } from './resolve-model-provider.query';
  */
 @Injectable()
 export class ResolveModelProviderUseCase {
-  private readonly logger = new Logger(ResolveModelProviderUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ResolveModelProviderUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly streamInferenceRegistry: StreamInferenceHandlerRegistry,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedModelError)
   execute(query: ResolveModelProviderQuery): Promise<ModelProvider> {
-    this.logger.log('Resolving model provider', {
-      model: query.model.name,
-      provider: query.model.provider,
-    });
+    this.logger.info(
+      {
+        model: query.model.name,
+        provider: query.model.provider,
+      },
+      'Resolving model provider',
+    );
     return Promise.resolve(
       this.streamInferenceRegistry
         .getHandler(query.model.provider)

--- a/ayunis-core-backend/src/domain/models/application/use-cases/set-org-default-language-model/set-org-default-language-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/set-org-default-language-model/set-org-default-language-model.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { SetOrgDefaultLanguageModelUseCase } from './set-org-default-language-model.use-case';
@@ -34,6 +36,10 @@ describe('SetOrgDefaultLanguageModelUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(SetOrgDefaultLanguageModelUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         SetOrgDefaultLanguageModelUseCase,
         {
           provide: PermittedModelsRepository,

--- a/ayunis-core-backend/src/domain/models/application/use-cases/set-org-default-language-model/set-org-default-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/set-org-default-language-model/set-org-default-language-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SetOrgDefaultLanguageModelCommand } from './set-org-default-language-model.command';
 import { PermittedLanguageModel } from '../../../domain/permitted-model.entity';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
@@ -9,9 +10,10 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 @Injectable()
 export class SetOrgDefaultLanguageModelUseCase {
-  private readonly logger = new Logger(SetOrgDefaultLanguageModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(SetOrgDefaultLanguageModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -19,79 +21,77 @@ export class SetOrgDefaultLanguageModelUseCase {
   async execute(
     command: SetOrgDefaultLanguageModelCommand,
   ): Promise<PermittedLanguageModel> {
-    this.logger.log('execute', {
-      permittedModelId: command.permittedModelId,
-      orgId: command.orgId,
-    });
-
+    this.logger.info(
+      { permittedModelId: command.permittedModelId, orgId: command.orgId },
+      'execute',
+    );
     try {
-      // Check if the user is authorized to set the organization default model
-      const orgId = this.contextService.get('orgId');
-      const systemRole = this.contextService.get('systemRole');
-      const isFromOrg = orgId === command.orgId;
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-      if (!isFromOrg && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
-
-      // Only language models may participate in org-default flows.
-      const permittedModel =
-        await this.permittedModelsRepository.findOneLanguage({
-          id: command.permittedModelId,
-          orgId: command.orgId,
-        });
-
-      if (!permittedModel) {
-        this.logger.error('Permitted model not found', {
-          permittedModelId: command.permittedModelId,
-          orgId: command.orgId,
-        });
-        throw new PermittedModelNotFoundError(command.permittedModelId);
-      }
-
-      // Check if there's already a default model
-      const existingDefault =
-        await this.permittedModelsRepository.findOrgDefaultLanguage(
-          command.orgId,
-        );
-
-      const action = existingDefault ? 'updating' : 'setting';
-      this.logger.debug(
-        `Permitted model found, ${action} organization default`,
-        {
-          permittedModelId: command.permittedModelId,
-          orgId: command.orgId,
-          modelName: permittedModel.model.name,
-          modelProvider: permittedModel.model.provider,
-          existingDefaultId: existingDefault?.id,
-        },
-      );
-
-      // Set the model as the organization's default (handles both create and update)
-      const orgDefaultModel = await this.permittedModelsRepository.setAsDefault(
-        {
-          id: command.permittedModelId,
-          orgId: command.orgId,
-        },
-      );
-
-      this.logger.debug(`Organization default model ${action} successfully`, {
-        orgId: command.orgId,
-        modelId: orgDefaultModel.id,
-        action,
-      });
-
-      return orgDefaultModel;
+      return await this.setDefault(command);
     } catch (error) {
-      if (error instanceof ModelError) {
-        throw error;
-      }
-      this.logger.error('Failed to set organization default model', {
-        permittedModelId: command.permittedModelId,
-        orgId: command.orgId,
-        error: error instanceof Error ? error : new Error('Unknown error'),
-      });
+      if (error instanceof ModelError) throw error;
+      this.logger.error(
+        {
+          permittedModelId: command.permittedModelId,
+          orgId: command.orgId,
+          err: error instanceof Error ? error : new Error('Unknown error'),
+        },
+        'Failed to set organization default model',
+      );
       throw error;
     }
+  }
+
+  private async setDefault(
+    command: SetOrgDefaultLanguageModelCommand,
+  ): Promise<PermittedLanguageModel> {
+    this.assertAuthorized(command.orgId);
+    const permittedModel = await this.findPermittedModel(command);
+    const existingDefault =
+      await this.permittedModelsRepository.findOrgDefaultLanguage(
+        command.orgId,
+      );
+    const action = existingDefault ? 'updating' : 'setting';
+    this.logger.debug(
+      {
+        permittedModelId: command.permittedModelId,
+        orgId: command.orgId,
+        modelName: permittedModel.model.name,
+        modelProvider: permittedModel.model.provider,
+        existingDefaultId: existingDefault?.id,
+        action,
+      },
+      'Permitted model found for organization default',
+    );
+    const result = await this.permittedModelsRepository.setAsDefault({
+      id: command.permittedModelId,
+      orgId: command.orgId,
+    });
+    this.logger.debug(
+      { orgId: command.orgId, modelId: result.id, action },
+      'Organization default model changed successfully',
+    );
+    return result;
+  }
+
+  private assertAuthorized(orgId: string): void {
+    const isFromOrg = this.contextService.get('orgId') === orgId;
+    const isSuperAdmin =
+      this.contextService.get('systemRole') === SystemRole.SUPER_ADMIN;
+    if (!isFromOrg && !isSuperAdmin) throw new UnauthorizedAccessError();
+  }
+
+  private async findPermittedModel(
+    command: SetOrgDefaultLanguageModelCommand,
+  ): Promise<PermittedLanguageModel> {
+    const model = await this.permittedModelsRepository.findOneLanguage({
+      id: command.permittedModelId,
+      orgId: command.orgId,
+    });
+    if (model) return model;
+    this.logger.error(
+      { permittedModelId: command.permittedModelId, orgId: command.orgId },
+      'Permitted model not found',
+    );
+    throw new PermittedModelNotFoundError(command.permittedModelId);
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/set-team-default-model/set-team-default-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/set-team-default-model/set-team-default-model.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { SetTeamDefaultModelUseCase } from './set-team-default-model.use-case';
@@ -75,6 +77,10 @@ describe('SetTeamDefaultModelUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(SetTeamDefaultModelUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         SetTeamDefaultModelUseCase,
         TeamPermittedModelValidator,
         {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/set-team-default-model/set-team-default-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/set-team-default-model/set-team-default-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { SetTeamDefaultModelCommand } from './set-team-default-model.command';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
@@ -8,9 +9,10 @@ import { TeamPermittedModelValidator } from '../../services/team-permitted-model
 
 @Injectable()
 export class SetTeamDefaultModelUseCase {
-  private readonly logger = new Logger(SetTeamDefaultModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(SetTeamDefaultModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly validator: TeamPermittedModelValidator,
   ) {}
@@ -18,11 +20,14 @@ export class SetTeamDefaultModelUseCase {
   async execute(
     command: SetTeamDefaultModelCommand,
   ): Promise<PermittedLanguageModel> {
-    this.logger.log('execute', {
-      permittedModelId: command.permittedModelId,
-      orgId: command.orgId,
-      teamId: command.teamId,
-    });
+    this.logger.info(
+      {
+        permittedModelId: command.permittedModelId,
+        orgId: command.orgId,
+        teamId: command.teamId,
+      },
+      'execute',
+    );
 
     try {
       this.validator.validateAdminAccess(command.orgId);
@@ -42,7 +47,7 @@ export class SetTeamDefaultModelUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error setting team default model', error);
+      this.logger.error({ err: error }, 'Error setting team default model');
       throw new UnexpectedModelError(
         error instanceof Error ? error : new Error('Unknown error'),
       );

--- a/ayunis-core-backend/src/domain/models/application/use-cases/set-user-default-language-model/set-user-default-language-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/set-user-default-language-model/set-user-default-language-model.use-case.spec.ts
@@ -1,5 +1,6 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -13,6 +14,7 @@ import { SetUserDefaultLanguageModelCommand } from './set-user-default-language-
 import { SetUserDefaultLanguageModelUseCase } from './set-user-default-language-model.use-case';
 
 describe('SetUserDefaultLanguageModelUseCase', () => {
+  const logger = createPinoLoggerMock();
   const userId = randomUUID();
   const otherUserId = randomUUID();
   const orgId = randomUUID();
@@ -58,6 +60,10 @@ describe('SetUserDefaultLanguageModelUseCase', () => {
 
     const module = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(SetUserDefaultLanguageModelUseCase.name),
+          useValue: logger,
+        },
         SetUserDefaultLanguageModelUseCase,
         {
           provide: PermittedModelsRepository,
@@ -73,9 +79,9 @@ describe('SetUserDefaultLanguageModelUseCase', () => {
 
     useCase = module.get(SetUserDefaultLanguageModelUseCase);
 
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    logger.info.mockImplementation();
+    logger.debug.mockImplementation();
+    logger.error.mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/set-user-default-language-model/set-user-default-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/set-user-default-language-model/set-user-default-language-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SetUserDefaultLanguageModelCommand } from './set-user-default-language-model.command';
 import { PermittedLanguageModel } from '../../../domain/permitted-model.entity';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
@@ -9,9 +10,10 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 @Injectable()
 export class SetUserDefaultLanguageModelUseCase {
-  private readonly logger = new Logger(SetUserDefaultLanguageModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(SetUserDefaultLanguageModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly userDefaultModelsRepository: UserDefaultModelsRepository,
     private readonly contextService: ContextService,
@@ -20,67 +22,73 @@ export class SetUserDefaultLanguageModelUseCase {
   async execute(
     command: SetUserDefaultLanguageModelCommand,
   ): Promise<PermittedLanguageModel> {
-    this.logger.log('execute', {
-      userId: command.userId,
-      permittedModelId: command.permittedModelId,
-      orgId: command.orgId,
-    });
-
-    try {
-      // First, verify that the permitted model exists and belongs to the organization
-      const userId = this.contextService.get('userId');
-      if (userId !== command.userId) {
-        throw new UnauthorizedAccessError();
-      }
-      const permittedModel =
-        await this.permittedModelsRepository.findOneLanguage({
-          id: command.permittedModelId,
-        });
-
-      if (!permittedModel) {
-        this.logger.error('Permitted model not found', {
-          permittedModelId: command.permittedModelId,
-          orgId: command.orgId,
-        });
-        throw new PermittedModelNotFoundError(command.permittedModelId);
-      }
-
-      // Check if there's already a user default model
-      const existingUserDefault =
-        await this.userDefaultModelsRepository.findByUserId(command.userId);
-
-      const action = existingUserDefault ? 'updating' : 'setting';
-      this.logger.debug(`Permitted model found, ${action} user default`, {
-        modelName: permittedModel.model.name,
-        modelProvider: permittedModel.model.provider,
-        existingDefaultId: existingUserDefault?.id,
-      });
-
-      // Set the model as the user's default (handles both create and update)
-      const userDefaultModel =
-        await this.userDefaultModelsRepository.setAsDefault(
-          permittedModel,
-          command.userId,
-        );
-
-      this.logger.debug(`User default model ${action} successfully`, {
-        userId: command.userId,
-        modelId: userDefaultModel.id,
-        action,
-      });
-
-      return userDefaultModel;
-    } catch (error) {
-      if (error instanceof ModelError) {
-        throw error;
-      }
-      this.logger.error('Failed to set user default model', {
+    this.logger.info(
+      {
         userId: command.userId,
         permittedModelId: command.permittedModelId,
         orgId: command.orgId,
-        error: error instanceof Error ? error : new Error('Unknown error'),
-      });
+      },
+      'execute',
+    );
+    try {
+      return await this.setDefault(command);
+    } catch (error) {
+      if (error instanceof ModelError) throw error;
+      this.logger.error(
+        {
+          userId: command.userId,
+          permittedModelId: command.permittedModelId,
+          orgId: command.orgId,
+          err: error instanceof Error ? error : new Error('Unknown error'),
+        },
+        'Failed to set user default model',
+      );
       throw error;
     }
+  }
+
+  private async setDefault(
+    command: SetUserDefaultLanguageModelCommand,
+  ): Promise<PermittedLanguageModel> {
+    if (this.contextService.get('userId') !== command.userId) {
+      throw new UnauthorizedAccessError();
+    }
+    const permittedModel = await this.findPermittedModel(command);
+    const existingDefault = await this.userDefaultModelsRepository.findByUserId(
+      command.userId,
+    );
+    const action = existingDefault ? 'updating' : 'setting';
+    this.logger.debug(
+      {
+        modelName: permittedModel.model.name,
+        modelProvider: permittedModel.model.provider,
+        existingDefaultId: existingDefault?.id,
+        action,
+      },
+      'Permitted model found for user default',
+    );
+    const result = await this.userDefaultModelsRepository.setAsDefault(
+      permittedModel,
+      command.userId,
+    );
+    this.logger.debug(
+      { userId: command.userId, modelId: result.id, action },
+      'User default model changed successfully',
+    );
+    return result;
+  }
+
+  private async findPermittedModel(
+    command: SetUserDefaultLanguageModelCommand,
+  ): Promise<PermittedLanguageModel> {
+    const model = await this.permittedModelsRepository.findOneLanguage({
+      id: command.permittedModelId,
+    });
+    if (model) return model;
+    this.logger.error(
+      { permittedModelId: command.permittedModelId, orgId: command.orgId },
+      'Permitted model not found',
+    );
+    throw new PermittedModelNotFoundError(command.permittedModelId);
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/stream-inference/stream-inference.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/stream-inference/stream-inference.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { EMPTY, firstValueFrom, throwError } from 'rxjs';
 import { randomUUID } from 'crypto';
 import { StreamInferenceUseCase } from './stream-inference.use-case';
@@ -34,7 +35,7 @@ function useCaseWithFailingHandler(error: unknown): StreamInferenceUseCase {
   const registry = {
     getHandler: () => ({ answer: () => throwError(() => error) }),
   };
-  return new StreamInferenceUseCase(registry as never);
+  return new StreamInferenceUseCase(createPinoLoggerMock(), registry as never);
 }
 
 describe('StreamInferenceUseCase error mapping', () => {
@@ -160,7 +161,10 @@ describe('StreamInferenceUseCase replayed message sanitation', () => {
         },
       }),
     };
-    const useCase = new StreamInferenceUseCase(registry as never);
+    const useCase = new StreamInferenceUseCase(
+      createPinoLoggerMock(),
+      registry as never,
+    );
 
     useCase.execute(
       new StreamInferenceInput({

--- a/ayunis-core-backend/src/domain/models/application/use-cases/stream-inference/stream-inference.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/stream-inference/stream-inference.use-case.ts
@@ -1,5 +1,6 @@
 import { Observable, catchError, throwError } from 'rxjs';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { StreamInferenceHandlerRegistry } from '../../registry/stream-inference-handler.registry';
 import {
   StreamInferenceHandler,
@@ -19,8 +20,10 @@ import { stripReplayedToolNulls } from '../../helpers/strip-replayed-tool-nulls.
 
 @Injectable()
 export class StreamInferenceUseCase {
-  private readonly logger = new Logger(StreamInferenceUseCase.name);
   constructor(
+    @InjectPinoLogger(StreamInferenceUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly streamInferenceRegistry: StreamInferenceHandlerRegistry,
   ) {}
 
@@ -46,10 +49,13 @@ export class StreamInferenceUseCase {
   ): Error {
     if (error instanceof ApplicationError) return error;
     if (isAbortError(error)) {
-      this.logger.log('Streaming inference aborted by client', {
-        model: input.model.name,
-        provider: input.model.provider,
-      });
+      this.logger.info(
+        {
+          model: input.model.name,
+          provider: input.model.provider,
+        },
+        'Streaming inference aborted by client',
+      );
       return new InferenceAbortedError();
     }
     const providerError = wrapProviderFailure(error, {
@@ -57,23 +63,29 @@ export class StreamInferenceUseCase {
       modelId: input.model.name,
     });
     if (providerError) {
-      this.logger.error('Provider unavailable during stream inference', {
-        code: providerError.code,
-        ...providerError.context,
-      });
+      this.logger.error(
+        {
+          code: providerError.code,
+          ...providerError.context,
+        },
+        'Provider unavailable during stream inference',
+      );
       return providerError;
     }
     const status = extractUpstreamStatus(error);
     const message = error instanceof Error ? error.message : String(error);
-    this.logger.error('Provider stream inference failed', {
-      model: input.model.name,
-      provider: input.model.provider,
-      messageCount: input.messages.length,
-      toolCount: input.tools.length,
-      toolChoice: input.toolChoice,
-      errorName: error instanceof Error ? error.name : 'Unknown',
-      status,
-    });
+    this.logger.error(
+      {
+        model: input.model.name,
+        provider: input.model.provider,
+        messageCount: input.messages.length,
+        toolCount: input.tools.length,
+        toolChoice: input.toolChoice,
+        errorName: error instanceof Error ? error.name : 'Unknown',
+        status,
+      },
+      'Provider stream inference failed',
+    );
     // Anthropic/Bedrock reject oversized images with "image exceeds N MB
     // maximum" — surface a distinct code so the UI can tell the user to shrink
     // it instead of showing a generic failure.

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-embedding-model/update-embedding-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-embedding-model/update-embedding-model.use-case.ts
@@ -6,15 +6,17 @@ import {
   UnexpectedModelError,
 } from '../../models.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ClearDefaultsByCatalogModelIdUseCase } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case';
 import { ClearDefaultsByCatalogModelIdCommand } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.command';
 
 @Injectable()
 export class UpdateEmbeddingModelUseCase {
-  private readonly logger = new Logger(UpdateEmbeddingModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateEmbeddingModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly modelsRepository: ModelsRepository,
     private readonly clearDefaultsUseCase: ClearDefaultsByCatalogModelIdUseCase,
   ) {}
@@ -46,9 +48,12 @@ export class UpdateEmbeddingModelUseCase {
 
       // Clear defaults if model is being archived (for consistency, though embedding models typically don't have defaults)
       if (isBeingArchived) {
-        this.logger.log('Model is being archived, clearing defaults', {
-          modelId: command.id,
-        });
+        this.logger.info(
+          {
+            modelId: command.id,
+          },
+          'Model is being archived, clearing defaults',
+        );
         await this.clearDefaultsUseCase.execute(
           new ClearDefaultsByCatalogModelIdCommand(command.id),
         );

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-image-generation-model/update-image-generation-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-image-generation-model/update-image-generation-model.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { UpdateImageGenerationModelUseCase } from './update-image-generation-model.use-case';
@@ -32,6 +34,14 @@ describe('UpdateImageGenerationModelUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(UpdateImageGenerationModelUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
+        {
+          provide: getLoggerToken(ModelPolicyService.name),
+          useValue: createPinoLoggerMock(),
+        },
         UpdateImageGenerationModelUseCase,
         ModelPolicyService,
         { provide: ModelsRepository, useValue: mockModelsRepository },

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-image-generation-model/update-image-generation-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-image-generation-model/update-image-generation-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ImageGenerationModel } from 'src/domain/models/domain/models/image-generation.model';
 import {
@@ -11,9 +12,10 @@ import { UpdateImageGenerationModelCommand } from './update-image-generation-mod
 
 @Injectable()
 export class UpdateImageGenerationModelUseCase {
-  private readonly logger = new Logger(UpdateImageGenerationModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateImageGenerationModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly modelsRepository: ModelsRepository,
     private readonly modelPolicy: ModelPolicyService,
   ) {}
@@ -49,9 +51,12 @@ export class UpdateImageGenerationModelUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Unexpected error updating image-generation model', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error updating image-generation model',
+      );
       throw new UnexpectedModelError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.spec.ts
@@ -1,6 +1,7 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { UpdateLanguageModelUseCase } from './update-language-model.use-case';
 import { UpdateLanguageModelCommand } from './update-language-model.command';
 import { ModelsRepository } from '../../ports/models.repository';
@@ -15,6 +16,7 @@ import {
 import type { UUID } from 'crypto';
 
 describe('UpdateLanguageModelUseCase', () => {
+  const logger = createPinoLoggerMock();
   let useCase: UpdateLanguageModelUseCase;
   let modelsRepository: jest.Mocked<ModelsRepository>;
   let clearDefaultsUseCase: jest.Mocked<ClearDefaultsByCatalogModelIdUseCase>;
@@ -37,6 +39,10 @@ describe('UpdateLanguageModelUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(UpdateLanguageModelUseCase.name),
+          useValue: logger,
+        },
         UpdateLanguageModelUseCase,
         { provide: ModelsRepository, useValue: mockModelsRepository },
         {
@@ -53,8 +59,8 @@ describe('UpdateLanguageModelUseCase', () => {
     clearDefaultsUseCase = module.get(ClearDefaultsByCatalogModelIdUseCase);
 
     // Mock logger
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+    logger.info.mockImplementation();
+    logger.debug.mockImplementation();
   });
 
   afterEach(() => {
@@ -274,15 +280,15 @@ describe('UpdateLanguageModelUseCase', () => {
       modelsRepository.save.mockResolvedValue();
       clearDefaultsUseCase.execute.mockResolvedValue();
 
-      const logSpy = jest.spyOn(Logger.prototype, 'log');
+      const logSpy = logger.info;
 
       // Act
       await useCase.execute(command);
 
       // Assert
       expect(logSpy).toHaveBeenCalledWith(
-        'Model is being archived, clearing defaults',
         { modelId: mockModelId },
+        'Model is being archived, clearing defaults',
       );
     });
 
@@ -338,15 +344,15 @@ describe('UpdateLanguageModelUseCase', () => {
       modelsRepository.findOne.mockResolvedValue(existingModel);
       modelsRepository.save.mockResolvedValue();
 
-      const logSpy = jest.spyOn(Logger.prototype, 'log');
+      const logSpy = logger.info;
 
       // Act
       await useCase.execute(command);
 
       // Assert
       expect(logSpy).not.toHaveBeenCalledWith(
-        'Model is being archived, clearing defaults',
         expect.anything(),
+        'Model is being archived, clearing defaults',
       );
     });
   });

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-language-model/update-language-model.use-case.ts
@@ -7,22 +7,24 @@ import {
   UnexpectedModelError,
 } from '../../models.errors';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ClearDefaultsByCatalogModelIdUseCase } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.use-case';
 import { ClearDefaultsByCatalogModelIdCommand } from '../clear-defaults-by-catalog-model-id/clear-defaults-by-catalog-model-id.command';
 
 @Injectable()
 export class UpdateLanguageModelUseCase {
-  private readonly logger = new Logger(UpdateLanguageModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateLanguageModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly modelsRepository: ModelsRepository,
     private readonly clearDefaultsUseCase: ClearDefaultsByCatalogModelIdUseCase,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedModelError)
   async execute(command: UpdateLanguageModelCommand): Promise<LanguageModel> {
-    this.logger.log('Updating language model', { modelId: command.id });
+    this.logger.info({ modelId: command.id }, 'Updating language model');
 
     const existingModel = await this.modelsRepository.findOne({
       id: command.id,
@@ -44,9 +46,12 @@ export class UpdateLanguageModelUseCase {
     await this.modelsRepository.save(model);
 
     if (isBeingArchived) {
-      this.logger.log('Model is being archived, clearing defaults', {
-        modelId: command.id,
-      });
+      this.logger.info(
+        {
+          modelId: command.id,
+        },
+        'Model is being archived, clearing defaults',
+      );
       await this.clearDefaultsUseCase.execute(
         new ClearDefaultsByCatalogModelIdCommand(command.id),
       );

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-permitted-model/update-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-permitted-model/update-permitted-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UpdatePermittedModelCommand } from './update-permitted-model.command';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import {
@@ -20,98 +21,81 @@ import { ModelPolicyService } from '../../services/model-policy.service';
 
 @Injectable()
 export class UpdatePermittedModelUseCase {
-  private readonly logger = new Logger(UpdatePermittedModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdatePermittedModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly contextService: ContextService,
     private readonly modelPolicy: ModelPolicyService,
   ) {}
 
   async execute(command: UpdatePermittedModelCommand): Promise<PermittedModel> {
-    this.logger.log('execute', {
-      id: command.permittedModelId,
-      orgId: command.orgId,
-      anonymousOnly: command.anonymousOnly,
-    });
-
-    try {
-      const orgId = this.contextService.get('orgId');
-      const orgRole = this.contextService.get('role');
-      const systemRole = this.contextService.get('systemRole');
-      const isOrgAdmin = orgRole === UserRole.ADMIN && orgId === command.orgId;
-      const isSuperAdmin = systemRole === SystemRole.SUPER_ADMIN;
-
-      if (!isOrgAdmin && !isSuperAdmin) {
-        throw new UnauthorizedAccessError();
-      }
-
-      const existingModel = await this.permittedModelsRepository.findOne({
+    this.logger.info(
+      {
         id: command.permittedModelId,
-      });
-
-      if (!existingModel) {
-        throw new PermittedModelNotFoundError(command.permittedModelId);
-      }
-
-      // Verify the model belongs to the specified org
-      if (existingModel.orgId !== command.orgId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      this.modelPolicy.assertSupported(existingModel.model);
-
-      // Create updated model with new anonymousOnly value, preserving the correct type
-      let updatedModel: PermittedModel;
-      if (existingModel.model instanceof LanguageModel) {
-        updatedModel = new PermittedLanguageModel({
-          id: existingModel.id,
-          model: existingModel.model,
-          orgId: existingModel.orgId,
-          scope: existingModel.scope,
-          scopeId: existingModel.scopeId,
-          isDefault: existingModel.isDefault,
-          anonymousOnly: command.anonymousOnly,
-          createdAt: existingModel.createdAt,
-          updatedAt: new Date(),
-        });
-      } else if (existingModel.model instanceof EmbeddingModel) {
-        updatedModel = new PermittedEmbeddingModel({
-          id: existingModel.id,
-          model: existingModel.model,
-          orgId: existingModel.orgId,
-          scope: existingModel.scope,
-          scopeId: existingModel.scopeId,
-          isDefault: existingModel.isDefault,
-          anonymousOnly: command.anonymousOnly,
-          createdAt: existingModel.createdAt,
-          updatedAt: new Date(),
-        });
-      } else if (existingModel.model instanceof ImageGenerationModel) {
-        updatedModel = new PermittedImageGenerationModel({
-          id: existingModel.id,
-          model: existingModel.model,
-          orgId: existingModel.orgId,
-          scope: existingModel.scope,
-          scopeId: existingModel.scopeId,
-          isDefault: existingModel.isDefault,
-          anonymousOnly: command.anonymousOnly,
-          createdAt: existingModel.createdAt,
-          updatedAt: new Date(),
-        });
-      } else {
-        throw new Error(
-          `Unknown model type: ${existingModel.model.constructor.name}`,
-        );
-      }
-
-      return await this.permittedModelsRepository.update(updatedModel);
+        orgId: command.orgId,
+        anonymousOnly: command.anonymousOnly,
+      },
+      'execute',
+    );
+    try {
+      this.assertAuthorized(command);
+      const existing = await this.findExisting(command.permittedModelId);
+      if (existing.orgId !== command.orgId) throw new UnauthorizedAccessError();
+      this.modelPolicy.assertSupported(existing.model);
+      const updated = this.withAnonymousOnly(existing, command.anonymousOnly);
+      return await this.permittedModelsRepository.update(updated);
     } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error updating permitted model', error);
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error({ err: error }, 'Error updating permitted model');
       throw error;
     }
+  }
+
+  private assertAuthorized(command: UpdatePermittedModelCommand): void {
+    const isOrgAdmin =
+      this.contextService.get('role') === UserRole.ADMIN &&
+      this.contextService.get('orgId') === command.orgId;
+    const isSuperAdmin =
+      this.contextService.get('systemRole') === SystemRole.SUPER_ADMIN;
+    if (!isOrgAdmin && !isSuperAdmin) throw new UnauthorizedAccessError();
+  }
+
+  private async findExisting(
+    id: UpdatePermittedModelCommand['permittedModelId'],
+  ): Promise<PermittedModel> {
+    const existing = await this.permittedModelsRepository.findOne({ id });
+    if (existing) return existing;
+    throw new PermittedModelNotFoundError(id);
+  }
+
+  private withAnonymousOnly(
+    existing: PermittedModel,
+    anonymousOnly: boolean,
+  ): PermittedModel {
+    const common = {
+      id: existing.id,
+      orgId: existing.orgId,
+      scope: existing.scope,
+      scopeId: existing.scopeId,
+      isDefault: existing.isDefault,
+      anonymousOnly,
+      createdAt: existing.createdAt,
+      updatedAt: new Date(),
+    };
+    if (existing.model instanceof LanguageModel) {
+      return new PermittedLanguageModel({ ...common, model: existing.model });
+    }
+    if (existing.model instanceof EmbeddingModel) {
+      return new PermittedEmbeddingModel({ ...common, model: existing.model });
+    }
+    if (existing.model instanceof ImageGenerationModel) {
+      return new PermittedImageGenerationModel({
+        ...common,
+        model: existing.model,
+      });
+    }
+    throw new Error(`Unknown model type: ${existing.model.constructor.name}`);
   }
 }

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-team-permitted-model/update-team-permitted-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-team-permitted-model/update-team-permitted-model.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { UpdateTeamPermittedModelUseCase } from './update-team-permitted-model.use-case';
@@ -64,6 +66,10 @@ describe('UpdateTeamPermittedModelUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(UpdateTeamPermittedModelUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         UpdateTeamPermittedModelUseCase,
         TeamPermittedModelValidator,
         {

--- a/ayunis-core-backend/src/domain/models/application/use-cases/update-team-permitted-model/update-team-permitted-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/models/application/use-cases/update-team-permitted-model/update-team-permitted-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { PermittedModelsRepository } from '../../ports/permitted-models.repository';
 import { UpdateTeamPermittedModelCommand } from './update-team-permitted-model.command';
 import { PermittedLanguageModel } from 'src/domain/models/domain/permitted-model.entity';
@@ -12,9 +13,10 @@ import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 
 @Injectable()
 export class UpdateTeamPermittedModelUseCase {
-  private readonly logger = new Logger(UpdateTeamPermittedModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateTeamPermittedModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly permittedModelsRepository: PermittedModelsRepository,
     private readonly validator: TeamPermittedModelValidator,
   ) {}
@@ -22,12 +24,15 @@ export class UpdateTeamPermittedModelUseCase {
   async execute(
     command: UpdateTeamPermittedModelCommand,
   ): Promise<PermittedLanguageModel> {
-    this.logger.log('execute', {
-      permittedModelId: command.permittedModelId,
-      orgId: command.orgId,
-      teamId: command.teamId,
-      anonymousOnly: command.anonymousOnly,
-    });
+    this.logger.info(
+      {
+        permittedModelId: command.permittedModelId,
+        orgId: command.orgId,
+        teamId: command.teamId,
+        anonymousOnly: command.anonymousOnly,
+      },
+      'execute',
+    );
 
     try {
       this.validator.validateAdminAccess(command.orgId);
@@ -61,7 +66,7 @@ export class UpdateTeamPermittedModelUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error updating team permitted model', error);
+      this.logger.error({ err: error }, 'Error updating team permitted model');
       throw new UnexpectedModelError(
         error instanceof Error ? error : new Error('Unknown error'),
       );

--- a/ayunis-core-backend/src/domain/models/infrastructure/image-generation/azure.image-generation.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/image-generation/azure.image-generation.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { ConfigService } from '@nestjs/config';
 import { AzureImageGenerationHandler } from './azure.image-generation';
 import {
@@ -26,6 +26,7 @@ jest.mock('openai', () => {
 const mockAzureOpenAICtor = jest.mocked(AzureOpenAI);
 
 describe('AzureImageGenerationHandler', () => {
+  const logger = createPinoLoggerMock();
   let handler: AzureImageGenerationHandler;
   let configService: jest.Mocked<ConfigService>;
 
@@ -41,10 +42,10 @@ describe('AzureImageGenerationHandler', () => {
       get: jest.fn().mockReturnValue('mock-value'),
     } as unknown as jest.Mocked<ConfigService>;
 
-    handler = new AzureImageGenerationHandler(configService);
+    handler = new AzureImageGenerationHandler(logger, configService);
 
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    logger.info.mockImplementation();
+    logger.error.mockImplementation();
 
     mockImagesGenerate.mockReset();
     mockImagesEdit.mockReset();

--- a/ayunis-core-backend/src/domain/models/infrastructure/image-generation/azure.image-generation.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/image-generation/azure.image-generation.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { APIError, AzureOpenAI, toFile } from 'openai';
 import type { ImageEditParams, ImagesResponse } from 'openai/resources/images';
@@ -48,7 +49,6 @@ function isValidQuality(value: string): value is ImageQuality {
 
 @Injectable()
 export class AzureImageGenerationHandler extends ImageGenerationHandler {
-  private readonly logger = new Logger(AzureImageGenerationHandler.name);
   // Keyed by deployment: the SDK only prefixes /deployments/{name} when the
   // client is constructed with `deployment` — for images.edit the body is
   // multipart FormData by the time buildRequest looks for a model name, so a
@@ -56,7 +56,11 @@ export class AzureImageGenerationHandler extends ImageGenerationHandler {
   // is a singleton serving every org's model, hence one client per name.
   private readonly clients = new Map<string, AzureOpenAI>();
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    @InjectPinoLogger(AzureImageGenerationHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {
     super();
   }
 
@@ -98,12 +102,15 @@ export class AzureImageGenerationHandler extends ImageGenerationHandler {
   }
 
   async generate(input: ImageGenerationInput): Promise<ImageGenerationResult> {
-    this.logger.log('Generating image', {
-      model: input.model.name,
-      size: input.size,
-      quality: input.quality,
-      referenceImageCount: input.referenceImages?.length ?? 0,
-    });
+    this.logger.info(
+      {
+        model: input.model.name,
+        size: input.size,
+        quality: input.quality,
+        referenceImageCount: input.referenceImages?.length ?? 0,
+      },
+      'Generating image',
+    );
 
     const { size, quality } = this.validateParams(input);
     const client = this.getClient(input.model.name);
@@ -180,13 +187,16 @@ export class AzureImageGenerationHandler extends ImageGenerationHandler {
         }
       : undefined;
 
-    this.logger.log('Image generated successfully', {
-      model: modelName,
-      sizeBytes: imageBuffer.length,
-      inputTokens: usage?.inputTokens,
-      outputTokens: usage?.outputTokens,
-      totalTokens: usage?.totalTokens,
-    });
+    this.logger.info(
+      {
+        model: modelName,
+        sizeBytes: imageBuffer.length,
+        inputTokens: usage?.inputTokens,
+        outputTokens: usage?.outputTokens,
+        totalTokens: usage?.totalTokens,
+      },
+      'Image generated successfully',
+    );
 
     return new ImageGenerationResult(
       imageBuffer,
@@ -203,12 +213,15 @@ export class AzureImageGenerationHandler extends ImageGenerationHandler {
 
     if (error instanceof APIError) {
       const errorCode = String(error.code ?? '');
-      this.logger.error('Azure OpenAI API error during image generation', {
-        status: String(error.status ?? ''),
-        code: errorCode,
-        message: error.message,
-        model: modelName,
-      });
+      this.logger.error(
+        {
+          status: String(error.status ?? ''),
+          code: errorCode,
+          message: error.message,
+          model: modelName,
+        },
+        'Azure OpenAI API error during image generation',
+      );
 
       if (errorCode === 'content_policy_violation') {
         throw new ImageGenerationFailedError(
@@ -221,10 +234,13 @@ export class AzureImageGenerationHandler extends ImageGenerationHandler {
       );
     }
 
-    this.logger.error('Unexpected error during image generation', {
-      error: error instanceof Error ? error.message : 'Unknown error',
-      model: modelName,
-    });
+    this.logger.error(
+      {
+        error: error instanceof Error ? error.message : 'Unknown error',
+        model: modelName,
+      },
+      'Unexpected error during image generation',
+    );
 
     throw new ImageGenerationFailedError(
       'An unexpected error occurred while generating the image. Please try again later.',

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/local-models.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/local-models.repository.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { QueryFailedError, type EntityManager, type Repository } from 'typeorm';
 import type { TransactionHost } from '@nestjs-cls/transactional';
 import type { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
@@ -44,7 +45,7 @@ describe('LocalModelsRepository', () => {
       delete: jest.fn(),
     } as unknown as jest.Mocked<Repository<ModelRecord>>;
 
-    mapper = new ModelMapper();
+    mapper = new ModelMapper(createPinoLoggerMock());
     transactionManager = { delete: jest.fn(), findOne: jest.fn() };
     withTransaction = jest.fn(async (callback: () => Promise<unknown>) =>
       callback(),
@@ -55,6 +56,7 @@ describe('LocalModelsRepository', () => {
     } as unknown as TransactionHost<TransactionalAdapterTypeOrm>;
 
     repository = new LocalModelsRepository(
+      createPinoLoggerMock(),
       localModelRepository,
       mapper,
       txHost,

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/local-models.repository.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/local-models.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
@@ -63,9 +64,10 @@ function isUsageModelForeignKeyViolation(error: unknown): boolean {
 
 @Injectable()
 export class LocalModelsRepository extends ModelsRepository {
-  private readonly logger = new Logger(LocalModelsRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalModelsRepository.name)
+    private readonly logger: PinoLogger,
+
     @InjectRepository(ModelRecord)
     private readonly localModelRepository: Repository<ModelRecord>,
     private readonly localModelMapper: ModelMapper,
@@ -75,7 +77,7 @@ export class LocalModelsRepository extends ModelsRepository {
   }
 
   async findAll(): Promise<Model[]> {
-    this.logger.log('findAll');
+    this.logger.info('findAll');
 
     const modelRecords = await this.localModelRepository.find();
 
@@ -85,7 +87,7 @@ export class LocalModelsRepository extends ModelsRepository {
   }
 
   async findOne(params: FindOneModelParams): Promise<Model | undefined> {
-    this.logger.log('findOne', params);
+    this.logger.info(params, 'findOne');
 
     const where =
       'id' in params
@@ -101,7 +103,7 @@ export class LocalModelsRepository extends ModelsRepository {
     id: UUID,
     operation: (model: Model | undefined) => Promise<Result>,
   ): Promise<Result> {
-    this.logger.log('withCatalogModelLocked', { id });
+    this.logger.info({ id }, 'withCatalogModelLocked');
 
     return await this.txHost.withTransaction(async () => {
       const record = await this.txHost.tx.findOne(ModelRecord, {
@@ -146,11 +148,14 @@ export class LocalModelsRepository extends ModelsRepository {
   }
 
   async save(model: Model): Promise<void> {
-    this.logger.log('save', {
-      modelName: model.name,
-      modelProvider: model.provider,
-      displayName: model.displayName,
-    });
+    this.logger.info(
+      {
+        modelName: model.name,
+        modelProvider: model.provider,
+        displayName: model.displayName,
+      },
+      'save',
+    );
 
     const modelEntity = this.localModelMapper.toRecord(model);
     try {
@@ -164,12 +169,15 @@ export class LocalModelsRepository extends ModelsRepository {
   }
 
   async update<T extends Model>(id: UUID, model: T): Promise<T> {
-    this.logger.log('update', {
-      id,
-      modelName: model.name,
-      modelProvider: model.provider,
-      displayName: model.displayName,
-    });
+    this.logger.info(
+      {
+        id,
+        modelName: model.name,
+        modelProvider: model.provider,
+        displayName: model.displayName,
+      },
+      'update',
+    );
 
     const modelEntity = this.localModelMapper.toRecord(model);
     modelEntity.id = id;
@@ -181,7 +189,7 @@ export class LocalModelsRepository extends ModelsRepository {
   }
 
   async delete(id: UUID): Promise<void> {
-    this.logger.log('delete', { id });
+    this.logger.info({ id }, 'delete');
 
     try {
       const result = await this.txHost.tx.delete(ModelRecord, { id });

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/mappers/model.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/mappers/model.mapper.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { ModelMapper } from './model.mapper';
 import {
   ImageGenerationModelRecord,
@@ -11,14 +11,16 @@ import { ModelTier } from 'src/domain/models/domain/value-objects/model-tier.enu
 import type { UUID } from 'crypto';
 
 describe('ModelMapper', () => {
+  const logger = createPinoLoggerMock();
   let mapper: ModelMapper;
   let warnSpy: jest.SpyInstance;
 
   const mockId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
 
   beforeEach(() => {
-    mapper = new ModelMapper();
-    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    logger.warn.mockReset();
+    mapper = new ModelMapper(logger);
+    warnSpy = logger.warn;
   });
 
   afterEach(() => {
@@ -84,12 +86,12 @@ describe('ModelMapper', () => {
       expect((domain as LanguageModel).tier).toBeUndefined();
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy).toHaveBeenCalledWith(
-        'Encountered unknown model tier value, ignoring',
         expect.objectContaining({
           value: 'platinum',
           modelId: mockId,
           modelName: 'gpt-4',
         }),
+        'Encountered unknown model tier value, ignoring',
       );
     });
 

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/mappers/model.mapper.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-models/mappers/model.mapper.ts
@@ -1,4 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerConfig } from 'src/common/logger/pino-logger.config';
 import { Model } from 'src/domain/models/domain/model.entity';
 import { LanguageModel } from 'src/domain/models/domain/models/language.model';
 import { EmbeddingModel } from 'src/domain/models/domain/models/embedding.model';
@@ -13,7 +15,10 @@ import {
 
 @Injectable()
 export class ModelMapper {
-  private readonly logger = new Logger(ModelMapper.name);
+  constructor(
+    @InjectPinoLogger(ModelMapper.name)
+    private readonly logger: PinoLogger = createModelMapperLogger(),
+  ) {}
 
   private parseTier(
     value: string | null | undefined,
@@ -27,11 +32,14 @@ export class ModelMapper {
     if (allowed.includes(value)) {
       return value as ModelTier;
     }
-    this.logger.warn('Encountered unknown model tier value, ignoring', {
-      value,
-      modelId: rowId,
-      modelName: rowName,
-    });
+    this.logger.warn(
+      {
+        value,
+        modelId: rowId,
+        modelName: rowName,
+      },
+      'Encountered unknown model tier value, ignoring',
+    );
     return undefined;
   }
 
@@ -141,4 +149,10 @@ export class ModelMapper {
 
     throw new Error(`Unknown model domain type: ${domain.constructor.name}`);
   }
+}
+
+function createModelMapperLogger(): PinoLogger {
+  const logger = new PinoLogger(createPinoLoggerConfig());
+  logger.setContext(ModelMapper.name);
+  return logger;
 }

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models.repository.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { LocalPermittedModelsRepository } from './local-permitted-models.repository';
 import type { PermittedModelMapper } from './mappers/permitted-model.mapper';
 import { PermittedModelRecord } from './schema/permitted-model.record';
@@ -40,11 +41,13 @@ describe('LocalPermittedModelsRepository', () => {
     } as unknown as jest.Mocked<PermittedModelMapper>;
 
     finder = new PermittedModelFinder(
+      createPinoLoggerMock(),
       permittedModelRepository,
       permittedModelMapper,
     );
 
     repository = new LocalPermittedModelsRepository(
+      createPinoLoggerMock(),
       permittedModelRepository,
       permittedModelMapper,
       finder,

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models.repository.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/local-permitted-models.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
   FindOneParams,
@@ -27,8 +28,10 @@ import { PermittedModelFinder } from './permitted-model-finder';
 
 @Injectable()
 export class LocalPermittedModelsRepository extends PermittedModelsRepository {
-  private readonly logger = new Logger(LocalPermittedModelsRepository.name);
   constructor(
+    @InjectPinoLogger(LocalPermittedModelsRepository.name)
+    private readonly logger: PinoLogger,
+
     @InjectRepository(PermittedModelRecord)
     private readonly permittedModelRepository: Repository<PermittedModelRecord>,
     private readonly permittedModelMapper: PermittedModelMapper,
@@ -62,9 +65,12 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
   async findOrgDefaultLanguage(
     orgId: UUID,
   ): Promise<PermittedLanguageModel | null> {
-    this.logger.log('findDefault', {
-      orgId,
-    });
+    this.logger.info(
+      {
+        orgId,
+      },
+      'findDefault',
+    );
     const permittedModel = await this.permittedModelRepository.findOne({
       where: {
         orgId,
@@ -84,9 +90,12 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
     ) {
       return null;
     }
-    this.logger.debug('Default model found', {
-      permittedModel,
-    });
+    this.logger.debug(
+      {
+        permittedModel,
+      },
+      'Default model found',
+    );
     return this.permittedModelMapper.toDomain(
       permittedModel,
     ) as PermittedLanguageModel;
@@ -96,7 +105,7 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
     teamId: UUID,
     orgId: UUID,
   ): Promise<PermittedLanguageModel | null> {
-    this.logger.log('findTeamDefaultLanguage', { teamId, orgId });
+    this.logger.info({ teamId, orgId }, 'findTeamDefaultLanguage');
     const permittedModel = await this.permittedModelRepository.findOne({
       where: {
         scopeId: teamId,
@@ -253,17 +262,20 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
     orgId: UUID,
     modelId: UUID,
   ): Promise<void> {
-    this.logger.log('deleteTeamScopedByOrgAndModelId', { orgId, modelId });
+    this.logger.info({ orgId, modelId }, 'deleteTeamScopedByOrgAndModelId');
     const result = await this.permittedModelRepository.delete({
       orgId,
       modelId,
       scope: PermittedModelScope.TEAM,
     });
-    this.logger.debug('Deleted team-scoped permitted models', {
-      orgId,
-      modelId,
-      affected: result.affected,
-    });
+    this.logger.debug(
+      {
+        orgId,
+        modelId,
+        affected: result.affected,
+      },
+      'Deleted team-scoped permitted models',
+    );
   }
 
   async setAsDefault(params: {
@@ -271,11 +283,14 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
     orgId: UUID;
     teamId?: UUID;
   }): Promise<PermittedLanguageModel> {
-    this.logger.log('setAsDefault', {
-      id: params.id,
-      orgId: params.orgId,
-      teamId: params.teamId,
-    });
+    this.logger.info(
+      {
+        id: params.id,
+        orgId: params.orgId,
+        teamId: params.teamId,
+      },
+      'setAsDefault',
+    );
 
     const unsetWhere = this.buildUnsetDefaultWhere(params);
     const setWhere = this.buildSetDefaultWhere(params);
@@ -333,13 +348,16 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
       );
     }
 
-    this.logger.debug('Model set as default', {
-      id: params.id,
-      orgId: params.orgId,
-      teamId: params.teamId,
-      modelName: updatedModel.model.name,
-      modelProvider: updatedModel.model.provider,
-    });
+    this.logger.debug(
+      {
+        id: params.id,
+        orgId: params.orgId,
+        teamId: params.teamId,
+        modelName: updatedModel.model.name,
+        modelProvider: updatedModel.model.provider,
+      },
+      'Model set as default',
+    );
 
     return this.permittedModelMapper.toDomain(
       updatedModel,
@@ -347,11 +365,14 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
   }
 
   async update(permittedModel: PermittedModel): Promise<PermittedModel> {
-    this.logger.log('update', {
-      id: permittedModel.id,
-      orgId: permittedModel.orgId,
-      anonymousOnly: permittedModel.anonymousOnly,
-    });
+    this.logger.info(
+      {
+        id: permittedModel.id,
+        orgId: permittedModel.orgId,
+        anonymousOnly: permittedModel.anonymousOnly,
+      },
+      'update',
+    );
 
     const updateResult = await this.permittedModelRepository.update(
       { id: permittedModel.id, orgId: permittedModel.orgId },
@@ -375,33 +396,39 @@ export class LocalPermittedModelsRepository extends PermittedModelsRepository {
   async findAllByCatalogModelId(
     catalogModelId: UUID,
   ): Promise<PermittedModel[]> {
-    this.logger.log('findAllByCatalogModelId', { catalogModelId });
+    this.logger.info({ catalogModelId }, 'findAllByCatalogModelId');
 
     const permittedModels = await this.permittedModelRepository.find({
       where: { modelId: catalogModelId },
       relations: { model: true },
     });
 
-    this.logger.debug('Found permitted models by catalog model id', {
-      catalogModelId,
-      count: permittedModels.length,
-    });
+    this.logger.debug(
+      {
+        catalogModelId,
+        count: permittedModels.length,
+      },
+      'Found permitted models by catalog model id',
+    );
 
     return permittedModels.map((pm) => this.permittedModelMapper.toDomain(pm));
   }
 
   async unsetDefaultsByCatalogModelId(catalogModelId: UUID): Promise<void> {
-    this.logger.log('unsetDefaultsByCatalogModelId', { catalogModelId });
+    this.logger.info({ catalogModelId }, 'unsetDefaultsByCatalogModelId');
 
     const result = await this.permittedModelRepository.update(
       { modelId: catalogModelId, isDefault: true },
       { isDefault: false },
     );
 
-    this.logger.debug('Unset defaults for catalog model', {
-      catalogModelId,
-      affected: result.affected,
-    });
+    this.logger.debug(
+      {
+        catalogModelId,
+        affected: result.affected,
+      },
+      'Unset defaults for catalog model',
+    );
   }
 
   private buildUnsetDefaultWhere(params: {

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/permitted-model-finder.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-permitted-models/permitted-model-finder.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import type { UUID } from 'crypto';
 import type { FindManyOptions, Repository } from 'typeorm';
@@ -19,27 +20,28 @@ import { PermittedModelMapper } from './mappers/permitted-model.mapper';
 
 @Injectable()
 export class PermittedModelFinder {
-  private readonly logger = new Logger(PermittedModelFinder.name);
-
   constructor(
+    @InjectPinoLogger(PermittedModelFinder.name)
+    private readonly logger: PinoLogger,
+
     @InjectRepository(PermittedModelRecord)
     private readonly permittedModelRepository: Repository<PermittedModelRecord>,
     private readonly permittedModelMapper: PermittedModelMapper,
   ) {}
 
   async findOneEmbedding(orgId: UUID): Promise<PermittedEmbeddingModel | null> {
-    this.logger.debug('findOneEmbedding', { orgId });
+    this.logger.debug({ orgId }, 'findOneEmbedding');
     const permittedEmbeddingModels = await this.findManyEmbedding(orgId);
     if (permittedEmbeddingModels.length === 0) {
       return null;
     }
     if (permittedEmbeddingModels.length > 1) {
       this.logger.warn(
-        'Multiple permitted embedding models found for org; returning the first. Write path enforces single-per-org.',
         {
           orgId,
           permittedEmbeddingModelIds: permittedEmbeddingModels.map((m) => m.id),
         },
+        'Multiple permitted embedding models found for org; returning the first. Write path enforces single-per-org.',
       );
     }
     return permittedEmbeddingModels[0];
@@ -48,7 +50,7 @@ export class PermittedModelFinder {
   async findOneImageGeneration(
     orgId: UUID,
   ): Promise<PermittedImageGenerationModel | null> {
-    this.logger.debug('findOneImageGeneration', { orgId });
+    this.logger.debug({ orgId }, 'findOneImageGeneration');
     const permittedImageGenerationModels =
       await this.findManyImageGeneration(orgId);
     if (permittedImageGenerationModels.length === 0) {
@@ -56,13 +58,13 @@ export class PermittedModelFinder {
     }
     if (permittedImageGenerationModels.length > 1) {
       this.logger.warn(
-        'Multiple permitted image-generation models found for org; returning the first. Write path enforces single-per-org.',
         {
           orgId,
           permittedImageGenerationModelIds: permittedImageGenerationModels.map(
             (m) => m.id,
           ),
         },
+        'Multiple permitted image-generation models found for org; returning the first. Write path enforces single-per-org.',
       );
     }
     return permittedImageGenerationModels[0];

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-user-default-models/local-user-default-models.repository.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-user-default-models/local-user-default-models.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { UUID } from 'crypto';
@@ -9,9 +10,10 @@ import { UserDefaultModelMapper } from './mappers/user-default-model.mapper';
 
 @Injectable()
 export class LocalUserDefaultModelsRepository extends UserDefaultModelsRepository {
-  private readonly logger = new Logger(LocalUserDefaultModelsRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalUserDefaultModelsRepository.name)
+    private readonly logger: PinoLogger,
+
     @InjectRepository(UserDefaultModelRecord)
     private readonly userDefaultModelRepository: Repository<UserDefaultModelRecord>,
     private readonly userDefaultModelMapper: UserDefaultModelMapper,
@@ -20,7 +22,7 @@ export class LocalUserDefaultModelsRepository extends UserDefaultModelsRepositor
   }
 
   async findByUserId(userId: UUID): Promise<PermittedLanguageModel | null> {
-    this.logger.log('findByUserId', { userId });
+    this.logger.info({ userId }, 'findByUserId');
 
     const userDefaultModel = await this.userDefaultModelRepository.findOne({
       where: { userId },
@@ -28,14 +30,17 @@ export class LocalUserDefaultModelsRepository extends UserDefaultModelsRepositor
     });
 
     if (!userDefaultModel) {
-      this.logger.debug('No user default model found', { userId });
+      this.logger.debug({ userId }, 'No user default model found');
       return null;
     }
 
-    this.logger.debug('User default model found', {
-      userId,
-      model: userDefaultModel,
-    });
+    this.logger.debug(
+      {
+        userId,
+        model: userDefaultModel,
+      },
+      'User default model found',
+    );
 
     return this.userDefaultModelMapper.toDomain(
       userDefaultModel,
@@ -46,7 +51,7 @@ export class LocalUserDefaultModelsRepository extends UserDefaultModelsRepositor
     permittedModel: PermittedLanguageModel,
     userId: UUID,
   ): Promise<PermittedLanguageModel> {
-    this.logger.log('create', { userId, modelId: permittedModel.id });
+    this.logger.info({ userId, modelId: permittedModel.id }, 'create');
 
     // First, delete any existing default model for this user
     await this.userDefaultModelRepository.delete({ userId });
@@ -59,10 +64,13 @@ export class LocalUserDefaultModelsRepository extends UserDefaultModelsRepositor
       userDefaultModelEntity,
     );
 
-    this.logger.debug('User default model created', {
-      userId,
-      modelId: savedEntity.model.id,
-    });
+    this.logger.debug(
+      {
+        userId,
+        modelId: savedEntity.model.id,
+      },
+      'User default model created',
+    );
 
     return this.userDefaultModelMapper.toDomain(
       savedEntity,
@@ -73,7 +81,7 @@ export class LocalUserDefaultModelsRepository extends UserDefaultModelsRepositor
     permittedModel: PermittedLanguageModel,
     userId: UUID,
   ): Promise<PermittedLanguageModel> {
-    this.logger.log('update', { userId, modelId: permittedModel.id });
+    this.logger.info({ userId, modelId: permittedModel.id }, 'update');
 
     // Delete existing and create new (simpler than complex update logic)
     await this.userDefaultModelRepository.delete({ userId });
@@ -86,10 +94,13 @@ export class LocalUserDefaultModelsRepository extends UserDefaultModelsRepositor
       userDefaultModelEntity,
     );
 
-    this.logger.debug('User default model updated', {
-      userId,
-      modelId: savedEntity.model.id,
-    });
+    this.logger.debug(
+      {
+        userId,
+        modelId: savedEntity.model.id,
+      },
+      'User default model updated',
+    );
 
     return this.userDefaultModelMapper.toDomain(
       savedEntity,
@@ -100,7 +111,7 @@ export class LocalUserDefaultModelsRepository extends UserDefaultModelsRepositor
     permittedModel: PermittedLanguageModel,
     userId: UUID,
   ): Promise<PermittedLanguageModel> {
-    this.logger.log('setAsDefault', { userId, modelId: permittedModel.id });
+    this.logger.info({ userId, modelId: permittedModel.id }, 'setAsDefault');
 
     // Delete any existing default model for this user (handles both create and update)
     await this.userDefaultModelRepository.delete({ userId });
@@ -109,9 +120,12 @@ export class LocalUserDefaultModelsRepository extends UserDefaultModelsRepositor
       permittedModel,
       userId,
     );
-    this.logger.debug('userDefaultModelRecord save', {
-      userDefaultModelRecord,
-    });
+    this.logger.debug(
+      {
+        userDefaultModelRecord,
+      },
+      'userDefaultModelRecord save',
+    );
     const savedEntity = await this.userDefaultModelRepository.save(
       userDefaultModelRecord,
     );
@@ -128,10 +142,13 @@ export class LocalUserDefaultModelsRepository extends UserDefaultModelsRepositor
       );
     }
 
-    this.logger.debug('User default model set as default', {
-      userId,
-      modelId: reloadedEntity.model.id,
-    });
+    this.logger.debug(
+      {
+        userId,
+        modelId: reloadedEntity.model.id,
+      },
+      'User default model set as default',
+    );
 
     return this.userDefaultModelMapper.toDomain(
       reloadedEntity,
@@ -142,7 +159,7 @@ export class LocalUserDefaultModelsRepository extends UserDefaultModelsRepositor
     permittedModel: PermittedLanguageModel,
     userId: UUID,
   ): Promise<void> {
-    this.logger.log('delete', { userId, modelId: permittedModel.id });
+    this.logger.info({ userId, modelId: permittedModel.id }, 'delete');
 
     const result = await this.userDefaultModelRepository.delete({
       userId,
@@ -150,30 +167,39 @@ export class LocalUserDefaultModelsRepository extends UserDefaultModelsRepositor
     });
 
     if (result.affected === 0) {
-      this.logger.warn('No user default model found to delete', {
-        userId,
-        modelId: permittedModel.id,
-      });
+      this.logger.warn(
+        {
+          userId,
+          modelId: permittedModel.id,
+        },
+        'No user default model found to delete',
+      );
       throw new Error(
         `User default model with userId ${userId} and modelId ${permittedModel.id} not found`,
       );
     }
 
-    this.logger.debug('User default model deleted', {
-      userId,
-      modelId: permittedModel.id,
-    });
+    this.logger.debug(
+      {
+        userId,
+        modelId: permittedModel.id,
+      },
+      'User default model deleted',
+    );
   }
 
   async deleteByModelId(modelId: UUID): Promise<void> {
-    this.logger.log('deleteByModelId', { modelId });
+    this.logger.info({ modelId }, 'deleteByModelId');
     const result = await this.userDefaultModelRepository.delete({
       model: { id: modelId },
     });
-    this.logger.debug('Deleted user default models by model id', {
-      modelId,
-      affected: result.affected,
-    });
+    this.logger.debug(
+      {
+        modelId,
+        affected: result.affected,
+      },
+      'Deleted user default models by model id',
+    );
   }
 
   async deleteByPermittedModelIds(permittedModelIds: UUID[]): Promise<void> {
@@ -182,17 +208,23 @@ export class LocalUserDefaultModelsRepository extends UserDefaultModelsRepositor
       return;
     }
 
-    this.logger.log('deleteByPermittedModelIds', {
-      count: permittedModelIds.length,
-    });
+    this.logger.info(
+      {
+        count: permittedModelIds.length,
+      },
+      'deleteByPermittedModelIds',
+    );
 
     const result = await this.userDefaultModelRepository.delete({
       model: { id: In(permittedModelIds) },
     });
 
-    this.logger.debug('Deleted user default models by permitted model ids', {
-      affected: result.affected,
-      permittedModelIds,
-    });
+    this.logger.debug(
+      {
+        affected: result.affected,
+        permittedModelIds,
+      },
+      'Deleted user default models by permitted model ids',
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-user-default-models/mappers/user-default-model.mapper.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/persistence/local-user-default-models/mappers/user-default-model.mapper.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UserDefaultModelRecord } from '../schema/user-default-model.record';
 import { PermittedModel } from 'src/domain/models/domain/permitted-model.entity';
 import { UUID } from 'crypto';
@@ -6,12 +7,21 @@ import { PermittedModelMapper } from '../../local-permitted-models/mappers/permi
 
 @Injectable()
 export class UserDefaultModelMapper {
-  private readonly logger = new Logger(UserDefaultModelMapper.name);
-
-  constructor(private readonly permittedModelMapper: PermittedModelMapper) {}
+  constructor(
+    @InjectPinoLogger(UserDefaultModelMapper.name)
+    private readonly logger: PinoLogger,
+    private readonly permittedModelMapper: PermittedModelMapper,
+  ) {}
 
   toDomain(entity: UserDefaultModelRecord): PermittedModel {
-    this.logger.log('toDomain', { entity });
+    this.logger.info(
+      {
+        userDefaultModelId: entity.id,
+        userId: entity.userId,
+        permittedModelId: entity.model.id,
+      },
+      'toDomain',
+    );
     return this.permittedModelMapper.toDomain(entity.model);
   }
 

--- a/ayunis-core-backend/src/domain/models/infrastructure/runtime/runtime-stream-inference.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/runtime/runtime-stream-inference.handler.spec.ts
@@ -1,4 +1,5 @@
 import type { ModelProvider } from '@ayunis/inference';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { ImageContentService } from 'src/domain/messages/application/services/image-content.service';
 import type { StreamInferenceInput } from '../../application/ports/stream-inference.handler';
 import { InferenceStreamStalledError } from '../../application/models.errors';
@@ -44,7 +45,7 @@ function stallingProvider(): {
 
 class TestHandler extends RuntimeStreamInferenceHandler {
   constructor(private readonly provider: ModelProvider) {
-    super({} as ImageContentService);
+    super(createPinoLoggerMock(), {} as ImageContentService);
   }
   protected createProvider(): ModelProvider {
     return this.provider;

--- a/ayunis-core-backend/src/domain/models/infrastructure/runtime/runtime-stream-inference.handler.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/runtime/runtime-stream-inference.handler.ts
@@ -16,14 +16,12 @@ import {
   StreamIdleWatchdog,
   STREAM_IDLE_TIMEOUT_MS,
 } from 'src/common/streaming/stream-idle-watchdog';
-import { Logger } from '@nestjs/common';
+import type { PinoLogger } from 'nestjs-pino';
 import {
   isRetryableSetupFailure,
   SETUP_RETRY_BACKOFF_MS,
 } from 'src/common/errors/provider-transport-error.classifier';
 import { InferenceStreamStalledError } from '../../application/models.errors';
-
-const logger = new Logger('RuntimeStreamInferenceHandler');
 
 /**
  * One retry, and only when the failed attempt emitted nothing: once a chunk
@@ -51,6 +49,7 @@ export abstract class RuntimeStreamInferenceHandler extends StreamInferenceHandl
   private readonly providerCache = new Map<string, ModelProvider>();
 
   protected constructor(
+    protected readonly logger: PinoLogger,
     protected readonly imageContentService: ImageContentService,
   ) {
     super();
@@ -140,12 +139,15 @@ export abstract class RuntimeStreamInferenceHandler extends StreamInferenceHandl
         if (controller.signal.aborted) {
           throw setupFailure;
         }
-        logger.warn('Provider stream failed before the first chunk', {
-          model: input.model.name,
-          provider: input.model.provider,
-          attempt,
-          error: setupFailure.message,
-        });
+        this.logger.warn(
+          {
+            model: input.model.name,
+            provider: input.model.provider,
+            attempt,
+            err: setupFailure,
+          },
+          'Provider stream failed before the first chunk',
+        );
       }
     } catch (error) {
       // A stalled stream surfaces from the SDK as a generic AbortError, which

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/anthropic.stream-inference.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/anthropic.stream-inference.spec.ts
@@ -1,4 +1,5 @@
 import type { ConfigService } from '@nestjs/config';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { ModelProvider } from '@ayunis/inference';
 import { AnthropicStreamInferenceHandler } from './anthropic.stream-inference';
 import { CLAUDE_MAX_OUTPUT_TOKENS } from '../runtime/inference-config';
@@ -27,6 +28,7 @@ describe('AnthropicStreamInferenceHandler', () => {
       get: jest.fn().mockReturnValue('sk-ant-test'),
     } as unknown as ConfigService;
     const handler = new AnthropicStreamInferenceHandler(
+      createPinoLoggerMock(),
       configService,
       {} as ImageContentService,
     );

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/anthropic.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/anthropic.stream-inference.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { anthropic } from '@ayunis/provider-anthropic';
 import type { ModelProvider } from '@ayunis/inference';
@@ -13,10 +14,13 @@ import {
 @Injectable()
 export class AnthropicStreamInferenceHandler extends RuntimeStreamInferenceHandler {
   constructor(
+    @InjectPinoLogger('RuntimeStreamInferenceHandler')
+    logger: PinoLogger,
+
     private readonly configService: ConfigService,
     imageContentService: ImageContentService,
   ) {
-    super(imageContentService);
+    super(logger, imageContentService);
   }
 
   protected createProvider(model: Model): ModelProvider {

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/ayunis-ollama.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/ayunis-ollama.stream-inference.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { ollama } from '@ayunis/provider-ollama';
 import type { ModelProvider } from '@ayunis/inference';
@@ -10,10 +11,13 @@ import { INFERENCE_MAX_RETRIES } from '../runtime/inference-config';
 @Injectable()
 export class AyunisOllamaStreamInferenceHandler extends ThinkingTagStreamInferenceHandler {
   constructor(
+    @InjectPinoLogger('RuntimeStreamInferenceHandler')
+    logger: PinoLogger,
+
     private readonly configService: ConfigService,
     imageContentService: ImageContentService,
   ) {
-    super(imageContentService);
+    super(logger, imageContentService);
   }
 
   protected createProvider(model: Model): ModelProvider {

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/azure.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/azure.stream-inference.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { azure } from '@ayunis/provider-openai';
 import type { ModelProvider } from '@ayunis/inference';
@@ -10,10 +11,13 @@ import { INFERENCE_MAX_RETRIES } from '../runtime/inference-config';
 @Injectable()
 export class AzureStreamInferenceHandler extends RuntimeStreamInferenceHandler {
   constructor(
+    @InjectPinoLogger('RuntimeStreamInferenceHandler')
+    logger: PinoLogger,
+
     private readonly configService: ConfigService,
     imageContentService: ImageContentService,
   ) {
-    super(imageContentService);
+    super(logger, imageContentService);
   }
 
   protected createProvider(model: Model): ModelProvider {

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/bedrock.stream-inference.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/bedrock.stream-inference.spec.ts
@@ -1,4 +1,5 @@
 import type { ConfigService } from '@nestjs/config';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { ModelProvider } from '@ayunis/inference';
 import { BedrockStreamInferenceHandler } from './bedrock.stream-inference';
 import { CLAUDE_MAX_OUTPUT_TOKENS } from '../runtime/inference-config';
@@ -24,6 +25,7 @@ describe('BedrockStreamInferenceHandler', () => {
       get: jest.fn().mockReturnValue(undefined),
     } as unknown as ConfigService;
     const handler = new BedrockStreamInferenceHandler(
+      createPinoLoggerMock(),
       configService,
       {} as ImageContentService,
     );

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/bedrock.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/bedrock.stream-inference.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { bedrock } from '@ayunis/provider-anthropic/bedrock';
 import type { ModelProvider } from '@ayunis/inference';
@@ -13,10 +14,13 @@ import {
 @Injectable()
 export class BedrockStreamInferenceHandler extends RuntimeStreamInferenceHandler {
   constructor(
+    @InjectPinoLogger('RuntimeStreamInferenceHandler')
+    logger: PinoLogger,
+
     private readonly configService: ConfigService,
     imageContentService: ImageContentService,
   ) {
-    super(imageContentService);
+    super(logger, imageContentService);
   }
 
   protected createProvider(model: Model): ModelProvider {

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/gemini.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/gemini.stream-inference.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { gemini } from '@ayunis/provider-gemini';
 import type { ModelProvider } from '@ayunis/inference';
@@ -10,10 +11,13 @@ import { INFERENCE_MAX_RETRIES } from '../runtime/inference-config';
 @Injectable()
 export class GeminiStreamInferenceHandler extends RuntimeStreamInferenceHandler {
   constructor(
+    @InjectPinoLogger('RuntimeStreamInferenceHandler')
+    logger: PinoLogger,
+
     private readonly configService: ConfigService,
     imageContentService: ImageContentService,
   ) {
-    super(imageContentService);
+    super(logger, imageContentService);
   }
 
   protected createProvider(model: Model): ModelProvider {

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/local-ollama.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/local-ollama.stream-inference.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { ollama } from '@ayunis/provider-ollama';
 import type { ModelProvider } from '@ayunis/inference';
@@ -10,10 +11,13 @@ import { INFERENCE_MAX_RETRIES } from '../runtime/inference-config';
 @Injectable()
 export class LocalOllamaStreamInferenceHandler extends ThinkingTagStreamInferenceHandler {
   constructor(
+    @InjectPinoLogger('RuntimeStreamInferenceHandler')
+    logger: PinoLogger,
+
     private readonly configService: ConfigService,
     imageContentService: ImageContentService,
   ) {
-    super(imageContentService);
+    super(logger, imageContentService);
   }
 
   protected createProvider(model: Model): ModelProvider {

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/mistral.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/mistral.stream-inference.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { mistral } from '@ayunis/provider-mistral';
 import type { ModelProvider } from '@ayunis/inference';
@@ -10,10 +11,13 @@ import { INFERENCE_MAX_RETRIES } from '../runtime/inference-config';
 @Injectable()
 export class MistralStreamInferenceHandler extends RuntimeStreamInferenceHandler {
   constructor(
+    @InjectPinoLogger('RuntimeStreamInferenceHandler')
+    logger: PinoLogger,
+
     private readonly configService: ConfigService,
     imageContentService: ImageContentService,
   ) {
-    super(imageContentService);
+    super(logger, imageContentService);
   }
 
   protected createProvider(model: Model): ModelProvider {

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/openai.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/openai.stream-inference.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { openai } from '@ayunis/provider-openai';
 import type { ModelProvider } from '@ayunis/inference';
@@ -10,10 +11,13 @@ import { INFERENCE_MAX_RETRIES } from '../runtime/inference-config';
 @Injectable()
 export class OpenAIStreamInferenceHandler extends RuntimeStreamInferenceHandler {
   constructor(
+    @InjectPinoLogger('RuntimeStreamInferenceHandler')
+    logger: PinoLogger,
+
     private readonly configService: ConfigService,
     imageContentService: ImageContentService,
   ) {
-    super(imageContentService);
+    super(logger, imageContentService);
   }
 
   protected createProvider(model: Model): ModelProvider {

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/otc.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/otc.stream-inference.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { openai } from '@ayunis/provider-openai';
 import type { ModelProvider } from '@ayunis/inference';
@@ -10,10 +11,13 @@ import { INFERENCE_MAX_RETRIES } from '../runtime/inference-config';
 @Injectable()
 export class OtcStreamInferenceHandler extends ThinkingTagStreamInferenceHandler {
   constructor(
+    @InjectPinoLogger('RuntimeStreamInferenceHandler')
+    logger: PinoLogger,
+
     private readonly configService: ConfigService,
     imageContentService: ImageContentService,
   ) {
-    super(imageContentService);
+    super(logger, imageContentService);
   }
 
   protected createProvider(model: Model): ModelProvider {

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/scaleway.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/scaleway.stream-inference.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { openai } from '@ayunis/provider-openai';
 import type { ModelProvider } from '@ayunis/inference';
@@ -10,10 +11,13 @@ import { INFERENCE_MAX_RETRIES } from '../runtime/inference-config';
 @Injectable()
 export class ScalewayStreamInferenceHandler extends ThinkingTagStreamInferenceHandler {
   constructor(
+    @InjectPinoLogger('RuntimeStreamInferenceHandler')
+    logger: PinoLogger,
+
     private readonly configService: ConfigService,
     imageContentService: ImageContentService,
   ) {
-    super(imageContentService);
+    super(logger, imageContentService);
   }
 
   protected createProvider(model: Model): ModelProvider {

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/stackit.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/stackit.stream-inference.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { openai } from '@ayunis/provider-openai';
 import type { ModelProvider } from '@ayunis/inference';
@@ -10,10 +11,13 @@ import { INFERENCE_MAX_RETRIES } from '../runtime/inference-config';
 @Injectable()
 export class StackitStreamInferenceHandler extends ThinkingTagStreamInferenceHandler {
   constructor(
+    @InjectPinoLogger('RuntimeStreamInferenceHandler')
+    logger: PinoLogger,
+
     private readonly configService: ConfigService,
     imageContentService: ImageContentService,
   ) {
-    super(imageContentService);
+    super(logger, imageContentService);
   }
 
   protected createProvider(model: Model): ModelProvider {

--- a/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/synaforce.stream-inference.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/stream-inference/synaforce.stream-inference.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { ollama } from '@ayunis/provider-ollama';
 import type { ModelProvider } from '@ayunis/inference';
@@ -10,10 +11,13 @@ import { INFERENCE_MAX_RETRIES } from '../runtime/inference-config';
 @Injectable()
 export class SynaforceStreamInferenceHandler extends ThinkingTagStreamInferenceHandler {
   constructor(
+    @InjectPinoLogger('RuntimeStreamInferenceHandler')
+    logger: PinoLogger,
+
     private readonly configService: ConfigService,
     imageContentService: ImageContentService,
   ) {
-    super(imageContentService);
+    super(logger, imageContentService);
   }
 
   protected createProvider(model: Model): ModelProvider {

--- a/ayunis-core-backend/src/domain/models/models.module.ts
+++ b/ayunis-core-backend/src/domain/models/models.module.ts
@@ -1,4 +1,5 @@
 import { forwardRef, Module } from '@nestjs/common';
+import { getLoggerToken, type PinoLogger } from 'nestjs-pino';
 import { ModelsController } from './presenters/http/models.controller';
 import { ModelsDefaultsController } from './presenters/http/models-defaults.controller';
 import { SuperAdminPermittedModelsController } from './presenters/http/super-admin-permitted-models.controller';
@@ -180,9 +181,13 @@ import { UsageReferencesModule } from '../usage/usage-references.module';
         stackitHandler: StackitStreamInferenceHandler,
         scalewayHandler: ScalewayStreamInferenceHandler,
         mockHandler: MockStreamInferenceHandler,
+        logger: PinoLogger,
         configService: ConfigService,
       ) => {
-        const registry = new StreamInferenceHandlerRegistry(configService);
+        const registry = new StreamInferenceHandlerRegistry(
+          logger,
+          configService,
+        );
         registry.register(ModelProvider.OPENAI, openaiHandler);
         registry.register(ModelProvider.ANTHROPIC, anthropicHandler);
         registry.register(ModelProvider.BEDROCK, bedrockHandler);
@@ -212,6 +217,7 @@ import { UsageReferencesModule } from '../usage/usage-references.module';
         StackitStreamInferenceHandler,
         ScalewayStreamInferenceHandler,
         MockStreamInferenceHandler,
+        getLoggerToken(StreamInferenceHandlerRegistry.name),
         ConfigService,
       ],
     },
@@ -231,9 +237,10 @@ import { UsageReferencesModule } from '../usage/usage-references.module';
         stackitHandler: StackitInferenceHandler,
         scalewayHandler: ScalewayInferenceHandler,
         mockHandler: MockInferenceHandler,
+        logger: PinoLogger,
         configService: ConfigService,
       ) => {
-        const registry = new InferenceHandlerRegistry(configService);
+        const registry = new InferenceHandlerRegistry(logger, configService);
         registry.register(ModelProvider.MISTRAL, mistralHandler);
         registry.register(ModelProvider.OPENAI, openaiHandler);
         registry.register(ModelProvider.ANTHROPIC, anthropicHandler);
@@ -263,6 +270,7 @@ import { UsageReferencesModule } from '../usage/usage-references.module';
         StackitInferenceHandler,
         ScalewayInferenceHandler,
         MockInferenceHandler,
+        getLoggerToken(InferenceHandlerRegistry.name),
         ConfigService,
       ],
     },
@@ -271,9 +279,13 @@ import { UsageReferencesModule } from '../usage/usage-references.module';
       useFactory: (
         azureHandler: AzureImageGenerationHandler,
         mockHandler: MockImageGenerationHandler,
+        logger: PinoLogger,
         configService: ConfigService,
       ) => {
-        const registry = new ImageGenerationHandlerRegistry(configService);
+        const registry = new ImageGenerationHandlerRegistry(
+          logger,
+          configService,
+        );
         registry.register(ModelProvider.AZURE, azureHandler);
         registry.registerMockHandler(mockHandler);
         return registry;
@@ -281,6 +293,7 @@ import { UsageReferencesModule } from '../usage/usage-references.module';
       inject: [
         AzureImageGenerationHandler,
         MockImageGenerationHandler,
+        getLoggerToken(ImageGenerationHandlerRegistry.name),
         ConfigService,
       ],
     },

--- a/ayunis-core-backend/src/domain/models/presenters/http/models-defaults.controller.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/models-defaults.controller.ts
@@ -1,4 +1,5 @@
-import { Body, Controller, Delete, Get, Logger, Put } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Put } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Roles } from 'src/iam/authorization/application/decorators/roles.decorator';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 import {
@@ -38,9 +39,10 @@ import { ModelResponseDtoMapper } from './mappers/model-response-dto.mapper';
 @ApiTags('models')
 @Controller('models')
 export class ModelsDefaultsController {
-  private readonly logger = new Logger(ModelsDefaultsController.name);
-
   constructor(
+    @InjectPinoLogger(ModelsDefaultsController.name)
+    private readonly logger: PinoLogger,
+
     private readonly getDefaultModelUseCase: GetDefaultModelUseCase,
     private readonly setUserDefaultLanguageModelUseCase: SetUserDefaultLanguageModelUseCase,
     private readonly deleteUserDefaultModelUseCase: DeleteUserDefaultModelUseCase,
@@ -80,11 +82,14 @@ export class ModelsDefaultsController {
       if (error instanceof ModelNotFoundError) {
         return { permittedLanguageModel: undefined };
       }
-      this.logger.error('Failed to get effective default model', {
-        orgId,
-        userId,
-        error: error instanceof Error ? error : new Error('Unknown error'),
-      });
+      this.logger.error(
+        {
+          orgId,
+          userId,
+          err: error instanceof Error ? error : new Error('Unknown error'),
+        },
+        'Failed to get effective default model',
+      );
       throw error;
     }
   }

--- a/ayunis-core-backend/src/domain/models/presenters/http/models.controller.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/models.controller.ts
@@ -5,11 +5,11 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   Patch,
   Post,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiBody,
   ApiExtraModels,
@@ -66,9 +66,10 @@ import { ModelWithConfigResponseDtoMapper } from './mappers/model-with-config-re
 @ApiTags('models')
 @Controller('models')
 export class ModelsController {
-  private readonly logger = new Logger(ModelsController.name);
-
   constructor(
+    @InjectPinoLogger(ModelsController.name)
+    private readonly logger: PinoLogger,
+
     private readonly createPermittedModelUseCase: CreatePermittedModelUseCase,
     private readonly getConfiguredModelsByTypeUseCase: GetConfiguredModelsByTypeUseCase,
     private readonly getPermittedModelsUseCase: GetPermittedModelsUseCase,
@@ -102,7 +103,7 @@ export class ModelsController {
   async getAvailableLanguageModels(
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
   ): Promise<ModelWithConfigResponseDto[]> {
-    this.logger.log('getAvailableLanguageModels');
+    this.logger.info('getAvailableLanguageModels');
     const availableModels = await this.getConfiguredModelsByTypeUseCase.execute(
       new GetConfiguredModelsByTypeQuery(orgId, ModelType.LANGUAGE),
     );
@@ -133,7 +134,7 @@ export class ModelsController {
   async getAvailableEmbeddingModels(
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
   ): Promise<ModelWithConfigResponseDto[]> {
-    this.logger.log('getAvailableEmbeddingModels');
+    this.logger.info('getAvailableEmbeddingModels');
     const availableModels = await this.getConfiguredModelsByTypeUseCase.execute(
       new GetConfiguredModelsByTypeQuery(orgId, ModelType.EMBEDDING),
     );
@@ -163,7 +164,7 @@ export class ModelsController {
   async getAvailableImageGenerationModels(
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
   ): Promise<ModelWithConfigResponseDto[]> {
-    this.logger.log('getAvailableImageGenerationModels');
+    this.logger.info('getAvailableImageGenerationModels');
     const availableModels = await this.getConfiguredModelsByTypeUseCase.execute(
       new GetConfiguredModelsByTypeQuery(orgId, ModelType.IMAGE_GENERATION),
     );
@@ -187,7 +188,7 @@ export class ModelsController {
   })
   @ApiExtraModels(ModelProviderInfoResponseDto)
   getProviders(): ModelProviderInfoResponseDto[] {
-    this.logger.log('getProviders');
+    this.logger.info('getProviders');
     return this.modelProviderInfoRegistry
       .getAllProviderInfos()
       .map((info) => this.modelProviderInfoResponseDtoMapper.toDto(info));
@@ -368,7 +369,7 @@ export class ModelsController {
   getModelProviderInfo(
     @Param('provider') provider: ModelProvider,
   ): ModelProviderInfoResponseDto {
-    this.logger.log('getModelProviderInfo', { provider });
+    this.logger.info({ provider }, 'getModelProviderInfo');
     const query = new GetModelProviderInfoQuery(provider);
     const entity = this.getModelProviderInfoUseCase.execute(query);
     return this.modelProviderInfoResponseDtoMapper.toDto(entity);

--- a/ayunis-core-backend/src/domain/models/presenters/http/super-admin-catalog-models.controller.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/super-admin-catalog-models.controller.ts
@@ -4,9 +4,9 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiExtraModels,
   ApiInternalServerErrorResponse,
@@ -45,9 +45,10 @@ import { CatalogModelResponseDtoMapper } from './mappers/catalog-model-response-
   ImageGenerationModelResponseDto,
 )
 export class SuperAdminCatalogModelsController {
-  private readonly logger = new Logger(SuperAdminCatalogModelsController.name);
-
   constructor(
+    @InjectPinoLogger(SuperAdminCatalogModelsController.name)
+    private readonly logger: PinoLogger,
+
     private readonly getAllModelsUseCase: GetAllModelsUseCase,
     private readonly getModelByIdUseCase: GetModelByIdUseCase,
     private readonly catalogModelResponseDtoMapper: CatalogModelResponseDtoMapper,
@@ -83,10 +84,13 @@ export class SuperAdminCatalogModelsController {
   async getAllCatalogModels(
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<ModelResponseDto[]> {
-    this.logger.log(`Getting all catalog models by super admin ${userId}`);
+    this.logger.info({ userId }, 'Getting all catalog models by super admin');
     const models = await this.getAllModelsUseCase.execute();
     const responseDtos = this.catalogModelResponseDtoMapper.toDtoArray(models);
-    this.logger.log(`Successfully retrieved ${models.length} catalog models`);
+    this.logger.info(
+      { modelCount: models.length },
+      'Successfully retrieved catalog models',
+    );
     return responseDtos;
   }
 
@@ -127,11 +131,14 @@ export class SuperAdminCatalogModelsController {
     @Param('id') id: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<ModelResponseDto> {
-    this.logger.log(`Getting catalog model ${id} by super admin ${userId}`);
+    this.logger.info(
+      { modelId: id, userId },
+      'Getting catalog model by super admin',
+    );
     const query = new GetModelByIdQuery(id);
     const model = await this.getModelByIdUseCase.execute(query);
     const responseDto = this.catalogModelResponseDtoMapper.toDto(model);
-    this.logger.log(`Successfully retrieved catalog model ${id}`);
+    this.logger.info({ modelId: id }, 'Successfully retrieved catalog model');
     return responseDto;
   }
 
@@ -166,9 +173,12 @@ export class SuperAdminCatalogModelsController {
     @Param('id') id: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<void> {
-    this.logger.log(`Deleting catalog model ${id} by super admin ${userId}`);
+    this.logger.info(
+      { modelId: id, userId },
+      'Deleting catalog model by super admin',
+    );
     const command = new DeleteModelCommand(id);
     await this.deleteModelUseCase.execute(command);
-    this.logger.log(`Successfully deleted catalog model ${id}`);
+    this.logger.info({ modelId: id }, 'Successfully deleted catalog model');
   }
 }

--- a/ayunis-core-backend/src/domain/models/presenters/http/super-admin-embedding-catalog-models.controller.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/super-admin-embedding-catalog-models.controller.ts
@@ -4,11 +4,11 @@ import {
   Controller,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   Patch,
   Post,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiBody,
   ApiCreatedResponse,
@@ -45,11 +45,10 @@ import { CatalogModelResponseDtoMapper } from './mappers/catalog-model-response-
   EmbeddingModelResponseDto,
 )
 export class SuperAdminEmbeddingCatalogModelsController {
-  private readonly logger = new Logger(
-    SuperAdminEmbeddingCatalogModelsController.name,
-  );
-
   constructor(
+    @InjectPinoLogger(SuperAdminEmbeddingCatalogModelsController.name)
+    private readonly logger: PinoLogger,
+
     private readonly createEmbeddingModelUseCase: CreateEmbeddingModelUseCase,
     private readonly updateEmbeddingModelUseCase: UpdateEmbeddingModelUseCase,
     private readonly catalogModelResponseDtoMapper: CatalogModelResponseDtoMapper,
@@ -85,22 +84,19 @@ export class SuperAdminEmbeddingCatalogModelsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() dto: CreateEmbeddingModelRequestDto,
   ): Promise<EmbeddingModelResponseDto> {
-    this.logger.log(
-      `Creating embedding model ${dto.name} by super admin ${userId}`,
+    this.logger.info(
+      { modelName: dto.name, userId },
+      'Creating embedding model by super admin',
     );
-    const command = new CreateEmbeddingModelCommand({
-      name: dto.name,
-      provider: dto.provider,
-      displayName: dto.displayName,
-      dimensions: dto.dimensions,
-      isArchived: dto.isArchived,
-      inputTokenCost: dto.inputTokenCost,
-      outputTokenCost: dto.outputTokenCost,
-    });
-    const model = await this.createEmbeddingModelUseCase.execute(command);
+    const model = await this.createEmbeddingModelUseCase.execute(
+      this.toCreateCommand(dto),
+    );
     const responseDto =
       this.catalogModelResponseDtoMapper.toEmbeddingModelDto(model);
-    this.logger.log(`Successfully created embedding model ${model.id}`);
+    this.logger.info(
+      { modelId: model.id },
+      'Successfully created embedding model',
+    );
     return responseDto;
   }
 
@@ -141,8 +137,38 @@ export class SuperAdminEmbeddingCatalogModelsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() dto: UpdateEmbeddingModelRequestDto,
   ): Promise<EmbeddingModelResponseDto> {
-    this.logger.log(`Updating embedding model ${id} by super admin ${userId}`);
-    const command = new UpdateEmbeddingModelCommand({
+    this.logger.info(
+      { modelId: id, userId },
+      'Updating embedding model by super admin',
+    );
+    const model = await this.updateEmbeddingModelUseCase.execute(
+      this.toUpdateCommand(id, dto),
+    );
+    const responseDto =
+      this.catalogModelResponseDtoMapper.toEmbeddingModelDto(model);
+    this.logger.info({ modelId: id }, 'Successfully updated embedding model');
+    return responseDto;
+  }
+
+  private toCreateCommand(
+    dto: CreateEmbeddingModelRequestDto,
+  ): CreateEmbeddingModelCommand {
+    return new CreateEmbeddingModelCommand({
+      name: dto.name,
+      provider: dto.provider,
+      displayName: dto.displayName,
+      dimensions: dto.dimensions,
+      isArchived: dto.isArchived,
+      inputTokenCost: dto.inputTokenCost,
+      outputTokenCost: dto.outputTokenCost,
+    });
+  }
+
+  private toUpdateCommand(
+    id: UUID,
+    dto: UpdateEmbeddingModelRequestDto,
+  ): UpdateEmbeddingModelCommand {
+    return new UpdateEmbeddingModelCommand({
       id,
       name: dto.name,
       provider: dto.provider,
@@ -152,10 +178,5 @@ export class SuperAdminEmbeddingCatalogModelsController {
       inputTokenCost: dto.inputTokenCost,
       outputTokenCost: dto.outputTokenCost,
     });
-    const model = await this.updateEmbeddingModelUseCase.execute(command);
-    const responseDto =
-      this.catalogModelResponseDtoMapper.toEmbeddingModelDto(model);
-    this.logger.log(`Successfully updated embedding model ${id}`);
-    return responseDto;
   }
 }

--- a/ayunis-core-backend/src/domain/models/presenters/http/super-admin-image-generation-catalog-models.controller.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/super-admin-image-generation-catalog-models.controller.ts
@@ -4,11 +4,11 @@ import {
   Controller,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   Patch,
   Post,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiBody,
   ApiCreatedResponse,
@@ -45,11 +45,10 @@ import { CatalogModelResponseDtoMapper } from './mappers/catalog-model-response-
   ImageGenerationModelResponseDto,
 )
 export class SuperAdminImageGenerationCatalogModelsController {
-  private readonly logger = new Logger(
-    SuperAdminImageGenerationCatalogModelsController.name,
-  );
-
   constructor(
+    @InjectPinoLogger(SuperAdminImageGenerationCatalogModelsController.name)
+    private readonly logger: PinoLogger,
+
     private readonly createImageGenerationModelUseCase: CreateImageGenerationModelUseCase,
     private readonly updateImageGenerationModelUseCase: UpdateImageGenerationModelUseCase,
     private readonly catalogModelResponseDtoMapper: CatalogModelResponseDtoMapper,
@@ -85,8 +84,9 @@ export class SuperAdminImageGenerationCatalogModelsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() dto: CreateImageGenerationModelRequestDto,
   ): Promise<ImageGenerationModelResponseDto> {
-    this.logger.log(
-      `Creating image-generation model ${dto.name} by super admin ${userId}`,
+    this.logger.info(
+      { modelName: dto.name, userId },
+      'Creating image-generation model by super admin',
     );
     const command = new CreateImageGenerationModelCommand({
       name: dto.name,
@@ -137,10 +137,21 @@ export class SuperAdminImageGenerationCatalogModelsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() dto: UpdateImageGenerationModelRequestDto,
   ): Promise<ImageGenerationModelResponseDto> {
-    this.logger.log(
-      `Updating image-generation model ${id} by super admin ${userId}`,
+    this.logger.info(
+      { modelId: id, userId },
+      'Updating image-generation model by super admin',
     );
-    const command = new UpdateImageGenerationModelCommand({
+    const model = await this.updateImageGenerationModelUseCase.execute(
+      this.toUpdateCommand(id, dto),
+    );
+    return this.catalogModelResponseDtoMapper.toImageGenerationModelDto(model);
+  }
+
+  private toUpdateCommand(
+    id: UUID,
+    dto: UpdateImageGenerationModelRequestDto,
+  ): UpdateImageGenerationModelCommand {
+    return new UpdateImageGenerationModelCommand({
       id,
       name: dto.name,
       provider: dto.provider,
@@ -149,7 +160,5 @@ export class SuperAdminImageGenerationCatalogModelsController {
       inputTokenCost: dto.inputTokenCost,
       outputTokenCost: dto.outputTokenCost,
     });
-    const model = await this.updateImageGenerationModelUseCase.execute(command);
-    return this.catalogModelResponseDtoMapper.toImageGenerationModelDto(model);
   }
 }

--- a/ayunis-core-backend/src/domain/models/presenters/http/super-admin-language-catalog-models.controller.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/super-admin-language-catalog-models.controller.ts
@@ -4,11 +4,11 @@ import {
   Controller,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   Patch,
   Post,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiBody,
   ApiCreatedResponse,
@@ -45,11 +45,10 @@ import { CatalogModelResponseDtoMapper } from './mappers/catalog-model-response-
   LanguageModelResponseDto,
 )
 export class SuperAdminLanguageCatalogModelsController {
-  private readonly logger = new Logger(
-    SuperAdminLanguageCatalogModelsController.name,
-  );
-
   constructor(
+    @InjectPinoLogger(SuperAdminLanguageCatalogModelsController.name)
+    private readonly logger: PinoLogger,
+
     private readonly createLanguageModelUseCase: CreateLanguageModelUseCase,
     private readonly updateLanguageModelUseCase: UpdateLanguageModelUseCase,
     private readonly catalogModelResponseDtoMapper: CatalogModelResponseDtoMapper,
@@ -85,14 +84,18 @@ export class SuperAdminLanguageCatalogModelsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() dto: CreateLanguageModelRequestDto,
   ): Promise<LanguageModelResponseDto> {
-    this.logger.log(
-      `Creating language model ${dto.name} by super admin ${userId}`,
+    this.logger.info(
+      { modelName: dto.name, userId },
+      'Creating language model by super admin',
     );
     const command = new CreateLanguageModelCommand(dto);
     const model = await this.createLanguageModelUseCase.execute(command);
     const responseDto =
       this.catalogModelResponseDtoMapper.toLanguageModelDto(model);
-    this.logger.log(`Successfully created language model ${model.id}`);
+    this.logger.info(
+      { modelId: model.id },
+      'Successfully created language model',
+    );
     return responseDto;
   }
 
@@ -133,12 +136,15 @@ export class SuperAdminLanguageCatalogModelsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() dto: UpdateLanguageModelRequestDto,
   ): Promise<LanguageModelResponseDto> {
-    this.logger.log(`Updating language model ${id} by super admin ${userId}`);
+    this.logger.info(
+      { modelId: id, userId },
+      'Updating language model by super admin',
+    );
     const command = new UpdateLanguageModelCommand({ ...dto, id });
     const model = await this.updateLanguageModelUseCase.execute(command);
     const responseDto =
       this.catalogModelResponseDtoMapper.toLanguageModelDto(model);
-    this.logger.log(`Successfully updated language model ${id}`);
+    this.logger.info({ modelId: id }, 'Successfully updated language model');
     return responseDto;
   }
 }

--- a/ayunis-core-backend/src/domain/models/presenters/http/super-admin-permitted-models.controller.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/super-admin-permitted-models.controller.ts
@@ -5,12 +5,12 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   Patch,
   Post,
   Put,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiBody,
   ApiExtraModels,
@@ -58,6 +58,19 @@ import { UpdatePermittedModelDto } from './dto/update-permitted-model.dto';
 import { ModelResponseDtoMapper } from './mappers/model-response-dto.mapper';
 import { ModelWithConfigResponseDtoMapper } from './mappers/model-with-config-response-dto.mapper';
 
+type PermittedModelResponseDto =
+  | PermittedLanguageModelResponseDto
+  | PermittedEmbeddingModelResponseDto
+  | PermittedImageGenerationModelResponseDto;
+
+const permittedModelResponseSchema = {
+  oneOf: [
+    { $ref: getSchemaPath(PermittedLanguageModelResponseDto) },
+    { $ref: getSchemaPath(PermittedEmbeddingModelResponseDto) },
+    { $ref: getSchemaPath(PermittedImageGenerationModelResponseDto) },
+  ],
+};
+
 @ApiTags('Super Admin Models')
 @Controller('super-admin/models')
 @SystemRoles(SystemRole.SUPER_ADMIN)
@@ -69,11 +82,10 @@ import { ModelWithConfigResponseDtoMapper } from './mappers/model-with-config-re
   ModelWithConfigResponseDto,
 )
 export class SuperAdminPermittedModelsController {
-  private readonly logger = new Logger(
-    SuperAdminPermittedModelsController.name,
-  );
-
   constructor(
+    @InjectPinoLogger(SuperAdminPermittedModelsController.name)
+    private readonly logger: PinoLogger,
+
     private readonly createPermittedModelUseCase: CreatePermittedModelUseCase,
     private readonly deletePermittedModelUseCase: DeletePermittedModelUseCase,
     private readonly getPermittedModelsUseCase: GetPermittedModelsUseCase,
@@ -101,8 +113,9 @@ export class SuperAdminPermittedModelsController {
     @Param('orgId') orgId: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<ModelWithConfigResponseDto[]> {
-    this.logger.log(
-      `Getting available language models for org ${orgId} by super admin ${userId}`,
+    this.logger.info(
+      { orgId, userId },
+      'Getting available language models for org by super admin',
     );
     const availableModels = await this.getConfiguredModelsByTypeUseCase.execute(
       new GetConfiguredModelsByTypeQuery(orgId, ModelType.LANGUAGE),
@@ -133,8 +146,9 @@ export class SuperAdminPermittedModelsController {
     @Param('orgId') orgId: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<ModelWithConfigResponseDto[]> {
-    this.logger.log(
-      `Getting available embedding models for org ${orgId} by super admin ${userId}`,
+    this.logger.info(
+      { orgId, userId },
+      'Getting available embedding models for org by super admin',
     );
     const availableModels = await this.getConfiguredModelsByTypeUseCase.execute(
       new GetConfiguredModelsByTypeQuery(orgId, ModelType.EMBEDDING),
@@ -165,8 +179,9 @@ export class SuperAdminPermittedModelsController {
     @Param('orgId') orgId: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<ModelWithConfigResponseDto[]> {
-    this.logger.log(
-      `Getting available image-generation models for org ${orgId} by super admin ${userId}`,
+    this.logger.info(
+      { orgId, userId },
+      'Getting available image-generation models for org by super admin',
     );
     const availableModels = await this.getConfiguredModelsByTypeUseCase.execute(
       new GetConfiguredModelsByTypeQuery(orgId, ModelType.IMAGE_GENERATION),
@@ -217,8 +232,9 @@ export class SuperAdminPermittedModelsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() setOrgDefaultModelDto: SetOrgDefaultModelDto,
   ): Promise<PermittedLanguageModelResponseDto> {
-    this.logger.log(
-      `Managing org default model for org ${orgId} by super admin ${userId}`,
+    this.logger.info(
+      { orgId, userId },
+      'Managing org default model by super admin',
     );
     const command = new SetOrgDefaultLanguageModelCommand(
       setOrgDefaultModelDto.permittedModelId,
@@ -270,18 +286,11 @@ export class SuperAdminPermittedModelsController {
       | PermittedImageGenerationModelResponseDto
     )[]
   > {
-    this.logger.log(
-      `Getting permitted models for org ${orgId} by super admin ${userId}`,
+    this.logger.info(
+      { orgId, userId },
+      'Getting permitted models for org by super admin',
     );
-    const query = new GetPermittedModelsQuery(orgId);
-    const models = await this.getPermittedModelsUseCase.execute(query);
-    const responseDtos = models.map((model) =>
-      this.modelResponseDtoMapper.toDto(model),
-    );
-    this.logger.log(
-      `Successfully retrieved ${models.length} permitted models for org ${orgId}`,
-    );
-    return responseDtos;
+    return this.getPermittedModelDtos(orgId);
   }
 
   @Post(':orgId/permitted-models')
@@ -321,8 +330,9 @@ export class SuperAdminPermittedModelsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() dto: CreatePermittedModelDto,
   ): Promise<void> {
-    this.logger.log(
-      `Creating permitted model ${dto.modelId} for org ${orgId} by super admin ${userId}`,
+    this.logger.info(
+      { modelId: dto.modelId, orgId, userId },
+      'Creating permitted model for org by super admin',
     );
     const command = new CreatePermittedModelCommand(
       dto.modelId,
@@ -375,14 +385,10 @@ export class SuperAdminPermittedModelsController {
     @Param('id') id: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<void> {
-    this.logger.log(
-      `Deleting permitted model ${id} for org ${orgId} by super admin ${userId}`,
+    this.logDelete(id, orgId, userId);
+    await this.deletePermittedModelUseCase.execute(
+      new DeletePermittedModelCommand({ orgId, permittedModelId: id }),
     );
-    const command = new DeletePermittedModelCommand({
-      orgId,
-      permittedModelId: id,
-    });
-    await this.deletePermittedModelUseCase.execute(command);
   }
 
   @Patch(':orgId/permitted-models/:id')
@@ -407,13 +413,7 @@ export class SuperAdminPermittedModelsController {
   @ApiBody({ type: UpdatePermittedModelDto })
   @ApiOkResponse({
     description: 'Successfully updated permitted model',
-    schema: {
-      oneOf: [
-        { $ref: getSchemaPath(PermittedLanguageModelResponseDto) },
-        { $ref: getSchemaPath(PermittedEmbeddingModelResponseDto) },
-        { $ref: getSchemaPath(PermittedImageGenerationModelResponseDto) },
-      ],
-    },
+    schema: permittedModelResponseSchema,
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
@@ -434,32 +434,65 @@ export class SuperAdminPermittedModelsController {
     @Param('id') id: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() dto: UpdatePermittedModelDto,
+  ): Promise<PermittedModelResponseDto> {
+    this.logUpdate(id, orgId, userId);
+    return this.updateModel(orgId, id, dto);
+  }
+
+  private async getPermittedModelDtos(
+    orgId: UUID,
   ): Promise<
-    | PermittedLanguageModelResponseDto
-    | PermittedEmbeddingModelResponseDto
-    | PermittedImageGenerationModelResponseDto
+    (
+      | PermittedLanguageModelResponseDto
+      | PermittedEmbeddingModelResponseDto
+      | PermittedImageGenerationModelResponseDto
+    )[]
   > {
-    this.logger.log(
-      `Updating permitted model ${id} for org ${orgId} by super admin ${userId}`,
+    const models = await this.getPermittedModelsUseCase.execute(
+      new GetPermittedModelsQuery(orgId),
     );
-    const command = new UpdatePermittedModelCommand({
-      permittedModelId: id,
-      orgId,
-      anonymousOnly: dto.anonymousOnly,
-    });
-    const updatedModel =
-      await this.updatePermittedModelUseCase.execute(command);
-    if (updatedModel instanceof PermittedLanguageModel) {
-      return this.modelResponseDtoMapper.toLanguageModelDto(updatedModel);
+    this.logger.info(
+      { modelCount: models.length, orgId },
+      'Successfully retrieved permitted models for org',
+    );
+    return models.map((model) => this.modelResponseDtoMapper.toDto(model));
+  }
+
+  private async updateModel(
+    orgId: UUID,
+    id: UUID,
+    dto: UpdatePermittedModelDto,
+  ): Promise<PermittedModelResponseDto> {
+    const updated = await this.updatePermittedModelUseCase.execute(
+      new UpdatePermittedModelCommand({
+        permittedModelId: id,
+        orgId,
+        anonymousOnly: dto.anonymousOnly,
+      }),
+    );
+    if (updated instanceof PermittedLanguageModel) {
+      return this.modelResponseDtoMapper.toLanguageModelDto(updated);
     }
-    if (updatedModel instanceof PermittedEmbeddingModel) {
-      return this.modelResponseDtoMapper.toEmbeddingModelDto(updatedModel);
+    if (updated instanceof PermittedEmbeddingModel) {
+      return this.modelResponseDtoMapper.toEmbeddingModelDto(updated);
     }
-    if (updatedModel instanceof PermittedImageGenerationModel) {
-      return this.modelResponseDtoMapper.toImageGenerationModelDto(
-        updatedModel,
-      );
+    if (updated instanceof PermittedImageGenerationModel) {
+      return this.modelResponseDtoMapper.toImageGenerationModelDto(updated);
     }
-    throw new Error(`Unknown model type: ${updatedModel.constructor.name}`);
+    throw new Error(`Unknown model type: ${updated.constructor.name}`);
+  }
+
+  private logDelete(id: UUID, orgId: UUID, userId: UUID): void {
+    this.logger.info(
+      { permittedModelId: id, orgId, userId },
+      'Deleting permitted model for org by super admin',
+    );
+  }
+
+  private logUpdate(id: UUID, orgId: UUID, userId: UUID): void {
+    this.logger.info(
+      { permittedModelId: id, orgId, userId },
+      'Updating permitted model for org by super admin',
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/models/presenters/http/team-permitted-models.controller.ts
+++ b/ayunis-core-backend/src/domain/models/presenters/http/team-permitted-models.controller.ts
@@ -10,8 +10,8 @@ import {
   ParseUUIDPipe,
   HttpCode,
   HttpStatus,
-  Logger,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -56,9 +56,10 @@ import { ModelResponseDtoMapper } from './mappers/model-response-dto.mapper';
   PermittedImageGenerationModelResponseDto,
 )
 export class TeamPermittedModelsController {
-  private readonly logger = new Logger(TeamPermittedModelsController.name);
-
   constructor(
+    @InjectPinoLogger(TeamPermittedModelsController.name)
+    private readonly logger: PinoLogger,
+
     private readonly getTeamPermittedModelsUseCase: GetTeamPermittedModelsUseCase,
     private readonly getTeamPermittedImageGenerationModelsUseCase: GetTeamPermittedImageGenerationModelsUseCase,
     private readonly createTeamPermittedModelUseCase: CreateTeamPermittedModelUseCase,
@@ -85,7 +86,7 @@ export class TeamPermittedModelsController {
     @Param('teamId', ParseUUIDPipe) teamId: UUID,
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
   ): Promise<PermittedLanguageModelResponseDto[]> {
-    this.logger.log('listTeamPermittedModels', { teamId });
+    this.logger.info({ teamId }, 'listTeamPermittedModels');
     const query = new GetTeamPermittedModelsQuery(teamId, orgId);
     const models = await this.getTeamPermittedModelsUseCase.execute(query);
     return models.map((model) =>
@@ -113,7 +114,7 @@ export class TeamPermittedModelsController {
     @Param('teamId', ParseUUIDPipe) teamId: UUID,
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
   ): Promise<PermittedImageGenerationModelResponseDto[]> {
-    this.logger.log('listTeamImageGenerationModels', { teamId });
+    this.logger.info({ teamId }, 'listTeamImageGenerationModels');
     const query = new GetTeamPermittedImageGenerationModelsQuery(teamId, orgId);
     const models =
       await this.getTeamPermittedImageGenerationModelsUseCase.execute(query);
@@ -155,10 +156,13 @@ export class TeamPermittedModelsController {
   ): Promise<
     PermittedLanguageModelResponseDto | PermittedImageGenerationModelResponseDto
   > {
-    this.logger.log('createTeamPermittedModel', {
-      teamId,
-      modelId: dto.modelId,
-    });
+    this.logger.info(
+      {
+        teamId,
+        modelId: dto.modelId,
+      },
+      'createTeamPermittedModel',
+    );
     const command = new CreateTeamPermittedModelCommand(
       dto.modelId,
       orgId,
@@ -188,11 +192,14 @@ export class TeamPermittedModelsController {
     @Body() dto: UpdatePermittedModelDto,
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
   ): Promise<PermittedLanguageModelResponseDto> {
-    this.logger.log('updateTeamPermittedModel', {
-      teamId,
-      permittedModelId: id,
-      anonymousOnly: dto.anonymousOnly,
-    });
+    this.logger.info(
+      {
+        teamId,
+        permittedModelId: id,
+        anonymousOnly: dto.anonymousOnly,
+      },
+      'updateTeamPermittedModel',
+    );
     const command = new UpdateTeamPermittedModelCommand(
       id,
       orgId,
@@ -218,10 +225,13 @@ export class TeamPermittedModelsController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
   ): Promise<void> {
-    this.logger.log('deleteTeamPermittedModel', {
-      teamId,
-      permittedModelId: id,
-    });
+    this.logger.info(
+      {
+        teamId,
+        permittedModelId: id,
+      },
+      'deleteTeamPermittedModel',
+    );
     const command = new DeleteTeamPermittedModelCommand(id, orgId, teamId);
     await this.deleteTeamPermittedModelUseCase.execute(command);
   }
@@ -244,10 +254,13 @@ export class TeamPermittedModelsController {
     @Body() dto: SetTeamDefaultModelDto,
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
   ): Promise<PermittedLanguageModelResponseDto> {
-    this.logger.log('setTeamDefaultModel', {
-      teamId,
-      permittedModelId: dto.permittedModelId,
-    });
+    this.logger.info(
+      {
+        teamId,
+        permittedModelId: dto.permittedModelId,
+      },
+      'setTeamDefaultModel',
+    );
     const command = new SetTeamDefaultModelCommand(
       dto.permittedModelId,
       orgId,

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-error.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-error.mapper.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { OpenAIErrorMapper } from './openai-error.mapper';
 import { QuotaExceededError } from 'src/iam/quotas/application/quotas.errors';
 import { QuotaType } from 'src/iam/quotas/domain/quota-type.enum';
@@ -21,7 +22,7 @@ class UnexpectedOpenAIError extends ApplicationError {
 }
 
 describe('OpenAIErrorMapper', () => {
-  const mapper = new OpenAIErrorMapper();
+  const mapper = new OpenAIErrorMapper(createPinoLoggerMock());
 
   describe('429 → rate_limit_error (regression for AYC-92 / AYC-78 finding I5)', () => {
     it('maps QuotaExceededError (HTTP 429) to rate_limit_error', () => {

--- a/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-error.mapper.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/mappers/openai-error.mapper.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, HttpException } from '@nestjs/common';
+import { Injectable, HttpException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { mappedError } from './openai-error-helpers';
 import type { MappedOpenAIError } from './openai-error.types';
@@ -6,7 +7,10 @@ import { envelope } from './openai-error-helpers';
 
 @Injectable()
 export class OpenAIErrorMapper {
-  private readonly logger = new Logger(OpenAIErrorMapper.name);
+  constructor(
+    @InjectPinoLogger(OpenAIErrorMapper.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   /**
    * Convert any thrown value into an OpenAI error envelope. Domain errors
@@ -57,7 +61,7 @@ export class OpenAIErrorMapper {
     }
     // Log structurally — never include the raw error object, which can
     // echo prompt fragments from upstream SDKs (AYC-92 redaction sweep).
-    this.logger.error('Unhandled error in OpenAI-compat path', { status });
+    this.logger.error({ status }, 'Unhandled error in OpenAI-compat path');
     return {
       status: 500,
       body: envelope({

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { Observable, Subject } from 'rxjs';
 import { ExecuteOpenAIChatCompletionUseCase } from './execute-openai-chat-completion.use-case';
@@ -83,6 +84,7 @@ describe('ExecuteOpenAIChatCompletionUseCase', () => {
     } as unknown as jest.Mocked<InferenceUsageGuard>;
 
     useCase = new ExecuteOpenAIChatCompletionUseCase(
+      createPinoLoggerMock(),
       getPermittedLanguageModelsUseCase,
       getInferenceUseCase,
       streamInferenceUseCase,

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.use-case.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/execute-openai-chat-completion/execute-openai-chat-completion.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { randomUUID } from 'crypto';
 import { Observable, finalize, map } from 'rxjs';
 import { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
@@ -36,9 +37,10 @@ import type { ChatCompletionChunk } from '../../types/openai-chunk.types';
  */
 @Injectable()
 export class ExecuteOpenAIChatCompletionUseCase {
-  private readonly logger = new Logger(ExecuteOpenAIChatCompletionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ExecuteOpenAIChatCompletionUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly getPermittedLanguageModelsUseCase: GetPermittedLanguageModelsUseCase,
     private readonly getInferenceUseCase: GetInferenceUseCase,
     private readonly streamInferenceUseCase: StreamInferenceUseCase,
@@ -188,10 +190,13 @@ export class ExecuteOpenAIChatCompletionUseCase {
     );
     const match = permitted.find((pm) => pm.model.name === modelName);
     if (!match) {
-      this.logger.debug('OpenAI-compat model not found', {
-        orgId,
-        requestedModel: modelName,
-      });
+      this.logger.debug(
+        {
+          orgId,
+          requestedModel: modelName,
+        },
+        'OpenAI-compat model not found',
+      );
       throw new OpenAIModelNotFoundError(modelName);
     }
     return match.model;

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/get-openai-model/get-openai-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/get-openai-model/get-openai-model.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { GetOpenAIModelUseCase } from './get-openai-model.use-case';
 import { GetOpenAIModelQuery } from './get-openai-model.query';
@@ -25,7 +26,10 @@ describe('GetOpenAIModelUseCase', () => {
         .mockResolvedValue({ object: 'list', data: [modelObject] }),
     } as unknown as jest.Mocked<ListOpenAIModelsUseCase>;
 
-    useCase = new GetOpenAIModelUseCase(listOpenAIModelsUseCase);
+    useCase = new GetOpenAIModelUseCase(
+      createPinoLoggerMock(),
+      listOpenAIModelsUseCase,
+    );
   });
 
   it('returns the model object matching the requested name', async () => {

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/get-openai-model/get-openai-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/get-openai-model/get-openai-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import {
   OpenAIModelNotFoundError,
@@ -11,17 +12,21 @@ import { GetOpenAIModelQuery } from './get-openai-model.query';
 
 @Injectable()
 export class GetOpenAIModelUseCase {
-  private readonly logger = new Logger(GetOpenAIModelUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetOpenAIModelUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly listOpenAIModelsUseCase: ListOpenAIModelsUseCase,
   ) {}
 
   async execute(query: GetOpenAIModelQuery): Promise<OpenAIModelObject> {
-    this.logger.log('Getting OpenAI-compatible model', {
-      orgId: query.orgId,
-      modelName: query.modelName,
-    });
+    this.logger.info(
+      {
+        orgId: query.orgId,
+        modelName: query.modelName,
+      },
+      'Getting OpenAI-compatible model',
+    );
 
     try {
       const list = await this.listOpenAIModelsUseCase.execute(
@@ -34,9 +39,12 @@ export class GetOpenAIModelUseCase {
       return match;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting OpenAI-compatible model', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error getting OpenAI-compatible model',
+      );
       throw new OpenAIUnexpectedError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/list-openai-models/list-openai-models.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/list-openai-models/list-openai-models.use-case.spec.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { ListOpenAIModelsUseCase } from './list-openai-models.use-case';
 import { ListOpenAIModelsQuery } from './list-openai-models.query';
 import type { GetPermittedLanguageModelsUseCase } from 'src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.use-case';
@@ -12,6 +13,7 @@ import { OpenAIModelMapper } from '../../mappers/openai-model.mapper';
 describe('ListOpenAIModelsUseCase', () => {
   let useCase: ListOpenAIModelsUseCase;
   let getPermittedLanguageModelsUseCase: jest.Mocked<GetPermittedLanguageModelsUseCase>;
+  const logger = createPinoLoggerMock();
 
   const orgId = randomUUID();
 
@@ -34,11 +36,13 @@ describe('ListOpenAIModelsUseCase', () => {
     new PermittedLanguageModel({ model, orgId });
 
   beforeEach(() => {
+    logger.info.mockReset();
     getPermittedLanguageModelsUseCase = {
       execute: jest.fn().mockResolvedValue([]),
     } as unknown as jest.Mocked<GetPermittedLanguageModelsUseCase>;
 
     useCase = new ListOpenAIModelsUseCase(
+      logger,
       getPermittedLanguageModelsUseCase,
       new OpenAIModelMapper(),
     );
@@ -58,6 +62,10 @@ describe('ListOpenAIModelsUseCase', () => {
 
     const result = await useCase.execute(new ListOpenAIModelsQuery(orgId));
 
+    expect(logger.info).toHaveBeenCalledWith(
+      { orgId },
+      'Listing OpenAI-compatible models',
+    );
     expect(result.object).toBe('list');
     expect(result.data).toHaveLength(2);
     expect(result.data[0]).toEqual({

--- a/ayunis-core-backend/src/domain/openai-compat/application/use-cases/list-openai-models/list-openai-models.use-case.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/application/use-cases/list-openai-models/list-openai-models.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { GetPermittedLanguageModelsUseCase } from 'src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.use-case';
 import { GetPermittedLanguageModelsQuery } from 'src/domain/models/application/use-cases/get-permitted-language-models/get-permitted-language-models.query';
@@ -10,9 +11,10 @@ import { ListOpenAIModelsQuery } from './list-openai-models.query';
 
 @Injectable()
 export class ListOpenAIModelsUseCase {
-  private readonly logger = new Logger(ListOpenAIModelsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ListOpenAIModelsUseCase.name)
+    private readonly logger: PinoLogger,
+
     private readonly getPermittedLanguageModelsUseCase: GetPermittedLanguageModelsUseCase,
     private readonly modelMapper: OpenAIModelMapper,
   ) {}
@@ -20,7 +22,10 @@ export class ListOpenAIModelsUseCase {
   async execute(
     query: ListOpenAIModelsQuery,
   ): Promise<OpenAIModelListResponse> {
-    this.logger.log('Listing OpenAI-compatible models', { orgId: query.orgId });
+    this.logger.info(
+      { orgId: query.orgId },
+      'Listing OpenAI-compatible models',
+    );
 
     try {
       const permitted = await this.getPermittedLanguageModelsUseCase.execute(
@@ -40,9 +45,12 @@ export class ListOpenAIModelsUseCase {
       return this.modelMapper.toListResponse([...byName.values()]);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error listing OpenAI-compatible models', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error listing OpenAI-compatible models',
+      );
       throw new OpenAIUnexpectedError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/openai-compat/presenters/http/chat-completions.controller.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/presenters/http/chat-completions.controller.ts
@@ -1,13 +1,13 @@
 import {
   Body,
   Controller,
-  Logger,
   Post,
   Req,
   Res,
   UseFilters,
   UseGuards,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { AuthGuard } from '@nestjs/passport';
 import type { Response } from 'express';
 import type { Subscription } from 'rxjs';
@@ -56,9 +56,10 @@ import { OpenAIExceptionFilter } from './filters/openai-exception.filter';
 @UseFilters(OpenAIExceptionFilter)
 @RateLimit({ limit: 60, windowMs: 60_000 })
 export class ChatCompletionsController {
-  private readonly logger = new Logger(ChatCompletionsController.name);
-
   constructor(
+    @InjectPinoLogger(ChatCompletionsController.name)
+    private readonly logger: PinoLogger,
+
     private readonly useCase: ExecuteOpenAIChatCompletionUseCase,
     private readonly contextService: ContextService,
     private readonly incrementTrialMessagesUseCase: IncrementTrialMessagesUseCase,
@@ -112,10 +113,13 @@ export class ChatCompletionsController {
     void this.incrementTrialMessagesUseCase
       .execute(new IncrementTrialMessagesCommand(orgId))
       .catch((error: unknown) => {
-        this.logger.warn('Failed to increment trial messages', {
-          orgId,
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
+        this.logger.warn(
+          {
+            orgId,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          },
+          'Failed to increment trial messages',
+        );
       });
   }
 

--- a/ayunis-core-backend/src/domain/openai-compat/presenters/http/filters/openai-exception.filter.ts
+++ b/ayunis-core-backend/src/domain/openai-compat/presenters/http/filters/openai-exception.filter.ts
@@ -1,4 +1,5 @@
-import { ArgumentsHost, Catch, Logger } from '@nestjs/common';
+import { ArgumentsHost, Catch } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { BaseExceptionFilter } from '@nestjs/core';
 import type { Request, Response } from 'express';
 import { OpenAIErrorMapper } from 'src/domain/openai-compat/application/mappers/openai-error.mapper';
@@ -29,9 +30,10 @@ import { reportUnexpectedError } from 'src/common/errors/report-unexpected-error
  */
 @Catch()
 export class OpenAIExceptionFilter extends BaseExceptionFilter {
-  private readonly openaiCompatLogger = new Logger(OpenAIExceptionFilter.name);
-
   constructor(
+    @InjectPinoLogger(OpenAIExceptionFilter.name)
+    private readonly openaiCompatLogger: PinoLogger,
+
     private readonly errorMapper: OpenAIErrorMapper,
     private readonly applicationErrorFilter: ApplicationErrorFilter,
   ) {
@@ -64,11 +66,14 @@ export class OpenAIExceptionFilter extends BaseExceptionFilter {
         response.write('data: [DONE]\n\n');
         response.end();
       } catch (writeError) {
-        this.openaiCompatLogger.warn('Failed to emit final SSE error frame', {
-          status: mapped.status,
-          writeError:
-            writeError instanceof Error ? writeError.message : 'Unknown',
-        });
+        this.openaiCompatLogger.warn(
+          {
+            status: mapped.status,
+            writeError:
+              writeError instanceof Error ? writeError.message : 'Unknown',
+          },
+          'Failed to emit final SSE error frame',
+        );
       }
       return;
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only change with no business-logic alterations; constructor signature changes require correct DI in modules (already covered by updated unit tests).
> 
> **Overview**
> **Migrates the models domain** from `@nestjs/common` `Logger` to **nestjs-pino** `PinoLogger` across registries, `ModelPolicyService`, and the full set of application use cases (CRUD, permitted/team defaults, inference, image generation).
> 
> Injected loggers use `@InjectPinoLogger(ClassName.name)`; calls move to Pino’s **`(object, message)`** shape (`info`/`debug`/`warn`/`error`, with **`err`** for errors instead of `error`). Tests swap `Logger.prototype` spies for **`createPinoLoggerMock()`** and **`getLoggerToken(...)`** in Nest testing modules; manual `new UseCase(...)` specs pass the mock as the first constructor arg where needed.
> 
> **Small refactors** alongside logging: `DeleteUserDefaultModelUseCase` and set-org/set-user default use cases extract private helpers; `DeletePermittedModelUseCase` adds `logLanguageModelCleanup`; `UpdatePermittedModelUseCase` simplifies update flow; `MapMessagesToInferenceUseCase` can fall back to a standalone Pino logger via `createPinoLoggerConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa687904069a7b7b3c06781bcb4b6cdb4b5cb83a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->