### PR TITLE
wip(logging): migrate threads, shares, and retention logging (AYC-751)

### DIFF
--- a/ayunis-core-backend/src/domain/retention-policies/application/use-cases/enforce-retention/enforce-retention.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/application/use-cases/enforce-retention/enforce-retention.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { randomUUID } from 'crypto';
@@ -42,6 +44,10 @@ describe('EnforceRetentionUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EnforceRetentionUseCase,
+        {
+          provide: getLoggerToken(EnforceRetentionUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: RetentionPoliciesRepository, useValue: retentionRepo },
         { provide: FindExpiredThreadRefsByOrgUseCase, useValue: findExpired },
         { provide: DeleteThreadUseCase, useValue: deleteThread },

--- a/ayunis-core-backend/src/domain/retention-policies/application/use-cases/enforce-retention/enforce-retention.use-case.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/application/use-cases/enforce-retention/enforce-retention.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import type { UUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -30,9 +31,9 @@ export const MAX_BATCHES_PER_ORG = 10_000;
  */
 @Injectable()
 export class EnforceRetentionUseCase {
-  private readonly logger = new Logger(EnforceRetentionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(EnforceRetentionUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly retentionPoliciesRepository: RetentionPoliciesRepository,
     private readonly findExpiredThreadRefsByOrg: FindExpiredThreadRefsByOrgUseCase,
     private readonly deleteThreadUseCase: DeleteThreadUseCase,
@@ -45,10 +46,13 @@ export class EnforceRetentionUseCase {
     const policies = await this.retentionPoliciesRepository.findAllEnabled();
     const now = new Date();
 
-    this.logger.log('Starting retention enforcement', {
-      enabledOrgs: policies.length,
-      dryRun,
-    });
+    this.logger.info(
+      {
+        enabledOrgs: policies.length,
+        dryRun,
+      },
+      'Starting retention enforcement',
+    );
 
     const perOrg: OrgRetentionResult[] = [];
     for (const policy of policies) {
@@ -62,12 +66,15 @@ export class EnforceRetentionUseCase {
       dryRun,
       perOrg,
     };
-    this.logger.log('Retention enforcement complete', {
-      orgsProcessed: result.orgsProcessed,
-      totalDeleted: result.totalDeleted,
-      totalFailed: result.totalFailed,
-      dryRun,
-    });
+    this.logger.info(
+      {
+        orgsProcessed: result.orgsProcessed,
+        totalDeleted: result.totalDeleted,
+        totalFailed: result.totalFailed,
+        dryRun,
+      },
+      'Retention enforcement complete',
+    );
     return result;
   }
 
@@ -95,12 +102,12 @@ export class EnforceRetentionUseCase {
     result.capReached = await this.drainExpiredThreads(policy, cutoff, result);
     if (result.capReached) {
       this.logger.warn(
-        'Retention batch cap reached; expired threads may remain for org',
         { maxBatches: MAX_BATCHES_PER_ORG, ...result },
+        'Retention batch cap reached; expired threads may remain for org',
       );
     }
 
-    this.logger.log('Retention enforced for org', { cutoff, ...result });
+    this.logger.info({ cutoff, ...result }, 'Retention enforced for org');
     return result;
   }
 
@@ -179,11 +186,14 @@ export class EnforceRetentionUseCase {
       } catch (error) {
         result.failed += 1;
         advance += 1;
-        this.logger.warn('Failed to delete expired thread', {
-          orgId,
-          threadId: ref.id,
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
+        this.logger.warn(
+          {
+            orgId,
+            threadId: ref.id,
+            err: error as Error,
+          },
+          'Failed to delete expired thread',
+        );
       }
     }
     return advance;

--- a/ayunis-core-backend/src/domain/retention-policies/application/use-cases/get-org-retention-policy/get-org-retention-policy.use-case.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/application/use-cases/get-org-retention-policy/get-org-retention-policy.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { RetentionPoliciesRepository } from '../../ports/retention-policies.repository';
 import { UnexpectedRetentionPolicyError } from '../../retention-policies.errors';
@@ -7,25 +8,30 @@ import type { GetOrgRetentionPolicyQuery } from './get-org-retention-policy.quer
 
 @Injectable()
 export class GetOrgRetentionPolicyUseCase {
-  private readonly logger = new Logger(GetOrgRetentionPolicyUseCase.name);
-
-  constructor(private readonly repository: RetentionPoliciesRepository) {}
+  constructor(
+    @InjectPinoLogger(GetOrgRetentionPolicyUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: RetentionPoliciesRepository,
+  ) {}
 
   /** Returns the org's policy, or null when retention has never been set. */
   async execute(
     query: GetOrgRetentionPolicyQuery,
   ): Promise<OrgRetentionPolicy | null> {
-    this.logger.debug('Getting retention policy', { orgId: query.orgId });
+    this.logger.debug({ orgId: query.orgId }, 'Getting retention policy');
 
     try {
       return await this.repository.findByOrgId(query.orgId);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
 
-      this.logger.error('Failed to get retention policy', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: query.orgId,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          orgId: query.orgId,
+        },
+        'Failed to get retention policy',
+      );
 
       throw new UnexpectedRetentionPolicyError('get', {
         orgId: query.orgId,

--- a/ayunis-core-backend/src/domain/retention-policies/application/use-cases/upsert-org-retention-policy/upsert-org-retention-policy.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/application/use-cases/upsert-org-retention-policy/upsert-org-retention-policy.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
 import { randomUUID } from 'crypto';
 import { UpsertOrgRetentionPolicyUseCase } from './upsert-org-retention-policy.use-case';
@@ -29,6 +31,10 @@ describe('UpsertOrgRetentionPolicyUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UpsertOrgRetentionPolicyUseCase,
+        {
+          provide: getLoggerToken(UpsertOrgRetentionPolicyUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: RetentionPoliciesRepository, useValue: repository },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/retention-policies/application/use-cases/upsert-org-retention-policy/upsert-org-retention-policy.use-case.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/application/use-cases/upsert-org-retention-policy/upsert-org-retention-policy.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { RetentionPoliciesRepository } from '../../ports/retention-policies.repository';
 import {
@@ -11,17 +12,22 @@ import type { UpsertOrgRetentionPolicyCommand } from './upsert-org-retention-pol
 
 @Injectable()
 export class UpsertOrgRetentionPolicyUseCase {
-  private readonly logger = new Logger(UpsertOrgRetentionPolicyUseCase.name);
-
-  constructor(private readonly repository: RetentionPoliciesRepository) {}
+  constructor(
+    @InjectPinoLogger(UpsertOrgRetentionPolicyUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: RetentionPoliciesRepository,
+  ) {}
 
   async execute(
     command: UpsertOrgRetentionPolicyCommand,
   ): Promise<OrgRetentionPolicy> {
-    this.logger.log('Upserting retention policy', {
-      orgId: command.orgId,
-      retentionDays: command.retentionDays,
-    });
+    this.logger.info(
+      {
+        orgId: command.orgId,
+        retentionDays: command.retentionDays,
+      },
+      'Upserting retention policy',
+    );
 
     if (!isValidRetentionDays(command.retentionDays)) {
       throw new InvalidRetentionPeriodError(command.retentionDays, {
@@ -42,10 +48,13 @@ export class UpsertOrgRetentionPolicyUseCase {
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
 
-      this.logger.error('Failed to upsert retention policy', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          orgId: command.orgId,
+        },
+        'Failed to upsert retention policy',
+      );
 
       throw new UnexpectedRetentionPolicyError('upsert', {
         orgId: command.orgId,

--- a/ayunis-core-backend/src/domain/retention-policies/infrastructure/persistence/postgres/postgres-retention-policies.repository.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/infrastructure/persistence/postgres/postgres-retention-policies.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Not, IsNull, Repository } from 'typeorm';
 import type { UUID } from 'crypto';
@@ -9,11 +10,9 @@ import { OrgRetentionPolicyMapper } from './mappers/org-retention-policy.mapper'
 
 @Injectable()
 export class PostgresRetentionPoliciesRepository extends RetentionPoliciesRepository {
-  private readonly logger = new Logger(
-    PostgresRetentionPoliciesRepository.name,
-  );
-
   constructor(
+    @InjectPinoLogger(PostgresRetentionPoliciesRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(OrgRetentionPolicyRecord)
     private readonly repository: Repository<OrgRetentionPolicyRecord>,
   ) {
@@ -26,10 +25,13 @@ export class PostgresRetentionPoliciesRepository extends RetentionPoliciesReposi
   }
 
   async upsert(policy: OrgRetentionPolicy): Promise<OrgRetentionPolicy> {
-    this.logger.debug('upsert', {
-      orgId: policy.orgId,
-      retentionDays: policy.retentionDays,
-    });
+    this.logger.debug(
+      {
+        orgId: policy.orgId,
+        retentionDays: policy.retentionDays,
+      },
+      'upsert',
+    );
     const saved = await this.repository.save(
       OrgRetentionPolicyMapper.toRecord(policy),
     );

--- a/ayunis-core-backend/src/domain/retention-policies/infrastructure/tasks/retention-cleanup.task.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/infrastructure/tasks/retention-cleanup.task.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { EnforceRetentionUseCase } from '../../application/use-cases/enforce-retention/enforce-retention.use-case';
 
@@ -9,10 +10,11 @@ import { EnforceRetentionUseCase } from '../../application/use-cases/enforce-ret
  */
 @Injectable()
 export class RetentionCleanupTask {
-  private readonly logger = new Logger(RetentionCleanupTask.name);
   private isRunning = false;
 
   constructor(
+    @InjectPinoLogger(RetentionCleanupTask.name)
+    private readonly logger: PinoLogger,
     private readonly enforceRetentionUseCase: EnforceRetentionUseCase,
   ) {}
 
@@ -26,20 +28,23 @@ export class RetentionCleanupTask {
     }
 
     this.isRunning = true;
-    this.logger.log('Starting scheduled retention cleanup');
+    this.logger.info('Starting scheduled retention cleanup');
 
     try {
       const result = await this.enforceRetentionUseCase.execute();
-      this.logger.log('Scheduled retention cleanup completed', {
-        orgsProcessed: result.orgsProcessed,
-        totalDeleted: result.totalDeleted,
-        totalFailed: result.totalFailed,
-        dryRun: result.dryRun,
-      });
+      this.logger.info(
+        {
+          orgsProcessed: result.orgsProcessed,
+          totalDeleted: result.totalDeleted,
+          totalFailed: result.totalFailed,
+          dryRun: result.dryRun,
+        },
+        'Scheduled retention cleanup completed',
+      );
     } catch (error) {
       this.logger.error(
+        { err: error as Error },
         'Scheduled retention cleanup failed',
-        error instanceof Error ? error.stack : undefined,
       );
     } finally {
       this.isRunning = false;

--- a/ayunis-core-backend/src/domain/retention-policies/presenters/http/retention-policies.controller.ts
+++ b/ayunis-core-backend/src/domain/retention-policies/presenters/http/retention-policies.controller.ts
@@ -1,4 +1,5 @@
-import { Body, Controller, Get, Logger, Put } from '@nestjs/common';
+import { Body, Controller, Get, Put } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiExtraModels,
   ApiOperation,
@@ -25,9 +26,9 @@ import { RetentionPolicyResponseDto } from './dtos/retention-policy-response.dto
 @Controller('retention-policies')
 @ApiExtraModels(RetentionPolicyResponseDto)
 export class RetentionPoliciesController {
-  private readonly logger = new Logger(RetentionPoliciesController.name);
-
   constructor(
+    @InjectPinoLogger(RetentionPoliciesController.name)
+    private readonly logger: PinoLogger,
     private readonly getOrgRetentionPolicy: GetOrgRetentionPolicyUseCase,
     private readonly upsertOrgRetentionPolicy: UpsertOrgRetentionPolicyUseCase,
   ) {}
@@ -45,7 +46,7 @@ export class RetentionPoliciesController {
   async get(
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
   ): Promise<RetentionPolicyResponseDto> {
-    this.logger.log(`Getting retention policy for org ${orgId}`);
+    this.logger.info({ orgId }, 'Getting retention policy for org');
 
     const policy = await this.getOrgRetentionPolicy.execute(
       new GetOrgRetentionPolicyQuery(orgId),
@@ -71,9 +72,10 @@ export class RetentionPoliciesController {
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
     @Body() dto: UpdateRetentionPolicyRequestDto,
   ): Promise<RetentionPolicyResponseDto> {
-    this.logger.log(`Updating retention policy for org ${orgId}`, {
-      retentionDays: dto.retentionDays,
-    });
+    this.logger.info(
+      { orgId, retentionDays: dto.retentionDays },
+      'Updating retention policy for org',
+    );
 
     const policy = await this.upsertOrgRetentionPolicy.execute(
       new UpsertOrgRetentionPolicyCommand(orgId, dto.retentionDays),

--- a/ayunis-core-backend/src/domain/shares/application/services/share-scope-resolver.service.spec.ts
+++ b/ayunis-core-backend/src/domain/shares/application/services/share-scope-resolver.service.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
 import { ShareScopeResolverService } from './share-scope-resolver.service';
 import { FindAllUserIdsByOrgIdUseCase } from 'src/iam/users/application/use-cases/find-all-user-ids-by-org-id/find-all-user-ids-by-org-id.use-case';
@@ -25,6 +27,10 @@ describe('ShareScopeResolverService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ShareScopeResolverService,
+        {
+          provide: getLoggerToken(ShareScopeResolverService.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: FindAllUserIdsByOrgIdUseCase,
           useValue: findAllUserIdsByOrgId,

--- a/ayunis-core-backend/src/domain/shares/application/services/share-scope-resolver.service.ts
+++ b/ayunis-core-backend/src/domain/shares/application/services/share-scope-resolver.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { ShareScopeType } from '../../domain/value-objects/share-scope-type.enum';
 import {
@@ -12,9 +13,9 @@ import { FindAllUserIdsByTeamIdQuery } from 'src/iam/teams/application/use-cases
 
 @Injectable()
 export class ShareScopeResolverService {
-  private readonly logger = new Logger(ShareScopeResolverService.name);
-
   constructor(
+    @InjectPinoLogger(ShareScopeResolverService.name)
+    private readonly logger: PinoLogger,
     private readonly findAllUserIdsByOrgId: FindAllUserIdsByOrgIdUseCase,
     private readonly findAllUserIdsByTeamId: FindAllUserIdsByTeamIdUseCase,
   ) {}
@@ -61,9 +62,12 @@ export class ShareScopeResolverService {
           new FindAllUserIdsByTeamIdQuery(scope.scopeId),
         );
       default:
-        this.logger.warn('Unknown scope type', {
-          scopeType: scope.scopeType,
-        });
+        this.logger.warn(
+          {
+            scopeType: scope.scopeType,
+          },
+          'Unknown scope type',
+        );
         return [];
     }
   }

--- a/ayunis-core-backend/src/domain/shares/application/use-cases/delete-share/delete-share.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/shares/application/use-cases/delete-share/delete-share.use-case.spec.ts
@@ -1,4 +1,6 @@
 // Mock the Transactional decorator
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken, type PinoLogger } from 'nestjs-pino';
 jest.mock('@nestjs-cls/transactional', () => ({
   Transactional:
     () => (target: any, propertyName: string, descriptor: PropertyDescriptor) =>
@@ -27,14 +29,20 @@ describe('DeleteShareUseCase', () => {
   let contextService: ContextService;
   let repository: SharesRepository;
   let eventEmitter: EventEmitter2;
+  let logger: jest.Mocked<PinoLogger>;
 
   const mockUserId = randomUUID();
   const mockOrgId = randomUUID();
 
   beforeAll(async () => {
+    logger = createPinoLoggerMock();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeleteShareUseCase,
+        {
+          provide: getLoggerToken(DeleteShareUseCase.name),
+          useValue: logger,
+        },
         {
           provide: ContextService,
           useValue: {
@@ -190,11 +198,15 @@ describe('DeleteShareUseCase', () => {
     expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
   });
 
-  it('should throw when share does not exist', async () => {
+  it('should log unexpected deletion failures with a message', async () => {
     (contextService.get as jest.Mock).mockReturnValue(mockUserId);
     (repository.findById as jest.Mock).mockResolvedValue(null);
 
     await expect(useCase.execute(randomUUID())).rejects.toThrow();
+    expect(logger.error).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      'Failed to delete share',
+    );
     expect(eventEmitter.emitAsync).not.toHaveBeenCalled();
   });
 

--- a/ayunis-core-backend/src/domain/shares/application/use-cases/delete-share/delete-share.use-case.ts
+++ b/ayunis-core-backend/src/domain/shares/application/use-cases/delete-share/delete-share.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { SharesRepository } from '../../ports/shares-repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -18,8 +19,9 @@ import {
 
 @Injectable()
 export class DeleteShareUseCase {
-  private logger = new Logger(DeleteShareUseCase.name);
   constructor(
+    @InjectPinoLogger(DeleteShareUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: SharesRepository,
     private readonly contextService: ContextService,
     private readonly eventEmitter: EventEmitter2,
@@ -70,13 +72,14 @@ export class DeleteShareUseCase {
           ),
         )
         .catch((err: unknown) => {
-          this.logger.error(`Failed to emit ${ShareDeletedEvent.EVENT_NAME}`, {
-            error: err instanceof Error ? err.message : 'Unknown error',
-          });
+          this.logger.error(
+            { err: err as Error },
+            'Failed to emit share deletion event',
+          );
         });
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error(error);
+      this.logger.error({ err: error as Error }, 'Failed to delete share');
       throw new Error('Unexpected error occurred');
     }
   }

--- a/ayunis-core-backend/src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case.ts
+++ b/ayunis-core-backend/src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case.ts
@@ -1,9 +1,5 @@
-import {
-  Inject,
-  Injectable,
-  Logger,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SharesRepository } from '../../ports/shares-repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
 import { FindShareByEntityQuery } from './find-share-by-entity.query';
@@ -17,9 +13,9 @@ import { ListMyTeamsUseCase } from 'src/iam/teams/application/use-cases/list-my-
  */
 @Injectable()
 export class FindShareByEntityUseCase {
-  private readonly logger = new Logger(FindShareByEntityUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindShareByEntityUseCase.name)
+    private readonly logger: PinoLogger,
     @Inject(SharesRepository)
     private readonly sharesRepository: SharesRepository,
     private readonly contextService: ContextService,
@@ -33,10 +29,13 @@ export class FindShareByEntityUseCase {
    * @throws UnauthorizedException if user is not authenticated or has no organization
    */
   async execute(query: FindShareByEntityQuery): Promise<Share | null> {
-    this.logger.log('execute', {
-      entityType: query.entityType,
-      entityId: query.entityId,
-    });
+    this.logger.info(
+      {
+        entityType: query.entityType,
+        entityId: query.entityId,
+      },
+      'execute',
+    );
 
     // Get current user's organization from context
     const orgId = this.contextService.get('orgId');

--- a/ayunis-core-backend/src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.use-case.ts
+++ b/ayunis-core-backend/src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.use-case.ts
@@ -1,9 +1,5 @@
-import {
-  Inject,
-  Injectable,
-  Logger,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SharesRepository } from '../../ports/shares-repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
 import { FindSharesByScopeQuery } from './find-shares-by-scope.query';
@@ -18,9 +14,9 @@ import { ListMyTeamsUseCase } from 'src/iam/teams/application/use-cases/list-my-
  */
 @Injectable()
 export class FindSharesByScopeUseCase {
-  private readonly logger = new Logger(FindSharesByScopeUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindSharesByScopeUseCase.name)
+    private readonly logger: PinoLogger,
     @Inject(SharesRepository)
     private readonly sharesRepository: SharesRepository,
     private readonly contextService: ContextService,
@@ -34,9 +30,12 @@ export class FindSharesByScopeUseCase {
    * @throws UnauthorizedException if user is not authenticated or has no organization
    */
   async execute(query: FindSharesByScopeQuery): Promise<Share[]> {
-    this.logger.log('execute', {
-      entityType: query.entityType,
-    });
+    this.logger.info(
+      {
+        entityType: query.entityType,
+      },
+      'execute',
+    );
 
     // Get current user's organization from context
     const orgId = this.contextService.get('orgId');

--- a/ayunis-core-backend/src/domain/shares/application/use-cases/get-shares/get-shares.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/shares/application/use-cases/get-shares/get-shares.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
 import { UnauthorizedException, ForbiddenException } from '@nestjs/common';
 import { GetSharesUseCase } from './get-shares.use-case';
@@ -46,6 +48,10 @@ describe('GetSharesUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetSharesUseCase,
+        {
+          provide: getLoggerToken(GetSharesUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: SharesRepository,
           useValue: mockSharesRepository,

--- a/ayunis-core-backend/src/domain/shares/application/use-cases/get-shares/get-shares.use-case.ts
+++ b/ayunis-core-backend/src/domain/shares/application/use-cases/get-shares/get-shares.use-case.ts
@@ -1,10 +1,10 @@
 import {
   Inject,
   Injectable,
-  Logger,
   ForbiddenException,
   UnauthorizedException,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SharesRepository } from '../../ports/shares-repository.port';
 import { ShareAuthorizationFactory } from '../../factories/share-authorization.factory';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -17,9 +17,9 @@ import { Share } from 'src/domain/shares/domain/share.entity';
  */
 @Injectable()
 export class GetSharesUseCase {
-  private readonly logger = new Logger(GetSharesUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetSharesUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly authFactory: ShareAuthorizationFactory,
     @Inject(SharesRepository)
     private readonly sharesRepository: SharesRepository,
@@ -34,10 +34,13 @@ export class GetSharesUseCase {
    * @throws ForbiddenException if user cannot view shares for the entity
    */
   async execute(query: GetSharesQuery): Promise<Share[]> {
-    this.logger.log('execute', {
-      entityId: query.entityId,
-      entityType: query.entityType,
-    });
+    this.logger.info(
+      {
+        entityId: query.entityId,
+        entityType: query.entityType,
+      },
+      'execute',
+    );
 
     // Get current user from context
     const userId = this.contextService.get('userId');

--- a/ayunis-core-backend/src/domain/shares/presenters/http/shares.controller.spec.ts
+++ b/ayunis-core-backend/src/domain/shares/presenters/http/shares.controller.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
 import { SharesController } from './shares.controller';
 import { CreateShareUseCase } from '../../application/use-cases/create-share/create-share.use-case';
@@ -37,6 +39,10 @@ describe('SharesController', () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [SharesController],
       providers: [
+        {
+          provide: getLoggerToken(SharesController.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: CreateShareUseCase,
           useValue: {

--- a/ayunis-core-backend/src/domain/shares/presenters/http/shares.controller.ts
+++ b/ayunis-core-backend/src/domain/shares/presenters/http/shares.controller.ts
@@ -7,10 +7,10 @@ import {
   Query,
   Param,
   ParseUUIDPipe,
-  Logger,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import {
   ApiTags,
@@ -51,9 +51,9 @@ import { Permission } from 'src/iam/permissions/domain/value-objects/permission.
 @ApiTags('shares')
 @Controller('shares')
 export class SharesController {
-  private readonly logger = new Logger(SharesController.name);
-
   constructor(
+    @InjectPinoLogger(SharesController.name)
+    private readonly logger: PinoLogger,
     private readonly createShareUseCase: CreateShareUseCase,
     private readonly deleteShareUseCase: DeleteShareUseCase,
     private readonly getSharesUseCase: GetSharesUseCase,
@@ -82,10 +82,13 @@ export class SharesController {
   async createSkillShare(
     @Body() dto: CreateSkillShareDto,
   ): Promise<ShareResponseDto> {
-    this.logger.log('createSkillShare', {
-      skillId: dto.skillId,
-      teamId: dto.teamId,
-    });
+    this.logger.info(
+      {
+        skillId: dto.skillId,
+        teamId: dto.teamId,
+      },
+      'createSkillShare',
+    );
 
     const command = dto.teamId
       ? new CreateTeamSkillShareCommand(dto.skillId as UUID, dto.teamId as UUID)
@@ -125,10 +128,13 @@ export class SharesController {
   async createKnowledgeBaseShare(
     @Body() dto: CreateKnowledgeBaseShareDto,
   ): Promise<ShareResponseDto> {
-    this.logger.log('createKnowledgeBaseShare', {
-      knowledgeBaseId: dto.knowledgeBaseId,
-      teamId: dto.teamId,
-    });
+    this.logger.info(
+      {
+        knowledgeBaseId: dto.knowledgeBaseId,
+        teamId: dto.teamId,
+      },
+      'createKnowledgeBaseShare',
+    );
 
     const command = dto.teamId
       ? new CreateTeamKnowledgeBaseShareCommand(
@@ -180,7 +186,7 @@ export class SharesController {
     @Query('entityId', ParseUUIDPipe) entityId: UUID,
     @Query('entityType') entityType: SharedEntityType,
   ): Promise<ShareResponseDto[]> {
-    this.logger.log('getShares', { entityId, entityType });
+    this.logger.info({ entityId, entityType }, 'getShares');
 
     const shares = await this.getSharesUseCase.execute(
       new GetSharesQuery(entityId, entityType),
@@ -224,7 +230,7 @@ export class SharesController {
   @ApiResponse({ status: 500, description: 'Internal server error' })
   @HttpCode(HttpStatus.NO_CONTENT)
   async deleteShare(@Param('id', ParseUUIDPipe) id: UUID): Promise<void> {
-    this.logger.log('deleteShare', { id });
+    this.logger.info({ id }, 'deleteShare');
 
     await this.deleteShareUseCase.execute(id);
   }

--- a/ayunis-core-backend/src/domain/threads/application/listeners/share-deleted.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/listeners/share-deleted.listener.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
 import { ShareDeletedListener } from './share-deleted.listener';
 import { RemoveSkillSourcesFromThreadsUseCase } from '../use-cases/remove-skill-sources-from-threads/remove-skill-sources-from-threads.use-case';
@@ -54,6 +56,10 @@ describe('ShareDeletedListener (threads)', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ShareDeletedListener,
+        {
+          provide: getLoggerToken(ShareDeletedListener.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: RemoveSkillSourcesFromThreadsUseCase,
           useValue: removeSkillSources,

--- a/ayunis-core-backend/src/domain/threads/application/listeners/share-deleted.listener.ts
+++ b/ayunis-core-backend/src/domain/threads/application/listeners/share-deleted.listener.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OnEvent } from '@nestjs/event-emitter';
 import { ShareDeletedEvent } from 'src/domain/shares/application/events/share-deleted.event';
 import { SharedEntityType } from 'src/domain/shares/domain/value-objects/shared-entity-type.enum';
@@ -11,9 +12,9 @@ import { RemoveDirectKnowledgeBaseFromThreadsUseCase } from '../use-cases/remove
 import { RemoveDirectKnowledgeBaseFromThreadsCommand } from '../use-cases/remove-direct-knowledge-base-from-threads/remove-direct-knowledge-base-from-threads.command';
 @Injectable()
 export class ShareDeletedListener {
-  private readonly logger = new Logger(ShareDeletedListener.name);
-
   constructor(
+    @InjectPinoLogger(ShareDeletedListener.name)
+    private readonly logger: PinoLogger,
     private readonly removeSkillSourcesFromThreads: RemoveSkillSourcesFromThreadsUseCase,
     private readonly removeKbAssignmentsByOriginSkill: RemoveKnowledgeBaseAssignmentsByOriginSkillUseCase,
     private readonly removeDirectKbFromThreads: RemoveDirectKnowledgeBaseFromThreadsUseCase,
@@ -34,13 +35,13 @@ export class ShareDeletedListener {
   private async handleSkillShareDeleted(
     event: ShareDeletedEvent,
   ): Promise<void> {
-    this.logger.log(
-      'Cleaning up thread assignments after skill share deletion',
+    this.logger.info(
       {
         skillId: event.entityId,
         ownerId: event.ownerId,
         remainingScopeCount: event.remainingScopes.length,
       },
+      'Cleaning up thread assignments after skill share deletion',
     );
 
     const lostAccessUserIds =
@@ -64,13 +65,13 @@ export class ShareDeletedListener {
   private async handleKnowledgeBaseShareDeleted(
     event: ShareDeletedEvent,
   ): Promise<void> {
-    this.logger.log(
-      'Cleaning up direct thread KB assignments after KB share deletion',
+    this.logger.info(
       {
         knowledgeBaseId: event.entityId,
         ownerId: event.ownerId,
         remainingScopeCount: event.remainingScopes.length,
       },
+      'Cleaning up direct thread KB assignments after KB share deletion',
     );
 
     const lostAccessUserIds =

--- a/ayunis-core-backend/src/domain/threads/application/listeners/user-deletion-requested.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/listeners/user-deletion-requested.listener.spec.ts
@@ -1,6 +1,8 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import type { UUID } from 'crypto';
 import { ThreadsUserDeletionRequestedListener } from './user-deletion-requested.listener';
 import { ThreadsRepository } from '../ports/threads.repository';
@@ -24,6 +26,10 @@ describe('ThreadsUserDeletionRequestedListener', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ThreadsUserDeletionRequestedListener,
+        {
+          provide: getLoggerToken(ThreadsUserDeletionRequestedListener.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ThreadsRepository, useValue: threadsRepository },
         {
           provide: PurgeStoragePrefixesUseCase,
@@ -33,8 +39,6 @@ describe('ThreadsUserDeletionRequestedListener', () => {
     }).compile();
 
     listener = module.get(ThreadsUserDeletionRequestedListener);
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/domain/threads/application/listeners/user-deletion-requested.listener.ts
+++ b/ayunis-core-backend/src/domain/threads/application/listeners/user-deletion-requested.listener.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OnEvent } from '@nestjs/event-emitter';
 import { UserDeletionRequestedEvent } from 'src/iam/users/application/events/user-deletion-requested.event';
 import { ThreadsRepository } from '../ports/threads.repository';
@@ -20,11 +21,9 @@ import { PurgeStoragePrefixesCommand } from 'src/domain/storage/application/use-
  */
 @Injectable()
 export class ThreadsUserDeletionRequestedListener {
-  private readonly logger = new Logger(
-    ThreadsUserDeletionRequestedListener.name,
-  );
-
   constructor(
+    @InjectPinoLogger(ThreadsUserDeletionRequestedListener.name)
+    private readonly logger: PinoLogger,
     private readonly threadsRepository: ThreadsRepository,
     private readonly purgeStoragePrefixesUseCase: PurgeStoragePrefixesUseCase,
   ) {}
@@ -42,10 +41,13 @@ export class ThreadsUserDeletionRequestedListener {
         return;
       }
 
-      this.logger.log('Deferring thread storage cleanup for deleted user', {
-        userId: event.userId,
-        threadCount: threadIds.length,
-      });
+      this.logger.info(
+        {
+          userId: event.userId,
+          threadCount: threadIds.length,
+        },
+        'Deferring thread storage cleanup for deleted user',
+      );
 
       const prefixes = threadIds.flatMap((threadId) => [
         `${event.orgId}/${threadId}/`,
@@ -57,10 +59,13 @@ export class ThreadsUserDeletionRequestedListener {
         );
       });
     } catch (error) {
-      this.logger.error('Failed to resolve thread storage for deleted user', {
-        userId: event.userId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          userId: event.userId,
+          err: error as Error,
+        },
+        'Failed to resolve thread storage for deleted user',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/listeners/workspace-deletion-requested.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/listeners/workspace-deletion-requested.listener.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { WorkspaceDeletionRequestedEvent } from 'src/domain/workspaces/application/events/workspace-deletion-requested.event';
 import type { RemoveFavoriteReferenceUseCase } from 'src/domain/favorites/application/use-cases/remove-favorite-reference/remove-favorite-reference.use-case';
@@ -23,11 +23,6 @@ describe('ThreadsWorkspaceDeletionRequestedListener', () => {
     return new WorkspaceDeletionRequestedEvent(WORKSPACE_ID, USER_ID, ORG_ID);
   }
 
-  beforeAll(() => {
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
-  });
-
   beforeEach(() => {
     threadsRepository = {
       findAllIdsByWorkspaceId: jest.fn().mockResolvedValue([THREAD_ID]),
@@ -40,6 +35,7 @@ describe('ThreadsWorkspaceDeletionRequestedListener', () => {
       execute: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<RemoveFavoriteReferenceUseCase>;
     listener = new ThreadsWorkspaceDeletionRequestedListener(
+      createPinoLoggerMock(),
       threadsRepository,
       purgeStoragePrefixesUseCase,
       removeFavoriteReferenceUseCase,

--- a/ayunis-core-backend/src/domain/threads/application/listeners/workspace-deletion-requested.listener.ts
+++ b/ayunis-core-backend/src/domain/threads/application/listeners/workspace-deletion-requested.listener.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OnEvent } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
 import { FavoriteReferenceType } from 'src/domain/favorites/domain/value-objects/favorite-reference-type.enum';
@@ -27,11 +28,9 @@ import { WorkspaceDeletionRequestedEvent } from 'src/domain/workspaces/applicati
  */
 @Injectable()
 export class ThreadsWorkspaceDeletionRequestedListener {
-  private readonly logger = new Logger(
-    ThreadsWorkspaceDeletionRequestedListener.name,
-  );
-
   constructor(
+    @InjectPinoLogger(ThreadsWorkspaceDeletionRequestedListener.name)
+    private readonly logger: PinoLogger,
     private readonly threadsRepository: ThreadsRepository,
     private readonly purgeStoragePrefixesUseCase: PurgeStoragePrefixesUseCase,
     private readonly removeFavoriteReferenceUseCase: RemoveFavoriteReferenceUseCase,
@@ -50,12 +49,12 @@ export class ThreadsWorkspaceDeletionRequestedListener {
         return;
       }
 
-      this.logger.log(
-        'Deferring thread storage cleanup for deleted workspace',
+      this.logger.info(
         {
           workspaceId: event.workspaceId,
           threadCount: threadIds.length,
         },
+        'Deferring thread storage cleanup for deleted workspace',
       );
 
       event.deferCleanup('clean up cascaded workspace threads', () =>
@@ -63,11 +62,11 @@ export class ThreadsWorkspaceDeletionRequestedListener {
       );
     } catch (error) {
       this.logger.error(
-        'Failed to resolve thread storage for deleted workspace',
         {
           workspaceId: event.workspaceId,
-          error: error instanceof Error ? error.message : 'Unknown error',
+          err: error as Error,
         },
+        'Failed to resolve thread storage for deleted workspace',
       );
     }
   }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-file-source-to-thread/add-file-source-to-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-file-source-to-thread/add-file-source-to-thread.use-case.spec.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import type { UUID } from 'crypto';
 
@@ -65,6 +66,7 @@ describe('AddFileSourceToThreadUseCase', () => {
       get: jest.fn().mockReturnValue(orgId),
     } as unknown as ContextService;
     useCase = new AddFileSourceToThreadUseCase(
+      createPinoLoggerMock(),
       findThread,
       addSourceToThread,
       startDocumentProcessing,

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-file-source-to-thread/add-file-source-to-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-file-source-to-thread/add-file-source-to-thread.use-case.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -37,9 +38,9 @@ import { AddFileSourceToThreadCommand } from './add-file-source-to-thread.comman
 
 @Injectable()
 export class AddFileSourceToThreadUseCase {
-  private readonly logger = new Logger(AddFileSourceToThreadUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AddFileSourceToThreadUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly findThreadUseCase: FindThreadUseCase,
     private readonly addSourceToThreadUseCase: AddSourceToThreadUseCase,
     private readonly startDocumentProcessingUseCase: StartDocumentProcessingUseCase,
@@ -50,10 +51,13 @@ export class AddFileSourceToThreadUseCase {
 
   @HandleUnexpectedErrors(UnexpecteThreadError)
   async execute(command: AddFileSourceToThreadCommand): Promise<Source[]> {
-    this.logger.log('addFileSourceToThread', {
-      threadId: command.threadId,
-      fileName: command.file.originalname,
-    });
+    this.logger.info(
+      {
+        threadId: command.threadId,
+        fileName: command.file.originalname,
+      },
+      'addFileSourceToThread',
+    );
 
     const detectedType = detectFileType(
       command.file.mimetype,
@@ -149,10 +153,13 @@ export class AddFileSourceToThreadUseCase {
           ),
         );
       } catch (cleanupError) {
-        this.logger.error('Failed to delete sources after attach failure', {
-          sourceIds: sources.map((source) => source.id),
-          error: cleanupError as Error,
-        });
+        this.logger.error(
+          {
+            sourceIds: sources.map((source) => source.id),
+            err: cleanupError as Error,
+          },
+          'Failed to delete sources after attach failure',
+        );
       }
       throw error;
     }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-knowledge-base-to-thread/add-knowledge-base-to-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-knowledge-base-to-thread/add-knowledge-base-to-thread.use-case.spec.ts
@@ -1,6 +1,8 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { AddKnowledgeBaseToThreadUseCase } from './add-knowledge-base-to-thread.use-case';
 import { AddKnowledgeBaseToThreadCommand } from './add-knowledge-base-to-thread.command';
 import { ThreadsRepository } from '../../ports/threads.repository';
@@ -48,6 +50,10 @@ describe('AddKnowledgeBaseToThreadUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AddKnowledgeBaseToThreadUseCase,
+        {
+          provide: getLoggerToken(AddKnowledgeBaseToThreadUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ThreadsRepository, useValue: mockThreadsRepository },
         {
           provide: KnowledgeBaseRepository,
@@ -60,9 +66,6 @@ describe('AddKnowledgeBaseToThreadUseCase', () => {
     useCase = module.get(AddKnowledgeBaseToThreadUseCase);
     threadsRepository = module.get(ThreadsRepository);
     knowledgeBaseRepository = module.get(KnowledgeBaseRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-knowledge-base-to-thread/add-knowledge-base-to-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-knowledge-base-to-thread/add-knowledge-base-to-thread.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { AddKnowledgeBaseToThreadCommand } from './add-knowledge-base-to-thread.command';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -9,20 +10,23 @@ import { KnowledgeBaseNotFoundError } from 'src/domain/knowledge-bases/applicati
 
 @Injectable()
 export class AddKnowledgeBaseToThreadUseCase {
-  private readonly logger = new Logger(AddKnowledgeBaseToThreadUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AddKnowledgeBaseToThreadUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly threadsRepository: ThreadsRepository,
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(command: AddKnowledgeBaseToThreadCommand): Promise<void> {
-    this.logger.log('execute', {
-      threadId: command.threadId,
-      knowledgeBaseId: command.knowledgeBaseId,
-      originSkillId: command.originSkillId,
-    });
+    this.logger.info(
+      {
+        threadId: command.threadId,
+        knowledgeBaseId: command.knowledgeBaseId,
+        originSkillId: command.originSkillId,
+      },
+      'execute',
+    );
 
     const userId = this.contextService.get('userId');
     if (!userId) {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-mcp-integration-to-thread/add-mcp-integration-to-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-mcp-integration-to-thread/add-mcp-integration-to-thread.use-case.spec.ts
@@ -1,6 +1,8 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { AddMcpIntegrationToThreadUseCase } from './add-mcp-integration-to-thread.use-case';
 import { AddMcpIntegrationToThreadCommand } from './add-mcp-integration-to-thread.command';
 import { ThreadsRepository } from '../../ports/threads.repository';
@@ -45,6 +47,10 @@ describe('AddMcpIntegrationToThreadUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AddMcpIntegrationToThreadUseCase,
+        {
+          provide: getLoggerToken(AddMcpIntegrationToThreadUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ThreadsRepository, useValue: mockThreadsRepository },
         { provide: ContextService, useValue: mockContextService },
         {
@@ -57,9 +63,6 @@ describe('AddMcpIntegrationToThreadUseCase', () => {
     useCase = module.get(AddMcpIntegrationToThreadUseCase);
     threadsRepository = module.get(ThreadsRepository);
     getMcpIntegrationsByIdsUseCase = module.get(GetMcpIntegrationsByIdsUseCase);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-mcp-integration-to-thread/add-mcp-integration-to-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-mcp-integration-to-thread/add-mcp-integration-to-thread.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { AddMcpIntegrationToThreadCommand } from './add-mcp-integration-to-thread.command';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -10,19 +11,22 @@ import { McpIntegrationNotFoundError } from 'src/domain/mcp/application/mcp.erro
 
 @Injectable()
 export class AddMcpIntegrationToThreadUseCase {
-  private readonly logger = new Logger(AddMcpIntegrationToThreadUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AddMcpIntegrationToThreadUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly threadsRepository: ThreadsRepository,
     private readonly contextService: ContextService,
     private readonly getMcpIntegrationsByIdsUseCase: GetMcpIntegrationsByIdsUseCase,
   ) {}
 
   async execute(command: AddMcpIntegrationToThreadCommand): Promise<void> {
-    this.logger.log('execute', {
-      threadId: command.threadId,
-      mcpIntegrationId: command.mcpIntegrationId,
-    });
+    this.logger.info(
+      {
+        threadId: command.threadId,
+        mcpIntegrationId: command.mcpIntegrationId,
+      },
+      'execute',
+    );
 
     const userId = this.contextService.get('userId');
     if (!userId) {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-message-to-thread/add-message-to-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-message-to-thread/add-message-to-thread.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
 import { AddMessageToThreadUseCase } from './add-message-to-thread.use-case';
 import { AddMessageCommand } from './add-message.command';
@@ -26,6 +28,10 @@ describe('AddMessageToThreadUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AddMessageToThreadUseCase,
+        {
+          provide: getLoggerToken(AddMessageToThreadUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ContextService, useValue: mockContextService },
         { provide: EventEmitter2, useValue: mockEventEmitter },
       ],

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-message-to-thread/add-message-to-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-message-to-thread/add-message-to-thread.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
 import { Thread } from 'src/domain/threads/domain/thread.entity';
@@ -9,18 +10,21 @@ import { ThreadMessageAddedEvent } from '../../events/thread-message-added.event
 
 @Injectable()
 export class AddMessageToThreadUseCase {
-  private readonly logger = new Logger(AddMessageToThreadUseCase.name);
-
   constructor(
     private readonly contextService: ContextService,
     private readonly eventEmitter: EventEmitter2,
+    @InjectPinoLogger(AddMessageToThreadUseCase.name)
+    private readonly logger: PinoLogger,
   ) {}
 
   execute(command: AddMessageCommand): Thread {
-    this.logger.log('addMessage', {
-      threadId: command.thread.id,
-      messageRole: command.message.role,
-    });
+    this.logger.info(
+      {
+        threadId: command.thread.id,
+        messageRole: command.message.role,
+      },
+      'addMessage',
+    );
     try {
       command.thread.messages.push(command.message);
 
@@ -40,18 +44,24 @@ export class AddMessageToThreadUseCase {
           ),
         )
         .catch((err: unknown) => {
-          this.logger.error('Failed to emit ThreadMessageAddedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            threadId: command.thread.id,
-          });
+          this.logger.error(
+            {
+              err: err as Error,
+              threadId: command.thread.id,
+            },
+            'Failed to emit ThreadMessageAddedEvent',
+          );
         });
 
       return command.thread;
     } catch (error) {
-      this.logger.error('Failed to add message to thread', {
-        threadId: command.thread.id,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          threadId: command.thread.id,
+          err: error as Error,
+        },
+        'Failed to add message to thread',
+      );
       throw error instanceof Error
         ? new MessageAdditionError(command.thread.id, error)
         : new MessageAdditionError(

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.spec.ts
@@ -1,6 +1,8 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import type { UUID } from 'crypto';
 import { randomUUID } from 'crypto';
 
@@ -57,6 +59,10 @@ describe('AddSourceToThreadUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AddSourceToThreadUseCase,
+        {
+          provide: getLoggerToken(AddSourceToThreadUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ThreadsRepository, useValue: mockThreadsRepository },
         { provide: ContextService, useValue: mockContextService },
       ],
@@ -64,9 +70,6 @@ describe('AddSourceToThreadUseCase', () => {
 
     useCase = module.get<AddSourceToThreadUseCase>(AddSourceToThreadUseCase);
     threadsRepository = module.get(ThreadsRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { AddSourceCommand } from './add-source.command';
@@ -28,19 +29,22 @@ function isUniqueConstraintViolation(error: unknown): boolean {
 
 @Injectable()
 export class AddSourceToThreadUseCase {
-  private readonly logger = new Logger(AddSourceToThreadUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AddSourceToThreadUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly threadsRepository: ThreadsRepository,
     private readonly contextService: ContextService,
   ) {}
 
   @Transactional()
   async execute(command: AddSourceCommand): Promise<void> {
-    this.logger.log('addSource', {
-      threadId: command.thread.id,
-      sourceId: command.source.id,
-    });
+    this.logger.info(
+      {
+        threadId: command.thread.id,
+        sourceId: command.source.id,
+      },
+      'addSource',
+    );
     try {
       const userId = this.contextService.get('userId');
       if (!userId) {
@@ -95,7 +99,7 @@ export class AddSourceToThreadUseCase {
     if (isUniqueConstraintViolation(error)) {
       return new SourceAlreadyAssignedError(command.source.id);
     }
-    this.logger.error('addSource', error);
+    this.logger.error({ err: error as Error }, 'addSource');
     return new SourceAdditionError(command.thread.id, error as Error);
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/assign-thread-to-workspace/assign-thread-to-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/assign-thread-to-workspace/assign-thread-to-workspace.use-case.spec.ts
@@ -1,5 +1,7 @@
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
+
 import type { UUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -30,6 +32,10 @@ describe('AssignThreadToWorkspaceUseCase', () => {
     const module = await Test.createTestingModule({
       providers: [
         AssignThreadToWorkspaceUseCase,
+        {
+          provide: getLoggerToken(AssignThreadToWorkspaceUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ThreadsRepository, useValue: threadsRepository },
         { provide: FindWorkspaceUseCase, useValue: findWorkspaceUseCase },
         {
@@ -40,11 +46,6 @@ describe('AssignThreadToWorkspaceUseCase', () => {
     }).compile();
     useCase = module.get(AssignThreadToWorkspaceUseCase);
   }
-
-  beforeAll(() => {
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
-  });
 
   beforeEach(async () => {
     await setup();

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/assign-thread-to-workspace/assign-thread-to-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/assign-thread-to-workspace/assign-thread-to-workspace.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -11,9 +12,9 @@ import { AssignThreadToWorkspaceCommand } from './assign-thread-to-workspace.com
 
 @Injectable()
 export class AssignThreadToWorkspaceUseCase {
-  private readonly logger = new Logger(AssignThreadToWorkspaceUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AssignThreadToWorkspaceUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly threadsRepository: ThreadsRepository,
     private readonly contextService: ContextService,
     private readonly findWorkspaceUseCase: FindWorkspaceUseCase,
@@ -21,10 +22,13 @@ export class AssignThreadToWorkspaceUseCase {
 
   @HandleUnexpectedErrors(UnexpecteThreadError)
   async execute(command: AssignThreadToWorkspaceCommand): Promise<void> {
-    this.logger.log('assignThreadToWorkspace', {
-      threadId: command.threadId,
-      workspaceId: command.workspaceId,
-    });
+    this.logger.info(
+      {
+        threadId: command.threadId,
+        workspaceId: command.workspaceId,
+      },
+      'assignThreadToWorkspace',
+    );
 
     const userId = this.resolveUserId();
 

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/cleanup-stale-thread-sources/cleanup-stale-thread-sources.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/cleanup-stale-thread-sources/cleanup-stale-thread-sources.use-case.spec.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { CleanupStaleThreadSourcesUseCase } from './cleanup-stale-thread-sources.use-case';
 import type { ThreadsRepository } from '../../ports/threads.repository';
@@ -28,6 +29,7 @@ describe('CleanupStaleThreadSourcesUseCase', () => {
     deleteSourcesUseCase = { execute: jest.fn() };
 
     useCase = new CleanupStaleThreadSourcesUseCase(
+      createPinoLoggerMock(),
       threadsRepository as unknown as ThreadsRepository,
       findUnreferencedSourceIdsUseCase as unknown as FindUnreferencedSourceIdsUseCase,
       deleteSourcesUseCase as unknown as DeleteSourcesUseCase,

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/cleanup-stale-thread-sources/cleanup-stale-thread-sources.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/cleanup-stale-thread-sources/cleanup-stale-thread-sources.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import {
   ThreadsRepository,
@@ -30,9 +31,9 @@ function groupSourcesByOrg(
 
 @Injectable()
 export class CleanupStaleThreadSourcesUseCase {
-  private readonly logger = new Logger(CleanupStaleThreadSourcesUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CleanupStaleThreadSourcesUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly threadsRepository: ThreadsRepository,
     private readonly findUnreferencedSourceIdsUseCase: FindUnreferencedSourceIdsUseCase,
     private readonly deleteSourcesUseCase: DeleteSourcesUseCase,
@@ -40,7 +41,10 @@ export class CleanupStaleThreadSourcesUseCase {
 
   async execute(): Promise<CleanupStaleThreadSourcesResult> {
     const cutoff = new Date(Date.now() - STALE_THREAD_SOURCE_DAYS * MS_PER_DAY);
-    this.logger.log('execute', { cutoff, staleDays: STALE_THREAD_SOURCE_DAYS });
+    this.logger.info(
+      { cutoff, staleDays: STALE_THREAD_SOURCE_DAYS },
+      'execute',
+    );
     const candidates =
       await this.threadsRepository.findSourcesWithOnlyStaleDirectAssignments(
         cutoff,
@@ -85,11 +89,14 @@ export class CleanupStaleThreadSourcesUseCase {
         result.errors.push(
           ...sourceIds.map((sourceId) => ({ sourceId, error: message })),
         );
-        this.logger.error('Batch delete failed', {
-          error: error as Error,
-          count: sourceIds.length,
-          orgId,
-        });
+        this.logger.error(
+          {
+            err: error as Error,
+            count: sourceIds.length,
+            orgId,
+          },
+          'Batch delete failed',
+        );
       }
     }
   }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/create-thread/create-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/create-thread/create-thread.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken, type PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { CreateThreadUseCase } from './create-thread.use-case';
 import { CreateThreadCommand } from './create-thread.command';
 import { ThreadsRepository } from '../../ports/threads.repository';
@@ -23,12 +24,14 @@ describe('CreateThreadUseCase', () => {
   let threadsRepository: jest.Mocked<ThreadsRepository>;
   let getPermittedLanguageModelUseCase: jest.Mocked<GetPermittedLanguageModelUseCase>;
   let contextService: jest.Mocked<ContextService>;
+  let logger: jest.Mocked<PinoLogger>;
 
   const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
   const mockOrgId = '123e4567-e89b-12d3-a456-426614174001' as UUID;
   const mockModelId = '123e4567-e89b-12d3-a456-426614174002' as UUID;
 
   beforeEach(async () => {
+    logger = createPinoLoggerMock();
     const mockThreadsRepository = {
       create: jest.fn(),
       findById: jest.fn(),
@@ -55,6 +58,10 @@ describe('CreateThreadUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateThreadUseCase,
+        {
+          provide: getLoggerToken(CreateThreadUseCase.name),
+          useValue: logger,
+        },
         { provide: ThreadsRepository, useValue: mockThreadsRepository },
         {
           provide: GetPermittedLanguageModelUseCase,
@@ -74,10 +81,6 @@ describe('CreateThreadUseCase', () => {
       GetPermittedLanguageModelUseCase,
     );
     contextService = module.get(ContextService);
-
-    // Mock logger
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {
@@ -216,7 +219,6 @@ describe('CreateThreadUseCase', () => {
       getPermittedLanguageModelUseCase.execute.mockResolvedValue(mockModel);
       threadsRepository.create.mockResolvedValue(mockCreatedThread);
 
-      const logSpy = jest.spyOn(Logger.prototype, 'log');
       const getModelExecuteSpy = jest.spyOn(
         getPermittedLanguageModelUseCase,
         'execute',
@@ -226,7 +228,7 @@ describe('CreateThreadUseCase', () => {
       await useCase.execute(command);
 
       // Assert
-      expect(logSpy).toHaveBeenCalledWith('execute');
+      expect(logger.info).toHaveBeenCalledWith('execute');
       expect(getModelExecuteSpy).toHaveBeenCalled();
     });
 
@@ -263,7 +265,6 @@ describe('CreateThreadUseCase', () => {
       const repositoryError = new Error('Database connection failed');
       threadsRepository.create.mockRejectedValue(repositoryError);
 
-      const errorSpy = jest.spyOn(Logger.prototype, 'error');
       const getModelExecuteSpy = jest.spyOn(
         getPermittedLanguageModelUseCase,
         'execute',
@@ -273,10 +274,10 @@ describe('CreateThreadUseCase', () => {
       await expect(useCase.execute(command)).rejects.toThrow(
         ThreadCreationError,
       );
-      expect(errorSpy).toHaveBeenCalledWith('Failed to create thread', {
-        userId: mockUserId,
-        error: 'Database connection failed',
-      });
+      expect(logger.error).toHaveBeenCalledWith(
+        { userId: mockUserId, err: repositoryError },
+        'Failed to create thread',
+      );
       expect(getModelExecuteSpy).toHaveBeenCalled();
     });
   });

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/create-thread/create-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/create-thread/create-thread.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Thread } from '../../../domain/thread.entity';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { CreateThreadCommand } from './create-thread.command';
@@ -17,9 +18,9 @@ import { FindWorkspaceQuery } from 'src/domain/workspaces/application/use-cases/
 
 @Injectable()
 export class CreateThreadUseCase {
-  private readonly logger = new Logger(CreateThreadUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateThreadUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly threadsRepository: ThreadsRepository,
     private readonly getPermittedLanguageModelUseCase: GetPermittedLanguageModelUseCase,
     private readonly contextService: ContextService,
@@ -28,7 +29,7 @@ export class CreateThreadUseCase {
 
   @HandleUnexpectedErrors(UnexpecteThreadError)
   async execute(command: CreateThreadCommand): Promise<Thread> {
-    this.logger.log('execute');
+    this.logger.info('execute');
     const userId = this.contextService.get('userId');
     if (!userId) {
       throw new UnauthorizedException('User not authenticated');
@@ -57,10 +58,13 @@ export class CreateThreadUseCase {
         ...createdThread,
       });
     } catch (error) {
-      this.logger.error('Failed to create thread', {
-        userId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          userId,
+          err: error as Error,
+        },
+        'Failed to create thread',
+      );
       throw new ThreadCreationError(error as Error, userId);
     }
   }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/delete-thread/delete-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/delete-thread/delete-thread.use-case.spec.ts
@@ -1,6 +1,8 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken, type PinoLogger } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
 import { DeleteThreadUseCase } from './delete-thread.use-case';
@@ -15,12 +17,14 @@ describe('DeleteThreadUseCase', () => {
   let threadsRepository: jest.Mocked<ThreadsRepository>;
   let purgeStoragePrefixesUseCase: { execute: jest.Mock };
   let eventEmitter: { emitAsync: jest.Mock };
+  let logger: jest.Mocked<PinoLogger>;
 
   const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
   const mockOrgId = '123e4567-e89b-12d3-a456-426614174002' as UUID;
   const mockThreadId = '123e4567-e89b-12d3-a456-426614174001' as UUID;
 
   beforeEach(async () => {
+    logger = createPinoLoggerMock();
     const mockThreadsRepository = {
       findOne: jest.fn(),
       delete: jest.fn(),
@@ -46,6 +50,10 @@ describe('DeleteThreadUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeleteThreadUseCase,
+        {
+          provide: getLoggerToken(DeleteThreadUseCase.name),
+          useValue: logger,
+        },
         { provide: ThreadsRepository, useValue: mockThreadsRepository },
         { provide: ContextService, useValue: mockContextService },
         {
@@ -61,10 +69,6 @@ describe('DeleteThreadUseCase', () => {
 
     useCase = module.get<DeleteThreadUseCase>(DeleteThreadUseCase);
     threadsRepository = module.get(ThreadsRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {
@@ -129,10 +133,8 @@ describe('DeleteThreadUseCase', () => {
 
     it('should propagate repository errors and not purge storage', async () => {
       threadsRepository.findOne.mockResolvedValue(existingThread as never);
-      threadsRepository.delete.mockRejectedValue(
-        new Error('Database connection failed'),
-      );
-      const errorSpy = jest.spyOn(Logger.prototype, 'error');
+      const repositoryError = new Error('Database connection failed');
+      threadsRepository.delete.mockRejectedValue(repositoryError);
 
       await expect(
         useCase.execute(new DeleteThreadCommand(mockThreadId)),
@@ -140,11 +142,14 @@ describe('DeleteThreadUseCase', () => {
 
       expect(purgeStoragePrefixesUseCase.execute).not.toHaveBeenCalled();
       expect(eventEmitter.emitAsync).toHaveBeenCalled();
-      expect(errorSpy).toHaveBeenCalledWith('Failed to delete thread', {
-        threadId: mockThreadId,
-        userId: mockUserId,
-        error: 'Database connection failed',
-      });
+      expect(logger.error).toHaveBeenCalledWith(
+        {
+          threadId: mockThreadId,
+          userId: mockUserId,
+          err: repositoryError,
+        },
+        'Failed to delete thread',
+      );
     });
 
     it('should swallow purge failures after a successful delete', async () => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/delete-thread/delete-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/delete-thread/delete-thread.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { DeleteThreadCommand } from './delete-thread.command';
@@ -10,9 +11,9 @@ import { ThreadDeletionRequestedEvent } from '../../events/thread-deletion-reque
 
 @Injectable()
 export class DeleteThreadUseCase {
-  private readonly logger = new Logger(DeleteThreadUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteThreadUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly threadsRepository: ThreadsRepository,
     private readonly contextService: ContextService,
     private readonly purgeStoragePrefixesUseCase: PurgeStoragePrefixesUseCase,
@@ -20,7 +21,7 @@ export class DeleteThreadUseCase {
   ) {}
 
   async execute(command: DeleteThreadCommand): Promise<void> {
-    this.logger.log('delete', { threadId: command.id });
+    this.logger.info({ threadId: command.id }, 'delete');
 
     const userId = this.contextService.get('userId');
     const orgId = this.contextService.get('orgId');
@@ -33,18 +34,14 @@ export class DeleteThreadUseCase {
       throw new UnauthorizedException('Organization context required');
     }
 
+    const logContext = { threadId: command.id, userId };
     try {
-      // First verify the thread exists and belongs to the user
       const thread = await this.threadsRepository.findOne(command.id, userId);
 
       if (!thread) {
-        // Idempotent delete: treat already-deleted threads as success
         this.logger.warn(
+          logContext,
           'Thread already deleted or not found, treating as success',
-          {
-            threadId: command.id,
-            userId,
-          },
         );
         return;
       }
@@ -61,16 +58,12 @@ export class DeleteThreadUseCase {
       await this.threadsRepository.delete(command.id, userId);
       await runDeferredCleanup(event.takeCleanupTasks(), this.logger);
 
-      this.logger.log('Thread deleted successfully', {
-        threadId: command.id,
-        userId,
-      });
+      this.logger.info(logContext, 'Thread deleted successfully');
     } catch (error) {
-      this.logger.error('Failed to delete thread', {
-        threadId: command.id,
-        userId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        { ...logContext, err: error as Error },
+        'Failed to delete thread',
+      );
       throw error;
     }
   }
@@ -92,10 +85,13 @@ export class DeleteThreadUseCase {
         ]),
       );
     } catch (error) {
-      this.logger.error('Failed to purge storage for deleted thread', {
-        threadId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          threadId,
+          err: error as Error,
+        },
+        'Failed to purge storage for deleted thread',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/download-message-image/download-message-image.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/download-message-image/download-message-image.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { Readable } from 'stream';
 import type { ContextService } from 'src/common/context/services/context.service';
@@ -50,13 +50,11 @@ describe('DownloadMessageImageUseCase', () => {
     } as unknown as jest.Mocked<ContextService>;
 
     useCase = new DownloadMessageImageUseCase(
+      createPinoLoggerMock(),
       contextService,
       threadsRepository,
       downloadObjectUseCase,
     );
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/download-message-image/download-message-image.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/download-message-image/download-message-image.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ContextService } from 'src/common/context/services/context.service';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -26,9 +27,9 @@ export interface MessageImageDownload {
 
 @Injectable()
 export class DownloadMessageImageUseCase {
-  private readonly logger = new Logger(DownloadMessageImageUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DownloadMessageImageUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly contextService: ContextService,
     private readonly threadsRepository: ThreadsRepository,
     private readonly downloadObjectUseCase: DownloadObjectUseCase,
@@ -38,11 +39,14 @@ export class DownloadMessageImageUseCase {
   async execute(
     query: DownloadMessageImageQuery,
   ): Promise<MessageImageDownload> {
-    this.logger.log('Downloading message image', {
-      threadId: query.threadId,
-      messageId: query.messageId,
-      index: query.index,
-    });
+    this.logger.info(
+      {
+        threadId: query.threadId,
+        messageId: query.messageId,
+        index: query.index,
+      },
+      'Downloading message image',
+    );
 
     const orgId = this.contextService.get('orgId');
     if (!orgId) {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/download-reference-images/download-reference-images.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/download-reference-images/download-reference-images.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { randomUUID } from 'crypto';
 import { Readable } from 'stream';
@@ -48,14 +48,12 @@ describe('DownloadReferenceImagesUseCase', () => {
     } as unknown as jest.Mocked<DownloadObjectUseCase>;
 
     useCase = new DownloadReferenceImagesUseCase(
+      createPinoLoggerMock(),
       contextService,
       threadsRepository,
       generatedImagesRepository,
       downloadObjectUseCase,
     );
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/download-reference-images/download-reference-images.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/download-reference-images/download-reference-images.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ContextService } from 'src/common/context/services/context.service';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -36,9 +37,9 @@ const MAX_REFERENCE_IMAGE_BYTES = 10 * 1024 * 1024;
 
 @Injectable()
 export class DownloadReferenceImagesUseCase {
-  private readonly logger = new Logger(DownloadReferenceImagesUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DownloadReferenceImagesUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly contextService: ContextService,
     private readonly threadsRepository: ThreadsRepository,
     private readonly generatedImagesRepository: GeneratedImagesRepository,
@@ -49,11 +50,14 @@ export class DownloadReferenceImagesUseCase {
   async execute(
     query: DownloadReferenceImagesQuery,
   ): Promise<ReferenceImageDownload[]> {
-    this.logger.log('Downloading reference images', {
-      threadId: query.threadId,
-      uploadedImageCount: query.uploadedImageRefs.length,
-      generatedImageCount: query.generatedImageIds.length,
-    });
+    this.logger.info(
+      {
+        threadId: query.threadId,
+        uploadedImageCount: query.uploadedImageRefs.length,
+        generatedImageCount: query.generatedImageIds.length,
+      },
+      'Downloading reference images',
+    );
 
     const orgId = this.contextService.get('orgId');
     if (!orgId) {
@@ -153,10 +157,13 @@ export class DownloadReferenceImagesUseCase {
     if (data.length <= MAX_REFERENCE_IMAGE_BYTES) {
       return true;
     }
-    this.logger.warn('Skipping oversized reference image', {
-      objectName,
-      sizeBytes: data.length,
-    });
+    this.logger.warn(
+      {
+        fileName: objectName,
+        sizeBytes: data.length,
+      },
+      'Skipping oversized reference image',
+    );
     return false;
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads-by-org-with-sources/find-all-threads-by-org-with-sources.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads-by-org-with-sources/find-all-threads-by-org-with-sources.use-case.ts
@@ -1,18 +1,19 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Thread } from 'src/domain/threads/domain/thread.entity';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { FindAllThreadsByOrgWithSourcesQuery } from './find-all-threads-by-org-with-sources.query';
 
 @Injectable()
 export class FindAllThreadsByOrgWithSourcesUseCase {
-  private readonly logger = new Logger(
-    FindAllThreadsByOrgWithSourcesUseCase.name,
-  );
-
-  constructor(private readonly threadsRepository: ThreadsRepository) {}
+  constructor(
+    @InjectPinoLogger(FindAllThreadsByOrgWithSourcesUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly threadsRepository: ThreadsRepository,
+  ) {}
 
   async execute(query: FindAllThreadsByOrgWithSourcesQuery): Promise<Thread[]> {
-    this.logger.log('execute', { orgId: query.orgId });
+    this.logger.info({ orgId: query.orgId }, 'execute');
     return this.threadsRepository.findAllByOrgIdWithSources(query.orgId);
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads/find-all-threads.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/find-all-threads/find-all-threads.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Thread } from 'src/domain/threads/domain/thread.entity';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { FindAllThreadsQuery } from './find-all-threads.query';
@@ -6,17 +7,24 @@ import { Paginated } from 'src/common/pagination/paginated.entity';
 
 @Injectable()
 export class FindAllThreadsUseCase {
-  private readonly logger = new Logger(FindAllThreadsUseCase.name);
-
-  constructor(private readonly threadsRepository: ThreadsRepository) {}
+  constructor(
+    @InjectPinoLogger(FindAllThreadsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly threadsRepository: ThreadsRepository,
+  ) {}
 
   async execute(query: FindAllThreadsQuery): Promise<Paginated<Thread>> {
-    this.logger.log('findAll', {
-      userId: query.userId,
-      filters: query.filters,
-      limit: query.limit,
-      offset: query.offset,
-    });
+    const { search: text, ...safeFilters } = query.filters ?? {};
+    this.logger.info(
+      {
+        userId: query.userId,
+        ...safeFilters,
+        text,
+        limit: query.limit,
+        offset: query.offset,
+      },
+      'findAll',
+    );
     try {
       return await this.threadsRepository.findAll(
         query.userId,
@@ -28,10 +36,13 @@ export class FindAllThreadsUseCase {
         },
       );
     } catch (error) {
-      this.logger.error('Failed to find all threads', {
-        userId: query.userId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          userId: query.userId,
+          err: error as Error,
+        },
+        'Failed to find all threads',
+      );
       throw error;
     }
   }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/find-expired-thread-refs-by-org/find-expired-thread-refs-by-org.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/find-expired-thread-refs-by-org/find-expired-thread-refs-by-org.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import type { ExpiredThreadRef } from '../../ports/threads.repository';
 import type { FindExpiredThreadRefsByOrgQuery } from './find-expired-thread-refs-by-org.query';
@@ -16,19 +17,24 @@ export type { ExpiredThreadRef };
  */
 @Injectable()
 export class FindExpiredThreadRefsByOrgUseCase {
-  private readonly logger = new Logger(FindExpiredThreadRefsByOrgUseCase.name);
-
-  constructor(private readonly threadsRepository: ThreadsRepository) {}
+  constructor(
+    @InjectPinoLogger(FindExpiredThreadRefsByOrgUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly threadsRepository: ThreadsRepository,
+  ) {}
 
   async execute(
     query: FindExpiredThreadRefsByOrgQuery,
   ): Promise<ExpiredThreadRef[]> {
-    this.logger.debug('findExpiredThreadRefsByOrg', {
-      orgId: query.orgId,
-      activeBefore: query.activeBefore,
-      limit: query.limit,
-      offset: query.offset,
-    });
+    this.logger.debug(
+      {
+        orgId: query.orgId,
+        activeBefore: query.activeBefore,
+        limit: query.limit,
+        offset: query.offset,
+      },
+      'findExpiredThreadRefsByOrg',
+    );
     return this.threadsRepository.findExpiredThreadRefsByOrg({
       orgId: query.orgId,
       activeBefore: query.activeBefore,

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/find-thread/find-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/find-thread/find-thread.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Thread } from 'src/domain/threads/domain/thread.entity';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { FindThreadQuery } from './find-thread.query';
@@ -17,16 +18,16 @@ export interface FindThreadResult {
 
 @Injectable()
 export class FindThreadUseCase {
-  private readonly logger = new Logger(FindThreadUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindThreadUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly threadsRepository: ThreadsRepository,
     private readonly contextService: ContextService,
     private readonly countMessagesTokensUseCase: CountMessagesTokensUseCase,
   ) {}
 
   async execute(query: FindThreadQuery): Promise<FindThreadResult> {
-    this.logger.log('findOne', { threadId: query.id });
+    this.logger.info({ threadId: query.id }, 'findOne');
     try {
       const userId = this.contextService.get('userId');
       if (!userId) {
@@ -47,10 +48,13 @@ export class FindThreadUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Failed to find thread', {
-        threadId: query.id,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          threadId: query.id,
+          err: error as Error,
+        },
+        'Failed to find thread',
+      );
       throw error;
     }
   }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/find-threads-by-ids/find-threads-by-ids.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/find-threads-by-ids/find-threads-by-ids.use-case.spec.ts
@@ -1,4 +1,5 @@
 import { FindThreadsByIdsUseCase } from './find-threads-by-ids.use-case';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { FindThreadsByIdsQuery } from './find-threads-by-ids.query';
 import type { ThreadsRepository } from '../../ports/threads.repository';
 import type { UUID } from 'crypto';
@@ -8,7 +9,10 @@ describe('FindThreadsByIdsUseCase', () => {
     const repository = {
       findAllByIds: jest.fn().mockResolvedValue([]),
     } as unknown as jest.Mocked<ThreadsRepository>;
-    const useCase = new FindThreadsByIdsUseCase(repository);
+    const useCase = new FindThreadsByIdsUseCase(
+      createPinoLoggerMock(),
+      repository,
+    );
     const userId = '11111111-1111-4111-8111-111111111111' as UUID;
     const ids = ['22222222-2222-4222-8222-222222222222'] as UUID[];
 

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/find-threads-by-ids/find-threads-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/find-threads-by-ids/find-threads-by-ids.use-case.ts
@@ -1,19 +1,25 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import type { Thread } from '../../../domain/thread.entity';
 import type { FindThreadsByIdsQuery } from './find-threads-by-ids.query';
 
 @Injectable()
 export class FindThreadsByIdsUseCase {
-  private readonly logger = new Logger(FindThreadsByIdsUseCase.name);
-
-  constructor(private readonly threadsRepository: ThreadsRepository) {}
+  constructor(
+    @InjectPinoLogger(FindThreadsByIdsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly threadsRepository: ThreadsRepository,
+  ) {}
 
   async execute(query: FindThreadsByIdsQuery): Promise<Thread[]> {
-    this.logger.debug('findThreadsByIds', {
-      userId: query.userId,
-      count: query.ids.length,
-    });
+    this.logger.debug(
+      {
+        userId: query.userId,
+        count: query.ids.length,
+      },
+      'findThreadsByIds',
+    );
     return this.threadsRepository.findAllByIds(query.userId, query.ids);
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/generate-and-set-thread-title/generate-and-set-thread-title.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/generate-and-set-thread-title/generate-and-set-thread-title.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
 import { GenerateAndSetThreadTitleUseCase } from './generate-and-set-thread-title.use-case';
 import { UpdateThreadTitleUseCase } from '../update-thread-title/update-thread-title.use-case';
@@ -11,6 +13,10 @@ describe('GenerateAndSetThreadTitleUseCase - Markdown Stripping', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GenerateAndSetThreadTitleUseCase,
+        {
+          provide: getLoggerToken(GenerateAndSetThreadTitleUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: UpdateThreadTitleUseCase,
           useValue: {},

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/generate-and-set-thread-title/generate-and-set-thread-title.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/generate-and-set-thread-title/generate-and-set-thread-title.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GenerateAndSetThreadTitleCommand } from './generate-and-set-thread-title.command';
 import { UpdateThreadTitleUseCase } from '../update-thread-title/update-thread-title.use-case';
 import { UpdateThreadTitleCommand } from '../update-thread-title/update-thread-title.command';
@@ -15,9 +16,9 @@ import { ModelToolChoice } from 'src/domain/models/domain/value-objects/model-to
 
 @Injectable()
 export class GenerateAndSetThreadTitleUseCase {
-  private readonly logger = new Logger(GenerateAndSetThreadTitleUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GenerateAndSetThreadTitleUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly updateThreadTitleUseCase: UpdateThreadTitleUseCase,
     private readonly triggerInferenceUseCase: GetInferenceUseCase,
   ) {}
@@ -25,84 +26,74 @@ export class GenerateAndSetThreadTitleUseCase {
   async execute(
     command: GenerateAndSetThreadTitleCommand,
   ): Promise<string | null> {
-    this.logger.log('generateAndSetTitle', { threadId: command.thread.id });
+    this.logger.info({ threadId: command.thread.id }, 'generateAndSetTitle');
 
     try {
-      // Prompt for title generation
-      const prompt = `Based on the following user message, generate a short, concise title (maximum 50 characters):
+      return await this.generateTitle(command);
+    } catch (error) {
+      const logContext = {
+        threadId: command.thread.id,
+        err: this.toTitleGenerationError(command.thread.id, error),
+      };
+      this.logger.error(logContext, 'Failed to generate title');
+      return null;
+    }
+  }
+
+  private async generateTitle(
+    command: GenerateAndSetThreadTitleCommand,
+  ): Promise<string> {
+    const prompt = `Based on the following user message, generate a short, concise title (maximum 50 characters):
       
       "${command.message}"
       
       Title:`;
-      const userMessage = new UserMessage({
-        threadId: command.thread.id,
-        content: [new TextMessageContent(prompt)],
-      });
-
-      const response = await this.triggerInferenceUseCase.execute(
-        new GetInferenceCommand({
-          model: command.model,
-          messages: [userMessage],
-          tools: [],
-          toolChoice: ModelToolChoice.AUTO,
-        }),
-      );
-
-      // Validate response content
-      if (!response.content.length) {
-        throw new EmptyTitleResponseError(command.thread.id);
-      }
-
-      const firstContent = response.content.find(
-        (content) => content instanceof TextMessageContent,
-      );
-      if (!firstContent) {
-        throw new InvalidTitleResponseTypeError(
-          command.thread.id,
-          response.content
-            .map((content) => content.constructor.name)
-            .join(', '),
-        );
-      }
-
-      // Remove extra spaces and <think>...</think> blocks
-      let title = firstContent.text
-        .replace(/<think(ing)?>([\s\S]*?)<\/think(ing)?>/g, '')
-        .trim();
-
-      // Strip markdown formatting
-      title = this.stripMarkdownFormatting(title);
-
-      if (!title) {
-        throw new EmptyTitleResponseError(command.thread.id);
-      }
-
-      // Update thread with new title
-      await this.updateThreadTitleUseCase.execute(
-        new UpdateThreadTitleCommand({
-          threadId: command.thread.id,
-          title,
-        }),
-      );
-      return title;
-    } catch (error) {
-      // Log the error with appropriate context
-      let logError = error as Error;
-      if (
-        !(error instanceof EmptyTitleResponseError) &&
-        !(error instanceof InvalidTitleResponseTypeError)
-      ) {
-        logError = new TitleGenerationError(command.thread.id, error as Error);
-      }
-
-      this.logger.error('Failed to generate title', {
-        threadId: command.thread.id,
-        error: logError instanceof Error ? logError.message : 'Unknown error',
-      });
-
-      // Don't throw error - just log it
-      return null;
+    const userMessage = new UserMessage({
+      threadId: command.thread.id,
+      content: [new TextMessageContent(prompt)],
+    });
+    const response = await this.triggerInferenceUseCase.execute(
+      new GetInferenceCommand({
+        model: command.model,
+        messages: [userMessage],
+        tools: [],
+        toolChoice: ModelToolChoice.AUTO,
+      }),
+    );
+    if (!response.content.length) {
+      throw new EmptyTitleResponseError(command.thread.id);
     }
+    const firstContent = response.content.find(
+      (content) => content instanceof TextMessageContent,
+    );
+    if (!firstContent) {
+      throw new InvalidTitleResponseTypeError(
+        command.thread.id,
+        response.content.map((content) => content.constructor.name).join(', '),
+      );
+    }
+    const title = this.stripMarkdownFormatting(
+      firstContent.text
+        .replace(/<think(ing)?>([\s\S]*?)<\/think(ing)?>/g, '')
+        .trim(),
+    );
+    if (!title) {
+      throw new EmptyTitleResponseError(command.thread.id);
+    }
+    await this.updateThreadTitleUseCase.execute(
+      new UpdateThreadTitleCommand({ threadId: command.thread.id, title }),
+    );
+    return title;
+  }
+
+  private toTitleGenerationError(threadId: string, error: unknown): Error {
+    if (
+      error instanceof EmptyTitleResponseError ||
+      error instanceof InvalidTitleResponseTypeError
+    ) {
+      return error;
+    }
+    return new TitleGenerationError(threadId, error as Error);
   }
 
   /**
@@ -125,9 +116,9 @@ export class GenerateAndSetThreadTitleUseCase {
         // Remove headers: # text
         .replace(/^#{1,6}\s+/gm, '')
         // Remove links: [text](url) -> text
-        .replace(/\[(.+?)\]\(.+?\)/g, '$1')
+        .replace(/\[([^\]\r\n]{1,500})\]\([^)\r\n]{1,2000}\)/g, '$1')
         // Remove quotes
-        .replace(/["""]/g, '')
+        .replace(/"/g, '')
         // Clean up any extra whitespace
         .replace(/\s+/g, ' ')
         .trim()

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/get-thread-sources/get-thread-sources.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/get-thread-sources/get-thread-sources.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Source } from '../../../../sources/domain/source.entity';
 import { FindThreadSourcesQuery } from './get-thread-sources.query';
 import { FindThreadUseCase } from '../find-thread/find-thread.use-case';
@@ -8,21 +9,26 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetThreadSourcesUseCase {
-  private readonly logger = new Logger(GetThreadSourcesUseCase.name);
-
-  constructor(private readonly findThreadUseCase: FindThreadUseCase) {}
+  constructor(
+    @InjectPinoLogger(GetThreadSourcesUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly findThreadUseCase: FindThreadUseCase,
+  ) {}
 
   async execute(query: FindThreadSourcesQuery): Promise<Source[]> {
-    this.logger.log('getThreadSources', {
-      threadId: query.threadId,
-    });
+    this.logger.info(
+      {
+        threadId: query.threadId,
+      },
+      'getThreadSources',
+    );
 
     try {
       const { thread } = await this.findThreadUseCase.execute(
         new FindThreadQuery(query.threadId),
       );
       return (
-        thread.sourceAssignments?.map((assignment) => assignment.source) || []
+        thread.sourceAssignments?.map((assignment) => assignment.source) ?? []
       );
     } catch (error) {
       if (error instanceof ApplicationError) {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/record-thread-activity/record-thread-activity.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/record-thread-activity/record-thread-activity.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
 import { randomUUID } from 'crypto';
 import { RecordThreadActivityUseCase } from './record-thread-activity.use-case';
@@ -17,6 +19,10 @@ describe('RecordThreadActivityUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RecordThreadActivityUseCase,
+        {
+          provide: getLoggerToken(RecordThreadActivityUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ThreadsRepository, useValue: mockThreadsRepository },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/record-thread-activity/record-thread-activity.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/record-thread-activity/record-thread-activity.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { RecordThreadActivityCommand } from './record-thread-activity.command';
 
@@ -11,9 +12,11 @@ import { RecordThreadActivityCommand } from './record-thread-activity.command';
  */
 @Injectable()
 export class RecordThreadActivityUseCase {
-  private readonly logger = new Logger(RecordThreadActivityUseCase.name);
-
-  constructor(private readonly threadsRepository: ThreadsRepository) {}
+  constructor(
+    @InjectPinoLogger(RecordThreadActivityUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly threadsRepository: ThreadsRepository,
+  ) {}
 
   async execute(command: RecordThreadActivityCommand): Promise<void> {
     try {
@@ -22,10 +25,13 @@ export class RecordThreadActivityUseCase {
         lastActivityAt: command.occurredAt,
       });
     } catch (error) {
-      this.logger.error('Failed to record thread activity', {
-        threadId: command.threadId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          threadId: command.threadId,
+          err: error as Error,
+        },
+        'Failed to record thread activity',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-direct-knowledge-base-from-threads/remove-direct-knowledge-base-from-threads.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-direct-knowledge-base-from-threads/remove-direct-knowledge-base-from-threads.use-case.spec.ts
@@ -1,6 +1,8 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { randomUUID } from 'crypto';
 import { RemoveDirectKnowledgeBaseFromThreadsUseCase } from './remove-direct-knowledge-base-from-threads.use-case';
 import { RemoveDirectKnowledgeBaseFromThreadsCommand } from './remove-direct-knowledge-base-from-threads.command';
@@ -18,14 +20,18 @@ describe('RemoveDirectKnowledgeBaseFromThreadsUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RemoveDirectKnowledgeBaseFromThreadsUseCase,
+        {
+          provide: getLoggerToken(
+            RemoveDirectKnowledgeBaseFromThreadsUseCase.name,
+          ),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ThreadsRepository, useValue: mockThreadsRepository },
       ],
     }).compile();
 
     useCase = module.get(RemoveDirectKnowledgeBaseFromThreadsUseCase);
     threadsRepository = module.get(ThreadsRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-direct-knowledge-base-from-threads/remove-direct-knowledge-base-from-threads.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-direct-knowledge-base-from-threads/remove-direct-knowledge-base-from-threads.use-case.ts
@@ -1,22 +1,26 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { RemoveDirectKnowledgeBaseFromThreadsCommand } from './remove-direct-knowledge-base-from-threads.command';
 
 @Injectable()
 export class RemoveDirectKnowledgeBaseFromThreadsUseCase {
-  private readonly logger = new Logger(
-    RemoveDirectKnowledgeBaseFromThreadsUseCase.name,
-  );
-
-  constructor(private readonly threadsRepository: ThreadsRepository) {}
+  constructor(
+    @InjectPinoLogger(RemoveDirectKnowledgeBaseFromThreadsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly threadsRepository: ThreadsRepository,
+  ) {}
 
   async execute(
     command: RemoveDirectKnowledgeBaseFromThreadsCommand,
   ): Promise<void> {
-    this.logger.log('execute', {
-      knowledgeBaseId: command.knowledgeBaseId,
-      userCount: command.userIds.length,
-    });
+    this.logger.info(
+      {
+        knowledgeBaseId: command.knowledgeBaseId,
+        userCount: command.userIds.length,
+      },
+      'execute',
+    );
 
     if (command.userIds.length === 0) {
       return;

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-assignments-by-origin-skill/remove-knowledge-base-assignments-by-origin-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-assignments-by-origin-skill/remove-knowledge-base-assignments-by-origin-skill.use-case.spec.ts
@@ -1,6 +1,8 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { randomUUID } from 'crypto';
 import { RemoveKnowledgeBaseAssignmentsByOriginSkillUseCase } from './remove-knowledge-base-assignments-by-origin-skill.use-case';
 import { RemoveKnowledgeBaseAssignmentsByOriginSkillCommand } from './remove-knowledge-base-assignments-by-origin-skill.command';
@@ -18,14 +20,18 @@ describe('RemoveKnowledgeBaseAssignmentsByOriginSkillUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RemoveKnowledgeBaseAssignmentsByOriginSkillUseCase,
+        {
+          provide: getLoggerToken(
+            RemoveKnowledgeBaseAssignmentsByOriginSkillUseCase.name,
+          ),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ThreadsRepository, useValue: mockThreadsRepository },
       ],
     }).compile();
 
     useCase = module.get(RemoveKnowledgeBaseAssignmentsByOriginSkillUseCase);
     threadsRepository = module.get(ThreadsRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-assignments-by-origin-skill/remove-knowledge-base-assignments-by-origin-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-assignments-by-origin-skill/remove-knowledge-base-assignments-by-origin-skill.use-case.ts
@@ -1,23 +1,27 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { RemoveKnowledgeBaseAssignmentsByOriginSkillCommand } from './remove-knowledge-base-assignments-by-origin-skill.command';
 
 @Injectable()
 export class RemoveKnowledgeBaseAssignmentsByOriginSkillUseCase {
-  private readonly logger = new Logger(
-    RemoveKnowledgeBaseAssignmentsByOriginSkillUseCase.name,
-  );
-
-  constructor(private readonly threadsRepository: ThreadsRepository) {}
+  constructor(
+    @InjectPinoLogger(RemoveKnowledgeBaseAssignmentsByOriginSkillUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly threadsRepository: ThreadsRepository,
+  ) {}
 
   async execute(
     command: RemoveKnowledgeBaseAssignmentsByOriginSkillCommand,
   ): Promise<void> {
-    this.logger.log('execute', {
-      skillId: command.skillId,
-      userCount: command.userIds.length,
-      knowledgeBaseId: command.knowledgeBaseId,
-    });
+    this.logger.info(
+      {
+        skillId: command.skillId,
+        userCount: command.userIds.length,
+        knowledgeBaseId: command.knowledgeBaseId,
+      },
+      'execute',
+    );
 
     if (command.userIds.length === 0) {
       return;

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-from-thread/remove-knowledge-base-from-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-from-thread/remove-knowledge-base-from-thread.use-case.spec.ts
@@ -1,6 +1,8 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { RemoveKnowledgeBaseFromThreadUseCase } from './remove-knowledge-base-from-thread.use-case';
 import { RemoveKnowledgeBaseFromThreadCommand } from './remove-knowledge-base-from-thread.command';
 import { ThreadsRepository } from '../../ports/threads.repository';
@@ -37,6 +39,10 @@ describe('RemoveKnowledgeBaseFromThreadUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RemoveKnowledgeBaseFromThreadUseCase,
+        {
+          provide: getLoggerToken(RemoveKnowledgeBaseFromThreadUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ThreadsRepository, useValue: mockThreadsRepository },
         { provide: ContextService, useValue: mockContextService },
       ],
@@ -44,9 +50,6 @@ describe('RemoveKnowledgeBaseFromThreadUseCase', () => {
 
     useCase = module.get(RemoveKnowledgeBaseFromThreadUseCase);
     threadsRepository = module.get(ThreadsRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-from-thread/remove-knowledge-base-from-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-knowledge-base-from-thread/remove-knowledge-base-from-thread.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { RemoveKnowledgeBaseFromThreadCommand } from './remove-knowledge-base-from-thread.command';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -7,21 +8,22 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 @Injectable()
 export class RemoveKnowledgeBaseFromThreadUseCase {
-  private readonly logger = new Logger(
-    RemoveKnowledgeBaseFromThreadUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(RemoveKnowledgeBaseFromThreadUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly threadsRepository: ThreadsRepository,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(command: RemoveKnowledgeBaseFromThreadCommand): Promise<void> {
-    this.logger.log('execute', {
-      threadId: command.threadId,
-      knowledgeBaseId: command.knowledgeBaseId,
-      originSkillId: command.originSkillId,
-    });
+    this.logger.info(
+      {
+        threadId: command.threadId,
+        knowledgeBaseId: command.knowledgeBaseId,
+        originSkillId: command.originSkillId,
+      },
+      'execute',
+    );
 
     const userId = this.contextService.get('userId');
     if (!userId) {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-mcp-integration-from-thread/remove-mcp-integration-from-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-mcp-integration-from-thread/remove-mcp-integration-from-thread.use-case.spec.ts
@@ -1,6 +1,8 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { RemoveMcpIntegrationFromThreadUseCase } from './remove-mcp-integration-from-thread.use-case';
 import { RemoveMcpIntegrationFromThreadCommand } from './remove-mcp-integration-from-thread.command';
 import { ThreadsRepository } from '../../ports/threads.repository';
@@ -36,6 +38,10 @@ describe('RemoveMcpIntegrationFromThreadUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RemoveMcpIntegrationFromThreadUseCase,
+        {
+          provide: getLoggerToken(RemoveMcpIntegrationFromThreadUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ThreadsRepository, useValue: mockThreadsRepository },
         { provide: ContextService, useValue: mockContextService },
       ],
@@ -43,9 +49,6 @@ describe('RemoveMcpIntegrationFromThreadUseCase', () => {
 
     useCase = module.get(RemoveMcpIntegrationFromThreadUseCase);
     threadsRepository = module.get(ThreadsRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-mcp-integration-from-thread/remove-mcp-integration-from-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-mcp-integration-from-thread/remove-mcp-integration-from-thread.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { RemoveMcpIntegrationFromThreadCommand } from './remove-mcp-integration-from-thread.command';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -7,20 +8,21 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 @Injectable()
 export class RemoveMcpIntegrationFromThreadUseCase {
-  private readonly logger = new Logger(
-    RemoveMcpIntegrationFromThreadUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(RemoveMcpIntegrationFromThreadUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly threadsRepository: ThreadsRepository,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(command: RemoveMcpIntegrationFromThreadCommand): Promise<void> {
-    this.logger.log('execute', {
-      threadId: command.threadId,
-      mcpIntegrationId: command.mcpIntegrationId,
-    });
+    this.logger.info(
+      {
+        threadId: command.threadId,
+        mcpIntegrationId: command.mcpIntegrationId,
+      },
+      'execute',
+    );
 
     const userId = this.contextService.get('userId');
     if (!userId) {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-skill-sources-from-threads/remove-skill-sources-from-threads.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-skill-sources-from-threads/remove-skill-sources-from-threads.use-case.spec.ts
@@ -1,6 +1,8 @@
 import type { TestingModule } from '@nestjs/testing';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { randomUUID } from 'crypto';
 import { RemoveSkillSourcesFromThreadsUseCase } from './remove-skill-sources-from-threads.use-case';
 import { RemoveSkillSourcesFromThreadsCommand } from './remove-skill-sources-from-threads.command';
@@ -18,6 +20,10 @@ describe('RemoveSkillSourcesFromThreadsUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RemoveSkillSourcesFromThreadsUseCase,
+        {
+          provide: getLoggerToken(RemoveSkillSourcesFromThreadsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ThreadsRepository, useValue: mockThreadsRepository },
       ],
     }).compile();
@@ -26,8 +32,6 @@ describe('RemoveSkillSourcesFromThreadsUseCase', () => {
       RemoveSkillSourcesFromThreadsUseCase,
     );
     threadsRepository = module.get(ThreadsRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-skill-sources-from-threads/remove-skill-sources-from-threads.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-skill-sources-from-threads/remove-skill-sources-from-threads.use-case.ts
@@ -1,20 +1,24 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { RemoveSkillSourcesFromThreadsCommand } from './remove-skill-sources-from-threads.command';
 
 @Injectable()
 export class RemoveSkillSourcesFromThreadsUseCase {
-  private readonly logger = new Logger(
-    RemoveSkillSourcesFromThreadsUseCase.name,
-  );
-
-  constructor(private readonly threadsRepository: ThreadsRepository) {}
+  constructor(
+    @InjectPinoLogger(RemoveSkillSourcesFromThreadsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly threadsRepository: ThreadsRepository,
+  ) {}
 
   async execute(command: RemoveSkillSourcesFromThreadsCommand): Promise<void> {
-    this.logger.log('execute', {
-      skillId: command.skillId,
-      userCount: command.userIds.length,
-    });
+    this.logger.info(
+      {
+        skillId: command.skillId,
+        userCount: command.userIds.length,
+      },
+      'execute',
+    );
 
     if (command.userIds.length === 0) {
       return;

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/remove-source-from-thread/remove-source-from-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/remove-source-from-thread/remove-source-from-thread.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { RemoveSourceCommand } from './remove-source.command';
 import { SourceRemovalError, SourceNotFoundError } from '../../threads.errors';
@@ -10,19 +11,22 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 @Injectable()
 export class RemoveSourceFromThreadUseCase {
-  private readonly logger = new Logger(RemoveSourceFromThreadUseCase.name);
-
   constructor(
+    @InjectPinoLogger(RemoveSourceFromThreadUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly threadsRepository: ThreadsRepository,
     private readonly deleteSourceUseCase: DeleteSourceUseCase,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(command: RemoveSourceCommand): Promise<void> {
-    this.logger.log('removeSource', {
-      threadId: command.thread.id,
-      sourceId: command.sourceId,
-    });
+    this.logger.info(
+      {
+        threadId: command.thread.id,
+        sourceId: command.sourceId,
+      },
+      'removeSource',
+    );
 
     try {
       if (!command.thread.sourceAssignments) {
@@ -47,11 +51,14 @@ export class RemoveSourceFromThreadUseCase {
         throw error;
       }
 
-      this.logger.error('Failed to remove source from thread', {
-        threadId: command.thread.id,
-        sourceId: command.sourceId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          threadId: command.thread.id,
+          sourceId: command.sourceId,
+          err: error as Error,
+        },
+        'Failed to remove source from thread',
+      );
 
       throw error instanceof Error
         ? new SourceRemovalError(command.thread.id, error)

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/replace-model-with-user-default/replace-model-with-user-default.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ReplaceModelWithUserDefaultCommand } from './replace-model-with-user-default.command';
 import { ThreadsRepository } from '../../ports/threads.repository';
 import { GetDefaultModelQuery } from 'src/domain/models/application/use-cases/get-default-model/get-default-model.query';
@@ -8,60 +9,70 @@ import { Thread } from 'src/domain/threads/domain/thread.entity';
 
 @Injectable()
 export class ReplaceModelWithUserDefaultUseCase {
-  private readonly logger = new Logger(ReplaceModelWithUserDefaultUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ReplaceModelWithUserDefaultUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly threadsRepository: ThreadsRepository,
     private readonly getDefaultModelUseCase: GetDefaultModelUseCase,
   ) {}
 
   async execute(command: ReplaceModelWithUserDefaultCommand): Promise<void> {
-    this.logger.debug('execute', {
-      command,
-    });
+    this.logger.debug(
+      {
+        orgId: command.orgId,
+        oldPermittedModelId: command.oldPermittedModelId,
+        catalogModelId: command.catalogModelId,
+      },
+      'execute',
+    );
     try {
       const threads: Thread[] = await this.threadsRepository.findAllByModel(
         command.oldPermittedModelId,
       );
-      this.logger.debug('Found threads', {
-        threads,
-      });
+      this.logger.debug({ threadCount: threads.length }, 'Found threads');
       for (const thread of threads) {
-        const defaultModel = await this.getDefaultModelUseCase.execute(
-          new GetDefaultModelQuery({
-            orgId: command.orgId,
-            userId: thread.userId,
-            blacklistedModelIds: command.catalogModelId
-              ? [command.catalogModelId]
-              : [],
-          }),
-        );
-        this.logger.debug('Found default model', {
-          defaultModel,
-          oldPermittedModelId: command.oldPermittedModelId,
-        });
-        if (defaultModel.id === command.oldPermittedModelId) {
-          throw new ModelReplacementError(
-            thread.id,
-            command.oldPermittedModelId,
-          );
-        }
-
-        this.logger.debug('Updating thread', {
-          threadId: thread.id,
-          newModelId: defaultModel.id,
-        });
-        await this.threadsRepository.updateModel({
-          threadId: thread.id,
-          userId: thread.userId,
-          permittedModelId: defaultModel.id,
-        });
+        await this.replaceThreadModel(thread, command);
       }
     } catch (error) {
-      this.logger.error('Error replacing model with user default', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        { err: error as Error },
+        'Error replacing model with user default',
+      );
       throw error;
     }
+  }
+
+  private async replaceThreadModel(
+    thread: Thread,
+    command: ReplaceModelWithUserDefaultCommand,
+  ): Promise<void> {
+    const defaultModel = await this.getDefaultModelUseCase.execute(
+      new GetDefaultModelQuery({
+        orgId: command.orgId,
+        userId: thread.userId,
+        blacklistedModelIds: command.catalogModelId
+          ? [command.catalogModelId]
+          : [],
+      }),
+    );
+    this.logger.debug(
+      {
+        newModelId: defaultModel.id,
+        oldPermittedModelId: command.oldPermittedModelId,
+      },
+      'Found default model',
+    );
+    if (defaultModel.id === command.oldPermittedModelId) {
+      throw new ModelReplacementError(thread.id, command.oldPermittedModelId);
+    }
+    this.logger.debug(
+      { threadId: thread.id, newModelId: defaultModel.id },
+      'Updating thread',
+    );
+    await this.threadsRepository.updateModel({
+      threadId: thread.id,
+      userId: thread.userId,
+      permittedModelId: defaultModel.id,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/resolve-generated-image/resolve-generated-image.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/resolve-generated-image/resolve-generated-image.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { ResolveGeneratedImageUseCase } from './resolve-generated-image.use-case';
 import { ResolveGeneratedImageQuery } from './resolve-generated-image.query';
@@ -39,13 +39,11 @@ describe('ResolveGeneratedImageUseCase', () => {
     } as unknown as jest.Mocked<GetPresignedUrlUseCase>;
 
     useCase = new ResolveGeneratedImageUseCase(
+      createPinoLoggerMock(),
       threadsRepository,
       generatedImagesRepository,
       getPresignedUrlUseCase,
     );
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/resolve-generated-image/resolve-generated-image.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/resolve-generated-image/resolve-generated-image.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { GetPresignedUrlUseCase } from 'src/domain/storage/application/use-cases/get-presigned-url/get-presigned-url.use-case';
 import { GetPresignedUrlCommand } from 'src/domain/storage/application/use-cases/get-presigned-url/get-presigned-url.command';
@@ -20,9 +21,9 @@ export interface ResolveGeneratedImageResult {
 
 @Injectable()
 export class ResolveGeneratedImageUseCase {
-  private readonly logger = new Logger(ResolveGeneratedImageUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ResolveGeneratedImageUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly threadsRepository: ThreadsRepository,
     private readonly generatedImagesRepository: GeneratedImagesRepository,
     private readonly getPresignedUrlUseCase: GetPresignedUrlUseCase,
@@ -31,10 +32,11 @@ export class ResolveGeneratedImageUseCase {
   async execute(
     query: ResolveGeneratedImageQuery,
   ): Promise<ResolveGeneratedImageResult> {
-    this.logger.log('execute', {
+    const logContext = {
       threadId: query.threadId,
       imageId: query.imageId,
-    });
+    };
+    this.logger.info(logContext, 'execute');
 
     try {
       const thread = await this.threadsRepository.findOne(
@@ -77,11 +79,10 @@ export class ResolveGeneratedImageUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Failed to resolve generated image', {
-        threadId: query.threadId,
-        imageId: query.imageId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        { ...logContext, err: error as Error },
+        'Failed to resolve generated image',
+      );
       throw error;
     }
   }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/save-generated-image/save-generated-image.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/save-generated-image/save-generated-image.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { SaveGeneratedImageUseCase } from './save-generated-image.use-case';
 import { SaveGeneratedImageCommand } from './save-generated-image.command';
@@ -42,13 +42,11 @@ describe('SaveGeneratedImageUseCase', () => {
     } as unknown as jest.Mocked<DeleteObjectUseCase>;
 
     useCase = new SaveGeneratedImageUseCase(
+      createPinoLoggerMock(),
       generatedImagesRepository,
       uploadObjectUseCase,
       deleteObjectUseCase,
     );
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/save-generated-image/save-generated-image.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/save-generated-image/save-generated-image.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { randomUUID } from 'crypto';
 import type { UUID } from 'crypto';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -20,23 +21,20 @@ import { SaveGeneratedImageCommand } from './save-generated-image.command';
 
 @Injectable()
 export class SaveGeneratedImageUseCase {
-  private readonly logger = new Logger(SaveGeneratedImageUseCase.name);
-
   constructor(
+    @InjectPinoLogger(SaveGeneratedImageUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly generatedImagesRepository: GeneratedImagesRepository,
     private readonly uploadObjectUseCase: UploadObjectUseCase,
     private readonly deleteObjectUseCase: DeleteObjectUseCase,
   ) {}
 
   async execute(command: SaveGeneratedImageCommand): Promise<{ id: UUID }> {
-    this.logger.log('execute', {
+    const logContext = {
       orgId: command.orgId,
       threadId: command.threadId,
-    });
-
-    // Validate at the boundary so that unsupported content types surface as
-    // a 400-class domain error instead of being wrapped as a 500 by the
-    // catch-all below (which is reserved for true infrastructure failures).
+    };
+    this.logger.info(logContext, 'execute');
     if (!isAllowedImageContentType(command.contentType)) {
       throw new UnsupportedImageContentTypeError(command.contentType);
     }
@@ -69,21 +67,18 @@ export class SaveGeneratedImageUseCase {
         throw dbError;
       }
 
-      this.logger.log('Generated image saved', {
-        imageId,
-        storageKey,
-      });
+      const savedLogContext = { imageId, fileName: storageKey };
+      this.logger.info(savedLogContext, 'Generated image saved');
 
       return { id: imageId };
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Failed to save generated image', {
-        orgId: command.orgId,
-        threadId: command.threadId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        { ...logContext, err: error as Error },
+        'Failed to save generated image',
+      );
       throw new GeneratedImageSaveFailedError(
         error instanceof Error ? error : new Error('Unknown error'),
       );
@@ -95,17 +90,20 @@ export class SaveGeneratedImageUseCase {
       await this.deleteObjectUseCase.execute(
         new DeleteObjectCommand(storageKey),
       );
-      this.logger.log('Cleaned up orphaned blob after DB save failure', {
-        storageKey,
-      });
+      this.logger.info(
+        {
+          fileName: storageKey,
+        },
+        'Cleaned up orphaned blob after DB save failure',
+      );
     } catch (cleanupError) {
-      this.logger.error('Failed to clean up orphaned blob', {
-        storageKey,
-        error:
-          cleanupError instanceof Error
-            ? cleanupError.message
-            : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          fileName: storageKey,
+          err: cleanupError as Error,
+        },
+        'Failed to clean up orphaned blob',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/update-thread-title/update-thread-title.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/update-thread-title/update-thread-title.use-case.spec.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { ContextService } from 'src/common/context/services/context.service';
 import type { ThreadsRepository } from '../../ports/threads.repository';
 import { ThreadErrorCode, ThreadNotFoundError } from '../../threads.errors';
@@ -18,6 +19,7 @@ describe('UpdateThreadTitleUseCase', () => {
       get: jest.fn().mockReturnValue(userId),
     } as unknown as ContextService;
     const useCase = new UpdateThreadTitleUseCase(
+      createPinoLoggerMock(),
       threadsRepository,
       contextService,
     );

--- a/ayunis-core-backend/src/domain/threads/application/use-cases/update-thread-title/update-thread-title.use-case.ts
+++ b/ayunis-core-backend/src/domain/threads/application/use-cases/update-thread-title/update-thread-title.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -8,19 +9,22 @@ import { UpdateThreadTitleCommand } from './update-thread-title.command';
 
 @Injectable()
 export class UpdateThreadTitleUseCase {
-  private readonly logger = new Logger(UpdateThreadTitleUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateThreadTitleUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly threadsRepository: ThreadsRepository,
     private readonly contextService: ContextService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpecteThreadError)
   async execute(command: UpdateThreadTitleCommand): Promise<void> {
-    this.logger.log('updateTitle', {
-      threadId: command.threadId,
-      title: command.title,
-    });
+    this.logger.info(
+      {
+        threadId: command.threadId,
+        text: command.title,
+      },
+      'updateTitle',
+    );
     const userId = this.contextService.get('userId');
     if (!userId) {
       throw new UnauthorizedAccessError();

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-thread-assignments.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-thread-assignments.repository.spec.ts
@@ -1,4 +1,5 @@
 import { randomUUID, type UUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { Repository, SelectQueryBuilder } from 'typeorm';
 
 import { LocalThreadAssignmentsRepository } from './local-thread-assignments.repository';
@@ -82,6 +83,7 @@ describe('LocalThreadAssignmentsRepository', () => {
       ThreadSourceAssignmentMapper;
 
     repository = new LocalThreadAssignmentsRepository(
+      createPinoLoggerMock(),
       threadRepo as unknown as Repository<ThreadRecord>,
       sourceAssignmentRepo as unknown as Repository<ThreadSourceAssignmentRecord>,
       kbAssignmentRepo,

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-thread-assignments.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-thread-assignments.repository.ts
@@ -1,4 +1,5 @@
-import { Logger, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { IsNull, Repository } from 'typeorm';
 import { UUID, randomUUID } from 'crypto';
@@ -12,9 +13,9 @@ import type { McpIntegrationRecord } from 'src/domain/mcp/infrastructure/persist
 
 @Injectable()
 export class LocalThreadAssignmentsRepository {
-  private readonly logger = new Logger(LocalThreadAssignmentsRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalThreadAssignmentsRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(ThreadRecord)
     private readonly threadRepository: Repository<ThreadRecord>,
     @InjectRepository(ThreadSourceAssignmentRecord)
@@ -48,11 +49,14 @@ export class LocalThreadAssignmentsRepository {
     userId: UUID;
     sourceAssignment: SourceAssignment;
   }): Promise<void> {
-    this.logger.log('addSourceAssignment', {
-      threadId: params.threadId,
-      userId: params.userId,
-      sourceId: params.sourceAssignment.source.id,
-    });
+    this.logger.info(
+      {
+        threadId: params.threadId,
+        userId: params.userId,
+        sourceId: params.sourceAssignment.source.id,
+      },
+      'addSourceAssignment',
+    );
 
     const threadExists = await this.threadRepository.exists({
       where: { id: params.threadId, userId: params.userId },
@@ -74,10 +78,13 @@ export class LocalThreadAssignmentsRepository {
     userId: UUID;
     mcpIntegrationIds: UUID[];
   }): Promise<void> {
-    this.logger.log('updateMcpIntegrations', {
-      threadId: params.threadId,
-      mcpIntegrationIds: params.mcpIntegrationIds,
-    });
+    this.logger.info(
+      {
+        threadId: params.threadId,
+        mcpIntegrationIds: params.mcpIntegrationIds,
+      },
+      'updateMcpIntegrations',
+    );
 
     const threadEntity = await this.threadRepository.findOne({
       where: { id: params.threadId, userId: params.userId },
@@ -101,11 +108,14 @@ export class LocalThreadAssignmentsRepository {
     knowledgeBaseId: UUID;
     originSkillId?: UUID;
   }): Promise<void> {
-    this.logger.log('addKnowledgeBaseAssignment', {
-      threadId: params.threadId,
-      knowledgeBaseId: params.knowledgeBaseId,
-      originSkillId: params.originSkillId,
-    });
+    this.logger.info(
+      {
+        threadId: params.threadId,
+        knowledgeBaseId: params.knowledgeBaseId,
+        originSkillId: params.originSkillId,
+      },
+      'addKnowledgeBaseAssignment',
+    );
 
     const threadEntity = await this.threadRepository.findOne({
       where: { id: params.threadId, userId: params.userId },
@@ -130,11 +140,14 @@ export class LocalThreadAssignmentsRepository {
     knowledgeBaseId: UUID;
     originSkillId?: UUID;
   }): Promise<void> {
-    this.logger.log('removeKnowledgeBaseAssignment', {
-      threadId: params.threadId,
-      knowledgeBaseId: params.knowledgeBaseId,
-      originSkillId: params.originSkillId,
-    });
+    this.logger.info(
+      {
+        threadId: params.threadId,
+        knowledgeBaseId: params.knowledgeBaseId,
+        originSkillId: params.originSkillId,
+      },
+      'removeKnowledgeBaseAssignment',
+    );
 
     const threadEntity = await this.threadRepository.findOne({
       where: { id: params.threadId, userId: params.userId },
@@ -155,10 +168,13 @@ export class LocalThreadAssignmentsRepository {
     originSkillId: UUID;
     userIds: UUID[];
   }): Promise<void> {
-    this.logger.log('removeSourceAssignmentsByOriginSkill', {
-      originSkillId: params.originSkillId,
-      userCount: params.userIds.length,
-    });
+    this.logger.info(
+      {
+        originSkillId: params.originSkillId,
+        userCount: params.userIds.length,
+      },
+      'removeSourceAssignmentsByOriginSkill',
+    );
 
     if (params.userIds.length === 0) {
       return;
@@ -191,11 +207,14 @@ export class LocalThreadAssignmentsRepository {
     userIds: UUID[];
     knowledgeBaseId?: UUID;
   }): Promise<void> {
-    this.logger.log('removeKnowledgeBaseAssignmentsByOriginSkill', {
-      originSkillId: params.originSkillId,
-      userCount: params.userIds.length,
-      knowledgeBaseId: params.knowledgeBaseId,
-    });
+    this.logger.info(
+      {
+        originSkillId: params.originSkillId,
+        userCount: params.userIds.length,
+        knowledgeBaseId: params.knowledgeBaseId,
+      },
+      'removeKnowledgeBaseAssignmentsByOriginSkill',
+    );
 
     if (params.userIds.length === 0) {
       return;
@@ -233,7 +252,10 @@ export class LocalThreadAssignmentsRepository {
   async findSourcesWithOnlyStaleDirectAssignments(
     olderThan: Date,
   ): Promise<{ sourceId: UUID; orgId: UUID }[]> {
-    this.logger.log('findSourcesWithOnlyStaleDirectAssignments', { olderThan });
+    this.logger.info(
+      { olderThan },
+      'findSourcesWithOnlyStaleDirectAssignments',
+    );
 
     const rows = await this.threadSourceAssignmentRepository
       .createQueryBuilder('tsa')
@@ -271,10 +293,13 @@ export class LocalThreadAssignmentsRepository {
     knowledgeBaseId: UUID;
     userIds: UUID[];
   }): Promise<void> {
-    this.logger.log('removeDirectKnowledgeBaseAssignments', {
-      knowledgeBaseId: params.knowledgeBaseId,
-      userCount: params.userIds.length,
-    });
+    this.logger.info(
+      {
+        knowledgeBaseId: params.knowledgeBaseId,
+        userCount: params.userIds.length,
+      },
+      'removeDirectKnowledgeBaseAssignments',
+    );
 
     if (params.userIds.length === 0) {
       return;

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.spec.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { Repository } from 'typeorm';
 
 import { LocalThreadsRepository } from './local-threads.repository';
@@ -22,6 +23,7 @@ describe('LocalThreadsRepository', () => {
         .mockResolvedValue(sourceAssignments),
     } as unknown as LocalThreadAssignmentsRepository;
     const repository = new LocalThreadsRepository(
+      createPinoLoggerMock(),
       threadRepository,
       threadMapper,
       assignments,
@@ -71,6 +73,7 @@ describe('LocalThreadsRepository', () => {
       findSourceAssignmentsByThreadId: jest.fn().mockResolvedValue([]),
     } as unknown as LocalThreadAssignmentsRepository;
     const repository = new LocalThreadsRepository(
+      createPinoLoggerMock(),
       threadRepository,
       threadMapper,
       assignments,

--- a/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/persistence/local/local-threads.repository.ts
@@ -7,7 +7,8 @@ import {
   ThreadsPagination,
   ThreadsRepository,
 } from 'src/domain/threads/application/ports/threads.repository';
-import { Logger, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository, SelectQueryBuilder } from 'typeorm';
 import { ThreadRecord } from './schema/thread.record';
@@ -21,9 +22,9 @@ import { LocalThreadAssignmentsRepository } from './local-thread-assignments.rep
 
 @Injectable()
 export class LocalThreadsRepository extends ThreadsRepository {
-  private readonly logger = new Logger(LocalThreadsRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalThreadsRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(ThreadRecord)
     private readonly threadRepository: Repository<ThreadRecord>,
     private readonly threadMapper: ThreadMapper,
@@ -33,7 +34,7 @@ export class LocalThreadsRepository extends ThreadsRepository {
   }
 
   async create(thread: Thread): Promise<Thread> {
-    this.logger.log('create', { thread });
+    this.logger.info({ threadId: thread.id, userId: thread.userId }, 'create');
     const threadEntity = this.threadMapper.toRecord(thread);
     const savedThreadEntity = await this.threadRepository.save(threadEntity);
     const reloadedThreadEntity = await this.threadRepository.findOne({
@@ -64,7 +65,7 @@ export class LocalThreadsRepository extends ThreadsRepository {
   }
 
   async findOne(id: UUID, userId: UUID): Promise<Thread | null> {
-    this.logger.log('findOne', { id, userId });
+    this.logger.info({ id, userId }, 'findOne');
     const threadEntity = await this.threadRepository.findOne({
       where: { id, userId },
       relationLoadStrategy: 'query',
@@ -102,7 +103,8 @@ export class LocalThreadsRepository extends ThreadsRepository {
     filters?: ThreadsFindAllFilters,
     pagination?: ThreadsPagination,
   ): Promise<Paginated<Thread>> {
-    this.logger.log('findAll', { userId, filters, pagination });
+    const { search: text, ...safeFilters } = filters ?? {};
+    this.logger.info({ userId, ...safeFilters, text, pagination }, 'findAll');
 
     const queryBuilder = this.threadRepository
       .createQueryBuilder('thread')
@@ -191,7 +193,7 @@ export class LocalThreadsRepository extends ThreadsRepository {
     modelId: UUID,
     options?: ThreadsFindAllOptions,
   ): Promise<Thread[]> {
-    this.logger.log('findAllByModel', { modelId });
+    this.logger.info({ modelId }, 'findAllByModel');
     const threadEntities = await this.threadRepository.find({
       where: { modelId },
       relations: this.getRelations(options),
@@ -223,7 +225,7 @@ export class LocalThreadsRepository extends ThreadsRepository {
   }
 
   async update(thread: Thread): Promise<Thread> {
-    this.logger.log('update', { threadId: thread.id });
+    this.logger.info({ threadId: thread.id }, 'update');
     const threadRecord = this.threadMapper.toRecord(thread);
     const savedThreadRecord = await this.threadRepository.save(threadRecord);
     return this.threadMapper.toDomain(savedThreadRecord);
@@ -234,7 +236,14 @@ export class LocalThreadsRepository extends ThreadsRepository {
     userId: UUID;
     title: string;
   }): Promise<void> {
-    this.logger.log('updateTitle', { params });
+    this.logger.info(
+      {
+        threadId: params.threadId,
+        userId: params.userId,
+        text: params.title,
+      },
+      'updateTitle',
+    );
     const result = await this.threadRepository.update(
       { id: params.threadId, userId: params.userId },
       { title: params.title },
@@ -268,11 +277,14 @@ export class LocalThreadsRepository extends ThreadsRepository {
     userId: UUID;
     permittedModelId: UUID;
   }): Promise<void> {
-    this.logger.log('updateModel', {
-      threadId: params.threadId,
-      userId: params.userId,
-      permittedModelId: params.permittedModelId,
-    });
+    this.logger.info(
+      {
+        threadId: params.threadId,
+        userId: params.userId,
+        permittedModelId: params.permittedModelId,
+      },
+      'updateModel',
+    );
     const result = await this.threadRepository
       .createQueryBuilder()
       .update(ThreadRecord)
@@ -316,12 +328,12 @@ export class LocalThreadsRepository extends ThreadsRepository {
   }
 
   async delete(id: UUID, userId: UUID): Promise<void> {
-    this.logger.log('delete', { id, userId });
+    this.logger.info({ id, userId }, 'delete');
     await this.threadRepository.delete({ id, userId });
   }
 
   async findAllIdsByUserId(userId: UUID): Promise<UUID[]> {
-    this.logger.log('findAllIdsByUserId', { userId });
+    this.logger.info({ userId }, 'findAllIdsByUserId');
     const rows = await this.threadRepository.find({
       where: { userId },
       select: { id: true },
@@ -330,7 +342,7 @@ export class LocalThreadsRepository extends ThreadsRepository {
   }
 
   async findAllIdsByWorkspaceId(workspaceId: UUID): Promise<UUID[]> {
-    this.logger.log('findAllIdsByWorkspaceId', { workspaceId });
+    this.logger.info({ workspaceId }, 'findAllIdsByWorkspaceId');
     const rows = await this.threadRepository.find({
       where: { workspaceId },
       select: { id: true },
@@ -352,7 +364,14 @@ export class LocalThreadsRepository extends ThreadsRepository {
     userId: UUID;
     workspaceId: UUID | null;
   }): Promise<void> {
-    this.logger.log('assignToWorkspace', { params });
+    this.logger.info(
+      {
+        threadId: params.threadId,
+        userId: params.userId,
+        workspaceId: params.workspaceId,
+      },
+      'assignToWorkspace',
+    );
     const result = await this.threadRepository.update(
       { id: params.threadId, userId: params.userId },
       { workspaceId: params.workspaceId },
@@ -395,7 +414,7 @@ export class LocalThreadsRepository extends ThreadsRepository {
   }
 
   async findAllByOrgIdWithSources(orgId: UUID): Promise<Thread[]> {
-    this.logger.log('findAllByOrgIdWithSources', { orgId });
+    this.logger.info({ orgId }, 'findAllByOrgIdWithSources');
     const threadEntities = await this.threadRepository
       .createQueryBuilder('thread')
       .innerJoin('users', 'user', 'user.id = thread.userId')
@@ -410,12 +429,15 @@ export class LocalThreadsRepository extends ThreadsRepository {
   async findExpiredThreadRefsByOrg(
     params: FindExpiredThreadRefsParams,
   ): Promise<ExpiredThreadRef[]> {
-    this.logger.log('findExpiredThreadRefsByOrg', {
-      orgId: params.orgId,
-      activeBefore: params.activeBefore,
-      limit: params.limit,
-      offset: params.offset,
-    });
+    this.logger.info(
+      {
+        orgId: params.orgId,
+        activeBefore: params.activeBefore,
+        limit: params.limit,
+        offset: params.offset,
+      },
+      'findExpiredThreadRefsByOrg',
+    );
     // Select only id + owner (no message/source hydration) — enforcement
     // deletes via DeleteThreadUseCase by id, so the full entity is unneeded.
     // COALESCE(lastActivityAt, createdAt) defends against any null slipping

--- a/ayunis-core-backend/src/domain/threads/infrastructure/tasks/stale-thread-sources-cleanup.task.ts
+++ b/ayunis-core-backend/src/domain/threads/infrastructure/tasks/stale-thread-sources-cleanup.task.ts
@@ -1,13 +1,15 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { CleanupStaleThreadSourcesUseCase } from '../../application/use-cases/cleanup-stale-thread-sources/cleanup-stale-thread-sources.use-case';
 
 @Injectable()
 export class StaleThreadSourcesCleanupTask {
-  private readonly logger = new Logger(StaleThreadSourcesCleanupTask.name);
   private isRunning = false;
 
   constructor(
+    @InjectPinoLogger(StaleThreadSourcesCleanupTask.name)
+    private readonly logger: PinoLogger,
     private readonly cleanupStaleThreadSourcesUseCase: CleanupStaleThreadSourcesUseCase,
   ) {}
 
@@ -19,26 +21,29 @@ export class StaleThreadSourcesCleanupTask {
     }
 
     this.isRunning = true;
-    this.logger.log('Starting scheduled stale thread sources cleanup');
+    this.logger.info('Starting scheduled stale thread sources cleanup');
 
     try {
       const result = await this.cleanupStaleThreadSourcesUseCase.execute();
-      this.logger.log('Scheduled cleanup completed', {
-        scanned: result.scannedCount,
-        unreferenced: result.unreferencedCount,
-        deleted: result.deletedCount,
-        failed: result.failedCount,
-      });
+      this.logger.info(
+        {
+          scanned: result.scannedCount,
+          unreferenced: result.unreferencedCount,
+          deleted: result.deletedCount,
+          failed: result.failedCount,
+        },
+        'Scheduled cleanup completed',
+      );
       if (result.failedCount > 0) {
-        this.logger.warn('Some sources failed to delete', {
-          errors: result.errors,
-        });
+        this.logger.warn(
+          {
+            error: result.errors,
+          },
+          'Some sources failed to delete',
+        );
       }
     } catch (error) {
-      this.logger.error(
-        'Scheduled cleanup failed',
-        error instanceof Error ? error.stack : undefined,
-      );
+      this.logger.error({ err: error as Error }, 'Scheduled cleanup failed');
     } finally {
       this.isRunning = false;
     }

--- a/ayunis-core-backend/src/domain/threads/presenters/http/generated-images.controller.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/generated-images.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, Logger, Param, ParseUUIDPipe } from '@nestjs/common';
+import { Controller, Get, Param, ParseUUIDPipe } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import type { UUID } from 'crypto';
 import {
@@ -12,9 +13,9 @@ import { GeneratedImageUrlResponseDto } from './dto/generated-image-url-response
 @ApiTags('threads')
 @Controller('threads')
 export class GeneratedImagesController {
-  private readonly logger = new Logger(GeneratedImagesController.name);
-
   constructor(
+    @InjectPinoLogger(GeneratedImagesController.name)
+    private readonly logger: PinoLogger,
     private readonly resolveGeneratedImageUseCase: ResolveGeneratedImageUseCase,
   ) {}
 
@@ -33,7 +34,7 @@ export class GeneratedImagesController {
     @Param('threadId', ParseUUIDPipe) threadId: UUID,
     @Param('imageId', ParseUUIDPipe) imageId: UUID,
   ): Promise<GeneratedImageUrlResponseDto> {
-    this.logger.log('resolve', { threadId, imageId });
+    this.logger.info({ threadId, imageId }, 'resolve');
 
     return this.resolveGeneratedImageUseCase.execute(
       new ResolveGeneratedImageQuery(threadId, imageId, userId),

--- a/ayunis-core-backend/src/domain/threads/presenters/http/message-images.controller.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/message-images.controller.ts
@@ -1,13 +1,13 @@
 import {
   Controller,
   Get,
-  Logger,
   Param,
   ParseIntPipe,
   ParseUUIDPipe,
   Res,
   StreamableFile,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import type { UUID } from 'crypto';
 import { Response } from 'express';
@@ -22,9 +22,9 @@ import { DownloadMessageImageQuery } from '../../application/use-cases/download-
 @ApiTags('threads')
 @Controller('threads')
 export class MessageImagesController {
-  private readonly logger = new Logger(MessageImagesController.name);
-
   constructor(
+    @InjectPinoLogger(MessageImagesController.name)
+    private readonly logger: PinoLogger,
     private readonly downloadMessageImageUseCase: DownloadMessageImageUseCase,
   ) {}
 
@@ -45,7 +45,7 @@ export class MessageImagesController {
     @Param('index', ParseIntPipe) index: number,
     @Res({ passthrough: true }) res: Response,
   ): Promise<StreamableFile> {
-    this.logger.log('download', { threadId, messageId, index });
+    this.logger.info({ threadId, messageId, index }, 'download');
 
     const download = await this.downloadMessageImageUseCase.execute(
       new DownloadMessageImageQuery(threadId, messageId, index, userId),

--- a/ayunis-core-backend/src/domain/threads/presenters/http/thread-knowledge-bases.controller.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/thread-knowledge-bases.controller.ts
@@ -4,10 +4,10 @@ import {
   Delete,
   Param,
   ParseUUIDPipe,
-  Logger,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { ApiOperation, ApiResponse, ApiParam, ApiTags } from '@nestjs/swagger';
 
@@ -24,9 +24,9 @@ import { RequireAcademyCertificate } from 'src/iam/academy-access/application/de
 @RequireAcademyCertificate()
 @Controller('threads')
 export class ThreadKnowledgeBasesController {
-  private readonly logger = new Logger(ThreadKnowledgeBasesController.name);
-
   constructor(
+    @InjectPinoLogger(ThreadKnowledgeBasesController.name)
+    private readonly logger: PinoLogger,
     private readonly addKnowledgeBaseToThreadUseCase: AddKnowledgeBaseToThreadUseCase,
     private readonly removeKnowledgeBaseFromThreadUseCase: RemoveKnowledgeBaseFromThreadUseCase,
   ) {}
@@ -58,7 +58,7 @@ export class ThreadKnowledgeBasesController {
     @Param('id', ParseUUIDPipe) threadId: UUID,
     @Param('knowledgeBaseId', ParseUUIDPipe) knowledgeBaseId: UUID,
   ): Promise<void> {
-    this.logger.log('addKnowledgeBase', { threadId, knowledgeBaseId });
+    this.logger.info({ threadId, knowledgeBaseId }, 'addKnowledgeBase');
     await this.addKnowledgeBaseToThreadUseCase.execute(
       new AddKnowledgeBaseToThreadCommand(threadId, knowledgeBaseId),
     );
@@ -89,7 +89,7 @@ export class ThreadKnowledgeBasesController {
     @Param('id', ParseUUIDPipe) threadId: UUID,
     @Param('knowledgeBaseId', ParseUUIDPipe) knowledgeBaseId: UUID,
   ): Promise<void> {
-    this.logger.log('removeKnowledgeBase', { threadId, knowledgeBaseId });
+    this.logger.info({ threadId, knowledgeBaseId }, 'removeKnowledgeBase');
     await this.removeKnowledgeBaseFromThreadUseCase.execute(
       new RemoveKnowledgeBaseFromThreadCommand(threadId, knowledgeBaseId),
     );

--- a/ayunis-core-backend/src/domain/threads/presenters/http/thread-mcp-integrations.controller.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/thread-mcp-integrations.controller.ts
@@ -4,10 +4,10 @@ import {
   Delete,
   Param,
   ParseUUIDPipe,
-  Logger,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { ApiOperation, ApiResponse, ApiParam, ApiTags } from '@nestjs/swagger';
 
@@ -21,9 +21,9 @@ import { RequireAcademyCertificate } from 'src/iam/academy-access/application/de
 @RequireAcademyCertificate()
 @Controller('threads')
 export class ThreadMcpIntegrationsController {
-  private readonly logger = new Logger(ThreadMcpIntegrationsController.name);
-
   constructor(
+    @InjectPinoLogger(ThreadMcpIntegrationsController.name)
+    private readonly logger: PinoLogger,
     private readonly addMcpIntegrationToThreadUseCase: AddMcpIntegrationToThreadUseCase,
     private readonly removeMcpIntegrationFromThreadUseCase: RemoveMcpIntegrationFromThreadUseCase,
   ) {}
@@ -56,7 +56,7 @@ export class ThreadMcpIntegrationsController {
     @Param('id', ParseUUIDPipe) threadId: UUID,
     @Param('mcpIntegrationId', ParseUUIDPipe) mcpIntegrationId: UUID,
   ): Promise<void> {
-    this.logger.log('addMcpIntegration', { threadId, mcpIntegrationId });
+    this.logger.info({ threadId, mcpIntegrationId }, 'addMcpIntegration');
     await this.addMcpIntegrationToThreadUseCase.execute(
       new AddMcpIntegrationToThreadCommand(threadId, mcpIntegrationId),
     );
@@ -87,7 +87,7 @@ export class ThreadMcpIntegrationsController {
     @Param('id', ParseUUIDPipe) threadId: UUID,
     @Param('mcpIntegrationId', ParseUUIDPipe) mcpIntegrationId: UUID,
   ): Promise<void> {
-    this.logger.log('removeMcpIntegration', { threadId, mcpIntegrationId });
+    this.logger.info({ threadId, mcpIntegrationId }, 'removeMcpIntegration');
     await this.removeMcpIntegrationFromThreadUseCase.execute(
       new RemoveMcpIntegrationFromThreadCommand(threadId, mcpIntegrationId),
     );

--- a/ayunis-core-backend/src/domain/threads/presenters/http/thread-sources.controller.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/thread-sources.controller.ts
@@ -4,7 +4,6 @@ import {
   Post,
   Get,
   Delete,
-  Logger,
   Param,
   ParseUUIDPipe,
   UploadedFile,
@@ -13,6 +12,7 @@ import {
   Res,
   StreamableFile,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Response } from 'express';
 import { UUID } from 'crypto';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
@@ -57,9 +57,9 @@ import { RequireAcademyCertificate } from 'src/iam/academy-access/application/de
 @RequireAcademyCertificate()
 @Controller('threads')
 export class ThreadSourcesController {
-  private readonly logger = new Logger(ThreadSourcesController.name);
-
   constructor(
+    @InjectPinoLogger(ThreadSourcesController.name)
+    private readonly logger: PinoLogger,
     private readonly findThreadUseCase: FindThreadUseCase,
     private readonly addFileSourceToThreadUseCase: AddFileSourceToThreadUseCase,
     private readonly removeSourceFromThreadUseCase: RemoveSourceFromThreadUseCase,
@@ -79,7 +79,7 @@ export class ThreadSourcesController {
   ): Promise<
     (FileSourceResponseDto | UrlSourceResponseDto | CSVDataSourceResponseDto)[]
   > {
-    this.logger.log('getThreadSources', { threadId });
+    this.logger.info({ threadId }, 'getThreadSources');
     const sources = await this.getThreadSourcesUseCase.execute(
       new FindThreadSourcesQuery(threadId),
     );
@@ -100,7 +100,10 @@ export class ThreadSourcesController {
       throw new BadRequestException('No file was provided in the request');
     }
 
-    this.logger.log('addFileSource', { threadId, fileName: file.originalname });
+    this.logger.info(
+      { threadId, fileName: file.originalname },
+      'addFileSource',
+    );
     try {
       const sources = await this.addFileSourceToThreadUseCase.execute(
         new AddFileSourceToThreadCommand({ threadId, file }),
@@ -110,7 +113,7 @@ export class ThreadSourcesController {
         this.sourceDtoMapper.toDto(source, threadId),
       );
     } catch (error: unknown) {
-      this.logger.error('addFileSource', { error });
+      this.logger.error({ err: error as Error }, 'addFileSource');
       throw error;
     } finally {
       removeUploadedFile(file.path);
@@ -131,7 +134,7 @@ export class ThreadSourcesController {
     @Param('id', ParseUUIDPipe) threadId: UUID,
     @Param('sourceId', ParseUUIDPipe) sourceId: UUID,
   ): Promise<void> {
-    this.logger.log('removeSource', { threadId, sourceId });
+    this.logger.info({ threadId, sourceId }, 'removeSource');
 
     const { thread } = await this.findThreadUseCase.execute(
       new FindThreadQuery(threadId),
@@ -148,7 +151,7 @@ export class ThreadSourcesController {
     @Param('sourceId', ParseUUIDPipe) sourceId: UUID,
     @Res({ passthrough: true }) res: Response,
   ): Promise<StreamableFile> {
-    this.logger.log('downloadSource', { threadId, sourceId });
+    this.logger.info({ threadId, sourceId }, 'downloadSource');
 
     const { thread } = await this.findThreadUseCase.execute(
       new FindThreadQuery(threadId),

--- a/ayunis-core-backend/src/domain/threads/presenters/http/threads.controller.ts
+++ b/ayunis-core-backend/src/domain/threads/presenters/http/threads.controller.ts
@@ -1,7 +1,6 @@
 import {
   Controller,
   Post,
-  Logger,
   Get,
   Param,
   ParseUUIDPipe,
@@ -13,6 +12,7 @@ import {
   NotFoundException,
   Query,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import {
   CurrentUser,
@@ -62,9 +62,9 @@ import { ConfigService } from '@nestjs/config';
 @RequireAcademyCertificate()
 @Controller('threads')
 export class ThreadsController {
-  private readonly logger = new Logger(ThreadsController.name);
-
   constructor(
+    @InjectPinoLogger(ThreadsController.name)
+    private readonly logger: PinoLogger,
     private readonly createThreadUseCase: CreateThreadUseCase,
     private readonly findThreadUseCase: FindThreadUseCase,
     private readonly findAllThreadsUseCase: FindAllThreadsUseCase,
@@ -106,9 +106,12 @@ export class ThreadsController {
   async create(
     @Body() createThreadDto: CreateThreadDto,
   ): Promise<GetThreadResponseDto> {
-    this.logger.log('create', {
-      modelId: createThreadDto.modelId,
-    });
+    this.logger.info(
+      {
+        modelId: createThreadDto.modelId,
+      },
+      'create',
+    );
     this.assertWorkspaceParamAllowed(createThreadDto.workspaceId);
     const thread = await this.createThreadUseCase.execute(
       new CreateThreadCommand({
@@ -152,7 +155,8 @@ export class ThreadsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Query() queryParams: FindAllThreadsQueryParamsDto,
   ): Promise<GetThreadsResponseDto> {
-    this.logger.log('findAll', { filters: queryParams });
+    const { search: text, ...safeQueryParams } = queryParams;
+    this.logger.info({ ...safeQueryParams, text }, 'findAll');
     this.assertWorkspaceParamAllowed(queryParams.workspaceId);
     const threads = await this.findAllThreadsUseCase.execute(
       new FindAllThreadsQuery(
@@ -189,7 +193,7 @@ export class ThreadsController {
   async findOne(
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<GetThreadResponseDto> {
-    this.logger.log('findOne', { id });
+    this.logger.info({ id }, 'findOne');
     const result = await this.findThreadUseCase.execute(
       new FindThreadQuery(id),
     );
@@ -220,7 +224,7 @@ export class ThreadsController {
   @ApiResponse({ status: 500, description: 'Internal server error' })
   @HttpCode(HttpStatus.NO_CONTENT)
   async delete(@Param('id', ParseUUIDPipe) id: UUID): Promise<void> {
-    this.logger.log('delete', { id });
+    this.logger.info({ id }, 'delete');
     await this.deleteThreadUseCase.execute(new DeleteThreadCommand(id));
   }
 
@@ -245,7 +249,7 @@ export class ThreadsController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() updateThreadTitleDto: UpdateThreadTitleDto,
   ): Promise<void> {
-    this.logger.log('updateTitle', { id, title: updateThreadTitleDto.title });
+    this.logger.info({ id, text: updateThreadTitleDto.title }, 'updateTitle');
     await this.updateThreadTitleUseCase.execute(
       new UpdateThreadTitleCommand({
         threadId: id,
@@ -271,7 +275,7 @@ export class ThreadsController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() dto: AssignThreadWorkspaceDto,
   ): Promise<void> {
-    this.logger.log('assignWorkspace', { id, workspaceId: dto.workspaceId });
+    this.logger.info({ id, workspaceId: dto.workspaceId }, 'assignWorkspace');
     await this.assignThreadToWorkspaceUseCase.execute(
       new AssignThreadToWorkspaceCommand({
         threadId: id,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability and test wiring only, with no intentional changes to retention deletion, share authorization, or thread mutation flows beyond minor title-generation string handling.
> 
> **Overview**
> Continues the **nestjs-pino** rollout across **retention policies**, **shares**, and **threads** (use cases, controllers, listeners, cron task, and local persistence helpers).
> 
> Classes stop using `new Logger(...)` and instead take **`@InjectPinoLogger` / `PinoLogger`**. Log calls move to Pino’s **`(bindings, message)`** shape: **`log` → `info`**, errors use **`err`** on the binding object instead of stringified messages or stack args. Unit tests register **`getLoggerToken(...)`** with **`createPinoLoggerMock()`** and drop **`Logger.prototype`** spies; **`DeleteShareUseCase`** gains an assertion that unexpected failures log **`Failed to delete share`**.
> 
> Alongside the mechanical logging changes, a few small behavior tweaks appear: **`GenerateAndSetThreadTitleUseCase`** refactors title generation and tightens markdown link/quote stripping; **`FindAllThreadsUseCase`** logs search text under **`text`**; **`UpdateThreadTitleUseCase`** logs the title as **`text`**; reference-image and storage logs use **`fileName`** where object names were logged before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be4a4ee75abadc51724fc33eb0900e8ccb0bb379. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->