### PR TITLE
wip(logging): migrate tools and MCP to pino (AYC-748)

### DIFF
--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { McpClientService } from './mcp-client.service';
@@ -74,6 +76,11 @@ describe('McpClientService', () => {
         {
           provide: McpIntegrationUserConfigRepositoryPort,
           useValue: userConfigRepo,
+        },
+
+        {
+          provide: getLoggerToken(McpClientService.name),
+          useValue: createPinoLoggerMock(),
         },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import {
   McpClientPort,
@@ -30,9 +31,9 @@ import { handleMcpOperationError } from './mcp-operation-error';
 
 @Injectable()
 export class McpClientService {
-  private readonly logger = new Logger(McpClientService.name);
-
   constructor(
+    @InjectPinoLogger(McpClientService.name)
+    private readonly logger: PinoLogger,
     private readonly mcpClient: McpClientPort,
     private readonly credentialEncryption: McpCredentialEncryptionPort,
     private readonly userConfigRepository: McpIntegrationUserConfigRepositoryPort,
@@ -81,10 +82,13 @@ export class McpClientService {
       if (error instanceof McpAuthenticationError) {
         throw error;
       }
-      this.logger.error('Failed to build schema-configured connection config', {
-        error: error as Error,
-        integrationId: integration.id,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          integrationId: integration.id,
+        },
+        'Failed to build schema-configured connection config',
+      );
       throw new McpAuthenticationError('Authentication configuration failed');
     }
   }
@@ -217,10 +221,13 @@ export class McpClientService {
         throw error;
       }
 
-      this.logger.error('Failed to build connection config', {
-        error: error as Error,
-        integrationId: integration.id,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          integrationId: integration.id,
+        },
+        'Failed to build connection config',
+      );
       throw new McpAuthenticationError('Authentication configuration failed');
     }
   }
@@ -257,9 +264,12 @@ export class McpClientService {
           ? `Bearer ${decryptedToken}`
           : decryptedToken;
 
-      this.logger.log('Built connection config for bearer authentication', {
-        integrationId: integration.id,
-      });
+      this.logger.info(
+        {
+          integrationId: integration.id,
+        },
+        'Built connection config for bearer authentication',
+      );
     } else if (auth instanceof CustomHeaderMcpIntegrationAuth) {
       if (!auth.secret) {
         throw new McpAuthenticationError('Header secret not configured');
@@ -304,13 +314,6 @@ export class McpClientService {
     }
   }
 
-  /**
-   * Lists all resources available on the MCP server.
-   *
-   * @param integration The MCP integration entity
-   * @returns List of available resources
-   * @throws McpAuthenticationError on 401 responses
-   */
   async listResources(
     integration: McpIntegration,
     userId?: UUID,
@@ -472,13 +475,6 @@ export class McpClientService {
     );
   }
 
-  /**
-   * Handles errors from MCP operations, with special handling for 401 responses.
-   *
-   * @param error The error that occurred
-   * @param integration The integration entity (for updating status)
-   * @param operation The operation name (for logging)
-   */
   private async handleOperationError(
     error: unknown,
     integration: McpIntegration,

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-operation-error.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-operation-error.ts
@@ -1,4 +1,4 @@
-import type { Logger } from '@nestjs/common';
+import type { PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import type { McpIntegration } from '../../domain/mcp-integration.entity';
 import { SchemaConfiguredMcpIntegration } from '../../domain/integrations/schema-configured-mcp-integration.entity';
@@ -16,7 +16,7 @@ interface McpOperationErrorContext {
   userId?: UUID;
   oauthTokens?: McpOAuthUserTokenRepositoryPort;
   capabilityCache?: McpCapabilityCacheService;
-  logger: Logger;
+  logger: PinoLogger;
 }
 
 export async function handleMcpOperationError({
@@ -37,17 +37,17 @@ export async function handleMcpOperationError({
     );
   }
   if ((error as { status?: number }).status === 401) {
-    logger.warn(`Authentication failed for MCP operation: ${operation}`, {
-      integrationId: integration.id,
-    });
+    logger.warn(
+      { integrationId: integration.id, operation },
+      'Authentication failed for MCP operation',
+    );
     integration.updateConnectionStatus('error', 'Authentication failed');
     throw new McpAuthenticationError('Invalid authentication credentials');
   }
-  logger.error('Failed to execute MCP operation', {
-    error: error as Error,
-    integrationId: integration.id,
-    operation,
-  });
+  logger.error(
+    { err: error as Error, integrationId: integration.id, operation },
+    'Failed to execute MCP operation',
+  );
   throw error;
 }
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { UnauthorizedException } from '@nestjs/common';
@@ -158,6 +160,11 @@ describe('CreateMcpIntegrationUseCase', () => {
         {
           provide: McpOAuthClientConfigurationService,
           useValue: oauthClientConfiguration,
+        },
+
+        {
+          provide: getLoggerToken(CreateMcpIntegrationUseCase.name),
+          useValue: createPinoLoggerMock(),
         },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/create-mcp-integration/create-mcp-integration.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { CreatePredefinedMcpIntegrationCommand } from './create-predefined-mcp-integration.command';
 import { CreateCustomMcpIntegrationCommand } from './create-custom-mcp-integration.command';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
@@ -31,9 +32,9 @@ import { McpOAuthClientConfigurationService } from '../../services/mcp-oauth-cli
 
 @Injectable()
 export class CreateMcpIntegrationUseCase {
-  private readonly logger = new Logger(CreateMcpIntegrationUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateMcpIntegrationUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: McpIntegrationsRepositoryPort,
     private readonly registryService: PredefinedMcpIntegrationRegistry,
     private readonly contextService: ContextService,
@@ -76,7 +77,7 @@ export class CreateMcpIntegrationUseCase {
     command: CreatePredefinedMcpIntegrationCommand,
     orgId: UUID,
   ): Promise<PredefinedMcpIntegration> {
-    this.logger.log('createPredefinedIntegration', { slug: command.slug });
+    this.logger.info({ slug: command.slug }, 'createPredefinedIntegration');
 
     try {
       if (!this.registryService.isValidSlug(command.slug)) {
@@ -184,9 +185,7 @@ export class CreateMcpIntegrationUseCase {
     command: CreateCustomMcpIntegrationCommand,
     orgId: UUID,
   ): Promise<CustomMcpIntegration> {
-    this.logger.log('createCustomIntegration', {
-      serverUrl: command.serverUrl,
-    });
+    this.logger.info({ url: command.serverUrl }, 'createCustomIntegration');
 
     try {
       if (!this.isValidUrl(command.serverUrl)) {
@@ -271,9 +270,10 @@ export class CreateMcpIntegrationUseCase {
       throw error;
     }
 
-    this.logger.error(`Unexpected error creating ${kind} integration`, {
-      error: error as Error,
-    });
+    this.logger.error(
+      { err: error as Error, kind },
+      'Unexpected error creating integration',
+    );
     throw new UnexpectedMcpError('Unexpected error occurred');
   }
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.spec.ts
@@ -1,6 +1,8 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger, UnauthorizedException } from '@nestjs/common';
+import { UnauthorizedException } from '@nestjs/common';
 import { PinoLogger } from 'nestjs-pino';
 import { randomUUID } from 'crypto';
 import { DeleteMcpIntegrationUseCase } from './delete-mcp-integration.use-case';
@@ -20,6 +22,7 @@ import { PredefinedMcpIntegrationSlug } from 'src/domain/mcp/domain/value-object
 import { NoAuthMcpIntegrationAuth } from 'src/domain/mcp/domain/auth/no-auth-mcp-integration-auth.entity';
 
 describe('DeleteMcpIntegrationUseCase', () => {
+  let logger: jest.Mocked<PinoLogger>;
   let useCase: DeleteMcpIntegrationUseCase;
   let repository: McpIntegrationsRepositoryPort;
   let userConfigRepository: McpIntegrationUserConfigRepositoryPort;
@@ -28,8 +31,6 @@ describe('DeleteMcpIntegrationUseCase', () => {
   let mcpClientService: jest.Mocked<
     Pick<McpClientService, 'invalidateConnections'>
   >;
-  let loggerLogSpy: jest.SpyInstance;
-  let loggerErrorSpy: jest.SpyInstance;
   let decoratorErrorSpy: jest.SpyInstance;
 
   const mockOrgId = randomUUID();
@@ -56,6 +57,7 @@ describe('DeleteMcpIntegrationUseCase', () => {
     });
 
   beforeAll(async () => {
+    logger = createPinoLoggerMock();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeleteMcpIntegrationUseCase,
@@ -83,6 +85,11 @@ describe('DeleteMcpIntegrationUseCase', () => {
             get: jest.fn(),
           },
         },
+
+        {
+          provide: getLoggerToken(DeleteMcpIntegrationUseCase.name),
+          useValue: logger,
+        },
       ],
     }).compile();
 
@@ -102,8 +109,6 @@ describe('DeleteMcpIntegrationUseCase', () => {
     mcpClientService = module.get(McpClientService);
 
     // Spy on logger methods
-    loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
     decoratorErrorSpy = jest
       .spyOn(PinoLogger.prototype, 'error')
       .mockImplementation();
@@ -135,9 +140,12 @@ describe('DeleteMcpIntegrationUseCase', () => {
       expect(mcpClientService.invalidateConnections).toHaveBeenCalledWith(
         mockIntegration,
       );
-      expect(loggerLogSpy).toHaveBeenCalledWith('deleteMcpIntegration', {
-        id: mockIntegrationId,
-      });
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          id: mockIntegrationId,
+        },
+        'deleteMcpIntegration',
+      );
     });
 
     it('should delete associated user config records when deleting an integration', async () => {
@@ -284,7 +292,7 @@ describe('DeleteMcpIntegrationUseCase', () => {
         McpIntegrationNotFoundError,
       );
       // Should not log as unexpected error
-      expect(loggerErrorSpy).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it('should re-throw McpIntegrationAccessDeniedError without wrapping', async () => {
@@ -301,7 +309,7 @@ describe('DeleteMcpIntegrationUseCase', () => {
         McpIntegrationAccessDeniedError,
       );
       // Should not log as unexpected error
-      expect(loggerErrorSpy).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it('should log operation start with integration id', async () => {
@@ -318,9 +326,12 @@ describe('DeleteMcpIntegrationUseCase', () => {
       await useCase.execute(command);
 
       // Assert
-      expect(loggerLogSpy).toHaveBeenCalledWith('deleteMcpIntegration', {
-        id: mockIntegrationId,
-      });
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          id: mockIntegrationId,
+        },
+        'deleteMcpIntegration',
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { DeleteMcpIntegrationCommand } from './delete-mcp-integration.command';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
@@ -17,9 +18,9 @@ import { McpClientService } from '../../services/mcp-client.service';
  */
 @Injectable()
 export class DeleteMcpIntegrationUseCase {
-  private readonly logger = new Logger(DeleteMcpIntegrationUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteMcpIntegrationUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: McpIntegrationsRepositoryPort,
     private readonly userConfigRepository: McpIntegrationUserConfigRepositoryPort,
     private readonly contextService: ContextService,
@@ -36,7 +37,7 @@ export class DeleteMcpIntegrationUseCase {
    */
   @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(command: DeleteMcpIntegrationCommand): Promise<void> {
-    this.logger.log('deleteMcpIntegration', { id: command.integrationId });
+    this.logger.info({ id: command.integrationId }, 'deleteMcpIntegration');
 
     // Get organization ID from context
     const orgId = this.contextService.get('orgId');

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/disable-mcp-integration/disable-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/disable-mcp-integration/disable-mcp-integration.use-case.spec.ts
@@ -1,6 +1,9 @@
+import type { PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger, UnauthorizedException } from '@nestjs/common';
+import { UnauthorizedException } from '@nestjs/common';
 import type { UUID } from 'crypto';
 import { DisableMcpIntegrationUseCase } from './disable-mcp-integration.use-case';
 import { DisableMcpIntegrationCommand } from './disable-mcp-integration.command';
@@ -16,16 +19,16 @@ import { PredefinedMcpIntegrationSlug } from 'src/domain/mcp/domain/value-object
 import { NoAuthMcpIntegrationAuth } from 'src/domain/mcp/domain/auth/no-auth-mcp-integration-auth.entity';
 
 describe('DisableMcpIntegrationUseCase', () => {
+  let logger: jest.Mocked<PinoLogger>;
   let useCase: DisableMcpIntegrationUseCase;
   let repository: McpIntegrationsRepositoryPort;
   let contextService: ContextService;
-  let loggerLogSpy: jest.SpyInstance;
-  let loggerErrorSpy: jest.SpyInstance;
 
   const mockOrgId = 'org-123' as UUID;
   const mockIntegrationId = 'integration-456' as UUID;
 
   beforeAll(async () => {
+    logger = createPinoLoggerMock();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DisableMcpIntegrationUseCase,
@@ -42,6 +45,11 @@ describe('DisableMcpIntegrationUseCase', () => {
             get: jest.fn(),
           },
         },
+
+        {
+          provide: getLoggerToken(DisableMcpIntegrationUseCase.name),
+          useValue: logger,
+        },
       ],
     }).compile();
 
@@ -54,8 +62,6 @@ describe('DisableMcpIntegrationUseCase', () => {
     contextService = module.get<ContextService>(ContextService);
 
     // Spy on logger methods
-    loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {
@@ -103,9 +109,12 @@ describe('DisableMcpIntegrationUseCase', () => {
       expect(contextService.get).toHaveBeenCalledWith('orgId');
       expect(repository.findById).toHaveBeenCalledWith(mockIntegrationId);
       expect(repository.save).toHaveBeenCalledWith(mockIntegration);
-      expect(loggerLogSpy).toHaveBeenCalledWith('disableMcpIntegration', {
-        id: mockIntegrationId,
-      });
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          id: mockIntegrationId,
+        },
+        'disableMcpIntegration',
+      );
     });
 
     it('should be idempotent - disabling already-disabled integration succeeds', async () => {
@@ -236,9 +245,9 @@ describe('DisableMcpIntegrationUseCase', () => {
       await expect(useCase.execute(command)).rejects.toThrow(
         UnexpectedMcpError,
       );
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect(logger.error).toHaveBeenCalledWith(
+        { err: unexpectedError },
         'Unexpected error disabling integration',
-        { error: unexpectedError },
       );
     });
 
@@ -254,7 +263,7 @@ describe('DisableMcpIntegrationUseCase', () => {
         McpIntegrationNotFoundError,
       );
       // Should not log as unexpected error
-      expect(loggerErrorSpy).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it('should log operation start with integration id', async () => {
@@ -281,9 +290,12 @@ describe('DisableMcpIntegrationUseCase', () => {
       await useCase.execute(command);
 
       // Assert
-      expect(loggerLogSpy).toHaveBeenCalledWith('disableMcpIntegration', {
-        id: mockIntegrationId,
-      });
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          id: mockIntegrationId,
+        },
+        'disableMcpIntegration',
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/disable-mcp-integration/disable-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/disable-mcp-integration/disable-mcp-integration.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { DisableMcpIntegrationCommand } from './disable-mcp-integration.command';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -12,9 +13,9 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class DisableMcpIntegrationUseCase {
-  private readonly logger = new Logger(DisableMcpIntegrationUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DisableMcpIntegrationUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: McpIntegrationsRepositoryPort,
     private readonly contextService: ContextService,
   ) {}
@@ -22,7 +23,7 @@ export class DisableMcpIntegrationUseCase {
   async execute(
     command: DisableMcpIntegrationCommand,
   ): Promise<McpIntegration> {
-    this.logger.log('disableMcpIntegration', { id: command.integrationId });
+    this.logger.info({ id: command.integrationId }, 'disableMcpIntegration');
 
     try {
       const orgId = this.contextService.get('orgId');
@@ -52,9 +53,12 @@ export class DisableMcpIntegrationUseCase {
       ) {
         throw error;
       }
-      this.logger.error('Unexpected error disabling integration', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error disabling integration',
+      );
       throw new UnexpectedMcpError('Unexpected error occurred');
     }
   }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.spec.ts
@@ -1,6 +1,8 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger, UnauthorizedException } from '@nestjs/common';
+import { UnauthorizedException } from '@nestjs/common';
 import { PinoLogger } from 'nestjs-pino';
 import { randomUUID } from 'crypto';
 import { DiscoverMcpCapabilitiesUseCase } from './discover-mcp-capabilities.use-case';
@@ -24,13 +26,12 @@ import { NoAuthMcpIntegrationAuth } from 'src/domain/mcp/domain/auth/no-auth-mcp
 import { BearerMcpIntegrationAuth } from 'src/domain/mcp/domain/auth/bearer-mcp-integration-auth.entity';
 
 describe('DiscoverMcpCapabilitiesUseCase', () => {
+  let logger: jest.Mocked<PinoLogger>;
   let useCase: DiscoverMcpCapabilitiesUseCase;
   let repository: jest.Mocked<McpIntegrationsRepositoryPort>;
   let mcpClientService: jest.Mocked<McpClientService>;
   let contextService: jest.Mocked<ContextService>;
   let capabilityCache: McpCapabilityCacheService;
-  let loggerLogSpy: jest.SpyInstance;
-  let loggerErrorSpy: jest.SpyInstance;
   let decoratorErrorSpy: jest.SpyInstance;
 
   const mockOrgId = randomUUID();
@@ -85,6 +86,7 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
     });
 
   beforeAll(async () => {
+    logger = createPinoLoggerMock();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DiscoverMcpCapabilitiesUseCase,
@@ -110,6 +112,11 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
             get: jest.fn(),
           },
         },
+
+        {
+          provide: getLoggerToken(DiscoverMcpCapabilitiesUseCase.name),
+          useValue: logger,
+        },
       ],
     }).compile();
 
@@ -118,10 +125,6 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
     mcpClientService = module.get(McpClientService);
     contextService = module.get(ContextService);
     capabilityCache = module.get(McpCapabilityCacheService);
-
-    loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
     decoratorErrorSpy = jest
       .spyOn(PinoLogger.prototype, 'error')
       .mockImplementation();
@@ -194,18 +197,21 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
         integration,
         mockUserId,
       );
-      expect(loggerLogSpy).toHaveBeenCalledWith('discoverMcpCapabilities', {
-        id: mockIntegrationId,
-      });
-      expect(loggerLogSpy).toHaveBeenCalledWith(
-        'discoverMcpCapabilitiesSucceeded',
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          id: mockIntegrationId,
+        },
+        'discoverMcpCapabilities',
+      );
+      expect(logger.info).toHaveBeenCalledWith(
         expect.objectContaining({
           id: mockIntegrationId,
           name: integration.name,
-          tools: 1,
+          toolCount: 1,
           resources: 2,
           prompts: 1,
         }),
+        'discoverMcpCapabilitiesSucceeded',
       );
     });
 
@@ -243,7 +249,7 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
       ).rejects.toThrow(McpIntegrationNotFoundError);
 
       expect(mcpClientService.listTools).not.toHaveBeenCalled();
-      expect(loggerErrorSpy).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it('throws McpIntegrationAccessDeniedError for different organization', async () => {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { DiscoverMcpCapabilitiesQuery } from './discover-mcp-capabilities.query';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import {
@@ -46,9 +47,9 @@ export interface CapabilitiesResult {
  */
 @Injectable()
 export class DiscoverMcpCapabilitiesUseCase {
-  private readonly logger = new Logger(DiscoverMcpCapabilitiesUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DiscoverMcpCapabilitiesUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: McpIntegrationsRepositoryPort,
     private readonly mcpClientService: McpClientService,
     private readonly contextService: ContextService,
@@ -59,7 +60,7 @@ export class DiscoverMcpCapabilitiesUseCase {
   async execute(
     query: DiscoverMcpCapabilitiesQuery,
   ): Promise<CapabilitiesResult> {
-    this.logger.log('discoverMcpCapabilities', { id: query.integrationId });
+    this.logger.info({ id: query.integrationId }, 'discoverMcpCapabilities');
 
     const integration = await this.getAuthorizedIntegration(
       query.integrationId,
@@ -145,13 +146,16 @@ export class DiscoverMcpCapabilitiesUseCase {
       this.mapToMcpPrompt(prompt, integrationId),
     );
 
-    this.logger.log('discoverMcpCapabilitiesSucceeded', {
-      id: integrationId,
-      name: integration.name,
-      tools: mcpTools.length,
-      resources: mcpResources.length + mcpResourceTemplates.length,
-      prompts: mcpPrompts.length,
-    });
+    this.logger.info(
+      {
+        id: integrationId,
+        name: integration.name,
+        toolCount: mcpTools.length,
+        resources: mcpResources.length + mcpResourceTemplates.length,
+        prompts: mcpPrompts.length,
+      },
+      'discoverMcpCapabilitiesSucceeded',
+    );
 
     return {
       tools: mcpTools,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/enable-mcp-integration/enable-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/enable-mcp-integration/enable-mcp-integration.use-case.spec.ts
@@ -1,6 +1,8 @@
+import type { PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import type { UUID } from 'crypto';
 import { EnableMcpIntegrationUseCase } from './enable-mcp-integration.use-case';
 import { EnableMcpIntegrationCommand } from './enable-mcp-integration.command';
@@ -18,16 +20,16 @@ import { PredefinedMcpIntegrationSlug } from 'src/domain/mcp/domain/value-object
 import { NoAuthMcpIntegrationAuth } from 'src/domain/mcp/domain/auth/no-auth-mcp-integration-auth.entity';
 
 describe('EnableMcpIntegrationUseCase', () => {
+  let logger: jest.Mocked<PinoLogger>;
   let useCase: EnableMcpIntegrationUseCase;
   let repository: McpIntegrationsRepositoryPort;
   let contextService: ContextService;
-  let loggerLogSpy: jest.SpyInstance;
-  let loggerErrorSpy: jest.SpyInstance;
 
   const mockOrgId = 'org-123' as UUID;
   const mockIntegrationId = 'integration-456' as UUID;
 
   beforeAll(async () => {
+    logger = createPinoLoggerMock();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EnableMcpIntegrationUseCase,
@@ -45,6 +47,11 @@ describe('EnableMcpIntegrationUseCase', () => {
             get: jest.fn(),
           },
         },
+
+        {
+          provide: getLoggerToken(EnableMcpIntegrationUseCase.name),
+          useValue: logger,
+        },
       ],
     }).compile();
 
@@ -57,8 +64,6 @@ describe('EnableMcpIntegrationUseCase', () => {
     contextService = module.get<ContextService>(ContextService);
 
     // Spy on logger methods
-    loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {
@@ -107,9 +112,12 @@ describe('EnableMcpIntegrationUseCase', () => {
       expect(contextService.get).toHaveBeenCalledWith('orgId');
       expect(repository.findById).toHaveBeenCalledWith(mockIntegrationId);
       expect(repository.save).toHaveBeenCalled();
-      expect(loggerLogSpy).toHaveBeenCalledWith('enableMcpIntegration', {
-        id: mockIntegrationId,
-      });
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          id: mockIntegrationId,
+        },
+        'enableMcpIntegration',
+      );
     });
 
     it('should be idempotent - enabling already-enabled integration succeeds', async () => {
@@ -241,9 +249,9 @@ describe('EnableMcpIntegrationUseCase', () => {
       await expect(useCase.execute(command)).rejects.toThrow(
         UnexpectedMcpError,
       );
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect(logger.error).toHaveBeenCalledWith(
+        { err: unexpectedError },
         'Unexpected error enabling integration',
-        { error: unexpectedError },
       );
     });
 
@@ -259,7 +267,7 @@ describe('EnableMcpIntegrationUseCase', () => {
         McpIntegrationNotFoundError,
       );
       // Should not log as unexpected error
-      expect(loggerErrorSpy).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it('should re-throw McpIntegrationAccessDeniedError without wrapping', async () => {
@@ -286,7 +294,7 @@ describe('EnableMcpIntegrationUseCase', () => {
         McpIntegrationAccessDeniedError,
       );
       // Should not log as unexpected error
-      expect(loggerErrorSpy).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it('should log operation start with integration id', async () => {
@@ -313,9 +321,12 @@ describe('EnableMcpIntegrationUseCase', () => {
       await useCase.execute(command);
 
       // Assert
-      expect(loggerLogSpy).toHaveBeenCalledWith('enableMcpIntegration', {
-        id: mockIntegrationId,
-      });
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          id: mockIntegrationId,
+        },
+        'enableMcpIntegration',
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/enable-mcp-integration/enable-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/enable-mcp-integration/enable-mcp-integration.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EnableMcpIntegrationCommand } from './enable-mcp-integration.command';
 import { McpIntegration } from 'src/domain/mcp/domain/mcp-integration.entity';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
@@ -8,15 +9,15 @@ import { ValidateIntegrationAccessService } from '../../services/validate-integr
 
 @Injectable()
 export class EnableMcpIntegrationUseCase {
-  private readonly logger = new Logger(EnableMcpIntegrationUseCase.name);
-
   constructor(
+    @InjectPinoLogger(EnableMcpIntegrationUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: McpIntegrationsRepositoryPort,
     private readonly validateIntegrationAccess: ValidateIntegrationAccessService,
   ) {}
 
   async execute(command: EnableMcpIntegrationCommand): Promise<McpIntegration> {
-    this.logger.log('enableMcpIntegration', { id: command.integrationId });
+    this.logger.info({ id: command.integrationId }, 'enableMcpIntegration');
 
     try {
       const integration = await this.validateIntegrationAccess.validate(
@@ -31,9 +32,12 @@ export class EnableMcpIntegrationUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Unexpected error enabling integration', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error enabling integration',
+      );
       throw new UnexpectedMcpError('Unexpected error occurred');
     }
   }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.spec.ts
@@ -1,6 +1,8 @@
+import type { PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { setError } from '@appsignal/nodejs';
 import { ExecuteMcpToolUseCase } from './execute-mcp-tool.use-case';
@@ -55,17 +57,16 @@ const buildCustom = () =>
   });
 
 describe('ExecuteMcpToolUseCase', () => {
+  let logger: jest.Mocked<PinoLogger>;
   let useCase: ExecuteMcpToolUseCase;
   let repository: jest.Mocked<McpIntegrationsRepositoryPort>;
   let mcpClientService: {
     callTool: jest.Mock;
   };
   let contextService: jest.Mocked<ContextService>;
-  let loggerLogSpy: jest.SpyInstance;
-  let loggerWarnSpy: jest.SpyInstance;
-  let loggerErrorSpy: jest.SpyInstance;
 
   beforeAll(async () => {
+    logger = createPinoLoggerMock();
     repository = {
       findById: jest.fn(),
       save: jest.fn(),
@@ -90,14 +91,15 @@ describe('ExecuteMcpToolUseCase', () => {
         { provide: McpIntegrationsRepositoryPort, useValue: repository },
         { provide: McpClientService, useValue: mcpClientService },
         { provide: ContextService, useValue: contextService },
+
+        {
+          provide: getLoggerToken(ExecuteMcpToolUseCase.name),
+          useValue: logger,
+        },
       ],
     }).compile();
 
     useCase = module.get(ExecuteMcpToolUseCase);
-
-    loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    loggerWarnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {
@@ -131,7 +133,19 @@ describe('ExecuteMcpToolUseCase', () => {
       },
       mockUserId,
     );
-    expect(loggerLogSpy).toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      {
+        operation: 'execute_tool',
+        integration: {
+          id: mockIntegrationId,
+          name: 'Predefined Integration',
+        },
+        tool: { name: mockToolName },
+        status: 'success',
+        durationMs: expect.any(Number),
+      },
+      '[MCP] operation=execute_tool',
+    );
   });
 
   it('returns error result when MCP client throws', async () => {
@@ -144,7 +158,20 @@ describe('ExecuteMcpToolUseCase', () => {
 
     expect(result.isError).toBe(true);
     expect(result.errorMessage).toBe('tool failed');
-    expect(loggerWarnSpy).toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      {
+        operation: 'execute_tool',
+        integration: {
+          id: mockIntegrationId,
+          name: 'Predefined Integration',
+        },
+        tool: { name: mockToolName },
+        status: 'error',
+        error: 'tool failed',
+        durationMs: expect.any(Number),
+      },
+      '[MCP] operation=execute_tool',
+    );
   });
 
   // The soft-handled tool result is the only place classified MCP outages
@@ -239,7 +266,17 @@ describe('ExecuteMcpToolUseCase', () => {
     await expect(useCase.execute(buildCommand())).rejects.toBeInstanceOf(
       UnexpectedMcpError,
     );
-    expect(loggerErrorSpy).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      {
+        err: expect.any(Error),
+        operation: 'execute_tool',
+        integration: { id: mockIntegrationId },
+        tool: { name: mockToolName },
+        status: 'unexpected_error',
+        durationMs: expect.any(Number),
+      },
+      '[MCP] operation=execute_tool',
+    );
   });
 
   it('passes custom integrations to client service with userId', async () => {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ExecuteMcpToolCommand } from './execute-mcp-tool.command';
 import { McpToolCall } from '../../ports/mcp-client.port';
 import { McpClientService } from '../../services/mcp-client.service';
@@ -19,9 +20,9 @@ export interface ToolExecutionResult {
 
 @Injectable()
 export class ExecuteMcpToolUseCase {
-  private readonly logger = new Logger(ExecuteMcpToolUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ExecuteMcpToolUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly mcpClientService: McpClientService,
     private readonly validateIntegrationAccess: ValidateIntegrationAccessService,
     private readonly contextService: ContextService,
@@ -29,9 +30,7 @@ export class ExecuteMcpToolUseCase {
 
   async execute(command: ExecuteMcpToolCommand): Promise<ToolExecutionResult> {
     const startTime = Date.now();
-    this.logger.log(
-      `[MCP] operation=execute_tool integration=${command.integrationId} tool="${command.toolName}" status=started`,
-    );
+    this.logStarted(command);
 
     try {
       const integration = await this.validateIntegrationAccess.validate(
@@ -52,9 +51,11 @@ export class ExecuteMcpToolUseCase {
           userId,
         );
 
-        const duration = Date.now() - startTime;
-        this.logger.log(
-          `[MCP] operation=execute_tool integration=${command.integrationId} name="${integration.name}" tool="${command.toolName}" status=${result.isError ? 'tool_error' : 'success'} duration=${duration}ms`,
+        this.logCompleted(
+          command,
+          integration.name,
+          result.isError,
+          Date.now() - startTime,
         );
 
         return {
@@ -75,6 +76,36 @@ export class ExecuteMcpToolUseCase {
     }
   }
 
+  private logStarted(command: ExecuteMcpToolCommand): void {
+    this.logger.info(
+      {
+        operation: 'execute_tool',
+        integration: { id: command.integrationId },
+        tool: { name: command.toolName },
+        status: 'started',
+      },
+      '[MCP] operation=execute_tool',
+    );
+  }
+
+  private logCompleted(
+    command: ExecuteMcpToolCommand,
+    integrationName: string,
+    isError: boolean,
+    durationMs: number,
+  ): void {
+    this.logger.info(
+      {
+        operation: 'execute_tool',
+        integration: { id: command.integrationId, name: integrationName },
+        tool: { name: command.toolName },
+        status: isError ? 'tool_error' : 'success',
+        durationMs,
+      },
+      '[MCP] operation=execute_tool',
+    );
+  }
+
   private rethrowExecutionError(
     error: unknown,
     command: ExecuteMcpToolCommand,
@@ -84,14 +115,29 @@ export class ExecuteMcpToolUseCase {
 
     if (error instanceof ApplicationError) {
       this.logger.warn(
-        `[MCP] operation=execute_tool integration=${command.integrationId} tool="${command.toolName}" status=error error="${error.message}" duration=${duration}ms`,
+        {
+          operation: 'execute_tool',
+          integration: { id: command.integrationId },
+          tool: { name: command.toolName },
+          status: 'error',
+          error: error.message,
+          durationMs: duration,
+        },
+        '[MCP] operation=execute_tool',
       );
       throw error;
     }
 
     this.logger.error(
-      `[MCP] operation=execute_tool integration=${command.integrationId} tool="${command.toolName}" status=unexpected_error error="${(error as Error).message}" duration=${duration}ms`,
-      { error: error as Error },
+      {
+        err: error as Error,
+        operation: 'execute_tool',
+        integration: { id: command.integrationId },
+        tool: { name: command.toolName },
+        status: 'unexpected_error',
+        durationMs: duration,
+      },
+      '[MCP] operation=execute_tool',
     );
     throw new UnexpectedMcpError(
       'Unexpected error occurred during tool execution',
@@ -117,7 +163,15 @@ export class ExecuteMcpToolUseCase {
     const errorMsg = (toolError as Error).message || 'Tool execution failed';
 
     this.logger.warn(
-      `[MCP] operation=execute_tool integration=${command.integrationId} name="${integrationName}" tool="${command.toolName}" status=error error="${errorMsg}" duration=${duration}ms`,
+      {
+        operation: 'execute_tool',
+        integration: { id: command.integrationId, name: integrationName },
+        tool: { name: command.toolName },
+        status: 'error',
+        error: errorMsg,
+        durationMs: duration,
+      },
+      '[MCP] operation=execute_tool',
     );
 
     if (isMcpConnectivityOutage(toolError)) {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-integration/get-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-integration/get-mcp-integration.use-case.spec.ts
@@ -1,6 +1,9 @@
+import type { PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger, UnauthorizedException } from '@nestjs/common';
+import { UnauthorizedException } from '@nestjs/common';
 import type { UUID } from 'crypto';
 import { GetMcpIntegrationUseCase } from './get-mcp-integration.use-case';
 import { GetMcpIntegrationQuery } from './get-mcp-integration.query';
@@ -16,16 +19,16 @@ import { PredefinedMcpIntegrationSlug } from 'src/domain/mcp/domain/value-object
 import { NoAuthMcpIntegrationAuth } from 'src/domain/mcp/domain/auth/no-auth-mcp-integration-auth.entity';
 
 describe('GetMcpIntegrationUseCase', () => {
+  let logger: jest.Mocked<PinoLogger>;
   let useCase: GetMcpIntegrationUseCase;
   let repository: McpIntegrationsRepositoryPort;
   let contextService: ContextService;
-  let loggerLogSpy: jest.SpyInstance;
-  let loggerErrorSpy: jest.SpyInstance;
 
   const mockOrgId = 'org-123' as UUID;
   const mockIntegrationId = 'integration-456' as UUID;
 
   beforeAll(async () => {
+    logger = createPinoLoggerMock();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetMcpIntegrationUseCase,
@@ -41,6 +44,11 @@ describe('GetMcpIntegrationUseCase', () => {
             get: jest.fn(),
           },
         },
+
+        {
+          provide: getLoggerToken(GetMcpIntegrationUseCase.name),
+          useValue: logger,
+        },
       ],
     }).compile();
 
@@ -51,8 +59,6 @@ describe('GetMcpIntegrationUseCase', () => {
     contextService = module.get<ContextService>(ContextService);
 
     // Spy on logger methods
-    loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {
@@ -86,9 +92,12 @@ describe('GetMcpIntegrationUseCase', () => {
       expect(result).toEqual(mockIntegration);
       expect(contextService.get).toHaveBeenCalledWith('orgId');
       expect(repository.findById).toHaveBeenCalledWith(mockIntegrationId);
-      expect(loggerLogSpy).toHaveBeenCalledWith('getMcpIntegration', {
-        id: mockIntegrationId,
-      });
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          id: mockIntegrationId,
+        },
+        'getMcpIntegration',
+      );
     });
 
     it('should throw McpIntegrationNotFoundError when integration does not exist', async () => {
@@ -185,9 +194,9 @@ describe('GetMcpIntegrationUseCase', () => {
 
       // Act & Assert
       await expect(useCase.execute(query)).rejects.toThrow(UnexpectedMcpError);
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect(logger.error).toHaveBeenCalledWith(
+        { err: unexpectedError },
         'Unexpected error getting integration',
-        { error: unexpectedError },
       );
     });
 
@@ -203,7 +212,7 @@ describe('GetMcpIntegrationUseCase', () => {
         McpIntegrationNotFoundError,
       );
       // Should not log as unexpected error
-      expect(loggerErrorSpy).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it('should re-throw McpIntegrationAccessDeniedError without wrapping', async () => {
@@ -230,7 +239,7 @@ describe('GetMcpIntegrationUseCase', () => {
         McpIntegrationAccessDeniedError,
       );
       // Should not log as unexpected error
-      expect(loggerErrorSpy).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
     it('should log operation start with integration id', async () => {
@@ -256,9 +265,12 @@ describe('GetMcpIntegrationUseCase', () => {
       await useCase.execute(query);
 
       // Assert
-      expect(loggerLogSpy).toHaveBeenCalledWith('getMcpIntegration', {
-        id: mockIntegrationId,
-      });
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          id: mockIntegrationId,
+        },
+        'getMcpIntegration',
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-integration/get-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-integration/get-mcp-integration.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetMcpIntegrationQuery } from './get-mcp-integration.query';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -12,15 +13,15 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetMcpIntegrationUseCase {
-  private readonly logger = new Logger(GetMcpIntegrationUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetMcpIntegrationUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: McpIntegrationsRepositoryPort,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(query: GetMcpIntegrationQuery): Promise<McpIntegration> {
-    this.logger.log('getMcpIntegration', { id: query.integrationId });
+    this.logger.info({ id: query.integrationId }, 'getMcpIntegration');
 
     try {
       const orgId = this.contextService.get('orgId');
@@ -46,9 +47,12 @@ export class GetMcpIntegrationUseCase {
       ) {
         throw error;
       }
-      this.logger.error('Unexpected error getting integration', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error getting integration',
+      );
       throw new UnexpectedMcpError('Unexpected error occurred');
     }
   }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-integrations-by-ids/get-mcp-integrations-by-ids.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetMcpIntegrationsByIdsQuery } from './get-mcp-integrations-by-ids.query';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -12,9 +13,9 @@ import { ApplicationError } from 'src/common/errors/base.error';
  */
 @Injectable()
 export class GetMcpIntegrationsByIdsUseCase {
-  private readonly logger = new Logger(GetMcpIntegrationsByIdsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetMcpIntegrationsByIdsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: McpIntegrationsRepositoryPort,
     private readonly contextService: ContextService,
   ) {}
@@ -28,9 +29,12 @@ export class GetMcpIntegrationsByIdsUseCase {
   async execute(
     query: GetMcpIntegrationsByIdsQuery,
   ): Promise<McpIntegration[]> {
-    this.logger.log('getMcpIntegrationsByIds', {
-      count: query.integrationIds.length,
-    });
+    this.logger.info(
+      {
+        count: query.integrationIds.length,
+      },
+      'getMcpIntegrationsByIds',
+    );
 
     try {
       const orgId = this.contextService.get('orgId');
@@ -55,9 +59,12 @@ export class GetMcpIntegrationsByIdsUseCase {
       ) {
         throw error;
       }
-      this.logger.error('Unexpected error getting integrations by IDs', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error getting integrations by IDs',
+      );
       throw new UnexpectedMcpError('Unexpected error occurred');
     }
   }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-prompt/get-mcp-prompt.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-prompt/get-mcp-prompt.use-case.spec.ts
@@ -1,6 +1,8 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger, UnauthorizedException } from '@nestjs/common';
+import { UnauthorizedException } from '@nestjs/common';
+import { getLoggerToken, type PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { GetMcpPromptUseCase } from './get-mcp-prompt.use-case';
 import { GetMcpPromptQuery } from './get-mcp-prompt.query';
@@ -27,8 +29,7 @@ describe('GetMcpPromptUseCase', () => {
   let mcpClientService: McpClientService;
   let registryService: PredefinedMcpIntegrationRegistry;
   let contextService: ContextService;
-  let loggerLogSpy: jest.SpyInstance;
-  let loggerErrorSpy: jest.SpyInstance;
+  let logger: jest.Mocked<PinoLogger>;
 
   const mockOrgId = 'org-123' as UUID;
   const mockUserId = 'user-789' as UUID;
@@ -42,6 +43,7 @@ describe('GetMcpPromptUseCase', () => {
   };
 
   beforeEach(async () => {
+    logger = createPinoLoggerMock();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetMcpPromptUseCase,
@@ -69,6 +71,10 @@ describe('GetMcpPromptUseCase', () => {
             get: jest.fn(),
           },
         },
+        {
+          provide: getLoggerToken(GetMcpPromptUseCase.name),
+          useValue: logger,
+        },
       ],
     }).compile();
 
@@ -81,10 +87,6 @@ describe('GetMcpPromptUseCase', () => {
       PredefinedMcpIntegrationRegistry,
     );
     contextService = module.get<ContextService>(ContextService);
-
-    // Spy on logger methods
-    loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {
@@ -153,15 +155,18 @@ describe('GetMcpPromptUseCase', () => {
         mockArguments,
         mockUserId,
       );
-      expect(loggerLogSpy).toHaveBeenCalledWith('getMcpPrompt', {
-        id: mockIntegrationId,
-        prompt: mockPromptName,
-      });
-      expect(loggerLogSpy).toHaveBeenCalledWith('promptRetrieved', {
-        id: mockIntegrationId,
-        prompt: mockPromptName,
-        messageCount: 2,
-      });
+      expect(logger.info).toHaveBeenCalledWith(
+        { id: mockIntegrationId, prompt: mockPromptName },
+        'getMcpPrompt',
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          id: mockIntegrationId,
+          prompt: mockPromptName,
+          messageCount: 2,
+        },
+        'promptRetrieved',
+      );
     });
 
     it('should successfully retrieve prompt without arguments', async () => {
@@ -404,9 +409,9 @@ describe('GetMcpPromptUseCase', () => {
 
       // Act & Assert
       await expect(useCase.execute(query)).rejects.toThrow(UnexpectedMcpError);
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect(logger.error).toHaveBeenCalledWith(
+        { err: unexpectedError },
         'Unexpected error getting prompt',
-        { error: unexpectedError },
       );
     });
 
@@ -451,15 +456,18 @@ describe('GetMcpPromptUseCase', () => {
       await useCase.execute(query);
 
       // Assert
-      expect(loggerLogSpy).toHaveBeenCalledWith('getMcpPrompt', {
-        id: mockIntegrationId,
-        prompt: mockPromptName,
-      });
-      expect(loggerLogSpy).toHaveBeenCalledWith('promptRetrieved', {
-        id: mockIntegrationId,
-        prompt: mockPromptName,
-        messageCount: 3,
-      });
+      expect(logger.info).toHaveBeenCalledWith(
+        { id: mockIntegrationId, prompt: mockPromptName },
+        'getMcpPrompt',
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          id: mockIntegrationId,
+          prompt: mockPromptName,
+          messageCount: 3,
+        },
+        'promptRetrieved',
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-prompt/get-mcp-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-mcp-prompt/get-mcp-prompt.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetMcpPromptQuery } from './get-mcp-prompt.query';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpClientService } from '../../services/mcp-client.service';
@@ -10,6 +11,7 @@ import {
   UnexpectedMcpError,
 } from '../../mcp.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
+import type { McpIntegration } from 'src/domain/mcp/domain/mcp-integration.entity';
 
 export interface PromptMessage {
   role: string;
@@ -33,66 +35,37 @@ interface McpPromptResponse {
 
 @Injectable()
 export class GetMcpPromptUseCase {
-  private readonly logger = new Logger(GetMcpPromptUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetMcpPromptUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: McpIntegrationsRepositoryPort,
     private readonly mcpClientService: McpClientService,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(query: GetMcpPromptQuery): Promise<PromptResult> {
-    this.logger.log('getMcpPrompt', {
-      id: query.integrationId,
-      prompt: query.promptName,
-    });
+    this.logger.info(
+      { id: query.integrationId, prompt: query.promptName },
+      'getMcpPrompt',
+    );
 
     try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedException('User not authenticated');
-      }
-
-      const integration = await this.repository.findById(query.integrationId);
-      if (!integration) {
-        throw new McpIntegrationNotFoundError(query.integrationId);
-      }
-
-      if (integration.orgId !== orgId) {
-        throw new McpIntegrationAccessDeniedError(query.integrationId);
-      }
-
-      if (!integration.enabled) {
-        throw new McpIntegrationDisabledError(query.integrationId);
-      }
-
-      // Retrieve prompt from MCP server
-      const userId = this.contextService.get('userId');
+      const integration = await this.getAccessibleIntegration(query);
       const promptResponse = await this.mcpClientService.getPrompt(
         integration,
         query.promptName,
-        query.args || {},
-        userId,
+        query.args ?? {},
+        this.contextService.get('userId'),
       );
-
-      this.logger.log('promptRetrieved', {
-        id: query.integrationId,
-        prompt: query.promptName,
-        messageCount: promptResponse.messages.length,
-      });
-
-      // Map to PromptResult
-      const response = promptResponse as McpPromptResponse;
-      return {
-        messages: response.messages.map((msg) => ({
-          role: msg.role,
-          content:
-            typeof msg.content === 'string'
-              ? msg.content
-              : (msg.content.text ?? JSON.stringify(msg.content)),
-        })),
-        description: response.description,
-      };
+      this.logger.info(
+        {
+          id: query.integrationId,
+          prompt: query.promptName,
+          messageCount: promptResponse.messages.length,
+        },
+        'promptRetrieved',
+      );
+      return this.mapPromptResponse(promptResponse as McpPromptResponse);
     } catch (error) {
       if (
         error instanceof ApplicationError ||
@@ -100,10 +73,44 @@ export class GetMcpPromptUseCase {
       ) {
         throw error;
       }
-      this.logger.error('Unexpected error getting prompt', {
-        error: error as Error,
-      });
+      this.logger.error(
+        { err: error as Error },
+        'Unexpected error getting prompt',
+      );
       throw new UnexpectedMcpError('Unexpected error occurred');
     }
+  }
+
+  private async getAccessibleIntegration(
+    query: GetMcpPromptQuery,
+  ): Promise<McpIntegration> {
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) {
+      throw new UnauthorizedException('User not authenticated');
+    }
+    const integration = await this.repository.findById(query.integrationId);
+    if (!integration) {
+      throw new McpIntegrationNotFoundError(query.integrationId);
+    }
+    if (integration.orgId !== orgId) {
+      throw new McpIntegrationAccessDeniedError(query.integrationId);
+    }
+    if (!integration.enabled) {
+      throw new McpIntegrationDisabledError(query.integrationId);
+    }
+    return integration;
+  }
+
+  private mapPromptResponse(response: McpPromptResponse): PromptResult {
+    return {
+      messages: response.messages.map((message) => ({
+        role: message.role,
+        content:
+          typeof message.content === 'string'
+            ? message.content
+            : (message.content.text ?? JSON.stringify(message.content)),
+      })),
+      description: response.description,
+    };
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { GetUserMcpConfigUseCase } from './get-user-mcp-config.use-case';
 import { GetUserMcpConfigQuery } from './get-user-mcp-config.query';
 import type { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
@@ -92,6 +93,7 @@ describe('GetUserMcpConfigUseCase', () => {
     );
 
     useCase = new GetUserMcpConfigUseCase(
+      createPinoLoggerMock(),
       integrationRepository,
       userConfigRepository,
       contextService,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetUserMcpConfigQuery } from './get-user-mcp-config.query';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
@@ -19,16 +20,16 @@ export interface UserMcpConfigResult {
 
 @Injectable()
 export class GetUserMcpConfigUseCase {
-  private readonly logger = new Logger(GetUserMcpConfigUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetUserMcpConfigUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly integrationRepository: McpIntegrationsRepositoryPort,
     private readonly userConfigRepository: McpIntegrationUserConfigRepositoryPort,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(query: GetUserMcpConfigQuery): Promise<UserMcpConfigResult> {
-    this.logger.log('execute', { integrationId: query.integrationId });
+    this.logger.info({ integrationId: query.integrationId }, 'execute');
 
     const userId = this.contextService.get('userId');
     if (!userId) {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { InstallMarketplaceIntegrationUseCase } from './install-marketplace-integration.use-case';
 import { InstallMarketplaceIntegrationCommand } from './install-marketplace-integration.command';
 import type { GetMarketplaceIntegrationUseCase } from 'src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case';
@@ -179,6 +180,7 @@ describe('InstallMarketplaceIntegrationUseCase', () => {
     };
 
     useCase = new InstallMarketplaceIntegrationUseCase(
+      createPinoLoggerMock(),
       getMarketplaceIntegrationUseCase,
       repository,
       configService,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/install-marketplace-integration/install-marketplace-integration.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InstallMarketplaceIntegrationCommand } from './install-marketplace-integration.command';
 import { GetMarketplaceIntegrationUseCase } from 'src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case';
@@ -58,11 +59,9 @@ import { McpOAuthClientConfigurationService } from '../../services/mcp-oauth-cli
 
 @Injectable()
 export class InstallMarketplaceIntegrationUseCase {
-  private readonly logger = new Logger(
-    InstallMarketplaceIntegrationUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(InstallMarketplaceIntegrationUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly getMarketplaceIntegrationUseCase: GetMarketplaceIntegrationUseCase,
     private readonly repository: McpIntegrationsRepositoryPort,
     private readonly configService: McpConfigService,
@@ -77,7 +76,7 @@ export class InstallMarketplaceIntegrationUseCase {
   async execute(
     command: InstallMarketplaceIntegrationCommand,
   ): Promise<MarketplaceMcpIntegration> {
-    this.logger.log('execute', { identifier: command.identifier });
+    this.logger.info({ identifier: command.identifier }, 'execute');
 
     const orgId = this.contextService.get('orgId');
     const userId = this.contextService.get('userId');
@@ -94,10 +93,13 @@ export class InstallMarketplaceIntegrationUseCase {
       ) {
         throw error;
       }
-      this.logger.error('Unexpected error installing marketplace integration', {
-        identifier: command.identifier,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          identifier: command.identifier,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Unexpected error installing marketplace integration',
+      );
       throw new UnexpectedMcpError('Unexpected error occurred');
     }
   }
@@ -207,12 +209,12 @@ export class InstallMarketplaceIntegrationUseCase {
       )
       .catch((error: unknown) => {
         this.logger.error(
-          'Failed to emit MarketplaceIntegrationInstalledEvent',
           {
             error: error instanceof Error ? error.message : 'Unknown error',
             identifier,
             orgId,
           },
+          'Failed to emit MarketplaceIntegrationInstalledEvent',
         );
       });
   }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/list-available-mcp-integrations/list-available-mcp-integrations.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/list-available-mcp-integrations/list-available-mcp-integrations.use-case.ts
@@ -1,9 +1,5 @@
-import {
-  Injectable,
-  Logger,
-  Optional,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Injectable, Optional, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { McpIntegrationUserConfigRepositoryPort } from '../../ports/mcp-integration-user-config.repository.port';
@@ -30,11 +26,9 @@ export interface AvailableMcpIntegration {
  */
 @Injectable()
 export class ListAvailableMcpIntegrationsUseCase {
-  private readonly logger = new Logger(
-    ListAvailableMcpIntegrationsUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(ListAvailableMcpIntegrationsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: McpIntegrationsRepositoryPort,
     private readonly userConfigRepository: McpIntegrationUserConfigRepositoryPort,
     private readonly contextService: ContextService,
@@ -49,7 +43,7 @@ export class ListAvailableMcpIntegrationsUseCase {
    * @throws UnexpectedMcpError if an unexpected error occurs
    */
   async execute(): Promise<AvailableMcpIntegration[]> {
-    this.logger.log('listAvailableMcpIntegrations');
+    this.logger.info('listAvailableMcpIntegrations');
 
     try {
       const orgId = this.contextService.get('orgId');
@@ -84,9 +78,12 @@ export class ListAvailableMcpIntegrationsUseCase {
       ) {
         throw error;
       }
-      this.logger.error('Unexpected error listing available integrations', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error listing available integrations',
+      );
       throw new UnexpectedMcpError('Unexpected error occurred');
     }
   }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/list-org-mcp-integrations/list-org-mcp-integrations.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/list-org-mcp-integrations/list-org-mcp-integrations.use-case.spec.ts
@@ -1,6 +1,9 @@
+import type { PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger, UnauthorizedException } from '@nestjs/common';
+import { UnauthorizedException } from '@nestjs/common';
 import { ListOrgMcpIntegrationsUseCase } from './list-org-mcp-integrations.use-case';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -13,17 +16,17 @@ import { randomUUID } from 'crypto';
 import { NoAuthMcpIntegrationAuth } from 'src/domain/mcp/domain/auth/no-auth-mcp-integration-auth.entity';
 
 describe('ListOrgMcpIntegrationsUseCase', () => {
+  let logger: jest.Mocked<PinoLogger>;
   let useCase: ListOrgMcpIntegrationsUseCase;
   let repository: jest.Mocked<McpIntegrationsRepositoryPort>;
   let contextService: jest.Mocked<ContextService>;
-  let loggerLogSpy: jest.SpyInstance;
-  let loggerErrorSpy: jest.SpyInstance;
 
   const mockOrgId = randomUUID();
   const mockIntegrationId1 = randomUUID();
   const mockIntegrationId2 = randomUUID();
 
   beforeAll(async () => {
+    logger = createPinoLoggerMock();
     const mockRepository = {
       save: jest.fn(),
       findById: jest.fn(),
@@ -48,6 +51,11 @@ describe('ListOrgMcpIntegrationsUseCase', () => {
           useValue: mockRepository,
         },
         { provide: ContextService, useValue: mockContextService },
+
+        {
+          provide: getLoggerToken(ListOrgMcpIntegrationsUseCase.name),
+          useValue: logger,
+        },
       ],
     }).compile();
 
@@ -58,8 +66,6 @@ describe('ListOrgMcpIntegrationsUseCase', () => {
     contextService = module.get(ContextService);
 
     // Spy on logger methods
-    loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {
@@ -111,7 +117,7 @@ describe('ListOrgMcpIntegrationsUseCase', () => {
       expect(repository.findAll).toHaveBeenCalledTimes(1);
       expect(repository.findAll).toHaveBeenCalledWith(mockOrgId);
       expect(contextService.get).toHaveBeenCalledWith('orgId');
-      expect(loggerLogSpy).toHaveBeenCalledWith('listOrgMcpIntegrations');
+      expect(logger.info).toHaveBeenCalledWith('listOrgMcpIntegrations');
     });
 
     it('should return empty array when organization has no integrations', async () => {
@@ -126,7 +132,7 @@ describe('ListOrgMcpIntegrationsUseCase', () => {
       expect(repository.findAll).toHaveBeenCalledTimes(1);
       expect(repository.findAll).toHaveBeenCalledWith(mockOrgId);
       expect(contextService.get).toHaveBeenCalledWith('orgId');
-      expect(loggerLogSpy).toHaveBeenCalledWith('listOrgMcpIntegrations');
+      expect(logger.info).toHaveBeenCalledWith('listOrgMcpIntegrations');
     });
 
     it('should throw UnauthorizedException when user not authenticated', async () => {
@@ -158,9 +164,9 @@ describe('ListOrgMcpIntegrationsUseCase', () => {
 
       // Act & Assert
       await expect(useCase.execute()).rejects.toThrow(UnexpectedMcpError);
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect(logger.error).toHaveBeenCalledWith(
+        { err: unexpectedError },
         'Unexpected error listing integrations',
-        { error: unexpectedError },
       );
     });
 
@@ -172,7 +178,7 @@ describe('ListOrgMcpIntegrationsUseCase', () => {
       await useCase.execute();
 
       // Assert
-      expect(loggerLogSpy).toHaveBeenCalledWith('listOrgMcpIntegrations');
+      expect(logger.info).toHaveBeenCalledWith('listOrgMcpIntegrations');
     });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/list-org-mcp-integrations/list-org-mcp-integrations.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/list-org-mcp-integrations/list-org-mcp-integrations.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
 import { McpIntegration } from 'src/domain/mcp/domain/mcp-integration.entity';
@@ -11,9 +12,9 @@ import { UnexpectedMcpError } from '../../mcp.errors';
  */
 @Injectable()
 export class ListOrgMcpIntegrationsUseCase {
-  private readonly logger = new Logger(ListOrgMcpIntegrationsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ListOrgMcpIntegrationsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: McpIntegrationsRepositoryPort,
     private readonly contextService: ContextService,
   ) {}
@@ -25,7 +26,7 @@ export class ListOrgMcpIntegrationsUseCase {
    * @throws UnexpectedMcpError if an unexpected error occurs
    */
   async execute(): Promise<McpIntegration[]> {
-    this.logger.log('listOrgMcpIntegrations');
+    this.logger.info('listOrgMcpIntegrations');
 
     try {
       const orgId = this.contextService.get('orgId');
@@ -41,9 +42,12 @@ export class ListOrgMcpIntegrationsUseCase {
       ) {
         throw error;
       }
-      this.logger.error('Unexpected error listing integrations', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error listing integrations',
+      );
       throw new UnexpectedMcpError('Unexpected error occurred');
     }
   }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/list-predefined-mcp-integration-configs/list-predefined-mcp-integration-configs.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/list-predefined-mcp-integration-configs/list-predefined-mcp-integration-configs.use-case.spec.ts
@@ -1,6 +1,8 @@
+import type { PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { ListPredefinedMcpIntegrationConfigsUseCase } from './list-predefined-mcp-integration-configs.use-case';
 import { PredefinedMcpIntegrationRegistry } from '../../registries/predefined-mcp-integration-registry.service';
 import { UnexpectedMcpError } from '../../mcp.errors';
@@ -9,12 +11,12 @@ import { McpAuthMethod } from 'src/domain/mcp/domain/value-objects/mcp-auth-meth
 import { PredefinedMcpIntegrationConfig } from 'src/domain/mcp/domain/predefined-mcp-integration-config';
 
 describe('ListPredefinedMcpIntegrationConfigsUseCase', () => {
+  let logger: jest.Mocked<PinoLogger>;
   let useCase: ListPredefinedMcpIntegrationConfigsUseCase;
   let registryService: PredefinedMcpIntegrationRegistry;
-  let loggerLogSpy: jest.SpyInstance;
-  let loggerErrorSpy: jest.SpyInstance;
 
   beforeAll(async () => {
+    logger = createPinoLoggerMock();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ListPredefinedMcpIntegrationConfigsUseCase,
@@ -23,6 +25,13 @@ describe('ListPredefinedMcpIntegrationConfigsUseCase', () => {
           useValue: {
             getAllConfigs: jest.fn(),
           },
+        },
+
+        {
+          provide: getLoggerToken(
+            ListPredefinedMcpIntegrationConfigsUseCase.name,
+          ),
+          useValue: logger,
         },
       ],
     }).compile();
@@ -35,8 +44,6 @@ describe('ListPredefinedMcpIntegrationConfigsUseCase', () => {
     );
 
     // Spy on logger methods
-    loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {
@@ -64,7 +71,7 @@ describe('ListPredefinedMcpIntegrationConfigsUseCase', () => {
       expect(result).toEqual(mockConfigs);
 
       expect(registryService.getAllConfigs).toHaveBeenCalledTimes(1);
-      expect(loggerLogSpy).toHaveBeenCalledWith(
+      expect(logger.info).toHaveBeenCalledWith(
         'listPredefinedMcpIntegrationConfigs',
       );
     });
@@ -80,7 +87,7 @@ describe('ListPredefinedMcpIntegrationConfigsUseCase', () => {
       expect(result).toEqual([]);
 
       expect(registryService.getAllConfigs).toHaveBeenCalledTimes(1);
-      expect(loggerLogSpy).toHaveBeenCalledWith(
+      expect(logger.info).toHaveBeenCalledWith(
         'listPredefinedMcpIntegrationConfigs',
       );
     });
@@ -94,9 +101,9 @@ describe('ListPredefinedMcpIntegrationConfigsUseCase', () => {
 
       // Act & Assert
       expect(() => useCase.execute()).toThrow(UnexpectedMcpError);
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect(logger.error).toHaveBeenCalledWith(
+        { err: unexpectedError },
         'Unexpected error listing predefined configs',
-        { error: unexpectedError },
       );
     });
 
@@ -108,7 +115,7 @@ describe('ListPredefinedMcpIntegrationConfigsUseCase', () => {
       useCase.execute();
 
       // Assert
-      expect(loggerLogSpy).toHaveBeenCalledWith(
+      expect(logger.info).toHaveBeenCalledWith(
         'listPredefinedMcpIntegrationConfigs',
       );
     });
@@ -123,9 +130,8 @@ describe('ListPredefinedMcpIntegrationConfigsUseCase', () => {
           ListPredefinedMcpIntegrationConfigsUseCase,
         ) ?? [];
 
-      // Should only have PredefinedMcpIntegrationRegistryService
-      expect(constructorParams.length).toBe(1);
-      expect(constructorParams[0]).toBe(PredefinedMcpIntegrationRegistry);
+      expect(constructorParams.length).toBe(2);
+      expect(constructorParams[1]).toBe(PredefinedMcpIntegrationRegistry);
     });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/list-predefined-mcp-integration-configs/list-predefined-mcp-integration-configs.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/list-predefined-mcp-integration-configs/list-predefined-mcp-integration-configs.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { PredefinedMcpIntegrationRegistry } from '../../registries/predefined-mcp-integration-registry.service';
 import { PredefinedMcpIntegrationConfig } from 'src/domain/mcp/domain/predefined-mcp-integration-config';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -10,16 +11,14 @@ import { UnexpectedMcpError } from '../../mcp.errors';
  */
 @Injectable()
 export class ListPredefinedMcpIntegrationConfigsUseCase {
-  private readonly logger = new Logger(
-    ListPredefinedMcpIntegrationConfigsUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(ListPredefinedMcpIntegrationConfigsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly registryService: PredefinedMcpIntegrationRegistry,
   ) {}
 
   execute(): PredefinedMcpIntegrationConfig[] {
-    this.logger.log('listPredefinedMcpIntegrationConfigs');
+    this.logger.info('listPredefinedMcpIntegrationConfigs');
 
     try {
       return this.registryService.getAllConfigs();
@@ -30,9 +29,12 @@ export class ListPredefinedMcpIntegrationConfigsUseCase {
       }
 
       // Log and wrap unexpected errors
-      this.logger.error('Unexpected error listing predefined configs', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error listing predefined configs',
+      );
       throw new UnexpectedMcpError('Unexpected error occurred');
     }
   }

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.use-case.spec.ts
@@ -1,6 +1,8 @@
+import type { PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { RetrieveMcpResourceUseCase } from './retrieve-mcp-resource.use-case';
 import { RetrieveMcpResourceCommand } from './retrieve-mcp-resource.command';
@@ -20,12 +22,11 @@ import { PredefinedMcpIntegrationSlug } from 'src/domain/mcp/domain/value-object
 import { NoAuthMcpIntegrationAuth } from 'src/domain/mcp/domain/auth/no-auth-mcp-integration-auth.entity';
 
 describe('RetrieveMcpResourceUseCase', () => {
+  let logger: jest.Mocked<PinoLogger>;
   let useCase: RetrieveMcpResourceUseCase;
   let repository: jest.Mocked<McpIntegrationsRepositoryPort>;
   let mcpClientService: jest.Mocked<McpClientService>;
   let contextService: jest.Mocked<ContextService>;
-  let loggerLogSpy: jest.SpyInstance;
-  let loggerErrorSpy: jest.SpyInstance;
 
   const mockOrgId = randomUUID();
   const mockUserId = randomUUID();
@@ -53,6 +54,7 @@ describe('RetrieveMcpResourceUseCase', () => {
     });
 
   beforeAll(async () => {
+    logger = createPinoLoggerMock();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RetrieveMcpResourceUseCase,
@@ -75,6 +77,11 @@ describe('RetrieveMcpResourceUseCase', () => {
             get: jest.fn(),
           },
         },
+
+        {
+          provide: getLoggerToken(RetrieveMcpResourceUseCase.name),
+          useValue: logger,
+        },
       ],
     }).compile();
 
@@ -82,9 +89,6 @@ describe('RetrieveMcpResourceUseCase', () => {
     repository = module.get(McpIntegrationsRepositoryPort);
     mcpClientService = module.get(McpClientService);
     contextService = module.get(ContextService);
-
-    loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {
@@ -115,11 +119,14 @@ describe('RetrieveMcpResourceUseCase', () => {
         undefined,
         mockUserId,
       );
-      expect(loggerLogSpy).toHaveBeenCalledWith('retrieveMcpResource', {
-        integrationId: mockIntegrationId,
-        resourceUri: mockResourceUri,
-        parameters: undefined,
-      });
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          integrationId: mockIntegrationId,
+          url: mockResourceUri,
+          input: undefined,
+        },
+        'retrieveMcpResource',
+      );
     });
 
     it('passes parameters through to client service with userId', async () => {
@@ -222,11 +229,14 @@ describe('RetrieveMcpResourceUseCase', () => {
         ),
       ).rejects.toThrow(UnexpectedMcpError);
 
-      expect(loggerErrorSpy).toHaveBeenCalledWith('retrieveMcpResourceFailed', {
-        integrationId: mockIntegrationId,
-        resourceUri: mockResourceUri,
-        error: 'Network failure',
-      });
+      expect(logger.error).toHaveBeenCalledWith(
+        {
+          integrationId: mockIntegrationId,
+          url: mockResourceUri,
+          error: 'Network failure',
+        },
+        'retrieveMcpResourceFailed',
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { RetrieveMcpResourceCommand } from './retrieve-mcp-resource.command';
 import { McpClientService } from '../../services/mcp-client.service';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -8,9 +9,9 @@ import { ValidateIntegrationAccessService } from '../../services/validate-integr
 
 @Injectable()
 export class RetrieveMcpResourceUseCase {
-  private readonly logger = new Logger(RetrieveMcpResourceUseCase.name);
-
   constructor(
+    @InjectPinoLogger(RetrieveMcpResourceUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly mcpClientService: McpClientService,
     private readonly validateIntegrationAccess: ValidateIntegrationAccessService,
     private readonly contextService: ContextService,
@@ -19,11 +20,14 @@ export class RetrieveMcpResourceUseCase {
   async execute(
     command: RetrieveMcpResourceCommand,
   ): Promise<{ content: unknown; mimeType: string }> {
-    this.logger.log('retrieveMcpResource', {
-      integrationId: command.integrationId,
-      resourceUri: command.resourceUri,
-      parameters: command.parameters,
-    });
+    this.logger.info(
+      {
+        integrationId: command.integrationId,
+        url: command.resourceUri,
+        input: command.parameters,
+      },
+      'retrieveMcpResource',
+    );
     try {
       const integration = await this.validateIntegrationAccess.validate(
         command.integrationId,
@@ -44,11 +48,14 @@ export class RetrieveMcpResourceUseCase {
         throw error;
       }
 
-      this.logger.error('retrieveMcpResourceFailed', {
-        integrationId: command.integrationId,
-        resourceUri: command.resourceUri,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          integrationId: command.integrationId,
+          url: command.resourceUri,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'retrieveMcpResourceFailed',
+      );
       throw new UnexpectedMcpError(
         error instanceof Error ? error.message : 'Unknown error',
       );

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { SetUserMcpConfigUseCase } from './set-user-mcp-config.use-case';
 import { SetUserMcpConfigCommand } from './set-user-mcp-config.command';
 import type { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
@@ -111,6 +112,7 @@ describe('SetUserMcpConfigUseCase', () => {
     mcpClientService = { invalidateConnections: jest.fn() };
 
     useCase = new SetUserMcpConfigUseCase(
+      createPinoLoggerMock(),
       integrationRepository,
       userConfigRepository,
       contextService,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { SetUserMcpConfigCommand } from './set-user-mcp-config.command';
 import { UserMcpConfigResult } from '../get-user-mcp-config/get-user-mcp-config.use-case';
@@ -24,9 +25,9 @@ import { McpClientService } from '../../services/mcp-client.service';
 
 @Injectable()
 export class SetUserMcpConfigUseCase {
-  private readonly logger = new Logger(SetUserMcpConfigUseCase.name);
-
   constructor(
+    @InjectPinoLogger(SetUserMcpConfigUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly integrationRepository: McpIntegrationsRepositoryPort,
     private readonly userConfigRepository: McpIntegrationUserConfigRepositoryPort,
     private readonly contextService: ContextService,
@@ -39,7 +40,7 @@ export class SetUserMcpConfigUseCase {
   async execute(
     command: SetUserMcpConfigCommand,
   ): Promise<UserMcpConfigResult> {
-    this.logger.log('execute', { integrationId: command.integrationId });
+    this.logger.info({ integrationId: command.integrationId }, 'execute');
 
     const userId = this.contextService.get('userId');
     if (!userId) {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { UnauthorizedException } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { UpdateMcpIntegrationUseCase } from './update-mcp-integration.use-case';
@@ -72,6 +73,7 @@ describe('UpdateMcpIntegrationUseCase', () => {
     mcpClientService = { invalidateConnections: jest.fn() };
 
     useCase = new UpdateMcpIntegrationUseCase(
+      createPinoLoggerMock(),
       repository,
       context,
       encryption,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { UpdateMcpIntegrationCommand } from './update-mcp-integration.command';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
@@ -25,9 +26,9 @@ import { McpClientService } from '../../services/mcp-client.service';
 
 @Injectable()
 export class UpdateMcpIntegrationUseCase {
-  private readonly logger = new Logger(UpdateMcpIntegrationUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateMcpIntegrationUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: McpIntegrationsRepositoryPort,
     private readonly contextService: ContextService,
     private readonly credentialEncryption: McpCredentialEncryptionPort,
@@ -40,7 +41,7 @@ export class UpdateMcpIntegrationUseCase {
 
   @HandleUnexpectedErrors(UnexpectedMcpError)
   async execute(command: UpdateMcpIntegrationCommand): Promise<McpIntegration> {
-    this.logger.log('updateMcpIntegration', { id: command.integrationId });
+    this.logger.info({ id: command.integrationId }, 'updateMcpIntegration');
 
     const integration = await this.getAuthorizedIntegration(
       command.integrationId as UUID,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/validate-mcp-integration/validate-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/validate-mcp-integration/validate-mcp-integration.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { ValidateMcpIntegrationUseCase } from './validate-mcp-integration.use-case';
 import { ValidateMcpIntegrationCommand } from './validate-mcp-integration.command';
@@ -74,6 +75,7 @@ describe('ValidateMcpIntegrationUseCase', () => {
     repository.findById.mockResolvedValue(buildIntegration());
 
     useCase = new ValidateMcpIntegrationUseCase(
+      createPinoLoggerMock(),
       repository,
       mcpClientService,
       contextService,

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/validate-mcp-integration/validate-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/validate-mcp-integration/validate-mcp-integration.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { ValidateMcpIntegrationCommand } from './validate-mcp-integration.command';
 import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
@@ -25,9 +26,9 @@ export interface ValidationResult {
 
 @Injectable()
 export class ValidateMcpIntegrationUseCase {
-  private readonly logger = new Logger(ValidateMcpIntegrationUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ValidateMcpIntegrationUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: McpIntegrationsRepositoryPort,
     private readonly mcpClientService: McpClientService,
     private readonly contextService: ContextService,
@@ -36,9 +37,12 @@ export class ValidateMcpIntegrationUseCase {
   async execute(
     command: ValidateMcpIntegrationCommand,
   ): Promise<ValidationResult> {
-    this.logger.log('validateMcpIntegration', {
-      id: command.integrationId,
-    });
+    this.logger.info(
+      {
+        id: command.integrationId,
+      },
+      'validateMcpIntegration',
+    );
 
     try {
       const orgId = this.getOrgIdOrThrow();
@@ -48,54 +52,10 @@ export class ValidateMcpIntegrationUseCase {
 
       this.ensureOrgAccess(integration, orgId);
 
-      // Validation is an org-level connectivity check. We deliberately do not
-      // pass a userId so it neither merges per-user credentials nor trips the
-      // per-user authorization guard — those are enforced at runtime per user.
-      const capabilityResult = await this.collectCapabilities(
+      return await this.validateCapabilities(
         integration,
         command.integrationId,
       );
-
-      if (capabilityResult.kind === 'failure') {
-        return {
-          isValid: false,
-          errorMessage: capabilityResult.error,
-        };
-      }
-
-      const { tools, resources, resourceTemplates, prompts } = capabilityResult;
-      const toolCount = tools.length;
-      const resourceCount = resources.length + resourceTemplates.length;
-      const promptCount = prompts.length;
-      const totalCapabilities = toolCount + resourceCount + promptCount;
-
-      if (totalCapabilities === 0) {
-        const errorMessage = 'No capabilities found on MCP server';
-
-        this.logger.warn('validationFailed', {
-          id: command.integrationId,
-          error: errorMessage,
-        });
-
-        return {
-          isValid: false,
-          errorMessage,
-        };
-      }
-
-      this.logger.log('validationSucceeded', {
-        id: command.integrationId,
-        toolCount,
-        resourceCount,
-        promptCount,
-      });
-
-      return {
-        isValid: true,
-        toolCount,
-        resourceCount,
-        promptCount,
-      };
     } catch (error) {
       if (
         error instanceof ApplicationError ||
@@ -104,14 +64,46 @@ export class ValidateMcpIntegrationUseCase {
         throw error;
       }
 
-      this.logger.error('unexpectedError', {
-        id: command.integrationId,
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          id: command.integrationId,
+          err: error as Error,
+        },
+        'unexpectedError',
+      );
       throw new UnexpectedMcpError(
         'Unexpected error occurred during validation',
       );
     }
+  }
+
+  private async validateCapabilities(
+    integration: McpIntegration,
+    integrationId: UUID,
+  ): Promise<ValidationResult> {
+    const result = await this.collectCapabilities(integration, integrationId);
+    if (result.kind === 'failure') {
+      return { isValid: false, errorMessage: result.error };
+    }
+
+    const toolCount = result.tools.length;
+    const resourceCount =
+      result.resources.length + result.resourceTemplates.length;
+    const promptCount = result.prompts.length;
+    if (toolCount + resourceCount + promptCount === 0) {
+      const errorMessage = 'No capabilities found on MCP server';
+      this.logger.warn(
+        { id: integrationId, error: errorMessage },
+        'validationFailed',
+      );
+      return { isValid: false, errorMessage };
+    }
+
+    this.logger.info(
+      { id: integrationId, toolCount, resourceCount, promptCount },
+      'validationSucceeded',
+    );
+    return { isValid: true, toolCount, resourceCount, promptCount };
   }
 
   private getOrgIdOrThrow(): UUID {
@@ -158,42 +150,25 @@ export class ValidateMcpIntegrationUseCase {
       }
     | { kind: 'failure'; error: string }
   > {
-    const requests: [
-      Promise<unknown[]>,
-      Promise<unknown[]>,
-      Promise<unknown[]>,
-      Promise<unknown[]>,
-    ] = [
-      this.mcpClientService.listTools(integration),
-      this.mcpClientService.listResources(integration),
-      this.mcpClientService.listResourceTemplates(integration),
-      this.mcpClientService.listPrompts(integration),
-    ];
-
+    const results = await Promise.allSettled(
+      this.createCapabilityRequests(integration),
+    );
     const [toolsResult, resourcesResult, templatesResult, promptsResult] =
-      await Promise.allSettled(requests);
-
-    let criticalFailure: PromiseRejectedResult | undefined;
-
-    for (const result of [
-      toolsResult,
-      resourcesResult,
-      templatesResult,
-      promptsResult,
-    ]) {
-      if (this.isCriticalFailure(result)) {
-        criticalFailure = result;
-        break;
-      }
-    }
+      results;
+    const criticalFailure = results.find((result) =>
+      this.isCriticalFailure(result),
+    );
 
     if (criticalFailure) {
       const errorMessage = this.extractErrorMessage(criticalFailure.reason);
 
-      this.logger.warn('validationFailed', {
-        id: integrationId,
-        error: errorMessage,
-      });
+      this.logger.warn(
+        {
+          id: integrationId,
+          error: errorMessage,
+        },
+        'validationFailed',
+      );
 
       return {
         kind: 'failure',
@@ -208,6 +183,22 @@ export class ValidateMcpIntegrationUseCase {
       resourceTemplates: this.extractArray(templatesResult),
       prompts: this.extractArray(promptsResult),
     };
+  }
+
+  private createCapabilityRequests(
+    integration: McpIntegration,
+  ): [
+    Promise<unknown[]>,
+    Promise<unknown[]>,
+    Promise<unknown[]>,
+    Promise<unknown[]>,
+  ] {
+    return [
+      this.mcpClientService.listTools(integration),
+      this.mcpClientService.listResources(integration),
+      this.mcpClientService.listResourceTemplates(integration),
+      this.mcpClientService.listPrompts(integration),
+    ];
   }
 
   private isCriticalFailure(

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-client-pool.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-client-pool.service.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { Client } from '@modelcontextprotocol/client';
 import { randomUUID } from 'crypto';
 import type { McpConnectionConfig } from '../../application/ports/mcp-client.port';
@@ -24,8 +24,7 @@ describe('McpClientPoolService', () => {
     close = jest.fn().mockResolvedValue(undefined);
     client = { close } as unknown as Client;
     createClient = jest.fn().mockResolvedValue(client);
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    pool = new McpClientPoolService();
+    pool = new McpClientPoolService(createPinoLoggerMock());
   });
 
   afterEach(async () => {

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-client-pool.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-client-pool.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, type OnModuleDestroy } from '@nestjs/common';
+import { Injectable, type OnModuleDestroy } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { Client } from '@modelcontextprotocol/client';
 import { createHash } from 'crypto';
 import type {
@@ -21,7 +22,10 @@ interface CachedClient {
 
 @Injectable()
 export class McpClientPoolService implements OnModuleDestroy {
-  private readonly logger = new Logger(McpClientPoolService.name);
+  constructor(
+    @InjectPinoLogger(McpClientPoolService.name)
+    private readonly logger: PinoLogger,
+  ) {}
   private readonly clients = new Map<string, CachedClient>();
   private readonly liveClients = new Set<CachedClient>();
   private shuttingDown = false;
@@ -188,9 +192,12 @@ export class McpClientPoolService implements OnModuleDestroy {
     try {
       await client.close();
     } catch (error) {
-      this.logger.warn('Failed to close MCP client', {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      this.logger.warn(
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+        'Failed to close MCP client',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import {
   Client,
   StreamableHTTPClientTransport,
@@ -65,10 +65,8 @@ describe('McpSdkClientAdapter', () => {
     };
     (Client as unknown as jest.Mock).mockImplementation(() => clientMock);
 
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-
-    clientPool = new McpClientPoolService();
-    adapter = new McpSdkClientAdapter(clientPool);
+    clientPool = new McpClientPoolService(createPinoLoggerMock());
+    adapter = new McpSdkClientAdapter(createPinoLoggerMock(), clientPool);
   });
 
   afterEach(async () => {
@@ -123,6 +121,7 @@ describe('McpSdkClientAdapter', () => {
       };
       const oauthFetch = { fetch: jest.fn() };
       adapter = new McpSdkClientAdapter(
+        createPinoLoggerMock(),
         clientPool,
         providerFactory as never,
         integrations as never,

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   Client,
   StreamableHTTPClientTransport,
@@ -77,10 +78,11 @@ function isTimeoutOrAbortError(error: unknown, depth = 0): boolean {
  */
 @Injectable()
 export class McpSdkClientAdapter extends McpClientPort {
-  private readonly logger = new Logger(McpSdkClientAdapter.name);
   private readonly requestOptions = { timeout: 30000 };
 
   constructor(
+    @InjectPinoLogger(McpSdkClientAdapter.name)
+    private readonly logger: PinoLogger,
     private readonly clientPool: McpClientPoolService,
     @Optional() private readonly oauthProviderFactory?: McpOAuthProviderFactory,
     @Optional() private readonly integrations?: McpIntegrationsRepositoryPort,
@@ -280,10 +282,13 @@ export class McpSdkClientAdapter extends McpClientPort {
       });
       return { valid: true };
     } catch (error) {
-      this.logger.warn('Connection validation failed', {
-        serverUrl: config.serverUrl,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      this.logger.warn(
+        {
+          url: config.serverUrl,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        'Connection validation failed',
+      );
       return {
         valid: false,
         error: error instanceof Error ? error.message : String(error),

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/encryption/mcp-credential-encryption.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/encryption/mcp-credential-encryption.service.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
@@ -24,6 +26,11 @@ describe('McpCredentialEncryptionService', () => {
               return undefined;
             }),
           },
+        },
+
+        {
+          provide: getLoggerToken(McpCredentialEncryptionService.name),
+          useValue: createPinoLoggerMock(),
         },
       ],
     }).compile();
@@ -65,7 +72,10 @@ describe('McpCredentialEncryptionService', () => {
       // Re-instantiate service to trigger constructor validation
       expect(() => {
         // eslint-disable-next-line sonarjs/constructor-for-side-effects
-        new McpCredentialEncryptionService(configService);
+        new McpCredentialEncryptionService(
+          createPinoLoggerMock(),
+          configService,
+        );
       }).toThrow('MCP_ENCRYPTION_KEY environment variable is not configured');
     });
 
@@ -74,7 +84,10 @@ describe('McpCredentialEncryptionService', () => {
 
       expect(() => {
         // eslint-disable-next-line sonarjs/constructor-for-side-effects
-        new McpCredentialEncryptionService(configService);
+        new McpCredentialEncryptionService(
+          createPinoLoggerMock(),
+          configService,
+        );
       }).toThrow('MCP_ENCRYPTION_KEY environment variable is not configured');
     });
 
@@ -83,7 +96,10 @@ describe('McpCredentialEncryptionService', () => {
 
       expect(() => {
         // eslint-disable-next-line sonarjs/constructor-for-side-effects
-        new McpCredentialEncryptionService(configService);
+        new McpCredentialEncryptionService(
+          createPinoLoggerMock(),
+          configService,
+        );
       }).toThrow(
         'MCP_ENCRYPTION_KEY must be a 64-character hex string (32 bytes)',
       );

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/encryption/mcp-credential-encryption.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/encryption/mcp-credential-encryption.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import * as crypto from 'crypto';
 import { McpCredentialEncryptionPort } from '../../application/ports/mcp-credential-encryption.port';
@@ -19,13 +20,16 @@ import { McpCredentialEncryptionPort } from '../../application/ports/mcp-credent
  */
 @Injectable()
 export class McpCredentialEncryptionService extends McpCredentialEncryptionPort {
-  private readonly logger = new Logger(McpCredentialEncryptionService.name);
   private readonly algorithm = 'aes-256-gcm';
   private readonly ivLength = 16; // 128 bits
   private readonly authTagLength = 16; // 128 bits
   private readonly encryptionKey: Buffer;
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    @InjectPinoLogger(McpCredentialEncryptionService.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {
     super();
 
     // Read and validate encryption key from environment
@@ -47,7 +51,7 @@ export class McpCredentialEncryptionService extends McpCredentialEncryptionPort 
     }
 
     this.encryptionKey = Buffer.from(keyHex, 'hex');
-    this.logger.log('McpCredentialEncryptionService initialized successfully');
+    this.logger.info('McpCredentialEncryptionService initialized successfully');
   }
 
   /**
@@ -85,9 +89,12 @@ export class McpCredentialEncryptionService extends McpCredentialEncryptionPort 
       const combined = Buffer.concat([iv, encrypted, authTag]);
       return Promise.resolve(combined.toString('base64'));
     } catch (error) {
-      this.logger.error('Failed to encrypt credential', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Failed to encrypt credential',
+      );
       throw new Error('Failed to encrypt credential');
     }
   }
@@ -130,9 +137,12 @@ export class McpCredentialEncryptionService extends McpCredentialEncryptionPort 
 
       return Promise.resolve(decrypted.toString('utf8'));
     } catch (error) {
-      this.logger.error('Failed to decrypt credential', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Failed to decrypt credential',
+      );
       throw new Error('Failed to decrypt credential');
     }
   }

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-user-config.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-user-config.repository.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import type { Repository } from 'typeorm';
 import { McpIntegrationUserConfigRepository } from './mcp-integration-user-config.repository';
@@ -20,7 +21,10 @@ describe('McpIntegrationUserConfigRepository', () => {
       delete: jest.fn(),
     } as unknown as jest.Mocked<Repository<McpIntegrationUserConfigRecord>>;
 
-    repository = new McpIntegrationUserConfigRepository(mockTypeOrmRepo);
+    repository = new McpIntegrationUserConfigRepository(
+      createPinoLoggerMock(),
+      mockTypeOrmRepo,
+    );
   });
 
   describe('save', () => {

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-user-config.repository.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-user-config.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { UUID } from 'crypto';
@@ -12,9 +13,9 @@ import { McpIntegrationUserConfigRecord } from './schema/mcp-integration-user-co
  */
 @Injectable()
 export class McpIntegrationUserConfigRepository extends McpIntegrationUserConfigRepositoryPort {
-  private readonly logger = new Logger(McpIntegrationUserConfigRepository.name);
-
   constructor(
+    @InjectPinoLogger(McpIntegrationUserConfigRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(McpIntegrationUserConfigRecord)
     private readonly repository: Repository<McpIntegrationUserConfigRecord>,
   ) {
@@ -24,11 +25,14 @@ export class McpIntegrationUserConfigRepository extends McpIntegrationUserConfig
   async save(
     config: McpIntegrationUserConfig,
   ): Promise<McpIntegrationUserConfig> {
-    this.logger.log('save', {
-      configId: config.id,
-      integrationId: config.integrationId,
-      userId: config.userId,
-    });
+    this.logger.info(
+      {
+        configId: config.id,
+        integrationId: config.integrationId,
+        userId: config.userId,
+      },
+      'save',
+    );
 
     const record = this.toRecord(config);
     const saved = await this.repository.save(record);
@@ -39,7 +43,7 @@ export class McpIntegrationUserConfigRepository extends McpIntegrationUserConfig
     integrationId: UUID,
     userId: UUID,
   ): Promise<McpIntegrationUserConfig | null> {
-    this.logger.log('findByIntegrationAndUser', { integrationId, userId });
+    this.logger.info({ integrationId, userId }, 'findByIntegrationAndUser');
 
     const record = await this.repository.findOne({
       where: { integrationId, userId },
@@ -56,10 +60,13 @@ export class McpIntegrationUserConfigRepository extends McpIntegrationUserConfig
     integrationIds: UUID[],
     userId: UUID,
   ): Promise<McpIntegrationUserConfig[]> {
-    this.logger.log('findByIntegrationIdsAndUser', {
-      count: integrationIds.length,
-      userId,
-    });
+    this.logger.info(
+      {
+        count: integrationIds.length,
+        userId,
+      },
+      'findByIntegrationIdsAndUser',
+    );
 
     if (integrationIds.length === 0) {
       return [];
@@ -73,7 +80,7 @@ export class McpIntegrationUserConfigRepository extends McpIntegrationUserConfig
   }
 
   async deleteByIntegrationId(integrationId: UUID): Promise<void> {
-    this.logger.log('deleteByIntegrationId', { integrationId });
+    this.logger.info({ integrationId }, 'deleteByIntegrationId');
 
     await this.repository.delete({ integrationId });
   }

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integrations.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integrations.repository.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import type { Repository } from 'typeorm';
 import { McpIntegrationsRepository } from './mcp-integrations.repository';
@@ -68,6 +69,7 @@ describe('McpIntegrationsRepository', () => {
     });
 
     repository = new McpIntegrationsRepository(
+      createPinoLoggerMock(),
       ormRepository as unknown as Repository<McpIntegrationRecord>,
       authRepository as unknown as Repository<McpIntegrationAuthRecord>,
       predefinedRepository as unknown as Repository<PredefinedMcpIntegrationRecord>,

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integrations.repository.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integrations.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { UUID } from 'crypto';
@@ -17,9 +18,9 @@ import { McpIntegrationMapper } from './mappers/mcp-integration.mapper';
  */
 @Injectable()
 export class McpIntegrationsRepository extends McpIntegrationsRepositoryPort {
-  private readonly logger = new Logger(McpIntegrationsRepository.name);
-
   constructor(
+    @InjectPinoLogger(McpIntegrationsRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(McpIntegrationRecord)
     private readonly repository: Repository<McpIntegrationRecord>,
     @InjectRepository(McpIntegrationAuthRecord)
@@ -34,7 +35,7 @@ export class McpIntegrationsRepository extends McpIntegrationsRepositoryPort {
   }
 
   async save<T extends McpIntegration>(integration: T): Promise<T> {
-    this.logger.log('save', { integrationId: integration.id });
+    this.logger.info({ integrationId: integration.id }, 'save');
 
     const recordResult = this.mcpIntegrationMapper.toRecord(integration);
     if (recordResult instanceof Error) {
@@ -42,10 +43,6 @@ export class McpIntegrationsRepository extends McpIntegrationsRepositoryPort {
     }
     const record: McpIntegrationRecord = recordResult;
     const authRecord = record.auth;
-
-    if (!authRecord) {
-      throw new Error('Expected MCP integration auth record to be present');
-    }
 
     await this.repository.manager.transaction(async (manager) => {
       const integrationRepo = manager.getRepository(McpIntegrationRecord);
@@ -82,7 +79,7 @@ export class McpIntegrationsRepository extends McpIntegrationsRepositoryPort {
   }
 
   async findById(id: UUID): Promise<McpIntegration | null> {
-    this.logger.log('findById', { id });
+    this.logger.info({ id }, 'findById');
 
     const record = await this.repository.findOne({
       where: { id },
@@ -96,7 +93,7 @@ export class McpIntegrationsRepository extends McpIntegrationsRepositoryPort {
   }
 
   async findByIds(ids: UUID[]): Promise<McpIntegration[]> {
-    this.logger.log('findByIds', { count: ids.length });
+    this.logger.info({ count: ids.length }, 'findByIds');
 
     if (ids.length === 0) {
       return [];
@@ -113,7 +110,7 @@ export class McpIntegrationsRepository extends McpIntegrationsRepositoryPort {
     orgId: UUID,
     filter?: { enabled?: boolean },
   ): Promise<McpIntegration[]> {
-    this.logger.log('findAll', { orgId, filter });
+    this.logger.info({ orgId, filter }, 'findAll');
 
     const where: { orgId: UUID; enabled?: boolean } = { orgId };
     if (filter?.enabled !== undefined) {
@@ -132,7 +129,7 @@ export class McpIntegrationsRepository extends McpIntegrationsRepositoryPort {
     organizationId: UUID,
     slug: PredefinedMcpIntegrationSlug,
   ): Promise<McpIntegration | null> {
-    this.logger.log('findByOrgIdAndSlug', { organizationId, slug });
+    this.logger.info({ organizationId, slug }, 'findByOrgIdAndSlug');
 
     const record = await this.predefinedRepository.findOne({
       where: {
@@ -155,10 +152,13 @@ export class McpIntegrationsRepository extends McpIntegrationsRepositoryPort {
     orgId: UUID,
     marketplaceIdentifier: string,
   ): Promise<McpIntegration | null> {
-    this.logger.log('findByOrgIdAndMarketplaceIdentifier', {
-      orgId,
-      marketplaceIdentifier,
-    });
+    this.logger.info(
+      {
+        orgId,
+        marketplaceIdentifier,
+      },
+      'findByOrgIdAndMarketplaceIdentifier',
+    );
 
     const record = await this.marketplaceRepository.findOne({
       where: {
@@ -178,7 +178,7 @@ export class McpIntegrationsRepository extends McpIntegrationsRepositoryPort {
   }
 
   async delete(id: UUID): Promise<void> {
-    this.logger.log('delete', { id });
+    this.logger.info({ id }, 'delete');
 
     await this.repository.delete({ id });
   }

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/mcp-integrations.controller.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/mcp-integrations.controller.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
@@ -88,6 +90,10 @@ describe('McpIntegrationsController', () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [McpIntegrationsController],
       providers: [
+        {
+          provide: getLoggerToken(McpIntegrationsController.name),
+          useValue: createPinoLoggerMock(),
+        },
         McpIntegrationDtoMapper,
         McpIntegrationResponseMapper,
         PredefinedConfigDtoMapper,

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/mcp-integrations.controller.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/mcp-integrations.controller.ts
@@ -9,9 +9,9 @@ import {
   HttpCode,
   HttpStatus,
   ParseUUIDPipe,
-  Logger,
   ForbiddenException,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -75,9 +75,9 @@ import {
 @ApiTags('mcp-integrations')
 @Controller('mcp-integrations')
 export class McpIntegrationsController {
-  private readonly logger = new Logger(McpIntegrationsController.name);
-
   constructor(
+    @InjectPinoLogger(McpIntegrationsController.name)
+    private readonly logger: PinoLogger,
     private readonly createMcpIntegrationUseCase: CreateMcpIntegrationUseCase,
     private readonly getMcpIntegrationUseCase: GetMcpIntegrationUseCase,
     private readonly listOrgMcpIntegrationsUseCase: ListOrgMcpIntegrationsUseCase,
@@ -142,7 +142,7 @@ export class McpIntegrationsController {
   async createPredefined(
     @Body() dto: CreatePredefinedIntegrationDto,
   ): Promise<McpIntegrationResponseDto> {
-    this.logger.log('createPredefined', { slug: dto.slug });
+    this.logger.info({ slug: dto.slug }, 'createPredefined');
 
     // Map DTO config values to domain credential fields
     const credentialFields: CredentialFieldValue[] = dto.configValues.map(
@@ -175,10 +175,7 @@ export class McpIntegrationsController {
   async createCustom(
     @Body() dto: CreateCustomIntegrationDto,
   ): Promise<McpIntegrationResponseDto> {
-    this.logger.log('createCustom', {
-      name: dto.name,
-      serverUrl: dto.serverUrl,
-    });
+    this.logger.info({ name: dto.name, url: dto.serverUrl }, 'createCustom');
 
     const isCloud =
       this.configService.get<boolean>('app.isCloudHosted') ?? false;
@@ -216,7 +213,7 @@ export class McpIntegrationsController {
     type: [McpIntegrationResponseDto],
   })
   async list(): Promise<McpIntegrationResponseDto[]> {
-    this.logger.log('listOrgMcpIntegrations');
+    this.logger.info('listOrgMcpIntegrations');
 
     const integrations = await this.listOrgMcpIntegrationsUseCase.execute();
 
@@ -234,7 +231,7 @@ export class McpIntegrationsController {
     type: [PredefinedConfigResponseDto],
   })
   listPredefinedConfigs(): PredefinedConfigResponseDto[] {
-    this.logger.log('listPredefinedConfigs');
+    this.logger.info('listPredefinedConfigs');
 
     const configs = this.listPredefinedConfigsUseCase.execute();
 
@@ -251,7 +248,7 @@ export class McpIntegrationsController {
     type: [McpIntegrationResponseDto],
   })
   async listAvailable(): Promise<McpIntegrationResponseDto[]> {
-    this.logger.log('listAvailableMcpIntegrations');
+    this.logger.info('listAvailableMcpIntegrations');
 
     const available = await this.listAvailableMcpIntegrationsUseCase.execute();
 
@@ -275,7 +272,7 @@ export class McpIntegrationsController {
   async getById(
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<McpIntegrationResponseDto> {
-    this.logger.log('getById', { id });
+    this.logger.info({ id }, 'getById');
 
     const integration = await this.getMcpIntegrationUseCase.execute(
       new GetMcpIntegrationQuery(id),
@@ -300,7 +297,7 @@ export class McpIntegrationsController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() dto: UpdateMcpIntegrationDto,
   ): Promise<McpIntegrationResponseDto> {
-    this.logger.log('update', { id });
+    this.logger.info({ id }, 'update');
 
     const command = new UpdateMcpIntegrationCommand({
       integrationId: id,
@@ -324,7 +321,7 @@ export class McpIntegrationsController {
   @ApiResponse({ status: 204, description: 'Integration deleted successfully' })
   @ApiResponse({ status: 404, description: 'Integration not found' })
   async delete(@Param('id', ParseUUIDPipe) id: UUID): Promise<void> {
-    this.logger.log('delete', { id });
+    this.logger.info({ id }, 'delete');
 
     await this.deleteMcpIntegrationUseCase.execute(
       new DeleteMcpIntegrationCommand(id),
@@ -344,7 +341,7 @@ export class McpIntegrationsController {
   async enable(
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<McpIntegrationResponseDto> {
-    this.logger.log('enable', { id });
+    this.logger.info({ id }, 'enable');
 
     const integration = await this.enableMcpIntegrationUseCase.execute(
       new EnableMcpIntegrationCommand(id),
@@ -366,7 +363,7 @@ export class McpIntegrationsController {
   async disable(
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<McpIntegrationResponseDto> {
-    this.logger.log('disable', { id });
+    this.logger.info({ id }, 'disable');
 
     const integration = await this.disableMcpIntegrationUseCase.execute(
       new DisableMcpIntegrationCommand(id),
@@ -397,9 +394,12 @@ export class McpIntegrationsController {
   async installFromMarketplace(
     @Body() dto: InstallMarketplaceIntegrationDto,
   ): Promise<McpIntegrationResponseDto> {
-    this.logger.log('installFromMarketplace', {
-      identifier: dto.identifier,
-    });
+    this.logger.info(
+      {
+        identifier: dto.identifier,
+      },
+      'installFromMarketplace',
+    );
 
     const command = new InstallMarketplaceIntegrationCommand(
       dto.identifier,
@@ -427,7 +427,7 @@ export class McpIntegrationsController {
   async getUserConfig(
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<UserConfigResponseDto> {
-    this.logger.log('getUserConfig', { id });
+    this.logger.info({ id }, 'getUserConfig');
 
     const result = await this.getUserMcpConfigUseCase.execute(
       new GetUserMcpConfigQuery(id),
@@ -457,7 +457,7 @@ export class McpIntegrationsController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() dto: SetUserConfigDto,
   ): Promise<UserConfigResponseDto> {
-    this.logger.log('setUserConfig', { id });
+    this.logger.info({ id }, 'setUserConfig');
 
     const command = new SetUserMcpConfigCommand(id, dto.configValues);
 
@@ -477,7 +477,7 @@ export class McpIntegrationsController {
   async validate(
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<ValidationResponseDto> {
-    this.logger.log('validate', { id });
+    this.logger.info({ id }, 'validate');
 
     const result = await this.validateMcpIntegrationUseCase.execute(
       new ValidateMcpIntegrationCommand(id),

--- a/ayunis-core-backend/src/domain/tools/application/handlers/activate-skill-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/activate-skill-tool.handler.spec.ts
@@ -1,6 +1,7 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { ActivateSkillToolHandler } from './activate-skill-tool.handler';
 import { FindSkillByNameUseCase } from 'src/domain/skills/application/use-cases/find-skill-by-name/find-skill-by-name.use-case';
@@ -50,13 +51,15 @@ describe('ActivateSkillToolHandler', () => {
           provide: FindAlwaysOnTemplateByNameUseCase,
           useValue: mockFindAlwaysOnTemplateByName,
         },
+
+        {
+          provide: getLoggerToken(ActivateSkillToolHandler.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
     handler = module.get<ActivateSkillToolHandler>(ActivateSkillToolHandler);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/tools/application/handlers/activate-skill-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/activate-skill-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import {
   ToolExecutionContext,
@@ -21,9 +22,9 @@ import {
 
 @Injectable()
 export class ActivateSkillToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(ActivateSkillToolHandler.name);
-
   constructor(
+    @InjectPinoLogger(ActivateSkillToolHandler.name)
+    private readonly logger: PinoLogger,
     private readonly findSkillByNameUseCase: FindSkillByNameUseCase,
     private readonly findThreadUseCase: FindThreadUseCase,
     private readonly skillActivationService: SkillActivationService,
@@ -39,7 +40,7 @@ export class ActivateSkillToolHandler extends ToolExecutionHandler {
   }): Promise<string> {
     const { tool, input, context } = params;
     const { threadId } = context;
-    this.logger.log('execute', tool, input);
+    this.logger.info({ name: tool.name, input: input }, 'execute');
 
     try {
       const validatedInput = tool.validateParams(input);
@@ -78,7 +79,7 @@ export class ActivateSkillToolHandler extends ToolExecutionHandler {
       if (error instanceof ToolExecutionFailedError) {
         throw error;
       }
-      this.logger.error('execute', error);
+      this.logger.error({ err: error }, 'execute');
       throw new ToolExecutionFailedError({
         toolName: tool.name,
         message: error instanceof Error ? error.message : 'Unknown error',

--- a/ayunis-core-backend/src/domain/tools/application/handlers/code-execution-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/code-execution-tool.handler.ts
@@ -10,7 +10,8 @@ import type {
   ExecutionRequest,
   ExecutionResponse,
 } from 'src/common/clients/code-execution/generated/ayunisCodeExecutionService.schemas';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetSourceByIdUseCase } from 'src/domain/sources/application/use-cases/get-source-by-id/get-source-by-id.use-case';
 import { GetSourceByIdQuery } from 'src/domain/sources/application/use-cases/get-source-by-id/get-source-by-id.query';
 import { CSVDataSource } from 'src/domain/sources/domain/sources/data-source.entity';
@@ -26,8 +27,9 @@ import { FindThreadQuery } from 'src/domain/threads/application/use-cases/find-t
 
 @Injectable()
 export class CodeExecutionToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(CodeExecutionToolHandler.name);
   constructor(
+    @InjectPinoLogger(CodeExecutionToolHandler.name)
+    private readonly logger: PinoLogger,
     private readonly getSourceByIdUseCase: GetSourceByIdUseCase,
     private readonly createDataSourceUseCase: CreateDataSourceUseCase,
     private readonly addSourceToThreadUseCase: AddSourceToThreadUseCase,
@@ -130,7 +132,7 @@ export class CodeExecutionToolHandler extends ToolExecutionHandler {
         new GetSourceByIdQuery(sourceId),
       );
     } catch (error) {
-      this.logger.error('Error getting CSV data source', error);
+      this.logger.error({ err: error }, 'Error getting CSV data source');
       throw new ToolExecutionFailedError({
         toolName,
         message: `Error getting CSV data source: ${error instanceof Error ? error.message : 'Unknown error. Source ID: ' + sourceId}`,
@@ -148,11 +150,15 @@ export class CodeExecutionToolHandler extends ToolExecutionHandler {
       const csvContent = convertCSVToString(csvSource.data);
       return Buffer.from(csvContent).toString('base64');
     } catch (error) {
-      this.logger.error('Error converting CSV data source to string', error, {
-        sourceId,
-        rowCount: csvSource.data.rows.length,
-        headerCount: csvSource.data.headers.length,
-      });
+      this.logger.error(
+        {
+          err: error,
+          sourceId,
+          rowCount: csvSource.data.rows.length,
+          headerCount: csvSource.data.headers.length,
+        },
+        'Error converting CSV data source to string',
+      );
       throw new ToolExecutionFailedError({
         toolName,
         message: `Error converting CSV data source to string: ${error instanceof Error ? error.message : 'Unknown error'}`,
@@ -187,7 +193,7 @@ export class CodeExecutionToolHandler extends ToolExecutionHandler {
         }
       }
     } catch (error) {
-      this.logger.error('Failed to handle output files', error);
+      this.logger.error({ err: error }, 'Failed to handle output files');
     }
 
     return createdSources;
@@ -216,14 +222,17 @@ export class CodeExecutionToolHandler extends ToolExecutionHandler {
         new AddSourceCommand(thread, source),
       );
 
-      this.logger.log(`Created and attached CSV source: ${sourceName}`, {
-        sourceId: source.id,
-        threadId,
-      });
+      this.logger.info(
+        { sourceId: source.id, threadId, name: sourceName },
+        'Created and attached CSV source',
+      );
 
       return `${sourceName} (ID: ${source.id})`;
     } catch (error) {
-      this.logger.error(`Failed to process output file ${filename}`, error);
+      this.logger.error(
+        { err: error, fileName: filename },
+        'Failed to process output file',
+      );
       return null;
     }
   }

--- a/ayunis-core-backend/src/domain/tools/application/handlers/create-diagram-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/create-diagram-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ToolExecutionContext,
   ToolExecutionHandler,
@@ -12,9 +13,11 @@ import { ArtifactType } from 'src/domain/artifacts/domain/value-objects/artifact
 
 @Injectable()
 export class CreateDiagramToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(CreateDiagramToolHandler.name);
-
-  constructor(private readonly createArtifactUseCase: CreateArtifactUseCase) {
+  constructor(
+    @InjectPinoLogger(CreateDiagramToolHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly createArtifactUseCase: CreateArtifactUseCase,
+  ) {
     super();
   }
 
@@ -24,7 +27,7 @@ export class CreateDiagramToolHandler extends ToolExecutionHandler {
     context: ToolExecutionContext;
   }): Promise<string> {
     const { tool, input, context } = params;
-    this.logger.log('Executing create_diagram tool');
+    this.logger.info('Executing create_diagram tool');
 
     try {
       const validatedInput = tool.validateParams(input);
@@ -44,7 +47,10 @@ export class CreateDiagramToolHandler extends ToolExecutionHandler {
       if (error instanceof ToolExecutionFailedError) {
         throw error;
       }
-      this.logger.error('Failed to execute create_diagram tool', error);
+      this.logger.error(
+        { err: error },
+        'Failed to execute create_diagram tool',
+      );
       throw new ToolExecutionFailedError({
         toolName: tool.name,
         message: error instanceof Error ? error.message : 'Unknown error',

--- a/ayunis-core-backend/src/domain/tools/application/handlers/create-document-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/create-document-tool.handler.spec.ts
@@ -1,6 +1,7 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { CreateDocumentToolHandler } from './create-document-tool.handler';
 import { CreateArtifactUseCase } from 'src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case';
@@ -29,13 +30,15 @@ describe('CreateDocumentToolHandler', () => {
           provide: CreateArtifactUseCase,
           useValue: mockCreateArtifactUseCase,
         },
+
+        {
+          provide: getLoggerToken(CreateDocumentToolHandler.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
     handler = module.get<CreateDocumentToolHandler>(CreateDocumentToolHandler);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/tools/application/handlers/create-document-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/create-document-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ToolExecutionContext,
   ToolExecutionHandler,
@@ -12,9 +13,11 @@ import type { UUID } from 'crypto';
 
 @Injectable()
 export class CreateDocumentToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(CreateDocumentToolHandler.name);
-
-  constructor(private readonly createArtifactUseCase: CreateArtifactUseCase) {
+  constructor(
+    @InjectPinoLogger(CreateDocumentToolHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly createArtifactUseCase: CreateArtifactUseCase,
+  ) {
     super();
   }
 
@@ -24,7 +27,7 @@ export class CreateDocumentToolHandler extends ToolExecutionHandler {
     context: ToolExecutionContext;
   }): Promise<string> {
     const { tool, input, context } = params;
-    this.logger.log('Executing create_document tool');
+    this.logger.info('Executing create_document tool');
 
     try {
       const validatedInput = tool.validateParams(input);
@@ -48,7 +51,10 @@ export class CreateDocumentToolHandler extends ToolExecutionHandler {
       if (error instanceof ToolExecutionFailedError) {
         throw error;
       }
-      this.logger.error('Failed to execute create_document tool', error);
+      this.logger.error(
+        { err: error },
+        'Failed to execute create_document tool',
+      );
       throw new ToolExecutionFailedError({
         toolName: tool.name,
         message: error instanceof Error ? error.message : 'Unknown error',

--- a/ayunis-core-backend/src/domain/tools/application/handlers/create-spreadsheet-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/create-spreadsheet-tool.handler.spec.ts
@@ -1,6 +1,7 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { CreateSpreadsheetToolHandler } from './create-spreadsheet-tool.handler';
 import { CreateArtifactUseCase } from 'src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case';
@@ -32,15 +33,17 @@ describe('CreateSpreadsheetToolHandler', () => {
           provide: CreateArtifactUseCase,
           useValue: mockCreateArtifactUseCase,
         },
+
+        {
+          provide: getLoggerToken(CreateSpreadsheetToolHandler.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
     handler = module.get<CreateSpreadsheetToolHandler>(
       CreateSpreadsheetToolHandler,
     );
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/tools/application/handlers/create-spreadsheet-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/create-spreadsheet-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ToolExecutionContext,
   ToolExecutionHandler,
@@ -13,9 +14,11 @@ import { serializeSpreadsheetContent } from 'src/domain/artifacts/application/he
 
 @Injectable()
 export class CreateSpreadsheetToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(CreateSpreadsheetToolHandler.name);
-
-  constructor(private readonly createArtifactUseCase: CreateArtifactUseCase) {
+  constructor(
+    @InjectPinoLogger(CreateSpreadsheetToolHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly createArtifactUseCase: CreateArtifactUseCase,
+  ) {
     super();
   }
 
@@ -25,7 +28,7 @@ export class CreateSpreadsheetToolHandler extends ToolExecutionHandler {
     context: ToolExecutionContext;
   }): Promise<string> {
     const { tool, input, context } = params;
-    this.logger.log('Executing create_spreadsheet tool');
+    this.logger.info('Executing create_spreadsheet tool');
 
     try {
       const validatedInput = tool.validateParams(input);
@@ -48,7 +51,10 @@ export class CreateSpreadsheetToolHandler extends ToolExecutionHandler {
       if (error instanceof ToolExecutionFailedError) {
         throw error;
       }
-      this.logger.error('Failed to execute create_spreadsheet tool', error);
+      this.logger.error(
+        { err: error },
+        'Failed to execute create_spreadsheet tool',
+      );
       throw new ToolExecutionFailedError({
         toolName: tool.name,
         message: error instanceof Error ? error.message : 'Unknown error',

--- a/ayunis-core-backend/src/domain/tools/application/handlers/edit-document-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/edit-document-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ToolExecutionContext,
   ToolExecutionHandler,
@@ -17,9 +18,9 @@ import {
 
 @Injectable()
 export class EditDocumentToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(EditDocumentToolHandler.name);
-
   constructor(
+    @InjectPinoLogger(EditDocumentToolHandler.name)
+    private readonly logger: PinoLogger,
     private readonly applyEditsToArtifactUseCase: ApplyEditsToArtifactUseCase,
   ) {
     super();
@@ -31,7 +32,7 @@ export class EditDocumentToolHandler extends ToolExecutionHandler {
     context: ToolExecutionContext;
   }): Promise<string> {
     const { tool, input } = params;
-    this.logger.log('Executing edit_document tool');
+    this.logger.info('Executing edit_document tool');
 
     try {
       const validatedInput = tool.validateParams(input);
@@ -54,36 +55,39 @@ export class EditDocumentToolHandler extends ToolExecutionHandler {
       const editWord = editCount === 1 ? 'edit' : 'edits';
       return `Document edited successfully. Applied ${editCount} ${editWord} to artifact ID: ${validatedInput.artifact_id}, version: ${version.versionNumber}`;
     } catch (error) {
-      if (error instanceof ToolExecutionFailedError) {
-        throw error;
-      }
-
-      // Map artifact errors to tool execution errors that can be retried by the LLM
-      if (error instanceof ArtifactExpectedVersionMismatchError) {
-        throw new ToolExecutionFailedError({
-          toolName: tool.name,
-          message: error.message,
-          exposeToLLM: true,
-        });
-      }
-
-      if (
-        error instanceof ArtifactEditNotFoundError ||
-        error instanceof ArtifactEditAmbiguousError
-      ) {
-        throw new ToolExecutionFailedError({
-          toolName: tool.name,
-          message: error.message,
-          exposeToLLM: true,
-        });
-      }
-
-      this.logger.error('Failed to execute edit_document tool', error);
-      throw new ToolExecutionFailedError({
-        toolName: tool.name,
-        message: error instanceof Error ? error.message : 'Unknown error',
-        exposeToLLM: false,
-      });
+      this.handleError(error, tool.name);
     }
+  }
+
+  private handleError(error: unknown, toolName: string): never {
+    if (error instanceof ToolExecutionFailedError) {
+      throw error;
+    }
+    if (error instanceof ArtifactExpectedVersionMismatchError) {
+      throw this.toRetryableError(toolName, error.message);
+    }
+    if (
+      error instanceof ArtifactEditNotFoundError ||
+      error instanceof ArtifactEditAmbiguousError
+    ) {
+      throw this.toRetryableError(toolName, error.message);
+    }
+    this.logger.error({ err: error }, 'Failed to execute edit_document tool');
+    throw new ToolExecutionFailedError({
+      toolName,
+      message: error instanceof Error ? error.message : 'Unknown error',
+      exposeToLLM: false,
+    });
+  }
+
+  private toRetryableError(
+    toolName: string,
+    message: string,
+  ): ToolExecutionFailedError {
+    return new ToolExecutionFailedError({
+      toolName,
+      message,
+      exposeToLLM: true,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/tools/application/handlers/generate-image-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/generate-image-tool.handler.spec.ts
@@ -1,6 +1,7 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { GenerateImageToolHandler } from './generate-image-tool.handler';
 import { GenerateImageTool } from '../../domain/tools/generate-image-tool.entity';
@@ -83,13 +84,15 @@ describe('GenerateImageToolHandler', () => {
           provide: CheckQuotaUseCase,
           useValue: mockCheckQuota,
         },
+
+        {
+          provide: getLoggerToken(GenerateImageToolHandler.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
     handler = module.get<GenerateImageToolHandler>(GenerateImageToolHandler);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/tools/application/handlers/generate-image-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/generate-image-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import {
   ToolExecutionContext,
@@ -42,9 +43,9 @@ type ValidatedGenerateImageInput = ReturnType<
 
 @Injectable()
 export class GenerateImageToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(GenerateImageToolHandler.name);
-
   constructor(
+    @InjectPinoLogger(GenerateImageToolHandler.name)
+    private readonly logger: PinoLogger,
     private readonly getPermittedImageGenerationModelUseCase: GetPermittedImageGenerationModelUseCase,
     private readonly generateImageUseCase: GenerateImageUseCase,
     private readonly saveGeneratedImageUseCase: SaveGeneratedImageUseCase,
@@ -61,7 +62,7 @@ export class GenerateImageToolHandler extends ToolExecutionHandler {
     input: Record<string, unknown>;
     context: ToolExecutionContext;
   }): Promise<string> {
-    this.logger.log('Executing generate_image tool');
+    this.logger.info('Executing generate_image tool');
     try {
       return await this.runGeneration(params);
     } catch (error) {
@@ -200,7 +201,7 @@ export class GenerateImageToolHandler extends ToolExecutionHandler {
         exposeToLLM: true,
       });
     }
-    this.logger.error('Failed to load reference images', error);
+    this.logger.error({ err: error }, 'Failed to load reference images');
     return new ToolExecutionFailedError({
       toolName,
       message:
@@ -257,7 +258,7 @@ export class GenerateImageToolHandler extends ToolExecutionHandler {
     if (error instanceof ToolExecutionFailedError) {
       throw error;
     }
-    this.logger.error('Failed to execute generate_image tool', error);
+    this.logger.error({ err: error }, 'Failed to execute generate_image tool');
     // ApplicationError messages (quota, content policy, provider outage) are
     // curated for end users — expose them so the model can explain the
     // failure instead of retrying blind into the repeated-failure breaker

--- a/ayunis-core-backend/src/domain/tools/application/handlers/http-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/http-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ToolExecutionFailedError } from '../tools.errors';
 import { HttpTool, HttpToolMethod } from '../../domain/tools/http-tool.entity';
 import {
@@ -8,7 +9,12 @@ import {
 
 @Injectable()
 export class HttpToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(HttpToolHandler.name);
+  constructor(
+    @InjectPinoLogger(HttpToolHandler.name)
+    private readonly logger: PinoLogger,
+  ) {
+    super();
+  }
 
   async execute(params: {
     tool: HttpTool;
@@ -16,47 +22,13 @@ export class HttpToolHandler extends ToolExecutionHandler {
     context: ToolExecutionContext;
   }): Promise<string> {
     const { tool, input } = params;
-    this.logger.log('execute', tool, input);
+    this.logger.info({ name: tool.name, input: input }, 'execute');
     try {
       const validatedInput = tool.validateParams(input);
       const requestInput = JSON.parse(
         validatedInput.bodyOrQueryParams,
       ) as Record<string, unknown>;
-      const options: RequestInit = {
-        method: tool.config.method,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      };
-
-      // Add body only for POST requests
-      if (tool.config.method === HttpToolMethod.POST) {
-        options.body = JSON.stringify(requestInput);
-      }
-
-      // For GET requests, append parameters to URL
-      let url = tool.config.endpointUrl;
-      if (
-        tool.config.method === HttpToolMethod.GET &&
-        Object.keys(requestInput).length > 0
-      ) {
-        const queryParams = new URLSearchParams();
-        for (const [key, value] of Object.entries(requestInput)) {
-          if (value !== undefined && value !== null) {
-            queryParams.append(key, value as string);
-          }
-        }
-        url = `${url}?${queryParams.toString()}`;
-      }
-
-      const response = await fetch(url, options).catch(() => {
-        this.logger.warn('execute', 'Request to the given endpoint failed');
-        throw new ToolExecutionFailedError({
-          toolName: tool.name,
-          message: 'Request to the given endpoint failed',
-          exposeToLLM: true,
-        });
-      });
+      const response = await this.fetchResponse(tool, requestInput);
 
       const data = (await response.json()) as Record<string, unknown>;
       return JSON.stringify(data);
@@ -64,7 +36,7 @@ export class HttpToolHandler extends ToolExecutionHandler {
       if (error instanceof ToolExecutionFailedError) {
         throw error;
       }
-      this.logger.error('execute', error);
+      this.logger.error({ err: error }, 'execute');
       throw new ToolExecutionFailedError({
         toolName: tool.name,
         message: error instanceof Error ? error.message : 'Unknown error',
@@ -74,5 +46,47 @@ export class HttpToolHandler extends ToolExecutionHandler {
         },
       });
     }
+  }
+
+  private async fetchResponse(
+    tool: HttpTool,
+    input: Record<string, unknown>,
+  ): Promise<Response> {
+    const options: RequestInit = {
+      method: tool.config.method,
+      headers: { 'Content-Type': 'application/json' },
+      ...(tool.config.method === HttpToolMethod.POST && {
+        body: JSON.stringify(input),
+      }),
+    };
+    try {
+      return await fetch(this.buildUrl(tool, input), options);
+    } catch {
+      this.logger.warn(
+        { error: 'Request to the given endpoint failed' },
+        'execute',
+      );
+      throw new ToolExecutionFailedError({
+        toolName: tool.name,
+        message: 'Request to the given endpoint failed',
+        exposeToLLM: true,
+      });
+    }
+  }
+
+  private buildUrl(tool: HttpTool, input: Record<string, unknown>): string {
+    if (tool.config.method !== HttpToolMethod.GET) {
+      return tool.config.endpointUrl;
+    }
+    const queryParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(input)) {
+      if (value !== undefined && value !== null) {
+        queryParams.append(key, value as string);
+      }
+    }
+    const query = queryParams.toString();
+    return query
+      ? `${tool.config.endpointUrl}?${query}`
+      : tool.config.endpointUrl;
   }
 }

--- a/ayunis-core-backend/src/domain/tools/application/handlers/internet-search-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/internet-search-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SearchWebUseCase } from 'src/domain/retrievers/internet-search-retrievers/application/use-cases/search-web/search-web.use-case';
 import { SearchWebCommand } from 'src/domain/retrievers/internet-search-retrievers/application/use-cases/search-web/search-web.command';
 import {
@@ -10,9 +11,11 @@ import { ToolExecutionFailedError } from '../tools.errors';
 
 @Injectable()
 export class InternetSearchToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(InternetSearchToolHandler.name);
-
-  constructor(private readonly searchWebUseCase: SearchWebUseCase) {
+  constructor(
+    @InjectPinoLogger(InternetSearchToolHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly searchWebUseCase: SearchWebUseCase,
+  ) {
     super();
   }
 
@@ -22,7 +25,7 @@ export class InternetSearchToolHandler extends ToolExecutionHandler {
     context: ToolExecutionContext;
   }): Promise<string> {
     const { tool, input } = params;
-    this.logger.log('execute', tool, input);
+    this.logger.info({ name: tool.name, input: input }, 'execute');
     try {
       const validatedInput = tool.validateParams(input);
       const results = await this.searchWebUseCase.execute(
@@ -33,7 +36,7 @@ export class InternetSearchToolHandler extends ToolExecutionHandler {
       if (error instanceof ToolExecutionFailedError) {
         throw error;
       }
-      this.logger.error('execute', error);
+      this.logger.error({ err: error }, 'execute');
       throw new ToolExecutionFailedError({
         toolName: tool.name,
         message: error instanceof Error ? error.message : 'Unknown error',

--- a/ayunis-core-backend/src/domain/tools/application/handlers/knowledge-get-text-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/knowledge-get-text-tool.handler.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { KnowledgeGetTextToolHandler } from './knowledge-get-text-tool.handler';
@@ -70,6 +72,11 @@ describe('KnowledgeGetTextToolHandler', () => {
         {
           provide: toolsConfig.KEY,
           useValue: mockToolsConfig,
+        },
+
+        {
+          provide: getLoggerToken(KnowledgeGetTextToolHandler.name),
+          useValue: createPinoLoggerMock(),
         },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/tools/application/handlers/knowledge-get-text-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/knowledge-get-text-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigType } from '@nestjs/config';
 import { KnowledgeGetTextTool } from '../../domain/tools/knowledge-get-text-tool.entity';
 import type { UUID } from 'crypto';
@@ -42,9 +43,9 @@ interface KnowledgeGetTextResult {
 
 @Injectable()
 export class KnowledgeGetTextToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(KnowledgeGetTextToolHandler.name);
-
   constructor(
+    @InjectPinoLogger(KnowledgeGetTextToolHandler.name)
+    private readonly logger: PinoLogger,
     private readonly getDocumentTextUseCase: GetKnowledgeBaseDocumentTextUseCase,
     private readonly extractTextLinesUseCase: ExtractTextLinesUseCase,
     private readonly contextService: ContextService,
@@ -61,88 +62,10 @@ export class KnowledgeGetTextToolHandler extends ToolExecutionHandler {
   }): Promise<string> {
     const { tool, input, context } = params;
     const { orgId } = context;
-    this.logger.log('execute', { tool: tool.name, input });
+    this.logger.info({ tool: tool.name, input }, 'execute');
 
     try {
-      const validatedInput = tool.validateParams(input);
-      const {
-        knowledgeBaseId,
-        documentId,
-        startLine = 1,
-        numLines = 100,
-      } = validatedInput;
-      const endLine = startLine + numLines - 1;
-      const { maxLines, maxChars } = this.config.sourceGetText;
-
-      const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new ToolExecutionFailedError({
-          toolName: tool.name,
-          message: 'User not authenticated',
-          exposeToLLM: false,
-        });
-      }
-
-      // Ownership check — returns metadata-only Source
-      const source = await this.getDocumentTextUseCase.execute(
-        new GetKnowledgeBaseDocumentTextQuery({
-          knowledgeBaseId: knowledgeBaseId as UUID,
-          documentId: documentId as UUID,
-          orgId,
-          userId,
-        }),
-      );
-
-      if (!(source instanceof TextSource)) {
-        throw new ToolExecutionFailedError({
-          toolName: tool.name,
-          message: `Document "${source.name}" is not a text source`,
-          exposeToLLM: true,
-        });
-      }
-
-      // Extract text lines at DB level
-      const dbEndLine = endLine === -1 ? MAX_END_LINE : endLine;
-      const dbResult = await this.extractTextLinesUseCase.execute(
-        new ExtractTextLinesQuery({
-          sourceId: source.id,
-          startLine,
-          endLine: dbEndLine,
-        }),
-      );
-
-      if (!dbResult) {
-        throw new ToolExecutionFailedError({
-          toolName: tool.name,
-          message: `Document text not found for "${source.name}"`,
-          exposeToLLM: true,
-        });
-      }
-
-      const extraction = validateTextExtraction({
-        toolName: tool.name,
-        dbResult,
-        startLine,
-        endLine,
-        maxLines,
-        maxChars,
-      });
-
-      return JSON.stringify(
-        this.buildResult({
-          knowledgeBaseId,
-          documentId,
-          documentName: source.name,
-          totalLines: extraction.totalLines,
-          startLine,
-          numLines,
-          actualStartLine: extraction.effectiveStartLine,
-          actualEndLine: extraction.effectiveEndLine,
-          truncated: extraction.truncated,
-          truncationReasons: extraction.truncationReasons,
-          text: extraction.extractedText,
-        }),
-      );
+      return await this.getText(tool, input, orgId);
     } catch (error) {
       if (error instanceof ToolExecutionFailedError) {
         throw error;
@@ -151,8 +74,111 @@ export class KnowledgeGetTextToolHandler extends ToolExecutionHandler {
     }
   }
 
+  private async getText(
+    tool: KnowledgeGetTextTool,
+    input: Record<string, unknown>,
+    orgId: UUID,
+  ): Promise<string> {
+    const validated = tool.validateParams(input);
+    const {
+      knowledgeBaseId,
+      documentId,
+      startLine = 1,
+      numLines = 100,
+    } = validated;
+    const endLine = startLine + numLines - 1;
+    const source = await this.getTextSource(
+      tool.name,
+      knowledgeBaseId as UUID,
+      documentId as UUID,
+      orgId,
+    );
+    const extraction = await this.extractText(
+      tool.name,
+      source,
+      startLine,
+      endLine,
+    );
+    return JSON.stringify(
+      this.buildResult({
+        knowledgeBaseId,
+        documentId,
+        documentName: source.name,
+        totalLines: extraction.totalLines,
+        startLine,
+        numLines,
+        actualStartLine: extraction.effectiveStartLine,
+        actualEndLine: extraction.effectiveEndLine,
+        truncated: extraction.truncated,
+        truncationReasons: extraction.truncationReasons,
+        text: extraction.extractedText,
+      }),
+    );
+  }
+
+  private async extractText(
+    toolName: string,
+    source: TextSource,
+    startLine: number,
+    endLine: number,
+  ): Promise<ReturnType<typeof validateTextExtraction>> {
+    const dbResult = await this.extractTextLinesUseCase.execute(
+      new ExtractTextLinesQuery({
+        sourceId: source.id,
+        startLine,
+        endLine: endLine === -1 ? MAX_END_LINE : endLine,
+      }),
+    );
+    if (!dbResult) {
+      throw new ToolExecutionFailedError({
+        toolName,
+        message: `Document text not found for "${source.name}"`,
+        exposeToLLM: true,
+      });
+    }
+    return validateTextExtraction({
+      toolName,
+      dbResult,
+      startLine,
+      endLine,
+      ...this.config.sourceGetText,
+    });
+  }
+
+  private async getTextSource(
+    toolName: string,
+    knowledgeBaseId: UUID,
+    documentId: UUID,
+    orgId: UUID,
+  ): Promise<TextSource> {
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new ToolExecutionFailedError({
+        toolName,
+        message: 'User not authenticated',
+        exposeToLLM: false,
+      });
+    }
+    const source = await this.getDocumentTextUseCase.execute(
+      new GetKnowledgeBaseDocumentTextQuery({
+        knowledgeBaseId,
+        documentId,
+        orgId,
+        userId,
+      }),
+    );
+    if (!(source instanceof TextSource)) {
+      throw new ToolExecutionFailedError({
+        toolName,
+        message: `Document "${source.name}" is not a text source`,
+        exposeToLLM: true,
+      });
+    }
+    return source;
+  }
+
   private handleError(error: unknown, toolName: string): never {
-    this.logger.error('execute', error);
+    this.logger.error({ err: error }, 'execute');
 
     if (error instanceof KnowledgeBaseNotFoundError) {
       throw new ToolExecutionFailedError({

--- a/ayunis-core-backend/src/domain/tools/application/handlers/knowledge-query-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/knowledge-query-tool.handler.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { KnowledgeQueryToolHandler } from './knowledge-query-tool.handler';
@@ -50,6 +52,11 @@ describe('KnowledgeQueryToolHandler', () => {
         {
           provide: ContextService,
           useValue: mockContextService,
+        },
+
+        {
+          provide: getLoggerToken(KnowledgeQueryToolHandler.name),
+          useValue: createPinoLoggerMock(),
         },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/tools/application/handlers/knowledge-query-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/knowledge-query-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { KnowledgeQueryTool } from '../../domain/tools/knowledge-query-tool.entity';
 import type { UUID } from 'crypto';
 import { ToolExecutionFailedError } from '../tools.errors';
@@ -14,9 +15,9 @@ import { handleEmbeddingError } from '../utils/embedding-error.utils';
 
 @Injectable()
 export class KnowledgeQueryToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(KnowledgeQueryToolHandler.name);
-
   constructor(
+    @InjectPinoLogger(KnowledgeQueryToolHandler.name)
+    private readonly logger: PinoLogger,
     private readonly queryKnowledgeBaseUseCase: QueryKnowledgeBaseUseCase,
     private readonly contextService: ContextService,
   ) {
@@ -29,7 +30,7 @@ export class KnowledgeQueryToolHandler extends ToolExecutionHandler {
     context: ToolExecutionContext;
   }): Promise<string> {
     const { tool, input } = params;
-    this.logger.log('execute', { tool: tool.name, input });
+    this.logger.info({ tool: tool.name, input }, 'execute');
 
     try {
       const validatedInput = tool.validateParams(input);
@@ -69,7 +70,7 @@ export class KnowledgeQueryToolHandler extends ToolExecutionHandler {
   }
 
   private handleError(error: unknown, toolName: string): never {
-    this.logger.error('execute', error);
+    this.logger.error({ err: error }, 'execute');
 
     if (error instanceof KnowledgeBaseNotFoundError) {
       throw new ToolExecutionFailedError({

--- a/ayunis-core-backend/src/domain/tools/application/handlers/mcp-integration-resource.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/mcp-integration-resource.handler.ts
@@ -5,7 +5,8 @@ import {
   ToolExecutionHandler,
 } from '../ports/execution.handler';
 import { RetrieveMcpResourceCommand } from 'src/domain/mcp/application/use-cases/retrieve-mcp-resource/retrieve-mcp-resource.command';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ToolExecutionFailedError } from '../tools.errors';
 import { parseCSV } from 'src/common/util/csv';
@@ -19,9 +20,9 @@ import { FindThreadQuery } from 'src/domain/threads/application/use-cases/find-t
 
 @Injectable()
 export class McpIntegrationResourceHandler implements ToolExecutionHandler {
-  private readonly logger = new Logger(McpIntegrationResourceHandler.name);
-
   constructor(
+    @InjectPinoLogger(McpIntegrationResourceHandler.name)
+    private readonly logger: PinoLogger,
     private readonly retrieveMcpResourceUseCase: RetrieveMcpResourceUseCase,
     private readonly createDataSourceUseCase: CreateDataSourceUseCase,
     private readonly addSourceToThreadUseCase: AddSourceToThreadUseCase,
@@ -34,7 +35,7 @@ export class McpIntegrationResourceHandler implements ToolExecutionHandler {
     context: ToolExecutionContext;
   }): Promise<string> {
     const { tool, input, context } = params;
-    this.logger.log('execute', tool, input);
+    this.logger.info({ name: tool.name, input: input }, 'execute');
     const validatedInput = tool.validateParams(input);
     try {
       const { content, mimeType } =
@@ -67,7 +68,7 @@ export class McpIntegrationResourceHandler implements ToolExecutionHandler {
       return JSON.stringify(content);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('error', error);
+      this.logger.error({ err: error }, 'error');
       throw new ToolExecutionFailedError({
         toolName: tool.name,
         message:

--- a/ayunis-core-backend/src/domain/tools/application/handlers/mcp-integration-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/mcp-integration-tool.handler.ts
@@ -2,7 +2,8 @@ import {
   ToolExecutionContext,
   ToolExecutionHandler,
 } from '../ports/execution.handler';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ExecuteMcpToolUseCase } from 'src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.use-case';
 import { McpIntegrationTool } from '../../domain/tools/mcp-integration-tool.entity';
 import { ExecuteMcpToolCommand } from 'src/domain/mcp/application/use-cases/execute-mcp-tool/execute-mcp-tool.command';
@@ -11,9 +12,11 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class McpIntegrationToolHandler implements ToolExecutionHandler {
-  private readonly logger = new Logger(McpIntegrationToolHandler.name);
-
-  constructor(private readonly executeMcpToolUseCase: ExecuteMcpToolUseCase) {}
+  constructor(
+    @InjectPinoLogger(McpIntegrationToolHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly executeMcpToolUseCase: ExecuteMcpToolUseCase,
+  ) {}
 
   async execute(params: {
     tool: McpIntegrationTool;
@@ -21,7 +24,7 @@ export class McpIntegrationToolHandler implements ToolExecutionHandler {
     context: ToolExecutionContext;
   }): Promise<string> {
     const { tool, input } = params;
-    this.logger.log('execute', tool, input);
+    this.logger.info({ name: tool.name, input: input }, 'execute');
     try {
       const validatedInput = tool.validateParams(input);
       const result = await this.executeMcpToolUseCase.execute(
@@ -34,7 +37,7 @@ export class McpIntegrationToolHandler implements ToolExecutionHandler {
       return JSON.stringify(result.content);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('error', error);
+      this.logger.error({ err: error }, 'error');
       throw new ToolExecutionFailedError({
         toolName: tool.name,
         message:

--- a/ayunis-core-backend/src/domain/tools/application/handlers/read-document-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/read-document-tool.handler.spec.ts
@@ -1,6 +1,7 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { ReadDocumentToolHandler } from './read-document-tool.handler';
 import { FindArtifactWithVersionsUseCase } from 'src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case';
@@ -31,13 +32,15 @@ describe('ReadDocumentToolHandler', () => {
           provide: FindArtifactWithVersionsUseCase,
           useValue: mockFindArtifactUseCase,
         },
+
+        {
+          provide: getLoggerToken(ReadDocumentToolHandler.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
     handler = module.get<ReadDocumentToolHandler>(ReadDocumentToolHandler);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/tools/application/handlers/read-document-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/read-document-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ToolExecutionContext,
   ToolExecutionHandler,
@@ -11,9 +12,9 @@ import { UUID } from 'crypto';
 
 @Injectable()
 export class ReadDocumentToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(ReadDocumentToolHandler.name);
-
   constructor(
+    @InjectPinoLogger(ReadDocumentToolHandler.name)
+    private readonly logger: PinoLogger,
     private readonly findArtifactWithVersionsUseCase: FindArtifactWithVersionsUseCase,
   ) {
     super();
@@ -25,7 +26,7 @@ export class ReadDocumentToolHandler extends ToolExecutionHandler {
     context: ToolExecutionContext;
   }): Promise<string> {
     const { tool, input } = params;
-    this.logger.log('Executing read_document tool');
+    this.logger.info('Executing read_document tool');
 
     try {
       const validatedInput = tool.validateParams(input);
@@ -54,7 +55,7 @@ export class ReadDocumentToolHandler extends ToolExecutionHandler {
       if (error instanceof ToolExecutionFailedError) {
         throw error;
       }
-      this.logger.error('Failed to execute read_document tool', error);
+      this.logger.error({ err: error }, 'Failed to execute read_document tool');
       throw new ToolExecutionFailedError({
         toolName: tool.name,
         message: error instanceof Error ? error.message : 'Unknown error',

--- a/ayunis-core-backend/src/domain/tools/application/handlers/source-get-text-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/source-get-text-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigType } from '@nestjs/config';
 import { SourceGetTextTool } from '../../domain/tools/source-get-text-tool.entity';
 import { UUID } from 'crypto';
@@ -36,9 +37,9 @@ interface SourceGetTextResult {
 
 @Injectable()
 export class SourceGetTextToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(SourceGetTextToolHandler.name);
-
   constructor(
+    @InjectPinoLogger(SourceGetTextToolHandler.name)
+    private readonly logger: PinoLogger,
     private readonly getSourceByIdUseCase: GetTextSourceByIdUseCase,
     private readonly extractTextLinesUseCase: ExtractTextLinesUseCase,
     @Inject(toolsConfig.KEY)
@@ -53,77 +54,83 @@ export class SourceGetTextToolHandler extends ToolExecutionHandler {
     context: ToolExecutionContext;
   }): Promise<string> {
     const { tool, input } = params;
-    this.logger.log('execute', { tool: tool.name, input });
+    this.logger.info({ tool: tool.name, input }, 'execute');
 
     try {
-      const validatedInput = tool.validateParams(input);
-      const { sourceId, startLine = 1, endLine = -1 } = validatedInput;
-      const { maxLines, maxChars } = this.config.sourceGetText;
-
-      // Load metadata-only source for type check and name
-      const source = await this.getSourceByIdUseCase.execute(
-        new GetTextSourceByIdQuery(sourceId as UUID),
-      );
-
-      if (!(source instanceof TextSource)) {
-        throw new ToolExecutionFailedError({
-          toolName: tool.name,
-          message: `Source "${source.name}" is not a text source and cannot be read with this tool`,
-          exposeToLLM: true,
-        });
-      }
-
-      // Extract text lines at DB level
-      const dbEndLine = endLine === -1 ? MAX_END_LINE : endLine;
-      const dbResult = await this.extractTextLinesUseCase.execute(
-        new ExtractTextLinesQuery({
-          sourceId: source.id,
-          startLine,
-          endLine: dbEndLine,
-        }),
-      );
-
-      if (!dbResult) {
-        throw new ToolExecutionFailedError({
-          toolName: tool.name,
-          message: `Source text not found for "${source.name}"`,
-          exposeToLLM: true,
-        });
-      }
-
-      const extraction = validateTextExtraction({
-        toolName: tool.name,
-        dbResult,
-        startLine,
-        endLine,
-        maxLines,
-        maxChars,
-      });
-
-      const result: SourceGetTextResult = {
-        sourceId: source.id,
-        sourceName: source.name,
-        totalLines: extraction.totalLines,
-        requestedStartLine: startLine,
-        requestedEndLine: endLine,
-        actualStartLine: extraction.effectiveStartLine,
-        actualEndLine: extraction.effectiveEndLine,
-        truncated: extraction.truncated,
-        truncationReasons: extraction.truncationReasons,
-        text: extraction.extractedText,
-      };
-
-      return JSON.stringify(result);
+      return await this.getText(tool, input);
     } catch (error) {
       if (error instanceof ToolExecutionFailedError) {
         throw error;
       }
-      this.logger.error('execute', error);
+      this.logger.error({ err: error }, 'execute');
       throw new ToolExecutionFailedError({
         toolName: tool.name,
         message: error instanceof Error ? error.message : 'Unknown error',
         exposeToLLM: false,
       });
     }
+  }
+
+  private async getText(
+    tool: SourceGetTextTool,
+    input: Record<string, unknown>,
+  ): Promise<string> {
+    const {
+      sourceId,
+      startLine = 1,
+      endLine = -1,
+    } = tool.validateParams(input);
+    const source = await this.getTextSource(sourceId as UUID, tool.name);
+    const dbResult = await this.extractTextLinesUseCase.execute(
+      new ExtractTextLinesQuery({
+        sourceId: source.id,
+        startLine,
+        endLine: endLine === -1 ? MAX_END_LINE : endLine,
+      }),
+    );
+    if (!dbResult) {
+      throw new ToolExecutionFailedError({
+        toolName: tool.name,
+        message: `Source text not found for "${source.name}"`,
+        exposeToLLM: true,
+      });
+    }
+    const extraction = validateTextExtraction({
+      toolName: tool.name,
+      dbResult,
+      startLine,
+      endLine,
+      ...this.config.sourceGetText,
+    });
+    const result: SourceGetTextResult = {
+      sourceId: source.id,
+      sourceName: source.name,
+      totalLines: extraction.totalLines,
+      requestedStartLine: startLine,
+      requestedEndLine: endLine,
+      actualStartLine: extraction.effectiveStartLine,
+      actualEndLine: extraction.effectiveEndLine,
+      truncated: extraction.truncated,
+      truncationReasons: extraction.truncationReasons,
+      text: extraction.extractedText,
+    };
+    return JSON.stringify(result);
+  }
+
+  private async getTextSource(
+    sourceId: UUID,
+    toolName: string,
+  ): Promise<TextSource> {
+    const source = await this.getSourceByIdUseCase.execute(
+      new GetTextSourceByIdQuery(sourceId),
+    );
+    if (!(source instanceof TextSource)) {
+      throw new ToolExecutionFailedError({
+        toolName,
+        message: `Source "${source.name}" is not a text source and cannot be read with this tool`,
+        exposeToLLM: true,
+      });
+    }
+    return source;
   }
 }

--- a/ayunis-core-backend/src/domain/tools/application/handlers/source-query-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/source-query-tool.handler.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { SourceQueryToolHandler } from './source-query-tool.handler';
@@ -49,6 +51,11 @@ describe('SourceQueryToolHandler', () => {
         {
           provide: QueryTextSourceUseCase,
           useValue: mockQueryTextSourceUseCase,
+        },
+
+        {
+          provide: getLoggerToken(SourceQueryToolHandler.name),
+          useValue: createPinoLoggerMock(),
         },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/tools/application/handlers/source-query-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/source-query-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SourceQueryTool } from '../../domain/tools/source-query-tool.entity';
 import { UUID } from 'crypto';
 import { ToolExecutionFailedError } from '../tools.errors';
@@ -14,9 +15,9 @@ import { handleEmbeddingError } from '../utils/embedding-error.utils';
 
 @Injectable()
 export class SourceQueryToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(SourceQueryToolHandler.name);
-
   constructor(
+    @InjectPinoLogger(SourceQueryToolHandler.name)
+    private readonly logger: PinoLogger,
     private readonly getSourceByIdUseCase: GetTextSourceByIdUseCase,
     private readonly matchSourceContentChunksUseCase: QueryTextSourceUseCase,
   ) {
@@ -30,7 +31,7 @@ export class SourceQueryToolHandler extends ToolExecutionHandler {
   }): Promise<string> {
     const { tool, input, context } = params;
     const { orgId } = context;
-    this.logger.log('execute', tool, input);
+    this.logger.info({ name: tool.name, input: input }, 'execute');
     try {
       const validatedInput = tool.validateParams(input);
       const source = await this.getSourceByIdUseCase.execute(
@@ -62,7 +63,7 @@ export class SourceQueryToolHandler extends ToolExecutionHandler {
       if (error instanceof ToolExecutionFailedError) {
         throw error;
       }
-      this.logger.error('execute', error);
+      this.logger.error({ err: error }, 'execute');
       handleEmbeddingError(error, tool.name);
     }
   }

--- a/ayunis-core-backend/src/domain/tools/application/handlers/update-diagram-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/update-diagram-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ToolExecutionContext,
   ToolExecutionHandler,
@@ -13,9 +14,11 @@ import { UUID } from 'crypto';
 
 @Injectable()
 export class UpdateDiagramToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(UpdateDiagramToolHandler.name);
-
-  constructor(private readonly updateArtifactUseCase: UpdateArtifactUseCase) {
+  constructor(
+    @InjectPinoLogger(UpdateDiagramToolHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly updateArtifactUseCase: UpdateArtifactUseCase,
+  ) {
     super();
   }
 
@@ -25,7 +28,7 @@ export class UpdateDiagramToolHandler extends ToolExecutionHandler {
     context: ToolExecutionContext;
   }): Promise<string> {
     const { tool, input } = params;
-    this.logger.log('Executing update_diagram tool');
+    this.logger.info('Executing update_diagram tool');
 
     try {
       const validatedInput = tool.validateParams(input);
@@ -53,7 +56,10 @@ export class UpdateDiagramToolHandler extends ToolExecutionHandler {
         });
       }
 
-      this.logger.error('Failed to execute update_diagram tool', error);
+      this.logger.error(
+        { err: error },
+        'Failed to execute update_diagram tool',
+      );
       throw new ToolExecutionFailedError({
         toolName: tool.name,
         message: error instanceof Error ? error.message : 'Unknown error',

--- a/ayunis-core-backend/src/domain/tools/application/handlers/update-document-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/update-document-tool.handler.spec.ts
@@ -1,6 +1,7 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { UpdateDocumentToolHandler } from './update-document-tool.handler';
 import { UpdateArtifactUseCase } from 'src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case';
@@ -30,13 +31,15 @@ describe('UpdateDocumentToolHandler', () => {
           provide: UpdateArtifactUseCase,
           useValue: mockUpdateArtifactUseCase,
         },
+
+        {
+          provide: getLoggerToken(UpdateDocumentToolHandler.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
     handler = module.get<UpdateDocumentToolHandler>(UpdateDocumentToolHandler);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/tools/application/handlers/update-document-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/update-document-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ToolExecutionContext,
   ToolExecutionHandler,
@@ -13,9 +14,11 @@ import { UUID } from 'crypto';
 
 @Injectable()
 export class UpdateDocumentToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(UpdateDocumentToolHandler.name);
-
-  constructor(private readonly updateArtifactUseCase: UpdateArtifactUseCase) {
+  constructor(
+    @InjectPinoLogger(UpdateDocumentToolHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly updateArtifactUseCase: UpdateArtifactUseCase,
+  ) {
     super();
   }
 
@@ -25,7 +28,7 @@ export class UpdateDocumentToolHandler extends ToolExecutionHandler {
     context: ToolExecutionContext;
   }): Promise<string> {
     const { tool, input } = params;
-    this.logger.log('Executing update_document tool');
+    this.logger.info('Executing update_document tool');
 
     try {
       const validatedInput = tool.validateParams(input);
@@ -58,7 +61,10 @@ export class UpdateDocumentToolHandler extends ToolExecutionHandler {
         });
       }
 
-      this.logger.error('Failed to execute update_document tool', error);
+      this.logger.error(
+        { err: error },
+        'Failed to execute update_document tool',
+      );
       throw new ToolExecutionFailedError({
         toolName: tool.name,
         message: error instanceof Error ? error.message : 'Unknown error',

--- a/ayunis-core-backend/src/domain/tools/application/handlers/update-spreadsheet-tool.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/update-spreadsheet-tool.handler.spec.ts
@@ -1,6 +1,7 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { UpdateSpreadsheetToolHandler } from './update-spreadsheet-tool.handler';
 import { UpdateArtifactUseCase } from 'src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case';
@@ -38,15 +39,17 @@ describe('UpdateSpreadsheetToolHandler', () => {
           provide: UpdateArtifactUseCase,
           useValue: mockUpdateArtifactUseCase,
         },
+
+        {
+          provide: getLoggerToken(UpdateSpreadsheetToolHandler.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
     handler = module.get<UpdateSpreadsheetToolHandler>(
       UpdateSpreadsheetToolHandler,
     );
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/tools/application/handlers/update-spreadsheet-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/update-spreadsheet-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ToolExecutionContext,
   ToolExecutionHandler,
@@ -14,9 +15,11 @@ import { UUID } from 'crypto';
 
 @Injectable()
 export class UpdateSpreadsheetToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(UpdateSpreadsheetToolHandler.name);
-
-  constructor(private readonly updateArtifactUseCase: UpdateArtifactUseCase) {
+  constructor(
+    @InjectPinoLogger(UpdateSpreadsheetToolHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly updateArtifactUseCase: UpdateArtifactUseCase,
+  ) {
     super();
   }
 
@@ -26,7 +29,7 @@ export class UpdateSpreadsheetToolHandler extends ToolExecutionHandler {
     context: ToolExecutionContext;
   }): Promise<string> {
     const { tool, input } = params;
-    this.logger.log('Executing update_spreadsheet tool');
+    this.logger.info('Executing update_spreadsheet tool');
 
     try {
       const validatedInput = tool.validateParams(input);
@@ -67,7 +70,10 @@ export class UpdateSpreadsheetToolHandler extends ToolExecutionHandler {
         });
       }
 
-      this.logger.error('Failed to execute update_spreadsheet tool', error);
+      this.logger.error(
+        { err: error },
+        'Failed to execute update_spreadsheet tool',
+      );
       throw new ToolExecutionFailedError({
         toolName: tool.name,
         message: error instanceof Error ? error.message : 'Unknown error',

--- a/ayunis-core-backend/src/domain/tools/application/handlers/website-content-tool.handler.ts
+++ b/ayunis-core-backend/src/domain/tools/application/handlers/website-content-tool.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { RetrieveUrlUseCase } from 'src/domain/retrievers/url-retrievers/application/use-cases/retrieve-url/retrieve-url.use-case';
 import { RetrieveUrlCommand } from 'src/domain/retrievers/url-retrievers/application/use-cases/retrieve-url/retrieve-url.command';
 import {
@@ -11,9 +12,11 @@ import { CrawlDomainAccessDeniedError } from 'src/domain/crawl-domain-grants/app
 
 @Injectable()
 export class WebsiteContentToolHandler extends ToolExecutionHandler {
-  private readonly logger = new Logger(WebsiteContentToolHandler.name);
-
-  constructor(private readonly retrieveUrlUseCase: RetrieveUrlUseCase) {
+  constructor(
+    @InjectPinoLogger(WebsiteContentToolHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly retrieveUrlUseCase: RetrieveUrlUseCase,
+  ) {
     super();
   }
 
@@ -23,7 +26,7 @@ export class WebsiteContentToolHandler extends ToolExecutionHandler {
     context: ToolExecutionContext;
   }): Promise<string> {
     const { tool, input, context } = params;
-    this.logger.log('execute', tool, input);
+    this.logger.info({ name: tool.name, input: input }, 'execute');
     try {
       const validatedInput = tool.validateParams(input);
       const content = await this.retrieveUrlUseCase.execute(
@@ -39,7 +42,7 @@ export class WebsiteContentToolHandler extends ToolExecutionHandler {
       if (error instanceof CrawlDomainAccessDeniedError) {
         throw error;
       }
-      this.logger.error('execute', error);
+      this.logger.error({ err: error }, 'execute');
       throw new ToolExecutionFailedError({
         toolName: tool.name,
         message: error instanceof Error ? error.message : 'Unknown error',

--- a/ayunis-core-backend/src/domain/tools/application/tool-handler.registry.ts
+++ b/ayunis-core-backend/src/domain/tools/application/tool-handler.registry.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Tool } from '../domain/tool.entity';
 import { ToolExecutionHandler } from './ports/execution.handler';
 import { ToolHandlerNotFoundError } from './tools.errors';
@@ -48,10 +49,11 @@ type ToolConstructor = abstract new (...args: any[]) => Tool;
 
 @Injectable()
 export class ToolHandlerRegistry {
-  private readonly logger = new Logger(ToolHandlerRegistry.name);
   private readonly handlers: [ToolConstructor, ToolExecutionHandler][];
 
   constructor(
+    @InjectPinoLogger(ToolHandlerRegistry.name)
+    private readonly logger: PinoLogger,
     httpToolHandler: HttpToolHandler,
     sourceQueryToolHandler: SourceQueryToolHandler,
     sourceGetTextToolHandler: SourceGetTextToolHandler,
@@ -98,7 +100,7 @@ export class ToolHandlerRegistry {
   }
 
   getHandler(tool: Tool): ToolExecutionHandler {
-    this.logger.log(`Getting handler for tool: ${tool.name}`);
+    this.logger.info({ name: tool.name }, 'Getting handler for tool');
 
     const entry = this.handlers.find(([ctor]) => tool instanceof ctor);
     if (entry) {

--- a/ayunis-core-backend/src/domain/tools/application/use-cases/check-tool-capabilities/check-tool-capabilities.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/use-cases/check-tool-capabilities/check-tool-capabilities.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { CheckToolCapabilitiesUseCase } from './check-tool-capabilities.use-case';
@@ -73,7 +75,13 @@ describe('CheckToolCapabilitiesUseCase', () => {
 
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CheckToolCapabilitiesUseCase],
+      providers: [
+        CheckToolCapabilitiesUseCase,
+        {
+          provide: getLoggerToken(CheckToolCapabilitiesUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
+      ],
     }).compile();
 
     useCase = module.get<CheckToolCapabilitiesUseCase>(

--- a/ayunis-core-backend/src/domain/tools/application/use-cases/check-tool-capabilities/check-tool-capabilities.use-case.ts
+++ b/ayunis-core-backend/src/domain/tools/application/use-cases/check-tool-capabilities/check-tool-capabilities.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { CheckToolCapabilitiesQuery } from './check-tool-capabilities.query';
 import { Tool } from 'src/domain/tools/domain/tool.entity';
 import { DisplayableTool } from 'src/domain/tools/domain/displayable-tool.entity';
@@ -10,10 +11,13 @@ export interface ToolCapabilities {
 
 @Injectable()
 export class CheckToolCapabilitiesUseCase {
-  private readonly logger = new Logger(CheckToolCapabilitiesUseCase.name);
+  constructor(
+    @InjectPinoLogger(CheckToolCapabilitiesUseCase.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   execute(query: CheckToolCapabilitiesQuery): ToolCapabilities {
-    this.logger.log('execute', query.tool.name);
+    this.logger.info({ name: query.tool.name }, 'execute');
 
     return {
       isDisplayable: this.isDisplayable(query.tool),

--- a/ayunis-core-backend/src/domain/tools/application/use-cases/execute-tool/execute-tool.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/use-cases/execute-tool/execute-tool.use-case.spec.ts
@@ -1,5 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
+import { getLoggerToken, type PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { ExecuteToolUseCase } from './execute-tool.use-case';
 import { ExecuteToolCommand } from './execute-tool.command';
 import { ToolHandlerRegistry } from '../../tool-handler.registry';
@@ -38,10 +40,12 @@ describe('ExecuteToolUseCase', () => {
   let useCase: ExecuteToolUseCase;
   let mockToolHandlerRegistry: Partial<ToolHandlerRegistry>;
   let mockHandler: { execute: jest.Mock };
+  let logger: jest.Mocked<PinoLogger>;
 
   const mockContext = '123e4567-e89b-12d3-a456-426614174000' as any;
 
   beforeAll(async () => {
+    logger = createPinoLoggerMock();
     mockHandler = {
       execute: jest.fn(),
     };
@@ -54,6 +58,10 @@ describe('ExecuteToolUseCase', () => {
       providers: [
         ExecuteToolUseCase,
         { provide: ToolHandlerRegistry, useValue: mockToolHandlerRegistry },
+        {
+          provide: getLoggerToken(ExecuteToolUseCase.name),
+          useValue: logger,
+        },
       ],
     }).compile();
 
@@ -206,18 +214,20 @@ describe('ExecuteToolUseCase', () => {
       const input = {};
       const command = new ExecuteToolCommand(mockTool, input, mockContext);
 
-      const loggerSpy = jest.spyOn(useCase['logger'], 'log');
       mockHandler.execute.mockResolvedValue('result');
 
       // Act
       await useCase.execute(command);
 
       // Assert
-      expect(loggerSpy).toHaveBeenCalledWith('execute', {
-        toolName: 'Test Tool',
-        input,
-        parameters: mockTool.parameters,
-      });
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          tool: { name: 'Test Tool' },
+          input,
+          tools: mockTool.parameters,
+        },
+        'execute',
+      );
     });
 
     it('strips schema-disallowed null params before invoking the handler', async () => {

--- a/ayunis-core-backend/src/domain/tools/application/use-cases/execute-tool/execute-tool.use-case.ts
+++ b/ayunis-core-backend/src/domain/tools/application/use-cases/execute-tool/execute-tool.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ToolHandlerRegistry } from '../../tool-handler.registry';
 import { ToolExecutionFailedError } from '../../tools.errors';
 import { ExecuteToolCommand } from './execute-tool.command';
@@ -7,16 +8,21 @@ import { stripDisallowedNulls } from 'src/common/util/strip-disallowed-nulls';
 
 @Injectable()
 export class ExecuteToolUseCase {
-  private readonly logger = new Logger(ExecuteToolUseCase.name);
-
-  constructor(private readonly toolHandlerRegistry: ToolHandlerRegistry) {}
+  constructor(
+    @InjectPinoLogger(ExecuteToolUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly toolHandlerRegistry: ToolHandlerRegistry,
+  ) {}
 
   async execute(command: ExecuteToolCommand): Promise<string> {
-    this.logger.log('execute', {
-      toolName: command.tool.name,
-      input: command.input,
-      parameters: command.tool.parameters,
-    });
+    this.logger.info(
+      {
+        tool: { name: command.tool.name },
+        input: command.input,
+        tools: command.tool.parameters,
+      },
+      'execute',
+    );
 
     try {
       const handler = this.toolHandlerRegistry.getHandler(command.tool);
@@ -29,7 +35,7 @@ export class ExecuteToolUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Unknown error', error as Error);
+      this.logger.error({ err: error as Error }, 'Unknown error');
       throw new ToolExecutionFailedError({
         toolName: command.tool.name,
         message: error instanceof Error ? error.message : 'Unknown error',

--- a/ayunis-core-backend/src/domain/tools/application/use-cases/execute-tool/startdeliver-mcp-payload.regression.spec.ts
+++ b/ayunis-core-backend/src/domain/tools/application/use-cases/execute-tool/startdeliver-mcp-payload.regression.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { McpTool } from 'src/domain/mcp/domain/mcp-tool.entity';
 import { McpIntegrationTool } from '../../../domain/tools/mcp-integration-tool.entity';
@@ -54,11 +55,14 @@ describe('Startdeliver MCP payload regression (AYC-413)', () => {
         return Promise.resolve({ isError: false, content: [] });
       },
     } as unknown as ExecuteMcpToolUseCase;
-    const handler = new McpIntegrationToolHandler(executeMcpTool);
+    const handler = new McpIntegrationToolHandler(
+      createPinoLoggerMock(),
+      executeMcpTool,
+    );
     const registry = {
       getHandler: () => handler,
     } as unknown as ToolHandlerRegistry;
-    const useCase = new ExecuteToolUseCase(registry);
+    const useCase = new ExecuteToolUseCase(createPinoLoggerMock(), registry);
 
     // What a strict-mode model (or an imitating Claude/Opus turn) emits for
     // the search "Stadt Ladenburg": nulls for every optional date filter.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability and test wiring only; no API or auth behavior changes beyond log field names and message format.
> 
> **Overview**
> **MCP and tools logging** now use **nestjs-pino** (`@InjectPinoLogger`, `PinoLogger`) instead of Nest’s `Logger`. Call sites move from `log`/`error` with ad-hoc objects to Pino’s **`(bindings, message)`** shape, with errors on **`err`** and info-level ops on **`info`**.
> 
> **`ExecuteMcpToolUseCase`** is the main behavioral change for observability: tool runs log **structured fields** (`operation`, `integration`, `tool`, `status`, `durationMs`) under a fixed `[MCP] operation=execute_tool` message instead of one long interpolated string. **`handleMcpOperationError`** and **`McpClientService`** follow the same Pino patterns.
> 
> **Tests** register loggers via **`getLoggerToken(...)`** and **`createPinoLoggerMock()`**, asserting `logger.info`/`warn`/`error` directly instead of spying on `Logger.prototype`.
> 
> Smaller cleanups ride along: **`ValidateMcpIntegrationUseCase`** pulls success/failure logging into **`validateCapabilities`**; **`GetMcpPromptUseCase`** splits access checks/mapping into helpers; **`McpIntegrationsRepository.save`** drops a redundant auth guard; discovery success logs use **`toolCount`** instead of **`tools`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b2b30722ba0cb3d9942ba5421d778981e9cb1f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->