### PR TITLE
wip(logging): migrate runs, messages, and usage to pino (AYC-747)

### DIFF
--- a/ayunis-core-backend/src/domain/messages/application/use-cases/cleanup-orphaned-images/cleanup-orphaned-images.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/cleanup-orphaned-images/cleanup-orphaned-images.use-case.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { ObjectStoragePort } from 'src/domain/storage/application/ports/object-storage.port';
 import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
@@ -16,17 +17,17 @@ import {
  */
 @Injectable()
 export class CleanupOrphanedImagesUseCase {
-  private readonly logger = new Logger(CleanupOrphanedImagesUseCase.name);
-
   constructor(
     private readonly objectStoragePort: ObjectStoragePort,
     private readonly deleteObjectUseCase: DeleteObjectUseCase,
     @Inject(MESSAGES_REPOSITORY)
     private readonly messagesRepository: MessagesRepository,
+    @InjectPinoLogger(CleanupOrphanedImagesUseCase.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async execute(): Promise<CleanupResult> {
-    this.logger.log('Starting orphaned images cleanup');
+    this.logger.info('Starting orphaned images cleanup');
 
     const result: CleanupResult = {
       scannedCount: 0,
@@ -41,80 +42,95 @@ export class CleanupOrphanedImagesUseCase {
       const allObjects = await this.objectStoragePort.listObjects();
       result.scannedCount = allObjects.length;
 
-      this.logger.log(`Scanning ${allObjects.length} objects for orphans`);
-
-      // Group objects by messageId to batch check existence
-      const messageIdToObjects = this.groupObjectsByMessageId(allObjects);
-      const uniqueMessageIds = Array.from(messageIdToObjects.keys());
-
-      this.logger.debug(
-        `Found ${uniqueMessageIds.length} unique message IDs to check`,
+      this.logger.info(
+        { objectCount: allObjects.length },
+        'Scanning objects for orphans',
       );
 
-      // Check each message existence and collect orphaned paths
-      const orphanedPaths: string[] = [];
-
-      for (const messageId of uniqueMessageIds) {
-        try {
-          const message = await this.messagesRepository.findById(
-            messageId as UUID,
-          );
-
-          if (!message) {
-            // Message doesn't exist, all its images are orphaned
-            const paths = messageIdToObjects.get(messageId) || [];
-            orphanedPaths.push(...paths);
-            this.logger.debug(
-              `Message ${messageId} not found, marking ${paths.length} images as orphaned`,
-            );
-          }
-        } catch (error) {
-          this.logger.warn(`Failed to check message ${messageId}`, {
-            error: error instanceof Error ? error.message : 'Unknown error',
-          });
-        }
-      }
-
-      this.logger.log(
-        `Found ${orphanedPaths.length} orphaned images to delete`,
+      const orphanedPaths = await this.findOrphanedPaths(allObjects);
+      this.logger.info(
+        { imageCount: orphanedPaths.length },
+        'Found orphaned images to delete',
       );
+      await this.deleteOrphanedPaths(orphanedPaths, result);
 
-      // Delete orphaned images
-      for (const path of orphanedPaths) {
-        try {
-          await this.deleteObjectUseCase.execute(new DeleteObjectCommand(path));
-          result.deletedCount++;
-          result.deletedPaths.push(path);
-          this.logger.debug(`Deleted orphaned image: ${path}`);
-        } catch (error) {
-          // If object doesn't exist, it's already cleaned up - don't count as failure
-          if (error instanceof ObjectNotFoundError) {
-            this.logger.debug(`Orphaned image already deleted: ${path}`);
-            continue;
-          }
-
-          result.failedCount++;
-          const errorMessage =
-            error instanceof Error ? error.message : 'Unknown error';
-          result.errors.push({ path, error: errorMessage });
-          this.logger.warn(`Failed to delete orphaned image: ${path}`, {
-            error: errorMessage,
-          });
-        }
-      }
-
-      this.logger.log('Orphaned images cleanup completed', {
-        scanned: result.scannedCount,
-        deleted: result.deletedCount,
-        failed: result.failedCount,
-      });
+      this.logger.info(
+        {
+          scanned: result.scannedCount,
+          deleted: result.deletedCount,
+          failed: result.failedCount,
+        },
+        'Orphaned images cleanup completed',
+      );
 
       return result;
     } catch (error) {
-      this.logger.error('Orphaned images cleanup failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Orphaned images cleanup failed',
+      );
       throw error;
+    }
+  }
+
+  private async findOrphanedPaths(allObjects: string[]): Promise<string[]> {
+    const objectsByMessageId = this.groupObjectsByMessageId(allObjects);
+    this.logger.debug(
+      { messageCount: objectsByMessageId.size },
+      'Found unique message IDs to check',
+    );
+    const orphanedPaths: string[] = [];
+    for (const [messageId, paths] of objectsByMessageId) {
+      try {
+        const message = await this.messagesRepository.findById(
+          messageId as UUID,
+        );
+        if (!message) {
+          orphanedPaths.push(...paths);
+          this.logger.debug(
+            { messageId, imageCount: paths.length },
+            'Message not found, marking images as orphaned',
+          );
+        }
+      } catch (error) {
+        this.logger.warn(
+          {
+            messageId,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          },
+          'Failed to check message',
+        );
+      }
+    }
+    return orphanedPaths;
+  }
+
+  private async deleteOrphanedPaths(
+    paths: string[],
+    result: CleanupResult,
+  ): Promise<void> {
+    for (const path of paths) {
+      try {
+        await this.deleteObjectUseCase.execute(new DeleteObjectCommand(path));
+        result.deletedCount++;
+        result.deletedPaths.push(path);
+        this.logger.debug({ path }, 'Deleted orphaned image');
+      } catch (error) {
+        if (error instanceof ObjectNotFoundError) {
+          this.logger.debug({ path }, 'Orphaned image already deleted');
+          continue;
+        }
+        result.failedCount++;
+        const errorMessage =
+          error instanceof Error ? error.message : 'Unknown error';
+        result.errors.push({ path, error: errorMessage });
+        this.logger.warn(
+          { path, error: errorMessage },
+          'Failed to delete orphaned image',
+        );
+      }
     }
   }
 
@@ -130,7 +146,7 @@ export class CleanupOrphanedImagesUseCase {
     for (const path of objectPaths) {
       const messageId = this.extractMessageIdFromPath(path);
       if (messageId) {
-        const existing = map.get(messageId) || [];
+        const existing = map.get(messageId) ?? [];
         existing.push(path);
         map.set(messageId, existing);
       }
@@ -150,7 +166,10 @@ export class CleanupOrphanedImagesUseCase {
     const parts = path.split('/');
     // Expected: [orgId, threadId, messageId, filename]
     if (parts.length !== 4) {
-      this.logger.debug(`Skipping path with unexpected segment count: ${path}`);
+      this.logger.debug(
+        { path },
+        'Skipping path with unexpected segment count',
+      );
       return null; // Not a valid image path format
     }
 
@@ -164,14 +183,14 @@ export class CleanupOrphanedImagesUseCase {
       !uuidRegex.test(threadId) ||
       !uuidRegex.test(messageId)
     ) {
-      this.logger.debug(`Skipping path with invalid UUID format: ${path}`);
+      this.logger.debug({ path }, 'Skipping path with invalid UUID format');
       return null; // Not a valid image path - skip
     }
 
     // Validate filename matches image pattern: <index>.<ext>
     const imageFilePattern = /^\d+\.(jpg|jpeg|png|gif|webp)$/i;
     if (!imageFilePattern.test(filename)) {
-      this.logger.debug(`Skipping path with non-image filename: ${path}`);
+      this.logger.debug({ path }, 'Skipping path with non-image filename');
       return null; // Not a valid image filename - skip
     }
 

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/count-messages-tokens/count-messages-tokens.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/count-messages-tokens/count-messages-tokens.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { CountTokensUseCase } from 'src/common/token-counter/application/use-cases/count-tokens/count-tokens.use-case';
 import { CountTokensCommand } from 'src/common/token-counter/application/use-cases/count-tokens/count-tokens.command';
 import { CountMessagesTokensCommand } from './count-messages-tokens.command';
@@ -6,12 +7,14 @@ import { extractTextFromContent } from '../../utils/message-text-extractor.util'
 
 @Injectable()
 export class CountMessagesTokensUseCase {
-  private readonly logger = new Logger(CountMessagesTokensUseCase.name);
-
-  constructor(private readonly countTokensUseCase: CountTokensUseCase) {}
+  constructor(
+    private readonly countTokensUseCase: CountTokensUseCase,
+    @InjectPinoLogger(CountMessagesTokensUseCase.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   execute(command: CountMessagesTokensCommand): number {
-    this.logger.log('execute', { messageCount: command.messages.length });
+    this.logger.info({ messageCount: command.messages.length }, 'execute');
 
     const allText = command.messages
       .flatMap((message) => message.content)

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-assistant-message/create-assistant-message.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-assistant-message/create-assistant-message.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { CreateAssistantMessageUseCase } from './create-assistant-message.use-case';
@@ -38,6 +40,10 @@ describe('CreateAssistantMessageUseCase', () => {
         { provide: MESSAGES_REPOSITORY, useValue: mockMessagesRepository },
         { provide: ContextService, useValue: mockContextService },
         { provide: EventEmitter2, useValue: mockEventEmitter },
+        {
+          provide: getLoggerToken(CreateAssistantMessageUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
@@ -260,15 +266,18 @@ describe('CreateAssistantMessageUseCase', () => {
         .spyOn(mockMessagesRepository, 'create')
         .mockResolvedValue(expectedMessage);
 
-      const loggerSpy = jest.spyOn(useCase['logger'], 'log');
+      const loggerSpy = jest.spyOn(useCase['logger'], 'info');
 
       // Act
       await useCase.execute(command);
 
       // Assert
-      expect(loggerSpy).toHaveBeenCalledWith('Creating assistant message', {
-        threadId,
-      });
+      expect(loggerSpy).toHaveBeenCalledWith(
+        {
+          threadId,
+        },
+        'Creating assistant message',
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-assistant-message/create-assistant-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-assistant-message/create-assistant-message.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, Inject } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CreateAssistantMessageCommand } from './create-assistant-message.command';
 import { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
@@ -14,21 +15,22 @@ import type { UUID } from 'crypto';
 
 @Injectable()
 export class CreateAssistantMessageUseCase {
-  private readonly logger = new Logger(CreateAssistantMessageUseCase.name);
-
   constructor(
     @Inject(MESSAGES_REPOSITORY)
     private readonly messagesRepository: MessagesRepository,
     private readonly contextService: ContextService,
     private readonly eventEmitter: EventEmitter2,
+    @InjectPinoLogger(CreateAssistantMessageUseCase.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async execute(
     command: CreateAssistantMessageCommand,
   ): Promise<AssistantMessage> {
-    this.logger.log('Creating assistant message', {
-      threadId: command.threadId,
-    });
+    this.logger.info(
+      { threadId: command.threadId },
+      'Creating assistant message',
+    );
 
     const assistantMessage = new AssistantMessage({
       threadId: command.threadId,
@@ -40,31 +42,16 @@ export class CreateAssistantMessageUseCase {
         assistantMessage,
       )) as AssistantMessage;
 
-      const userId = this.contextService.get('userId');
-      const orgId = this.contextService.get('orgId');
-      this.eventEmitter
-        .emitAsync(
-          AssistantMessageCreatedEvent.EVENT_NAME,
-          new AssistantMessageCreatedEvent(
-            userId ?? ('unknown' as UUID),
-            orgId ?? ('unknown' as UUID),
-            command.threadId,
-            saved.id,
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit AssistantMessageCreatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            messageId: saved.id,
-          });
-        });
-
+      this.emitMessageCreated(command.threadId, saved.id);
       return saved;
     } catch (error) {
-      this.logger.error('Failed to create assistant message', {
-        threadId: command.threadId,
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          threadId: command.threadId,
+          err: error as Error,
+        },
+        'Failed to create assistant message',
+      );
       throw error instanceof Error
         ? new MessageCreationError(MessageRole.ASSISTANT.toLowerCase(), error)
         : new MessageCreationError(
@@ -72,5 +59,29 @@ export class CreateAssistantMessageUseCase {
             new Error('Unknown error'),
           );
     }
+  }
+
+  private emitMessageCreated(threadId: UUID, messageId: UUID): void {
+    const userId = this.contextService.get('userId');
+    const orgId = this.contextService.get('orgId');
+    this.eventEmitter
+      .emitAsync(
+        AssistantMessageCreatedEvent.EVENT_NAME,
+        new AssistantMessageCreatedEvent(
+          userId ?? ('unknown' as UUID),
+          orgId ?? ('unknown' as UUID),
+          threadId,
+          messageId,
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error(
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            messageId,
+          },
+          'Failed to emit AssistantMessageCreatedEvent',
+        );
+      });
   }
 }

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-system-message/create-system-message.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-system-message/create-system-message.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { CreateSystemMessageUseCase } from './create-system-message.use-case';
@@ -22,6 +24,10 @@ describe('CreateSystemMessageUseCase', () => {
       providers: [
         CreateSystemMessageUseCase,
         { provide: MESSAGES_REPOSITORY, useValue: mockMessagesRepository },
+        {
+          provide: getLoggerToken(CreateSystemMessageUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
@@ -166,15 +172,18 @@ describe('CreateSystemMessageUseCase', () => {
         .spyOn(mockMessagesRepository, 'create')
         .mockResolvedValue(expectedMessage);
 
-      const loggerSpy = jest.spyOn(useCase['logger'], 'log');
+      const loggerSpy = jest.spyOn(useCase['logger'], 'info');
 
       // Act
       await useCase.execute(command);
 
       // Assert
-      expect(loggerSpy).toHaveBeenCalledWith('Creating system message', {
-        threadId,
-      });
+      expect(loggerSpy).toHaveBeenCalledWith(
+        {
+          threadId,
+        },
+        'Creating system message',
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-system-message/create-system-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-system-message/create-system-message.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, Inject } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { CreateSystemMessageCommand } from './create-system-message.command';
 import { SystemMessage } from 'src/domain/messages/domain/messages/system-message.entity';
 import {
@@ -10,15 +11,15 @@ import { MessageCreationError } from '../../messages.errors';
 
 @Injectable()
 export class CreateSystemMessageUseCase {
-  private readonly logger = new Logger(CreateSystemMessageUseCase.name);
-
   constructor(
     @Inject(MESSAGES_REPOSITORY)
     private readonly messagesRepository: MessagesRepository,
+    @InjectPinoLogger(CreateSystemMessageUseCase.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async execute(command: CreateSystemMessageCommand): Promise<SystemMessage> {
-    this.logger.log('Creating system message', { threadId: command.threadId });
+    this.logger.info({ threadId: command.threadId }, 'Creating system message');
 
     const systemMessage = new SystemMessage({
       threadId: command.threadId,
@@ -30,10 +31,13 @@ export class CreateSystemMessageUseCase {
         systemMessage,
       )) as SystemMessage;
     } catch (error) {
-      this.logger.error('Failed to create system message', {
-        threadId: command.threadId,
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          threadId: command.threadId,
+          err: error as Error,
+        },
+        'Failed to create system message',
+      );
       throw error instanceof Error
         ? new MessageCreationError(MessageRole.SYSTEM.toLowerCase(), error)
         : new MessageCreationError(

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-tool-result-message/create-tool-result-message.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-tool-result-message/create-tool-result-message.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { CreateToolResultMessageUseCase } from './create-tool-result-message.use-case';
@@ -22,6 +24,10 @@ describe('CreateToolResultMessageUseCase', () => {
       providers: [
         CreateToolResultMessageUseCase,
         { provide: MESSAGES_REPOSITORY, useValue: mockMessagesRepository },
+        {
+          provide: getLoggerToken(CreateToolResultMessageUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
@@ -227,15 +233,18 @@ describe('CreateToolResultMessageUseCase', () => {
         .spyOn(mockMessagesRepository, 'create')
         .mockResolvedValue(expectedMessage);
 
-      const loggerSpy = jest.spyOn(useCase['logger'], 'log');
+      const loggerSpy = jest.spyOn(useCase['logger'], 'info');
 
       // Act
       await useCase.execute(command);
 
       // Assert
-      expect(loggerSpy).toHaveBeenCalledWith('Creating tool result message', {
-        threadId,
-      });
+      expect(loggerSpy).toHaveBeenCalledWith(
+        {
+          threadId,
+        },
+        'Creating tool result message',
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-tool-result-message/create-tool-result-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-tool-result-message/create-tool-result-message.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, Inject } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { CreateToolResultMessageCommand } from './create-tool-result-message.command';
 import { ToolResultMessage } from 'src/domain/messages/domain/messages/tool-result-message.entity';
 import {
@@ -10,19 +11,22 @@ import { MessageCreationError } from '../../messages.errors';
 
 @Injectable()
 export class CreateToolResultMessageUseCase {
-  private readonly logger = new Logger(CreateToolResultMessageUseCase.name);
-
   constructor(
     @Inject(MESSAGES_REPOSITORY)
     private readonly messagesRepository: MessagesRepository,
+    @InjectPinoLogger(CreateToolResultMessageUseCase.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async execute(
     command: CreateToolResultMessageCommand,
   ): Promise<ToolResultMessage> {
-    this.logger.log('Creating tool result message', {
-      threadId: command.threadId,
-    });
+    this.logger.info(
+      {
+        threadId: command.threadId,
+      },
+      'Creating tool result message',
+    );
 
     const toolResultMessage = new ToolResultMessage({
       id: command.id,
@@ -35,10 +39,13 @@ export class CreateToolResultMessageUseCase {
         toolResultMessage,
       )) as ToolResultMessage;
     } catch (error) {
-      this.logger.error('Failed to create tool result message', {
-        threadId: command.threadId,
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          threadId: command.threadId,
+          err: error as Error,
+        },
+        'Failed to create tool result message',
+      );
       throw error instanceof Error
         ? new MessageCreationError(MessageRole.TOOL.toLowerCase(), error)
         : new MessageCreationError(

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { CreateUserMessageUseCase } from './create-user-message.use-case';
@@ -54,6 +56,10 @@ describe('CreateUserMessageUseCase', () => {
         { provide: DeleteObjectUseCase, useValue: mockDeleteObjectUseCase },
         { provide: ContextService, useValue: mockContextService },
         { provide: EventEmitter2, useValue: mockEventEmitter },
+        {
+          provide: getLoggerToken(CreateUserMessageUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
@@ -307,17 +313,20 @@ describe('CreateUserMessageUseCase', () => {
         .spyOn(mockMessagesRepository, 'create')
         .mockResolvedValue(expectedMessage);
 
-      const loggerSpy = jest.spyOn(useCase['logger'], 'log');
+      const loggerSpy = jest.spyOn(useCase['logger'], 'info');
 
       // Act
       await useCase.execute(command);
 
       // Assert
-      expect(loggerSpy).toHaveBeenCalledWith('Creating user message', {
-        threadId,
-        hasText: true,
-        imageCount: 0,
-      });
+      expect(loggerSpy).toHaveBeenCalledWith(
+        {
+          threadId,
+          hasText: true,
+          imageCount: 0,
+        },
+        'Creating user message',
+      );
     });
 
     it('should log correct information when creating message with images', async () => {
@@ -340,17 +349,20 @@ describe('CreateUserMessageUseCase', () => {
         .spyOn(mockMessagesRepository, 'create')
         .mockResolvedValue(expectedMessage);
 
-      const loggerSpy = jest.spyOn(useCase['logger'], 'log');
+      const loggerSpy = jest.spyOn(useCase['logger'], 'info');
 
       // Act
       await useCase.execute(command);
 
       // Assert
-      expect(loggerSpy).toHaveBeenCalledWith('Creating user message', {
-        threadId,
-        hasText: true,
-        imageCount: 1,
-      });
+      expect(loggerSpy).toHaveBeenCalledWith(
+        {
+          threadId,
+          hasText: true,
+          imageCount: 1,
+        },
+        'Creating user message',
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/create-user-message/create-user-message.use-case.ts
@@ -1,9 +1,5 @@
-import {
-  Injectable,
-  Logger,
-  Inject,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Injectable, Inject, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CreateUserMessageCommand } from './create-user-message.command';
 import { UserMessage } from '../../../domain/messages/user-message.entity';
@@ -26,8 +22,6 @@ import type { UUID } from 'crypto';
 
 @Injectable()
 export class CreateUserMessageUseCase {
-  private readonly logger = new Logger(CreateUserMessageUseCase.name);
-
   constructor(
     @Inject(MESSAGES_REPOSITORY)
     private readonly messagesRepository: MessagesRepository,
@@ -35,6 +29,8 @@ export class CreateUserMessageUseCase {
     private readonly deleteObjectUseCase: DeleteObjectUseCase,
     private readonly contextService: ContextService,
     private readonly eventEmitter: EventEmitter2,
+    @InjectPinoLogger(CreateUserMessageUseCase.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async execute(command: CreateUserMessageCommand): Promise<UserMessage> {
@@ -43,105 +39,43 @@ export class CreateUserMessageUseCase {
       throw new UnauthorizedException('Organization context required');
     }
 
-    this.logger.log('Creating user message', {
-      threadId: command.threadId,
-      hasText: !!command.text?.trim(),
-      imageCount: command.pendingImages.length,
-    });
+    this.logger.info(
+      {
+        threadId: command.threadId,
+        hasText: !!command.text?.trim(),
+        imageCount: command.pendingImages.length,
+      },
+      'Creating user message',
+    );
 
     // Track uploaded images for potential rollback
     const uploadedPaths: string[] = [];
 
     try {
-      // Build content array
-      const content: (TextMessageContent | ImageMessageContent)[] = [];
-
-      // Prepend skill instructions if provided (marked as isSkillInstruction)
-      if (command.skillInstructions?.trim()) {
-        content.push(
-          new TextMessageContent(command.skillInstructions, null, true),
-        );
-      }
-
-      // Add text content if provided
-      if (command.text?.trim()) {
-        content.push(new TextMessageContent(command.text));
-      }
-
-      // Create ImageMessageContent objects with index and contentType
-      const imageContents = command.pendingImages.map(
-        (img, index) =>
-          new ImageMessageContent(index, img.contentType, img.altText),
-      );
-      content.push(...imageContents);
-
-      // Create the message to get its ID (UUID generated in constructor)
-      const userMessage = new UserMessage({
-        threadId: command.threadId,
-        content,
-      });
-
-      // Upload images to MinIO with deterministic paths
-      for (let i = 0; i < command.pendingImages.length; i++) {
-        const pendingImage = command.pendingImages[i];
-        const storagePath = getImageStoragePath({
-          orgId,
-          threadId: command.threadId,
-          messageId: userMessage.id,
-          index: i,
-          contentType: pendingImage.contentType,
-        });
-
-        this.logger.debug('Uploading image to storage', {
-          storagePath,
-          contentType: pendingImage.contentType,
-          size: pendingImage.buffer.length,
-        });
-
-        await this.uploadObjectUseCase.execute(
-          new UploadObjectCommand(storagePath, pendingImage.buffer, {
-            contentType: pendingImage.contentType,
-          }),
-        );
-        uploadedPaths.push(storagePath);
-      }
-
-      // Save message to database
+      const userMessage = this.buildUserMessage(command);
+      await this.uploadImages(command, orgId, userMessage, uploadedPaths);
       const savedMessage = (await this.messagesRepository.create(
         userMessage,
       )) as UserMessage;
-
-      const userId = this.contextService.get('userId');
-      this.eventEmitter
-        .emitAsync(
-          UserMessageCreatedEvent.EVENT_NAME,
-          new UserMessageCreatedEvent(
-            userId ?? ('unknown' as UUID),
-            orgId,
-            command.threadId,
-            savedMessage.id,
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit UserMessageCreatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            messageId: savedMessage.id,
-          });
-        });
-
-      this.logger.log('User message created successfully', {
-        messageId: savedMessage.id,
-        threadId: command.threadId,
-        imageCount: uploadedPaths.length,
-      });
-
+      this.emitMessageCreated(orgId, command.threadId, savedMessage.id);
+      this.logger.info(
+        {
+          messageId: savedMessage.id,
+          threadId: command.threadId,
+          imageCount: uploadedPaths.length,
+        },
+        'User message created successfully',
+      );
       return savedMessage;
     } catch (error) {
-      this.logger.error('Failed to create user message', {
-        threadId: command.threadId,
-        uploadedImageCount: uploadedPaths.length,
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          threadId: command.threadId,
+          uploadedImageCount: uploadedPaths.length,
+          err: error as Error,
+        },
+        'Failed to create user message',
+      );
 
       // Compensating action: cleanup uploaded images
       await this.cleanupUploadedImages(uploadedPaths);
@@ -155,17 +89,97 @@ export class CreateUserMessageUseCase {
     }
   }
 
+  private buildUserMessage(command: CreateUserMessageCommand): UserMessage {
+    const content: (TextMessageContent | ImageMessageContent)[] = [];
+    if (command.skillInstructions?.trim()) {
+      content.push(
+        new TextMessageContent(command.skillInstructions, null, true),
+      );
+    }
+    if (command.text?.trim()) {
+      content.push(new TextMessageContent(command.text));
+    }
+    content.push(
+      ...command.pendingImages.map(
+        (image, index) =>
+          new ImageMessageContent(index, image.contentType, image.altText),
+      ),
+    );
+    return new UserMessage({ threadId: command.threadId, content });
+  }
+
+  private async uploadImages(
+    command: CreateUserMessageCommand,
+    orgId: UUID,
+    message: UserMessage,
+    uploadedPaths: string[],
+  ): Promise<void> {
+    for (const [index, pendingImage] of command.pendingImages.entries()) {
+      const storagePath = getImageStoragePath({
+        orgId,
+        threadId: command.threadId,
+        messageId: message.id,
+        index,
+        contentType: pendingImage.contentType,
+      });
+      this.logger.debug(
+        {
+          storagePath,
+          contentType: pendingImage.contentType,
+          size: pendingImage.buffer.length,
+        },
+        'Uploading image to storage',
+      );
+      await this.uploadObjectUseCase.execute(
+        new UploadObjectCommand(storagePath, pendingImage.buffer, {
+          contentType: pendingImage.contentType,
+        }),
+      );
+      uploadedPaths.push(storagePath);
+    }
+  }
+
+  private emitMessageCreated(
+    orgId: UUID,
+    threadId: UUID,
+    messageId: UUID,
+  ): void {
+    const userId = this.contextService.get('userId');
+    this.eventEmitter
+      .emitAsync(
+        UserMessageCreatedEvent.EVENT_NAME,
+        new UserMessageCreatedEvent(
+          userId ?? ('unknown' as UUID),
+          orgId,
+          threadId,
+          messageId,
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error(
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            messageId,
+          },
+          'Failed to emit UserMessageCreatedEvent',
+        );
+      });
+  }
+
   private async cleanupUploadedImages(paths: string[]): Promise<void> {
     for (const path of paths) {
       try {
         await this.deleteObjectUseCase.execute(new DeleteObjectCommand(path));
-        this.logger.debug('Cleaned up orphaned image', { path });
+        this.logger.debug({ path }, 'Cleaned up orphaned image');
       } catch (deleteError) {
         // Best-effort cleanup - log but don't throw (ObjectNotFoundError is acceptable)
-        this.logger.error('Failed to cleanup orphaned image', {
-          path,
-          error: deleteError as Error,
-        });
+        this.logger.error(
+          {
+            path,
+            err: deleteError as Error,
+          },
+          'Failed to cleanup orphaned image',
+        );
       }
     }
   }

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/delete-message/delete-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/delete-message/delete-message.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, Inject } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { DeleteMessageCommand } from './delete-message.command';
 import {
   MESSAGES_REPOSITORY,
@@ -7,28 +8,37 @@ import {
 
 @Injectable()
 export class DeleteMessageUseCase {
-  private readonly logger = new Logger(DeleteMessageUseCase.name);
-
   constructor(
     @Inject(MESSAGES_REPOSITORY)
     private readonly messagesRepository: MessagesRepository,
+    @InjectPinoLogger(DeleteMessageUseCase.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async execute(command: DeleteMessageCommand): Promise<void> {
-    this.logger.log('Deleting message', {
-      messageId: command.messageId,
-    });
+    this.logger.info(
+      {
+        messageId: command.messageId,
+      },
+      'Deleting message',
+    );
 
     try {
       await this.messagesRepository.delete(command.messageId);
-      this.logger.log('Message deleted successfully', {
-        messageId: command.messageId,
-      });
+      this.logger.info(
+        {
+          messageId: command.messageId,
+        },
+        'Message deleted successfully',
+      );
     } catch (error) {
-      this.logger.error('Failed to delete message', {
-        messageId: command.messageId,
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          messageId: command.messageId,
+          err: error as Error,
+        },
+        'Failed to delete message',
+      );
       throw error;
     }
   }

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/save-assistant-message/save-assistant-message.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/save-assistant-message/save-assistant-message.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { SaveAssistantMessageUseCase } from './save-assistant-message.use-case';
@@ -39,6 +41,10 @@ describe('SaveAssistantMessageUseCase', () => {
         { provide: MESSAGES_REPOSITORY, useValue: mockMessagesRepository },
         { provide: ContextService, useValue: mockContextService },
         { provide: EventEmitter2, useValue: mockEventEmitter },
+        {
+          provide: getLoggerToken(SaveAssistantMessageUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/save-assistant-message/save-assistant-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/save-assistant-message/save-assistant-message.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, Inject } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { SaveAssistantMessageCommand } from './save-assistant-message.command';
 import { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
@@ -17,22 +18,25 @@ import type { UUID } from 'crypto';
 
 @Injectable()
 export class SaveAssistantMessageUseCase {
-  private readonly logger = new Logger(SaveAssistantMessageUseCase.name);
-
   constructor(
     @Inject(MESSAGES_REPOSITORY)
     private readonly messagesRepository: MessagesRepository,
     private readonly contextService: ContextService,
     private readonly eventEmitter: EventEmitter2,
+    @InjectPinoLogger(SaveAssistantMessageUseCase.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async execute(
     command: SaveAssistantMessageCommand,
   ): Promise<AssistantMessage | null> {
-    this.logger.log('Saving assistant message', {
-      messageId: command.message.id,
-      threadId: command.message.threadId,
-    });
+    this.logger.info(
+      {
+        messageId: command.message.id,
+        threadId: command.message.threadId,
+      },
+      'Saving assistant message',
+    );
 
     try {
       const saved = (await this.messagesRepository.create(
@@ -44,19 +48,22 @@ export class SaveAssistantMessageUseCase {
     } catch (error) {
       if (error instanceof MessageThreadMissingError) {
         this.logger.warn(
-          'Skipped saving assistant message because thread no longer exists',
           {
             messageId: command.message.id,
             threadId: command.message.threadId,
           },
+          'Skipped saving assistant message because thread no longer exists',
         );
         return null;
       }
-      this.logger.error('Failed to save assistant message', {
-        messageId: command.message.id,
-        threadId: command.message.threadId,
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          messageId: command.message.id,
+          threadId: command.message.threadId,
+          err: error as Error,
+        },
+        'Failed to save assistant message',
+      );
       throw error instanceof Error
         ? new MessageCreationError(MessageRole.ASSISTANT.toLowerCase(), error)
         : new MessageCreationError(
@@ -83,10 +90,13 @@ export class SaveAssistantMessageUseCase {
         ),
       )
       .catch((err: unknown) => {
-        this.logger.error('Failed to emit AssistantMessageCreatedEvent', {
-          error: err instanceof Error ? err.message : 'Unknown error',
-          messageId: saved.id,
-        });
+        this.logger.error(
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            messageId: saved.id,
+          },
+          'Failed to emit AssistantMessageCreatedEvent',
+        );
       });
   }
 }

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -51,6 +53,10 @@ describe('TrimMessagesForContextUseCase', () => {
       providers: [
         TrimMessagesForContextUseCase,
         { provide: CountTokensUseCase, useValue: mockCountTokensUseCase },
+        {
+          provide: getLoggerToken(TrimMessagesForContextUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case.ts
+++ b/ayunis-core-backend/src/domain/messages/application/use-cases/trim-messages-for-context/trim-messages-for-context.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { CountTokensUseCase } from 'src/common/token-counter/application/use-cases/count-tokens/count-tokens.use-case';
 import { CountTokensCommand } from 'src/common/token-counter/application/use-cases/count-tokens/count-tokens.command';
 import { TokenCounterType } from 'src/common/token-counter/application/ports/token-counter.handler.port';
@@ -9,15 +10,20 @@ import { extractTextFromMessage } from '../../utils/message-text-extractor.util'
 
 @Injectable()
 export class TrimMessagesForContextUseCase {
-  private readonly logger = new Logger(TrimMessagesForContextUseCase.name);
-
-  constructor(private readonly countTokensUseCase: CountTokensUseCase) {}
+  constructor(
+    private readonly countTokensUseCase: CountTokensUseCase,
+    @InjectPinoLogger(TrimMessagesForContextUseCase.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   execute(command: TrimMessagesForContextCommand): Message[] {
-    this.logger.log('execute', {
-      messageCount: command.messages.length,
-      maxTokens: command.maxTokens,
-    });
+    this.logger.info(
+      {
+        messageCount: command.messages.length,
+        maxTokens: command.maxTokens,
+      },
+      'execute',
+    );
 
     if (command.messages.length === 0) {
       return [];
@@ -53,11 +59,14 @@ export class TrimMessagesForContextUseCase {
     // Ensure the first message is a user message
     const trimmedMessages = this.ensureFirstMessageIsUser(selectedMessages);
 
-    this.logger.log('execute completed', {
-      originalCount: command.messages.length,
-      selectedCount: trimmedMessages.length,
-      totalTokens,
-    });
+    this.logger.info(
+      {
+        originalCount: command.messages.length,
+        selectedCount: trimmedMessages.length,
+        totalTokens,
+      },
+      'execute completed',
+    );
 
     return trimmedMessages;
   }

--- a/ayunis-core-backend/src/domain/messages/infrastructure/tasks/orphaned-images-cleanup.task.spec.ts
+++ b/ayunis-core-backend/src/domain/messages/infrastructure/tasks/orphaned-images-cleanup.task.spec.ts
@@ -1,0 +1,35 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import type { CleanupOrphanedImagesUseCase } from '../../application/use-cases/cleanup-orphaned-images/cleanup-orphaned-images.use-case';
+import { OrphanedImagesCleanupTask } from './orphaned-images-cleanup.task';
+
+describe('OrphanedImagesCleanupTask', () => {
+  it('logs the paths and redacted reasons for deletion failures', async () => {
+    const errors = [
+      {
+        path: 'org-id/thread-id/message-id/0.png',
+        error: 'storage unavailable',
+      },
+    ];
+    const cleanupOrphanedImagesUseCase = {
+      execute: jest.fn().mockResolvedValue({
+        scannedCount: 2,
+        deletedCount: 1,
+        failedCount: 1,
+        deletedPaths: ['org-id/thread-id/message-id/1.png'],
+        errors,
+      }),
+    } as unknown as CleanupOrphanedImagesUseCase;
+    const logger = createPinoLoggerMock();
+    const task = new OrphanedImagesCleanupTask(
+      cleanupOrphanedImagesUseCase,
+      logger,
+    );
+
+    await task.handleCleanup();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      { errors },
+      'Some images failed to delete',
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/messages/infrastructure/tasks/orphaned-images-cleanup.task.ts
+++ b/ayunis-core-backend/src/domain/messages/infrastructure/tasks/orphaned-images-cleanup.task.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { CleanupOrphanedImagesUseCase } from '../../application/use-cases/cleanup-orphaned-images/cleanup-orphaned-images.use-case';
 
@@ -9,11 +10,12 @@ import { CleanupOrphanedImagesUseCase } from '../../application/use-cases/cleanu
  */
 @Injectable()
 export class OrphanedImagesCleanupTask {
-  private readonly logger = new Logger(OrphanedImagesCleanupTask.name);
   private isRunning = false;
 
   constructor(
     private readonly cleanupOrphanedImagesUseCase: CleanupOrphanedImagesUseCase,
+    @InjectPinoLogger(OrphanedImagesCleanupTask.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   /**
@@ -28,26 +30,33 @@ export class OrphanedImagesCleanupTask {
     }
 
     this.isRunning = true;
-    this.logger.log('Starting scheduled orphaned images cleanup');
+    this.logger.info('Starting scheduled orphaned images cleanup');
 
     try {
       const result = await this.cleanupOrphanedImagesUseCase.execute();
 
-      this.logger.log('Scheduled cleanup completed', {
-        scanned: result.scannedCount,
-        deleted: result.deletedCount,
-        failed: result.failedCount,
-      });
+      this.logger.info(
+        {
+          scanned: result.scannedCount,
+          deleted: result.deletedCount,
+          failed: result.failedCount,
+        },
+        'Scheduled cleanup completed',
+      );
 
       if (result.failedCount > 0) {
-        this.logger.warn('Some images failed to delete', {
-          errors: result.errors,
-        });
+        this.logger.warn(
+          { errors: result.errors },
+          'Some images failed to delete',
+        );
       }
     } catch (error) {
-      this.logger.error('Scheduled cleanup failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Scheduled cleanup failed',
+      );
     } finally {
       this.isRunning = false;
     }

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/hooks/tool-usage-hook.factory.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/hooks/tool-usage-hook.factory.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import type { EventEmitter2 } from '@nestjs/event-emitter';
 import { ToolUsedEvent } from '../../events/tool-used.event';
@@ -19,7 +20,10 @@ describe('ToolUsageHookFactory', () => {
         logoUrl: null,
       }),
     } as unknown as RuntimeToolIntegrationRegistry;
-    const hook = new ToolUsageHookFactory(eventEmitter).create({
+    const hook = new ToolUsageHookFactory(
+      eventEmitter,
+      createPinoLoggerMock(),
+    ).create({
       userId,
       orgId,
       integrations,

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/hooks/tool-usage-hook.factory.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/hooks/tool-usage-hook.factory.ts
@@ -1,5 +1,6 @@
 import type { Hook } from '@ayunis/agent-runtime';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
 import { ToolUsedEvent } from '../../events/tool-used.event';
@@ -13,9 +14,11 @@ interface ToolUsageHookParams {
 
 @Injectable()
 export class ToolUsageHookFactory {
-  private readonly logger = new Logger(ToolUsageHookFactory.name);
-
-  constructor(private readonly eventEmitter: EventEmitter2) {}
+  constructor(
+    private readonly eventEmitter: EventEmitter2,
+    @InjectPinoLogger(ToolUsageHookFactory.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   create(params: ToolUsageHookParams): Hook {
     return {
@@ -42,10 +45,13 @@ export class ToolUsageHookFactory {
         ),
       )
       .catch((error: unknown) => {
-        this.logger.error('Failed to emit ToolUsedEvent', {
-          error: error instanceof Error ? error.message : 'Unknown error',
-          toolName,
-        });
+        this.logger.error(
+          {
+            error: error instanceof Error ? error.message : 'Unknown error',
+            toolName,
+          },
+          'Failed to emit ToolUsedEvent',
+        );
       });
   }
 }

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/run-event-stream.adapter.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/run-event-stream.adapter.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { RunEvent, RunEventPayload } from '@ayunis/agent-runtime';
 import type { UUID } from 'crypto';
 import type { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
@@ -50,16 +51,21 @@ async function* eventsFrom(
 
 async function collect(
   events: AsyncIterable<RunEvent>,
+  logger = createPinoLoggerMock(),
 ): Promise<RunStreamItem[]> {
   const items: RunStreamItem[] = [];
-  for await (const item of adaptRunEventsToStream(events, threadId)) {
+  for await (const item of adaptRunEventsToStream(events, threadId, logger)) {
     items.push(item);
   }
   return items;
 }
 
 async function collectWithOutcome(events: AsyncIterable<RunEvent>) {
-  const generator = adaptRunEventsToStream(events, threadId);
+  const generator = adaptRunEventsToStream(
+    events,
+    threadId,
+    createPinoLoggerMock(),
+  );
   const items: RunStreamItem[] = [];
   for (;;) {
     const next = await generator.next();
@@ -371,6 +377,9 @@ describe('adaptRunEventsToStream', () => {
   });
 
   it('maps other error events to a client-safe run error', async () => {
+    const logger = createPinoLoggerMock();
+    const details = { provider: 'test-provider', statusCode: 503 };
+
     await expect(
       collect(
         eventsFrom([
@@ -378,13 +387,23 @@ describe('adaptRunEventsToStream', () => {
             type: 'error',
             code: 'PROVIDER_FAILED',
             message: 'upstream exposed internal provider details',
+            details,
           },
           { type: 'run_end', status: 'error', usage: {} },
         ]),
+        logger,
       ),
     ).rejects.toMatchObject<Partial<RunExecutionFailedError>>({
       message: 'Run execution failed: Agent runtime failed',
     });
+    expect(logger.error).toHaveBeenCalledWith(
+      {
+        code: 'PROVIDER_FAILED',
+        message: 'upstream exposed internal provider details',
+        details,
+      },
+      'Agent runtime failed',
+    );
   });
 
   it.each([

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/run-event-stream.adapter.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/run-event-stream.adapter.ts
@@ -1,7 +1,7 @@
 import type { UUID } from 'crypto';
 import type { RunEvent, ToolCallSnapshot } from '@ayunis/agent-runtime';
 import { DEFAULT_MAX_ITERATIONS } from '@ayunis/agent-runtime';
-import { Logger } from '@nestjs/common';
+import type { PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import type { ThreadPiiMask } from 'src/domain/thread-pii-masks/domain/thread-pii-mask.entity';
 import { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
@@ -30,8 +30,6 @@ import { reconstructRuntimeModelError } from './runtime-model-error';
 import { InferenceFailedError } from 'src/domain/models/application/models.errors';
 import type { RunExecutionOutcome } from '../run-execution-outcome';
 
-const logger = new Logger('RunEventStreamAdapter');
-
 /** Accumulates one assistant turn's streamed text/thinking for live display. */
 interface StreamingTurn {
   id: UUID;
@@ -58,6 +56,7 @@ interface StreamingTurn {
 export async function* adaptRunEventsToStream(
   events: AsyncIterable<RunEvent>,
   threadId: UUID,
+  logger: PinoLogger,
   integrations?: RuntimeToolIntegrationRegistry,
 ): AsyncGenerator<RunStreamItem, RunExecutionOutcome, void> {
   const assistant = new AssistantTurnAccumulator(threadId, integrations);
@@ -75,6 +74,7 @@ export async function* adaptRunEventsToStream(
       event,
       threadId,
       assistant.lastCompletedIteration(),
+      logger,
     );
     if (side instanceof ApplicationError) {
       pendingError = side;
@@ -169,6 +169,7 @@ function toSideStreamItem(
   event: RunEvent,
   threadId: UUID,
   iteration: number,
+  logger: PinoLogger,
 ): RunStreamItem | ApplicationError | null {
   if (event.type === 'tool_result_message') {
     return toBackendToolResultMessage(
@@ -183,28 +184,29 @@ function toSideStreamItem(
       : null;
   }
   if (event.type === 'error') {
-    return mapRunError(event);
+    return mapRunError(event, logger);
   }
   if (event.type === 'finalization_error') {
-    return mapFinalizationError(event);
+    return mapFinalizationError(event, logger);
   }
   return null;
 }
 
 function mapFinalizationError(
   event: Extract<RunEvent, { type: 'finalization_error' }>,
+  logger: PinoLogger,
 ): ApplicationError | null {
   const context = {
     hookName: event.hookName,
     phase: 'runEnd',
     originalOutcome: event.outcome,
-    runtimeMessage: event.message,
+    message: event.message,
   };
   if (!event.critical) {
-    logger.warn('Best-effort agent runtime finalization hook failed', context);
+    logger.warn(context, 'Best-effort agent runtime finalization hook failed');
     return null;
   }
-  logger.error('Critical agent runtime finalization hook failed', context);
+  logger.error(context, 'Critical agent runtime finalization hook failed');
   return new RunExecutionFailedError('Agent runtime finalization failed', {
     hookName: event.hookName,
     phase: 'runEnd',
@@ -300,7 +302,10 @@ const RUN_ERROR_MAPPERS = new Map<
   ['CONTEXT_BUDGET_EXCEEDED', () => new RunContextBudgetExceededError()],
 ]);
 
-function mapRunError(event: RunErrorEvent): ApplicationError {
+function mapRunError(
+  event: RunErrorEvent,
+  logger: PinoLogger,
+): ApplicationError {
   if (event.code === 'ANONYMIZATION_UNAVAILABLE') {
     // Checked before the generic reconstruction: the run error keeps the
     // user-facing code and localized message, while the classified provider
@@ -319,10 +324,13 @@ function mapRunError(event: RunErrorEvent): ApplicationError {
   if (mapper) {
     return mapper(event);
   }
-  logger.error('Agent runtime failed', {
-    code: event.code,
-    runtimeMessage: event.message,
-    details: event.details,
-  });
+  logger.error(
+    {
+      code: event.code,
+      message: event.message,
+      details: event.details,
+    },
+    'Agent runtime failed',
+  );
   return new RunExecutionFailedError('Agent runtime failed');
 }

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-provider.decorator.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-provider.decorator.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { RunAbortedError, type AgentRuntimeError } from '@ayunis/agent-runtime';
 import type {
   ModelProvider,
@@ -32,9 +33,12 @@ interface Harness {
 
 function buildHarness(): Harness {
   const emitAsync = jest.fn().mockResolvedValue([]);
-  const decorator = new RuntimeModelProviderDecorator({
-    emitAsync,
-  } as unknown as EventEmitter2);
+  const decorator = new RuntimeModelProviderDecorator(
+    {
+      emitAsync,
+    } as unknown as EventEmitter2,
+    createPinoLoggerMock(),
+  );
   return {
     decorate: (provider) =>
       decorator.decorate(provider, { userId, orgId, model }),

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-provider.decorator.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/runtime-model-provider.decorator.ts
@@ -7,7 +7,8 @@ import type {
   ProviderRequest,
   ToolSchema,
 } from '@ayunis/inference';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -52,9 +53,11 @@ function backoff(ms: number): Promise<void> {
 
 @Injectable()
 export class RuntimeModelProviderDecorator {
-  private readonly logger = new Logger(RuntimeModelProviderDecorator.name);
-
-  constructor(private readonly eventEmitter: EventEmitter2) {}
+  constructor(
+    private readonly eventEmitter: EventEmitter2,
+    @InjectPinoLogger(RuntimeModelProviderDecorator.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   decorate(
     provider: ModelProvider,
@@ -100,8 +103,8 @@ export class RuntimeModelProviderDecorator {
         }
       }
       this.logger.warn(
-        'Provider stream failed before producing output; retrying once',
         { model: context.model.name, reason },
+        'Provider stream failed before producing output; retrying once',
       );
     }
     yield* this.stream(provider, request, context);
@@ -162,10 +165,13 @@ export class RuntimeModelProviderDecorator {
         ),
       )
       .catch((emitError: unknown) => {
-        this.logger.error('Failed to emit InferenceCompletedEvent', {
-          error:
-            emitError instanceof Error ? emitError.message : 'Unknown error',
-        });
+        this.logger.error(
+          {
+            error:
+              emitError instanceof Error ? emitError.message : 'Unknown error',
+          },
+          'Failed to emit InferenceCompletedEvent',
+        );
       });
   }
 }

--- a/ayunis-core-backend/src/domain/runs/application/helpers/stream-usage.helper.ts
+++ b/ayunis-core-backend/src/domain/runs/application/helpers/stream-usage.helper.ts
@@ -1,6 +1,4 @@
-import { Logger } from '@nestjs/common';
-
-const logger = new Logger('StreamUsage');
+import type { PinoLogger } from 'nestjs-pino';
 
 /** The one facet of a stream chunk this helper reads — structural on purpose, so it needs no cross-module port import. */
 interface UsageBearingChunk {
@@ -14,6 +12,7 @@ interface UsageBearingChunk {
 
 export function extractUsageFromChunks(
   chunks: UsageBearingChunk[],
+  logger: PinoLogger,
 ): { inputTokens: number; outputTokens: number } | undefined {
   const usage = lastWinsUsage(chunks);
   const uncachedInputTokens = usage.inputTokens ?? 0;
@@ -28,11 +27,14 @@ export function extractUsageFromChunks(
     return undefined;
   }
   if (hasCache) {
-    logger.debug('Prompt cache activity', {
-      uncachedInputTokens,
-      cacheReadInputTokens: cacheRead,
-      cacheWriteInputTokens: cacheWrite,
-    });
+    logger.debug(
+      {
+        uncachedInputTokens,
+        cacheReadInputTokens: cacheRead,
+        cacheWriteInputTokens: cacheWrite,
+      },
+      'Prompt cache activity',
+    );
   }
   // Cached prompt tokens are billed as ordinary input: the provider's
   // inputTokens excludes tokens covered by the prompt cache, so without

--- a/ayunis-core-backend/src/domain/runs/application/helpers/tool-call-arguments.helper.ts
+++ b/ayunis-core-backend/src/domain/runs/application/helpers/tool-call-arguments.helper.ts
@@ -1,11 +1,9 @@
-import { Logger } from '@nestjs/common';
+import type { PinoLogger } from 'nestjs-pino';
 import { safeJsonParse } from 'src/common/util/unicode-sanitizer';
 import {
   InferenceFailedError,
   InferenceTokenLimitError,
 } from 'src/domain/models/application/models.errors';
-
-const logger = new Logger('ToolCallArguments');
 
 export interface CompletedToolCall {
   id: string | null;
@@ -41,6 +39,7 @@ export function parseFinalToolArguments(
 export function assertToolCallArgumentsIntact(
   toolCalls: Iterable<CompletedToolCall>,
   finishReason: string | null,
+  logger: PinoLogger,
 ): void {
   const calls = [...toolCalls].filter((call) => call.id && call.name);
   if (calls.length === 0) return;
@@ -57,13 +56,16 @@ export function assertToolCallArgumentsIntact(
   // not leave the run transcript for centralized logs. Length + finish reason
   // are enough to attribute the truncation (a token-limit cut shows up as
   // finishReason 'length' with a stable length across retries).
-  logger.warn('Model emitted unparseable tool call arguments', {
-    toolCalls: malformed.map((call) => ({
-      name: call.name,
-      argumentsLength: call.arguments.length,
-    })),
-    finishReason,
-  });
+  logger.warn(
+    {
+      toolCalls: malformed.map((call) => ({
+        toolName: call.name,
+        argumentsLength: call.arguments.length,
+      })),
+      finishReason,
+    },
+    'Model emitted unparseable tool call arguments',
+  );
   throw new InferenceFailedError(
     'model emitted unparseable tool call arguments',
     { toolNames: malformed.map((call) => call.name) },

--- a/ayunis-core-backend/src/domain/runs/application/services/artifact-tool-assembler.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/artifact-tool-assembler.service.spec.ts
@@ -1,6 +1,7 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import type { UUID } from 'crypto';
 import { ArtifactToolAssemblerService } from './artifact-tool-assembler.service';
@@ -94,15 +95,16 @@ describe('ArtifactToolAssemblerService', () => {
           provide: FindAllLetterheadsUseCase,
           useValue: mockFindAllLetterheadsUseCase,
         },
+        {
+          provide: getLoggerToken(ArtifactToolAssemblerService.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
     service = module.get<ArtifactToolAssemblerService>(
       ArtifactToolAssemblerService,
     );
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/runs/application/services/artifact-tool-assembler.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/artifact-tool-assembler.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Tool } from 'src/domain/tools/domain/tool.entity';
 import { ToolType } from 'src/domain/tools/domain/value-objects/tool-type.enum';
 import { AssembleToolUseCase } from 'src/domain/tools/application/use-cases/assemble-tool/assemble-tool.use-case';
@@ -27,13 +28,13 @@ import { buildLetterheadSuffix } from './letterhead-suffix.helper';
  */
 @Injectable()
 export class ArtifactToolAssemblerService {
-  private readonly logger = new Logger(ArtifactToolAssemblerService.name);
-
   constructor(
     private readonly assembleToolsUseCase: AssembleToolUseCase,
     private readonly findArtifactsByThreadUseCase: FindArtifactsByThreadUseCase,
     private readonly findArtifactWithVersionsUseCase: FindArtifactWithVersionsUseCase,
     private readonly findAllLetterheadsUseCase: FindAllLetterheadsUseCase,
+    @InjectPinoLogger(ArtifactToolAssemblerService.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async assembleArtifactTools(thread: Thread): Promise<Tool[]> {
@@ -168,9 +169,12 @@ export class ArtifactToolAssemblerService {
     try {
       return await this.findAllLetterheadsUseCase.execute();
     } catch (error) {
-      this.logger.warn('Failed to fetch letterheads, continuing without them', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.warn(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Failed to fetch letterheads, continuing without them',
+      );
       return [];
     }
   }

--- a/ayunis-core-backend/src/domain/runs/application/services/credit-budget-guard.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/credit-budget-guard.service.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { CreditBudgetGuardService } from './credit-budget-guard.service';
@@ -32,6 +34,10 @@ describe('CreditBudgetGuardService', () => {
         {
           provide: GetMonthlyCreditUsageUseCase,
           useValue: mockGetMonthlyCreditUsage,
+        },
+        {
+          provide: getLoggerToken(CreditBudgetGuardService.name),
+          useValue: createPinoLoggerMock(),
         },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/runs/application/services/credit-budget-guard.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/credit-budget-guard.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { GetMonthlyCreditLimitUseCase } from 'src/iam/subscriptions/application/use-cases/get-monthly-credit-limit/get-monthly-credit-limit.use-case';
 import { GetMonthlyCreditLimitQuery } from 'src/iam/subscriptions/application/use-cases/get-monthly-credit-limit/get-monthly-credit-limit.query';
@@ -17,11 +18,11 @@ import { CreditBudgetExceededError } from 'src/iam/subscriptions/application/sub
  */
 @Injectable()
 export class CreditBudgetGuardService {
-  private readonly logger = new Logger(CreditBudgetGuardService.name);
-
   constructor(
     private readonly getMonthlyCreditLimitUseCase: GetMonthlyCreditLimitUseCase,
     private readonly getMonthlyCreditUsageUseCase: GetMonthlyCreditUsageUseCase,
+    @InjectPinoLogger(CreditBudgetGuardService.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async ensureBudgetAvailable(orgId: UUID): Promise<void> {
@@ -39,11 +40,14 @@ export class CreditBudgetGuardService {
     );
 
     if (creditsUsed >= monthlyCredits) {
-      this.logger.warn('Credit budget exceeded', {
-        orgId,
-        creditsUsed,
-        monthlyCredits,
-      });
+      this.logger.warn(
+        {
+          orgId,
+          creditsUsed,
+          monthlyCredits,
+        },
+        'Credit budget exceeded',
+      );
       throw new CreditBudgetExceededError({
         orgId,
         creditsUsed,

--- a/ayunis-core-backend/src/domain/runs/application/services/credit-limit-guard.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/credit-limit-guard.service.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -47,6 +49,10 @@ describe('CreditLimitGuardService', () => {
         {
           provide: IsUsageBasedSubscriptionUseCase,
           useValue: isUsageBased,
+        },
+        {
+          provide: getLoggerToken(CreditLimitGuardService.name),
+          useValue: createPinoLoggerMock(),
         },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/runs/application/services/credit-limit-guard.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/credit-limit-guard.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { ResolveCreditLimitsForUserUseCase } from 'src/iam/credit-limits/application/use-cases/resolve-credit-limits-for-user/resolve-credit-limits-for-user.use-case';
 import { ResolveCreditLimitsForUserQuery } from 'src/iam/credit-limits/application/use-cases/resolve-credit-limits-for-user/resolve-credit-limits-for-user.query';
@@ -19,13 +20,13 @@ import { IsUsageBasedSubscriptionQuery } from 'src/iam/subscriptions/application
  */
 @Injectable()
 export class CreditLimitGuardService {
-  private readonly logger = new Logger(CreditLimitGuardService.name);
-
   constructor(
     private readonly resolveCreditLimitsForUserUseCase: ResolveCreditLimitsForUserUseCase,
     private readonly getMonthlyCreditUsageForUserUseCase: GetMonthlyCreditUsageForUserUseCase,
     private readonly getMonthlyCreditUsageForTeamUseCase: GetMonthlyCreditUsageForTeamUseCase,
     private readonly isUsageBasedSubscriptionUseCase: IsUsageBasedSubscriptionUseCase,
+    @InjectPinoLogger(CreditLimitGuardService.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async ensureWithinLimits(orgId: UUID, userId: UUID): Promise<void> {
@@ -80,11 +81,14 @@ export class CreditLimitGuardService {
       return;
     }
 
-    this.logger.warn('User credit limit exceeded', {
-      userId,
-      creditsUsed,
-      monthlyCreditLimit,
-    });
+    this.logger.warn(
+      {
+        userId,
+        creditsUsed,
+        monthlyCreditLimit,
+      },
+      'User credit limit exceeded',
+    );
     throw new UserCreditLimitExceededError({
       userId,
       creditsUsed,
@@ -106,11 +110,14 @@ export class CreditLimitGuardService {
       return;
     }
 
-    this.logger.warn('Team credit limit exceeded', {
-      teamId,
-      creditsUsed,
-      monthlyCreditLimit,
-    });
+    this.logger.warn(
+      {
+        teamId,
+        creditsUsed,
+        monthlyCreditLimit,
+      },
+      'Team credit limit exceeded',
+    );
     throw new TeamCreditLimitExceededError({
       teamId,
       creditsUsed,

--- a/ayunis-core-backend/src/domain/runs/application/services/image-generation-tool-assembly.helper.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/image-generation-tool-assembly.helper.ts
@@ -1,4 +1,4 @@
-import type { Logger } from '@nestjs/common';
+import type { PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import type { Tool } from 'src/domain/tools/domain/tool.entity';
 import { ToolType } from 'src/domain/tools/domain/value-objects/tool-type.enum';
@@ -12,7 +12,7 @@ export async function assembleImageGenerationTools(args: {
   orgId: UUID | undefined;
   getPermittedImageGenerationModelUseCase: GetPermittedImageGenerationModelUseCase;
   assembleToolsUseCase: AssembleToolUseCase;
-  logger: Logger;
+  logger: PinoLogger;
 }): Promise<Tool[]> {
   const {
     orgId,
@@ -28,15 +28,18 @@ export async function assembleImageGenerationTools(args: {
   } catch (error) {
     if (error instanceof PermittedImageGenerationModelNotFoundForOrgError) {
       logger.debug(
-        'No permitted image-generation model; dropping generate_image tool',
         { orgId },
+        'No permitted image-generation model; dropping generate_image tool',
       );
       return [];
     }
-    logger.error('Failed to check image generation model availability', {
-      orgId,
-      error: error instanceof Error ? error.message : 'Unknown error',
-    });
+    logger.error(
+      {
+        orgId,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      'Failed to check image generation model availability',
+    );
     throw error;
   }
   return [

--- a/ayunis-core-backend/src/domain/runs/application/services/inference-orchestrator.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/inference-orchestrator.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Message } from 'src/domain/messages/domain/message.entity';
 import { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
 import { CreateAssistantMessageUseCase } from 'src/domain/messages/application/use-cases/create-assistant-message/create-assistant-message.use-case';
@@ -19,8 +20,6 @@ const MAX_CONTEXT_TOKENS = 80000;
 
 @Injectable()
 export class InferenceOrchestratorService {
-  private readonly logger = new Logger(InferenceOrchestratorService.name);
-
   constructor(
     private readonly createAssistantMessageUseCase: CreateAssistantMessageUseCase,
     private readonly addMessageToThreadUseCase: AddMessageToThreadUseCase,
@@ -28,6 +27,8 @@ export class InferenceOrchestratorService {
     private readonly streamingInferenceService: StreamingInferenceService,
     private readonly nonStreamingInferenceService: NonStreamingInferenceService,
     private readonly inferenceUsageGuard: InferenceUsageGuard,
+    @InjectPinoLogger(InferenceOrchestratorService.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async *runInference(
@@ -47,7 +48,10 @@ export class InferenceOrchestratorService {
       return yield* this.runNonStreamingInference(params, trimmedMessages);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Inference failed', error);
+      this.logger.error(
+        { err: error instanceof Error ? error : new Error(String(error)) },
+        'Inference failed',
+      );
       throw new RunExecutionFailedError(
         error instanceof Error ? error.message : 'Inference error',
         { originalError: error as Error },

--- a/ayunis-core-backend/src/domain/runs/application/services/mcp-tool-assembler.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/mcp-tool-assembler.service.spec.ts
@@ -1,6 +1,6 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { setError } from '@appsignal/nodejs';
-import { Logger } from '@nestjs/common';
 import { McpToolAssemblerService } from './mcp-tool-assembler.service';
 import {
   McpConnectionFailedError,
@@ -17,10 +17,6 @@ jest.mock('@appsignal/nodejs', () => ({
 describe('McpToolAssemblerService — discovery outage reporting (AYC-616)', () => {
   const integrationId = randomUUID();
 
-  beforeAll(() => {
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -34,7 +30,9 @@ describe('McpToolAssemblerService — discovery outage reporting (AYC-616)', () 
         .fn()
         .mockResolvedValue([{ id: integrationId, name: 'Test Integration' }]),
     } as unknown as GetMcpIntegrationsByIdsUseCase;
-    return new McpToolAssemblerService(discover, getByIds);
+    const logger = createPinoLoggerMock();
+    const service = new McpToolAssemblerService(discover, getByIds, logger);
+    return { service, logger };
   };
 
   const thread = { mcpIntegrationIds: [integrationId] } as unknown as Thread;
@@ -44,7 +42,7 @@ describe('McpToolAssemblerService — discovery outage reporting (AYC-616)', () 
       'https://example.com/mcp',
       new Error('getaddrinfo EAI_AGAIN example.com'),
     );
-    const service = buildService(outage);
+    const { service } = buildService(outage);
 
     const tools = await service.assemble(thread, new Set());
 
@@ -57,7 +55,7 @@ describe('McpToolAssemblerService — discovery outage reporting (AYC-616)', () 
       'https://example.com/mcp',
       30_000,
     );
-    const service = buildService(timeout);
+    const { service } = buildService(timeout);
 
     const tools = await service.assemble(thread, new Set());
 
@@ -66,11 +64,15 @@ describe('McpToolAssemblerService — discovery outage reporting (AYC-616)', () 
   });
 
   it('does not report discovery failures that are not connectivity outages', async () => {
-    const service = buildService(new Error('Method not found'));
+    const { service, logger } = buildService(new Error('Method not found'));
 
     const tools = await service.assemble(thread, new Set());
 
     expect(tools).toEqual([]);
     expect(setError).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ integrationName: 'Test Integration' }),
+      'MCP integration unavailable, skipping',
+    );
   });
 });

--- a/ayunis-core-backend/src/domain/runs/application/services/mcp-tool-assembler.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/mcp-tool-assembler.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { Thread } from 'src/domain/threads/domain/thread.entity';
 import { Tool } from 'src/domain/tools/domain/tool.entity';
@@ -24,11 +25,11 @@ type McpIntegrationMeta = { name: string; logoUrl: string | null };
  */
 @Injectable()
 export class McpToolAssemblerService {
-  private readonly logger = new Logger(McpToolAssemblerService.name);
-
   constructor(
     private readonly discoverMcpCapabilitiesUseCase: DiscoverMcpCapabilitiesUseCase,
     private readonly getMcpIntegrationsByIdsUseCase: GetMcpIntegrationsByIdsUseCase,
+    @InjectPinoLogger(McpToolAssemblerService.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   /**
@@ -48,7 +49,8 @@ export class McpToolAssemblerService {
     );
     for (const duplicate of duplicates) {
       this.logger.warn(
-        `Duplicate MCP tool name '${duplicate.name}', skipping later occurrence`,
+        { toolName: duplicate.name },
+        'Duplicate MCP tool name, skipping later occurrence',
       );
     }
     return unique;
@@ -139,14 +141,15 @@ export class McpToolAssemblerService {
         const failedId = integrationIdList[index];
         const meta = integrationMetaMap.get(failedId);
         this.logger.warn(
-          `MCP integration '${meta?.name ?? failedId}' unavailable, skipping`,
           {
             integrationId: failedId,
+            integrationName: meta?.name,
             error:
               result.reason instanceof Error
                 ? result.reason.message
                 : 'Unknown error',
           },
+          'MCP integration unavailable, skipping',
         );
         // The skip is the only place run-time discovery outages surface, and
         // their raw transport duplicates are suppressed AppSignal-side

--- a/ayunis-core-backend/src/domain/runs/application/services/message-cleanup.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/message-cleanup.service.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID, type UUID } from 'crypto';
 import type { DeleteMessageUseCase } from 'src/domain/messages/application/use-cases/delete-message/delete-message.use-case';
 import type { DeleteMessageCommand } from 'src/domain/messages/application/use-cases/delete-message/delete-message.command';
@@ -18,6 +19,7 @@ describe('MessageCleanupService', () => {
     const service = new MessageCleanupService(
       {} as FindThreadUseCase,
       deleteMessageUseCase as unknown as DeleteMessageUseCase,
+      createPinoLoggerMock(),
     );
     const firstToolCallId = 'lookup-permit';
     const orphanedToolCallId = 'fetch-owner';
@@ -51,6 +53,7 @@ describe('MessageCleanupService', () => {
     const service = new MessageCleanupService(
       {} as FindThreadUseCase,
       deleteMessageUseCase as unknown as DeleteMessageUseCase,
+      createPinoLoggerMock(),
     );
     const toolCallId = 'lookup-permit';
     const userMessage = userText('Find permit B-2026-184.');

--- a/ayunis-core-backend/src/domain/runs/application/services/message-cleanup.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/message-cleanup.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { Message } from 'src/domain/messages/domain/message.entity';
 import { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
@@ -18,11 +19,11 @@ import { FindThreadQuery } from 'src/domain/threads/application/use-cases/find-t
  */
 @Injectable()
 export class MessageCleanupService {
-  private readonly logger = new Logger(MessageCleanupService.name);
-
   constructor(
     private readonly findThreadUseCase: FindThreadUseCase,
     private readonly deleteMessageUseCase: DeleteMessageUseCase,
+    @InjectPinoLogger(MessageCleanupService.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async cleanupTrailingNonAssistantMessages(threadId: UUID): Promise<void> {
@@ -33,16 +34,19 @@ export class MessageCleanupService {
 
       const threadMessages = updatedThread.messages;
       if (threadMessages.length === 0) {
-        this.logger.warn('Thread has no messages after save', { threadId });
+        this.logger.warn({ threadId }, 'Thread has no messages after save');
         return;
       }
 
       await this.deleteMessagesUntilAssistant(threadId, threadMessages);
     } catch (error) {
-      this.logger.error('Error during message cleanup', {
-        threadId,
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          threadId,
+          err: error as Error,
+        },
+        'Error during message cleanup',
+      );
       // Don't throw - we want to gracefully handle cleanup failures
     }
   }
@@ -63,35 +67,47 @@ export class MessageCleanupService {
   ): Promise<void> {
     if (messages.length === 0) return;
 
-    this.logger.log('Deleting trailing messages', {
-      threadId,
-      count: messages.length,
-      messageIds: messages.map((m) => m.id),
-    });
+    this.logger.info(
+      {
+        threadId,
+        count: messages.length,
+        messageIds: messages.map((m) => m.id),
+      },
+      'Deleting trailing messages',
+    );
 
     for (const message of messages) {
       try {
         await this.deleteMessageUseCase.execute(
           new DeleteMessageCommand(message.id),
         );
-        this.logger.debug('Deleted trailing message', {
-          messageId: message.id,
-          role: message.role,
-        });
+        this.logger.debug(
+          {
+            messageId: message.id,
+            role: message.role,
+          },
+          'Deleted trailing message',
+        );
       } catch (error) {
-        this.logger.error('Failed to delete trailing message', {
-          messageId: message.id,
-          role: message.role,
-          error: error as Error,
-        });
+        this.logger.error(
+          {
+            messageId: message.id,
+            role: message.role,
+            err: error as Error,
+          },
+          'Failed to delete trailing message',
+        );
         // Continue with cleanup even if one deletion fails
       }
     }
 
-    this.logger.log('Successfully cleaned up trailing messages', {
-      threadId,
-      deletedCount: messages.length,
-    });
+    this.logger.info(
+      {
+        threadId,
+        deletedCount: messages.length,
+      },
+      'Successfully cleaned up trailing messages',
+    );
   }
 }
 

--- a/ayunis-core-backend/src/domain/runs/application/services/non-streaming-inference.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/non-streaming-inference.service.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { NonStreamingInferenceService } from './non-streaming-inference.service';
 import type { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
 import { InferenceResponse } from 'src/domain/models/application/ports/inference.handler';
@@ -35,6 +36,7 @@ describe('NonStreamingInferenceService', () => {
       getInferenceUseCase as unknown as GetInferenceUseCase,
       mockContextService as never,
       mockEventEmitter as never,
+      createPinoLoggerMock(),
     );
   });
 

--- a/ayunis-core-backend/src/domain/runs/application/services/non-streaming-inference.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/non-streaming-inference.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
 import { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
@@ -17,12 +18,12 @@ import { extractInferenceErrorInfo } from '../helpers/extract-inference-error-in
  */
 @Injectable()
 export class NonStreamingInferenceService {
-  private readonly logger = new Logger(NonStreamingInferenceService.name);
-
   constructor(
     private readonly getInferenceUseCase: GetInferenceUseCase,
     private readonly contextService: ContextService,
     private readonly eventEmitter: EventEmitter2,
+    @InjectPinoLogger(NonStreamingInferenceService.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async execute(params: {
@@ -66,9 +67,12 @@ export class NonStreamingInferenceService {
           ),
         )
         .catch((err: unknown) => {
-          this.logger.error('Failed to emit InferenceCompletedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-          });
+          this.logger.error(
+            {
+              error: err instanceof Error ? err.message : 'Unknown error',
+            },
+            'Failed to emit InferenceCompletedEvent',
+          );
         });
     }
   }

--- a/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { from, Observable, throwError } from 'rxjs';
 import type { UUID } from 'crypto';
 import { StreamingInferenceService } from './streaming-inference.service';
@@ -39,32 +40,41 @@ describe('extractUsageFromChunks', () => {
 
   it('returns undefined when no chunk carries usage', () => {
     expect(
-      extractUsageFromChunks([
-        StreamInferenceResponseChunk.text('a'),
-        StreamInferenceResponseChunk.text('b'),
-      ]),
+      extractUsageFromChunks(
+        [
+          StreamInferenceResponseChunk.text('a'),
+          StreamInferenceResponseChunk.text('b'),
+        ],
+        createPinoLoggerMock(),
+      ),
     ).toBeUndefined();
   });
 
   it('takes last-wins instead of summing cumulative per-chunk usage', () => {
     // Providers (e.g. Gemini, Mistral) report cumulative usage on every chunk.
     // Summing would over-count; the final values are the truth.
-    const usage = extractUsageFromChunks([
-      chunkWithUsage({ inputTokens: 100, outputTokens: 10 }),
-      chunkWithUsage({ inputTokens: 100, outputTokens: 25 }),
-      chunkWithUsage({ inputTokens: 100, outputTokens: 42 }),
-    ]);
+    const usage = extractUsageFromChunks(
+      [
+        chunkWithUsage({ inputTokens: 100, outputTokens: 10 }),
+        chunkWithUsage({ inputTokens: 100, outputTokens: 25 }),
+        chunkWithUsage({ inputTokens: 100, outputTokens: 42 }),
+      ],
+      createPinoLoggerMock(),
+    );
     expect(usage).toEqual({ inputTokens: 100, outputTokens: 42 });
   });
 
   it('carries forward the last defined value of each field independently', () => {
     // Gemini repeats promptTokenCount on every chunk but only emits
     // candidatesTokenCount on the final chunk.
-    const usage = extractUsageFromChunks([
-      chunkWithUsage({ inputTokens: 100 }),
-      chunkWithUsage({ inputTokens: 100 }),
-      chunkWithUsage({ inputTokens: 100, outputTokens: 30 }),
-    ]);
+    const usage = extractUsageFromChunks(
+      [
+        chunkWithUsage({ inputTokens: 100 }),
+        chunkWithUsage({ inputTokens: 100 }),
+        chunkWithUsage({ inputTokens: 100, outputTokens: 30 }),
+      ],
+      createPinoLoggerMock(),
+    );
     expect(usage).toEqual({ inputTokens: 100, outputTokens: 30 });
   });
 
@@ -72,26 +82,32 @@ describe('extractUsageFromChunks', () => {
     // Anthropic's input_tokens excludes tokens served by or written to the
     // prompt cache. Option A billing: customers pay for the full prompt as
     // if uncached, so cache read/write tokens count as input.
-    const usage = extractUsageFromChunks([
-      chunkWithUsage({
-        inputTokens: 3,
-        cacheWriteInputTokens: 9677,
-        cacheReadInputTokens: 0,
-      }),
-      chunkWithUsage({ outputTokens: 42 }),
-    ]);
+    const usage = extractUsageFromChunks(
+      [
+        chunkWithUsage({
+          inputTokens: 3,
+          cacheWriteInputTokens: 9677,
+          cacheReadInputTokens: 0,
+        }),
+        chunkWithUsage({ outputTokens: 42 }),
+      ],
+      createPinoLoggerMock(),
+    );
     expect(usage).toEqual({ inputTokens: 9680, outputTokens: 42 });
   });
 
   it('bills cache reads and writes together with uncached input', () => {
-    const usage = extractUsageFromChunks([
-      chunkWithUsage({
-        inputTokens: 10,
-        cacheWriteInputTokens: 200,
-        cacheReadInputTokens: 3000,
-        outputTokens: 5,
-      }),
-    ]);
+    const usage = extractUsageFromChunks(
+      [
+        chunkWithUsage({
+          inputTokens: 10,
+          cacheWriteInputTokens: 200,
+          cacheReadInputTokens: 3000,
+          outputTokens: 5,
+        }),
+      ],
+      createPinoLoggerMock(),
+    );
     expect(usage).toEqual({ inputTokens: 3210, outputTokens: 5 });
   });
 });
@@ -168,14 +184,25 @@ describe('StreamingInferenceService.executeStreamingInference — tool-call inte
     const eventEmitter = {
       emitAsync: jest.fn().mockResolvedValue([]),
     } as unknown as EventEmitter2;
+    const logger = createPinoLoggerMock();
+    const toolCallArgumentsLogger = createPinoLoggerMock();
     const service = new StreamingInferenceService(
       streamInferenceUseCase,
       saveAssistantMessageUseCase,
       inferenceUsageGuard,
       contextService,
       eventEmitter,
+      logger,
+      createPinoLoggerMock(),
+      toolCallArgumentsLogger,
     );
-    return { service, savedMessages, saveAssistantMessage };
+    return {
+      service,
+      savedMessages,
+      saveAssistantMessage,
+      logger,
+      toolCallArgumentsLogger,
+    };
   };
 
   const consume = async (service: StreamingInferenceService) => {
@@ -243,7 +270,7 @@ describe('StreamingInferenceService.executeStreamingInference — tool-call inte
   });
 
   it('throws InferenceFailedError instead of executing a tool call whose final arguments are unparseable', async () => {
-    const { service, savedMessages } = buildService([
+    const { service, savedMessages, toolCallArgumentsLogger } = buildService([
       toolCallChunk({
         id: 'call_1',
         name: 'create_document',
@@ -261,6 +288,12 @@ describe('StreamingInferenceService.executeStreamingInference — tool-call inte
       (block) => block instanceof ToolUseMessageContent,
     );
     expect(toolUses).toHaveLength(0);
+    expect(toolCallArgumentsLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCalls: [expect.objectContaining({ toolName: 'create_document' })],
+      }),
+      'Model emitted unparseable tool call arguments',
+    );
   });
 
   it('throws InferenceTokenLimitError when the stream hits the token limit while emitting tool calls', async () => {

--- a/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/streaming-inference.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UUID } from 'crypto';
 import { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
@@ -75,14 +76,18 @@ const freshTracker = (): OutputTracker => ({
  */
 @Injectable()
 export class StreamingInferenceService {
-  private readonly logger = new Logger(StreamingInferenceService.name);
-
   constructor(
     private readonly streamInferenceUseCase: StreamInferenceUseCase,
     private readonly saveAssistantMessageUseCase: SaveAssistantMessageUseCase,
     private readonly inferenceUsageGuard: InferenceUsageGuard,
     private readonly contextService: ContextService,
     private readonly eventEmitter: EventEmitter2,
+    @InjectPinoLogger(StreamingInferenceService.name)
+    private readonly logger: PinoLogger,
+    @InjectPinoLogger('StreamUsage')
+    private readonly streamUsageLogger: PinoLogger,
+    @InjectPinoLogger('ToolCallArguments')
+    private readonly toolCallArgumentsLogger: PinoLogger,
   ) {}
 
   async *executeStreamingInference(
@@ -110,8 +115,8 @@ export class StreamingInferenceService {
       // as the stall retry; a second empty attempt falls through to the
       // orchestrator's RUN_EXECUTION_FAILED (incident #548).
       this.logger.warn(
-        'Provider stream completed without any output; retrying once',
         { threadId: params.threadId },
+        'Provider stream completed without any output; retrying once',
       );
     } catch (error) {
       // A stall or a token-limit-truncated tool call is safe to retry as
@@ -123,11 +128,11 @@ export class StreamingInferenceService {
         throw error;
       }
       this.logger.warn(
-        'Recoverable inference failure before durable output; retrying once',
         {
           threadId: params.threadId,
           reason: error.constructor.name,
         },
+        'Recoverable inference failure before durable output; retrying once',
       );
     }
     return yield* this.streamAttempt(params, freshTracker(), assistantMessage);
@@ -219,7 +224,7 @@ export class StreamingInferenceService {
     chunks: StreamInferenceResponseChunk[],
     messageId: UUID,
   ): void {
-    const usage = extractUsageFromChunks(chunks);
+    const usage = extractUsageFromChunks(chunks, this.streamUsageLogger);
     if (usage) {
       this.inferenceUsageGuard.collectUsage(model, usage, messageId);
     }
@@ -249,9 +254,12 @@ export class StreamingInferenceService {
         ),
       )
       .catch((err: unknown) => {
-        this.logger.error('Failed to emit InferenceCompletedEvent', {
-          error: err instanceof Error ? err.message : 'Unknown error',
-        });
+        this.logger.error(
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+          },
+          'Failed to emit InferenceCompletedEvent',
+        );
       });
   }
 
@@ -285,6 +293,7 @@ export class StreamingInferenceService {
       assertToolCallArgumentsIntact(
         state.toolCalls.values(),
         state.finishReason,
+        this.toolCallArgumentsLogger,
       );
     } catch (error) {
       state.toolCallsCorrupted = true;
@@ -353,14 +362,14 @@ export class StreamingInferenceService {
     streamCompletedSuccessfully: boolean,
     tools: Tool[],
   ): Promise<boolean> {
-    this.logger.log(
-      'Finalizing streaming inference, saving accumulated message',
+    this.logger.info(
       {
         threadId,
         hasText: state.text.length > 0,
         hasThinking: state.thinking.length > 0,
         toolCallsCount: state.toolCalls.size,
       },
+      'Finalizing streaming inference, saving accumulated message',
     );
 
     const finalContent = this.buildFinalContent(
@@ -375,14 +384,20 @@ export class StreamingInferenceService {
         new SaveAssistantMessageCommand(assistantMessage),
       );
       if (!saved) return false;
-      this.logger.log('Successfully saved message to database', {
-        threadId,
-        messageId: assistantMessage.id,
-      });
+      this.logger.info(
+        {
+          threadId,
+          messageId: assistantMessage.id,
+        },
+        'Successfully saved message to database',
+      );
     } else {
-      this.logger.warn('No content to save for assistant message', {
-        threadId,
-      });
+      this.logger.warn(
+        {
+          threadId,
+        },
+        'No content to save for assistant message',
+      );
     }
     return true;
   }
@@ -397,9 +412,9 @@ export class StreamingInferenceService {
     if (includeToolCalls) {
       this.addFinalToolCalls(content, state.toolCalls, tools);
     } else {
-      this.logger.log(
-        'Streaming was interrupted, excluding tool calls from saved message',
+      this.logger.info(
         { toolCallCount: state.toolCalls.size },
+        'Streaming was interrupted, excluding tool calls from saved message',
       );
     }
 
@@ -416,8 +431,11 @@ export class StreamingInferenceService {
       const parsedArgs = parseFinalToolArguments(toolCall.arguments);
       if (parsedArgs === null) {
         this.logger.warn(
-          `Discarding tool call with unparseable arguments: ${toolCall.name}`,
-          { argumentsLength: toolCall.arguments.length },
+          {
+            toolName: toolCall.name,
+            argumentsLength: toolCall.arguments.length,
+          },
+          'Discarding tool call with unparseable arguments',
         );
         return;
       }

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { Thread } from 'src/domain/threads/domain/thread.entity';
 import { SourceAssignment } from 'src/domain/threads/domain/thread-source-assignment.entity';
@@ -89,6 +90,7 @@ describe('ToolAssemblyService — image generation tool assembly', () => {
     const mcpToolAssembler = new (McpToolAssemblerService as any)(
       discoverMcpCapabilitiesUseCase,
       getMcpIntegrationsByIdsUseCase,
+      createPinoLoggerMock(),
     );
 
     const service = new (ToolAssemblyService as any)(
@@ -105,6 +107,7 @@ describe('ToolAssemblyService — image generation tool assembly', () => {
       getPermittedImageGenerationModelUseCase,
       artifactToolAssembler,
       getOrgChatSettingsUseCase,
+      createPinoLoggerMock(),
     );
 
     return {
@@ -243,11 +246,11 @@ describe('ToolAssemblyService — image generation tool assembly', () => {
     ).rejects.toThrow(unexpectedError);
 
     expect(loggerSpy).toHaveBeenCalledWith(
-      'Failed to check image generation model availability',
       expect.objectContaining({
         orgId: mockOrgId,
         error: 'Database connection failed',
       }),
+      'Failed to check image generation model availability',
     );
   });
 

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-assembly.service.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService, ConfigType } from '@nestjs/config';
 import { Thread } from 'src/domain/threads/domain/thread.entity';
 import { Tool } from 'src/domain/tools/domain/tool.entity';
@@ -35,8 +36,6 @@ import { McpToolAssemblerService } from './mcp-tool-assembler.service';
 
 @Injectable()
 export class ToolAssemblyService {
-  private readonly logger = new Logger(ToolAssemblyService.name);
-
   constructor(
     private readonly configService: ConfigService,
     private readonly assembleToolsUseCase: AssembleToolUseCase,
@@ -52,6 +51,8 @@ export class ToolAssemblyService {
     private readonly getPermittedImageGenerationModelUseCase: GetPermittedImageGenerationModelUseCase,
     private readonly artifactToolAssembler: ArtifactToolAssemblerService,
     private readonly getOrgChatSettingsUseCase: GetOrgChatSettingsUseCase,
+    @InjectPinoLogger(ToolAssemblyService.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async findActiveSkills(): Promise<Skill[]> {
@@ -110,8 +111,8 @@ export class ToolAssemblyService {
       );
     } catch (error) {
       this.logger.error(
-        'Failed to fetch always-on templates, continuing without them',
         { error: error instanceof Error ? error.message : 'Unknown error' },
+        'Failed to fetch always-on templates, continuing without them',
       );
       return [];
     }
@@ -177,10 +178,10 @@ export class ToolAssemblyService {
       } catch (error) {
         const message =
           error instanceof SlugCollisionError
-            ? `Slug collision, skipping skill "${input.name}"`
-            : `Failed to build slug for skill "${input.name}", skipping`;
+            ? 'Slug collision, skipping skill'
+            : 'Failed to build slug for skill, skipping';
         const detail = error instanceof Error ? error.message : 'Unknown error';
-        this.logger.warn(message, { error: detail });
+        this.logger.warn({ skillName: input.name, error: detail }, message);
       }
     }
 

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { AnonymizationFailedError } from 'src/common/anonymization/application/anonymization.errors';
 import type { AnonymizeTextForThreadUseCase } from 'src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case';
 import { RunAnonymizationUnavailableError } from '../runs.errors';
@@ -96,6 +97,7 @@ describe('ToolResultCollectorService', () => {
       anonymizeTextForThreadUseCase,
       contextService,
       eventEmitter as never,
+      createPinoLoggerMock(),
     );
   });
 

--- a/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/tool-result-collector.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UUID } from 'crypto';
 import { ToolResultMessageContent } from 'src/domain/messages/domain/message-contents/tool-result.message-content.entity';
@@ -49,14 +50,14 @@ export interface CollectedToolResults {
 
 @Injectable()
 export class ToolResultCollectorService {
-  private readonly logger = new Logger(ToolResultCollectorService.name);
-
   constructor(
     private readonly executeToolUseCase: ExecuteToolUseCase,
     private readonly checkToolCapabilitiesUseCase: CheckToolCapabilitiesUseCase,
     private readonly anonymizeTextForThreadUseCase: AnonymizeTextForThreadUseCase,
     private readonly contextService: ContextService,
     private readonly eventEmitter: EventEmitter2,
+    @InjectPinoLogger(ToolResultCollectorService.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async collectToolResults(params: {
@@ -138,7 +139,13 @@ export class ToolResultCollectorService {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error(`Error processing tool ${content.name}`, error);
+      this.logger.error(
+        {
+          toolName: content.name,
+          err: error instanceof Error ? error : new Error(String(error)),
+        },
+        'Error processing tool',
+      );
       throw new RunToolExecutionFailedError(content.name, {
         error: error as Error,
       });
@@ -159,10 +166,13 @@ export class ToolResultCollectorService {
         ),
       )
       .catch((err: unknown) => {
-        this.logger.error('Failed to emit ToolUsedEvent', {
-          error: err instanceof Error ? err.message : 'Unknown error',
-          toolName: content.name,
-        });
+        this.logger.error(
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            toolName: content.name,
+          },
+          'Failed to emit ToolUsedEvent',
+        );
       });
   }
 
@@ -279,7 +289,10 @@ export class ToolResultCollectorService {
       );
       if (displayOnlyCalls.length > 0 && allValid) return true;
     } catch (error) {
-      this.logger.error('Error checking for display tools', error);
+      this.logger.error(
+        { err: error instanceof Error ? error : new Error(String(error)) },
+        'Error checking for display tools',
+      );
     }
 
     return false;
@@ -292,7 +305,8 @@ export class ToolResultCollectorService {
     const tool = tools.find((candidate) => candidate.name === content.name);
     if (!tool) {
       this.logger.warn(
-        `Tool ${content.name} mentioned in response but not found`,
+        { toolName: content.name },
+        'Tool mentioned in response but not found',
       );
       return undefined;
     }

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID, type UUID } from 'crypto';
 import { ExecuteRunAndSetTitleUseCase } from './execute-run-and-set-title.use-case';
 import { ExecuteRunAndSetTitleCommand } from './execute-run-and-set-title.command';
@@ -90,6 +91,7 @@ describe('ExecuteRunAndSetTitleUseCase', () => {
       generateAndSetThreadTitleUseCase,
       anonymizeTextForOrgUseCase,
       contextService,
+      createPinoLoggerMock(),
     );
   });
 

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-and-set-title/execute-run-and-set-title.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { ExecuteRunAndSetTitleCommand } from './execute-run-and-set-title.command';
 import { ExecuteRunUseCase } from '../execute-run/execute-run.use-case';
@@ -39,14 +40,14 @@ import type { RunExecutionOutcome } from '../../run-execution-outcome';
 
 @Injectable()
 export class ExecuteRunAndSetTitleUseCase {
-  private readonly logger = new Logger(ExecuteRunAndSetTitleUseCase.name);
-
   constructor(
     private readonly executeRunUseCase: ExecuteRunUseCase,
     private readonly findThreadUseCase: FindThreadUseCase,
     private readonly generateAndSetThreadTitleUseCase: GenerateAndSetThreadTitleUseCase,
     private readonly anonymizeTextForOrgUseCase: AnonymizeTextForOrgUseCase,
     private readonly contextService: ContextService,
+    @InjectPinoLogger(ExecuteRunAndSetTitleUseCase.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async *execute(
@@ -56,7 +57,10 @@ export class ExecuteRunAndSetTitleUseCase {
       yield this.sessionEvent(command.threadId, true);
       yield* this.executeRun(command);
     } catch (error) {
-      this.logger.error('Error in executeRunAndSetTitle', error);
+      this.logger.error(
+        { err: error instanceof Error ? error : new Error(String(error)) },
+        'Error in executeRunAndSetTitle',
+      );
       // The SSE response was committed as 200 before the run started, so the
       // global exception filter never sees this failure — report it here or
       // provider outages produce no AppSignal incident at all (AYC-653).
@@ -171,10 +175,10 @@ export class ExecuteRunAndSetTitleUseCase {
         ? await this.anonymizeText(firstUserMessage)
         : firstUserMessage;
 
-      this.logger.log('Generating thread title', {
-        threadId: command.threadId,
-        isAnonymous: thread.isAnonymous,
-      });
+      this.logger.info(
+        { threadId: command.threadId, isAnonymous: thread.isAnonymous },
+        'Generating thread title',
+      );
 
       const model = thread.model;
       if (!model) {
@@ -191,24 +195,27 @@ export class ExecuteRunAndSetTitleUseCase {
         }),
       );
 
-      if (title) {
-        return {
-          type: 'thread',
-          threadId: thread.id,
-          updateType: 'title_updated',
-          title: title,
-          timestamp: new Date().toISOString(),
-        };
-      }
-
-      return null;
+      return title ? this.titleUpdatedEvent(thread.id, title) : null;
     } catch (error) {
-      this.logger.warn('Error in generateTitle', {
-        threadId: command.threadId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.warn(
+        {
+          threadId: command.threadId,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Error in generateTitle',
+      );
       return null;
     }
+  }
+
+  private titleUpdatedEvent(threadId: UUID, title: string): RunThreadEvent {
+    return {
+      type: 'thread',
+      threadId,
+      updateType: 'title_updated',
+      title,
+      timestamp: new Date().toISOString(),
+    };
   }
 
   private extractUserMessage(input: RunInput): string | undefined {
@@ -232,11 +239,14 @@ export class ExecuteRunAndSetTitleUseCase {
       new AnonymizeTextForOrgCommand(text, orgId),
     );
     if (result.replacements.length > 0) {
-      this.logger.log('Anonymized text for title generation', {
-        originalLength: text.length,
-        anonymizedLength: result.anonymizedText.length,
-        replacementsCount: result.replacements.length,
-      });
+      this.logger.info(
+        {
+          originalLength: text.length,
+          anonymizedLength: result.anonymizedText.length,
+          replacementsCount: result.replacements.length,
+        },
+        'Anonymized text for title generation',
+      );
     }
     return result.anonymizedText;
   }

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { MockProvider, textTurn, toolCallTurn } from '@ayunis/agent-runtime';
 import type {
   ProviderRequest,
@@ -200,9 +201,10 @@ function buildHarness(overrides: HarnessOptions = {}): Harness {
   const createUserMessageUseCase = {
     execute: createUser,
   } as unknown as CreateUserMessageUseCase;
-  const addMessageToThreadUseCase = new AddMessageToThreadUseCase(
-    contextService,
-    eventEmitter,
+  // The third argument is ignored before AYC-751 and becomes the required logger after restacking.
+  const addMessageToThreadUseCase = Reflect.construct(
+    AddMessageToThreadUseCase,
+    [contextService, eventEmitter, createPinoLoggerMock()],
   );
   const runtimeHistoryMaterializer = {
     materialize: jest
@@ -261,7 +263,10 @@ function buildHarness(overrides: HarnessOptions = {}): Harness {
   );
   const collectUsage = inferenceUsageGuard.collectUsage as jest.Mock;
   const usageHookFactory = new UsageHookFactory(inferenceUsageGuard);
-  const toolUsageHookFactory = new ToolUsageHookFactory(eventEmitter);
+  const toolUsageHookFactory = new ToolUsageHookFactory(
+    eventEmitter,
+    createPinoLoggerMock(),
+  );
   const toolResultCollector = overrides.toolResultCollector ?? {
     collectToolResults: jest
       .fn()
@@ -290,6 +295,8 @@ function buildHarness(overrides: HarnessOptions = {}): Harness {
     toolResultCollector as ToolResultCollectorService,
     toolUsageHookFactory,
     contextBudgetHookFactory,
+    createPinoLoggerMock(),
+    createPinoLoggerMock(),
   );
 
   return {
@@ -857,6 +864,7 @@ describe('ExecuteRunViaRuntimeUseCase', () => {
       { execute: jest.fn() } as never,
       { get: jest.fn().mockReturnValue(userId) } as never,
       { emitAsync: jest.fn().mockResolvedValue([]) } as never,
+      createPinoLoggerMock(),
     );
     const { useCase, createSeedToolResult } = buildHarness({
       backendTools: [displayTool, searchTool],
@@ -906,6 +914,7 @@ describe('ExecuteRunViaRuntimeUseCase', () => {
       { execute: jest.fn() } as never,
       { get: jest.fn().mockReturnValue(userId) } as never,
       { emitAsync: jest.fn().mockResolvedValue([]) } as never,
+      createPinoLoggerMock(),
     );
     const { useCase } = buildHarness({
       backendTools: [displayTool, searchTool],

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.ts
@@ -1,5 +1,6 @@
 import { run, RunContext, type Hook } from '@ayunis/agent-runtime';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -88,8 +89,6 @@ interface PreparedToolResultInput {
  */
 @Injectable()
 export class ExecuteRunViaRuntimeUseCase {
-  private readonly logger = new Logger(ExecuteRunViaRuntimeUseCase.name);
-
   constructor(
     private readonly contextService: ContextService,
     private readonly findThreadUseCase: FindThreadUseCase,
@@ -112,13 +111,17 @@ export class ExecuteRunViaRuntimeUseCase {
     private readonly toolResultCollectorService: ToolResultCollectorService,
     private readonly toolUsageHookFactory: ToolUsageHookFactory,
     private readonly contextBudgetHookFactory: ContextBudgetHookFactory,
+    @InjectPinoLogger(ExecuteRunViaRuntimeUseCase.name)
+    private readonly logger: PinoLogger,
+    @InjectPinoLogger('RunEventStreamAdapter')
+    private readonly runEventStreamLogger: PinoLogger,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedRunError)
   async execute(
     command: ExecuteRunCommand,
   ): Promise<AsyncGenerator<RunStreamItem, RunExecutionOutcome, void>> {
-    this.logger.log('executeRunViaRuntime', { threadId: command.threadId });
+    this.logger.info({ threadId: command.threadId }, 'executeRunViaRuntime');
     const prepared = await this.prepareRun(command);
     return this.streamRun(prepared, command.input, command.signal);
   }
@@ -232,6 +235,7 @@ export class ExecuteRunViaRuntimeUseCase {
       const outcome = yield* adaptRunEventsToStream(
         await this.startRun(prepared, signal),
         prepared.thread.id,
+        this.runEventStreamLogger,
         prepared.toolIntegrations,
       );
       cleanupRequired = outcome === 'aborted';
@@ -246,7 +250,7 @@ export class ExecuteRunViaRuntimeUseCase {
         cleanupRequired = false;
       }
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Runtime run failed', { error: error as Error });
+      this.logger.error({ err: error as Error }, 'Runtime run failed');
       throw new RunExecutionFailedError(
         error instanceof Error ? error.message : 'Unknown error',
         { originalError: error as Error },
@@ -472,9 +476,12 @@ export class ExecuteRunViaRuntimeUseCase {
         new RunExecutedEvent(userId, orgId),
       )
       .catch((err: unknown) => {
-        this.logger.error('Failed to emit RunExecutedEvent', {
-          error: err instanceof Error ? err.message : 'Unknown error',
-        });
+        this.logger.error(
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+          },
+          'Failed to emit RunExecutedEvent',
+        );
       });
   }
 }

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import {
   AnonymizationFailedError,
   AnonymizationInputTooLongError,
@@ -160,6 +161,7 @@ describe('ExecuteRunUseCase', () => {
       {
         execute: jest.fn(),
       } as unknown as ExecuteRunViaRuntimeUseCase,
+      createPinoLoggerMock(),
     );
   });
 

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Message } from 'src/domain/messages/domain/message.entity';
 import type { AssistantMessage } from 'src/domain/messages/domain/messages/assistant-message.entity';
@@ -54,8 +55,6 @@ import type { RunExecutionOutcome } from '../../run-execution-outcome';
 
 @Injectable()
 export class ExecuteRunUseCase {
-  private readonly logger = new Logger(ExecuteRunUseCase.name);
-
   constructor(
     private readonly createUserMessageUseCase: CreateUserMessageUseCase,
     private readonly createToolResultMessageUseCase: CreateToolResultMessageUseCase,
@@ -72,16 +71,21 @@ export class ExecuteRunUseCase {
     private readonly eventEmitter: EventEmitter2,
     private readonly configService: ConfigService,
     private readonly executeRunViaRuntimeUseCase: ExecuteRunViaRuntimeUseCase,
+    @InjectPinoLogger(ExecuteRunUseCase.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async execute(
     command: ExecuteRunCommand,
   ): Promise<AsyncGenerator<RunStreamItem, RunExecutionOutcome | void, void>> {
-    this.logger.log('executeRun', {
-      threadId: command.threadId,
-      streaming: command.streaming,
-      inputType: command.input.constructor.name,
-    });
+    this.logger.info(
+      {
+        threadId: command.threadId,
+        streaming: command.streaming,
+        inputType: command.input.constructor.name,
+      },
+      'executeRun',
+    );
     if (this.configService.get<boolean>('features.agentRuntimeEnabled')) {
       return this.executeRunViaRuntimeUseCase.execute(command);
     }
@@ -170,10 +174,13 @@ export class ExecuteRunUseCase {
         new RunExecutedEvent(userId, orgId),
       )
       .catch((err: unknown) => {
-        this.logger.error('Failed to emit RunExecutedEvent', {
-          error: err instanceof Error ? err.message : 'Unknown error',
-          userId,
-        });
+        this.logger.error(
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            userId,
+          },
+          'Failed to emit RunExecutedEvent',
+        );
       });
   }
 
@@ -190,14 +197,14 @@ export class ExecuteRunUseCase {
   private async *orchestrateRun(
     params: RunParams,
   ): AsyncGenerator<RunStreamItem, RunExecutionOutcome, void> {
-    this.logger.log('orchestrateRun', { threadId: params.thread.id });
+    this.logger.info({ threadId: params.thread.id }, 'orchestrateRun');
     const iterations = 50;
     const breaker = new ToolFailureBreaker();
     let succeeded = false;
     let preserveTranscript = false;
     try {
       for (let i = 0; i < iterations; i++) {
-        this.logger.debug('iteration', i);
+        this.logger.debug({ value: i }, 'iteration');
         const assistantMessage = yield* this.runIteration(
           params,
           breaker,
@@ -227,7 +234,7 @@ export class ExecuteRunUseCase {
       // streamed — rolling it back would re-arm the pending tool calls.
       preserveTranscript = error instanceof RunToolRepeatedlyFailingError;
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Run execution failed', { error: error as Error });
+      this.logger.error({ err: error as Error }, 'Run execution failed');
       throw new RunExecutionFailedError(
         error instanceof Error ? error.message : 'Unknown error',
         { originalError: error as Error },
@@ -453,20 +460,26 @@ export class ExecuteRunUseCase {
         new AnonymizeTextForThreadCommand(text, orgId, threadId),
       );
       if (result.replacements.length > 0) {
-        this.logger.log('Anonymized text', {
-          originalLength: text.length,
-          anonymizedLength: result.anonymizedText.length,
-          replacementsCount: result.replacements.length,
-        });
+        this.logger.info(
+          {
+            originalLength: text.length,
+            anonymizedLength: result.anonymizedText.length,
+            replacementsCount: result.replacements.length,
+          },
+          'Anonymized text',
+        );
       }
       return { anonymizedText: result.anonymizedText, masks: result.masks };
     } catch (error) {
       if (error instanceof AnonymizationInputTooLongError) {
         throw error;
       }
-      this.logger.error('Anonymization service unavailable', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Anonymization service unavailable',
+      );
       throw new RunAnonymizationUnavailableError(
         {
           originalError:

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/send-message/send-message.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/send-message/send-message.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import type { ContextService } from 'src/common/context/services/context.service';
 import type { IncrementTrialMessagesUseCase } from 'src/iam/trials/application/use-cases/increment-trial-messages/increment-trial-messages.use-case';
@@ -67,6 +68,7 @@ describe('SendMessageUseCase', () => {
       executeRunAndSetTitleUseCase as unknown as ExecuteRunAndSetTitleUseCase,
       incrementTrialMessagesUseCase as unknown as IncrementTrialMessagesUseCase,
       contextService as unknown as ContextService,
+      createPinoLoggerMock(),
     );
   });
 

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/send-message/send-message.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/send-message/send-message.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ContextService } from 'src/common/context/services/context.service';
 import { IncrementTrialMessagesUseCase } from 'src/iam/trials/application/use-cases/increment-trial-messages/increment-trial-messages.use-case';
 import { IncrementTrialMessagesCommand } from 'src/iam/trials/application/use-cases/increment-trial-messages/increment-trial-messages.command';
@@ -9,12 +10,12 @@ import { SendMessageCommand } from './send-message.command';
 
 @Injectable()
 export class SendMessageUseCase {
-  private readonly logger = new Logger(SendMessageUseCase.name);
-
   constructor(
     private readonly executeRunAndSetTitleUseCase: ExecuteRunAndSetTitleUseCase,
     private readonly incrementTrialMessagesUseCase: IncrementTrialMessagesUseCase,
     private readonly contextService: ContextService,
+    @InjectPinoLogger(SendMessageUseCase.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async *execute(command: SendMessageCommand): AsyncGenerator<RunEvent> {
@@ -41,19 +42,25 @@ export class SendMessageUseCase {
       return;
     }
 
-    this.logger.debug('Incrementing trial messages for non-subscription org', {
-      orgId,
-    });
+    this.logger.debug(
+      {
+        orgId,
+      },
+      'Incrementing trial messages for non-subscription org',
+    );
 
     // Fire-and-forget by design: trial accounting must not delay or fail the
     // run. The .catch keeps a failure out of the unhandledRejection path.
     this.incrementTrialMessagesUseCase
       .execute(new IncrementTrialMessagesCommand(orgId))
       .catch((error: unknown) => {
-        this.logger.error('Failed to increment trial messages', {
-          orgId,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        this.logger.error(
+          {
+            orgId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          'Failed to increment trial messages',
+        );
       });
   }
 }

--- a/ayunis-core-backend/src/domain/runs/presenters/http/runs.controller.ts
+++ b/ayunis-core-backend/src/domain/runs/presenters/http/runs.controller.ts
@@ -1,13 +1,13 @@
 import {
   Body,
   Controller,
-  Logger,
   Post,
   Req,
   Res,
   UseInterceptors,
   UploadedFiles,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { FilesInterceptor } from '@nestjs/platform-express';
 import {
   ApiOperation,
@@ -88,12 +88,12 @@ import { RequireAcademyCertificate } from 'src/iam/academy-access/application/de
 @RequireAcademyCertificate()
 @Controller('runs')
 export class RunsController {
-  private readonly logger = new Logger(RunsController.name);
-
   constructor(
     private readonly sendMessageUseCase: SendMessageUseCase,
     private readonly requestValidator: SendMessageRequestValidator,
     private readonly ssePresenter: RunSsePresenter,
+    @InjectPinoLogger(RunsController.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   @Post('send-message')
@@ -115,21 +115,19 @@ export class RunsController {
   ): Promise<void> {
     const uploadedFiles = files ?? [];
 
-    this.logger.log('sendMessage', {
-      userId,
-      threadId: sendMessageDto.threadId,
-      streaming: sendMessageDto.streaming,
-      fileCount: uploadedFiles.length,
-      hasText: !!sendMessageDto.text?.trim(),
-      hasToolResult: !!sendMessageDto.toolResult,
-    });
+    this.logger.info(
+      {
+        userId,
+        threadId: sendMessageDto.threadId,
+        streaming: sendMessageDto.streaming,
+        fileCount: uploadedFiles.length,
+        hasText: !!sendMessageDto.text?.trim(),
+        hasToolResult: !!sendMessageDto.toolResult,
+      },
+      'sendMessage',
+    );
 
     this.requestValidator.validate(sendMessageDto, uploadedFiles);
-    const input = RunInputMapper.toCommand(
-      sendMessageDto,
-      uploadedFiles,
-      sendMessageDto.skillId,
-    );
     const consumeTrialMessage = Boolean(
       request.subscriptionContext?.hasRemainingTrialMessages,
     );
@@ -139,14 +137,28 @@ export class RunsController {
       sendMessageDto.threadId,
       (signal) =>
         this.sendMessageUseCase.execute(
-          new SendMessageCommand({
-            threadId: sendMessageDto.threadId,
-            input,
-            streaming: sendMessageDto.streaming ?? true,
+          this.createCommand(
+            sendMessageDto,
+            uploadedFiles,
             consumeTrialMessage,
             signal,
-          }),
+          ),
         ),
     );
+  }
+
+  private createCommand(
+    dto: SendMessageDto,
+    files: Express.Multer.File[],
+    consumeTrialMessage: boolean,
+    signal: AbortSignal,
+  ): SendMessageCommand {
+    return new SendMessageCommand({
+      threadId: dto.threadId,
+      input: RunInputMapper.toCommand(dto, files, dto.skillId),
+      streaming: dto.streaming ?? true,
+      consumeTrialMessage,
+      signal,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/runs/presenters/http/sse/run-sse.presenter.socket.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/presenters/http/sse/run-sse.presenter.socket.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { createServer, type Server } from 'http';
 import { connect, type Socket, type AddressInfo } from 'net';
 import type { Response } from 'express';
@@ -95,6 +96,7 @@ describe('RunSsePresenter over real sockets', () => {
 
   const presenter = new RunSsePresenter(
     eventMapper as unknown as RunEventResponseMapper,
+    createPinoLoggerMock(),
   );
 
   let server: Server;

--- a/ayunis-core-backend/src/domain/runs/presenters/http/sse/run-sse.presenter.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/presenters/http/sse/run-sse.presenter.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { EventEmitter } from 'events';
 import type { Response } from 'express';
 import type { UUID } from 'crypto';
@@ -58,6 +59,7 @@ describe('RunSsePresenter', () => {
     jest.clearAllMocks();
     presenter = new RunSsePresenter(
       eventMapper as unknown as RunEventResponseMapper,
+      createPinoLoggerMock(),
     );
     response = new FakeSseResponse();
   });

--- a/ayunis-core-backend/src/domain/runs/presenters/http/sse/run-sse.presenter.ts
+++ b/ayunis-core-backend/src/domain/runs/presenters/http/sse/run-sse.presenter.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { Response } from 'express';
 import type { UUID } from 'crypto';
 import {
@@ -30,9 +31,11 @@ type RunEventSource = (signal: AbortSignal) => AsyncIterable<RunEvent>;
  */
 @Injectable()
 export class RunSsePresenter {
-  private readonly logger = new Logger(RunSsePresenter.name);
-
-  constructor(private readonly eventMapper: RunEventResponseMapper) {}
+  constructor(
+    private readonly eventMapper: RunEventResponseMapper,
+    @InjectPinoLogger(RunSsePresenter.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   async stream(
     response: Response,
@@ -83,7 +86,7 @@ export class RunSsePresenter {
   ): Promise<void> {
     for await (const event of events) {
       if (state.disconnected) {
-        this.logger.log('Stopping event stream due to client disconnect');
+        this.logger.info('Stopping event stream due to client disconnect');
         break;
       }
 
@@ -109,15 +112,18 @@ export class RunSsePresenter {
     // Object wrapper so TS recognises async mutation from the handlers
     const state: ConnectionState = { disconnected: false };
     const disconnectHandler = () => {
-      this.logger.log('Client disconnected from SSE stream', { threadId });
+      this.logger.info({ threadId }, 'Client disconnected from SSE stream');
       state.disconnected = true;
       abortController.abort();
     };
     const errorHandler = (err: Error) => {
-      this.logger.warn('SSE response stream error', {
-        threadId,
-        error: err.message,
-      });
+      this.logger.warn(
+        {
+          threadId,
+          error: err.message,
+        },
+        'SSE response stream error',
+      );
       state.disconnected = true;
       abortController.abort(err);
     };
@@ -164,10 +170,13 @@ export class RunSsePresenter {
       } catch (err) {
         state.disconnected = true;
         abortController.abort(err);
-        this.logger.warn('SSE heartbeat write failed', {
-          threadId,
-          error: err instanceof Error ? err.message : String(err),
-        });
+        this.logger.warn(
+          {
+            threadId,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          'SSE heartbeat write failed',
+        );
       }
     }, HEARTBEAT_INTERVAL_MS);
   }
@@ -181,7 +190,10 @@ export class RunSsePresenter {
     threadId: UUID,
     error: unknown,
   ): void {
-    this.logger.error('Error in run event stream', error);
+    this.logger.error(
+      { err: error instanceof Error ? error : new Error(String(error)) },
+      'Error in run event stream',
+    );
 
     const clientError =
       error instanceof ApplicationError ? error.toClientResponse() : undefined;
@@ -197,11 +209,16 @@ export class RunSsePresenter {
     try {
       this.writeEvent(response, 'execution-error', errorResponse);
     } catch (writeError) {
-      this.logger.warn('Failed to write SSE error event', {
-        threadId,
-        error:
-          writeError instanceof Error ? writeError.message : String(writeError),
-      });
+      this.logger.warn(
+        {
+          threadId,
+          error:
+            writeError instanceof Error
+              ? writeError.message
+              : String(writeError),
+        },
+        'Failed to write SSE error event',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/usage/application/services/collect-usage-async.service.ts
+++ b/ayunis-core-backend/src/domain/usage/application/services/collect-usage-async.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -14,12 +15,12 @@ import { TokensConsumedEvent } from '../events/tokens-consumed.event';
  */
 @Injectable()
 export class CollectUsageAsyncService {
-  private readonly logger = new Logger(CollectUsageAsyncService.name);
-
   constructor(
     private readonly collectUsageUseCase: CollectUsageUseCase,
     private readonly contextService: ContextService,
     private readonly eventEmitter: EventEmitter2,
+    @InjectPinoLogger(CollectUsageAsyncService.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   collect(
@@ -28,13 +29,16 @@ export class CollectUsageAsyncService {
     outputTokens: number,
     messageId?: UUID,
   ): void {
-    this.logger.debug('Collecting usage', {
-      modelId: model.id,
-      modelName: model.name,
-      inputTokens,
-      outputTokens,
-      messageId,
-    });
+    this.logger.debug(
+      {
+        modelId: model.id,
+        modelName: model.name,
+        inputTokens,
+        outputTokens,
+        messageId,
+      },
+      'Collecting usage',
+    );
 
     const userId = this.contextService.get('userId');
     const apiKeyId = this.contextService.get('apiKeyId');
@@ -64,9 +68,12 @@ export class CollectUsageAsyncService {
       )
       .then(() => this.emitTokensConsumed(event))
       .catch((error) => {
-        this.logger.debug('Usage collection failed', {
-          error: error as Error,
-        });
+        this.logger.debug(
+          {
+            err: error as Error,
+          },
+          'Usage collection failed',
+        );
       });
   }
 
@@ -74,9 +81,12 @@ export class CollectUsageAsyncService {
     try {
       await this.eventEmitter.emitAsync(TokensConsumedEvent.EVENT_NAME, event);
     } catch (err) {
-      this.logger.error('Failed to emit TokensConsumedEvent', {
-        error: err instanceof Error ? err.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          error: err instanceof Error ? err.message : 'Unknown error',
+        },
+        'Failed to emit TokensConsumedEvent',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -83,6 +85,10 @@ describe('CollectUsageUseCase', () => {
           useValue: mockGetCreditsPerEuroUseCase,
         },
         { provide: EventEmitter2, useValue: mockEventEmitter },
+        {
+          provide: getLoggerToken(CollectUsageUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/collect-usage/collect-usage.use-case.ts
@@ -1,6 +1,7 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { randomUUID } from 'crypto';
+import { randomUUID, type UUID } from 'crypto';
 import { CollectUsageCommand } from './collect-usage.command';
 import { Usage } from '../../../domain/usage.entity';
 import { UsageRepository } from '../../ports/usage.repository';
@@ -15,15 +16,21 @@ import { ContextService } from '../../../../../common/context/services/context.s
 import { GetCreditsPerEuroUseCase } from '../../../../../iam/platform-config/application/use-cases/get-credits-per-euro/get-credits-per-euro.use-case';
 import { PlatformConfigNotFoundError } from '../../../../../iam/platform-config/application/platform-config.errors';
 
+interface UsagePrincipal {
+  userId: UUID | undefined;
+  apiKeyId: UUID | undefined;
+  organizationId: UUID;
+}
+
 @Injectable()
 export class CollectUsageUseCase {
-  private readonly logger = new Logger(CollectUsageUseCase.name);
-
   constructor(
     private readonly usageRepository: UsageRepository,
     private readonly contextService: ContextService,
     private readonly getCreditsPerEuroUseCase: GetCreditsPerEuroUseCase,
     private readonly eventEmitter: EventEmitter2,
+    @InjectPinoLogger(CollectUsageUseCase.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async execute(command: CollectUsageCommand): Promise<void> {
@@ -49,71 +56,15 @@ export class CollectUsageUseCase {
       );
     }
 
-    this.logger.log('CollectUsageUseCase.execute called', {
-      userId,
-      apiKeyId,
-      organizationId,
-      modelId: command.modelId,
-      provider: command.provider,
-      totalTokens: command.totalTokens,
-    });
-
+    const principal = { userId, apiKeyId, organizationId };
+    this.logCollection(command, principal);
     try {
-      this.validateCommand(command);
-
-      const cost = this.calculateCost(command);
-      const creditsConsumed = await this.calculateCredits(cost);
-
-      const usage = new Usage({
-        userId: userId ?? null,
-        apiKeyId: apiKeyId ?? null,
-        organizationId,
-        modelId: command.modelId,
-        provider: command.provider,
-        inputTokens: command.inputTokens,
-        outputTokens: command.outputTokens,
-        totalTokens: command.totalTokens,
-        cost,
-        creditsConsumed,
-        requestId: command.requestId ?? randomUUID(),
-      });
-
-      await this.usageRepository.save(usage);
-
-      // Fire-and-forget: notify downstream listeners (webhook dispatch,
-      // metrics, sync services) that a usage row has been persisted.
-      // We do this AFTER save() resolves so receivers never observe
-      // usage that did not actually make it to the database.
-      this.eventEmitter
-        .emitAsync(
-          UsageCollectedEvent.EVENT_NAME,
-          new UsageCollectedEvent(usage, command.model.name),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit UsageCollectedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            usageId: usage.id,
-          });
-        });
-
-      this.logger.log('Usage collected successfully', {
-        userId,
-        apiKeyId,
-        organizationId,
-        modelId: command.modelId,
-        provider: command.provider,
-        totalTokens: command.totalTokens,
-        cost,
-        requestId: command.requestId,
-      });
+      await this.collectUsage(command, principal);
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Failed to collect usage', {
-        error: error as Error,
-        command,
-      });
+      this.logCollectionFailure(command, error);
       throw new UnexpectedUsageError(
         error instanceof Error ? error : new Error('Unknown error'),
         {
@@ -123,6 +74,100 @@ export class CollectUsageUseCase {
         },
       );
     }
+  }
+
+  private logCollectionFailure(
+    command: CollectUsageCommand,
+    error: unknown,
+  ): void {
+    this.logger.error(
+      {
+        err: error as Error,
+        modelId: command.modelId,
+        provider: command.provider,
+        inputTokens: command.inputTokens,
+        outputTokens: command.outputTokens,
+        totalTokens: command.totalTokens,
+        requestId: command.requestId,
+      },
+      'Failed to collect usage',
+    );
+  }
+
+  private logCollection(
+    command: CollectUsageCommand,
+    principal: UsagePrincipal,
+  ): void {
+    this.logger.info(
+      {
+        ...principal,
+        modelId: command.modelId,
+        provider: command.provider,
+        totalTokens: command.totalTokens,
+      },
+      'CollectUsageUseCase.execute called',
+    );
+  }
+
+  private async collectUsage(
+    command: CollectUsageCommand,
+    principal: UsagePrincipal,
+  ): Promise<void> {
+    this.validateCommand(command);
+    const cost = this.calculateCost(command);
+    const creditsConsumed = await this.calculateCredits(cost);
+    const usage = this.createUsage(command, principal, cost, creditsConsumed);
+    await this.usageRepository.save(usage);
+    this.emitUsageCollected(usage, command.model.name);
+    this.logger.info(
+      {
+        ...principal,
+        modelId: command.modelId,
+        provider: command.provider,
+        totalTokens: command.totalTokens,
+        cost,
+        requestId: command.requestId,
+      },
+      'Usage collected successfully',
+    );
+  }
+
+  private createUsage(
+    command: CollectUsageCommand,
+    principal: UsagePrincipal,
+    cost: number | undefined,
+    creditsConsumed: number | undefined,
+  ): Usage {
+    return new Usage({
+      userId: principal.userId ?? null,
+      apiKeyId: principal.apiKeyId ?? null,
+      organizationId: principal.organizationId,
+      modelId: command.modelId,
+      provider: command.provider,
+      inputTokens: command.inputTokens,
+      outputTokens: command.outputTokens,
+      totalTokens: command.totalTokens,
+      cost,
+      creditsConsumed,
+      requestId: command.requestId ?? randomUUID(),
+    });
+  }
+
+  private emitUsageCollected(usage: Usage, modelName: string): void {
+    this.eventEmitter
+      .emitAsync(
+        UsageCollectedEvent.EVENT_NAME,
+        new UsageCollectedEvent(usage, modelName),
+      )
+      .catch((err: unknown) => {
+        this.logger.error(
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            usageId: usage.id,
+          },
+          'Failed to emit UsageCollectedEvent',
+        );
+      });
   }
 
   private validateCommand(command: CollectUsageCommand): void {
@@ -155,9 +200,12 @@ export class CollectUsageUseCase {
       return cost * creditsPerEuro;
     } catch (error) {
       if (error instanceof PlatformConfigNotFoundError) {
-        this.logger.warn('Could not calculate credits consumed', {
-          error: error.message,
-        });
+        this.logger.warn(
+          {
+            error: error.message,
+          },
+          'Could not calculate credits consumed',
+        );
         return undefined;
       }
       throw error;
@@ -175,11 +223,14 @@ export class CollectUsageUseCase {
     const outputTokenCost = model.outputTokenCost;
 
     if (inputTokenCost === undefined || outputTokenCost === undefined) {
-      this.logger.debug('No cost information available for model', {
-        modelId: model.id,
-        hasInputCost: inputTokenCost !== undefined,
-        hasOutputCost: outputTokenCost !== undefined,
-      });
+      this.logger.debug(
+        {
+          modelId: model.id,
+          hasInputCost: inputTokenCost !== undefined,
+          hasOutputCost: outputTokenCost !== undefined,
+        },
+        'No cost information available for model',
+      );
 
       return undefined;
     }
@@ -188,16 +239,19 @@ export class CollectUsageUseCase {
     const outputCost = (command.outputTokens / 1_000_000) * outputTokenCost;
     const totalCost = inputCost + outputCost;
 
-    this.logger.debug('Cost calculated for usage (EUR)', {
-      modelId: model.id,
-      inputTokens: command.inputTokens,
-      outputTokens: command.outputTokens,
-      inputTokenCost: model.inputTokenCost,
-      outputTokenCost: model.outputTokenCost,
-      inputCost,
-      outputCost,
-      totalCost,
-    });
+    this.logger.debug(
+      {
+        modelId: model.id,
+        inputTokens: command.inputTokens,
+        outputTokens: command.outputTokens,
+        inputTokenCost: model.inputTokenCost,
+        outputTokenCost: model.outputTokenCost,
+        inputCost,
+        outputCost,
+        totalCost,
+      },
+      'Cost calculated for usage (EUR)',
+    );
 
     return totalCost;
   }

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-credit-usage/get-credit-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-credit-usage/get-credit-usage.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetCreditUsageUseCase } from './get-credit-usage.use-case';
@@ -33,6 +35,10 @@ describe('GetCreditUsageUseCase', () => {
         {
           provide: GetMonthlyCreditUsageUseCase,
           useValue: mockMonthlyCreditUsage,
+        },
+        {
+          provide: getLoggerToken(GetCreditUsageUseCase.name),
+          useValue: createPinoLoggerMock(),
         },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-credit-usage/get-credit-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-credit-usage/get-credit-usage.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetCreditUsageQuery } from './get-credit-usage.query';
 import { GetMonthlyCreditUsageUseCase } from '../get-monthly-credit-usage/get-monthly-credit-usage.use-case';
 import { GetMonthlyCreditUsageQuery } from '../get-monthly-credit-usage/get-monthly-credit-usage.query';
@@ -10,15 +11,15 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetCreditUsageUseCase {
-  private readonly logger = new Logger(GetCreditUsageUseCase.name);
-
   constructor(
     private readonly getMonthlyCreditLimitUseCase: GetMonthlyCreditLimitUseCase,
     private readonly getMonthlyCreditUsageUseCase: GetMonthlyCreditUsageUseCase,
+    @InjectPinoLogger(GetCreditUsageUseCase.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async execute(query: GetCreditUsageQuery): Promise<CreditUsage> {
-    this.logger.log('Getting credit usage', { orgId: query.orgId });
+    this.logger.info({ orgId: query.orgId }, 'Getting credit usage');
 
     try {
       const { monthlyCredits, startsAt } =
@@ -38,7 +39,10 @@ export class GetCreditUsageUseCase {
       return { monthlyCredits, creditsUsed, creditsRemaining };
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get credit usage', error);
+      this.logger.error(
+        { err: error instanceof Error ? error : new Error(String(error)) },
+        'Failed to get credit usage',
+      );
       throw new UnexpectedUsageError(error as Error, {
         orgId: query.orgId,
       });

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-model-distribution/get-model-distribution.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-model-distribution/get-model-distribution.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetModelDistributionUseCase } from './get-model-distribution.use-case';
@@ -23,6 +25,10 @@ describe('GetModelDistributionUseCase', () => {
       providers: [
         GetModelDistributionUseCase,
         { provide: UsageRepository, useValue: mockUsageRepository },
+        {
+          provide: getLoggerToken(GetModelDistributionUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-model-distribution/get-model-distribution.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-model-distribution/get-model-distribution.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetModelDistributionQuery } from './get-model-distribution.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { ModelDistribution } from 'src/domain/usage/domain/model-distribution.entity';
@@ -14,9 +15,11 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetModelDistributionUseCase {
-  private readonly logger = new Logger(GetModelDistributionUseCase.name);
-
-  constructor(private readonly usageRepository: UsageRepository) {}
+  constructor(
+    private readonly usageRepository: UsageRepository,
+    @InjectPinoLogger(GetModelDistributionUseCase.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   async execute(
     query: GetModelDistributionQuery,
@@ -27,13 +30,16 @@ export class GetModelDistributionUseCase {
       throw new InvalidDateRangeError('Max models must be greater than 0');
     }
 
-    this.logger.log('Getting model distribution', {
-      organizationId: query.organizationId,
-      maxModels: query.maxModels,
-      modelId: query.modelId,
-      startDate: query.startDate?.toISOString(),
-      endDate: query.endDate?.toISOString(),
-    });
+    this.logger.info(
+      {
+        organizationId: query.organizationId,
+        maxModels: query.maxModels,
+        modelId: query.modelId,
+        startDate: query.startDate?.toISOString(),
+        endDate: query.endDate?.toISOString(),
+      },
+      'Getting model distribution',
+    );
 
     try {
       const modelDistribution = await this.usageRepository.getModelDistribution(
@@ -49,7 +55,10 @@ export class GetModelDistributionUseCase {
       return processModelDistribution(modelDistribution, query.maxModels);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get model distribution', error);
+      this.logger.error(
+        { err: error instanceof Error ? error : new Error(String(error)) },
+        'Failed to get model distribution',
+      );
       throw new UnexpectedUsageError(error as Error, {
         organizationId: query.organizationId,
         maxModels: query.maxModels,

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-team/get-monthly-credit-usage-for-team.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-team/get-monthly-credit-usage-for-team.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -25,6 +27,10 @@ describe('GetMonthlyCreditUsageForTeamUseCase', () => {
         GetMonthlyCreditUsageForTeamUseCase,
         { provide: UsageRepository, useValue: repository },
         { provide: FindAllUserIdsByTeamIdUseCase, useValue: findMembers },
+        {
+          provide: getLoggerToken(GetMonthlyCreditUsageForTeamUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-team/get-monthly-credit-usage-for-team.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-team/get-monthly-credit-usage-for-team.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetMonthlyCreditUsageForTeamQuery } from './get-monthly-credit-usage-for-team.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { UnexpectedUsageError } from '../../usage.errors';
@@ -10,13 +11,11 @@ import { FindAllUserIdsByTeamIdQuery } from 'src/iam/teams/application/use-cases
 // A team's consumption is the shared pool: the sum over its current members.
 @Injectable()
 export class GetMonthlyCreditUsageForTeamUseCase {
-  private readonly logger = new Logger(
-    GetMonthlyCreditUsageForTeamUseCase.name,
-  );
-
   constructor(
     private readonly usageRepository: UsageRepository,
     private readonly findAllUserIdsByTeamIdUseCase: FindAllUserIdsByTeamIdUseCase,
+    @InjectPinoLogger(GetMonthlyCreditUsageForTeamUseCase.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   async execute(
@@ -24,10 +23,13 @@ export class GetMonthlyCreditUsageForTeamUseCase {
   ): Promise<{ creditsUsed: number }> {
     const effectiveStart = getEffectiveMonthStart(query.since);
 
-    this.logger.log('Getting monthly credit usage for team', {
-      teamId: query.teamId,
-      effectiveStart: effectiveStart.toISOString(),
-    });
+    this.logger.info(
+      {
+        teamId: query.teamId,
+        effectiveStart: effectiveStart.toISOString(),
+      },
+      'Getting monthly credit usage for team',
+    );
 
     try {
       const memberIds = await this.findAllUserIdsByTeamIdUseCase.execute(
@@ -44,7 +46,10 @@ export class GetMonthlyCreditUsageForTeamUseCase {
       return { creditsUsed };
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get monthly credit usage for team', error);
+      this.logger.error(
+        { err: error instanceof Error ? error : new Error(String(error)) },
+        'Failed to get monthly credit usage for team',
+      );
       throw new UnexpectedUsageError(error as Error, {
         teamId: query.teamId,
       });

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-user/get-monthly-credit-usage-for-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-user/get-monthly-credit-usage-for-user.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -19,6 +21,10 @@ describe('GetMonthlyCreditUsageForUserUseCase', () => {
       providers: [
         GetMonthlyCreditUsageForUserUseCase,
         { provide: UsageRepository, useValue: repository },
+        {
+          provide: getLoggerToken(GetMonthlyCreditUsageForUserUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-user/get-monthly-credit-usage-for-user.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-user/get-monthly-credit-usage-for-user.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetMonthlyCreditUsageForUserQuery } from './get-monthly-credit-usage-for-user.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { UnexpectedUsageError } from '../../usage.errors';
@@ -7,21 +8,24 @@ import { getEffectiveMonthStart } from '../../util/get-effective-month-start';
 
 @Injectable()
 export class GetMonthlyCreditUsageForUserUseCase {
-  private readonly logger = new Logger(
-    GetMonthlyCreditUsageForUserUseCase.name,
-  );
-
-  constructor(private readonly usageRepository: UsageRepository) {}
+  constructor(
+    private readonly usageRepository: UsageRepository,
+    @InjectPinoLogger(GetMonthlyCreditUsageForUserUseCase.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   async execute(
     query: GetMonthlyCreditUsageForUserQuery,
   ): Promise<{ creditsUsed: number }> {
     const effectiveStart = getEffectiveMonthStart(query.since);
 
-    this.logger.log('Getting monthly credit usage for user', {
-      userId: query.userId,
-      effectiveStart: effectiveStart.toISOString(),
-    });
+    this.logger.info(
+      {
+        userId: query.userId,
+        effectiveStart: effectiveStart.toISOString(),
+      },
+      'Getting monthly credit usage for user',
+    );
 
     try {
       const creditsUsed =
@@ -34,7 +38,10 @@ export class GetMonthlyCreditUsageForUserUseCase {
       return { creditsUsed };
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get monthly credit usage for user', error);
+      this.logger.error(
+        { err: error instanceof Error ? error : new Error(String(error)) },
+        'Failed to get monthly credit usage for user',
+      );
       throw new UnexpectedUsageError(error as Error, {
         userId: query.userId,
       });

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-users/get-monthly-credit-usage-for-users.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-users/get-monthly-credit-usage-for-users.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -20,6 +22,10 @@ describe('GetMonthlyCreditUsageForUsersUseCase', () => {
       providers: [
         GetMonthlyCreditUsageForUsersUseCase,
         { provide: UsageRepository, useValue: repository },
+        {
+          provide: getLoggerToken(GetMonthlyCreditUsageForUsersUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-users/get-monthly-credit-usage-for-users.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage-for-users/get-monthly-credit-usage-for-users.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { GetMonthlyCreditUsageForUsersQuery } from './get-monthly-credit-usage-for-users.query';
 import { UsageRepository } from '../../ports/usage.repository';
@@ -8,21 +9,24 @@ import { getEffectiveMonthStart } from '../../util/get-effective-month-start';
 
 @Injectable()
 export class GetMonthlyCreditUsageForUsersUseCase {
-  private readonly logger = new Logger(
-    GetMonthlyCreditUsageForUsersUseCase.name,
-  );
-
-  constructor(private readonly usageRepository: UsageRepository) {}
+  constructor(
+    private readonly usageRepository: UsageRepository,
+    @InjectPinoLogger(GetMonthlyCreditUsageForUsersUseCase.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   async execute(
     query: GetMonthlyCreditUsageForUsersQuery,
   ): Promise<Map<UUID, number>> {
     const effectiveStart = getEffectiveMonthStart(query.since);
 
-    this.logger.log('Getting monthly credit usage for users', {
-      userCount: query.userIds.length,
-      effectiveStart: effectiveStart.toISOString(),
-    });
+    this.logger.info(
+      {
+        userCount: query.userIds.length,
+        effectiveStart: effectiveStart.toISOString(),
+      },
+      'Getting monthly credit usage for users',
+    );
 
     try {
       return await this.usageRepository.getMonthlyCreditUsagePerUser(
@@ -32,7 +36,10 @@ export class GetMonthlyCreditUsageForUsersUseCase {
       );
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get monthly credit usage for users', error);
+      this.logger.error(
+        { err: error instanceof Error ? error : new Error(String(error)) },
+        'Failed to get monthly credit usage for users',
+      );
       throw new UnexpectedUsageError(error as Error, {
         userCount: query.userIds.length,
       });

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage/get-monthly-credit-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage/get-monthly-credit-usage.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetMonthlyCreditUsageUseCase } from './get-monthly-credit-usage.use-case';
@@ -20,6 +22,10 @@ describe('GetMonthlyCreditUsageUseCase', () => {
       providers: [
         GetMonthlyCreditUsageUseCase,
         { provide: UsageRepository, useValue: mockUsageRepository },
+        {
+          provide: getLoggerToken(GetMonthlyCreditUsageUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage/get-monthly-credit-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-monthly-credit-usage/get-monthly-credit-usage.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetMonthlyCreditUsageQuery } from './get-monthly-credit-usage.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { UnexpectedUsageError } from '../../usage.errors';
@@ -7,19 +8,24 @@ import { getEffectiveMonthStart } from '../../util/get-effective-month-start';
 
 @Injectable()
 export class GetMonthlyCreditUsageUseCase {
-  private readonly logger = new Logger(GetMonthlyCreditUsageUseCase.name);
-
-  constructor(private readonly usageRepository: UsageRepository) {}
+  constructor(
+    private readonly usageRepository: UsageRepository,
+    @InjectPinoLogger(GetMonthlyCreditUsageUseCase.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   async execute(
     query: GetMonthlyCreditUsageQuery,
   ): Promise<{ creditsUsed: number }> {
     const effectiveStart = getEffectiveMonthStart(query.since);
 
-    this.logger.log('Getting monthly credit usage', {
-      orgId: query.orgId,
-      effectiveStart: effectiveStart.toISOString(),
-    });
+    this.logger.info(
+      {
+        orgId: query.orgId,
+        effectiveStart: effectiveStart.toISOString(),
+      },
+      'Getting monthly credit usage',
+    );
 
     try {
       const creditsUsed = await this.usageRepository.getMonthlyCreditUsage(
@@ -30,7 +36,10 @@ export class GetMonthlyCreditUsageUseCase {
       return { creditsUsed };
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get monthly credit usage', error);
+      this.logger.error(
+        { err: error instanceof Error ? error : new Error(String(error)) },
+        'Failed to get monthly credit usage',
+      );
       throw new UnexpectedUsageError(error as Error, {
         orgId: query.orgId,
         effectiveStart: effectiveStart.toISOString(),

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-provider-usage/get-provider-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-provider-usage/get-provider-usage.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetProviderUsageUseCase } from './get-provider-usage.use-case';
@@ -24,6 +26,10 @@ describe('GetProviderUsageUseCase', () => {
       providers: [
         GetProviderUsageUseCase,
         { provide: UsageRepository, useValue: mockUsageRepository },
+        {
+          provide: getLoggerToken(GetProviderUsageUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-provider-usage/get-provider-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-provider-usage/get-provider-usage.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetProviderUsageQuery } from './get-provider-usage.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { ProviderUsage } from 'src/domain/usage/domain/provider-usage.entity';
@@ -11,25 +12,33 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetProviderUsageUseCase {
-  private readonly logger = new Logger(GetProviderUsageUseCase.name);
-
-  constructor(private readonly usageRepository: UsageRepository) {}
+  constructor(
+    private readonly usageRepository: UsageRepository,
+    @InjectPinoLogger(GetProviderUsageUseCase.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   async execute(query: GetProviderUsageQuery): Promise<ProviderUsage[]> {
     validateOptionalDateRange(query.startDate, query.endDate);
 
-    this.logger.log('Getting provider usage', {
-      organizationId: query.organizationId,
-      startDate: query.startDate?.toISOString(),
-      endDate: query.endDate?.toISOString(),
-    });
+    this.logger.info(
+      {
+        organizationId: query.organizationId,
+        startDate: query.startDate?.toISOString(),
+        endDate: query.endDate?.toISOString(),
+      },
+      'Getting provider usage',
+    );
 
     try {
       const providerUsage = await this.usageRepository.getProviderUsage(query);
       return calculateProviderPercentages(providerUsage);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get provider usage', error);
+      this.logger.error(
+        { err: error instanceof Error ? error : new Error(String(error)) },
+        'Failed to get provider usage',
+      );
       throw new UnexpectedUsageError(error as Error, {
         organizationId: query.organizationId,
       });

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-usage-stats/get-usage-stats.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-usage-stats/get-usage-stats.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetUsageStatsUseCase } from './get-usage-stats.use-case';
@@ -22,6 +24,10 @@ describe('GetUsageStatsUseCase', () => {
       providers: [
         GetUsageStatsUseCase,
         { provide: UsageRepository, useValue: mockUsageRepository },
+        {
+          provide: getLoggerToken(GetUsageStatsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-usage-stats/get-usage-stats.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-usage-stats/get-usage-stats.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetUsageStatsQuery } from './get-usage-stats.query';
 import { UsageRepository } from '../../ports/usage.repository';
 import { UsageStats } from 'src/domain/usage/domain/usage-stats.entity';
@@ -8,18 +9,23 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetUsageStatsUseCase {
-  private readonly logger = new Logger(GetUsageStatsUseCase.name);
-
-  constructor(private readonly usageRepository: UsageRepository) {}
+  constructor(
+    private readonly usageRepository: UsageRepository,
+    @InjectPinoLogger(GetUsageStatsUseCase.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   async execute(query: GetUsageStatsQuery): Promise<UsageStats> {
     validateOptionalDateRange(query.startDate, query.endDate);
 
-    this.logger.log('Getting usage stats', {
-      organizationId: query.organizationId,
-      startDate: query.startDate?.toISOString(),
-      endDate: query.endDate?.toISOString(),
-    });
+    this.logger.info(
+      {
+        organizationId: query.organizationId,
+        startDate: query.startDate?.toISOString(),
+        endDate: query.endDate?.toISOString(),
+      },
+      'Getting usage stats',
+    );
 
     try {
       const stats = await this.usageRepository.getUsageStats({
@@ -40,7 +46,10 @@ export class GetUsageStatsUseCase {
       });
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get usage stats', error);
+      this.logger.error(
+        { err: error instanceof Error ? error : new Error(String(error)) },
+        'Failed to get usage stats',
+      );
       throw new UnexpectedUsageError(error as Error, {
         organizationId: query.organizationId,
       });

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetUserUsageUseCase } from './get-user-usage.use-case';
@@ -35,6 +37,10 @@ describe('GetUserUsageUseCase', () => {
       providers: [
         GetUserUsageUseCase,
         { provide: UsageRepository, useValue: mockUsageRepository },
+        {
+          provide: getLoggerToken(GetUserUsageUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/get-user-usage/get-user-usage.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetUserUsageQuery } from './get-user-usage.query';
 import {
   UsageRepository,
@@ -14,9 +15,11 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetUserUsageUseCase {
-  private readonly logger = new Logger(GetUserUsageUseCase.name);
-
-  constructor(private readonly usageRepository: UsageRepository) {}
+  constructor(
+    private readonly usageRepository: UsageRepository,
+    @InjectPinoLogger(GetUserUsageUseCase.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   async execute(query: GetUserUsageQuery): Promise<UserUsageResult> {
     this.validateQuery(query);
@@ -25,7 +28,10 @@ export class GetUserUsageUseCase {
       return await this.usageRepository.getUserUsage(query);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get user usage', error);
+      this.logger.error(
+        { err: error instanceof Error ? error : new Error(String(error)) },
+        'Failed to get user usage',
+      );
       throw new UnexpectedUsageError(error as Error, {
         organizationId: query.organizationId,
       });

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/has-usage-for-model/has-usage-for-model.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/has-usage-for-model/has-usage-for-model.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import type { UsageRepository } from '../../ports/usage.repository';
 import { UnexpectedUsageError } from '../../usage.errors';
@@ -12,6 +13,7 @@ describe('HasUsageForModelUseCase', () => {
     usageRepository = { existsByModelId: jest.fn() };
     useCase = new HasUsageForModelUseCase(
       usageRepository as unknown as UsageRepository,
+      createPinoLoggerMock(),
     );
   });
 

--- a/ayunis-core-backend/src/domain/usage/application/use-cases/has-usage-for-model/has-usage-for-model.use-case.ts
+++ b/ayunis-core-backend/src/domain/usage/application/use-cases/has-usage-for-model/has-usage-for-model.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UsageRepository } from '../../ports/usage.repository';
 import { UnexpectedUsageError } from '../../usage.errors';
@@ -6,15 +7,20 @@ import { HasUsageForModelQuery } from './has-usage-for-model.query';
 
 @Injectable()
 export class HasUsageForModelUseCase {
-  private readonly logger = new Logger(HasUsageForModelUseCase.name);
-
-  constructor(private readonly usageRepository: UsageRepository) {}
+  constructor(
+    private readonly usageRepository: UsageRepository,
+    @InjectPinoLogger(HasUsageForModelUseCase.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   @HandleUnexpectedErrors(UnexpectedUsageError)
   async execute(query: HasUsageForModelQuery): Promise<boolean> {
-    this.logger.log('Checking usage references for model', {
-      modelId: query.modelId,
-    });
+    this.logger.info(
+      {
+        modelId: query.modelId,
+      },
+      'Checking usage references for model',
+    );
 
     return await this.usageRepository.existsByModelId(query.modelId);
   }

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/local-usage.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/local-usage.repository.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import type { Repository } from 'typeorm';
 import type { UserRecord } from 'src/iam/users/infrastructure/repositories/local/schema/user.record';
@@ -17,6 +18,7 @@ describe('LocalUsageRepository', () => {
       {} as Repository<UserRecord>,
       {} as UsageMapper,
       {} as UsageQueryMapper,
+      createPinoLoggerMock(),
     );
 
     const result = await repository.existsByModelId(modelId);

--- a/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/local-usage.repository.ts
+++ b/ayunis-core-backend/src/domain/usage/infrastructure/persistence/local-usage/local-usage.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UUID } from 'crypto';
@@ -36,8 +37,6 @@ import { UsageQueryMapper } from './mappers/usage-query.mapper';
 
 @Injectable()
 export class LocalUsageRepository extends UsageRepository {
-  private readonly logger = new Logger(LocalUsageRepository.name);
-
   constructor(
     @InjectRepository(UsageRecord)
     private readonly usageRepository: Repository<UsageRecord>,
@@ -45,6 +44,8 @@ export class LocalUsageRepository extends UsageRepository {
     private readonly userRepository: Repository<UserRecord>,
     private readonly usageMapper: UsageMapper,
     private readonly usageQueryMapper: UsageQueryMapper,
+    @InjectPinoLogger(LocalUsageRepository.name)
+    private readonly logger: PinoLogger,
   ) {
     super();
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only migration with broad test updates; behavior should match prior flows aside from log shape and field names.
> 
> **Overview**
> This PR continues the **AYC-747** logging migration for the **messages**, **runs**, and **usage** areas of the backend. Nest’s built-in `Logger` is removed in favor of **`nestjs-pino`** (`@InjectPinoLogger` + `PinoLogger`), with calls moved to Pino’s **`info` / `warn` / `error` / `debug`** style and **structured fields first**, message second (e.g. `{ threadId }, 'Creating user message'`). Errors generally use an **`err`** field for stack-friendly serialization.
> 
> **Messages** — All create/save/delete/count/trim use cases and the orphaned-images cleanup job/task are updated; cleanup logic is split into **`findOrphanedPaths`** / **`deleteOrphanedPaths`** without changing behavior. **`create-user-message`** and **`create-assistant-message`** pull event emission into private helpers. A new **`orphaned-images-cleanup.task.spec`** asserts failure logging shape.
> 
> **Runs** — The full run stack (execute run, runtime adapter, streaming inference, tool assembly, SSE presenter, controllers, guards) injects loggers; **`adaptRunEventsToStream`** and helpers like **`extractUsageFromChunks`** / **`assertToolCallArgumentsIntact`** now take a **`PinoLogger`** instead of a module-level logger. Specs wire **`createPinoLoggerMock()`** and adjust expectations for Pino call signatures.
> 
> **Usage** — **`CollectUsageAsyncService`** and **`CollectUsageUseCase`** follow the same pattern.
> 
> No intentional changes to business rules beyond logging and small readability refactors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83d00333200ff6237c707cb7d8736e87b42508a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->