### PR TITLE
wip(logging): migrate rag and retriever logging (AYC-749)

### DIFF
--- a/ayunis-core-backend/src/domain/rag/embeddings/application/embeddings-handler.registry.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/application/embeddings-handler.registry.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EmbeddingsHandler } from './ports/embeddings.handler';
 import { EmbeddingsProvider } from '../domain/embeddings-provider.enum';
 import {
@@ -8,7 +9,11 @@ import {
 
 @Injectable()
 export class EmbeddingsHandlerRegistry {
-  private readonly logger = new Logger(EmbeddingsHandlerRegistry.name);
+  constructor(
+    @InjectPinoLogger(EmbeddingsHandlerRegistry.name)
+    private readonly logger: PinoLogger,
+  ) {}
+
   private readonly handlers = new Map<EmbeddingsProvider, EmbeddingsHandler>();
 
   registerHandler(
@@ -19,7 +24,7 @@ export class EmbeddingsHandlerRegistry {
   }
 
   getHandler(provider: EmbeddingsProvider): EmbeddingsHandler {
-    this.logger.debug('getHandler', { provider });
+    this.logger.debug({ provider }, 'getHandler');
     const handler = this.handlers.get(provider);
 
     if (!handler) {

--- a/ayunis-core-backend/src/domain/rag/embeddings/application/services/embeddings-throttle.service.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/application/services/embeddings-throttle.service.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { ConfigService } from '@nestjs/config';
 import {
   EmbeddingsThrottleService,
@@ -39,7 +40,7 @@ describe('EmbeddingsThrottleService', () => {
   } as unknown as ConfigService;
 
   beforeEach(() => {
-    service = new TestableThrottle(configService);
+    service = new TestableThrottle(createPinoLoggerMock(), configService);
   });
 
   it('runs the task and returns its result', async () => {

--- a/ayunis-core-backend/src/domain/rag/embeddings/application/services/embeddings-throttle.service.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/application/services/embeddings-throttle.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import PQueue from 'p-queue';
 import { EmbeddingPriority } from '../../domain/embedding-priority.enum';
@@ -32,10 +33,13 @@ const INGESTION_PRIORITY = 0;
  */
 @Injectable()
 export class EmbeddingsThrottleService {
-  private readonly logger = new Logger(EmbeddingsThrottleService.name);
   private sharedQueue: PriorityQueue | null = null;
 
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    @InjectPinoLogger(EmbeddingsThrottleService.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {}
 
   run<T>(priority: EmbeddingPriority, fn: () => Promise<T>): Promise<T> {
     const queue = this.getQueue();
@@ -57,7 +61,7 @@ export class EmbeddingsThrottleService {
     const concurrency =
       this.configService.get<number>('embeddings.throttle.maxConcurrency') ??
       DEFAULT_MAX_CONCURRENCY;
-    this.logger.log('Embeddings throttle initialized', { concurrency });
+    this.logger.info({ concurrency }, 'Embeddings throttle initialized');
     return new PQueue({ concurrency });
   }
 }

--- a/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { EmbedTextUseCase } from './embed-text.use-case';
 import { EmbedTextCommand } from './embed-text.command';
 import { NoEmbeddingsReturnedError } from '../../embeddings.errors';
@@ -30,7 +31,11 @@ function useCaseWithFailingHandler(error: Error): EmbedTextUseCase {
   const throttle = {
     run: (_priority: unknown, fn: () => Promise<unknown>) => fn(),
   };
-  return new EmbedTextUseCase(registry as never, throttle as never);
+  return new EmbedTextUseCase(
+    createPinoLoggerMock(),
+    registry as never,
+    throttle as never,
+  );
 }
 
 describe('EmbedTextUseCase error mapping', () => {
@@ -99,7 +104,11 @@ describe('EmbedTextUseCase payload sanitization', () => {
     const throttle = {
       run: (_priority: unknown, fn: () => Promise<unknown>) => fn(),
     };
-    const useCase = new EmbedTextUseCase(registry as never, throttle as never);
+    const useCase = new EmbedTextUseCase(
+      createPinoLoggerMock(),
+      registry as never,
+      throttle as never,
+    );
 
     await useCase.execute(
       new EmbedTextCommand({

--- a/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/embed-text/embed-text.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EmbedTextCommand } from './embed-text.command';
 import { EmbeddingsHandlerRegistry } from '../../embeddings-handler.registry';
 import { EmbeddingsThrottleService } from '../../services/embeddings-throttle.service';
@@ -9,17 +10,15 @@ import { toWellFormedText } from 'src/common/util/unicode-sanitizer';
 
 @Injectable()
 export class EmbedTextUseCase {
-  private readonly logger = new Logger(EmbedTextUseCase.name);
-
   constructor(
+    @InjectPinoLogger(EmbedTextUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly providerRegistry: EmbeddingsHandlerRegistry,
     private readonly throttle: EmbeddingsThrottleService,
   ) {}
 
   async execute(command: EmbedTextCommand): Promise<Embedding[]> {
-    this.logger.log('execute', {
-      model: command.model,
-    });
+    this.logger.info({ model: command.model }, 'execute');
     try {
       const handler = this.providerRegistry.getHandler(command.model.provider);
 
@@ -45,15 +44,13 @@ export class EmbedTextUseCase {
         modelId: command.model.name,
       });
       if (providerError) {
-        this.logger.error('Embeddings provider unavailable', {
-          code: providerError.code,
-          ...providerError.context,
-        });
+        this.logger.error(
+          { code: providerError.code, ...providerError.context },
+          'Embeddings provider unavailable',
+        );
         throw providerError;
       }
-      this.logger.error('Error embedding text', {
-        error: error as Error,
-      });
+      this.logger.error({ err: error as Error }, 'Error embedding text');
       throw error;
     }
   }

--- a/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/get-available-providers/get-available-providers.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/get-available-providers/get-available-providers.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetAvailableProvidersUseCase } from './get-available-providers.use-case';
@@ -19,6 +21,10 @@ describe('GetAvailableProvidersUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetAvailableProvidersUseCase,
+        {
+          provide: getLoggerToken(GetAvailableProvidersUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: EmbeddingsHandlerRegistry, useValue: mockProviderRegistry },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/get-available-providers/get-available-providers.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/application/use-cases/get-available-providers/get-available-providers.use-case.ts
@@ -1,16 +1,19 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetAvailableProvidersQuery } from './get-available-providers.query';
 import { EmbeddingsHandlerRegistry } from '../../embeddings-handler.registry';
 import { EmbeddingsProvider } from 'src/domain/rag/embeddings/domain/embeddings-provider.enum';
 
 @Injectable()
 export class GetAvailableProvidersUseCase {
-  private readonly logger = new Logger(GetAvailableProvidersUseCase.name);
-
-  constructor(private readonly providerRegistry: EmbeddingsHandlerRegistry) {}
+  constructor(
+    @InjectPinoLogger(GetAvailableProvidersUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly providerRegistry: EmbeddingsHandlerRegistry,
+  ) {}
 
   execute(query: GetAvailableProvidersQuery): EmbeddingsProvider[] {
-    this.logger.log('execute', query);
+    this.logger.info(query, 'execute');
     return this.providerRegistry.getAvailableProviders();
   }
 }

--- a/ayunis-core-backend/src/domain/rag/embeddings/embeddings.module.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/embeddings.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { getLoggerToken, type PinoLogger } from 'nestjs-pino';
 import { ConfigModule } from '@nestjs/config';
 import { OpenAIEmbeddingsHandler } from './infrastructure/handler/openai-embeddings.handler';
 import { EmbeddingsHandlerRegistry } from './application/embeddings-handler.registry';
@@ -18,8 +19,9 @@ import { EmbeddingsThrottleService } from './application/services/embeddings-thr
         openaiHandler: OpenAIEmbeddingsHandler,
         mistralHandler: MistralEmbeddingsHandler,
         ayunisHandler: AyunisOllamaEmbeddingsHandler,
+        logger: PinoLogger,
       ) => {
-        const registry = new EmbeddingsHandlerRegistry();
+        const registry = new EmbeddingsHandlerRegistry(logger);
         registry.registerHandler(EmbeddingsProvider.OPENAI, openaiHandler);
         registry.registerHandler(EmbeddingsProvider.MISTRAL, mistralHandler);
         registry.registerHandler(EmbeddingsProvider.AYUNIS, ayunisHandler);
@@ -29,6 +31,7 @@ import { EmbeddingsThrottleService } from './application/services/embeddings-thr
         OpenAIEmbeddingsHandler,
         MistralEmbeddingsHandler,
         AyunisOllamaEmbeddingsHandler,
+        getLoggerToken(EmbeddingsHandlerRegistry.name),
       ],
     },
     MistralEmbeddingsHandler,

--- a/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/mistral-embeddings.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/mistral-embeddings.handler.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
 import type { TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
@@ -47,6 +49,10 @@ describe('MistralEmbeddingsHandler', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MistralEmbeddingsHandler,
+        {
+          provide: getLoggerToken(MistralEmbeddingsHandler.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: ConfigService,
           useValue: { get: jest.fn().mockReturnValue('mistral-api-key') },

--- a/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/mistral-embeddings.handler.ts
+++ b/ayunis-core-backend/src/domain/rag/embeddings/infrastructure/handler/mistral-embeddings.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EmbeddingsHandler } from '../../application/ports/embeddings.handler';
 import { Embedding } from '../../domain/embedding.entity';
 import { Mistral } from '@mistralai/mistralai';
@@ -17,10 +18,13 @@ const EMBEDDINGS_TIMEOUT_MS = 30_000;
 
 @Injectable()
 export class MistralEmbeddingsHandler extends EmbeddingsHandler {
-  private readonly logger = new Logger(MistralEmbeddingsHandler.name);
   private readonly mistral: Mistral;
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    @InjectPinoLogger(MistralEmbeddingsHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {
     super();
     this.mistral = new Mistral({
       apiKey: this.configService.get('embeddings.mistral.apiKey'),
@@ -33,10 +37,7 @@ export class MistralEmbeddingsHandler extends EmbeddingsHandler {
   }
 
   async embed(input: string[], model: EmbeddingModel): Promise<Embedding[]> {
-    this.logger.log('embed', {
-      model: model.name,
-      input: input.length,
-    });
+    this.logger.info({ model: model.name, inputCount: input.length }, 'embed');
     const embeddingsBatchResponse = await retryWithBackoff({
       fn: () =>
         this.mistral.embeddings.create({
@@ -49,11 +50,8 @@ export class MistralEmbeddingsHandler extends EmbeddingsHandler {
         const isTransient = isTransientMistralError(error);
         if (isTransient) {
           this.logger.warn(
+            { err: error },
             'Retrying Mistral embeddings after transient error',
-            {
-              name: error.name,
-              message: error.message,
-            },
           );
         }
         return isTransient;
@@ -62,17 +60,19 @@ export class MistralEmbeddingsHandler extends EmbeddingsHandler {
 
     return embeddingsBatchResponse.data.map((data) => {
       if (!data.embedding) {
-        this.logger.error('No embedding returned from Mistral', {
-          data,
-        });
+        this.logger.error(
+          { model: model.name },
+          'No embedding returned from Mistral',
+        );
         throw new NoEmbeddingsReturnedError(EmbeddingsProvider.MISTRAL, {
           data,
         });
       }
       if (data.index === undefined) {
-        this.logger.error('No index returned from Mistral', {
-          data,
-        });
+        this.logger.error(
+          { model: model.name },
+          'No index returned from Mistral',
+        );
         throw new NoEmbeddingsReturnedError(EmbeddingsProvider.MISTRAL, {
           data,
         });

--- a/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/delete-content/delete-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/delete-content/delete-content.use-case.ts
@@ -1,12 +1,16 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { IndexRegistry } from '../../indexer.registry';
 import { DeleteContentCommand } from './delete-content.command';
 import { UnexpectedIndexError } from '../../indexer.errors';
 
 @Injectable()
 export class DeleteContentUseCase {
-  private readonly logger = new Logger(DeleteContentUseCase.name);
-  constructor(private readonly indexRegistry: IndexRegistry) {}
+  constructor(
+    @InjectPinoLogger(DeleteContentUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly indexRegistry: IndexRegistry,
+  ) {}
 
   async execute(command: DeleteContentCommand): Promise<void> {
     try {
@@ -19,7 +23,7 @@ export class DeleteContentUseCase {
         await index.delete(command.documentId);
       }
     } catch (error) {
-      this.logger.error(error);
+      this.logger.error({ err: error as Error }, 'Failed to delete content');
       throw new UnexpectedIndexError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { IndexRegistry } from '../../indexer.registry';
 import { IngestBulkContentCommand } from './ingest-bulk-content.command';
 import { IndexEntry } from 'src/domain/rag/indexers/domain/index-entry.entity';
@@ -7,8 +8,11 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class IngestBulkContentUseCase {
-  private readonly logger = new Logger(IngestBulkContentUseCase.name);
-  constructor(private readonly indexRegistry: IndexRegistry) {}
+  constructor(
+    @InjectPinoLogger(IngestBulkContentUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly indexRegistry: IndexRegistry,
+  ) {}
 
   async execute(command: IngestBulkContentCommand): Promise<void> {
     try {
@@ -27,7 +31,7 @@ export class IngestBulkContentUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error(error);
+      this.logger.error({ err: error as Error }, 'Failed to ingest content');
       throw new UnexpectedIndexError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/search-content/search-content.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/search-content/search-content.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { SearchContentUseCase } from './search-content.use-case';
@@ -37,6 +39,10 @@ describe('SearchContentUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SearchContentUseCase,
+        {
+          provide: getLoggerToken(SearchContentUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: IndexRegistry, useValue: mockRegistry },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/search-content/search-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/application/use-cases/search-content/search-content.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { IndexRegistry } from '../../indexer.registry';
 import {
   SearchContentQuery,
@@ -10,8 +11,11 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class SearchContentUseCase {
-  private readonly logger = new Logger(SearchContentUseCase.name);
-  constructor(private readonly indexRegistry: IndexRegistry) {}
+  constructor(
+    @InjectPinoLogger(SearchContentUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly indexRegistry: IndexRegistry,
+  ) {}
 
   async execute(query: SearchContentQuery): Promise<IndexEntry[]> {
     try {
@@ -26,7 +30,7 @@ export class SearchContentUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error(error);
+      this.logger.error({ err: error as Error }, 'Failed to search content');
       throw new UnexpectedIndexError(error as Error);
     }
   }
@@ -44,7 +48,7 @@ export class SearchContentUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error(error);
+      this.logger.error({ err: error as Error }, 'Failed to search content');
       throw new UnexpectedIndexError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/delete-content/delete-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/delete-content/delete-content.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { DeleteContentCommand } from './delete-content.command';
 import { ParentChildIndexerRepository } from 'src/domain/rag/indexers/infrastructure/adapters/parent-child-index/parent-child-index.repository';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -6,8 +7,9 @@ import { UnexpectedIndexError } from 'src/domain/rag/indexers/application/indexe
 
 @Injectable()
 export class DeleteContentUseCase {
-  private readonly logger = new Logger(DeleteContentUseCase.name);
   constructor(
+    @InjectPinoLogger(DeleteContentUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly parentChildIndexerRepository: ParentChildIndexerRepository,
   ) {}
 
@@ -18,7 +20,7 @@ export class DeleteContentUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error(error);
+      this.logger.error({ err: error as Error }, 'Failed to delete content');
       throw new UnexpectedIndexError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/delete-contents/delete-contents.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/delete-contents/delete-contents.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { DeleteContentsCommand } from './delete-contents.command';
 import { ParentChildIndexerRepository } from 'src/domain/rag/indexers/infrastructure/adapters/parent-child-index/parent-child-index.repository';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -6,8 +7,9 @@ import { UnexpectedIndexError } from 'src/domain/rag/indexers/application/indexe
 
 @Injectable()
 export class DeleteContentsUseCase {
-  private readonly logger = new Logger(DeleteContentsUseCase.name);
   constructor(
+    @InjectPinoLogger(DeleteContentsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly parentChildIndexerRepository: ParentChildIndexerRepository,
   ) {}
 
@@ -21,7 +23,7 @@ export class DeleteContentsUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error(error);
+      this.logger.error({ err: error as Error }, 'Failed to delete contents');
       throw new UnexpectedIndexError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { IngestBulkContentUseCase } from './ingest-bulk-content.use-case';
@@ -68,6 +70,10 @@ describe('IngestBulkContentUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         IngestBulkContentUseCase,
+        {
+          provide: getLoggerToken(IngestBulkContentUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ParentChildIndexerRepositoryPort, useValue: mockRepo },
         { provide: SplitTextUseCase, useValue: mockSplitter },
         { provide: EmbedTextUseCase, useValue: mockEmbedder },

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ParentChildIndexerRepositoryPort } from '../../ports/parent-child-indexer-repository.port';
 import { ParentChunk } from 'src/domain/rag/indexers/infrastructure/adapters/parent-child-index/domain/parent-chunk.entity';
 import { SplitTextUseCase } from 'src/domain/rag/splitters/application/use-cases/split-text/split-text.use-case';
@@ -29,8 +30,9 @@ const EMBEDDING_BATCH_SIZE = 64;
 
 @Injectable()
 export class IngestBulkContentUseCase {
-  private readonly logger = new Logger(IngestBulkContentUseCase.name);
   constructor(
+    @InjectPinoLogger(IngestBulkContentUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly parentChildIndexerRepository: ParentChildIndexerRepositoryPort,
     private readonly splitTextUseCase: SplitTextUseCase,
     private readonly embedTextUseCase: EmbedTextUseCase,
@@ -41,7 +43,8 @@ export class IngestBulkContentUseCase {
     if (command.entries.length === 0) return;
 
     this.logger.debug(
-      `Bulk ingesting ${command.entries.length} entries for org ${command.orgId}`,
+      { entryCount: command.entries.length, orgId: command.orgId },
+      'Bulk ingesting entries',
     );
 
     // 1. Resolve embedding model ONCE for the entire batch
@@ -56,8 +59,12 @@ export class IngestBulkContentUseCase {
     const allChildTexts = parentPlans.flatMap((plan) => plan.childTexts);
 
     this.logger.debug(
-      `Split ${command.entries.length} entries into ` +
-        `${parentPlans.length} parent chunks with ${allChildTexts.length} child texts total`,
+      {
+        entryCount: command.entries.length,
+        parentChunkCount: parentPlans.length,
+        childTextCount: allChildTexts.length,
+      },
+      'Split entries into chunks',
     );
 
     // 4. Embed all child texts in batches
@@ -74,8 +81,11 @@ export class IngestBulkContentUseCase {
     await this.parentChildIndexerRepository.saveMany(parentChunks);
 
     this.logger.debug(
-      `Bulk ingested ${parentChunks.length} parent chunks ` +
-        `with ${allChildTexts.length} child embeddings`,
+      {
+        parentChunkCount: parentChunks.length,
+        childEmbeddingCount: allChildTexts.length,
+      },
+      'Bulk ingested chunks',
     );
   }
 

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/search-content/search-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/application/use-cases/search-content/search-content.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type {
   SearchInput,
   SearchMultiInput,
@@ -15,8 +16,9 @@ import type { ParentChunk } from 'src/domain/rag/indexers/infrastructure/adapter
 
 @Injectable()
 export class SearchContentUseCase {
-  private readonly logger = new Logger(SearchContentUseCase.name);
   constructor(
+    @InjectPinoLogger(SearchContentUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly parentChildIndexerRepository: ParentChildIndexerRepositoryPort,
     private readonly embedTextUseCase: EmbedTextUseCase,
     private readonly getPermittedEmbeddingModelUseCase: GetPermittedEmbeddingModelUseCase,
@@ -47,7 +49,7 @@ export class SearchContentUseCase {
   }
 
   private async embedQuery(orgId: UUID, query: string): Promise<number[]> {
-    this.logger.debug('Embedding query for search', { orgId });
+    this.logger.debug({ orgId }, 'Embedding query for search');
     const model = await this.getPermittedEmbeddingModelUseCase.execute(
       new GetPermittedEmbeddingModelQuery({ orgId }),
     );
@@ -60,9 +62,10 @@ export class SearchContentUseCase {
         priority: EmbeddingPriority.RETRIEVAL,
       }),
     );
-    this.logger.debug('Embedded query', {
-      vectorLength: embeddedQuery[0].vector.length,
-    });
+    this.logger.debug(
+      { vectorLength: embeddedQuery[0].vector.length },
+      'Embedded query',
+    );
     return embeddedQuery[0].vector;
   }
 

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/parent-child-index.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/parent-child-index.repository.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ParentChildIndexerRepository } from './parent-child-index.repository';
@@ -19,6 +21,10 @@ describe('ParentChildIndexerRepository', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ParentChildIndexerRepository,
+        {
+          provide: getLoggerToken(ParentChildIndexerRepository.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: getRepositoryToken(ParentChunkRecord),
           useValue: mockTypeOrmRepo,

--- a/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/parent-child-index.repository.ts
+++ b/ayunis-core-backend/src/domain/rag/indexers/infrastructure/adapters/parent-child-index/parent-child-index.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ParentChunkRecord } from './infrastructure/persistence/schema/parent-chunk.record';
 import { Repository, SelectQueryBuilder } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -16,8 +17,9 @@ const EMBEDDING_COLUMNS: Record<number, string> = {
 
 @Injectable()
 export class ParentChildIndexerRepository extends ParentChildIndexerRepositoryPort {
-  private readonly logger = new Logger(ParentChildIndexerRepository.name);
   constructor(
+    @InjectPinoLogger(ParentChildIndexerRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(ParentChunkRecord)
     private readonly parentChunkRepository: Repository<ParentChunkRecord>,
     private readonly parentChildIndexerMapper: ParentChildIndexerMapper,
@@ -73,7 +75,8 @@ export class ParentChildIndexerRepository extends ParentChildIndexerRepositoryPo
     }
 
     this.logger.debug(
-      `Starting vector search for document ${relatedDocumentId} with vector of dimension ${queryVector.length}`,
+      { relatedDocumentId, queryVectorLength: queryVector.length },
+      'Starting vector search',
     );
 
     return this.vectorSearch(
@@ -103,7 +106,11 @@ export class ParentChildIndexerRepository extends ParentChildIndexerRepositoryPo
     }
 
     this.logger.debug(
-      `Starting multi-document vector search across ${relatedDocumentIds.length} documents with vector of dimension ${queryVector.length}`,
+      {
+        documentCount: relatedDocumentIds.length,
+        queryVectorLength: queryVector.length,
+      },
+      'Starting multi-document vector search',
     );
 
     return this.vectorSearch(
@@ -131,7 +138,11 @@ export class ParentChildIndexerRepository extends ParentChildIndexerRepositoryPo
     const embeddingColumn = EMBEDDING_COLUMNS[queryVector.length];
     if (!embeddingColumn) {
       this.logger.warn(
-        `Unsupported query vector dimension ${queryVector.length}. Only ${Object.keys(EMBEDDING_COLUMNS).join(', ')} are supported.`,
+        {
+          queryVectorLength: queryVector.length,
+          supportedDimensions: Object.keys(EMBEDDING_COLUMNS),
+        },
+        'Unsupported query vector dimension',
       );
       return [];
     }
@@ -156,11 +167,10 @@ export class ParentChildIndexerRepository extends ParentChildIndexerRepositoryPo
         this.parentChildIndexerMapper.toParentChunkEntity(entity),
       );
     } catch (error) {
-      this.logger.error(`Error performing vector search:`, {
-        error: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-        ...errorContext,
-      });
+      this.logger.error(
+        { err: error as Error, ...errorContext },
+        'Error performing vector search',
+      );
       throw new Error(
         `Vector search failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );

--- a/ayunis-core-backend/src/domain/rag/splitters/application/splitter-handler.registry.ts
+++ b/ayunis-core-backend/src/domain/rag/splitters/application/splitter-handler.registry.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SplitterHandler } from './ports/splitter.handler';
 import { SplitterType } from '../domain/splitter-type.enum';
 import {
@@ -8,7 +9,11 @@ import {
 
 @Injectable()
 export class SplitterHandlerRegistry {
-  private readonly logger = new Logger(SplitterHandlerRegistry.name);
+  constructor(
+    @InjectPinoLogger(SplitterHandlerRegistry.name)
+    private readonly logger: PinoLogger,
+  ) {}
+
   private readonly handlers = new Map<SplitterType, SplitterHandler>();
 
   registerHandler(type: SplitterType, handler: SplitterHandler): void {
@@ -16,7 +21,7 @@ export class SplitterHandlerRegistry {
   }
 
   getHandler(type: SplitterType): SplitterHandler {
-    this.logger.debug('getHandler', { type });
+    this.logger.debug({ type }, 'getHandler');
     const handler = this.handlers.get(type);
 
     if (!handler) {

--- a/ayunis-core-backend/src/domain/rag/splitters/application/use-cases/split-text/split-text.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/splitters/application/use-cases/split-text/split-text.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { SplitTextUseCase } from './split-text.use-case';
@@ -26,6 +28,10 @@ describe('ProcessTextUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SplitTextUseCase,
+        {
+          provide: getLoggerToken(SplitTextUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: SplitterHandlerRegistry,
           useValue: mockProviderRegistry,

--- a/ayunis-core-backend/src/domain/rag/splitters/application/use-cases/split-text/split-text.use-case.ts
+++ b/ayunis-core-backend/src/domain/rag/splitters/application/use-cases/split-text/split-text.use-case.ts
@@ -1,19 +1,23 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SplitResult } from 'src/domain/rag/splitters/domain/split-result.entity';
 import { SplitterHandlerRegistry } from '../../splitter-handler.registry';
 import { SplitTextCommand } from './split-text.command';
 
 @Injectable()
 export class SplitTextUseCase {
-  private readonly logger = new Logger(SplitTextUseCase.name);
-
-  constructor(private readonly providerRegistry: SplitterHandlerRegistry) {}
+  constructor(
+    @InjectPinoLogger(SplitTextUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly providerRegistry: SplitterHandlerRegistry,
+  ) {}
 
   execute(command: SplitTextCommand): SplitResult {
     const handler = this.providerRegistry.getHandler(command.type);
 
     this.logger.debug(
-      `Processing text with splitter provider: ${command.type}`,
+      { type: command.type },
+      'Processing text with splitter provider',
     );
 
     return handler.processText({

--- a/ayunis-core-backend/src/domain/rag/splitters/infrastructure/handlers/recursive.splitter.spec.ts
+++ b/ayunis-core-backend/src/domain/rag/splitters/infrastructure/handlers/recursive.splitter.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { RecursiveSplitterHandler } from './recursive.splitter';
 import type { SplitterInput } from '../../application/ports/splitter.handler';
 import type { TextChunk } from '../../domain/split-result.entity';
@@ -6,7 +7,7 @@ describe('RecursiveSplitterHandler', () => {
   let handler: RecursiveSplitterHandler;
 
   beforeEach(() => {
-    handler = new RecursiveSplitterHandler();
+    handler = new RecursiveSplitterHandler(createPinoLoggerMock());
   });
 
   it('should be defined', () => {

--- a/ayunis-core-backend/src/domain/rag/splitters/infrastructure/handlers/recursive.splitter.ts
+++ b/ayunis-core-backend/src/domain/rag/splitters/infrastructure/handlers/recursive.splitter.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   SplitterHandler,
   SplitterInput,
@@ -39,7 +40,12 @@ interface RecursiveSplitContext {
 
 @Injectable()
 export class RecursiveSplitterHandler extends SplitterHandler {
-  private readonly logger = new Logger(RecursiveSplitterHandler.name);
+  constructor(
+    @InjectPinoLogger(RecursiveSplitterHandler.name)
+    private readonly logger: PinoLogger,
+  ) {
+    super();
+  }
 
   isAvailable(): boolean {
     return true;
@@ -47,12 +53,13 @@ export class RecursiveSplitterHandler extends SplitterHandler {
 
   processText(input: SplitterInput): SplitResult {
     try {
-      this.logger.debug(`Processing text with Recursive Text Splitter`);
+      this.logger.debug('Processing text with Recursive Text Splitter');
 
       const config = this.resolveAndValidateConfig(input);
 
       this.logger.debug(
-        `Chunk size: ${config.chunkSize}, Chunk overlap: ${config.chunkOverlap}`,
+        { chunkSize: config.chunkSize, chunkOverlap: config.chunkOverlap },
+        'Resolved recursive text splitter configuration',
       );
 
       const rawChunks = this.ensureChunkSizeLimit(
@@ -73,8 +80,8 @@ export class RecursiveSplitterHandler extends SplitterHandler {
       });
     } catch (error) {
       this.logger.error(
-        `Recursive Text Splitter processing failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        error instanceof Error ? error.stack : undefined,
+        { err: error as Error },
+        'Recursive Text Splitter processing failed',
       );
       throw new SplitterProcessingError(
         `Failed to process text with Recursive Text Splitter`,

--- a/ayunis-core-backend/src/domain/rag/splitters/splitter.module.ts
+++ b/ayunis-core-backend/src/domain/rag/splitters/splitter.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { getLoggerToken, type PinoLogger } from 'nestjs-pino';
 import { RecursiveSplitterHandler } from './infrastructure/handlers/recursive.splitter';
 import { SplitterType } from './domain/splitter-type.enum';
 import { SplitterHandlerRegistry } from './application/splitter-handler.registry';
@@ -8,15 +9,21 @@ import { SplitTextUseCase } from './application/use-cases/split-text/split-text.
   providers: [
     {
       provide: SplitterHandlerRegistry,
-      useFactory: (recursiveSplitterHandler: RecursiveSplitterHandler) => {
-        const registry = new SplitterHandlerRegistry();
+      useFactory: (
+        recursiveSplitterHandler: RecursiveSplitterHandler,
+        logger: PinoLogger,
+      ) => {
+        const registry = new SplitterHandlerRegistry(logger);
         registry.registerHandler(
           SplitterType.RECURSIVE,
           recursiveSplitterHandler,
         );
         return registry;
       },
-      inject: [RecursiveSplitterHandler],
+      inject: [
+        RecursiveSplitterHandler,
+        getLoggerToken(SplitterHandlerRegistry.name),
+      ],
     },
     SplitTextUseCase,
     RecursiveSplitterHandler,

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/preflight-check/preflight-check.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/preflight-check/preflight-check.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { PreflightCheckUseCase } from './preflight-check.use-case';
@@ -26,6 +28,10 @@ describe('PreflightCheckUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         PreflightCheckUseCase,
+        {
+          provide: getLoggerToken(PreflightCheckUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: retrievalConfig.KEY,
           useValue: defaultConfig,

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/preflight-check/preflight-check.use-case.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/preflight-check/preflight-check.use-case.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigType } from '@nestjs/config';
 import { PreflightCheckCommand } from './preflight-check.command';
 import { TooManyPagesError } from '../../file-retriever.errors';
@@ -8,9 +9,9 @@ import PdfParse from 'pdf-parse';
 
 @Injectable()
 export class PreflightCheckUseCase {
-  private readonly logger = new Logger(PreflightCheckUseCase.name);
-
   constructor(
+    @InjectPinoLogger(PreflightCheckUseCase.name)
+    private readonly logger: PinoLogger,
     @Inject(retrievalConfig.KEY)
     private readonly config: ConfigType<typeof retrievalConfig>,
   ) {}
@@ -44,14 +45,16 @@ export class PreflightCheckUseCase {
       // If pdf-parse fails to read metadata, let it through — the actual
       // processing step will handle or fail on the content itself
       this.logger.warn(
-        `Could not read PDF metadata for preflight: ${(error as Error).message}`,
+        { err: error as Error, fileName },
+        'Could not read PDF metadata for preflight',
       );
       return;
     }
 
     if (pageCount > maxPages) {
       this.logger.warn(
-        `PDF "${fileName}" has ${pageCount} pages (max: ${maxPages})`,
+        { fileName, pageCount, maxPages },
+        'PDF exceeds the page limit',
       );
       throw new TooManyPagesError({ fileName, pageCount, maxPages });
     }

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { RetrieveFileContentUseCase } from './retrieve-file-content.use-case';
@@ -57,6 +59,10 @@ describe('RetrieveFileContentUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RetrieveFileContentUseCase,
+        {
+          provide: getLoggerToken(RetrieveFileContentUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: FileRetrieverRegistry, useValue: mockRegistry },
         { provide: ContextService, useValue: mockContextService },
         { provide: DocumentConverterPort, useValue: mockDocumentConverter },

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigType } from '@nestjs/config';
 import {
   FileRetrieverPage,
@@ -29,9 +30,9 @@ import { TranscribeCommand } from 'src/domain/transcriptions/application/use-cas
 
 @Injectable()
 export class RetrieveFileContentUseCase {
-  private readonly logger = new Logger(RetrieveFileContentUseCase.name);
-
   constructor(
+    @InjectPinoLogger(RetrieveFileContentUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly fileRetrieverRegistry: FileRetrieverRegistry,
     private readonly contextService: ContextService,
     private readonly documentConverter: DocumentConverterPort,
@@ -44,7 +45,10 @@ export class RetrieveFileContentUseCase {
   async execute(
     command: RetrieveFileContentCommand,
   ): Promise<FileRetrieverResult> {
-    this.logger.debug(`Retrieving file content: ${command.fileName}`);
+    this.logger.debug(
+      { fileName: command.fileName },
+      'Retrieving file content',
+    );
     const orgId = this.contextService.get('orgId');
     if (!orgId) {
       throw new FileRetrieverUnauthorizedError();
@@ -116,9 +120,10 @@ export class RetrieveFileContentUseCase {
     file: File,
     emptyOcrError: EmptyOcrResultError,
   ): Promise<FileRetrieverResult> {
-    this.logger.warn('Mistral returned no pages; trying local PDF parsing', {
-      fileName: file.filename,
-    });
+    this.logger.warn(
+      { fileName: file.filename },
+      'Mistral returned no pages; trying local PDF parsing',
+    );
     try {
       const result = await this.fileRetrieverRegistry
         .getHandler(FileRetrieverType.NPM_PDF_PARSE)
@@ -127,10 +132,10 @@ export class RetrieveFileContentUseCase {
         return result;
       }
     } catch (error) {
-      this.logger.warn('Local PDF fallback failed', {
-        fileName: file.filename,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.warn(
+        { fileName: file.filename, err: error as Error },
+        'Local PDF fallback failed',
+      );
     }
     throw emptyOcrError;
   }

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/gotenberg-converter.service.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/gotenberg-converter.service.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
 import type { TestingModule } from '@nestjs/testing';
 import axios from 'axios';
@@ -26,6 +28,10 @@ describe('GotenbergConverterService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GotenbergConverterService,
+        {
+          provide: getLoggerToken(GotenbergConverterService.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: gotenbergConfig.KEY,
           useValue: { url: 'https://gotenberg:3000' },

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/gotenberg-converter.service.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/gotenberg-converter.service.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import axios from 'axios';
 import type { AxiosError } from 'axios';
 import FormData from 'form-data';
@@ -14,11 +15,12 @@ import {
 
 @Injectable()
 export class GotenbergConverterService extends DocumentConverterPort {
-  private readonly logger = new Logger(GotenbergConverterService.name);
   /** 10 minutes — large documents can take a while to convert */
   private readonly TIMEOUT_MS = 10 * 60 * 1000;
 
   constructor(
+    @InjectPinoLogger(GotenbergConverterService.name)
+    private readonly logger: PinoLogger,
     @Inject(gotenbergConfig.KEY)
     private readonly config: GotenbergConfig,
   ) {
@@ -32,7 +34,7 @@ export class GotenbergConverterService extends DocumentConverterPort {
    * @returns PDF file as a Buffer
    */
   async convertToPdf(fileData: Buffer, fileName: string): Promise<Buffer> {
-    this.logger.debug(`Converting ${fileName} to PDF via Gotenberg`);
+    this.logger.debug({ fileName }, 'Converting document to PDF via Gotenberg');
 
     try {
       const formData = new FormData();
@@ -49,7 +51,8 @@ export class GotenbergConverterService extends DocumentConverterPort {
 
       const pdfBuffer = Buffer.from(response.data as ArrayBuffer);
       this.logger.debug(
-        `Gotenberg conversion complete: ${fileName} → ${pdfBuffer.length} bytes PDF`,
+        { fileName, pdfBytes: pdfBuffer.length },
+        'Gotenberg conversion complete',
       );
 
       return pdfBuffer;

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
 import type { TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
@@ -91,6 +93,10 @@ describe('MistralFileRetrieverHandler', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MistralFileRetrieverHandler,
+        {
+          provide: getLoggerToken(MistralFileRetrieverHandler.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: ConfigService,
           useValue: {

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/infrastructure/adapters/mistral-file-retriever.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { FileRetrieverHandler } from '../../application/ports/file-retriever.handler';
 import {
   FileRetrieverResult,
@@ -37,7 +38,6 @@ function isFileNotFound(error: unknown): boolean {
 
 @Injectable()
 export class MistralFileRetrieverHandler extends FileRetrieverHandler {
-  private readonly logger = new Logger(MistralFileRetrieverHandler.name);
   private readonly client: Mistral;
   private readonly MODEL_NAME = 'mistral-ocr-latest';
   // Per-attempt timeout for the Mistral file APIs (upload, signed URL, OCR,
@@ -47,7 +47,11 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
   // 5-minute slice per attempt (AYC-422).
   private readonly TIMEOUT_MS = 120 * 1000;
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    @InjectPinoLogger(MistralFileRetrieverHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {
     super();
     this.client = new Mistral({
       apiKey: this.configService.get('retrieval.mistral.apiKey'),
@@ -58,7 +62,8 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
   async processFile(file: File): Promise<FileRetrieverResult> {
     try {
       this.logger.debug(
-        `Processing file with Mistral OCR: ${file.filename} (${file.fileType})`,
+        { fileName: file.filename, fileType: file.fileType },
+        'Processing file with Mistral OCR',
       );
 
       // Convert Buffer to Blob for Mistral API with the correct MIME type
@@ -70,8 +75,8 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
       return this.parseResponse(ocrResponse);
     } catch (error) {
       this.logger.error(
-        `Mistral OCR processing failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        error instanceof Error ? error.stack : 'Unknown error',
+        { err: error as Error },
+        'Mistral OCR processing failed',
       );
 
       throw this.mapProcessingError(error);
@@ -151,9 +156,10 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
       delay: 1000,
       retryIfError: isTransientMistralError,
     }).catch((error) => {
-      this.logger.debug('File upload to Mistral failed', {
-        error: error as Error,
-      });
+      this.logger.debug(
+        { err: error as Error },
+        'File upload to Mistral failed',
+      );
       this.logger.error('File upload to Mistral failed');
       throw error;
     });
@@ -188,8 +194,8 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
         throw error;
       }
       this.logger.warn(
-        'Uploaded file was removed before OCR ran; re-uploading once',
         { fileId },
+        'Uploaded file was removed before OCR ran; re-uploading once',
       );
     }
 
@@ -240,8 +246,8 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
       retryIfError: isTransientOcrError,
     }).catch((error) => {
       this.logger.error(
-        `Mistral OCR processing failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        error instanceof Error ? error.stack : 'Unknown error',
+        { err: error as Error },
+        'Mistral OCR processing failed',
       );
       throw error;
     });
@@ -257,10 +263,10 @@ export class MistralFileRetrieverHandler extends FileRetrieverHandler {
       delay: 1000,
       retryIfError: isTransientMistralError,
     }).catch((error) => {
-      this.logger.warn('Failed to delete file from Mistral (best-effort)', {
-        fileId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.warn(
+        { fileId, err: error as Error },
+        'Failed to delete file from Mistral (best-effort)',
+      );
     });
   }
 

--- a/ayunis-core-backend/src/domain/retrievers/internet-search-retrievers/application/use-cases/search-web/search-web.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/internet-search-retrievers/application/use-cases/search-web/search-web.use-case.spec.ts
@@ -1,5 +1,8 @@
+import type { PinoLogger } from 'nestjs-pino';
+import { getLoggerToken } from 'nestjs-pino';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { SearchWebUseCase } from './search-web.use-case';
 import { SearchWebCommand } from './search-web.command';
 import { InternetSearchHandler } from '../../ports/internet-search.handler';
@@ -7,10 +10,12 @@ import { InternetSearchResult } from 'src/domain/retrievers/internet-search-retr
 import { InternetSearchResultType } from 'src/domain/retrievers/internet-search-retrievers/domain/value-objects/internet-search-result-type.enum';
 
 describe('SearchWebUseCase', () => {
+  let logger: jest.Mocked<PinoLogger>;
   let useCase: SearchWebUseCase;
   let mockHandler: Partial<InternetSearchHandler>;
 
   beforeAll(async () => {
+    logger = createPinoLoggerMock();
     mockHandler = {
       search: jest.fn(),
     };
@@ -19,6 +24,10 @@ describe('SearchWebUseCase', () => {
       providers: [
         SearchWebUseCase,
         { provide: InternetSearchHandler, useValue: mockHandler },
+        {
+          provide: getLoggerToken(SearchWebUseCase.name),
+          useValue: logger,
+        },
       ],
     }).compile();
 
@@ -49,5 +58,9 @@ describe('SearchWebUseCase', () => {
 
     expect(result).toBe(expectedResults);
     expect(mockHandler.search).toHaveBeenCalledWith(command.query);
+    expect(logger.debug).toHaveBeenCalledWith(
+      { input: command.query },
+      'Searching web',
+    );
   });
 });

--- a/ayunis-core-backend/src/domain/retrievers/internet-search-retrievers/application/use-cases/search-web/search-web.use-case.ts
+++ b/ayunis-core-backend/src/domain/retrievers/internet-search-retrievers/application/use-cases/search-web/search-web.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InternetSearchHandler } from '../../ports/internet-search.handler';
 import { InternetSearchResult } from 'src/domain/retrievers/internet-search-retrievers/domain/internet-search-result.entity';
 import { SearchWebCommand } from './search-web.command';
@@ -7,13 +8,15 @@ import { UnexpectedInternetSearchError } from '../../internet-search.errors';
 
 @Injectable()
 export class SearchWebUseCase {
-  private readonly logger = new Logger(SearchWebUseCase.name);
-
-  constructor(private readonly internetSearchHandler: InternetSearchHandler) {}
+  constructor(
+    @InjectPinoLogger(SearchWebUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly internetSearchHandler: InternetSearchHandler,
+  ) {}
 
   async execute(command: SearchWebCommand): Promise<InternetSearchResult[]> {
     try {
-      this.logger.debug(`Searching web for: ${command.query}`);
+      this.logger.debug({ input: command.query }, 'Searching web');
 
       return this.internetSearchHandler.search(command.query);
     } catch (error) {
@@ -21,8 +24,8 @@ export class SearchWebUseCase {
         throw error;
       }
       this.logger.error(
-        `Unexpected error searching web for: ${command.query}`,
-        error,
+        { err: error as Error, input: command.query },
+        'Unexpected error searching web',
       );
       throw new UnexpectedInternetSearchError(error as Error);
     }

--- a/ayunis-core-backend/src/domain/retrievers/internet-search-retrievers/infrastructure/handlers/brave-internet-search.handler.ts
+++ b/ayunis-core-backend/src/domain/retrievers/internet-search-retrievers/infrastructure/handlers/brave-internet-search.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InternetSearchHandler } from '../../application/ports/internet-search.handler';
 import { InternetSearchResult } from '../../domain/internet-search-result.entity';
 import { ConfigService } from '@nestjs/config';
@@ -31,33 +32,30 @@ type BraveSearchErrorResult = {
 
 @Injectable()
 export class BraveInternetSearchHandler implements InternetSearchHandler {
-  private readonly logger = new Logger(BraveInternetSearchHandler.name);
-
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    @InjectPinoLogger(BraveInternetSearchHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {}
 
   async search(query: string): Promise<InternetSearchResult[]> {
-    this.logger.debug('Using Brave internet search handler', {
-      query,
-    });
+    this.logger.debug({ input: query }, 'Using Brave internet search handler');
     try {
       const response = await fetch(...this.buildRequest(query));
       const data = (await response.json()) as
         BraveSearchResult | BraveSearchErrorResult;
       if ('error' in data) {
-        this.logger.error('Brave search error', {
-          error: data.error,
-        });
+        this.logger.error({ response: data.error }, 'Brave search error');
         throw new Error(data.error.detail);
       }
       const results = this.mapResults(data);
-      this.logger.debug('Processed results', {
-        results,
-      });
+      this.logger.debug(
+        { resultCount: results.length },
+        'Processed search results',
+      );
       return results;
     } catch (error) {
-      this.logger.error('Error searching web', {
-        error: error as Error,
-      });
+      this.logger.error({ err: error as Error }, 'Error searching web');
       throw error;
     }
   }

--- a/ayunis-core-backend/src/domain/retrievers/internet-search-retrievers/infrastructure/handlers/staan-internet-search.handler.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/internet-search-retrievers/infrastructure/handlers/staan-internet-search.handler.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { ConfigService } from '@nestjs/config';
 import { StaanInternetSearchHandler } from './staan-internet-search.handler';
 import { InternetSearchResult } from '../../domain/internet-search-result.entity';
@@ -16,6 +17,7 @@ describe('StaanInternetSearchHandler', () => {
       }),
     };
     handler = new StaanInternetSearchHandler(
+      createPinoLoggerMock(),
       configService as unknown as ConfigService,
     );
   });

--- a/ayunis-core-backend/src/domain/retrievers/internet-search-retrievers/infrastructure/handlers/staan-internet-search.handler.ts
+++ b/ayunis-core-backend/src/domain/retrievers/internet-search-retrievers/infrastructure/handlers/staan-internet-search.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { InternetSearchHandler } from '../../application/ports/internet-search.handler';
 import { InternetSearchResult } from '../../domain/internet-search-result.entity';
@@ -18,22 +19,24 @@ type StaanSearchResult = {
 
 @Injectable()
 export class StaanInternetSearchHandler implements InternetSearchHandler {
-  private readonly logger = new Logger(StaanInternetSearchHandler.name);
-
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    @InjectPinoLogger(StaanInternetSearchHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {}
 
   async search(query: string): Promise<InternetSearchResult[]> {
-    this.logger.debug('Using Staan internet search handler', { query });
+    this.logger.debug({ input: query }, 'Using Staan internet search handler');
 
     const response = await fetch(...this.buildRequest(query));
 
     // fetch does not throw on HTTP error status — check explicitly.
     if (!response.ok) {
       const detail = await response.text();
-      this.logger.error('Staan search error', {
-        status: response.status,
-        detail,
-      });
+      this.logger.error(
+        { status: response.status, response: detail },
+        'Staan search error',
+      );
       throw new Error(`Staan search failed with status ${response.status}`);
     }
 

--- a/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/use-cases/crawl-url/crawl-url.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/use-cases/crawl-url/crawl-url.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
@@ -61,6 +63,10 @@ async function buildUseCase(
   const module: TestingModule = await Test.createTestingModule({
     providers: [
       CrawlUrlUseCase,
+      {
+        provide: getLoggerToken(CrawlUrlUseCase.name),
+        useValue: createPinoLoggerMock(),
+      },
       { provide: RetrieveUrlUseCase, useValue: retriever },
     ],
   }).compile();
@@ -326,12 +332,13 @@ describe('CrawlUrlUseCase', () => {
 
     await useCase.execute(new CrawlUrlCommand('https://acme.test/', ORG_ID, 1));
 
-    const logged = warnSpy.mock.calls.map((call) => String(call[0])).join('\n');
-    expect(logged).toContain('Skipping page during crawl');
-    expect(logged).toContain('https://acme.test/doc'); // redacted path retained
-    expect(logged).not.toContain('SECRET123'); // signed token dropped
-    expect(logged).not.toContain('token=');
-    expect(logged).toContain('PROVIDER_NOT_AVAILABLE'); // stable code, not raw msg
+    expect(warnSpy).toHaveBeenCalledWith(
+      {
+        url: 'https://acme.test/doc',
+        errorType: 'PROVIDER_NOT_AVAILABLE',
+      },
+      'Skipping page during crawl',
+    );
   });
 
   it('propagates the error when the root page fails to fetch', async () => {

--- a/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/use-cases/crawl-url/crawl-url.use-case.ts
+++ b/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/use-cases/crawl-url/crawl-url.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import pLimit from 'p-limit';
 import { RetrieveUrlUseCase } from '../retrieve-url/retrieve-url.use-case';
@@ -19,13 +20,15 @@ import { ApplicationError } from 'src/common/errors/base.error';
  */
 @Injectable()
 export class CrawlUrlUseCase {
-  private readonly logger = new Logger(CrawlUrlUseCase.name);
-
-  constructor(private readonly retrieveUrlUseCase: RetrieveUrlUseCase) {}
+  constructor(
+    @InjectPinoLogger(CrawlUrlUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly retrieveUrlUseCase: RetrieveUrlUseCase,
+  ) {}
 
   async execute(command: CrawlUrlCommand): Promise<UrlCrawlResult> {
     const maxDepth = this.clampDepth(command.maxDepth);
-    this.logger.debug(`Crawling ${command.url} to depth ${maxDepth}`);
+    this.logger.debug({ url: command.url, maxDepth }, 'Crawling URL');
 
     // Root failure aborts the whole crawl (error propagates to caller).
     const rootResult = await this.retrieveUrlUseCase.execute(
@@ -56,7 +59,8 @@ export class CrawlUrlUseCase {
     }
 
     this.logger.debug(
-      `Crawl of ${command.url} produced ${pages.length} page(s)`,
+      { url: command.url, pageCount: pages.length },
+      'URL crawl completed',
     );
     return new UrlCrawlResult(pages);
   }
@@ -125,7 +129,8 @@ export class CrawlUrlUseCase {
       // tokens; log a redacted URL and a stable error code only, never the raw
       // URL query or error text, so secrets never reach centralized logs/AppSignal.
       this.logger.warn(
-        `Skipping page during crawl: ${this.redactUrl(url)} (${this.describeError(error)})`,
+        { url: this.redactUrl(url), errorType: this.describeError(error) },
+        'Skipping page during crawl',
       );
       return null;
     }

--- a/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/use-cases/retrieve-url/retrieve-url.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/use-cases/retrieve-url/retrieve-url.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -46,6 +48,10 @@ describe('RetrieveUrlUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RetrieveUrlUseCase,
+        {
+          provide: getLoggerToken(RetrieveUrlUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: UrlRetrieverHandler, useValue: mockHandler },
         {
           provide: AssertCrawlDomainAccessUseCase,

--- a/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/use-cases/retrieve-url/retrieve-url.use-case.ts
+++ b/ayunis-core-backend/src/domain/retrievers/url-retrievers/application/use-cases/retrieve-url/retrieve-url.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UrlRetrieverResult } from 'src/domain/retrievers/url-retrievers/domain/url-retriever-result.entity';
 import { RetrieveUrlCommand } from './retrieve-url.command';
 import {
@@ -20,16 +21,16 @@ const PDF_MIME_TYPE = 'application/pdf';
 
 @Injectable()
 export class RetrieveUrlUseCase {
-  private readonly logger = new Logger(RetrieveUrlUseCase.name);
-
   constructor(
+    @InjectPinoLogger(RetrieveUrlUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly handler: UrlRetrieverHandler,
     private readonly assertCrawlDomainAccessUseCase: AssertCrawlDomainAccessUseCase,
     private readonly retrieveFileContentUseCase: RetrieveFileContentUseCase,
   ) {}
 
   async execute(command: RetrieveUrlCommand): Promise<UrlRetrieverResult> {
-    this.logger.debug(`Retrieving URL: ${command.url}`);
+    this.logger.debug({ url: command.url }, 'Retrieving URL');
 
     // Org-scoped crawl gate — runs BEFORE the try/catch so a thrown
     // CrawlDomainAccessDeniedError (404) is not swallowed into a retriever
@@ -115,10 +116,7 @@ export class RetrieveUrlUseCase {
     }
 
     // Otherwise log and convert to appropriate domain error
-    this.logger.error(
-      `URL retrieval failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      error instanceof Error ? error.stack : 'Unknown error',
-    );
+    this.logger.error({ err: error as Error, url }, 'URL retrieval failed');
 
     throw new UrlRetrieverProviderNotAvailableError(
       this.handler.constructor.name,

--- a/ayunis-core-backend/src/domain/retrievers/url-retrievers/infrastructure/cheerio.url-retriever.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/url-retrievers/infrastructure/cheerio.url-retriever.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { ConfigService } from '@nestjs/config';
 import { CheerioUrlRetrieverHandler } from './cheerio.url-retriever';
 import {
@@ -74,7 +75,7 @@ function streamedResponse({
 
 function makeHandler(): CheerioUrlRetrieverHandler {
   const config = { getOrThrow: () => 5000 } as unknown as ConfigService;
-  return new CheerioUrlRetrieverHandler(config);
+  return new CheerioUrlRetrieverHandler(createPinoLoggerMock(), config);
 }
 
 function makeHandlerWithCap(
@@ -84,7 +85,10 @@ function makeHandlerWithCap(
     getOrThrow: (key: string) =>
       key === 'url.maxDownloadBytes' ? maxDownloadBytes : 5000,
   } as unknown as ConfigService;
-  const handler = new CheerioUrlRetrieverHandler(config);
+  const handler = new CheerioUrlRetrieverHandler(
+    createPinoLoggerMock(),
+    config,
+  );
   jest.spyOn(handler['logger'], 'error').mockImplementation(() => undefined);
   return handler;
 }
@@ -94,7 +98,10 @@ function makeHandlerWithTimeout(timeoutMs: number): CheerioUrlRetrieverHandler {
     getOrThrow: (key: string) =>
       key === 'url.timeout' ? timeoutMs : 25 * 1024 * 1024,
   } as unknown as ConfigService;
-  const handler = new CheerioUrlRetrieverHandler(config);
+  const handler = new CheerioUrlRetrieverHandler(
+    createPinoLoggerMock(),
+    config,
+  );
   jest.spyOn(handler['logger'], 'error').mockImplementation(() => undefined);
   return handler;
 }

--- a/ayunis-core-backend/src/domain/retrievers/url-retrievers/infrastructure/cheerio.url-retriever.ts
+++ b/ayunis-core-backend/src/domain/retrievers/url-retrievers/infrastructure/cheerio.url-retriever.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import * as cheerio from 'cheerio';
 import {
@@ -27,14 +28,17 @@ const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
 
 @Injectable()
 export class CheerioUrlRetrieverHandler extends UrlRetrieverHandler {
-  private readonly logger = new Logger(CheerioUrlRetrieverHandler.name);
   private readonly defaultTimeout: number;
   private readonly maxDownloadBytes: number;
 
   // `url.timeout` and `url.maxDownloadBytes` always resolve — the `url` config
   // factory applies its own defaults (5s / 25 MB) — so read them with
   // getOrThrow rather than duplicating those defaults as dead fallbacks here.
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    @InjectPinoLogger(CheerioUrlRetrieverHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {
     super();
     this.defaultTimeout = this.configService.getOrThrow<number>('url.timeout');
     this.maxDownloadBytes = this.configService.getOrThrow<number>(
@@ -51,7 +55,10 @@ export class CheerioUrlRetrieverHandler extends UrlRetrieverHandler {
   }
 
   private async fetchRaw(input: UrlRetrieverInput): Promise<RawUrlResponse> {
-    this.logger.debug(`Retrieving URL: ${input.url} with Cheerio handler`);
+    this.logger.debug(
+      { url: input.url },
+      'Retrieving URL with Cheerio handler',
+    );
 
     const timeout = this.resolveTimeout(input);
     const controller = new AbortController();
@@ -303,8 +310,8 @@ export class CheerioUrlRetrieverHandler extends UrlRetrieverHandler {
     }
 
     this.logger.error(
-      `HTTP URL retrieval failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
-      error instanceof Error ? error.stack : 'Unknown error',
+      { err: error as Error, url },
+      'HTTP URL retrieval failed',
     );
 
     // Transport classification is attached for debuggability only — a dead


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mechanical logging and DI changes only; retrieval, embedding, and indexing behavior are unchanged aside from log format and observability.
> 
> **Overview**
> **Migrates logging** across the RAG stack (embeddings, indexers, splitters) and retriever domains (files, URLs, web search) from Nest’s built-in `Logger` to **nestjs-pino** `PinoLogger` injected with `@InjectPinoLogger`.
> 
> Call sites now follow Pino’s **structured shape** (`logger.info({ ... }, 'message')`, errors as `{ err }`) instead of string interpolation or Nest’s `(message, object)` order. Registry modules (`EmbeddingsHandlerRegistry`, `SplitterHandlerRegistry`) receive the logger in their factory `inject` arrays.
> 
> **Tests** wire `createPinoLoggerMock()` / `getLoggerToken(...)`; crawl and search specs were updated to assert the new log payloads (e.g. redacted URL + error code on skipped crawl pages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266fde3c6eec09c6c07db384cf370a9161c07c39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->