### PR TITLE
chore(api): sync Phase 5 SSO contract (AYC-642)

### DIFF
--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -5203,6 +5203,30 @@ export interface SsoDiscoveryResponseDto {
   orgId?: string;
 }
 
+export interface SsoAuthorizationResponseDto {
+  authorizationUrl: string;
+}
+
+/**
+ * Broker logout URL for the user agent, or null for Core-only logout
+ * @nullable
+ */
+export type SsoLogoutResponseDtoBrokerLogoutUrl = { [key: string]: unknown } | null;
+
+export interface SsoLogoutResponseDto {
+  success: boolean;
+  /**
+   * Broker logout URL for the user agent, or null for Core-only logout
+   * @nullable
+   */
+  brokerLogoutUrl: SsoLogoutResponseDtoBrokerLogoutUrl;
+}
+
+export interface SsoBackchannelLogoutRequestDto {
+  /** Signed OpenID Connect logout token */
+  logout_token: string;
+}
+
 export type UserControllerGetUsersInOrganizationParams = {
 /**
  * Search users by name or email

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -183,7 +183,10 @@ import type {
   SkillSourceResponseDto,
   SkillSourcesControllerAddFileSourceBody,
   SkillTemplateResponseDto,
+  SsoAuthorizationResponseDto,
+  SsoBackchannelLogoutRequestDto,
   SsoDiscoveryResponseDto,
+  SsoLogoutResponseDto,
   SubmitQuizRequestDto,
   SubscriptionResponseDto,
   SubscriptionResponseDtoNullable,
@@ -21071,7 +21074,7 @@ export const useAuthenticationControllerLogout = <TError = unknown,
     }
     
 /**
- * Requires the MFA pending cookie set by a successful password login.
+ * Requires the MFA pending cookie set by successful authentication.
  * @summary Complete login with a TOTP or recovery code
  */
 export const mfaLoginControllerVerify = (
@@ -23226,7 +23229,70 @@ export function useSsoLoginControllerStart<TData = Awaited<ReturnType<typeof sso
 
 
 /**
- * @summary Validate an organization-pinned OIDC callback
+ * @summary Start linking SSO to the current account
+ */
+export const ssoLoginControllerStartLink = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<SsoAuthorizationResponseDto>(
+      {url: `/auth/sso/link/start`, method: 'POST', signal
+    },
+      );
+    }
+  
+
+
+export const getSsoLoginControllerStartLinkMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof ssoLoginControllerStartLink>>, TError,void, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof ssoLoginControllerStartLink>>, TError,void, TContext> => {
+
+const mutationKey = ['ssoLoginControllerStartLink'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof ssoLoginControllerStartLink>>, void> = () => {
+          
+
+          return  ssoLoginControllerStartLink()
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SsoLoginControllerStartLinkMutationResult = NonNullable<Awaited<ReturnType<typeof ssoLoginControllerStartLink>>>
+    
+    export type SsoLoginControllerStartLinkMutationError = unknown
+
+    /**
+ * @summary Start linking SSO to the current account
+ */
+export const useSsoLoginControllerStartLink = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof ssoLoginControllerStartLink>>, TError,void, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof ssoLoginControllerStartLink>>,
+        TError,
+        void,
+        TContext
+      > => {
+
+      const mutationOptions = getSsoLoginControllerStartLinkMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Complete an organization-pinned SSO login
  */
 export const ssoLoginControllerCallback = (
     
@@ -23297,7 +23363,7 @@ export function useSsoLoginControllerCallback<TData = Awaited<ReturnType<typeof 
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
- * @summary Validate an organization-pinned OIDC callback
+ * @summary Complete an organization-pinned SSO login
  */
 
 export function useSsoLoginControllerCallback<TData = Awaited<ReturnType<typeof ssoLoginControllerCallback>>, TError = unknown>(
@@ -23318,3 +23384,133 @@ export function useSsoLoginControllerCallback<TData = Awaited<ReturnType<typeof 
 
 
 
+/**
+ * @summary Revoke the Core session and prepare broker logout
+ */
+export const ssoLoginControllerLogout = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<SsoLogoutResponseDto>(
+      {url: `/auth/sso/session/logout`, method: 'POST', signal
+    },
+      );
+    }
+  
+
+
+export const getSsoLoginControllerLogoutMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof ssoLoginControllerLogout>>, TError,void, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof ssoLoginControllerLogout>>, TError,void, TContext> => {
+
+const mutationKey = ['ssoLoginControllerLogout'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof ssoLoginControllerLogout>>, void> = () => {
+          
+
+          return  ssoLoginControllerLogout()
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SsoLoginControllerLogoutMutationResult = NonNullable<Awaited<ReturnType<typeof ssoLoginControllerLogout>>>
+    
+    export type SsoLoginControllerLogoutMutationError = unknown
+
+    /**
+ * @summary Revoke the Core session and prepare broker logout
+ */
+export const useSsoLoginControllerLogout = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof ssoLoginControllerLogout>>, TError,void, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof ssoLoginControllerLogout>>,
+        TError,
+        void,
+        TContext
+      > => {
+
+      const mutationOptions = getSsoLoginControllerLogoutMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Process a signed broker back-channel logout
+ */
+export const ssoLoginControllerBackchannelLogout = (
+    ssoBackchannelLogoutRequestDto: SsoBackchannelLogoutRequestDto,
+ signal?: AbortSignal
+) => {
+      
+      const formUrlEncoded = new URLSearchParams();
+formUrlEncoded.append(`logout_token`, ssoBackchannelLogoutRequestDto.logout_token)
+
+      return customAxiosInstance<void>(
+      {url: `/auth/sso/oidc/backchannel-logout`, method: 'POST',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded', },
+       data: formUrlEncoded, signal
+    },
+      );
+    }
+  
+
+
+export const getSsoLoginControllerBackchannelLogoutMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof ssoLoginControllerBackchannelLogout>>, TError,{data: SsoBackchannelLogoutRequestDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof ssoLoginControllerBackchannelLogout>>, TError,{data: SsoBackchannelLogoutRequestDto}, TContext> => {
+
+const mutationKey = ['ssoLoginControllerBackchannelLogout'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof ssoLoginControllerBackchannelLogout>>, {data: SsoBackchannelLogoutRequestDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  ssoLoginControllerBackchannelLogout(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type SsoLoginControllerBackchannelLogoutMutationResult = NonNullable<Awaited<ReturnType<typeof ssoLoginControllerBackchannelLogout>>>
+    export type SsoLoginControllerBackchannelLogoutMutationBody = SsoBackchannelLogoutRequestDto
+    export type SsoLoginControllerBackchannelLogoutMutationError = unknown
+
+    /**
+ * @summary Process a signed broker back-channel logout
+ */
+export const useSsoLoginControllerBackchannelLogout = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof ssoLoginControllerBackchannelLogout>>, TError,{data: SsoBackchannelLogoutRequestDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof ssoLoginControllerBackchannelLogout>>,
+        TError,
+        {data: SsoBackchannelLogoutRequestDto},
+        TContext
+      > => {
+
+      const mutationOptions = getSsoLoginControllerBackchannelLogoutMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -10112,7 +10112,7 @@
     },
     "/auth/mfa/verify": {
       "post": {
-        "description": "Requires the MFA pending cookie set by a successful password login.",
+        "description": "Requires the MFA pending cookie set by successful authentication.",
         "operationId": "MfaLoginController_verify",
         "parameters": [],
         "requestBody": {
@@ -10958,16 +10958,79 @@
         "tags": ["SSO"]
       }
     },
+    "/auth/sso/link/start": {
+      "post": {
+        "operationId": "SsoLoginController_startLink",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SsoAuthorizationResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Start linking SSO to the current account",
+        "tags": ["SSO"]
+      }
+    },
     "/auth/sso/oidc/callback": {
       "get": {
         "operationId": "SsoLoginController_callback",
         "parameters": [],
         "responses": {
           "204": {
-            "description": "OIDC response validated"
+            "description": "Core session or MFA-pending cookie issued"
           }
         },
-        "summary": "Validate an organization-pinned OIDC callback",
+        "summary": "Complete an organization-pinned SSO login",
+        "tags": ["SSO"]
+      }
+    },
+    "/auth/sso/session/logout": {
+      "post": {
+        "operationId": "SsoLoginController_logout",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SsoLogoutResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Revoke the Core session and prepare broker logout",
+        "tags": ["SSO"]
+      }
+    },
+    "/auth/sso/oidc/backchannel-logout": {
+      "post": {
+        "operationId": "SsoLoginController_backchannelLogout",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/SsoBackchannelLogoutRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Matching Core SSO sessions revoked"
+          }
+        },
+        "summary": "Process a signed broker back-channel logout",
         "tags": ["SSO"]
       }
     }
@@ -19223,6 +19286,41 @@
           }
         },
         "required": ["available"]
+      },
+      "SsoAuthorizationResponseDto": {
+        "type": "object",
+        "properties": {
+          "authorizationUrl": {
+            "type": "string",
+            "example": "https://sso.ayunis.de/oauth/v2/authorize?client_id=core"
+          }
+        },
+        "required": ["authorizationUrl"]
+      },
+      "SsoLogoutResponseDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "brokerLogoutUrl": {
+            "type": "object",
+            "nullable": true,
+            "description": "Broker logout URL for the user agent, or null for Core-only logout"
+          }
+        },
+        "required": ["success", "brokerLogoutUrl"]
+      },
+      "SsoBackchannelLogoutRequestDto": {
+        "type": "object",
+        "properties": {
+          "logout_token": {
+            "type": "string",
+            "description": "Signed OpenID Connect logout token"
+          }
+        },
+        "required": ["logout_token"]
       }
     }
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Generated-only changes with no runtime behavior in this diff; risk is limited to future callers wiring auth/logout flows against the new contract.
> 
> **Overview**
> **Syncs the generated API client** with the backend **Phase 5 SSO** contract (OpenAPI schema + Orval output). No feature UI in this PR—only types and HTTP helpers.
> 
> **New SSO surface for the frontend to call:** `POST /auth/sso/link/start` returns an `authorizationUrl` for **linking SSO to the logged-in account** (`useSsoLoginControllerStartLink`). `POST /auth/sso/session/logout` **revokes the Core session** and may return a **broker logout URL** (`SsoLogoutResponseDto`). `POST /auth/sso/oidc/backchannel-logout` accepts a signed **`logout_token`** for broker-initiated logout (generated client + hook; typically server-side).
> 
> **Contract clarifications:** MFA verify is documented as requiring the pending cookie after **any successful authentication** (not only password). The OIDC callback operation is labeled **complete org-pinned SSO login**, with a 204 description that a **Core session or MFA-pending cookie** is issued.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5c0216ef9f2345692b863c3eb61efbe3067648a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Phase 5 QA

Environment: isolated Core slot 5 against the local ZITADEL broker (`v4.16.2`).

- ✅ Authorization request used the exact Core callback and `max_age=86400`.
- ✅ First broker login JIT-provisioned one passwordless Core user and one `(issuer, subject)` identity.
- ✅ Repeat broker login reused that identity; it did not create another user.
- ✅ `/auth/me` returned `200` with the expected email and Core organization.
- ✅ SSO refresh rows persisted `authenticationMethod=sso`, a ZITADEL `sid`, and a 24-hour absolute lifetime.
- ✅ SSO logout returned the broker end-session URL, revoked the current Core family, and `/auth/me` returned `403` afterward.
- ✅ Existing local password login returned `200` and persisted `authenticationMethod=password`.
- ✅ 48 focused suites / 246 tests, backend build, dependency check, and lint passed.

Back-channel delivery cannot be triggered by the local broker because its configured URI is an HTTPS fixture; signed-token validation and sid/subject revocation are covered by the focused automated suites. Phase 6 owns the final employee-facing UI and redirects; this stack adds no feature UI.

![ZITADEL login](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-642/docs/pr-media/ayc-642/01-zitadel-login.png)

![Authenticated Core user](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-642/docs/pr-media/ayc-642/02-core-authenticated-user.png)

![Core session rejected after logout](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-642/docs/pr-media/ayc-642/03-after-logout.png)

![Phase 5 QA demo](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-642/docs/pr-media/ayc-642/demo.gif)

> Media is hosted on `pr-media/ayc-642` and is not part of this PR's diff.
