### PR TITLE
wip(logging): migrate sources, storage, and transcription logging (AYC-750)

### DIFF
--- a/ayunis-core-backend/src/domain/sources/application/services/source-processing-helper.service.ts
+++ b/ayunis-core-backend/src/domain/sources/application/services/source-processing-helper.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { IngestBulkContentUseCase } from 'src/domain/rag/indexers/application/use-cases/ingest-bulk-content/ingest-bulk-content.use-case';
 import { IngestBulkContentCommand } from 'src/domain/rag/indexers/application/use-cases/ingest-bulk-content/ingest-bulk-content.command';
@@ -16,9 +17,9 @@ import type { TextSourceContentChunk } from '../../domain/source-content-chunk.e
  */
 @Injectable()
 export class SourceProcessingHelper {
-  private readonly logger = new Logger(SourceProcessingHelper.name);
-
   constructor(
+    @InjectPinoLogger(SourceProcessingHelper.name)
+    private readonly logger: PinoLogger,
     private readonly ingestBulkContentUseCase: IngestBulkContentUseCase,
     private readonly deleteContentUseCase: DeleteContentUseCase,
     private readonly markSourceFailedUseCase: MarkSourceFailedUseCase,
@@ -51,10 +52,13 @@ export class SourceProcessingHelper {
         new DeleteContentCommand({ documentId: sourceId }),
       );
     } catch (err) {
-      this.logger.warn('Failed to clean up partial vector index entries', {
-        sourceId,
-        error: err as Error,
-      });
+      this.logger.warn(
+        {
+          sourceId,
+          err: err as Error,
+        },
+        'Failed to clean up partial vector index entries',
+      );
     }
   }
 
@@ -64,10 +68,13 @@ export class SourceProcessingHelper {
         new MarkSourceFailedCommand({ sourceId, errorMessage }),
       );
     } catch (err) {
-      this.logger.error('Failed to mark source as failed', {
-        sourceId,
-        error: err as Error,
-      });
+      this.logger.error(
+        {
+          sourceId,
+          err: err as Error,
+        },
+        'Failed to mark source as failed',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/cleanup-source-processing/cleanup-source-processing.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/cleanup-source-processing/cleanup-source-processing.use-case.spec.ts
@@ -1,6 +1,7 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import type { UUID } from 'crypto';
 import { CleanupSourceProcessingUseCase } from './cleanup-source-processing.use-case';
 import { CleanupSourceProcessingCommand } from './cleanup-source-processing.command';
@@ -32,6 +33,10 @@ describe('CleanupSourceProcessingUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CleanupSourceProcessingUseCase,
+        {
+          provide: getLoggerToken(CleanupSourceProcessingUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: DocumentProcessingPort, useValue: documentProcessingPort },
         { provide: UrlCrawlProcessingPort, useValue: urlCrawlProcessingPort },
         {
@@ -42,8 +47,6 @@ describe('CleanupSourceProcessingUseCase', () => {
     }).compile();
 
     useCase = module.get(CleanupSourceProcessingUseCase);
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/cleanup-source-processing/cleanup-source-processing.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/cleanup-source-processing/cleanup-source-processing.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { DocumentProcessingPort } from '../../ports/document-processing.port';
 import { UrlCrawlProcessingPort } from '../../ports/url-crawl-processing.port';
@@ -17,9 +18,9 @@ import { CleanupSourceProcessingCommand } from './cleanup-source-processing.comm
  */
 @Injectable()
 export class CleanupSourceProcessingUseCase {
-  private readonly logger = new Logger(CleanupSourceProcessingUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CleanupSourceProcessingUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly documentProcessingPort: DocumentProcessingPort,
     private readonly urlCrawlProcessingPort: UrlCrawlProcessingPort,
     private readonly purgeStoragePrefixesUseCase: PurgeStoragePrefixesUseCase,
@@ -29,10 +30,13 @@ export class CleanupSourceProcessingUseCase {
     if (command.sourceIds.length === 0) {
       return;
     }
-    this.logger.log('Cleaning up source processing', {
-      orgId: command.orgId,
-      sourceCount: command.sourceIds.length,
-    });
+    this.logger.info(
+      {
+        orgId: command.orgId,
+        sourceCount: command.sourceIds.length,
+      },
+      'Cleaning up source processing',
+    );
 
     for (const sourceId of command.sourceIds) {
       await this.cancelJobs(sourceId);
@@ -47,10 +51,10 @@ export class CleanupSourceProcessingUseCase {
         ),
       );
     } catch (error) {
-      this.logger.warn('Failed to purge source processing storage', {
-        orgId: command.orgId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.warn(
+        { err: error as Error, orgId: command.orgId },
+        'Failed to purge source processing storage',
+      );
     }
   }
 
@@ -60,18 +64,24 @@ export class CleanupSourceProcessingUseCase {
     try {
       await this.documentProcessingPort.cancelJob(sourceId);
     } catch (err) {
-      this.logger.warn('Failed to cancel document processing job', {
-        sourceId,
-        error: err as Error,
-      });
+      this.logger.warn(
+        {
+          sourceId,
+          err: err as Error,
+        },
+        'Failed to cancel document processing job',
+      );
     }
     try {
       await this.urlCrawlProcessingPort.cancelJob(sourceId);
     } catch (err) {
-      this.logger.warn('Failed to cancel URL crawl job', {
-        sourceId,
-        error: err as Error,
-      });
+      this.logger.warn(
+        {
+          sourceId,
+          err: err as Error,
+        },
+        'Failed to cancel URL crawl job',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-data-source/create-data-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-data-source/create-data-source.use-case.ts
@@ -7,7 +7,8 @@ import {
   CreateDataSourceCommand,
   CreateCSVDataSourceCommand,
 } from './create-data-source.command';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   InvalidSourceTypeError,
   UnexpectedSourceError,
@@ -16,22 +17,28 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class CreateDataSourceUseCase {
-  private readonly logger = new Logger(CreateDataSourceUseCase.name);
-  constructor(private readonly sourceRepository: SourceRepository) {}
+  constructor(
+    @InjectPinoLogger(CreateDataSourceUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly sourceRepository: SourceRepository,
+  ) {}
 
   async execute(command: CreateCSVDataSourceCommand): Promise<CSVDataSource>;
   async execute(command: CreateDataSourceCommand): Promise<DataSource>;
   async execute(command: CreateDataSourceCommand): Promise<DataSource> {
-    this.logger.log('execute', {
-      name:
-        command instanceof CreateCSVDataSourceCommand
-          ? command.name
-          : undefined,
-      rowCount:
-        command instanceof CreateCSVDataSourceCommand
-          ? command.data.rows.length
-          : undefined,
-    });
+    this.logger.info(
+      {
+        name:
+          command instanceof CreateCSVDataSourceCommand
+            ? command.name
+            : undefined,
+        rowCount:
+          command instanceof CreateCSVDataSourceCommand
+            ? command.data.rows.length
+            : undefined,
+      },
+      'execute',
+    );
     try {
       if (command instanceof CreateCSVDataSourceCommand) {
         const dataSource = new CSVDataSource({
@@ -45,9 +52,12 @@ export class CreateDataSourceUseCase {
       throw new InvalidSourceTypeError(command.constructor.name);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error creating data source', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error creating data source',
+      );
       throw new UnexpectedSourceError('Error creating data source', {
         error: error as Error,
       });

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-processing-source/create-processing-source.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-processing-source/create-processing-source.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { CreateProcessingSourceUseCase } from './create-processing-source.use-case';
@@ -18,6 +20,10 @@ describe('CreateProcessingSourceUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateProcessingSourceUseCase,
+        {
+          provide: getLoggerToken(CreateProcessingSourceUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SourceRepository, useValue: mockSourceRepository },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-processing-source/create-processing-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-processing-source/create-processing-source.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { FileType, TextType } from 'src/domain/sources/domain/source-type.enum';
 import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
@@ -13,14 +14,19 @@ import { CreateProcessingSourceCommand } from './create-processing-source.comman
 
 @Injectable()
 export class CreateProcessingSourceUseCase {
-  private readonly logger = new Logger(CreateProcessingSourceUseCase.name);
-
-  constructor(private readonly sourceRepository: SourceRepository) {}
+  constructor(
+    @InjectPinoLogger(CreateProcessingSourceUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly sourceRepository: SourceRepository,
+  ) {}
 
   async execute(command: CreateProcessingSourceCommand): Promise<FileSource> {
-    this.logger.debug('Creating processing source', {
-      fileName: command.fileName,
-    });
+    this.logger.debug(
+      {
+        fileName: command.fileName,
+      },
+      'Creating processing source',
+    );
 
     try {
       const source = new FileSource({
@@ -34,9 +40,12 @@ export class CreateProcessingSourceUseCase {
       return (await this.sourceRepository.save(source)) as FileSource;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error creating processing source', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error creating processing source',
+      );
       throw new UnexpectedSourceError('Error creating processing source', {
         error: error as Error,
       });

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-processing-url-source/create-processing-url-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-processing-url-source/create-processing-url-source.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UrlSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { TextType } from 'src/domain/sources/domain/source-type.enum';
 import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
@@ -10,12 +11,14 @@ import { CreateProcessingUrlSourceCommand } from './create-processing-url-source
 
 @Injectable()
 export class CreateProcessingUrlSourceUseCase {
-  private readonly logger = new Logger(CreateProcessingUrlSourceUseCase.name);
-
-  constructor(private readonly sourceRepository: SourceRepository) {}
+  constructor(
+    @InjectPinoLogger(CreateProcessingUrlSourceUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly sourceRepository: SourceRepository,
+  ) {}
 
   async execute(command: CreateProcessingUrlSourceCommand): Promise<UrlSource> {
-    this.logger.debug('Creating processing URL source', { url: command.url });
+    this.logger.debug({ url: command.url }, 'Creating processing URL source');
 
     try {
       const source = new UrlSource({
@@ -35,9 +38,12 @@ export class CreateProcessingUrlSourceUseCase {
       return (await this.sourceRepository.save(source)) as UrlSource;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error creating processing URL source', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error creating processing URL source',
+      );
       throw new UnexpectedSourceError('Error creating processing URL source', {
         error: error as Error,
       });

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import {
   FileSource,
@@ -42,9 +43,9 @@ interface TextSourceWithContent {
 
 @Injectable()
 export class CreateTextSourceUseCase {
-  private readonly logger = new Logger(CreateTextSourceUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateTextSourceUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly retrieveUrlUseCase: RetrieveUrlUseCase,
     private readonly contextService: ContextService,
     private readonly retrieveFileContentUseCase: RetrieveFileContentUseCase,
@@ -72,7 +73,7 @@ export class CreateTextSourceUseCase {
       } else {
         throw new InvalidSourceTypeError(command.constructor.name);
       }
-      this.logger.debug('Saving source', { sourceId: result.source.id });
+      this.logger.debug({ sourceId: result.source.id }, 'Saving source');
       const saved = await this.sourceRepository.saveTextSource(result.source, {
         text: result.text,
         chunks: result.chunks,
@@ -85,9 +86,12 @@ export class CreateTextSourceUseCase {
       return saved;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error creating text source', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error creating text source',
+      );
       throw new UnexpectedSourceError('Error creating text source', {
         error: error as Error,
       });
@@ -209,7 +213,7 @@ export class CreateTextSourceUseCase {
     chunks: TextSourceContentChunk[];
     orgId: UUID;
   }): Promise<void> {
-    this.logger.debug(`Indexing content for source: ${params.sourceId}`);
+    this.logger.debug({ sourceId: params.sourceId }, 'Indexing source content');
 
     // Step 1: Delete any existing index entries for this source
     // (handles re-upload/re-index scenarios, no-op for new sources)
@@ -231,7 +235,8 @@ export class CreateTextSourceUseCase {
     );
 
     this.logger.debug(
-      `Successfully indexed ${params.chunks.length} content blocks for source: ${params.sourceId}`,
+      { sourceId: params.sourceId, chunkCount: params.chunks.length },
+      'Successfully indexed source content',
     );
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/delete-source/delete-source.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/delete-source/delete-source.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 
@@ -64,6 +66,10 @@ describe('DeleteSourceUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeleteSourceUseCase,
+        {
+          provide: getLoggerToken(DeleteSourceUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SourceRepository, useValue: mockSourceRepository },
         {
           provide: CleanupSourceProcessingUseCase,

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/delete-source/delete-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/delete-source/delete-source.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SourceRepository } from '../../ports/source.repository';
 import { DeleteSourceCommand } from './delete-source.command';
 import { DeleteContentUseCase } from 'src/domain/rag/indexers/application/use-cases/delete-content/delete-content.use-case';
@@ -12,9 +13,9 @@ import { Transactional } from '@nestjs-cls/transactional';
 
 @Injectable()
 export class DeleteSourceUseCase {
-  private readonly logger = new Logger(DeleteSourceUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteSourceUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly deleteContentUseCase: DeleteContentUseCase,
     private readonly sourceRepository: SourceRepository,
     private readonly cleanupSourceProcessingUseCase: CleanupSourceProcessingUseCase,
@@ -22,7 +23,7 @@ export class DeleteSourceUseCase {
 
   @Transactional()
   async execute(command: DeleteSourceCommand): Promise<void> {
-    this.logger.debug(`Deleting source: ${command.sourceId}`);
+    this.logger.debug({ sourceId: command.sourceId }, 'Deleting source');
     try {
       const source = await this.sourceRepository.findById(command.sourceId);
 
@@ -41,15 +42,19 @@ export class DeleteSourceUseCase {
       await this.sourceRepository.delete(command.sourceId);
 
       this.logger.debug(
-        `Successfully deleted source and indexed content: ${command.sourceId}`,
+        { sourceId: command.sourceId },
+        'Successfully deleted source and indexed content',
       );
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error deleting source', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error deleting source',
+      );
       throw new UnexpectedSourceError('Error deleting source', {
         error: error as Error,
       });

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/delete-sources/delete-sources.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/delete-sources/delete-sources.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 
@@ -50,6 +52,10 @@ describe('DeleteSourcesUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeleteSourcesUseCase,
+        {
+          provide: getLoggerToken(DeleteSourcesUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SourceRepository, useValue: mockSourceRepository },
         {
           provide: CleanupSourceProcessingUseCase,

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/delete-sources/delete-sources.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/delete-sources/delete-sources.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { SourceRepository } from '../../ports/source.repository';
 import { DeleteSourcesCommand } from './delete-sources.command';
@@ -12,9 +13,9 @@ import { IndexRegistry } from 'src/domain/rag/indexers/application/indexer.regis
 
 @Injectable()
 export class DeleteSourcesUseCase {
-  private readonly logger = new Logger(DeleteSourcesUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteSourcesUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly indexRegistry: IndexRegistry,
     private readonly sourceRepository: SourceRepository,
     private readonly cleanupSourceProcessingUseCase: CleanupSourceProcessingUseCase,
@@ -26,7 +27,10 @@ export class DeleteSourcesUseCase {
       return;
     }
 
-    this.logger.debug(`Deleting ${command.sourceIds.length} sources`);
+    this.logger.debug(
+      { sourceCount: command.sourceIds.length },
+      'Deleting sources',
+    );
     try {
       // Cancel jobs and clean MinIO for any processing sources
       await this.cancelProcessingSources(command.sourceIds, command.orgId);
@@ -41,15 +45,19 @@ export class DeleteSourcesUseCase {
       await this.sourceRepository.deleteMany(command.sourceIds);
 
       this.logger.debug(
-        `Successfully deleted ${command.sourceIds.length} sources and their indexed content`,
+        { sourceCount: command.sourceIds.length },
+        'Successfully deleted sources and their indexed content',
       );
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error deleting sources', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error deleting sources',
+      );
       throw new UnexpectedSourceError('Error deleting sources', {
         error: error as Error,
       });

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/enqueue-data-source-processing/enqueue-data-source-processing.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/enqueue-data-source-processing/enqueue-data-source-processing.use-case.spec.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { EnqueueDataSourceProcessingUseCase } from './enqueue-data-source-processing.use-case';
 import { EnqueueDataSourceProcessingCommand } from './enqueue-data-source-processing.command';
 import type { DataSourceProcessingPort } from '../../ports/data-source-processing.port';
@@ -31,7 +32,10 @@ describe('EnqueueDataSourceProcessingUseCase', () => {
     port = {
       enqueue: jest.fn().mockResolvedValue(undefined),
     };
-    useCase = new EnqueueDataSourceProcessingUseCase(port);
+    useCase = new EnqueueDataSourceProcessingUseCase(
+      createPinoLoggerMock(),
+      port,
+    );
   });
 
   it('enqueues one job carrying the full upload batch', async () => {

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/enqueue-data-source-processing/enqueue-data-source-processing.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/enqueue-data-source-processing/enqueue-data-source-processing.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { DataSourceProcessingPort } from '../../ports/data-source-processing.port';
 import { EnqueueDataSourceProcessingCommand } from './enqueue-data-source-processing.command';
@@ -6,18 +7,21 @@ import { UnexpectedSourceError } from '../../sources.errors';
 
 @Injectable()
 export class EnqueueDataSourceProcessingUseCase {
-  private readonly logger = new Logger(EnqueueDataSourceProcessingUseCase.name);
-
   constructor(
+    @InjectPinoLogger(EnqueueDataSourceProcessingUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly dataSourceProcessingPort: DataSourceProcessingPort,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedSourceError)
   async execute(command: EnqueueDataSourceProcessingCommand): Promise<void> {
-    this.logger.debug('Enqueuing data source processing job', {
-      fileName: command.fileName,
-      targetCount: command.targets.length,
-    });
+    this.logger.debug(
+      {
+        fileName: command.fileName,
+        targetCount: command.targets.length,
+      },
+      'Enqueuing data source processing job',
+    );
 
     await this.dataSourceProcessingPort.enqueue({
       uploadId: command.uploadId,

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/enqueue-document-processing/enqueue-document-processing.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/enqueue-document-processing/enqueue-document-processing.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { DocumentProcessingPort } from '../../ports/document-processing.port';
 import { EnqueueDocumentProcessingCommand } from './enqueue-document-processing.command';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -6,17 +7,20 @@ import { UnexpectedSourceError } from '../../sources.errors';
 
 @Injectable()
 export class EnqueueDocumentProcessingUseCase {
-  private readonly logger = new Logger(EnqueueDocumentProcessingUseCase.name);
-
   constructor(
+    @InjectPinoLogger(EnqueueDocumentProcessingUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly documentProcessingPort: DocumentProcessingPort,
   ) {}
 
   async execute(command: EnqueueDocumentProcessingCommand): Promise<void> {
-    this.logger.debug('Enqueuing document processing job', {
-      sourceId: command.sourceId,
-      fileName: command.fileName,
-    });
+    this.logger.debug(
+      {
+        sourceId: command.sourceId,
+        fileName: command.fileName,
+      },
+      'Enqueuing document processing job',
+    );
 
     try {
       await this.documentProcessingPort.enqueue({
@@ -29,9 +33,12 @@ export class EnqueueDocumentProcessingUseCase {
       });
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error enqueuing document processing job', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error enqueuing document processing job',
+      );
       throw new UnexpectedSourceError(
         'Error enqueuing document processing job',
         { error: error as Error },

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/enqueue-url-crawl/enqueue-url-crawl.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/enqueue-url-crawl/enqueue-url-crawl.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UrlCrawlProcessingPort } from '../../ports/url-crawl-processing.port';
 import { EnqueueUrlCrawlCommand } from './enqueue-url-crawl.command';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -6,17 +7,20 @@ import { UnexpectedSourceError } from '../../sources.errors';
 
 @Injectable()
 export class EnqueueUrlCrawlUseCase {
-  private readonly logger = new Logger(EnqueueUrlCrawlUseCase.name);
-
   constructor(
+    @InjectPinoLogger(EnqueueUrlCrawlUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly urlCrawlProcessingPort: UrlCrawlProcessingPort,
   ) {}
 
   async execute(command: EnqueueUrlCrawlCommand): Promise<void> {
-    this.logger.debug('Enqueuing URL crawl job', {
-      sourceId: command.sourceId,
-      rootUrl: command.rootUrl,
-    });
+    this.logger.debug(
+      {
+        sourceId: command.sourceId,
+        url: command.rootUrl,
+      },
+      'Enqueuing URL crawl job',
+    );
 
     try {
       await this.urlCrawlProcessingPort.enqueue({
@@ -28,9 +32,12 @@ export class EnqueueUrlCrawlUseCase {
       });
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error enqueuing URL crawl job', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error enqueuing URL crawl job',
+      );
       throw new UnexpectedSourceError('Error enqueuing URL crawl job', {
         error: error as Error,
       });

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ExtractTextLinesUseCase } from './extract-text-lines.use-case';
@@ -18,6 +20,10 @@ describe('ExtractTextLinesUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ExtractTextLinesUseCase,
+        {
+          provide: getLoggerToken(ExtractTextLinesUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: SourceRepository,
           useValue: mockSourceRepository,

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/extract-text-lines/extract-text-lines.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { SourceRepository } from '../../ports/source.repository';
 import { UnexpectedSourceError } from '../../sources.errors';
@@ -11,18 +12,23 @@ export interface ExtractTextLinesResult {
 
 @Injectable()
 export class ExtractTextLinesUseCase {
-  private readonly logger = new Logger(ExtractTextLinesUseCase.name);
-
-  constructor(private readonly sourceRepository: SourceRepository) {}
+  constructor(
+    @InjectPinoLogger(ExtractTextLinesUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly sourceRepository: SourceRepository,
+  ) {}
 
   async execute(
     query: ExtractTextLinesQuery,
   ): Promise<ExtractTextLinesResult | null> {
-    this.logger.log('Extracting text lines', {
-      sourceId: query.sourceId,
-      startLine: query.startLine,
-      endLine: query.endLine,
-    });
+    this.logger.info(
+      {
+        sourceId: query.sourceId,
+        startLine: query.startLine,
+        endLine: query.endLine,
+      },
+      'Extracting text lines',
+    );
 
     try {
       return await this.sourceRepository.extractTextLines(
@@ -32,9 +38,12 @@ export class ExtractTextLinesUseCase {
       );
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error extracting text lines', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error extracting text lines',
+      );
       throw new UnexpectedSourceError(
         error instanceof Error ? error.message : 'Unknown error',
       );

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { FindContentChunksByIdsUseCase } from './find-content-chunks-by-ids.use-case';
@@ -20,6 +22,10 @@ describe('FindContentChunksByIdsUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FindContentChunksByIdsUseCase,
+        {
+          provide: getLoggerToken(FindContentChunksByIdsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: SourceRepository,
           useValue: mockSourceRepository,

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/find-content-chunks-by-ids/find-content-chunks-by-ids.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { ApplicationError } from 'src/common/errors/base.error';
 import type { TextSourceContentChunk } from 'src/domain/sources/domain/source-content-chunk.entity';
@@ -14,16 +15,21 @@ export interface ContentChunkWithSource {
 
 @Injectable()
 export class FindContentChunksByIdsUseCase {
-  private readonly logger = new Logger(FindContentChunksByIdsUseCase.name);
-
-  constructor(private readonly sourceRepository: SourceRepository) {}
+  constructor(
+    @InjectPinoLogger(FindContentChunksByIdsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly sourceRepository: SourceRepository,
+  ) {}
 
   async execute(
     query: FindContentChunksByIdsQuery,
   ): Promise<ContentChunkWithSource[]> {
-    this.logger.log('Finding content chunks by IDs', {
-      count: query.chunkIds.length,
-    });
+    this.logger.info(
+      {
+        count: query.chunkIds.length,
+      },
+      'Finding content chunks by IDs',
+    );
 
     try {
       if (query.chunkIds.length === 0) {
@@ -33,9 +39,12 @@ export class FindContentChunksByIdsUseCase {
       return await this.sourceRepository.findContentChunksByIds(query.chunkIds);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding content chunks by IDs', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error finding content chunks by IDs',
+      );
       throw new UnexpectedSourceError(
         error instanceof Error ? error.message : 'Unknown error',
       );

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/find-unreferenced-source-ids/find-unreferenced-source-ids.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/find-unreferenced-source-ids/find-unreferenced-source-ids.use-case.spec.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { FindUnreferencedSourceIdsUseCase } from './find-unreferenced-source-ids.use-case';
 import { FindUnreferencedSourceIdsQuery } from './find-unreferenced-source-ids.query';
@@ -13,7 +14,10 @@ describe('FindUnreferencedSourceIdsUseCase', () => {
   beforeEach(() => {
     sourceRepository = createMockSourceRepository();
 
-    useCase = new FindUnreferencedSourceIdsUseCase(sourceRepository);
+    useCase = new FindUnreferencedSourceIdsUseCase(
+      createPinoLoggerMock(),
+      sourceRepository,
+    );
   });
 
   it('returns the subset reported by the repository', async () => {

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/find-unreferenced-source-ids/find-unreferenced-source-ids.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/find-unreferenced-source-ids/find-unreferenced-source-ids.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { SourceRepository } from '../../ports/source.repository';
 import { FindUnreferencedSourceIdsQuery } from './find-unreferenced-source-ids.query';
@@ -11,15 +12,20 @@ import { ApplicationError } from 'src/common/errors/base.error';
 // agent schema knowledge out of other modules' adapters.
 @Injectable()
 export class FindUnreferencedSourceIdsUseCase {
-  private readonly logger = new Logger(FindUnreferencedSourceIdsUseCase.name);
-
-  constructor(private readonly sourceRepository: SourceRepository) {}
+  constructor(
+    @InjectPinoLogger(FindUnreferencedSourceIdsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly sourceRepository: SourceRepository,
+  ) {}
 
   async execute(query: FindUnreferencedSourceIdsQuery): Promise<UUID[]> {
-    this.logger.log('execute', {
-      candidateCount: query.candidateIds.length,
-      olderThan: query.olderThan,
-    });
+    this.logger.info(
+      {
+        candidateCount: query.candidateIds.length,
+        olderThan: query.olderThan,
+      },
+      'execute',
+    );
 
     if (query.candidateIds.length === 0) {
       return [];
@@ -32,9 +38,12 @@ export class FindUnreferencedSourceIdsUseCase {
       );
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding unreferenced source IDs', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error finding unreferenced source IDs',
+      );
       throw new UnexpectedSourceError(
         error instanceof Error ? error.message : 'Unknown error',
       );

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/get-source-by-id/get-source-by-id.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/get-source-by-id/get-source-by-id.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Source } from 'src/domain/sources/domain/source.entity';
 import { SourceRepository } from '../../ports/source.repository';
 import { GetSourceByIdQuery } from './get-source-by-id.query';
@@ -8,12 +9,14 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetSourceByIdUseCase {
-  private readonly logger = new Logger(GetSourceByIdUseCase.name);
-
-  constructor(private readonly sourceRepository: SourceRepository) {}
+  constructor(
+    @InjectPinoLogger(GetSourceByIdUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly sourceRepository: SourceRepository,
+  ) {}
 
   async execute(query: GetSourceByIdQuery): Promise<Source> {
-    this.logger.log('execute', { id: query.sourceId });
+    this.logger.info({ id: query.sourceId }, 'execute');
     try {
       const source = await this.sourceRepository.findById(query.sourceId);
       if (!source) {
@@ -22,9 +25,12 @@ export class GetSourceByIdUseCase {
       return source;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting source by ID', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error getting source by ID',
+      );
       throw new UnexpectedSourceError(
         error instanceof Error ? error.message : 'Unknown error',
       );

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { GetSourcesByIdsUseCase } from './get-sources-by-ids.use-case';
 import { GetSourcesByIdsQuery } from './get-sources-by-ids.query';
 import type { SourceRepository } from '../../ports/source.repository';
@@ -27,7 +28,10 @@ describe('GetSourcesByIdsUseCase', () => {
   beforeEach(() => {
     sourceRepository = createMockSourceRepository();
 
-    useCase = new GetSourcesByIdsUseCase(sourceRepository);
+    useCase = new GetSourcesByIdsUseCase(
+      createPinoLoggerMock(),
+      sourceRepository,
+    );
   });
 
   it('should return sources matching the provided IDs', async () => {

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Source } from 'src/domain/sources/domain/source.entity';
 import { SourceRepository } from '../../ports/source.repository';
 import { GetSourcesByIdsQuery } from './get-sources-by-ids.query';
@@ -7,12 +8,14 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetSourcesByIdsUseCase {
-  private readonly logger = new Logger(GetSourcesByIdsUseCase.name);
-
-  constructor(private readonly sourceRepository: SourceRepository) {}
+  constructor(
+    @InjectPinoLogger(GetSourcesByIdsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly sourceRepository: SourceRepository,
+  ) {}
 
   async execute(query: GetSourcesByIdsQuery): Promise<Source[]> {
-    this.logger.log('execute', { count: query.sourceIds.length });
+    this.logger.info({ count: query.sourceIds.length }, 'execute');
     try {
       if (query.sourceIds.length === 0) {
         return [];
@@ -20,9 +23,12 @@ export class GetSourcesByIdsUseCase {
       return await this.sourceRepository.findByIds(query.sourceIds);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting sources by IDs', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error getting sources by IDs',
+      );
       throw new UnexpectedSourceError(
         error instanceof Error ? error.message : 'Unknown error',
       );

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetSourcesByKnowledgeBaseIdUseCase } from './get-sources-by-knowledge-base-id.use-case';
@@ -19,6 +21,10 @@ describe('GetSourcesByKnowledgeBaseIdUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetSourcesByKnowledgeBaseIdUseCase,
+        {
+          provide: getLoggerToken(GetSourcesByKnowledgeBaseIdUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: SourceRepository,
           useValue: mockSourceRepository,

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/get-sources-by-knowledge-base-id/get-sources-by-knowledge-base-id.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import type { Source } from 'src/domain/sources/domain/source.entity';
 import { SourceRepository } from '../../ports/source.repository';
@@ -7,14 +8,19 @@ import { GetSourcesByKnowledgeBaseIdQuery } from './get-sources-by-knowledge-bas
 
 @Injectable()
 export class GetSourcesByKnowledgeBaseIdUseCase {
-  private readonly logger = new Logger(GetSourcesByKnowledgeBaseIdUseCase.name);
-
-  constructor(private readonly sourceRepository: SourceRepository) {}
+  constructor(
+    @InjectPinoLogger(GetSourcesByKnowledgeBaseIdUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly sourceRepository: SourceRepository,
+  ) {}
 
   async execute(query: GetSourcesByKnowledgeBaseIdQuery): Promise<Source[]> {
-    this.logger.log('Finding sources by knowledge base ID', {
-      knowledgeBaseId: query.knowledgeBaseId,
-    });
+    this.logger.info(
+      {
+        knowledgeBaseId: query.knowledgeBaseId,
+      },
+      'Finding sources by knowledge base ID',
+    );
 
     try {
       return await this.sourceRepository.findByKnowledgeBaseId(
@@ -22,9 +28,12 @@ export class GetSourcesByKnowledgeBaseIdUseCase {
       );
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding sources by knowledge base ID', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error finding sources by knowledge base ID',
+      );
       throw new UnexpectedSourceError(
         error instanceof Error ? error.message : 'Unknown error',
       );

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/get-text-source-by-id/get-text-source-by-id.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/get-text-source-by-id/get-text-source-by-id.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetTextSourceByIdUseCase } from './get-text-source-by-id.use-case';
@@ -19,6 +21,10 @@ describe('GetSourceByIdUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetTextSourceByIdUseCase,
+        {
+          provide: getLoggerToken(GetTextSourceByIdUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: SourceRepository,
           useValue: mockSourceRepository,

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/get-text-source-by-id/get-text-source-by-id.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/get-text-source-by-id/get-text-source-by-id.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Source } from 'src/domain/sources/domain/source.entity';
 import { SourceRepository } from '../../ports/source.repository';
 import { GetTextSourceByIdQuery } from './get-text-source-by-id.query';
@@ -8,12 +9,14 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetTextSourceByIdUseCase {
-  private readonly logger = new Logger(GetTextSourceByIdUseCase.name);
-
-  constructor(private readonly textSourceRepository: SourceRepository) {}
+  constructor(
+    @InjectPinoLogger(GetTextSourceByIdUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly textSourceRepository: SourceRepository,
+  ) {}
 
   async execute(query: GetTextSourceByIdQuery): Promise<Source> {
-    this.logger.log('execute', { id: query.id });
+    this.logger.info({ id: query.id }, 'execute');
     try {
       const source = await this.textSourceRepository.findById(query.id);
       if (!source) {
@@ -22,9 +25,12 @@ export class GetTextSourceByIdUseCase {
       return source;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting text source by ID', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error getting text source by ID',
+      );
       throw new UnexpectedSourceError(
         error instanceof Error ? error.message : 'Unknown error',
       );

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/mark-source-failed/mark-source-failed.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/mark-source-failed/mark-source-failed.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken, type PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -13,15 +15,21 @@ import { FileType, TextType } from 'src/domain/sources/domain/source-type.enum';
 describe('MarkSourceFailedUseCase', () => {
   let useCase: MarkSourceFailedUseCase;
   let mockSourceRepository: jest.Mocked<SourceRepository>;
+  let logger: jest.Mocked<PinoLogger>;
 
   const sourceId = '44444444-4444-4444-4444-444444444444' as UUID;
 
   beforeEach(async () => {
     mockSourceRepository = createMockSourceRepository();
+    logger = createPinoLoggerMock();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MarkSourceFailedUseCase,
+        {
+          provide: getLoggerToken(MarkSourceFailedUseCase.name),
+          useValue: logger,
+        },
         { provide: SourceRepository, useValue: mockSourceRepository },
       ],
     }).compile();
@@ -52,6 +60,15 @@ describe('MarkSourceFailedUseCase', () => {
     expect(savedSource.status).toBe(SourceStatus.FAILED);
     expect(savedSource.processingError).toBe(
       'Failed to upload file to storage',
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      {
+        sourceId,
+        err: expect.objectContaining({
+          message: 'Failed to upload file to storage',
+        }),
+      },
+      'Source marked as failed',
     );
   });
 

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/mark-source-failed/mark-source-failed.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/mark-source-failed/mark-source-failed.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
 import { SourceRepository } from '../../ports/source.repository';
 import {
@@ -10,9 +11,11 @@ import { MarkSourceFailedCommand } from './mark-source-failed.command';
 
 @Injectable()
 export class MarkSourceFailedUseCase {
-  private readonly logger = new Logger(MarkSourceFailedUseCase.name);
-
-  constructor(private readonly sourceRepository: SourceRepository) {}
+  constructor(
+    @InjectPinoLogger(MarkSourceFailedUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly sourceRepository: SourceRepository,
+  ) {}
 
   async execute(command: MarkSourceFailedCommand): Promise<void> {
     try {
@@ -25,15 +28,21 @@ export class MarkSourceFailedUseCase {
       source.processingError = command.errorMessage;
       await this.sourceRepository.save(source);
 
-      this.logger.warn('Source marked as failed', {
-        sourceId: command.sourceId,
-        errorMessage: command.errorMessage,
-      });
+      this.logger.warn(
+        {
+          sourceId: command.sourceId,
+          err: new Error(command.errorMessage),
+        },
+        'Source marked as failed',
+      );
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error marking source as failed', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error marking source as failed',
+      );
       throw new UnexpectedSourceError('Error marking source as failed', {
         error: error as Error,
       });

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/query-text-source/query-text-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/query-text-source/query-text-source.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SourceRepository } from '../../ports/source.repository';
 import { QueryTextSourceCommand } from './query-text-source.command';
 import { SearchContentUseCase } from 'src/domain/rag/indexers/application/use-cases/search-content/search-content.use-case';
@@ -8,9 +9,9 @@ import type { TextSourceContentChunk } from 'src/domain/sources/domain/source-co
 
 @Injectable()
 export class QueryTextSourceUseCase {
-  private readonly logger = new Logger(QueryTextSourceUseCase.name);
-
   constructor(
+    @InjectPinoLogger(QueryTextSourceUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly sourceRepository: SourceRepository,
     private readonly searchContentUseCase: SearchContentUseCase,
   ) {}
@@ -18,7 +19,11 @@ export class QueryTextSourceUseCase {
   async execute(
     command: QueryTextSourceCommand,
   ): Promise<TextSourceContentChunk[]> {
-    this.logger.log('execute', command);
+    const logContext = {
+      sourceId: command.filter.sourceId,
+      text: command.query,
+    };
+    this.logger.info({ orgId: command.orgId, ...logContext }, 'execute');
     // Validate input
     if (!command.query || command.query.trim().length === 0) {
       this.logger.warn('Empty query provided for vector search');
@@ -26,9 +31,7 @@ export class QueryTextSourceUseCase {
     }
 
     try {
-      this.logger.debug(
-        `Performing vector search for query: "${command.query}" in source: ${command.filter.sourceId}`,
-      );
+      this.logger.debug(logContext, 'Performing vector search');
 
       // Use the searchContentUseCase to search for relevant content
       const searchQuery = new SearchContentQuery({
@@ -42,7 +45,8 @@ export class QueryTextSourceUseCase {
       const indexEntries = await this.searchContentUseCase.execute(searchQuery);
 
       this.logger.debug(
-        `Found ${indexEntries.length} index entries for query: "${command.query}" in source: ${command.filter.sourceId}`,
+        { ...logContext, entryCount: indexEntries.length },
+        'Found index entries for vector search',
       );
 
       if (indexEntries.length === 0) {
@@ -55,14 +59,15 @@ export class QueryTextSourceUseCase {
         await this.sourceRepository.findContentChunksByIds(chunkIds);
 
       this.logger.debug(
-        `Successfully matched ${chunkResults.length} source content items for query: "${command.query}" in source: ${command.filter.sourceId}`,
+        { ...logContext, chunkCount: chunkResults.length },
+        'Matched source content for vector search',
       );
 
       return chunkResults.map((r) => r.chunk);
     } catch (error) {
       this.logger.error(
-        `Error during vector search for query "${command.query}":`,
-        error instanceof Error ? error.message : 'Unknown error',
+        { ...logContext, err: error as Error },
+        'Error during vector search',
       );
       throw new Error(`Vector search failed`);
     }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/start-data-source-processing/start-data-source-processing.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/start-data-source-processing/start-data-source-processing.use-case.spec.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 
 jest.mock('@nestjs-cls/transactional', () => ({
   Transactional:
@@ -58,6 +59,7 @@ describe('StartDataSourceProcessingUseCase', () => {
     } as unknown as ContextService;
 
     useCase = new StartDataSourceProcessingUseCase(
+      createPinoLoggerMock(),
       sourceRepository,
       parser,
       markSourceFailed,

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/start-data-source-processing/start-data-source-processing.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/start-data-source-processing/start-data-source-processing.use-case.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import type { UUID } from 'crypto';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { ContextService } from 'src/common/context/services/context.service';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
@@ -39,9 +40,9 @@ interface SourcePlan {
  */
 @Injectable()
 export class StartDataSourceProcessingUseCase {
-  private readonly logger = new Logger(StartDataSourceProcessingUseCase.name);
-
   constructor(
+    @InjectPinoLogger(StartDataSourceProcessingUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly sourceRepository: SourceRepository,
     private readonly spreadsheetParser: SpreadsheetParserPort,
     private readonly markSourceFailedUseCase: MarkSourceFailedUseCase,
@@ -55,10 +56,13 @@ export class StartDataSourceProcessingUseCase {
   async execute(
     command: StartDataSourceProcessingCommand,
   ): Promise<CSVDataSource[]> {
-    this.logger.log('Starting async data source processing', {
-      fileName: command.fileName,
-      kind: command.kind,
-    });
+    this.logger.info(
+      {
+        fileName: command.fileName,
+        kind: command.kind,
+      },
+      'Starting async data source processing',
+    );
 
     const orgId = this.contextService.get('orgId');
     if (!orgId) {
@@ -183,10 +187,13 @@ export class StartDataSourceProcessingUseCase {
         }),
       );
     } catch (error) {
-      this.logger.error('Failed to enqueue data source processing job', {
-        sourceIds: batch.sources.map((source) => source.id),
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          sourceIds: batch.sources.map((source) => source.id),
+          err: error as Error,
+        },
+        'Failed to enqueue data source processing job',
+      );
       await this.tryMarkSourcesFailed(
         batch.sources,
         'Failed to enqueue processing job',
@@ -202,10 +209,13 @@ export class StartDataSourceProcessingUseCase {
         new DeleteObjectCommand(minioPath),
       );
     } catch (err) {
-      this.logger.warn('Failed to clean up MinIO processing file', {
-        minioPath,
-        error: err as Error,
-      });
+      this.logger.warn(
+        {
+          fileName: minioPath,
+          err: err as Error,
+        },
+        'Failed to clean up MinIO processing file',
+      );
     }
   }
 
@@ -222,10 +232,13 @@ export class StartDataSourceProcessingUseCase {
           }),
         );
       } catch (err) {
-        this.logger.error('Failed to mark source as FAILED', {
-          sourceId: source.id,
-          error: err as Error,
-        });
+        this.logger.error(
+          {
+            sourceId: source.id,
+            err: err as Error,
+          },
+          'Failed to mark source as FAILED',
+        );
       }
     }
   }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -87,6 +89,10 @@ describe('StartDocumentProcessingUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         StartDocumentProcessingUseCase,
+        {
+          provide: getLoggerToken(StartDocumentProcessingUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: CreateProcessingSourceUseCase,
           useValue: mockCreateProcessingSourceUseCase,

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case.ts
@@ -1,5 +1,6 @@
 import type { UUID } from 'crypto';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { buildMinioProcessingPath } from '../../util/minio-processing-file.helpers';
@@ -23,9 +24,9 @@ import { StartDocumentProcessingCommand } from './start-document-processing.comm
 
 @Injectable()
 export class StartDocumentProcessingUseCase {
-  private readonly logger = new Logger(StartDocumentProcessingUseCase.name);
-
   constructor(
+    @InjectPinoLogger(StartDocumentProcessingUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly createProcessingSourceUseCase: CreateProcessingSourceUseCase,
     private readonly markSourceFailedUseCase: MarkSourceFailedUseCase,
     private readonly uploadObjectUseCase: UploadObjectUseCase,
@@ -37,19 +38,14 @@ export class StartDocumentProcessingUseCase {
   ) {}
 
   async execute(command: StartDocumentProcessingCommand): Promise<FileSource> {
-    this.logger.log('Starting async document processing', {
-      fileName: command.fileName,
-    });
+    const { fileName } = command;
+    this.logger.info({ fileName }, 'Starting async document processing');
 
     try {
       const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new Error('orgId is required');
-      }
+      if (!orgId) throw new Error('orgId is required');
       const userId = this.contextService.get('userId');
-      if (!userId) {
-        throw new Error('userId is required');
-      }
+      if (!userId) throw new Error('userId is required');
 
       // Indexing resolves the org's embedding model only inside the worker,
       // after the (expensive) OCR step — reject here so an unprovisioned org
@@ -89,9 +85,12 @@ export class StartDocumentProcessingUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error starting document processing', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error starting document processing',
+      );
       throw new UnexpectedSourceError('Error starting document processing', {
         error: error as Error,
       });
@@ -135,10 +134,13 @@ export class StartDocumentProcessingUseCase {
         }),
       );
     } catch (error) {
-      this.logger.error('Failed to enqueue document processing job', {
-        sourceId: source.id,
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          sourceId: source.id,
+          err: error as Error,
+        },
+        'Failed to enqueue document processing job',
+      );
       await this.tryMarkSourceFailed(
         source,
         'Failed to enqueue processing job',
@@ -154,10 +156,13 @@ export class StartDocumentProcessingUseCase {
         new DeleteObjectCommand(minioPath),
       );
     } catch (err) {
-      this.logger.warn('Failed to clean up MinIO processing file', {
-        minioPath,
-        error: err as Error,
-      });
+      this.logger.warn(
+        {
+          fileName: minioPath,
+          err: err as Error,
+        },
+        'Failed to clean up MinIO processing file',
+      );
     }
   }
 
@@ -173,10 +178,13 @@ export class StartDocumentProcessingUseCase {
         }),
       );
     } catch (err) {
-      this.logger.error('Failed to mark source as FAILED', {
-        sourceId: source.id,
-        error: err as Error,
-      });
+      this.logger.error(
+        {
+          sourceId: source.id,
+          err: err as Error,
+        },
+        'Failed to mark source as FAILED',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/start-url-crawl/start-url-crawl.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/start-url-crawl/start-url-crawl.use-case.ts
@@ -1,4 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UrlSource } from 'src/domain/sources/domain/sources/text-source.entity';
@@ -13,9 +15,9 @@ import { StartUrlCrawlCommand } from './start-url-crawl.command';
 
 @Injectable()
 export class StartUrlCrawlUseCase {
-  private readonly logger = new Logger(StartUrlCrawlUseCase.name);
-
   constructor(
+    @InjectPinoLogger(StartUrlCrawlUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly createProcessingUrlSourceUseCase: CreateProcessingUrlSourceUseCase,
     private readonly markSourceFailedUseCase: MarkSourceFailedUseCase,
     private readonly enqueueUrlCrawlUseCase: EnqueueUrlCrawlUseCase,
@@ -23,10 +25,10 @@ export class StartUrlCrawlUseCase {
   ) {}
 
   async execute(command: StartUrlCrawlCommand): Promise<UrlSource> {
-    this.logger.log('Starting async URL crawl', {
-      url: command.url,
-      maxDepth: command.maxDepth,
-    });
+    this.logger.info(
+      { maxDepth: command.maxDepth, url: command.url },
+      'Starting async URL crawl',
+    );
 
     try {
       const orgId = this.contextService.get('orgId');
@@ -42,36 +44,41 @@ export class StartUrlCrawlUseCase {
         }),
       );
 
-      // 2. Enqueue BullMQ crawl job
-      try {
-        await this.enqueueUrlCrawlUseCase.execute(
-          new EnqueueUrlCrawlCommand({
-            sourceId: savedSource.id,
-            orgId,
-            userId,
-            rootUrl: command.url,
-            maxDepth: command.maxDepth,
-          }),
-        );
-      } catch (error) {
-        this.logger.error('Failed to enqueue URL crawl job', {
-          sourceId: savedSource.id,
-          error: error as Error,
-        });
-        await this.tryMarkSourceFailed(
-          savedSource,
-          'Failed to enqueue crawl job',
-        );
-        throw error;
-      }
+      await this.enqueueOrFail(savedSource, orgId, userId, command);
 
       return savedSource;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error starting URL crawl', { error: error as Error });
+      this.logger.error({ err: error as Error }, 'Error starting URL crawl');
       throw new UnexpectedSourceError('Error starting URL crawl', {
         error: error as Error,
       });
+    }
+  }
+
+  private async enqueueOrFail(
+    source: UrlSource,
+    orgId: UUID,
+    userId: UUID,
+    command: StartUrlCrawlCommand,
+  ): Promise<void> {
+    try {
+      await this.enqueueUrlCrawlUseCase.execute(
+        new EnqueueUrlCrawlCommand({
+          sourceId: source.id,
+          orgId,
+          userId,
+          rootUrl: command.url,
+          maxDepth: command.maxDepth,
+        }),
+      );
+    } catch (error) {
+      this.logger.error(
+        { err: error as Error, sourceId: source.id },
+        'Failed to enqueue URL crawl job',
+      );
+      await this.tryMarkSourceFailed(source, 'Failed to enqueue crawl job');
+      throw error;
     }
   }
 
@@ -84,10 +91,13 @@ export class StartUrlCrawlUseCase {
         new MarkSourceFailedCommand({ sourceId: source.id, errorMessage }),
       );
     } catch (err) {
-      this.logger.error('Failed to mark source as FAILED', {
-        sourceId: source.id,
-        error: err as Error,
-      });
+      this.logger.error(
+        {
+          sourceId: source.id,
+          err: err as Error,
+        },
+        'Failed to mark source as FAILED',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/util/minio-processing-file.helpers.ts
+++ b/ayunis-core-backend/src/domain/sources/application/util/minio-processing-file.helpers.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import type { Logger } from '@nestjs/common';
+import type { PinoLogger } from 'nestjs-pino';
 import type { DownloadObjectUseCase } from 'src/domain/storage/application/use-cases/download-object/download-object.use-case';
 import { DownloadObjectCommand } from 'src/domain/storage/application/use-cases/download-object/download-object.command';
 import type { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
@@ -39,15 +39,18 @@ export async function downloadMinioFile(
 /** Best-effort: a failed cleanup is logged, never thrown. */
 export async function cleanupMinioProcessingFile(
   deleteObjectUseCase: DeleteObjectUseCase,
-  logger: Logger,
+  logger: PinoLogger,
   minioPath: string,
 ): Promise<void> {
   try {
     await deleteObjectUseCase.execute(new DeleteObjectCommand(minioPath));
   } catch (err) {
-    logger.warn('Failed to clean up MinIO processing file', {
-      minioPath,
-      error: err as Error,
-    });
+    logger.warn(
+      {
+        fileName: minioPath,
+        err: err as Error,
+      },
+      'Failed to clean up MinIO processing file',
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/local-source.repository.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/local-source.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { LessThan, Repository } from 'typeorm';
 import type { UUID } from 'crypto';
@@ -24,9 +25,9 @@ import { SourceContentChunkMapper } from './mappers/source-content-chunk.mapper'
 
 @Injectable()
 export class LocalSourceRepository extends SourceRepository {
-  private readonly logger = new Logger(LocalSourceRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalSourceRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(SourceRecord)
     private readonly sourceRepository: Repository<SourceRecord>,
     @InjectRepository(TextSourceDetailsRecord)
@@ -42,7 +43,7 @@ export class LocalSourceRepository extends SourceRepository {
   }
 
   async findById(id: UUID): Promise<TextSource | DataSource | null> {
-    this.logger.log('findById', { id });
+    this.logger.info({ id }, 'findById');
     const record = await this.sourceRepository.findOne({
       where: { id },
     });
@@ -79,7 +80,7 @@ export class LocalSourceRepository extends SourceRepository {
   }
 
   async findByIds(ids: UUID[]): Promise<Source[]> {
-    this.logger.log('findByIds', { count: ids.length });
+    this.logger.info({ count: ids.length }, 'findByIds');
     if (ids.length === 0) {
       return [];
     }
@@ -97,7 +98,7 @@ export class LocalSourceRepository extends SourceRepository {
   }
 
   async findByKnowledgeBaseId(knowledgeBaseId: UUID): Promise<Source[]> {
-    this.logger.log('findByKnowledgeBaseId', { knowledgeBaseId });
+    this.logger.info({ knowledgeBaseId }, 'findByKnowledgeBaseId');
     const records = await this.sourceRepository
       .createQueryBuilder('source')
       .leftJoinAndSelect(
@@ -115,18 +116,21 @@ export class LocalSourceRepository extends SourceRepository {
     source: TextSource,
     content: { text: string; chunks: TextSourceContentChunk[] },
   ): Promise<TextSource> {
-    this.logger.log('saveTextSource', { sourceId: source.id });
+    this.logger.info({ sourceId: source.id }, 'saveTextSource');
     const {
       source: sourceRecord,
       details,
       contentChunks,
     } = this.mapper.toTextSourceRecord(source, content);
-    this.logger.debug('Saving text source record', {
-      sourceId: sourceRecord.id,
-      chunksCount: contentChunks.length,
-    });
+    this.logger.debug(
+      {
+        sourceId: sourceRecord.id,
+        chunksCount: contentChunks.length,
+      },
+      'Saving text source record',
+    );
     const savedSource = await this.sourceRepository.save(sourceRecord);
-    this.logger.debug('Saved source record with id', { id: savedSource.id });
+    this.logger.debug({ id: savedSource.id }, 'Saved source record with id');
     const savedDetails = await this.textSourceDetailsRepository.save(details);
     const savedContentChunks =
       await this.sourceContentChunkRepository.save(contentChunks);
@@ -139,7 +143,7 @@ export class LocalSourceRepository extends SourceRepository {
     staleBefore: Date,
     limit: number,
   ): Promise<UUID[]> {
-    this.logger.log('findStaleProcessingSourceIds', { staleBefore, limit });
+    this.logger.info({ staleBefore, limit }, 'findStaleProcessingSourceIds');
     const records = await this.sourceRepository.find({
       select: { id: true },
       where: {
@@ -156,18 +160,18 @@ export class LocalSourceRepository extends SourceRepository {
   async save(source: DataSource): Promise<DataSource>;
   async save(source: Source): Promise<Source>;
   async save(source: Source): Promise<Source> {
-    this.logger.log('save', { sourceId: source.id });
+    this.logger.info({ sourceId: source.id }, 'save');
     if (source instanceof TextSource) {
       const { source: sourceRecord } = this.mapper.toRecord(source);
       const savedSource = await this.sourceRepository.save(sourceRecord);
-      this.logger.debug('Saved source record with id', { id: savedSource.id });
+      this.logger.debug({ id: savedSource.id }, 'Saved source record with id');
       return this.mapper.toDomain(savedSource as TextSourceRecord);
     }
     if (source instanceof DataSource) {
       const { source: sourceRecord, details } = this.mapper.toRecord(source);
       sourceRecord.dataSourceDetails = details;
       const savedSource = await this.sourceRepository.save(sourceRecord);
-      this.logger.debug('Saved source record with id', { id: savedSource.id });
+      this.logger.debug({ id: savedSource.id }, 'Saved source record with id');
       const savedDetails = await this.dataSourceDetailsRepository.save(details);
       savedSource.dataSourceDetails = savedDetails;
       return this.mapper.toDomain(savedSource);
@@ -181,11 +185,14 @@ export class LocalSourceRepository extends SourceRepository {
     toStatus: SourceStatus,
     updates?: Partial<{ processingError: string | null }>,
   ): Promise<boolean> {
-    this.logger.log('updateStatusConditionally', {
-      sourceId,
-      fromStatus,
-      toStatus,
-    });
+    this.logger.info(
+      {
+        sourceId,
+        fromStatus,
+        toStatus,
+      },
+      'updateStatusConditionally',
+    );
     const qb = this.sourceRepository
       .createQueryBuilder()
       .update()
@@ -234,7 +241,7 @@ export class LocalSourceRepository extends SourceRepository {
     startLine: number,
     endLine: number,
   ): Promise<{ totalLines: number; text: string } | null> {
-    this.logger.log('extractTextLines', { sourceId, startLine, endLine });
+    this.logger.info({ sourceId, startLine, endLine }, 'extractTextLines');
     const result: { totalLines: string; text: string }[] =
       await this.textSourceDetailsRepository.query(
         `SELECT
@@ -261,7 +268,7 @@ export class LocalSourceRepository extends SourceRepository {
   ): Promise<
     { chunk: TextSourceContentChunk; sourceId: UUID; sourceName: string }[]
   > {
-    this.logger.log('findContentChunksByIds', { count: chunkIds.length });
+    this.logger.info({ count: chunkIds.length }, 'findContentChunksByIds');
     if (chunkIds.length === 0) {
       return [];
     }
@@ -281,7 +288,7 @@ export class LocalSourceRepository extends SourceRepository {
   }
 
   async delete(sourceId: UUID): Promise<void> {
-    this.logger.log('delete', { sourceId });
+    this.logger.info({ sourceId }, 'delete');
     await this.sourceRepository
       .createQueryBuilder()
       .delete()
@@ -290,7 +297,7 @@ export class LocalSourceRepository extends SourceRepository {
   }
 
   async deleteMany(sourceIds: UUID[]): Promise<void> {
-    this.logger.log('deleteMany', { count: sourceIds.length });
+    this.logger.info({ count: sourceIds.length }, 'deleteMany');
     if (sourceIds.length === 0) {
       return;
     }
@@ -305,10 +312,13 @@ export class LocalSourceRepository extends SourceRepository {
     candidateIds: UUID[],
     olderThan: Date,
   ): Promise<UUID[]> {
-    this.logger.log('findUnreferencedIds', {
-      candidateCount: candidateIds.length,
-      olderThan,
-    });
+    this.logger.info(
+      {
+        candidateCount: candidateIds.length,
+        olderThan,
+      },
+      'findUnreferencedIds',
+    );
 
     if (candidateIds.length === 0) {
       return [];

--- a/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/mappers/source.mapper.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/mappers/source.mapper.ts
@@ -7,7 +7,7 @@ import {
   TextSourceDetailsRecord,
 } from '../schema/text-source-details.record';
 import { UrlSourceDetailsRecord } from '../schema/text-source-details.record';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { SourceContentChunkMapper } from './source-content-chunk.mapper';
 import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import {
@@ -30,7 +30,6 @@ import type { TextSourceContentChunk } from 'src/domain/sources/domain/source-co
 
 @Injectable()
 export class SourceMapper {
-  private readonly logger = new Logger(SourceMapper.name);
   constructor(
     private readonly sourceContentChunkMapper: SourceContentChunkMapper,
   ) {}

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/bullmq-job.helpers.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/bullmq-job.helpers.ts
@@ -1,4 +1,4 @@
-import type { Logger } from '@nestjs/common';
+import type { PinoLogger } from 'nestjs-pino';
 import type { Job, JobsOptions, Queue } from 'bullmq';
 import type { UUID } from 'crypto';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -174,27 +174,30 @@ function shouldScheduleRetry(
 export async function cancelQueueJob(
   queue: Queue,
   sourceId: UUID,
-  logger: Logger,
+  logger: PinoLogger,
 ): Promise<void> {
   try {
     const job = await queue.getJob(sourceId);
     if (!job) {
-      logger.debug('No job found to cancel', { sourceId });
+      logger.debug({ sourceId }, 'No job found to cancel');
       return;
     }
 
     const state = await job.getState();
     if (state === 'active') {
-      logger.debug('Job is active, skipping removal', { sourceId });
+      logger.debug({ sourceId }, 'Job is active, skipping removal');
       return;
     }
 
     await job.remove();
-    logger.log('Cancelled queued job', { sourceId, state });
+    logger.info({ sourceId, state }, 'Cancelled queued job');
   } catch (err) {
-    logger.warn('Best-effort job cancellation failed', {
-      sourceId,
-      error: err as Error,
-    });
+    logger.warn(
+      {
+        sourceId,
+        err: err as Error,
+      },
+      'Best-effort job cancellation failed',
+    );
   }
 }

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/data-source-processing.consumer.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/data-source-processing.consumer.spec.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { Job } from 'bullmq';
 import { DataSourceProcessingConsumer } from './data-source-processing.consumer';
 import type { DataSourceProcessingJobData } from '../../application/ports/data-source-processing.port';
@@ -78,6 +79,7 @@ describe('DataSourceProcessingConsumer', () => {
     } as unknown as ContextService;
 
     consumer = new DataSourceProcessingConsumer(
+      createPinoLoggerMock(),
       contextService,
       downloadObject,
       deleteObject,

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/data-source-processing.consumer.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/data-source-processing.consumer.ts
@@ -1,4 +1,5 @@
-import { Logger } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 import type { UUID } from 'crypto';
@@ -28,9 +29,9 @@ import {
 
 @Processor(DATA_SOURCE_PROCESSING_QUEUE, { concurrency: 2 })
 export class DataSourceProcessingConsumer extends WorkerHost {
-  private readonly logger = new Logger(DataSourceProcessingConsumer.name);
-
   constructor(
+    @InjectPinoLogger(DataSourceProcessingConsumer.name)
+    private readonly logger: PinoLogger,
     private readonly contextService: ContextService,
     private readonly downloadObjectUseCase: DownloadObjectUseCase,
     private readonly deleteObjectUseCase: DeleteObjectUseCase,
@@ -42,54 +43,57 @@ export class DataSourceProcessingConsumer extends WorkerHost {
   }
 
   async process(job: Job<DataSourceProcessingJobData>): Promise<void> {
+    this.logger.info(
+      {
+        fileName: job.data.fileName,
+        jobId: job.id,
+        targetCount: job.data.targets.length,
+      },
+      'Processing data source file',
+    );
+    await this.contextService.run(() => this.processJob(job));
+  }
+
+  private async processJob(
+    job: Job<DataSourceProcessingJobData>,
+  ): Promise<void> {
     const { orgId, userId, minioPath, fileName, kind, targets } = job.data;
+    this.validateAndSetContext(orgId, userId);
 
-    this.logger.log('Processing data source file', {
-      fileName,
-      targetCount: targets.length,
-      jobId: job.id,
-    });
-
-    // Set up CLS context so downstream use cases work
-    await this.contextService.run(async () => {
-      this.validateAndSetContext(orgId, userId);
-
-      try {
-        const pending = await this.loadPendingTargets(targets);
-        if (pending.length === 0) {
-          this.logger.warn('No pending sources left for job, skipping', {
-            jobId: job.id,
-          });
-          await this.cleanupMinioFile(minioPath);
-          return;
-        }
-
-        const fileBuffer = await this.downloadFile(minioPath);
-        const sheets = await this.parseFile(fileBuffer, kind);
-        await this.fillSources(pending, sheets);
+    try {
+      const pending = await this.loadPendingTargets(targets);
+      if (pending.length === 0) {
+        this.logger.warn(
+          { jobId: job.id },
+          'No pending sources left for job, skipping',
+        );
         await this.cleanupMinioFile(minioPath);
-
-        this.logger.log('Data source processing complete', {
-          fileName,
-          sources: pending.length,
-        });
-      } catch (error) {
-        this.logger.error('Data source processing failed', {
-          fileName,
-          error: error as Error,
-        });
-
-        const { final, rethrow } = classifyJobFailure(job, error);
-        if (final) {
-          await this.markPendingTargetsFailed(
-            targets,
-            error instanceof Error ? error.message : 'Unknown processing error',
-          );
-          await this.cleanupMinioFile(minioPath);
-        }
-        if (rethrow) throw rethrow;
+        return;
       }
-    });
+
+      const fileBuffer = await this.downloadFile(minioPath);
+      const sheets = await this.parseFile(fileBuffer, kind);
+      await this.fillSources(pending, sheets);
+      await this.cleanupMinioFile(minioPath);
+      this.logger.info(
+        { fileName, sources: pending.length },
+        'Data source processing complete',
+      );
+    } catch (error) {
+      this.logger.error(
+        { err: error as Error, fileName },
+        'Data source processing failed',
+      );
+      const { final, rethrow } = classifyJobFailure(job, error);
+      if (final) {
+        await this.markPendingTargetsFailed(
+          targets,
+          error instanceof Error ? error.message : 'Unknown processing error',
+        );
+        await this.cleanupMinioFile(minioPath);
+      }
+      if (rethrow) throw rethrow;
+    }
   }
 
   private validateAndSetContext(
@@ -113,10 +117,13 @@ export class DataSourceProcessingConsumer extends WorkerHost {
     for (const target of targets) {
       const source = await this.sourceRepository.findById(target.sourceId);
       if (source?.status !== SourceStatus.PROCESSING) {
-        this.logger.warn('Source missing or no longer processing, skipping', {
-          sourceId: target.sourceId,
-          found: !!source,
-        });
+        this.logger.warn(
+          {
+            sourceId: target.sourceId,
+            found: !!source,
+          },
+          'Source missing or no longer processing, skipping',
+        );
         continue;
       }
       if (!(source instanceof CSVDataSource)) {
@@ -131,9 +138,12 @@ export class DataSourceProcessingConsumer extends WorkerHost {
         target.sourceId,
       );
       if (!alive) {
-        this.logger.warn('Source deleted mid-load, skipping', {
-          sourceId: target.sourceId,
-        });
+        this.logger.warn(
+          {
+            sourceId: target.sourceId,
+          },
+          'Source deleted mid-load, skipping',
+        );
         continue;
       }
       pending.push({ source, sheetName: target.sheetName });
@@ -188,9 +198,12 @@ export class DataSourceProcessingConsumer extends WorkerHost {
       { headers: parsed.headers, rows: parsed.rows },
     );
     if (!dataWritten) {
-      this.logger.warn('Source deleted mid-processing, skipping', {
-        sourceId,
-      });
+      this.logger.warn(
+        {
+          sourceId,
+        },
+        'Source deleted mid-processing, skipping',
+      );
       return;
     }
 
@@ -202,8 +215,8 @@ export class DataSourceProcessingConsumer extends WorkerHost {
     );
     if (!updated) {
       this.logger.warn(
-        'Conditional update to READY failed — source was deleted or status changed',
         { sourceId },
+        'Conditional update to READY failed — source was deleted or status changed',
       );
     }
   }
@@ -230,10 +243,13 @@ export class DataSourceProcessingConsumer extends WorkerHost {
         new MarkSourceFailedCommand({ sourceId, errorMessage }),
       );
     } catch (err) {
-      this.logger.error('Failed to mark source as FAILED', {
-        sourceId,
-        error: err as Error,
-      });
+      this.logger.error(
+        {
+          sourceId,
+          err: err as Error,
+        },
+        'Failed to mark source as FAILED',
+      );
     }
   }
 

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/data-source-processing.producer.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/data-source-processing.producer.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import {
@@ -10,9 +11,9 @@ import { STANDARD_JOB_OPTIONS } from './bullmq-job.helpers';
 
 @Injectable()
 export class DataSourceProcessingProducer extends DataSourceProcessingPort {
-  private readonly logger = new Logger(DataSourceProcessingProducer.name);
-
   constructor(
+    @InjectPinoLogger(DataSourceProcessingProducer.name)
+    private readonly logger: PinoLogger,
     @InjectQueue(DATA_SOURCE_PROCESSING_QUEUE)
     private readonly queue: Queue<DataSourceProcessingJobData>,
   ) {
@@ -20,10 +21,13 @@ export class DataSourceProcessingProducer extends DataSourceProcessingPort {
   }
 
   async enqueue(data: DataSourceProcessingJobData): Promise<void> {
-    this.logger.log('Enqueuing data source processing job', {
-      fileName: data.fileName,
-      targetCount: data.targets.length,
-    });
+    this.logger.info(
+      {
+        fileName: data.fileName,
+        targetCount: data.targets.length,
+      },
+      'Enqueuing data source processing job',
+    );
 
     await this.queue.add('process-data-source', data, {
       jobId: data.uploadId,

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.spec.ts
@@ -1,4 +1,5 @@
 import type { UUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { Job } from 'bullmq';
 import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
 import { TextType } from 'src/domain/sources/domain/source-type.enum';
@@ -110,6 +111,7 @@ describe('DocumentProcessingConsumer', () => {
     jest.clearAllMocks();
 
     consumer = new DocumentProcessingConsumer(
+      createPinoLoggerMock(),
       contextService as never,
       retrieveFileContentUseCase as never,
       splitTextUseCase as never,

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.ts
@@ -1,4 +1,5 @@
-import { Logger } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 import type { UUID } from 'crypto';
@@ -25,9 +26,9 @@ import {
 
 @Processor(DOCUMENT_PROCESSING_QUEUE, { concurrency: 2 })
 export class DocumentProcessingConsumer extends WorkerHost {
-  private readonly logger = new Logger(DocumentProcessingConsumer.name);
-
   constructor(
+    @InjectPinoLogger(DocumentProcessingConsumer.name)
+    private readonly logger: PinoLogger,
     private readonly contextService: ContextService,
     private readonly retrieveFileContentUseCase: RetrieveFileContentUseCase,
     private readonly splitTextUseCase: SplitTextUseCase,
@@ -42,11 +43,14 @@ export class DocumentProcessingConsumer extends WorkerHost {
   async process(job: Job<DocumentProcessingJobData>): Promise<void> {
     const { sourceId, orgId, userId, minioPath, fileName } = job.data;
 
-    this.logger.log('Processing document', {
-      sourceId,
-      fileName,
-      jobId: job.id,
-    });
+    this.logger.info(
+      {
+        sourceId,
+        fileName,
+        jobId: job.id,
+      },
+      'Processing document',
+    );
 
     // Set up CLS context so downstream use cases (Mistral, etc.) work
     await this.contextService.run(async () => {
@@ -66,15 +70,21 @@ export class DocumentProcessingConsumer extends WorkerHost {
         await this.helper.index(sourceId, orgId, chunks);
         await this.markSourceReady(sourceId, minioPath);
 
-        this.logger.log('Document processing complete', {
-          sourceId,
-          chunks: chunks.length,
-        });
+        this.logger.info(
+          {
+            sourceId,
+            chunks: chunks.length,
+          },
+          'Document processing complete',
+        );
       } catch (error) {
-        this.logger.error('Document processing failed', {
-          sourceId,
-          error: error as Error,
-        });
+        this.logger.error(
+          {
+            sourceId,
+            err: error as Error,
+          },
+          'Document processing failed',
+        );
 
         const { final, rethrow } = classifyJobFailure(job, error);
         if (final) {
@@ -110,7 +120,7 @@ export class DocumentProcessingConsumer extends WorkerHost {
   ): Promise<TextSource | null> {
     const source = await this.sourceRepository.findById(sourceId);
     if (!source) {
-      this.logger.warn('Source not found, skipping', { sourceId });
+      this.logger.warn({ sourceId }, 'Source not found, skipping');
       await this.cleanupMinioFile(minioPath);
       return null;
     }
@@ -165,10 +175,13 @@ export class DocumentProcessingConsumer extends WorkerHost {
   ): Promise<boolean> {
     const source = await this.sourceRepository.findById(sourceId);
     if (source?.status !== SourceStatus.PROCESSING) {
-      this.logger.warn('Source deleted or status changed mid-processing', {
-        sourceId,
-        found: !!source,
-      });
+      this.logger.warn(
+        {
+          sourceId,
+          found: !!source,
+        },
+        'Source deleted or status changed mid-processing',
+      );
       await this.cleanupMinioFile(minioPath);
       return false;
     }
@@ -195,8 +208,8 @@ export class DocumentProcessingConsumer extends WorkerHost {
     );
     if (!updated) {
       this.logger.warn(
-        'Conditional update to READY failed — source was deleted or status changed',
         { sourceId },
+        'Conditional update to READY failed — source was deleted or status changed',
       );
       await this.helper.cleanupIndex(sourceId);
     }

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.producer.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.producer.spec.ts
@@ -1,4 +1,5 @@
 import type { UUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { Queue } from 'bullmq';
 import type { DocumentProcessingJobData } from '../../application/ports/document-processing.port';
 import { DocumentProcessingProducer } from './document-processing.producer';
@@ -26,6 +27,7 @@ describe('DocumentProcessingProducer', () => {
       getJob: jest.fn(),
     };
     producer = new DocumentProcessingProducer(
+      createPinoLoggerMock(),
       queue as unknown as Queue<DocumentProcessingJobData>,
     );
   });

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.producer.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.producer.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import type { UUID } from 'crypto';
@@ -11,9 +12,9 @@ import { STANDARD_JOB_OPTIONS, cancelQueueJob } from './bullmq-job.helpers';
 
 @Injectable()
 export class DocumentProcessingProducer extends DocumentProcessingPort {
-  private readonly logger = new Logger(DocumentProcessingProducer.name);
-
   constructor(
+    @InjectPinoLogger(DocumentProcessingProducer.name)
+    private readonly logger: PinoLogger,
     @InjectQueue(DOCUMENT_PROCESSING_QUEUE)
     private readonly queue: Queue<DocumentProcessingJobData>,
   ) {
@@ -21,10 +22,13 @@ export class DocumentProcessingProducer extends DocumentProcessingPort {
   }
 
   async enqueue(data: DocumentProcessingJobData): Promise<void> {
-    this.logger.log('Enqueuing document processing job', {
-      sourceId: data.sourceId,
-      fileName: data.fileName,
-    });
+    this.logger.info(
+      {
+        sourceId: data.sourceId,
+        fileName: data.fileName,
+      },
+      'Enqueuing document processing job',
+    );
 
     await this.queue.add('process-document', data, {
       jobId: data.sourceId,

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.spec.ts
@@ -1,4 +1,5 @@
 import type { UUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { Job } from 'bullmq';
 
 // p-limit is ESM-only — mock the dynamic import so Jest (CJS) doesn't choke.
@@ -104,6 +105,7 @@ describe('UrlCrawlConsumer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     consumer = new UrlCrawlConsumer(
+      createPinoLoggerMock(),
       contextService as never,
       crawlUrlUseCase as never,
       splitTextUseCase as never,

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.ts
@@ -1,4 +1,5 @@
-import { Logger } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
 import type { UUID } from 'crypto';
@@ -20,9 +21,9 @@ import { classifyJobFailure } from './bullmq-job.helpers';
 
 @Processor(URL_CRAWL_QUEUE, { concurrency: 2 })
 export class UrlCrawlConsumer extends WorkerHost {
-  private readonly logger = new Logger(UrlCrawlConsumer.name);
-
   constructor(
+    @InjectPinoLogger(UrlCrawlConsumer.name)
+    private readonly logger: PinoLogger,
     private readonly contextService: ContextService,
     private readonly crawlUrlUseCase: CrawlUrlUseCase,
     private readonly splitTextUseCase: SplitTextUseCase,
@@ -33,59 +34,53 @@ export class UrlCrawlConsumer extends WorkerHost {
   }
 
   async process(job: Job<UrlCrawlJobData>): Promise<void> {
+    this.logger.info(
+      {
+        jobId: job.id,
+        sourceId: job.data.sourceId,
+        url: job.data.rootUrl,
+      },
+      'Crawling URL source',
+    );
+    await this.contextService.run(() => this.processCrawl(job));
+  }
+
+  private async processCrawl(job: Job<UrlCrawlJobData>): Promise<void> {
     const { sourceId, orgId, userId, rootUrl, maxDepth } = job.data;
+    this.validateAndSetContext(orgId, userId);
 
-    this.logger.log('Crawling URL source', {
-      sourceId,
-      rootUrl,
-      jobId: job.id,
-    });
+    try {
+      const source = await this.loadSourceOrSkip(sourceId);
+      if (!source) return;
 
-    // Set up CLS context so downstream use cases (embeddings, etc.) work.
-    await this.contextService.run(async () => {
-      this.validateAndSetContext(orgId, userId);
+      const { text, chunks, title, pageCount } = await this.crawlAndBuild(
+        rootUrl,
+        orgId,
+        maxDepth,
+      );
+      // Re-checking prevents a concurrent deletion from being resurrected.
+      if (!(await this.isSourceStillProcessing(sourceId))) return;
 
-      try {
-        const source = await this.loadSourceOrSkip(sourceId);
-        if (!source) return;
-
-        const { text, chunks, title, pageCount } = await this.crawlAndBuild(
-          rootUrl,
-          orgId,
-          maxDepth,
+      if (title) source.name = title;
+      await this.sourceRepository.saveTextSource(source, { text, chunks });
+      await this.helper.index(sourceId, orgId, chunks);
+      await this.markSourceReady(sourceId);
+      this.logger.info(
+        { chunks: chunks.length, pages: pageCount, sourceId },
+        'URL crawl complete',
+      );
+    } catch (error) {
+      this.logger.error({ err: error as Error, sourceId }, 'URL crawl failed');
+      const { final, rethrow } = classifyJobFailure(job, error);
+      if (final) {
+        await this.helper.markFailed(
+          sourceId,
+          error instanceof Error ? error.message : 'Unknown crawl error',
         );
-
-        // Guard: re-check the source still exists and is PROCESSING before
-        // writing content. Prevents resurrection of deleted sources.
-        if (!(await this.isSourceStillProcessing(sourceId))) return;
-
-        if (title) source.name = title;
-        await this.sourceRepository.saveTextSource(source, { text, chunks });
-        await this.helper.index(sourceId, orgId, chunks);
-        await this.markSourceReady(sourceId);
-
-        this.logger.log('URL crawl complete', {
-          sourceId,
-          pages: pageCount,
-          chunks: chunks.length,
-        });
-      } catch (error) {
-        this.logger.error('URL crawl failed', {
-          sourceId,
-          error: error as Error,
-        });
-
-        const { final, rethrow } = classifyJobFailure(job, error);
-        if (final) {
-          await this.helper.markFailed(
-            sourceId,
-            error instanceof Error ? error.message : 'Unknown crawl error',
-          );
-          await this.helper.cleanupIndex(sourceId);
-        }
-        if (rethrow) throw rethrow;
+        await this.helper.cleanupIndex(sourceId);
       }
-    });
+      if (rethrow) throw rethrow;
+    }
   }
 
   private validateAndSetContext(
@@ -101,7 +96,7 @@ export class UrlCrawlConsumer extends WorkerHost {
   private async loadSourceOrSkip(sourceId: UUID): Promise<TextSource | null> {
     const source = await this.sourceRepository.findById(sourceId);
     if (!source) {
-      this.logger.warn('Source not found, skipping', { sourceId });
+      this.logger.warn({ sourceId }, 'Source not found, skipping');
       return null;
     }
     if (!(source instanceof TextSource)) {
@@ -165,10 +160,13 @@ export class UrlCrawlConsumer extends WorkerHost {
   private async isSourceStillProcessing(sourceId: UUID): Promise<boolean> {
     const source = await this.sourceRepository.findById(sourceId);
     if (source?.status !== SourceStatus.PROCESSING) {
-      this.logger.warn('Source deleted or status changed mid-crawl', {
-        sourceId,
-        found: !!source,
-      });
+      this.logger.warn(
+        {
+          sourceId,
+          found: !!source,
+        },
+        'Source deleted or status changed mid-crawl',
+      );
       return false;
     }
     return true;
@@ -183,8 +181,8 @@ export class UrlCrawlConsumer extends WorkerHost {
     );
     if (!updated) {
       this.logger.warn(
-        'Conditional update to READY failed — source was deleted or status changed',
         { sourceId },
+        'Conditional update to READY failed — source was deleted or status changed',
       );
       await this.helper.cleanupIndex(sourceId);
     }

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.producer.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.producer.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import type { UUID } from 'crypto';
@@ -11,9 +12,9 @@ import { STANDARD_JOB_OPTIONS, cancelQueueJob } from './bullmq-job.helpers';
 
 @Injectable()
 export class UrlCrawlProducer extends UrlCrawlProcessingPort {
-  private readonly logger = new Logger(UrlCrawlProducer.name);
-
   constructor(
+    @InjectPinoLogger(UrlCrawlProducer.name)
+    private readonly logger: PinoLogger,
     @InjectQueue(URL_CRAWL_QUEUE)
     private readonly queue: Queue<UrlCrawlJobData>,
   ) {
@@ -21,11 +22,14 @@ export class UrlCrawlProducer extends UrlCrawlProcessingPort {
   }
 
   async enqueue(data: UrlCrawlJobData): Promise<void> {
-    this.logger.log('Enqueuing URL crawl job', {
-      sourceId: data.sourceId,
-      rootUrl: data.rootUrl,
-      maxDepth: data.maxDepth,
-    });
+    this.logger.info(
+      {
+        sourceId: data.sourceId,
+        url: data.rootUrl,
+        maxDepth: data.maxDepth,
+      },
+      'Enqueuing URL crawl job',
+    );
 
     await this.queue.add('crawl-url', data, {
       jobId: data.sourceId,

--- a/ayunis-core-backend/src/domain/sources/infrastructure/tasks/stale-processing-cleanup.task.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/tasks/stale-processing-cleanup.task.spec.ts
@@ -1,4 +1,5 @@
 import type { UUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { SourceRepository } from 'src/domain/sources/application/ports/source.repository';
 import type { MarkSourceFailedUseCase } from 'src/domain/sources/application/use-cases/mark-source-failed/mark-source-failed.use-case';
 import { StaleProcessingCleanupTask } from './stale-processing-cleanup.task';
@@ -20,6 +21,7 @@ describe('StaleProcessingCleanupTask', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     task = new StaleProcessingCleanupTask(
+      createPinoLoggerMock(),
       sourceRepository as unknown as SourceRepository,
       markSourceFailedUseCase as unknown as MarkSourceFailedUseCase,
     );

--- a/ayunis-core-backend/src/domain/sources/infrastructure/tasks/stale-processing-cleanup.task.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/tasks/stale-processing-cleanup.task.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import type { UUID } from 'crypto';
 import { SourceRepository } from 'src/domain/sources/application/ports/source.repository';
@@ -12,10 +13,11 @@ const MAX_SOURCES_PER_RUN = 100;
 
 @Injectable()
 export class StaleProcessingCleanupTask {
-  private readonly logger = new Logger(StaleProcessingCleanupTask.name);
   private isRunning = false;
 
   constructor(
+    @InjectPinoLogger(StaleProcessingCleanupTask.name)
+    private readonly logger: PinoLogger,
     private readonly sourceRepository: SourceRepository,
     private readonly markSourceFailedUseCase: MarkSourceFailedUseCase,
   ) {}
@@ -31,9 +33,12 @@ export class StaleProcessingCleanupTask {
     try {
       await this.failStaleSources();
     } catch (error) {
-      this.logger.error('Stale processing cleanup failed', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Stale processing cleanup failed',
+      );
     } finally {
       this.isRunning = false;
     }
@@ -53,8 +58,8 @@ export class StaleProcessingCleanupTask {
     }
 
     this.logger.warn(
-      `Found ${staleSourceIds.length} stale processing sources`,
-      { sourceIds: staleSourceIds },
+      { sourceIds: staleSourceIds, sourceCount: staleSourceIds.length },
+      'Found stale processing sources',
     );
 
     for (const sourceId of staleSourceIds) {
@@ -70,12 +75,15 @@ export class StaleProcessingCleanupTask {
           errorMessage: 'Processing timed out',
         }),
       );
-      this.logger.warn('Marked stale source as failed', { sourceId });
+      this.logger.warn({ sourceId }, 'Marked stale source as failed');
     } catch (error) {
-      this.logger.error('Failed to mark stale source as failed', {
-        sourceId,
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          sourceId,
+          err: error as Error,
+        },
+        'Failed to mark stale source as failed',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/delete-object/delete-object.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/delete-object/delete-object.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ConfigModule } from '@nestjs/config';
@@ -27,6 +29,10 @@ describe('DeleteObjectUseCase', () => {
       imports: [ConfigModule.forFeature(storageConfig)],
       providers: [
         DeleteObjectUseCase,
+        {
+          provide: getLoggerToken(DeleteObjectUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ObjectStoragePort, useValue: mockObjectStorage },
         {
           provide: storageConfig.KEY,

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/delete-object/delete-object.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/delete-object/delete-object.use-case.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigType } from '@nestjs/config';
 import { ObjectStoragePort } from '../../ports/object-storage.port';
 import { DeleteObjectCommand } from './delete-object.command';
@@ -8,18 +9,22 @@ import { StorageUrl } from 'src/domain/storage/domain/storage-url.entity';
 
 @Injectable()
 export class DeleteObjectUseCase {
-  private readonly logger = new Logger(DeleteObjectUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteObjectUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly objectStorage: ObjectStoragePort,
     @Inject(storageConfig.KEY)
     private readonly config: ConfigType<typeof storageConfig>,
   ) {}
 
   async execute(command: DeleteObjectCommand): Promise<void> {
-    this.logger.debug(`Deleting object: ${command.objectName}`, {
-      bucket: command.bucket,
-    });
+    this.logger.debug(
+      {
+        bucket: command.bucket,
+        fileName: command.objectName,
+      },
+      'Deleting object',
+    );
 
     try {
       const bucketName = command.bucket || this.getDefaultBucket();
@@ -36,15 +41,18 @@ export class DeleteObjectUseCase {
       await this.objectStorage.delete(
         new StorageUrl(command.objectName, bucketName),
       );
-      this.logger.debug(`Successfully deleted object: ${command.objectName}`);
+      this.logger.debug(
+        { fileName: command.objectName },
+        'Successfully deleted object',
+      );
     } catch (error) {
       if (error instanceof ObjectNotFoundError) {
         throw error;
       }
 
       this.logger.error(
-        `Failed to delete object: ${command.objectName}`,
-        error,
+        { err: error as Error, fileName: command.objectName },
+        'Failed to delete object',
       );
       throw new DeleteFailedError();
     }

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/download-object/download-object.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/download-object/download-object.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ConfigModule } from '@nestjs/config';
@@ -34,6 +36,10 @@ describe('DownloadObjectUseCase', () => {
       imports: [ConfigModule.forFeature(storageConfig)],
       providers: [
         DownloadObjectUseCase,
+        {
+          provide: getLoggerToken(DownloadObjectUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ObjectStoragePort, useValue: mockObjectStorage },
         {
           provide: storageConfig.KEY,

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/download-object/download-object.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/download-object/download-object.use-case.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigType } from '@nestjs/config';
 import { ObjectStoragePort } from '../../ports/object-storage.port';
 import { DownloadObjectCommand } from './download-object.command';
@@ -33,9 +34,9 @@ function isTransientNetworkError(error: Error): boolean {
 
 @Injectable()
 export class DownloadObjectUseCase {
-  private readonly logger = new Logger(DownloadObjectUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DownloadObjectUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly objectStorage: ObjectStoragePort,
     @Inject(storageConfig.KEY)
     private readonly config: ConfigType<typeof storageConfig>,
@@ -44,9 +45,13 @@ export class DownloadObjectUseCase {
   async execute(
     command: DownloadObjectCommand,
   ): Promise<NodeJS.ReadableStream> {
-    this.logger.debug(`Downloading object: ${command.objectName}`, {
-      bucket: command.bucket,
-    });
+    this.logger.debug(
+      {
+        bucket: command.bucket,
+        fileName: command.objectName,
+      },
+      'Downloading object',
+    );
 
     try {
       const bucketName = command.bucket || this.getDefaultBucket();
@@ -65,7 +70,8 @@ export class DownloadObjectUseCase {
       });
 
       this.logger.debug(
-        `Successfully started download for object: ${command.objectName}`,
+        { fileName: command.objectName },
+        'Successfully started object download',
       );
 
       return stream;
@@ -75,8 +81,8 @@ export class DownloadObjectUseCase {
       }
 
       this.logger.error(
-        `Failed to download object: ${command.objectName}`,
-        error,
+        { err: error as Error, fileName: command.objectName },
+        'Failed to download object',
       );
       throw new DownloadFailedError();
     }

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/get-object-info/get-object-info.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/get-object-info/get-object-info.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ConfigModule } from '@nestjs/config';
@@ -27,6 +29,10 @@ describe('GetObjectInfoUseCase', () => {
       imports: [ConfigModule.forFeature(storageConfig)],
       providers: [
         GetObjectInfoUseCase,
+        {
+          provide: getLoggerToken(GetObjectInfoUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ObjectStoragePort, useValue: mockObjectStorage },
         {
           provide: storageConfig.KEY,

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/get-object-info/get-object-info.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/get-object-info/get-object-info.use-case.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigType } from '@nestjs/config';
 import { ObjectStoragePort } from '../../ports/object-storage.port';
 import { StorageObject } from 'src/domain/storage/domain/storage-object.entity';
@@ -9,18 +10,22 @@ import { StorageUrl } from 'src/domain/storage/domain/storage-url.entity';
 
 @Injectable()
 export class GetObjectInfoUseCase {
-  private readonly logger = new Logger(GetObjectInfoUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetObjectInfoUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly objectStorage: ObjectStoragePort,
     @Inject(storageConfig.KEY)
     private readonly config: ConfigType<typeof storageConfig>,
   ) {}
 
   async execute(command: GetObjectInfoCommand): Promise<StorageObject> {
-    this.logger.debug(`Getting info for object: ${command.objectName}`, {
-      bucket: command.bucket,
-    });
+    this.logger.debug(
+      {
+        bucket: command.bucket,
+        fileName: command.objectName,
+      },
+      'Getting object info',
+    );
 
     try {
       const bucketName = command.bucket || this.getDefaultBucket();
@@ -30,12 +35,13 @@ export class GetObjectInfoUseCase {
       );
 
       this.logger.debug(
-        `Successfully retrieved info for object: ${command.objectName}`,
         {
           bucket: bucketName,
+          fileName: command.objectName,
           size: info.size,
           etag: info.etag,
         },
+        'Successfully retrieved object info',
       );
 
       return new StorageObject(
@@ -55,8 +61,8 @@ export class GetObjectInfoUseCase {
       }
 
       this.logger.error(
-        `Failed to get object info: ${command.objectName}`,
-        error,
+        { err: error as Error, fileName: command.objectName },
+        'Failed to get object info',
       );
       throw new DownloadFailedError();
     }

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/get-presigned-url/get-presigned-url.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/get-presigned-url/get-presigned-url.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ConfigModule } from '@nestjs/config';
@@ -29,6 +31,10 @@ describe('GetPresignedUrlUseCase', () => {
       imports: [ConfigModule.forFeature(storageConfig)],
       providers: [
         GetPresignedUrlUseCase,
+        {
+          provide: getLoggerToken(GetPresignedUrlUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ObjectStoragePort, useValue: mockObjectStorage },
         {
           provide: storageConfig.KEY,

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/get-presigned-url/get-presigned-url.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/get-presigned-url/get-presigned-url.use-case.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigType } from '@nestjs/config';
 import { ObjectStoragePort } from '../../ports/object-storage.port';
 import { GetPresignedUrlCommand } from './get-presigned-url.command';
@@ -9,9 +10,9 @@ import { PresignedUrl } from 'src/domain/storage/domain/presigned-url.entity';
 
 @Injectable()
 export class GetPresignedUrlUseCase {
-  private readonly logger = new Logger(GetPresignedUrlUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetPresignedUrlUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly objectStorage: ObjectStoragePort,
     @Inject(storageConfig.KEY)
     private readonly config: ConfigType<typeof storageConfig>,
@@ -19,11 +20,12 @@ export class GetPresignedUrlUseCase {
 
   async execute(command: GetPresignedUrlCommand): Promise<PresignedUrl> {
     this.logger.debug(
-      `Generating presigned URL for object: ${command.objectName}`,
       {
         bucket: command.bucket,
         expiresIn: command.expiresIn,
+        fileName: command.objectName,
       },
+      'Generating presigned URL for object',
     );
 
     try {
@@ -53,7 +55,8 @@ export class GetPresignedUrlUseCase {
       );
 
       this.logger.debug(
-        `Successfully generated presigned URL for object: ${command.objectName}`,
+        { fileName: command.objectName },
+        'Successfully generated presigned URL for object',
       );
       return url;
     } catch (error) {
@@ -62,8 +65,8 @@ export class GetPresignedUrlUseCase {
       }
 
       this.logger.error(
-        `Failed to generate presigned URL for object: ${command.objectName}`,
-        error,
+        { err: error as Error, fileName: command.objectName },
+        'Failed to generate presigned URL for object',
       );
       throw new DownloadFailedError();
     }

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/list-objects/list-objects.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/list-objects/list-objects.use-case.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigType } from '@nestjs/config';
 import { ObjectStoragePort } from '../../ports/object-storage.port';
 import { ListObjectsCommand } from './list-objects.command';
@@ -6,16 +7,16 @@ import storageConfig from 'src/config/storage.config';
 
 @Injectable()
 export class ListObjectsUseCase {
-  private readonly logger = new Logger(ListObjectsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ListObjectsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly objectStorage: ObjectStoragePort,
     @Inject(storageConfig.KEY)
     private readonly config: ConfigType<typeof storageConfig>,
   ) {}
 
   async execute(command: ListObjectsCommand): Promise<string[]> {
-    this.logger.debug(`Listing objects with prefix: ${command.prefix}`);
+    this.logger.debug({ prefix: command.prefix }, 'Listing objects');
     const bucket = command.bucket ?? this.config.minio.bucket;
     return this.objectStorage.listObjects(command.prefix, bucket);
   }

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/purge-org-storage/purge-org-storage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/purge-org-storage/purge-org-storage.use-case.spec.ts
@@ -1,6 +1,7 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { PurgeOrgStorageUseCase } from './purge-org-storage.use-case';
 import { PurgeOrgStorageCommand } from './purge-org-storage.command';
 import { PurgeStoragePrefixesUseCase } from '../purge-storage-prefixes/purge-storage-prefixes.use-case';
@@ -21,6 +22,10 @@ describe('PurgeOrgStorageUseCase', () => {
       providers: [
         PurgeOrgStorageUseCase,
         {
+          provide: getLoggerToken(PurgeOrgStorageUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
+        {
           provide: PurgeStoragePrefixesUseCase,
           useValue: purgeStoragePrefixesUseCase,
         },
@@ -28,8 +33,6 @@ describe('PurgeOrgStorageUseCase', () => {
     }).compile();
 
     useCase = module.get(PurgeOrgStorageUseCase);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/purge-org-storage/purge-org-storage.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/purge-org-storage/purge-org-storage.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { PurgeOrgStorageCommand } from './purge-org-storage.command';
 import { PurgeStoragePrefixesUseCase } from '../purge-storage-prefixes/purge-storage-prefixes.use-case';
 import { PurgeStoragePrefixesCommand } from '../purge-storage-prefixes/purge-storage-prefixes.command';
@@ -20,16 +21,16 @@ export type PurgeOrgStorageResult = PurgeStoragePrefixesResult;
  */
 @Injectable()
 export class PurgeOrgStorageUseCase {
-  private readonly logger = new Logger(PurgeOrgStorageUseCase.name);
-
   constructor(
+    @InjectPinoLogger(PurgeOrgStorageUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly purgeStoragePrefixesUseCase: PurgeStoragePrefixesUseCase,
   ) {}
 
   async execute(
     command: PurgeOrgStorageCommand,
   ): Promise<PurgeOrgStorageResult> {
-    this.logger.log('Purging org storage', { orgId: command.orgId });
+    this.logger.info({ orgId: command.orgId }, 'Purging org storage');
     return this.purgeStoragePrefixesUseCase.execute(
       new PurgeStoragePrefixesCommand(orgStoragePrefixes(command.orgId)),
     );

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/purge-storage-prefixes/purge-storage-prefixes.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/purge-storage-prefixes/purge-storage-prefixes.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken, type PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { PurgeStoragePrefixesUseCase } from './purge-storage-prefixes.use-case';
 import { PurgeStoragePrefixesCommand } from './purge-storage-prefixes.command';
 import { ListObjectsUseCase } from '../list-objects/list-objects.use-case';
@@ -11,24 +12,26 @@ describe('PurgeStoragePrefixesUseCase', () => {
   let useCase: PurgeStoragePrefixesUseCase;
   let listObjectsUseCase: { execute: jest.Mock };
   let deleteObjectUseCase: { execute: jest.Mock };
+  let logger: jest.Mocked<PinoLogger>;
 
   beforeEach(async () => {
     listObjectsUseCase = { execute: jest.fn().mockResolvedValue([]) };
     deleteObjectUseCase = { execute: jest.fn().mockResolvedValue(undefined) };
+    logger = createPinoLoggerMock();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         PurgeStoragePrefixesUseCase,
+        {
+          provide: getLoggerToken(PurgeStoragePrefixesUseCase.name),
+          useValue: logger,
+        },
         { provide: ListObjectsUseCase, useValue: listObjectsUseCase },
         { provide: DeleteObjectUseCase, useValue: deleteObjectUseCase },
       ],
     }).compile();
 
     useCase = module.get(PurgeStoragePrefixesUseCase);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -85,9 +88,10 @@ describe('PurgeStoragePrefixesUseCase', () => {
     expect(result).toEqual({ deletedCount: 1, failedCount: 0 });
   });
 
-  it('skips a prefix that fails to list and still purges the other prefixes', async () => {
+  it('logs a prefix-list failure with structured error metadata and continues', async () => {
+    const error = new Error('storage unavailable');
     listObjectsUseCase.execute
-      .mockRejectedValueOnce(new Error('storage unavailable'))
+      .mockRejectedValueOnce(error)
       .mockResolvedValueOnce(['letterheads/org-1/letterhead.pdf']);
 
     const result = await useCase.execute(
@@ -95,6 +99,10 @@ describe('PurgeStoragePrefixesUseCase', () => {
     );
 
     expect(result).toEqual({ deletedCount: 1, failedCount: 0 });
+    expect(logger.error).toHaveBeenCalledWith(
+      { err: error, prefix: 'org-1/' },
+      'Failed to list storage prefix',
+    );
     expect(deleteObjectUseCase.execute).toHaveBeenCalledWith(
       expect.objectContaining({
         objectName: 'letterheads/org-1/letterhead.pdf',

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/purge-storage-prefixes/purge-storage-prefixes.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/purge-storage-prefixes/purge-storage-prefixes.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ListObjectsUseCase } from '../list-objects/list-objects.use-case';
 import { ListObjectsCommand } from '../list-objects/list-objects.command';
 import { DeleteObjectUseCase } from '../delete-object/delete-object.use-case';
@@ -25,9 +26,9 @@ export interface PurgeStoragePrefixesResult {
  */
 @Injectable()
 export class PurgeStoragePrefixesUseCase {
-  private readonly logger = new Logger(PurgeStoragePrefixesUseCase.name);
-
   constructor(
+    @InjectPinoLogger(PurgeStoragePrefixesUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly listObjectsUseCase: ListObjectsUseCase,
     private readonly deleteObjectUseCase: DeleteObjectUseCase,
   ) {}
@@ -35,9 +36,12 @@ export class PurgeStoragePrefixesUseCase {
   async execute(
     command: PurgeStoragePrefixesCommand,
   ): Promise<PurgeStoragePrefixesResult> {
-    this.logger.log('Purging storage prefixes', {
-      prefixCount: command.prefixes.length,
-    });
+    this.logger.info(
+      {
+        prefixCount: command.prefixes.length,
+      },
+      'Purging storage prefixes',
+    );
 
     const objectNames = await this.collectObjects(command.prefixes);
     if (objectNames.length === 0) {
@@ -45,7 +49,7 @@ export class PurgeStoragePrefixesUseCase {
     }
 
     const result = await this.deleteObjects(objectNames);
-    this.logger.log('Finished purging storage prefixes', { ...result });
+    this.logger.info({ ...result }, 'Finished purging storage prefixes');
     return result;
   }
 
@@ -62,10 +66,10 @@ export class PurgeStoragePrefixesUseCase {
           objectNames.add(name);
         }
       } catch (error) {
-        this.logger.error('Failed to list storage prefix', {
-          prefix,
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
+        this.logger.error(
+          { err: error as Error, prefix },
+          'Failed to list storage prefix',
+        );
       }
     }
     return Array.from(objectNames);
@@ -96,10 +100,10 @@ export class PurgeStoragePrefixesUseCase {
       if (error instanceof ObjectNotFoundError) {
         return true;
       }
-      this.logger.warn('Failed to delete object from storage', {
-        objectName,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.warn(
+        { err: error as Error, fileName: objectName },
+        'Failed to delete object from storage',
+      );
       return false;
     }
   }

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/sweep-orphan-storage/sweep-orphan-storage.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/sweep-orphan-storage/sweep-orphan-storage.use-case.spec.ts
@@ -1,6 +1,7 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import type { UUID } from 'crypto';
 import {
   ORPHAN_STORAGE_SAFETY_WINDOW_MS,
@@ -36,6 +37,10 @@ describe('SweepOrphanStorageUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SweepOrphanStorageUseCase,
+        {
+          provide: getLoggerToken(SweepOrphanStorageUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ObjectStoragePort, useValue: objectStorage },
         { provide: FindAllOrgIdsUseCase, useValue: findAllOrgIdsUseCase },
         { provide: PurgeOrgStorageUseCase, useValue: purgeOrgStorageUseCase },
@@ -43,10 +48,6 @@ describe('SweepOrphanStorageUseCase', () => {
     }).compile();
 
     useCase = module.get(SweepOrphanStorageUseCase);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/sweep-orphan-storage/sweep-orphan-storage.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/sweep-orphan-storage/sweep-orphan-storage.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { FindAllOrgIdsUseCase } from 'src/iam/orgs/application/use-cases/find-all-org-ids/find-all-org-ids.use-case';
 import { ObjectStoragePort } from '../../ports/object-storage.port';
@@ -37,16 +38,16 @@ export interface SweepOrphanStorageResult {
  */
 @Injectable()
 export class SweepOrphanStorageUseCase {
-  private readonly logger = new Logger(SweepOrphanStorageUseCase.name);
-
   constructor(
+    @InjectPinoLogger(SweepOrphanStorageUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly objectStorage: ObjectStoragePort,
     private readonly findAllOrgIdsUseCase: FindAllOrgIdsUseCase,
     private readonly purgeOrgStorageUseCase: PurgeOrgStorageUseCase,
   ) {}
 
   async execute(): Promise<SweepOrphanStorageResult> {
-    this.logger.log('Starting orphan storage sweep');
+    this.logger.info('Starting orphan storage sweep');
 
     const existingOrgIds = new Set<string>(
       await this.findAllOrgIdsUseCase.execute(),
@@ -76,7 +77,7 @@ export class SweepOrphanStorageUseCase {
       await this.purgeOrphan(orgId as UUID, result);
     }
 
-    this.logger.log('Finished orphan storage sweep', { ...result });
+    this.logger.info({ ...result }, 'Finished orphan storage sweep');
     return result;
   }
 
@@ -84,7 +85,7 @@ export class SweepOrphanStorageUseCase {
     orgId: UUID,
     result: SweepOrphanStorageResult,
   ): Promise<void> {
-    this.logger.warn('Purging storage of nonexistent org', { orgId });
+    this.logger.warn({ orgId }, 'Purging storage of nonexistent org');
     const purge = await this.purgeOrgStorageUseCase.execute(
       new PurgeOrgStorageCommand(orgId),
     );

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/upload-object/upload-object.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/upload-object/upload-object.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ConfigModule } from '@nestjs/config';
@@ -32,6 +34,10 @@ describe('UploadObjectUseCase', () => {
       imports: [ConfigModule.forFeature(storageConfig)],
       providers: [
         UploadObjectUseCase,
+        {
+          provide: getLoggerToken(UploadObjectUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ObjectStoragePort, useValue: mockObjectStorage },
         {
           provide: storageConfig.KEY,

--- a/ayunis-core-backend/src/domain/storage/application/use-cases/upload-object/upload-object.use-case.ts
+++ b/ayunis-core-backend/src/domain/storage/application/use-cases/upload-object/upload-object.use-case.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigType } from '@nestjs/config';
 import { ObjectStoragePort } from '../../ports/object-storage.port';
 import { StorageObject } from '../../../domain/storage-object.entity';
@@ -14,18 +15,22 @@ import { StorageObjectUpload } from '../../../domain/storage-object-upload.entit
 
 @Injectable()
 export class UploadObjectUseCase {
-  private readonly logger = new Logger(UploadObjectUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UploadObjectUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly objectStorage: ObjectStoragePort,
     @Inject(storageConfig.KEY)
     private readonly config: ConfigType<typeof storageConfig>,
   ) {}
 
   async execute(command: UploadObjectCommand): Promise<StorageObject> {
-    this.logger.debug(`Uploading object: ${command.objectName}`, {
-      bucket: command.bucket,
-    });
+    this.logger.debug(
+      {
+        bucket: command.bucket,
+        fileName: command.objectName,
+      },
+      'Uploading object',
+    );
 
     try {
       const bucketName = this.resolveTargetBucket(command);
@@ -39,11 +44,15 @@ export class UploadObjectUseCase {
         ),
       );
 
-      this.logger.debug(`Successfully uploaded object: ${command.objectName}`, {
-        bucket: bucketName,
-        size: result.size,
-        etag: result.etag,
-      });
+      this.logger.debug(
+        {
+          bucket: bucketName,
+          fileName: command.objectName,
+          size: result.size,
+          etag: result.etag,
+        },
+        'Successfully uploaded object',
+      );
 
       return new StorageObject(
         command.objectName,
@@ -63,8 +72,8 @@ export class UploadObjectUseCase {
       }
 
       this.logger.error(
-        `Failed to upload object: ${command.objectName}`,
-        error,
+        { err: error as Error, fileName: command.objectName },
+        'Failed to upload object',
       );
       throw new UploadFailedError();
     }
@@ -106,8 +115,8 @@ export class UploadObjectUseCase {
       return true;
     } catch (error) {
       this.logger.error(
-        `Error checking if bucket exists: ${bucketName}`,
-        error,
+        { bucket: bucketName, err: error as Error },
+        'Error checking if bucket exists',
       );
       return false;
     }

--- a/ayunis-core-backend/src/domain/storage/infrastructure/providers/minio-object-storage.provider.ts
+++ b/ayunis-core-backend/src/domain/storage/infrastructure/providers/minio-object-storage.provider.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigType } from '@nestjs/config';
 import * as Minio from 'minio';
 import { Readable } from 'stream';
@@ -31,11 +32,12 @@ export class MinioObjectStorageProvider
   extends ObjectStoragePort
   implements OnModuleInit
 {
-  private readonly logger = new Logger(MinioObjectStorageProvider.name);
   private client: Minio.Client;
   private defaultBucket: string;
 
   constructor(
+    @InjectPinoLogger(MinioObjectStorageProvider.name)
+    private readonly logger: PinoLogger,
     @Inject(storageConfig.KEY)
     private readonly config: ConfigType<typeof storageConfig>,
   ) {
@@ -55,7 +57,10 @@ export class MinioObjectStorageProvider
       // Add retry logic for MinIO connection
       await this.connectWithRetry();
     } catch (error) {
-      this.logger.error('Failed to initialize MinIO after retries', error);
+      this.logger.error(
+        { err: error as Error },
+        'Failed to initialize MinIO after retries',
+      );
       // Don't throw - let the application start and handle MinIO errors per request
     }
   }
@@ -63,19 +68,21 @@ export class MinioObjectStorageProvider
   private async connectWithRetry(maxRetries = 10, delay = 2000): Promise<void> {
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        this.logger.log(
-          `Connecting to MinIO (attempt ${attempt}/${maxRetries})`,
-        );
+        this.logger.info({ attempt, maxRetries }, 'Connecting to MinIO');
         const bucketExists = await this.client.bucketExists(this.defaultBucket);
         if (!bucketExists) {
           await this.client.makeBucket(this.defaultBucket, 'eu-central-1');
-          this.logger.log(`Created MinIO bucket: ${this.defaultBucket}`);
+          this.logger.info(
+            { bucket: this.defaultBucket },
+            'Created MinIO bucket',
+          );
         }
-        this.logger.log('MinIO connection successful');
+        this.logger.info('MinIO connection successful');
         return;
       } catch (error) {
         this.logger.warn(
-          `MinIO connection attempt ${attempt} failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          { attempt, err: error as Error },
+          'MinIO connection attempt failed',
         );
         if (attempt === maxRetries) {
           throw error;

--- a/ayunis-core-backend/src/domain/storage/infrastructure/tasks/orphan-storage-sweep.task.ts
+++ b/ayunis-core-backend/src/domain/storage/infrastructure/tasks/orphan-storage-sweep.task.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { SweepOrphanStorageUseCase } from '../../application/use-cases/sweep-orphan-storage/sweep-orphan-storage.use-case';
 
@@ -10,10 +11,11 @@ import { SweepOrphanStorageUseCase } from '../../application/use-cases/sweep-orp
  */
 @Injectable()
 export class OrphanStorageSweepTask {
-  private readonly logger = new Logger(OrphanStorageSweepTask.name);
   private isRunning = false;
 
   constructor(
+    @InjectPinoLogger(OrphanStorageSweepTask.name)
+    private readonly logger: PinoLogger,
     private readonly sweepOrphanStorageUseCase: SweepOrphanStorageUseCase,
   ) {}
 
@@ -27,17 +29,21 @@ export class OrphanStorageSweepTask {
     }
 
     this.isRunning = true;
-    this.logger.log('Starting scheduled orphan storage sweep');
+    this.logger.info('Starting scheduled orphan storage sweep');
 
     try {
       const result = await this.sweepOrphanStorageUseCase.execute();
-      this.logger.log('Scheduled orphan storage sweep completed', {
-        ...result,
-      });
+      this.logger.info(
+        {
+          ...result,
+        },
+        'Scheduled orphan storage sweep completed',
+      );
     } catch (error) {
-      this.logger.error('Scheduled orphan storage sweep failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        { err: error as Error },
+        'Scheduled orphan storage sweep failed',
+      );
     } finally {
       this.isRunning = false;
     }

--- a/ayunis-core-backend/src/domain/transcriptions/application/use-cases/transcribe/transcribe.use-case.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/application/use-cases/transcribe/transcribe.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TranscriptionPort } from '../../ports/transcription.port';
 import { TranscribeCommand } from './transcribe.command';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -11,22 +12,32 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 // 25 MB - matches Mistral's API limit for audio transcription
 const MAX_AUDIO_FILE_SIZE_BYTES = 25 * 1024 * 1024;
+const SUPPORTED_MIME_TYPES = [
+  'audio/webm',
+  'audio/mp4',
+  'audio/mpeg',
+  'audio/wav',
+  'audio/x-m4a',
+];
 
 @Injectable()
 export class TranscribeUseCase {
-  private readonly logger = new Logger(TranscribeUseCase.name);
-
   constructor(
+    @InjectPinoLogger(TranscribeUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly transcriptionPort: TranscriptionPort,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(command: TranscribeCommand): Promise<string> {
-    this.logger.log('execute', {
-      fileName: command.fileName,
-      mimeType: command.mimeType,
-      language: command.language,
-    });
+    this.logger.info(
+      {
+        fileName: command.fileName,
+        mimeType: command.mimeType,
+        language: command.language,
+      },
+      'execute',
+    );
 
     try {
       const userId = this.contextService.get('userId');
@@ -34,34 +45,8 @@ export class TranscribeUseCase {
         throw new UnauthorizedAccessError();
       }
 
-      // Validate audio file
-      if (!command.file || command.file.length === 0) {
-        throw new InvalidAudioFileError('Empty audio file');
-      }
+      this.validateAudio(command);
 
-      // Validate file size
-      if (command.file.length > MAX_AUDIO_FILE_SIZE_BYTES) {
-        const maxSizeMB = MAX_AUDIO_FILE_SIZE_BYTES / (1024 * 1024);
-        throw new InvalidAudioFileError(
-          `Audio file size exceeds maximum allowed size of ${maxSizeMB} MB`,
-        );
-      }
-
-      // Basic MIME type validation
-      const supportedMimeTypes = [
-        'audio/webm',
-        'audio/mp4',
-        'audio/mpeg',
-        'audio/wav',
-        'audio/x-m4a',
-      ];
-      if (!supportedMimeTypes.includes(command.mimeType)) {
-        throw new InvalidAudioFileError(
-          `Unsupported audio format: ${command.mimeType}`,
-        );
-      }
-
-      // Call the transcription service
       const transcriptedText = await this.transcriptionPort.transcribe(
         command.file,
         command.fileName,
@@ -69,22 +54,44 @@ export class TranscribeUseCase {
         command.language,
       );
 
-      this.logger.log('Transcription completed', {
-        fileName: command.fileName,
-        textLength: transcriptedText.length,
-      });
+      this.logger.info(
+        {
+          fileName: command.fileName,
+          textLength: transcriptedText.length,
+        },
+        'Transcription completed',
+      );
 
       return transcriptedText;
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Failed to transcribe audio', {
-        fileName: command.fileName,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new TranscriptionFailedError(
-        (error as Error).message ?? 'Unknown error during transcription',
+      this.logger.error(
+        { err: error as Error, fileName: command.fileName },
+        'Failed to transcribe audio',
+      );
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Unknown error during transcription';
+      throw new TranscriptionFailedError(message);
+    }
+  }
+
+  private validateAudio(command: TranscribeCommand): void {
+    if (command.file.length === 0) {
+      throw new InvalidAudioFileError('Empty audio file');
+    }
+    if (command.file.length > MAX_AUDIO_FILE_SIZE_BYTES) {
+      const maxSizeMB = MAX_AUDIO_FILE_SIZE_BYTES / (1024 * 1024);
+      throw new InvalidAudioFileError(
+        `Audio file size exceeds maximum allowed size of ${maxSizeMB} MB`,
+      );
+    }
+    if (!SUPPORTED_MIME_TYPES.includes(command.mimeType)) {
+      throw new InvalidAudioFileError(
+        `Unsupported audio format: ${command.mimeType}`,
       );
     }
   }

--- a/ayunis-core-backend/src/domain/transcriptions/infrastructure/mistral-transcription.service.spec.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/infrastructure/mistral-transcription.service.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
 import type { TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
@@ -29,6 +31,10 @@ describe('MistralTranscriptionService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MistralTranscriptionService,
+        {
+          provide: getLoggerToken(MistralTranscriptionService.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: ConfigService,
           useValue: {

--- a/ayunis-core-backend/src/domain/transcriptions/infrastructure/mistral-transcription.service.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/infrastructure/mistral-transcription.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { Mistral } from '@mistralai/mistralai';
 import { TranscriptionPort } from '../application/ports/transcription.port';
@@ -9,11 +10,14 @@ import { wrapProviderFailure } from 'src/common/errors/wrap-provider-failure.hel
 
 @Injectable()
 export class MistralTranscriptionService extends TranscriptionPort {
-  private readonly logger = new Logger(MistralTranscriptionService.name);
   private readonly client: Mistral;
   private readonly model: string;
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    @InjectPinoLogger(MistralTranscriptionService.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {
     super();
     this.client = new Mistral({
       apiKey: this.configService.get('models.mistral.apiKey'),
@@ -31,12 +35,15 @@ export class MistralTranscriptionService extends TranscriptionPort {
     mimeType: string,
     language?: string,
   ): Promise<string> {
-    this.logger.log('Starting transcription', {
-      fileName,
-      fileSize: file.length,
-      mimeType,
-      language,
-    });
+    this.logger.info(
+      {
+        fileName,
+        fileSize: file.length,
+        mimeType,
+        language,
+      },
+      'Starting transcription',
+    );
 
     try {
       // Create a File object from the buffer for the Mistral API
@@ -48,17 +55,20 @@ export class MistralTranscriptionService extends TranscriptionPort {
 
       const transcriptedText = response.text.trim() || '';
 
-      this.logger.log('Transcription completed successfully', {
-        fileName,
-        textLength: transcriptedText.length,
-      });
+      this.logger.info(
+        {
+          fileName,
+          textLength: transcriptedText.length,
+        },
+        'Transcription completed successfully',
+      );
 
       return transcriptedText;
     } catch (error) {
-      this.logger.error('Transcription failed', {
-        fileName,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        { err: error as Error, fileName },
+        'Transcription failed',
+      );
 
       // Availability failures (transport errors, SDK 5xx, timeouts) all
       // classify here; what falls through is a request-shaped failure.
@@ -85,10 +95,13 @@ export class MistralTranscriptionService extends TranscriptionPort {
       ...(language && { language }),
     };
 
-    this.logger.log('Sending transcription request to Mistral', {
-      model: this.model,
-      language,
-    });
+    this.logger.info(
+      {
+        model: this.model,
+        language,
+      },
+      'Sending transcription request to Mistral',
+    );
 
     return retryWithBackoff({
       fn: () => this.client.audio.transcriptions.complete(transcriptionRequest),
@@ -101,9 +114,10 @@ export class MistralTranscriptionService extends TranscriptionPort {
   private shouldRetry(error: Error): boolean {
     const isTransient = isTransientMistralError(error);
     if (isTransient) {
-      this.logger.warn('Retrying Mistral transcription after transient error', {
-        message: error.message,
-      });
+      this.logger.warn(
+        { err: error },
+        'Retrying Mistral transcription after transient error',
+      );
     }
     return isTransient;
   }

--- a/ayunis-core-backend/src/domain/transcriptions/presenters/http/transcriptions.controller.ts
+++ b/ayunis-core-backend/src/domain/transcriptions/presenters/http/transcriptions.controller.ts
@@ -5,8 +5,8 @@ import {
   UploadedFile,
   Body,
   BadRequestException,
-  Logger,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { TranscribeUseCase } from '../../application/use-cases/transcribe/transcribe.use-case';
@@ -20,9 +20,11 @@ import { RequireAcademyCertificate } from 'src/iam/academy-access/application/de
 @RequireAcademyCertificate()
 @Controller('transcriptions')
 export class TranscriptionsController {
-  private readonly logger = new Logger(TranscriptionsController.name);
-
-  constructor(private readonly transcribeUseCase: TranscribeUseCase) {}
+  constructor(
+    @InjectPinoLogger(TranscriptionsController.name)
+    private readonly logger: PinoLogger,
+    private readonly transcribeUseCase: TranscribeUseCase,
+  ) {}
 
   @Post()
   @UseInterceptors(
@@ -41,12 +43,15 @@ export class TranscriptionsController {
       throw new BadRequestException('No audio file provided');
     }
 
-    this.logger.log('Transcription request received', {
-      fileName: file.originalname,
-      mimeType: file.mimetype,
-      fileSize: file.size,
-      language,
-    });
+    this.logger.info(
+      {
+        fileName: file.originalname,
+        mimeType: file.mimetype,
+        fileSize: file.size,
+        language,
+      },
+      'Transcription request received',
+    );
 
     const command = new TranscribeCommand({
       file: file.buffer,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability and test wiring only; no auth, data model, or processing pipeline semantics changed beyond equivalent logging and minor internal extractions.
> 
> **Overview**
> **Migrates logging** in the **sources**, **storage**, and **transcription** domains from `@nestjs/common` `Logger` to **`nestjs-pino`** (`@InjectPinoLogger` + `PinoLogger`). Call sites now use Pino’s **`(context, message)`** shape, **`info`** instead of **`log`**, and **`err`** (not `error`) on failures so stack traces serialize correctly.
> 
> Coverage includes source use cases and helpers, BullMQ producers/consumers, repositories, MinIO/storage use cases, orphan sweep tasks, and the transcriptions controller and Mistral service. Shared helpers like **`cancelQueueJob`** and **`cleanupMinioProcessingFile`** now take **`PinoLogger`**.
> 
> **Tests** register **`getLoggerToken(...)`** with **`createPinoLoggerMock()`** instead of spying on `Logger.prototype`; **`mark-source-failed`** asserts structured **`warn`** metadata.
> 
> A few small refactors ride along (e.g. **`StartUrlCrawlUseCase`** `enqueueOrFail`, **`TranscribeUseCase`** `validateAudio`, consumer `processJob` extraction) without changing intended behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eb9f7b31ab42120843017c28533478314400b1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->