### PR TITLE
wip(logging): migrate skills and knowledge logging (AYC-752)

### DIFF
--- a/ayunis-core-backend/src/domain/knowledge-bases/application/listeners/share-deleted.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/listeners/share-deleted.listener.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { KnowledgeBaseShareDeletedListener } from './share-deleted.listener';
@@ -91,6 +93,10 @@ describe('KnowledgeBaseShareDeletedListener', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         KnowledgeBaseShareDeletedListener,
+        {
+          provide: getLoggerToken(KnowledgeBaseShareDeletedListener.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillRepository, useValue: skillRepository },
         { provide: SharesRepository, useValue: sharesRepository },
         {

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/listeners/share-deleted.listener.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/listeners/share-deleted.listener.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OnEvent } from '@nestjs/event-emitter';
 import { ShareDeletedEvent } from 'src/domain/shares/application/events/share-deleted.event';
 import { SharedEntityType } from 'src/domain/shares/domain/value-objects/shared-entity-type.enum';
@@ -18,9 +19,9 @@ import {
 
 @Injectable()
 export class KnowledgeBaseShareDeletedListener {
-  private readonly logger = new Logger(KnowledgeBaseShareDeletedListener.name);
-
   constructor(
+    @InjectPinoLogger(KnowledgeBaseShareDeletedListener.name)
+    private readonly logger: PinoLogger,
     @Inject(SkillRepository)
     private readonly skillRepository: SkillRepository,
     @Inject(SharesRepository)
@@ -35,11 +36,14 @@ export class KnowledgeBaseShareDeletedListener {
       return;
     }
 
-    this.logger.log('Cascading KB share deletion through skills and threads', {
-      knowledgeBaseId: event.entityId,
-      ownerId: event.ownerId,
-      remainingScopeCount: event.remainingScopes.length,
-    });
+    this.logger.info(
+      {
+        knowledgeBaseId: event.entityId,
+        ownerId: event.ownerId,
+        remainingScopeCount: event.remainingScopes.length,
+      },
+      'Cascading KB share deletion through skills and threads',
+    );
 
     const lostAccessUserIds =
       await this.shareScopeResolver.resolveLostAccessUserIds(event);
@@ -66,10 +70,13 @@ export class KnowledgeBaseShareDeletedListener {
       affectedSkillIds,
     );
 
-    this.logger.log('Removed KB from affected skills', {
-      knowledgeBaseId: event.entityId,
-      affectedSkillCount: affectedSkillIds.length,
-    });
+    this.logger.info(
+      {
+        knowledgeBaseId: event.entityId,
+        affectedSkillCount: affectedSkillIds.length,
+      },
+      'Removed KB from affected skills',
+    );
 
     // For each affected skill that is itself shared, clean up thread KB
     // assignments that originated from that skill (for ALL users, since the
@@ -108,12 +115,12 @@ export class KnowledgeBaseShareDeletedListener {
         ),
       );
 
-      this.logger.log(
-        'Removed KB thread assignments originating from shared skill',
+      this.logger.info(
         {
           skillId: skill.id,
           userCount: allUserIds.length,
         },
+        'Removed KB thread assignments originating from shared skill',
       );
     }
   }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/listeners/user-deletion-requested.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/listeners/user-deletion-requested.listener.spec.ts
@@ -1,6 +1,8 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import type { UUID } from 'crypto';
 import { KnowledgeBasesUserDeletionRequestedListener } from './user-deletion-requested.listener';
 import { KnowledgeBaseRepository } from '../ports/knowledge-base.repository';
@@ -32,6 +34,12 @@ describe('KnowledgeBasesUserDeletionRequestedListener', () => {
       providers: [
         KnowledgeBasesUserDeletionRequestedListener,
         {
+          provide: getLoggerToken(
+            KnowledgeBasesUserDeletionRequestedListener.name,
+          ),
+          useValue: createPinoLoggerMock(),
+        },
+        {
           provide: KnowledgeBaseRepository,
           useValue: knowledgeBaseRepository,
         },
@@ -43,8 +51,6 @@ describe('KnowledgeBasesUserDeletionRequestedListener', () => {
     }).compile();
 
     listener = module.get(KnowledgeBasesUserDeletionRequestedListener);
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/listeners/user-deletion-requested.listener.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/listeners/user-deletion-requested.listener.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OnEvent } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
 import { UserDeletionRequestedEvent } from 'src/iam/users/application/events/user-deletion-requested.event';
@@ -23,11 +24,9 @@ import { KnowledgeBaseRepository } from '../ports/knowledge-base.repository';
  */
 @Injectable()
 export class KnowledgeBasesUserDeletionRequestedListener {
-  private readonly logger = new Logger(
-    KnowledgeBasesUserDeletionRequestedListener.name,
-  );
-
   constructor(
+    @InjectPinoLogger(KnowledgeBasesUserDeletionRequestedListener.name)
+    private readonly logger: PinoLogger,
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
     private readonly cleanupSourceProcessingUseCase: CleanupSourceProcessingUseCase,
   ) {}
@@ -53,11 +52,14 @@ export class KnowledgeBasesUserDeletionRequestedListener {
         return;
       }
 
-      this.logger.log('Deferring source processing cleanup for deleted user', {
-        userId: event.userId,
-        knowledgeBaseCount: knowledgeBases.length,
-        sourceCount: sourceIds.length,
-      });
+      this.logger.info(
+        {
+          userId: event.userId,
+          knowledgeBaseCount: knowledgeBases.length,
+          sourceCount: sourceIds.length,
+        },
+        'Deferring source processing cleanup for deleted user',
+      );
 
       event.deferCleanup('cleanup knowledge base source processing', () =>
         this.cleanupSourceProcessingUseCase.execute(
@@ -66,11 +68,11 @@ export class KnowledgeBasesUserDeletionRequestedListener {
       );
     } catch (error) {
       this.logger.error(
-        'Failed to resolve knowledge base sources for deleted user',
         {
           userId: event.userId,
-          error: error instanceof Error ? error.message : 'Unknown error',
+          err: error as Error,
         },
+        'Failed to resolve knowledge base sources for deleted user',
       );
     }
   }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.spec.ts
@@ -1,6 +1,8 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { KnowledgeBaseAccessService } from './knowledge-base-access.service';
 import { KnowledgeBaseRepository } from '../ports/knowledge-base.repository';
 import { FindShareByEntityUseCase } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case';
@@ -39,6 +41,10 @@ describe('KnowledgeBaseAccessService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         KnowledgeBaseAccessService,
+        {
+          provide: getLoggerToken(KnowledgeBaseAccessService.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: KnowledgeBaseRepository,
           useValue: {
@@ -84,10 +90,6 @@ describe('KnowledgeBaseAccessService', () => {
       CheckKnowledgeBaseSkillShareAccessUseCase,
     );
     contextService = module.get(ContextService);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/services/knowledge-base-access.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { KnowledgeBaseRepository } from '../ports/knowledge-base.repository';
 import { FindShareByEntityUseCase } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case';
@@ -20,9 +21,9 @@ export interface KnowledgeBaseWithShareStatus {
 
 @Injectable()
 export class KnowledgeBaseAccessService {
-  private readonly logger = new Logger(KnowledgeBaseAccessService.name);
-
   constructor(
+    @InjectPinoLogger(KnowledgeBaseAccessService.name)
+    private readonly logger: PinoLogger,
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
     private readonly findShareByEntityUseCase: FindShareByEntityUseCase,
     private readonly findSharesByScopeUseCase: FindSharesByScopeUseCase,
@@ -140,18 +141,24 @@ export class KnowledgeBaseAccessService {
 
     const ownedKbIds = new Set(ownedKbs.map((kb) => kb.id));
 
-    this.logger.debug('Found owned knowledge bases', {
-      count: ownedKbs.length,
-    });
+    this.logger.debug(
+      {
+        count: ownedKbs.length,
+      },
+      'Found owned knowledge bases',
+    );
 
     // 2. Extract shared KB IDs and deduplicate against owned
     const sharedKbIds = shares
       .map((s) => s.entityId)
       .filter((id) => !ownedKbIds.has(id));
 
-    this.logger.debug('Found shared knowledge bases after deduplication', {
-      count: sharedKbIds.length,
-    });
+    this.logger.debug(
+      {
+        count: sharedKbIds.length,
+      },
+      'Found shared knowledge bases after deduplication',
+    );
 
     // 3. Fetch shared KBs
     const sharedKbs =

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/strategies/knowledge-base-share-authorization.strategy.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/strategies/knowledge-base-share-authorization.strategy.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { KnowledgeBaseShareAuthorizationStrategy } from './knowledge-base-share-authorization.strategy';
@@ -24,6 +26,10 @@ describe('KnowledgeBaseShareAuthorizationStrategy', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         KnowledgeBaseShareAuthorizationStrategy,
+        {
+          provide: getLoggerToken(KnowledgeBaseShareAuthorizationStrategy.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: KnowledgeBaseRepository,
           useValue: mockKnowledgeBaseRepository,

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/strategies/knowledge-base-share-authorization.strategy.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/strategies/knowledge-base-share-authorization.strategy.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { ShareAuthorizationStrategy } from 'src/domain/shares/application/ports/share-authorization-strategy.port';
 import { KnowledgeBaseRepository } from '../ports/knowledge-base.repository';
@@ -9,11 +10,9 @@ import { KnowledgeBaseRepository } from '../ports/knowledge-base.repository';
  */
 @Injectable()
 export class KnowledgeBaseShareAuthorizationStrategy implements ShareAuthorizationStrategy {
-  private readonly logger = new Logger(
-    KnowledgeBaseShareAuthorizationStrategy.name,
-  );
-
   constructor(
+    @InjectPinoLogger(KnowledgeBaseShareAuthorizationStrategy.name)
+    private readonly logger: PinoLogger,
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
   ) {}
 
@@ -22,7 +21,7 @@ export class KnowledgeBaseShareAuthorizationStrategy implements ShareAuthorizati
    * User must own the knowledge base to view its shares.
    */
   async canViewShares(knowledgeBaseId: UUID, userId: UUID): Promise<boolean> {
-    this.logger.log('canViewShares', { knowledgeBaseId, userId });
+    this.logger.info({ knowledgeBaseId, userId }, 'canViewShares');
 
     const kb = await this.knowledgeBaseRepository.findById(knowledgeBaseId);
     return kb !== null && kb.userId === userId;
@@ -33,7 +32,7 @@ export class KnowledgeBaseShareAuthorizationStrategy implements ShareAuthorizati
    * User must own the knowledge base to create shares for it.
    */
   async canCreateShare(knowledgeBaseId: UUID, userId: UUID): Promise<boolean> {
-    this.logger.log('canCreateShare', { knowledgeBaseId, userId });
+    this.logger.info({ knowledgeBaseId, userId }, 'canCreateShare');
 
     const kb = await this.knowledgeBaseRepository.findById(knowledgeBaseId);
     return kb !== null && kb.userId === userId;
@@ -44,7 +43,7 @@ export class KnowledgeBaseShareAuthorizationStrategy implements ShareAuthorizati
    * For knowledge base shares, this is handled at the share level by checking ownerId.
    */
   canDeleteShare(shareId: UUID, userId: UUID): Promise<boolean> {
-    this.logger.log('canDeleteShare', { shareId, userId });
+    this.logger.info({ shareId, userId }, 'canDeleteShare');
 
     return Promise.resolve(true);
   }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -65,6 +67,10 @@ describe('AddDocumentToKnowledgeBaseUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AddDocumentToKnowledgeBaseUseCase,
+        {
+          provide: getLoggerToken(AddDocumentToKnowledgeBaseUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: KnowledgeBaseRepository, useValue: mockKbRepository },
         {
           provide: StartDocumentProcessingUseCase,

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-document-to-knowledge-base/add-document-to-knowledge-base.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -16,9 +17,9 @@ import { AddDocumentToKnowledgeBaseCommand } from './add-document-to-knowledge-b
 
 @Injectable()
 export class AddDocumentToKnowledgeBaseUseCase {
-  private readonly logger = new Logger(AddDocumentToKnowledgeBaseUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AddDocumentToKnowledgeBaseUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
     private readonly startDocumentProcessingUseCase: StartDocumentProcessingUseCase,
     private readonly txHost: TransactionHost<TransactionalAdapterTypeOrm>,
@@ -27,33 +28,18 @@ export class AddDocumentToKnowledgeBaseUseCase {
   async execute(
     command: AddDocumentToKnowledgeBaseCommand,
   ): Promise<FileSource> {
-    this.logger.log('Adding document to knowledge base (async)', {
-      knowledgeBaseId: command.knowledgeBaseId,
-      fileName: command.fileName,
-    });
+    this.logger.info(
+      {
+        knowledgeBaseId: command.knowledgeBaseId,
+        fileName: command.fileName,
+      },
+      'Adding document to knowledge base (async)',
+    );
 
     try {
-      // 1. Validate KB exists and belongs to user, enforce source limit
-      await this.txHost.withTransaction(async () => {
-        const knowledgeBase = await this.knowledgeBaseRepository.findById(
-          command.knowledgeBaseId,
-        );
-        if (knowledgeBase?.userId !== command.userId) {
-          throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
-        }
+      await this.assertSourceCapacity(command);
 
-        const sourceCount =
-          await this.knowledgeBaseRepository.countSourcesByKnowledgeBaseId(
-            command.knowledgeBaseId,
-          );
-        if (sourceCount >= KnowledgeBasesConstants.MAX_SOURCES) {
-          throw new KnowledgeBaseSourceLimitExceededError(
-            KnowledgeBasesConstants.MAX_SOURCES,
-          );
-        }
-      });
-
-      // 2. Start async document processing (creates PROCESSING source, uploads to MinIO, enqueues job)
+      // Start async document processing (creates PROCESSING source, uploads to MinIO, enqueues job)
       const savedSource = await this.startDocumentProcessingUseCase.execute(
         new StartDocumentProcessingCommand({
           fileData: command.fileData,
@@ -62,7 +48,6 @@ export class AddDocumentToKnowledgeBaseUseCase {
         }),
       );
 
-      // 3. Assign source to KB
       await this.knowledgeBaseRepository.assignSourceToKnowledgeBase(
         savedSource.id,
         command.knowledgeBaseId,
@@ -73,13 +58,39 @@ export class AddDocumentToKnowledgeBaseUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error adding document to knowledge base', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error adding document to knowledge base',
+      );
       throw new UnexpectedKnowledgeBaseError(
         'Error adding document to knowledge base',
-        { error: error as Error },
+        { err: error as Error },
       );
     }
+  }
+
+  private async assertSourceCapacity(
+    command: AddDocumentToKnowledgeBaseCommand,
+  ): Promise<void> {
+    await this.txHost.withTransaction(async () => {
+      const knowledgeBase = await this.knowledgeBaseRepository.findById(
+        command.knowledgeBaseId,
+      );
+      if (knowledgeBase?.userId !== command.userId) {
+        throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
+      }
+
+      const sourceCount =
+        await this.knowledgeBaseRepository.countSourcesByKnowledgeBaseId(
+          command.knowledgeBaseId,
+        );
+      if (sourceCount >= KnowledgeBasesConstants.MAX_SOURCES) {
+        throw new KnowledgeBaseSourceLimitExceededError(
+          KnowledgeBasesConstants.MAX_SOURCES,
+        );
+      }
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { TransactionHost } from '@nestjs-cls/transactional';
@@ -70,6 +72,10 @@ describe('AddUrlToKnowledgeBaseUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AddUrlToKnowledgeBaseUseCase,
+        {
+          provide: getLoggerToken(AddUrlToKnowledgeBaseUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: KnowledgeBaseRepository, useValue: mockRepository },
         { provide: StartUrlCrawlUseCase, useValue: mockStartUrlCrawlUseCase },
         { provide: TransactionHost, useValue: txHost },

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/add-url-to-knowledge-base/add-url-to-knowledge-base.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
 import type { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
@@ -16,43 +17,28 @@ import { AddUrlToKnowledgeBaseCommand } from './add-url-to-knowledge-base.comman
 
 @Injectable()
 export class AddUrlToKnowledgeBaseUseCase {
-  private readonly logger = new Logger(AddUrlToKnowledgeBaseUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AddUrlToKnowledgeBaseUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
     private readonly startUrlCrawlUseCase: StartUrlCrawlUseCase,
     private readonly txHost: TransactionHost<TransactionalAdapterTypeOrm>,
   ) {}
 
   async execute(command: AddUrlToKnowledgeBaseCommand): Promise<TextSource> {
-    this.logger.log('Adding URL to knowledge base (async)', {
-      knowledgeBaseId: command.knowledgeBaseId,
-      url: command.url,
-      maxDepth: command.maxDepth,
-    });
+    this.logger.info(
+      {
+        knowledgeBaseId: command.knowledgeBaseId,
+        url: command.url,
+        maxDepth: command.maxDepth,
+      },
+      'Adding URL to knowledge base (async)',
+    );
 
     try {
-      // 1. Validate KB exists and belongs to user, enforce source limit
-      await this.txHost.withTransaction(async () => {
-        const knowledgeBase = await this.knowledgeBaseRepository.findById(
-          command.knowledgeBaseId,
-        );
-        if (knowledgeBase?.userId !== command.userId) {
-          throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
-        }
+      await this.assertSourceCapacity(command);
 
-        const sourceCount =
-          await this.knowledgeBaseRepository.countSourcesByKnowledgeBaseId(
-            command.knowledgeBaseId,
-          );
-        if (sourceCount >= KnowledgeBasesConstants.MAX_SOURCES) {
-          throw new KnowledgeBaseSourceLimitExceededError(
-            KnowledgeBasesConstants.MAX_SOURCES,
-          );
-        }
-      });
-
-      // 2. Start async crawl (creates PROCESSING source, enqueues job)
+      // Start async crawl (creates PROCESSING source, enqueues job)
       const source = await this.startUrlCrawlUseCase.execute(
         new StartUrlCrawlCommand({
           url: command.url,
@@ -60,7 +46,6 @@ export class AddUrlToKnowledgeBaseUseCase {
         }),
       );
 
-      // 3. Assign source to KB
       await this.knowledgeBaseRepository.assignSourceToKnowledgeBase(
         source.id,
         command.knowledgeBaseId,
@@ -71,13 +56,39 @@ export class AddUrlToKnowledgeBaseUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error adding URL to knowledge base', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error adding URL to knowledge base',
+      );
       throw new UnexpectedKnowledgeBaseError(
         'Error adding URL to knowledge base',
-        { error: error as Error },
+        { err: error as Error },
       );
     }
+  }
+
+  private async assertSourceCapacity(
+    command: AddUrlToKnowledgeBaseCommand,
+  ): Promise<void> {
+    await this.txHost.withTransaction(async () => {
+      const knowledgeBase = await this.knowledgeBaseRepository.findById(
+        command.knowledgeBaseId,
+      );
+      if (knowledgeBase?.userId !== command.userId) {
+        throw new KnowledgeBaseNotFoundError(command.knowledgeBaseId);
+      }
+
+      const sourceCount =
+        await this.knowledgeBaseRepository.countSourcesByKnowledgeBaseId(
+          command.knowledgeBaseId,
+        );
+      if (sourceCount >= KnowledgeBasesConstants.MAX_SOURCES) {
+        throw new KnowledgeBaseSourceLimitExceededError(
+          KnowledgeBasesConstants.MAX_SOURCES,
+        );
+      }
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/create-knowledge-base/create-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/create-knowledge-base/create-knowledge-base.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { CreateKnowledgeBaseUseCase } from './create-knowledge-base.use-case';
@@ -30,6 +32,10 @@ describe('CreateKnowledgeBaseUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateKnowledgeBaseUseCase,
+        {
+          provide: getLoggerToken(CreateKnowledgeBaseUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: KnowledgeBaseRepository, useValue: mockRepository },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/create-knowledge-base/create-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/create-knowledge-base/create-knowledge-base.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
 import { CreateKnowledgeBaseCommand } from './create-knowledge-base.command';
@@ -7,17 +8,20 @@ import { UnexpectedKnowledgeBaseError } from '../../knowledge-bases.errors';
 
 @Injectable()
 export class CreateKnowledgeBaseUseCase {
-  private readonly logger = new Logger(CreateKnowledgeBaseUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateKnowledgeBaseUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
   ) {}
 
   async execute(command: CreateKnowledgeBaseCommand): Promise<KnowledgeBase> {
-    this.logger.log('Creating knowledge base', {
-      name: command.name,
-      userId: command.userId,
-    });
+    this.logger.info(
+      {
+        name: command.name,
+        userId: command.userId,
+      },
+      'Creating knowledge base',
+    );
 
     try {
       const knowledgeBase = new KnowledgeBase({
@@ -32,11 +36,14 @@ export class CreateKnowledgeBaseUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error creating knowledge base', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error creating knowledge base',
+      );
       throw new UnexpectedKnowledgeBaseError('Error creating knowledge base', {
-        error: error as Error,
+        err: error as Error,
       });
     }
   }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 
@@ -60,6 +62,10 @@ describe('DeleteKnowledgeBaseUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeleteKnowledgeBaseUseCase,
+        {
+          provide: getLoggerToken(DeleteKnowledgeBaseUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: KnowledgeBaseRepository, useValue: mockKbRepository },
         {
           provide: GetSourcesByKnowledgeBaseIdUseCase,

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/delete-knowledge-base/delete-knowledge-base.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { DeleteSourcesUseCase } from 'src/domain/sources/application/use-cases/delete-sources/delete-sources.use-case';
@@ -14,9 +15,9 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class DeleteKnowledgeBaseUseCase {
-  private readonly logger = new Logger(DeleteKnowledgeBaseUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteKnowledgeBaseUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
     private readonly getSourcesByKnowledgeBaseIdUseCase: GetSourcesByKnowledgeBaseIdUseCase,
     private readonly deleteSourcesUseCase: DeleteSourcesUseCase,
@@ -24,10 +25,13 @@ export class DeleteKnowledgeBaseUseCase {
 
   @Transactional()
   async execute(command: DeleteKnowledgeBaseCommand): Promise<void> {
-    this.logger.log('Deleting knowledge base', {
-      knowledgeBaseId: command.knowledgeBaseId,
-      userId: command.userId,
-    });
+    this.logger.info(
+      {
+        knowledgeBaseId: command.knowledgeBaseId,
+        userId: command.userId,
+      },
+      'Deleting knowledge base',
+    );
 
     try {
       const existing = await this.knowledgeBaseRepository.findById(
@@ -50,11 +54,14 @@ export class DeleteKnowledgeBaseUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error deleting knowledge base', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error deleting knowledge base',
+      );
       throw new UnexpectedKnowledgeBaseError('Error deleting knowledge base', {
-        error: error as Error,
+        err: error as Error,
       });
     }
   }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/find-knowledge-base/find-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/find-knowledge-base/find-knowledge-base.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { FindKnowledgeBaseUseCase } from './find-knowledge-base.use-case';
@@ -34,6 +36,10 @@ describe('FindKnowledgeBaseUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FindKnowledgeBaseUseCase,
+        {
+          provide: getLoggerToken(FindKnowledgeBaseUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: KnowledgeBaseRepository, useValue: mockRepository },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/find-knowledge-base/find-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/find-knowledge-base/find-knowledge-base.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
 import { FindKnowledgeBaseQuery } from './find-knowledge-base.query';
@@ -10,17 +11,20 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class FindKnowledgeBaseUseCase {
-  private readonly logger = new Logger(FindKnowledgeBaseUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindKnowledgeBaseUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
   ) {}
 
   async execute(query: FindKnowledgeBaseQuery): Promise<KnowledgeBase> {
-    this.logger.log('Finding knowledge base', {
-      id: query.id,
-      userId: query.userId,
-    });
+    this.logger.info(
+      {
+        id: query.id,
+        userId: query.userId,
+      },
+      'Finding knowledge base',
+    );
 
     try {
       const knowledgeBase = await this.knowledgeBaseRepository.findById(
@@ -35,11 +39,14 @@ export class FindKnowledgeBaseUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error finding knowledge base', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error finding knowledge base',
+      );
       throw new UnexpectedKnowledgeBaseError('Error finding knowledge base', {
-        error: error as Error,
+        err: error as Error,
       });
     }
   }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-base-document-text/get-knowledge-base-document-text.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-base-document-text/get-knowledge-base-document-text.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetKnowledgeBaseDocumentTextUseCase } from './get-knowledge-base-document-text.use-case';
@@ -40,6 +42,10 @@ describe('GetKnowledgeBaseDocumentTextUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetKnowledgeBaseDocumentTextUseCase,
+        {
+          provide: getLoggerToken(GetKnowledgeBaseDocumentTextUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: KnowledgeBaseRepository,
           useValue: mockRepository,

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-base-document-text/get-knowledge-base-document-text.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-base-document-text/get-knowledge-base-document-text.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { GetKnowledgeBaseDocumentTextQuery } from './get-knowledge-base-document-text.query';
 import {
@@ -10,20 +11,21 @@ import { KnowledgeBaseAccessService } from '../../services/knowledge-base-access
 
 @Injectable()
 export class GetKnowledgeBaseDocumentTextUseCase {
-  private readonly logger = new Logger(
-    GetKnowledgeBaseDocumentTextUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(GetKnowledgeBaseDocumentTextUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
     private readonly knowledgeBaseAccessService: KnowledgeBaseAccessService,
   ) {}
 
   async execute(query: GetKnowledgeBaseDocumentTextQuery): Promise<Source> {
-    this.logger.debug('Getting document text from knowledge base', {
-      knowledgeBaseId: query.knowledgeBaseId,
-      documentId: query.documentId,
-    });
+    this.logger.debug(
+      {
+        knowledgeBaseId: query.knowledgeBaseId,
+        documentId: query.documentId,
+      },
+      'Getting document text from knowledge base',
+    );
 
     const knowledgeBase =
       await this.knowledgeBaseAccessService.findAccessibleKnowledgeBase(

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.use-case.spec.ts
@@ -1,6 +1,8 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { GetKnowledgeBasesByIdsUseCase } from './get-knowledge-bases-by-ids.use-case';
 import { GetKnowledgeBasesByIdsQuery } from './get-knowledge-bases-by-ids.query';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
@@ -25,6 +27,10 @@ describe('GetKnowledgeBasesByIdsUseCase', () => {
       providers: [
         GetKnowledgeBasesByIdsUseCase,
         {
+          provide: getLoggerToken(GetKnowledgeBasesByIdsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
+        {
           provide: KnowledgeBaseRepository,
           useValue: {
             findByIds: jest.fn(),
@@ -46,9 +52,6 @@ describe('GetKnowledgeBasesByIdsUseCase', () => {
     useCase = module.get(GetKnowledgeBasesByIdsUseCase);
     knowledgeBaseRepository = module.get(KnowledgeBaseRepository);
     contextService = module.get(ContextService);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.use-case.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetKnowledgeBasesByIdsQuery } from './get-knowledge-bases-by-ids.query';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -13,9 +14,9 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
  */
 @Injectable()
 export class GetKnowledgeBasesByIdsUseCase {
-  private readonly logger = new Logger(GetKnowledgeBasesByIdsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetKnowledgeBasesByIdsUseCase.name)
+    private readonly logger: PinoLogger,
     @Inject(KnowledgeBaseRepository)
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
     private readonly contextService: ContextService,
@@ -28,9 +29,12 @@ export class GetKnowledgeBasesByIdsUseCase {
    * @returns Array of KnowledgeBase entities (missing/unauthorized IDs omitted)
    */
   async execute(query: GetKnowledgeBasesByIdsQuery): Promise<KnowledgeBase[]> {
-    this.logger.log('getKnowledgeBasesByIds', {
-      count: query.knowledgeBaseIds.length,
-    });
+    this.logger.info(
+      {
+        count: query.knowledgeBaseIds.length,
+      },
+      'getKnowledgeBasesByIds',
+    );
 
     try {
       const orgId = this.contextService.get('orgId');
@@ -51,9 +55,12 @@ export class GetKnowledgeBasesByIdsUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Unexpected error getting knowledge bases by IDs', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error getting knowledge bases by IDs',
+      );
       throw new UnexpectedKnowledgeBaseError('Unexpected error occurred');
     }
   }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -33,6 +35,10 @@ describe('ListKnowledgeBaseDocumentsUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ListKnowledgeBaseDocumentsUseCase,
+        {
+          provide: getLoggerToken(ListKnowledgeBaseDocumentsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: KnowledgeBaseRepository, useValue: mockRepository },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-base-documents/list-knowledge-base-documents.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { Source } from 'src/domain/sources/domain/source.entity';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
@@ -10,16 +11,19 @@ import { ListKnowledgeBaseDocumentsQuery } from './list-knowledge-base-documents
 
 @Injectable()
 export class ListKnowledgeBaseDocumentsUseCase {
-  private readonly logger = new Logger(ListKnowledgeBaseDocumentsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ListKnowledgeBaseDocumentsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
   ) {}
 
   async execute(query: ListKnowledgeBaseDocumentsQuery): Promise<Source[]> {
-    this.logger.log('Listing knowledge base documents', {
-      knowledgeBaseId: query.knowledgeBaseId,
-    });
+    this.logger.info(
+      {
+        knowledgeBaseId: query.knowledgeBaseId,
+      },
+      'Listing knowledge base documents',
+    );
 
     try {
       const knowledgeBase = await this.knowledgeBaseRepository.findById(
@@ -36,12 +40,15 @@ export class ListKnowledgeBaseDocumentsUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error listing knowledge base documents', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error listing knowledge base documents',
+      );
       throw new UnexpectedKnowledgeBaseError(
         'Error listing knowledge base documents',
-        { error: error as Error },
+        { err: error as Error },
       );
     }
   }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-bases/list-knowledge-bases.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-bases/list-knowledge-bases.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ListKnowledgeBasesUseCase } from './list-knowledge-bases.use-case';
@@ -30,6 +32,10 @@ describe('ListKnowledgeBasesUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ListKnowledgeBasesUseCase,
+        {
+          provide: getLoggerToken(ListKnowledgeBasesUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: KnowledgeBaseRepository, useValue: mockRepository },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-bases/list-knowledge-bases.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/list-knowledge-bases/list-knowledge-bases.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
 import { ListKnowledgeBasesQuery } from './list-knowledge-bases.query';
@@ -7,14 +8,14 @@ import { UnexpectedKnowledgeBaseError } from '../../knowledge-bases.errors';
 
 @Injectable()
 export class ListKnowledgeBasesUseCase {
-  private readonly logger = new Logger(ListKnowledgeBasesUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ListKnowledgeBasesUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
   ) {}
 
   async execute(query: ListKnowledgeBasesQuery): Promise<KnowledgeBase[]> {
-    this.logger.log('Listing knowledge bases', { userId: query.userId });
+    this.logger.info({ userId: query.userId }, 'Listing knowledge bases');
 
     try {
       return await this.knowledgeBaseRepository.findAllByUserId(query.userId);
@@ -22,11 +23,14 @@ export class ListKnowledgeBasesUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error listing knowledge bases', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error listing knowledge bases',
+      );
       throw new UnexpectedKnowledgeBaseError('Error listing knowledge bases', {
-        error: error as Error,
+        err: error as Error,
       });
     }
   }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { QueryKnowledgeBaseUseCase } from './query-knowledge-base.use-case';
@@ -68,6 +70,10 @@ describe('QueryKnowledgeBaseUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         QueryKnowledgeBaseUseCase,
+        {
+          provide: getLoggerToken(QueryKnowledgeBaseUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: KnowledgeBaseRepository, useValue: mockKbRepo },
         { provide: FindContentChunksByIdsUseCase, useValue: mockFindChunks },
         { provide: SearchContentUseCase, useValue: mockSearchContent },

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/query-knowledge-base/query-knowledge-base.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { QueryKnowledgeBaseQuery } from './query-knowledge-base.query';
 import {
@@ -8,6 +9,7 @@ import {
 import { SearchContentUseCase } from 'src/domain/rag/indexers/application/use-cases/search-content/search-content.use-case';
 import { SearchMultiContentQuery } from 'src/domain/rag/indexers/application/use-cases/search-content/search-content.query';
 import { IndexType } from 'src/domain/rag/indexers/domain/value-objects/index-type.enum';
+import type { IndexEntry } from 'src/domain/rag/indexers/domain/index-entry.entity';
 import type { TextSourceContentChunk } from 'src/domain/sources/domain/source-content-chunk.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -23,9 +25,9 @@ export interface KnowledgeBaseQueryResult {
 
 @Injectable()
 export class QueryKnowledgeBaseUseCase {
-  private readonly logger = new Logger(QueryKnowledgeBaseUseCase.name);
-
   constructor(
+    @InjectPinoLogger(QueryKnowledgeBaseUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
     private readonly findContentChunksByIdsUseCase: FindContentChunksByIdsUseCase,
     private readonly searchContentUseCase: SearchContentUseCase,
@@ -42,11 +44,14 @@ export class QueryKnowledgeBaseUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error querying knowledge base', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error querying knowledge base',
+      );
       throw new UnexpectedKnowledgeBaseError('Error querying knowledge base', {
-        error: error as Error,
+        err: error as Error,
       });
     }
   }
@@ -56,9 +61,12 @@ export class QueryKnowledgeBaseUseCase {
   ): Promise<KnowledgeBaseQueryResult[]> {
     const orgId = this.contextService.get('orgId');
 
-    this.logger.debug('Querying knowledge base', {
-      knowledgeBaseId: query.knowledgeBaseId,
-    });
+    this.logger.debug(
+      {
+        knowledgeBaseId: query.knowledgeBaseId,
+      },
+      'Querying knowledge base',
+    );
 
     const knowledgeBase =
       await this.knowledgeBaseAccessService.findAccessibleKnowledgeBase(
@@ -91,36 +99,40 @@ export class QueryKnowledgeBaseUseCase {
       }),
     );
 
+    return this.resolveResults(indexEntries);
+  }
+
+  private async resolveResults(
+    indexEntries: IndexEntry[],
+  ): Promise<KnowledgeBaseQueryResult[]> {
     if (indexEntries.length === 0) {
       return [];
     }
 
-    // Fetch only the matched chunks by ID (single query)
     const chunkIds = indexEntries.map((entry) => entry.relatedChunkId);
     const chunkResults = await this.findContentChunksByIdsUseCase.execute(
       new FindContentChunksByIdsQuery(chunkIds),
     );
-
-    // Build a lookup map for quick access
-    const chunkMap = new Map(chunkResults.map((r) => [r.chunk.id, r]));
-
-    const results: KnowledgeBaseQueryResult[] = [];
-
-    for (const entry of indexEntries) {
+    const chunkMap = new Map(
+      chunkResults.map((result) => [result.chunk.id, result]),
+    );
+    const results = indexEntries.flatMap((entry) => {
       const match = chunkMap.get(entry.relatedChunkId);
-      if (match) {
-        results.push({
-          chunk: match.chunk,
-          sourceName: match.sourceName,
-          sourceId: match.sourceId,
-        });
-      }
-    }
+      return match
+        ? [
+            {
+              chunk: match.chunk,
+              sourceName: match.sourceName,
+              sourceId: match.sourceId,
+            },
+          ]
+        : [];
+    });
 
     this.logger.debug(
-      `Found ${results.length} results for knowledge base query`,
+      { resultCount: results.length },
+      'Found results for knowledge base query',
     );
-
     return results;
   }
 }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 jest.mock('@nestjs-cls/transactional', () => ({
   Transactional:
     () =>
@@ -50,6 +52,10 @@ describe('RemoveDocumentFromKnowledgeBaseUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RemoveDocumentFromKnowledgeBaseUseCase,
+        {
+          provide: getLoggerToken(RemoveDocumentFromKnowledgeBaseUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: KnowledgeBaseRepository, useValue: mockRepository },
         {
           provide: DeleteSourceUseCase,

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/remove-document-from-knowledge-base/remove-document-from-knowledge-base.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { DeleteSourceUseCase } from 'src/domain/sources/application/use-cases/delete-source/delete-source.use-case';
 import { DeleteSourceCommand } from 'src/domain/sources/application/use-cases/delete-source/delete-source.command';
@@ -13,11 +14,9 @@ import { RemoveDocumentFromKnowledgeBaseCommand } from './remove-document-from-k
 
 @Injectable()
 export class RemoveDocumentFromKnowledgeBaseUseCase {
-  private readonly logger = new Logger(
-    RemoveDocumentFromKnowledgeBaseUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(RemoveDocumentFromKnowledgeBaseUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
     private readonly deleteSourceUseCase: DeleteSourceUseCase,
   ) {}
@@ -26,10 +25,13 @@ export class RemoveDocumentFromKnowledgeBaseUseCase {
   async execute(
     command: RemoveDocumentFromKnowledgeBaseCommand,
   ): Promise<void> {
-    this.logger.log('Removing document from knowledge base', {
-      knowledgeBaseId: command.knowledgeBaseId,
-      documentId: command.documentId,
-    });
+    this.logger.info(
+      {
+        knowledgeBaseId: command.knowledgeBaseId,
+        documentId: command.documentId,
+      },
+      'Removing document from knowledge base',
+    );
 
     try {
       const knowledgeBase = await this.knowledgeBaseRepository.findById(
@@ -58,12 +60,15 @@ export class RemoveDocumentFromKnowledgeBaseUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error removing document from knowledge base', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error removing document from knowledge base',
+      );
       throw new UnexpectedKnowledgeBaseError(
         'Error removing document from knowledge base',
-        { error: error as Error },
+        { err: error as Error },
       );
     }
   }

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/update-knowledge-base/update-knowledge-base.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/update-knowledge-base/update-knowledge-base.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 
@@ -43,6 +45,10 @@ describe('UpdateKnowledgeBaseUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UpdateKnowledgeBaseUseCase,
+        {
+          provide: getLoggerToken(UpdateKnowledgeBaseUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: KnowledgeBaseRepository, useValue: mockRepository },
       ],
     }).compile();

--- a/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/update-knowledge-base/update-knowledge-base.use-case.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/application/use-cases/update-knowledge-base/update-knowledge-base.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { KnowledgeBaseRepository } from '../../ports/knowledge-base.repository';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
 import { UpdateKnowledgeBaseCommand } from './update-knowledge-base.command';
@@ -10,17 +11,20 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class UpdateKnowledgeBaseUseCase {
-  private readonly logger = new Logger(UpdateKnowledgeBaseUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateKnowledgeBaseUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly knowledgeBaseRepository: KnowledgeBaseRepository,
   ) {}
 
   async execute(command: UpdateKnowledgeBaseCommand): Promise<KnowledgeBase> {
-    this.logger.log('Updating knowledge base', {
-      knowledgeBaseId: command.knowledgeBaseId,
-      userId: command.userId,
-    });
+    this.logger.info(
+      {
+        knowledgeBaseId: command.knowledgeBaseId,
+        userId: command.userId,
+      },
+      'Updating knowledge base',
+    );
 
     try {
       const existing = await this.knowledgeBaseRepository.findById(
@@ -45,11 +49,14 @@ export class UpdateKnowledgeBaseUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error updating knowledge base', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error updating knowledge base',
+      );
       throw new UnexpectedKnowledgeBaseError('Error updating knowledge base', {
-        error: error as Error,
+        err: error as Error,
       });
     }
   }

--- a/ayunis-core-backend/src/domain/knowledge-bases/infrastructure/persistence/local/local-knowledge-base.repository.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/infrastructure/persistence/local/local-knowledge-base.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { UUID } from 'crypto';
@@ -12,9 +13,9 @@ import { SourceMapper } from 'src/domain/sources/infrastructure/persistence/loca
 
 @Injectable()
 export class LocalKnowledgeBaseRepository extends KnowledgeBaseRepository {
-  private readonly logger = new Logger(LocalKnowledgeBaseRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalKnowledgeBaseRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(KnowledgeBaseRecord)
     private readonly repository: Repository<KnowledgeBaseRecord>,
     @InjectRepository(SourceRecord)
@@ -26,7 +27,7 @@ export class LocalKnowledgeBaseRepository extends KnowledgeBaseRepository {
   }
 
   async findById(id: UUID): Promise<KnowledgeBase | null> {
-    this.logger.debug(`findById: ${id}`);
+    this.logger.debug({ id }, 'findById');
     const record = await this.repository.findOne({ where: { id } });
     if (!record) {
       return null;
@@ -35,7 +36,7 @@ export class LocalKnowledgeBaseRepository extends KnowledgeBaseRepository {
   }
 
   async findByIds(ids: UUID[]): Promise<KnowledgeBase[]> {
-    this.logger.debug(`findByIds: ${ids.length} ids`);
+    this.logger.debug({ count: ids.length }, 'findByIds');
     if (ids.length === 0) {
       return [];
     }
@@ -46,7 +47,7 @@ export class LocalKnowledgeBaseRepository extends KnowledgeBaseRepository {
   }
 
   async findAllByUserId(userId: UUID): Promise<KnowledgeBase[]> {
-    this.logger.debug(`findAllByUserId: ${userId}`);
+    this.logger.debug({ userId }, 'findAllByUserId');
     const records = await this.repository.find({
       where: { userId },
       order: { createdAt: 'DESC' },
@@ -55,14 +56,14 @@ export class LocalKnowledgeBaseRepository extends KnowledgeBaseRepository {
   }
 
   async save(knowledgeBase: KnowledgeBase): Promise<KnowledgeBase> {
-    this.logger.debug(`save: ${knowledgeBase.id}`);
+    this.logger.debug({ id: knowledgeBase.id }, 'save');
     const record = this.mapper.toRecord(knowledgeBase);
     const saved = await this.repository.save(record);
     return this.mapper.toDomain(saved);
   }
 
   async delete(knowledgeBase: KnowledgeBase): Promise<void> {
-    this.logger.debug(`delete: ${knowledgeBase.id}`);
+    this.logger.debug({ id: knowledgeBase.id }, 'delete');
     const record = this.mapper.toRecord(knowledgeBase);
     await this.repository.remove(record);
   }
@@ -72,13 +73,14 @@ export class LocalKnowledgeBaseRepository extends KnowledgeBaseRepository {
     knowledgeBaseId: UUID,
   ): Promise<void> {
     this.logger.debug(
-      `assignSourceToKnowledgeBase: ${sourceId} → ${knowledgeBaseId}`,
+      { sourceId, knowledgeBaseId },
+      'assignSourceToKnowledgeBase',
     );
     await this.sourceRepository.update(sourceId, { knowledgeBaseId });
   }
 
   async findSourcesByKnowledgeBaseId(knowledgeBaseId: UUID): Promise<Source[]> {
-    this.logger.debug(`findSourcesByKnowledgeBaseId: ${knowledgeBaseId}`);
+    this.logger.debug({ knowledgeBaseId }, 'findSourcesByKnowledgeBaseId');
     const records = await this.sourceRepository.find({
       where: { knowledgeBaseId },
       order: { createdAt: 'DESC' },
@@ -87,7 +89,7 @@ export class LocalKnowledgeBaseRepository extends KnowledgeBaseRepository {
   }
 
   async countSourcesByKnowledgeBaseId(knowledgeBaseId: UUID): Promise<number> {
-    this.logger.debug(`countSourcesByKnowledgeBaseId: ${knowledgeBaseId}`);
+    this.logger.debug({ knowledgeBaseId }, 'countSourcesByKnowledgeBaseId');
     return this.sourceRepository.count({ where: { knowledgeBaseId } });
   }
 
@@ -96,7 +98,8 @@ export class LocalKnowledgeBaseRepository extends KnowledgeBaseRepository {
     knowledgeBaseId: UUID,
   ): Promise<Source | null> {
     this.logger.debug(
-      `findSourceByIdAndKnowledgeBaseId: ${sourceId} in ${knowledgeBaseId}`,
+      { sourceId, knowledgeBaseId },
+      'findSourceByIdAndKnowledgeBaseId',
     );
     const record = await this.sourceRepository.findOne({
       where: { id: sourceId, knowledgeBaseId },

--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
@@ -7,13 +7,13 @@ import {
   Param,
   Body,
   ParseUUIDPipe,
-  Logger,
   HttpCode,
   HttpStatus,
   UseInterceptors,
   UploadedFile,
   BadRequestException,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import {
   ApiTags,
@@ -128,9 +128,9 @@ const DocumentUploadInterceptor = FileInterceptor('file', {
 @RequireFeature(FeatureFlag.KnowledgeBases)
 @Controller('knowledge-bases')
 export class KnowledgeBasesController {
-  private readonly logger = new Logger(KnowledgeBasesController.name);
-
   constructor(
+    @InjectPinoLogger(KnowledgeBasesController.name)
+    private readonly logger: PinoLogger,
     private readonly createKnowledgeBaseUseCase: CreateKnowledgeBaseUseCase,
     private readonly updateKnowledgeBaseUseCase: UpdateKnowledgeBaseUseCase,
     private readonly deleteKnowledgeBaseUseCase: DeleteKnowledgeBaseUseCase,
@@ -157,8 +157,7 @@ export class KnowledgeBasesController {
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
     @Body() dto: CreateKnowledgeBaseDto,
   ): Promise<KnowledgeBaseResponseDto> {
-    this.logger.log('create', { name: dto.name, userId });
-
+    this.logger.info({ name: dto.name, userId }, 'create');
     const knowledgeBase = await this.createKnowledgeBaseUseCase.execute(
       new CreateKnowledgeBaseCommand({
         name: dto.name,
@@ -167,7 +166,6 @@ export class KnowledgeBasesController {
         orgId,
       }),
     );
-
     return this.knowledgeBaseDtoMapper.toDto(knowledgeBase);
   }
 
@@ -183,10 +181,8 @@ export class KnowledgeBasesController {
   async findAll(
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<KnowledgeBaseListResponseDto> {
-    this.logger.log('findAll', { userId });
-
+    this.logger.info({ userId }, 'findAll');
     const results = await this.knowledgeBaseAccessService.findAllAccessible();
-
     return {
       data: results.map((r) =>
         this.knowledgeBaseDtoMapper.toDto(r.knowledgeBase, r.isShared),
@@ -211,11 +207,9 @@ export class KnowledgeBasesController {
   async findOne(
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<KnowledgeBaseResponseDto> {
-    this.logger.log('findOne', { id });
-
+    this.logger.info({ id }, 'findOne');
     const { knowledgeBase, isShared } =
       await this.knowledgeBaseAccessService.findOneAccessible(id);
-
     return this.knowledgeBaseDtoMapper.toDto(knowledgeBase, isShared);
   }
 
@@ -241,8 +235,7 @@ export class KnowledgeBasesController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() dto: UpdateKnowledgeBaseDto,
   ): Promise<KnowledgeBaseResponseDto> {
-    this.logger.log('update', { id, name: dto.name, userId });
-
+    this.logger.info({ id, name: dto.name, userId }, 'update');
     const knowledgeBase = await this.updateKnowledgeBaseUseCase.execute(
       new UpdateKnowledgeBaseCommand({
         knowledgeBaseId: id,
@@ -251,7 +244,6 @@ export class KnowledgeBasesController {
         description: dto.description,
       }),
     );
-
     return this.knowledgeBaseDtoMapper.toDto(knowledgeBase);
   }
 
@@ -274,8 +266,7 @@ export class KnowledgeBasesController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<void> {
-    this.logger.log('delete', { id, userId });
-
+    this.logger.info({ id, userId }, 'delete');
     await this.deleteKnowledgeBaseUseCase.execute(
       new DeleteKnowledgeBaseCommand({ knowledgeBaseId: id, userId }),
     );
@@ -301,10 +292,8 @@ export class KnowledgeBasesController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<KnowledgeBaseDocumentListResponseDto> {
-    this.logger.log('listDocuments', { knowledgeBaseId: id, userId });
-
+    this.logger.info({ knowledgeBaseId: id, userId }, 'listDocuments');
     await this.knowledgeBaseAccessService.findAccessibleKnowledgeBase(id);
-
     const sources = await this.listDocumentsUseCase.execute(
       new ListKnowledgeBaseDocumentsQuery(id),
     );
@@ -344,30 +333,44 @@ export class KnowledgeBasesController {
       throw new MissingFileError();
     }
 
-    this.logger.log('addDocument', {
-      knowledgeBaseId: id,
-      fileName: file.originalname,
-    });
-
+    this.logger.info(
+      {
+        knowledgeBaseId: id,
+        fileName: file.originalname,
+      },
+      'addDocument',
+    );
     const canonicalMimeType = await this.resolveDocumentMimeType(file);
 
     try {
-      const fileData = await fs.promises.readFile(file.path);
-
-      const source = await this.addDocumentUseCase.execute(
-        new AddDocumentToKnowledgeBaseCommand({
-          knowledgeBaseId: id,
-          userId,
-          fileData,
-          fileName: file.originalname,
-          fileType: canonicalMimeType,
-        }),
+      return await this.processDocumentUpload(
+        userId,
+        id,
+        file,
+        canonicalMimeType,
       );
-
-      return this.knowledgeBaseDtoMapper.toDocumentDto(source);
     } finally {
       await this.cleanupTempFile(file.path);
     }
+  }
+
+  private async processDocumentUpload(
+    userId: UUID,
+    knowledgeBaseId: UUID,
+    file: UploadedDocument,
+    fileType: string,
+  ): Promise<KnowledgeBaseDocumentResponseDto> {
+    const fileData = await fs.promises.readFile(file.path);
+    const source = await this.addDocumentUseCase.execute(
+      new AddDocumentToKnowledgeBaseCommand({
+        knowledgeBaseId,
+        userId,
+        fileData,
+        fileName: file.originalname,
+        fileType,
+      }),
+    );
+    return this.knowledgeBaseDtoMapper.toDocumentDto(source);
   }
 
   private async resolveDocumentMimeType(
@@ -415,12 +418,14 @@ export class KnowledgeBasesController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() dto: AddUrlToKnowledgeBaseDto,
   ): Promise<KnowledgeBaseDocumentResponseDto> {
-    this.logger.log('addUrl', {
-      knowledgeBaseId: id,
-      url: dto.url,
-      maxDepth: dto.maxDepth,
-    });
-
+    this.logger.info(
+      {
+        knowledgeBaseId: id,
+        url: dto.url,
+        maxDepth: dto.maxDepth,
+      },
+      'addUrl',
+    );
     const source = await this.addUrlUseCase.execute(
       new AddUrlToKnowledgeBaseCommand({
         knowledgeBaseId: id,
@@ -462,12 +467,14 @@ export class KnowledgeBasesController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Param('documentId', ParseUUIDPipe) documentId: UUID,
   ): Promise<void> {
-    this.logger.log('removeDocument', {
-      knowledgeBaseId: id,
-      documentId,
-      userId,
-    });
-
+    this.logger.info(
+      {
+        knowledgeBaseId: id,
+        documentId,
+        userId,
+      },
+      'removeDocument',
+    );
     await this.removeDocumentUseCase.execute(
       new RemoveDocumentFromKnowledgeBaseCommand({
         knowledgeBaseId: id,
@@ -481,10 +488,13 @@ export class KnowledgeBasesController {
     try {
       await fs.promises.unlink(filePath);
     } catch (error) {
-      this.logger.warn('Failed to clean up temp file', {
-        filePath,
-        error: error as Error,
-      });
+      this.logger.warn(
+        {
+          fileName: filePath,
+          err: error as Error,
+        },
+        'Failed to clean up temp file',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { GetMarketplaceIntegrationUseCase } from './get-marketplace-integration.use-case';
 import { GetMarketplaceIntegrationQuery } from './get-marketplace-integration.query';
 import type { MarketplaceClient } from '../../ports/marketplace-client.port';
@@ -54,7 +55,10 @@ describe('GetMarketplaceIntegrationUseCase', () => {
       getIntegrationByIdentifier: jest.fn(),
     };
 
-    useCase = new GetMarketplaceIntegrationUseCase(marketplaceClient);
+    useCase = new GetMarketplaceIntegrationUseCase(
+      createPinoLoggerMock(),
+      marketplaceClient,
+    );
   });
 
   it('should return integration details when integration is found', async () => {

--- a/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-integration/get-marketplace-integration.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { MarketplaceClient } from '../../ports/marketplace-client.port';
 import { GetMarketplaceIntegrationQuery } from './get-marketplace-integration.query';
 import { IntegrationResponseDto } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
@@ -10,14 +11,16 @@ import {
 
 @Injectable()
 export class GetMarketplaceIntegrationUseCase {
-  private readonly logger = new Logger(GetMarketplaceIntegrationUseCase.name);
-
-  constructor(private readonly marketplaceClient: MarketplaceClient) {}
+  constructor(
+    @InjectPinoLogger(GetMarketplaceIntegrationUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly marketplaceClient: MarketplaceClient,
+  ) {}
 
   async execute(
     query: GetMarketplaceIntegrationQuery,
   ): Promise<IntegrationResponseDto> {
-    this.logger.log('execute', { identifier: query.identifier });
+    this.logger.info({ identifier: query.identifier }, 'execute');
 
     try {
       const integration =
@@ -34,10 +37,13 @@ export class GetMarketplaceIntegrationUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Failed to fetch marketplace integration', {
-        identifier: query.identifier,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          identifier: query.identifier,
+          err: error as Error,
+        },
+        'Failed to fetch marketplace integration',
+      );
       throw new MarketplaceUnavailableError();
     }
   }

--- a/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { GetMarketplaceSkillUseCase } from './get-marketplace-skill.use-case';
 import { GetMarketplaceSkillQuery } from './get-marketplace-skill.query';
 import type { MarketplaceClient } from '../../ports/marketplace-client.port';
@@ -36,7 +37,10 @@ describe('GetMarketplaceSkillUseCase', () => {
       getIntegrationByIdentifier: jest.fn(),
     };
 
-    useCase = new GetMarketplaceSkillUseCase(marketplaceClient);
+    useCase = new GetMarketplaceSkillUseCase(
+      createPinoLoggerMock(),
+      marketplaceClient,
+    );
   });
 
   it('should return skill details when skill is found', async () => {

--- a/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { MarketplaceClient } from '../../ports/marketplace-client.port';
 import { GetMarketplaceSkillQuery } from './get-marketplace-skill.query';
 import { SkillResponseDto } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI.schemas';
@@ -10,12 +11,14 @@ import {
 
 @Injectable()
 export class GetMarketplaceSkillUseCase {
-  private readonly logger = new Logger(GetMarketplaceSkillUseCase.name);
-
-  constructor(private readonly marketplaceClient: MarketplaceClient) {}
+  constructor(
+    @InjectPinoLogger(GetMarketplaceSkillUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly marketplaceClient: MarketplaceClient,
+  ) {}
 
   async execute(query: GetMarketplaceSkillQuery): Promise<SkillResponseDto> {
-    this.logger.log('execute', { identifier: query.identifier });
+    this.logger.info({ identifier: query.identifier }, 'execute');
 
     try {
       const skill = await this.marketplaceClient.getSkillByIdentifier(
@@ -31,10 +34,13 @@ export class GetMarketplaceSkillUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Failed to fetch marketplace skill', {
-        identifier: query.identifier,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          identifier: query.identifier,
+          err: error as Error,
+        },
+        'Failed to fetch marketplace skill',
+      );
       throw new MarketplaceUnavailableError();
     }
   }

--- a/ayunis-core-backend/src/domain/marketplace/infrastructure/http/marketplace-http-client.spec.ts
+++ b/ayunis-core-backend/src/domain/marketplace/infrastructure/http/marketplace-http-client.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { MarketplaceUnavailableError } from '../../application/marketplace.errors';
 import { MarketplaceHttpError } from 'src/common/clients/marketplace/client';
 import { getAyunisMarketplaceAPI } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI';
@@ -22,7 +23,7 @@ describe('MarketplaceHttpClient', () => {
     getIntegrationByIdentifier.mockRejectedValue(
       new MarketplaceHttpError('Request failed with status code 502', 502),
     );
-    const client = new MarketplaceHttpClient();
+    const client = new MarketplaceHttpClient(createPinoLoggerMock());
 
     await expect(
       client.getIntegrationByIdentifier('oparl-council-data'),

--- a/ayunis-core-backend/src/domain/marketplace/infrastructure/http/marketplace-http-client.ts
+++ b/ayunis-core-backend/src/domain/marketplace/infrastructure/http/marketplace-http-client.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { MarketplaceClient } from '../../application/ports/marketplace-client.port';
 import { getAyunisMarketplaceAPI } from 'src/common/clients/marketplace/generated/ayunisMarketplaceAPI';
 import {
@@ -11,7 +12,13 @@ import { MarketplaceUnavailableError } from '../../application/marketplace.error
 
 @Injectable()
 export class MarketplaceHttpClient extends MarketplaceClient {
-  private readonly logger = new Logger(MarketplaceHttpClient.name);
+  constructor(
+    @InjectPinoLogger(MarketplaceHttpClient.name)
+    private readonly logger: PinoLogger,
+  ) {
+    super();
+  }
+
   private readonly api = getAyunisMarketplaceAPI();
 
   async getSkillByIdentifier(
@@ -21,15 +28,18 @@ export class MarketplaceHttpClient extends MarketplaceClient {
       return await this.api.publicSkillsControllerGetByIdentifier(identifier);
     } catch (error) {
       if (error instanceof MarketplaceHttpError && error.status === 404) {
-        this.logger.debug('Marketplace skill not found', { identifier });
+        this.logger.debug({ identifier }, 'Marketplace skill not found');
         return null;
       }
-      this.logger.warn('Failed to fetch marketplace skill', {
-        identifier,
-        error: error instanceof Error ? error.message : 'Unknown error',
-        status:
-          error instanceof MarketplaceHttpError ? error.status : undefined,
-      });
+      this.logger.warn(
+        {
+          identifier,
+          err: error as Error,
+          status:
+            error instanceof MarketplaceHttpError ? error.status : undefined,
+        },
+        'Failed to fetch marketplace skill',
+      );
       throw error;
     }
   }
@@ -38,11 +48,14 @@ export class MarketplaceHttpClient extends MarketplaceClient {
     try {
       return await this.api.publicSkillsControllerListPreInstalled();
     } catch (error) {
-      this.logger.warn('Failed to fetch pre-installed marketplace skills', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        status:
-          error instanceof MarketplaceHttpError ? error.status : undefined,
-      });
+      this.logger.warn(
+        {
+          err: error as Error,
+          status:
+            error instanceof MarketplaceHttpError ? error.status : undefined,
+        },
+        'Failed to fetch pre-installed marketplace skills',
+      );
       throw error;
     }
   }
@@ -56,15 +69,18 @@ export class MarketplaceHttpClient extends MarketplaceClient {
       );
     } catch (error) {
       if (error instanceof MarketplaceHttpError && error.status === 404) {
-        this.logger.debug('Marketplace integration not found', { identifier });
+        this.logger.debug({ identifier }, 'Marketplace integration not found');
         return null;
       }
-      this.logger.warn('Failed to fetch marketplace integration', {
-        identifier,
-        error: error instanceof Error ? error.message : 'Unknown error',
-        status:
-          error instanceof MarketplaceHttpError ? error.status : undefined,
-      });
+      this.logger.warn(
+        {
+          identifier,
+          err: error as Error,
+          status:
+            error instanceof MarketplaceHttpError ? error.status : undefined,
+        },
+        'Failed to fetch marketplace integration',
+      );
       throw new MarketplaceUnavailableError();
     }
   }

--- a/ayunis-core-backend/src/domain/marketplace/presenters/http/marketplace.controller.ts
+++ b/ayunis-core-backend/src/domain/marketplace/presenters/http/marketplace.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, Inject, Logger, Param } from '@nestjs/common';
+import { Controller, Get, Inject, Param } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { ConfigType } from '@nestjs/config';
 import { marketplaceConfig } from 'src/config/marketplace.config';
@@ -13,9 +14,9 @@ import { MarketplaceConfigResponseDto } from './dto/marketplace-config-response.
 @ApiTags('marketplace')
 @Controller('marketplace')
 export class MarketplaceController {
-  private readonly logger = new Logger(MarketplaceController.name);
-
   constructor(
+    @InjectPinoLogger(MarketplaceController.name)
+    private readonly logger: PinoLogger,
     private readonly getMarketplaceSkillUseCase: GetMarketplaceSkillUseCase,
     private readonly getMarketplaceIntegrationUseCase: GetMarketplaceIntegrationUseCase,
     @Inject(marketplaceConfig.KEY)
@@ -52,7 +53,7 @@ export class MarketplaceController {
   async getSkill(
     @Param('identifier') identifier: string,
   ): Promise<MarketplaceSkillResponseDto> {
-    this.logger.log('getSkill', { identifier });
+    this.logger.info({ identifier }, 'getSkill');
 
     return this.getMarketplaceSkillUseCase.execute(
       new GetMarketplaceSkillQuery(identifier),
@@ -80,7 +81,7 @@ export class MarketplaceController {
   async getIntegration(
     @Param('identifier') identifier: string,
   ): Promise<MarketplaceIntegrationResponseDto> {
-    this.logger.log('getIntegration', { identifier });
+    this.logger.info({ identifier }, 'getIntegration');
 
     const integration = await this.getMarketplaceIntegrationUseCase.execute(
       new GetMarketplaceIntegrationQuery(identifier),

--- a/ayunis-core-backend/src/domain/skill-templates/application/listeners/user-created.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/listeners/user-created.listener.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { SkillTemplateUserCreatedListener } from './user-created.listener';
 import type { SkillTemplateInstallationService } from '../services/skill-template-installation.service';
 import { UserCreatedEvent } from 'src/iam/users/application/events/user-created.event';
@@ -28,7 +29,10 @@ describe('SkillTemplateUserCreatedListener', () => {
       installAllPreCreatedForUser: jest.fn().mockResolvedValue(2),
     } as unknown as jest.Mocked<SkillTemplateInstallationService>;
 
-    listener = new SkillTemplateUserCreatedListener(installationService);
+    listener = new SkillTemplateUserCreatedListener(
+      createPinoLoggerMock(),
+      installationService,
+    );
   });
 
   it('should call installAllPreCreatedForUser with the user ID', async () => {

--- a/ayunis-core-backend/src/domain/skill-templates/application/listeners/user-created.listener.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/listeners/user-created.listener.ts
@@ -1,39 +1,49 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OnEvent } from '@nestjs/event-emitter';
 import { UserCreatedEvent } from 'src/iam/users/application/events/user-created.event';
 import { SkillTemplateInstallationService } from '../services/skill-template-installation.service';
 
 @Injectable()
 export class SkillTemplateUserCreatedListener {
-  private readonly logger = new Logger(SkillTemplateUserCreatedListener.name);
-
   constructor(
+    @InjectPinoLogger(SkillTemplateUserCreatedListener.name)
+    private readonly logger: PinoLogger,
     private readonly skillTemplateInstallationService: SkillTemplateInstallationService,
   ) {}
 
   @OnEvent(UserCreatedEvent.EVENT_NAME)
   async handleUserCreated(event: UserCreatedEvent): Promise<void> {
     try {
-      this.logger.log('Installing pre-created skill templates for new user', {
-        userId: event.userId,
-        orgId: event.orgId,
-      });
+      this.logger.info(
+        {
+          userId: event.userId,
+          orgId: event.orgId,
+        },
+        'Installing pre-created skill templates for new user',
+      );
 
       const successCount =
         await this.skillTemplateInstallationService.installAllPreCreatedForUser(
           event.userId,
         );
 
-      this.logger.log('Pre-created skill template installation complete', {
-        userId: event.userId,
-        count: successCount,
-      });
+      this.logger.info(
+        {
+          userId: event.userId,
+          count: successCount,
+        },
+        'Pre-created skill template installation complete',
+      );
     } catch (error) {
-      this.logger.error('Failed to install pre-created skill templates', {
-        userId: event.userId,
-        orgId: event.orgId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          userId: event.userId,
+          orgId: event.orgId,
+          err: error as Error,
+        },
+        'Failed to install pre-created skill templates',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/skill-templates/application/services/skill-template-installation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/services/skill-template-installation.service.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { SkillTemplateInstallationService } from './skill-template-installation.service';
 import type { FindActivePreCreatedTemplatesUseCase } from '../use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case';
 import type { CreateSkillWithUniqueNameUseCase } from 'src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case';
@@ -56,6 +57,7 @@ describe('SkillTemplateInstallationService', () => {
     } as unknown as jest.Mocked<CreateSkillWithUniqueNameUseCase>;
 
     service = new SkillTemplateInstallationService(
+      createPinoLoggerMock(),
       findActivePreCreatedTemplatesUseCase,
       createSkillWithUniqueNameUseCase,
     );

--- a/ayunis-core-backend/src/domain/skill-templates/application/services/skill-template-installation.service.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/services/skill-template-installation.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { CreateSkillWithUniqueNameUseCase } from 'src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case';
 import { CreateSkillWithUniqueNameCommand } from 'src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.command';
@@ -7,9 +8,9 @@ import { FindActivePreCreatedTemplatesQuery } from '../use-cases/find-active-pre
 
 @Injectable()
 export class SkillTemplateInstallationService {
-  private readonly logger = new Logger(SkillTemplateInstallationService.name);
-
   constructor(
+    @InjectPinoLogger(SkillTemplateInstallationService.name)
+    private readonly logger: PinoLogger,
     private readonly findActivePreCreatedTemplatesUseCase: FindActivePreCreatedTemplatesUseCase,
     private readonly createSkillWithUniqueNameUseCase: CreateSkillWithUniqueNameUseCase,
   ) {}
@@ -38,23 +39,26 @@ export class SkillTemplateInstallationService {
           }),
         );
 
-        this.logger.debug('Pre-created skill template installed', {
-          templateId: template.id,
-          skillId: created.id,
-          userId,
-          isActive: template.defaultActive,
-          isPinned: template.defaultPinned,
-        });
+        this.logger.debug(
+          {
+            templateId: template.id,
+            skillId: created.id,
+            userId,
+            isActive: template.defaultActive,
+            isPinned: template.defaultPinned,
+          },
+          'Pre-created skill template installed',
+        );
         successCount++;
       } catch (error) {
         this.logger.error(
-          'Failed to install individual pre-created skill template',
           {
             templateId: template.id,
-            templateName: template.name,
+            name: template.name,
             userId,
-            error: error instanceof Error ? error.message : 'Unknown error',
+            err: error as Error,
           },
+          'Failed to install individual pre-created skill template',
         );
       }
     }

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.spec.ts
@@ -1,6 +1,8 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { CreateSkillTemplateUseCase } from './create-skill-template.use-case';
 import { CreateSkillTemplateCommand } from './create-skill-template.command';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
@@ -24,6 +26,10 @@ describe('CreateSkillTemplateUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateSkillTemplateUseCase,
+        {
+          provide: getLoggerToken(CreateSkillTemplateUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillTemplateRepository, useValue: mockRepository },
       ],
     }).compile();
@@ -32,9 +38,6 @@ describe('CreateSkillTemplateUseCase', () => {
       CreateSkillTemplateUseCase,
     );
     repository = module.get(SkillTemplateRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/create-skill-template/create-skill-template.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { CreateSkillTemplateCommand } from './create-skill-template.command';
 import { SkillTemplate } from 'src/domain/skill-templates/domain/skill-template.entity';
@@ -14,14 +15,14 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class CreateSkillTemplateUseCase {
-  private readonly logger = new Logger(CreateSkillTemplateUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateSkillTemplateUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillTemplateRepository: SkillTemplateRepository,
   ) {}
 
   async execute(command: CreateSkillTemplateCommand): Promise<SkillTemplate> {
-    this.logger.log('Creating skill template', { name: command.name });
+    this.logger.info({ name: command.name }, 'Creating skill template');
     try {
       const existing = await this.skillTemplateRepository.findByName(
         command.name,
@@ -53,9 +54,12 @@ export class CreateSkillTemplateUseCase {
         error instanceof InvalidSkillTemplateNameError
       )
         throw error;
-      this.logger.error('Error creating skill template', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error creating skill template',
+      );
       throw new UnexpectedSkillTemplateError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/delete-skill-template/delete-skill-template.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/delete-skill-template/delete-skill-template.use-case.spec.ts
@@ -1,6 +1,8 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import type { UUID } from 'crypto';
 import { DeleteSkillTemplateUseCase } from './delete-skill-template.use-case';
 import { DeleteSkillTemplateCommand } from './delete-skill-template.command';
@@ -23,6 +25,10 @@ describe('DeleteSkillTemplateUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeleteSkillTemplateUseCase,
+        {
+          provide: getLoggerToken(DeleteSkillTemplateUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillTemplateRepository, useValue: mockRepository },
       ],
     }).compile();
@@ -31,9 +37,6 @@ describe('DeleteSkillTemplateUseCase', () => {
       DeleteSkillTemplateUseCase,
     );
     repository = module.get(SkillTemplateRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/delete-skill-template/delete-skill-template.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/delete-skill-template/delete-skill-template.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { DeleteSkillTemplateCommand } from './delete-skill-template.command';
 import {
@@ -9,16 +10,19 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class DeleteSkillTemplateUseCase {
-  private readonly logger = new Logger(DeleteSkillTemplateUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteSkillTemplateUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillTemplateRepository: SkillTemplateRepository,
   ) {}
 
   async execute(command: DeleteSkillTemplateCommand): Promise<void> {
-    this.logger.log('Deleting skill template', {
-      skillTemplateId: command.skillTemplateId,
-    });
+    this.logger.info(
+      {
+        skillTemplateId: command.skillTemplateId,
+      },
+      'Deleting skill template',
+    );
     try {
       const existing = await this.skillTemplateRepository.findOne(
         command.skillTemplateId,
@@ -30,9 +34,12 @@ export class DeleteSkillTemplateUseCase {
       await this.skillTemplateRepository.delete(command.skillTemplateId);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error deleting skill template', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error deleting skill template',
+      );
       throw new UnexpectedSkillTemplateError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { FindActiveAlwaysOnTemplatesUseCase } from './find-active-always-on-templates.use-case';
 import { FindActiveAlwaysOnTemplatesQuery } from './find-active-always-on-templates.query';
 import type { SkillTemplateRepository } from '../../ports/skill-template.repository';
@@ -31,7 +32,10 @@ describe('FindActiveAlwaysOnTemplatesUseCase', () => {
       findByName: jest.fn(),
     };
 
-    useCase = new FindActiveAlwaysOnTemplatesUseCase(repository);
+    useCase = new FindActiveAlwaysOnTemplatesUseCase(
+      createPinoLoggerMock(),
+      repository,
+    );
   });
 
   it('should return active always-on templates from repository', async () => {

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-always-on-templates/find-active-always-on-templates.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { SkillTemplate } from 'src/domain/skill-templates/domain/skill-template.entity';
 import { DistributionMode } from 'src/domain/skill-templates/domain/distribution-mode.enum';
@@ -10,11 +11,12 @@ const CACHE_TTL_MS = 60_000;
 
 @Injectable()
 export class FindActiveAlwaysOnTemplatesUseCase {
-  private readonly logger = new Logger(FindActiveAlwaysOnTemplatesUseCase.name);
   private cachedTemplates: SkillTemplate[] | null = null;
   private cacheExpiresAt = 0;
 
   constructor(
+    @InjectPinoLogger(FindActiveAlwaysOnTemplatesUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillTemplateRepository: SkillTemplateRepository,
   ) {}
 
@@ -36,9 +38,12 @@ export class FindActiveAlwaysOnTemplatesUseCase {
       return templates;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding active always-on templates', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error finding active always-on templates',
+      );
       throw new UnexpectedSkillTemplateError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { FindActivePreCreatedTemplatesUseCase } from './find-active-pre-created-templates.use-case';
 import { FindActivePreCreatedTemplatesQuery } from './find-active-pre-created-templates.query';
 import type { SkillTemplateRepository } from '../../ports/skill-template.repository';
@@ -31,7 +32,10 @@ describe('FindActivePreCreatedTemplatesUseCase', () => {
       findByName: jest.fn(),
     };
 
-    useCase = new FindActivePreCreatedTemplatesUseCase(repository);
+    useCase = new FindActivePreCreatedTemplatesUseCase(
+      createPinoLoggerMock(),
+      repository,
+    );
   });
 
   it('should return active pre-created templates from repository', async () => {

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-active-pre-created-templates/find-active-pre-created-templates.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { PreCreatedCopySkillTemplate } from 'src/domain/skill-templates/domain/pre-created-copy-skill-template.entity';
 import { DistributionMode } from 'src/domain/skill-templates/domain/distribution-mode.enum';
@@ -8,11 +9,9 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class FindActivePreCreatedTemplatesUseCase {
-  private readonly logger = new Logger(
-    FindActivePreCreatedTemplatesUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(FindActivePreCreatedTemplatesUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillTemplateRepository: SkillTemplateRepository,
   ) {}
 
@@ -20,16 +19,19 @@ export class FindActivePreCreatedTemplatesUseCase {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _query: FindActivePreCreatedTemplatesQuery,
   ): Promise<PreCreatedCopySkillTemplate[]> {
-    this.logger.log('Finding active pre-created copy templates');
+    this.logger.info('Finding active pre-created copy templates');
     try {
       return await this.skillTemplateRepository.findActiveByMode<PreCreatedCopySkillTemplate>(
         DistributionMode.PRE_CREATED_COPY,
       );
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding active pre-created templates', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error finding active pre-created templates',
+      );
       throw new UnexpectedSkillTemplateError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-all-skill-templates/find-all-skill-templates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-all-skill-templates/find-all-skill-templates.use-case.spec.ts
@@ -1,6 +1,8 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { FindAllSkillTemplatesUseCase } from './find-all-skill-templates.use-case';
 import { FindAllSkillTemplatesQuery } from './find-all-skill-templates.query';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
@@ -19,6 +21,10 @@ describe('FindAllSkillTemplatesUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FindAllSkillTemplatesUseCase,
+        {
+          provide: getLoggerToken(FindAllSkillTemplatesUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillTemplateRepository, useValue: mockRepository },
       ],
     }).compile();
@@ -27,9 +33,6 @@ describe('FindAllSkillTemplatesUseCase', () => {
       FindAllSkillTemplatesUseCase,
     );
     repository = module.get(SkillTemplateRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-all-skill-templates/find-all-skill-templates.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-all-skill-templates/find-all-skill-templates.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { SkillTemplate } from 'src/domain/skill-templates/domain/skill-template.entity';
 import { FindAllSkillTemplatesQuery } from './find-all-skill-templates.query';
@@ -7,22 +8,25 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class FindAllSkillTemplatesUseCase {
-  private readonly logger = new Logger(FindAllSkillTemplatesUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindAllSkillTemplatesUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillTemplateRepository: SkillTemplateRepository,
   ) {}
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async execute(_query: FindAllSkillTemplatesQuery): Promise<SkillTemplate[]> {
-    this.logger.log('Finding all skill templates');
+    this.logger.info('Finding all skill templates');
     try {
       return await this.skillTemplateRepository.findAll();
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding all skill templates', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error finding all skill templates',
+      );
       throw new UnexpectedSkillTemplateError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-one-skill-template/find-one-skill-template.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-one-skill-template/find-one-skill-template.use-case.spec.ts
@@ -1,6 +1,8 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import type { UUID } from 'crypto';
 import { FindOneSkillTemplateUseCase } from './find-one-skill-template.use-case';
 import { FindOneSkillTemplateQuery } from './find-one-skill-template.query';
@@ -22,6 +24,10 @@ describe('FindOneSkillTemplateUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FindOneSkillTemplateUseCase,
+        {
+          provide: getLoggerToken(FindOneSkillTemplateUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillTemplateRepository, useValue: mockRepository },
       ],
     }).compile();
@@ -30,9 +36,6 @@ describe('FindOneSkillTemplateUseCase', () => {
       FindOneSkillTemplateUseCase,
     );
     repository = module.get(SkillTemplateRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-one-skill-template/find-one-skill-template.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/find-one-skill-template/find-one-skill-template.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { FindOneSkillTemplateQuery } from './find-one-skill-template.query';
 import { SkillTemplate } from 'src/domain/skill-templates/domain/skill-template.entity';
@@ -10,14 +11,14 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class FindOneSkillTemplateUseCase {
-  private readonly logger = new Logger(FindOneSkillTemplateUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindOneSkillTemplateUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillTemplateRepository: SkillTemplateRepository,
   ) {}
 
   async execute(query: FindOneSkillTemplateQuery): Promise<SkillTemplate> {
-    this.logger.log('Finding skill template', { id: query.id });
+    this.logger.info({ id: query.id }, 'Finding skill template');
     try {
       const skillTemplate = await this.skillTemplateRepository.findOne(
         query.id,
@@ -28,9 +29,12 @@ export class FindOneSkillTemplateUseCase {
       return skillTemplate;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding skill template', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error finding skill template',
+      );
       throw new UnexpectedSkillTemplateError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.spec.ts
@@ -1,6 +1,8 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import type { UUID } from 'crypto';
 import { UpdateSkillTemplateUseCase } from './update-skill-template.use-case';
 import { UpdateSkillTemplateCommand } from './update-skill-template.command';
@@ -30,6 +32,10 @@ describe('UpdateSkillTemplateUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UpdateSkillTemplateUseCase,
+        {
+          provide: getLoggerToken(UpdateSkillTemplateUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillTemplateRepository, useValue: mockRepository },
       ],
     }).compile();
@@ -38,9 +44,6 @@ describe('UpdateSkillTemplateUseCase', () => {
       UpdateSkillTemplateUseCase,
     );
     repository = module.get(SkillTemplateRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/application/use-cases/update-skill-template/update-skill-template.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SkillTemplateRepository } from '../../ports/skill-template.repository';
 import { UpdateSkillTemplateCommand } from './update-skill-template.command';
 import { SkillTemplate } from '../../../domain/skill-template.entity';
@@ -15,73 +16,104 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class UpdateSkillTemplateUseCase {
-  private readonly logger = new Logger(UpdateSkillTemplateUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateSkillTemplateUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillTemplateRepository: SkillTemplateRepository,
   ) {}
 
   async execute(command: UpdateSkillTemplateCommand): Promise<SkillTemplate> {
-    this.logger.log('Updating skill template', {
-      skillTemplateId: command.skillTemplateId,
-    });
+    this.logger.info(
+      { skillTemplateId: command.skillTemplateId },
+      'Updating skill template',
+    );
     try {
-      const existing = await this.skillTemplateRepository.findOne(
-        command.skillTemplateId,
-      );
-      if (!existing) {
-        throw new SkillTemplateNotFoundError(command.skillTemplateId);
-      }
-
-      const name = command.name ?? existing.name;
-
-      if (name !== existing.name) {
-        const duplicate = await this.skillTemplateRepository.findByName(name);
-        if (duplicate) {
-          throw new DuplicateSkillTemplateNameError(name);
-        }
-      }
-
-      const distributionMode =
-        command.distributionMode ?? existing.distributionMode;
-      const baseParams = {
-        id: existing.id,
-        name,
-        shortDescription: command.shortDescription ?? existing.shortDescription,
-        instructions: command.instructions ?? existing.instructions,
-        isActive: command.isActive ?? existing.isActive,
-        createdAt: existing.createdAt,
-        updatedAt: new Date(),
-      };
-
-      const updated: SkillTemplate =
-        distributionMode === DistributionMode.ALWAYS_ON
-          ? new AlwaysOnSkillTemplate(baseParams)
-          : new PreCreatedCopySkillTemplate({
-              ...baseParams,
-              defaultActive:
-                command.defaultActive ??
-                (existing instanceof PreCreatedCopySkillTemplate
-                  ? existing.defaultActive
-                  : false),
-              defaultPinned:
-                command.defaultPinned ??
-                (existing instanceof PreCreatedCopySkillTemplate
-                  ? existing.defaultPinned
-                  : false),
-            });
-
+      const existing = await this.findExisting(command);
+      const name = await this.resolveName(command, existing);
+      const updated = this.buildUpdatedTemplate(command, existing, name);
       return await this.skillTemplateRepository.update(updated);
     } catch (error) {
       if (
         error instanceof ApplicationError ||
         error instanceof InvalidSkillTemplateNameError
-      )
+      ) {
         throw error;
-      this.logger.error('Error updating skill template', {
-        error: error as Error,
-      });
+      }
+      this.logger.error(
+        { err: error as Error },
+        'Error updating skill template',
+      );
       throw new UnexpectedSkillTemplateError(error);
     }
+  }
+
+  private async findExisting(
+    command: UpdateSkillTemplateCommand,
+  ): Promise<SkillTemplate> {
+    const existing = await this.skillTemplateRepository.findOne(
+      command.skillTemplateId,
+    );
+    if (!existing) {
+      throw new SkillTemplateNotFoundError(command.skillTemplateId);
+    }
+    return existing;
+  }
+
+  private async resolveName(
+    command: UpdateSkillTemplateCommand,
+    existing: SkillTemplate,
+  ): Promise<string> {
+    const name = command.name ?? existing.name;
+    if (name === existing.name) {
+      return name;
+    }
+    const duplicate = await this.skillTemplateRepository.findByName(name);
+    if (duplicate) {
+      throw new DuplicateSkillTemplateNameError(name);
+    }
+    return name;
+  }
+
+  private buildUpdatedTemplate(
+    command: UpdateSkillTemplateCommand,
+    existing: SkillTemplate,
+    name: string,
+  ): SkillTemplate {
+    const baseParams = this.buildBaseParams(command, existing, name);
+    const mode = command.distributionMode ?? existing.distributionMode;
+    if (mode === DistributionMode.ALWAYS_ON) {
+      return new AlwaysOnSkillTemplate(baseParams);
+    }
+    return this.buildPreCreatedTemplate(command, existing, baseParams);
+  }
+
+  private buildBaseParams(
+    command: UpdateSkillTemplateCommand,
+    existing: SkillTemplate,
+    name: string,
+  ) {
+    return {
+      id: existing.id,
+      name,
+      shortDescription: command.shortDescription ?? existing.shortDescription,
+      instructions: command.instructions ?? existing.instructions,
+      isActive: command.isActive ?? existing.isActive,
+      createdAt: existing.createdAt,
+      updatedAt: new Date(),
+    };
+  }
+
+  private buildPreCreatedTemplate(
+    command: UpdateSkillTemplateCommand,
+    existing: SkillTemplate,
+    baseParams: ConstructorParameters<typeof AlwaysOnSkillTemplate>[0],
+  ): PreCreatedCopySkillTemplate {
+    const previous =
+      existing instanceof PreCreatedCopySkillTemplate ? existing : undefined;
+    return new PreCreatedCopySkillTemplate({
+      ...baseParams,
+      defaultActive: command.defaultActive ?? previous?.defaultActive ?? false,
+      defaultPinned: command.defaultPinned ?? previous?.defaultPinned ?? false,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template.repository.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { ObjectLiteral, Repository } from 'typeorm';
 import { QueryFailedError } from 'typeorm';
 import { randomUUID } from 'crypto';
@@ -110,6 +111,7 @@ describe('LocalSkillTemplateRepository', () => {
     mockPreCreatedRepo = createMockRepo<PreCreatedCopySkillTemplateRecord>();
 
     repo = new LocalSkillTemplateRepository(
+      createPinoLoggerMock(),
       mockTypeOrmRepo,
       mockAlwaysOnRepo,
       mockPreCreatedRepo,

--- a/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template.repository.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/infrastructure/persistence/local/local-skill-template.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { QueryFailedError, Repository } from 'typeorm';
 import type { UUID } from 'crypto';
@@ -19,13 +20,14 @@ const PG_UNIQUE_VIOLATION = '23505';
 
 @Injectable()
 export class LocalSkillTemplateRepository implements SkillTemplateRepository {
-  private readonly logger = new Logger(LocalSkillTemplateRepository.name);
   private readonly childRepos: Record<
     DistributionMode,
     Repository<SkillTemplateRecord>
   >;
 
   constructor(
+    @InjectPinoLogger(LocalSkillTemplateRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(SkillTemplateRecord)
     private readonly repository: Repository<SkillTemplateRecord>,
     @InjectRepository(AlwaysOnSkillTemplateRecord)
@@ -41,17 +43,20 @@ export class LocalSkillTemplateRepository implements SkillTemplateRepository {
   }
 
   async create(skillTemplate: SkillTemplate): Promise<SkillTemplate> {
-    this.logger.log('create', { name: skillTemplate.name });
+    this.logger.info({ name: skillTemplate.name }, 'create');
     const record = this.mapper.toRecord(skillTemplate);
     const saved = await this.saveOrThrow(record, skillTemplate.name);
     return this.mapper.toDomain(saved);
   }
 
   async update(skillTemplate: SkillTemplate): Promise<SkillTemplate> {
-    this.logger.log('update', {
-      id: skillTemplate.id,
-      name: skillTemplate.name,
-    });
+    this.logger.info(
+      {
+        id: skillTemplate.id,
+        name: skillTemplate.name,
+      },
+      'update',
+    );
     const exists = await this.repository.findOne({
       where: { id: skillTemplate.id },
     });
@@ -64,7 +69,7 @@ export class LocalSkillTemplateRepository implements SkillTemplateRepository {
   }
 
   async delete(id: UUID): Promise<void> {
-    this.logger.log('delete', { id });
+    this.logger.info({ id }, 'delete');
     const result = await this.repository.delete({ id });
     if (result.affected === 0) {
       throw new SkillTemplateNotFoundError(id);
@@ -72,14 +77,14 @@ export class LocalSkillTemplateRepository implements SkillTemplateRepository {
   }
 
   async findOne(id: UUID): Promise<SkillTemplate | null> {
-    this.logger.log('findOne', { id });
+    this.logger.info({ id }, 'findOne');
     const record = await this.repository.findOne({ where: { id } });
     if (!record) return null;
     return this.mapper.toDomain(record);
   }
 
   async findAll(): Promise<SkillTemplate[]> {
-    this.logger.log('findAll');
+    this.logger.info('findAll');
     const records = await this.repository.find({
       order: { createdAt: 'DESC' },
     });
@@ -87,7 +92,7 @@ export class LocalSkillTemplateRepository implements SkillTemplateRepository {
   }
 
   async findByName(name: string): Promise<SkillTemplate | null> {
-    this.logger.log('findByName', { name });
+    this.logger.info({ name }, 'findByName');
     const record = await this.repository.findOne({ where: { name } });
     if (!record) return null;
     return this.mapper.toDomain(record);
@@ -96,7 +101,7 @@ export class LocalSkillTemplateRepository implements SkillTemplateRepository {
   async findActiveByMode<T extends SkillTemplate = SkillTemplate>(
     mode: DistributionMode,
   ): Promise<T[]> {
-    this.logger.log('findActiveByMode', { mode });
+    this.logger.info({ mode }, 'findActiveByMode');
     const childRepo = this.childRepos[mode];
     const records = await childRepo.find({
       where: { isActive: true },

--- a/ayunis-core-backend/src/domain/skill-templates/presenters/http/super-admin-skill-templates.controller.ts
+++ b/ayunis-core-backend/src/domain/skill-templates/presenters/http/super-admin-skill-templates.controller.ts
@@ -6,12 +6,12 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   ParseUUIDPipe,
   Patch,
   Post,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -46,9 +46,9 @@ import { SkillTemplateResponseMapper } from './mappers/skill-template-response.m
 @Controller('super-admin/skill-templates')
 @SystemRoles(SystemRole.SUPER_ADMIN)
 export class SuperAdminSkillTemplatesController {
-  private readonly logger = new Logger(SuperAdminSkillTemplatesController.name);
-
   constructor(
+    @InjectPinoLogger(SuperAdminSkillTemplatesController.name)
+    private readonly logger: PinoLogger,
     private readonly createSkillTemplateUseCase: CreateSkillTemplateUseCase,
     private readonly updateSkillTemplateUseCase: UpdateSkillTemplateUseCase,
     private readonly deleteSkillTemplateUseCase: DeleteSkillTemplateUseCase,
@@ -82,7 +82,7 @@ export class SuperAdminSkillTemplatesController {
   async create(
     @Body() dto: CreateSkillTemplateDto,
   ): Promise<SkillTemplateResponseDto> {
-    this.logger.log(`Creating skill template: ${dto.name}`);
+    this.logger.info({ name: dto.name }, 'Creating skill template');
 
     try {
       const command = new CreateSkillTemplateCommand({
@@ -97,7 +97,10 @@ export class SuperAdminSkillTemplatesController {
 
       const template = await this.createSkillTemplateUseCase.execute(command);
 
-      this.logger.log(`Successfully created skill template ${template.id}`);
+      this.logger.info(
+        { skillTemplateId: template.id },
+        'Successfully created skill template',
+      );
       return this.responseMapper.toDto(template);
     } catch (error) {
       if (error instanceof InvalidSkillTemplateNameError) {
@@ -125,14 +128,15 @@ export class SuperAdminSkillTemplatesController {
     description: 'Internal server error',
   })
   async findAll(): Promise<SkillTemplateResponseDto[]> {
-    this.logger.log('Finding all skill templates');
+    this.logger.info('Finding all skill templates');
 
     const templates = await this.findAllSkillTemplatesUseCase.execute(
       new FindAllSkillTemplatesQuery(),
     );
 
-    this.logger.log(
-      `Successfully retrieved ${templates.length} skill templates`,
+    this.logger.info(
+      { count: templates.length },
+      'Successfully retrieved skill templates',
     );
     return this.responseMapper.toDtoArray(templates);
   }
@@ -166,13 +170,16 @@ export class SuperAdminSkillTemplatesController {
   async findOne(
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<SkillTemplateResponseDto> {
-    this.logger.log(`Finding skill template ${id}`);
+    this.logger.info({ skillTemplateId: id }, 'Finding skill template');
 
     const template = await this.findOneSkillTemplateUseCase.execute(
       new FindOneSkillTemplateQuery(id),
     );
 
-    this.logger.log(`Successfully retrieved skill template ${id}`);
+    this.logger.info(
+      { skillTemplateId: id },
+      'Successfully retrieved skill template',
+    );
     return this.responseMapper.toDto(template);
   }
 
@@ -204,30 +211,20 @@ export class SuperAdminSkillTemplatesController {
   @ApiUnauthorizedResponse({
     description: 'User not authenticated or not authorized as super admin',
   })
-  @ApiInternalServerErrorResponse({
-    description: 'Internal server error',
-  })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
   async update(
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() dto: UpdateSkillTemplateDto,
   ): Promise<SkillTemplateResponseDto> {
-    this.logger.log(`Updating skill template ${id}`);
-
+    this.logger.info({ skillTemplateId: id }, 'Updating skill template');
     try {
-      const command = new UpdateSkillTemplateCommand({
-        skillTemplateId: id,
-        name: dto.name,
-        shortDescription: dto.shortDescription,
-        instructions: dto.instructions,
-        distributionMode: dto.distributionMode,
-        isActive: dto.isActive,
-        defaultActive: dto.defaultActive,
-        defaultPinned: dto.defaultPinned,
-      });
-
+      const command = this.createUpdateCommand(id, dto);
       const template = await this.updateSkillTemplateUseCase.execute(command);
 
-      this.logger.log(`Successfully updated skill template ${id}`);
+      this.logger.info(
+        { skillTemplateId: id },
+        'Successfully updated skill template',
+      );
       return this.responseMapper.toDto(template);
     } catch (error) {
       if (error instanceof InvalidSkillTemplateNameError) {
@@ -263,12 +260,31 @@ export class SuperAdminSkillTemplatesController {
     description: 'Internal server error',
   })
   async delete(@Param('id', ParseUUIDPipe) id: UUID): Promise<void> {
-    this.logger.log(`Deleting skill template ${id}`);
+    this.logger.info({ skillTemplateId: id }, 'Deleting skill template');
 
     await this.deleteSkillTemplateUseCase.execute(
       new DeleteSkillTemplateCommand({ skillTemplateId: id }),
     );
 
-    this.logger.log(`Successfully deleted skill template ${id}`);
+    this.logger.info(
+      { skillTemplateId: id },
+      'Successfully deleted skill template',
+    );
+  }
+
+  private createUpdateCommand(
+    id: UUID,
+    dto: UpdateSkillTemplateDto,
+  ): UpdateSkillTemplateCommand {
+    return new UpdateSkillTemplateCommand({
+      skillTemplateId: id,
+      name: dto.name,
+      shortDescription: dto.shortDescription,
+      instructions: dto.instructions,
+      distributionMode: dto.distributionMode,
+      isActive: dto.isActive,
+      defaultActive: dto.defaultActive,
+      defaultPinned: dto.defaultPinned,
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/listeners/share-deleted.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/listeners/share-deleted.listener.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ShareDeletedListener } from './share-deleted.listener';
@@ -29,6 +31,10 @@ describe('ShareDeletedListener', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ShareDeletedListener,
+        {
+          provide: getLoggerToken(ShareDeletedListener.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillRepository, useValue: skillRepository },
         {
           provide: ShareScopeResolverService,

--- a/ayunis-core-backend/src/domain/skills/application/listeners/share-deleted.listener.ts
+++ b/ayunis-core-backend/src/domain/skills/application/listeners/share-deleted.listener.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OnEvent } from '@nestjs/event-emitter';
 import { ShareDeletedEvent } from 'src/domain/shares/application/events/share-deleted.event';
 import { SharedEntityType } from 'src/domain/shares/domain/value-objects/shared-entity-type.enum';
@@ -7,9 +8,9 @@ import { SkillRepository } from '../ports/skill.repository';
 
 @Injectable()
 export class ShareDeletedListener {
-  private readonly logger = new Logger(ShareDeletedListener.name);
-
   constructor(
+    @InjectPinoLogger(ShareDeletedListener.name)
+    private readonly logger: PinoLogger,
     @Inject(SkillRepository)
     private readonly skillRepository: SkillRepository,
     private readonly shareScopeResolver: ShareScopeResolverService,
@@ -21,11 +22,14 @@ export class ShareDeletedListener {
       return;
     }
 
-    this.logger.log('Cleaning up skill activations after share deletion', {
-      skillId: event.entityId,
-      ownerId: event.ownerId,
-      remainingScopeCount: event.remainingScopes.length,
-    });
+    this.logger.info(
+      {
+        skillId: event.entityId,
+        ownerId: event.ownerId,
+        remainingScopeCount: event.remainingScopes.length,
+      },
+      'Cleaning up skill activations after share deletion',
+    );
 
     if (event.remainingScopes.length === 0) {
       await this.skillRepository.deactivateAllExceptOwner(

--- a/ayunis-core-backend/src/domain/skills/application/listeners/user-created.listener.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/listeners/user-created.listener.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { UserCreatedListener } from './user-created.listener';
 import { UserCreatedEvent } from 'src/iam/users/application/events/user-created.event';
 import type { MarketplaceSkillInstallationService } from '../services/marketplace-skill-installation.service';
@@ -31,7 +32,10 @@ describe('UserCreatedListener', () => {
       installFromMarketplace: jest.fn(),
     } as unknown as jest.Mocked<MarketplaceSkillInstallationService>;
 
-    listener = new UserCreatedListener(skillInstallationService);
+    listener = new UserCreatedListener(
+      createPinoLoggerMock(),
+      skillInstallationService,
+    );
   });
 
   it('should delegate to installAllPreInstalled with the user ID from the event', async () => {

--- a/ayunis-core-backend/src/domain/skills/application/listeners/user-created.listener.ts
+++ b/ayunis-core-backend/src/domain/skills/application/listeners/user-created.listener.ts
@@ -1,39 +1,49 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OnEvent } from '@nestjs/event-emitter';
 import { UserCreatedEvent } from 'src/iam/users/application/events/user-created.event';
 import { MarketplaceSkillInstallationService } from '../services/marketplace-skill-installation.service';
 
 @Injectable()
 export class UserCreatedListener {
-  private readonly logger = new Logger(UserCreatedListener.name);
-
   constructor(
+    @InjectPinoLogger(UserCreatedListener.name)
+    private readonly logger: PinoLogger,
     private readonly skillInstallationService: MarketplaceSkillInstallationService,
   ) {}
 
   @OnEvent(UserCreatedEvent.EVENT_NAME)
   async handleUserCreated(event: UserCreatedEvent): Promise<void> {
     try {
-      this.logger.log('Installing pre-installed skills for new user', {
-        userId: event.userId,
-        orgId: event.orgId,
-      });
+      this.logger.info(
+        {
+          userId: event.userId,
+          orgId: event.orgId,
+        },
+        'Installing pre-installed skills for new user',
+      );
 
       const successCount =
         await this.skillInstallationService.installAllPreInstalled(
           event.userId,
         );
 
-      this.logger.log('Pre-installed skills installation complete', {
-        userId: event.userId,
-        count: successCount,
-      });
+      this.logger.info(
+        {
+          userId: event.userId,
+          count: successCount,
+        },
+        'Pre-installed skills installation complete',
+      );
     } catch (error) {
-      this.logger.error('Failed to install pre-installed skills', {
-        userId: event.userId,
-        orgId: event.orgId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          userId: event.userId,
+          orgId: event.orgId,
+          err: error as Error,
+        },
+        'Failed to install pre-installed skills',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { MarketplaceSkillInstallationService } from './marketplace-skill-installation.service';
 import type { GetMarketplaceSkillUseCase } from 'src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case';
 import type { MarketplaceClient } from 'src/domain/marketplace/application/ports/marketplace-client.port';
@@ -47,6 +48,7 @@ describe('MarketplaceSkillInstallationService', () => {
     };
 
     service = new MarketplaceSkillInstallationService(
+      createPinoLoggerMock(),
       getMarketplaceSkillUseCase,
       createSkillWithUniqueNameUseCase,
       marketplaceClient,

--- a/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/marketplace-skill-installation.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { GetMarketplaceSkillUseCase } from 'src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.use-case';
 import { GetMarketplaceSkillQuery } from 'src/domain/marketplace/application/use-cases/get-marketplace-skill/get-marketplace-skill.query';
@@ -9,11 +10,9 @@ import { Skill } from '../../domain/skill.entity';
 
 @Injectable()
 export class MarketplaceSkillInstallationService {
-  private readonly logger = new Logger(
-    MarketplaceSkillInstallationService.name,
-  );
-
   constructor(
+    @InjectPinoLogger(MarketplaceSkillInstallationService.name)
+    private readonly logger: PinoLogger,
     private readonly getMarketplaceSkillUseCase: GetMarketplaceSkillUseCase,
     private readonly createSkillWithUniqueNameUseCase: CreateSkillWithUniqueNameUseCase,
     private readonly marketplaceClient: MarketplaceClient,
@@ -31,17 +30,23 @@ export class MarketplaceSkillInstallationService {
     for (const skillSummary of preInstalledSkills) {
       try {
         await this.installFromMarketplace(skillSummary.identifier, userId);
-        this.logger.debug('Pre-installed skill created and activated', {
-          identifier: skillSummary.identifier,
-          userId,
-        });
+        this.logger.debug(
+          {
+            identifier: skillSummary.identifier,
+            userId,
+          },
+          'Pre-installed skill created and activated',
+        );
         successCount++;
       } catch (error) {
-        this.logger.error('Failed to install individual pre-installed skill', {
-          identifier: skillSummary.identifier,
-          userId,
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
+        this.logger.error(
+          {
+            identifier: skillSummary.identifier,
+            userId,
+            err: error as Error,
+          },
+          'Failed to install individual pre-installed skill',
+        );
       }
     }
 
@@ -55,8 +60,8 @@ export class MarketplaceSkillInstallationService {
       return await this.marketplaceClient.getPreInstalledSkills();
     } catch (error) {
       this.logger.warn(
+        { err: error as Error },
         'Marketplace unavailable, skipping pre-installed skills',
-        { error: error instanceof Error ? error.message : 'Unknown error' },
       );
       return [];
     }
@@ -66,7 +71,7 @@ export class MarketplaceSkillInstallationService {
     identifier: string,
     userId: UUID,
   ): Promise<Skill> {
-    this.logger.log('installFromMarketplace', { identifier, userId });
+    this.logger.info({ identifier, userId }, 'installFromMarketplace');
 
     const marketplaceSkill = await this.getMarketplaceSkillUseCase.execute(
       new GetMarketplaceSkillQuery(identifier),

--- a/ayunis-core-backend/src/domain/skills/application/services/skill-access.service.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/skill-access.service.spec.ts
@@ -1,6 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { SkillAccessService } from './skill-access.service';
 import { SkillRepository } from '../ports/skill.repository';
 import { FindShareByEntityUseCase } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case';
@@ -64,9 +64,6 @@ describe('SkillAccessService', () => {
     skillRepository = module.get(SkillRepository);
     findShareByEntityUseCase = module.get(FindShareByEntityUseCase);
     contextService = module.get(ContextService);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/domain/skills/application/services/skill-access.service.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/skill-access.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import type { UUID } from 'crypto';
 import { SkillRepository } from '../ports/skill.repository';
 import { FindShareByEntityUseCase } from 'src/domain/shares/application/use-cases/find-share-by-entity/find-share-by-entity.use-case';
@@ -22,8 +22,6 @@ export interface SkillUserContextBatch {
 
 @Injectable()
 export class SkillAccessService {
-  private readonly logger = new Logger(SkillAccessService.name);
-
   constructor(
     private readonly skillRepository: SkillRepository,
     private readonly findShareByEntityUseCase: FindShareByEntityUseCase,

--- a/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.spec.ts
@@ -1,6 +1,8 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
+import { getLoggerToken, type PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { SkillActivationService } from './skill-activation.service';
 import { SkillAccessService } from 'src/domain/skills/application/services/skill-access.service';
 import { AddSourceToThreadUseCase } from 'src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case';
@@ -29,6 +31,7 @@ describe('SkillActivationService', () => {
   let addKnowledgeBaseToThreadUseCase: jest.Mocked<AddKnowledgeBaseToThreadUseCase>;
   let getSourcesByIdsUseCase: jest.Mocked<GetSourcesByIdsUseCase>;
   let eventEmitter: jest.Mocked<EventEmitter2>;
+  let logger: jest.Mocked<PinoLogger>;
 
   const userId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
   const orgId = '123e4567-e89b-12d3-a456-426614174001' as UUID;
@@ -71,9 +74,14 @@ describe('SkillActivationService', () => {
     });
 
   beforeEach(async () => {
+    logger = createPinoLoggerMock();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SkillActivationService,
+        {
+          provide: getLoggerToken(SkillActivationService.name),
+          useValue: logger,
+        },
         {
           provide: SkillAccessService,
           useValue: { findAccessibleSkill: jest.fn() },
@@ -116,9 +124,6 @@ describe('SkillActivationService', () => {
     );
     getSourcesByIdsUseCase = module.get(GetSourcesByIdsUseCase);
     eventEmitter = module.get(EventEmitter2);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -320,9 +325,9 @@ describe('SkillActivationService', () => {
       const result = await service.activateOnThread(skillId, thread);
 
       expect(addKnowledgeBaseToThreadUseCase.execute).toHaveBeenCalledTimes(2);
-      expect(Logger.prototype.warn).toHaveBeenCalledWith(
-        'Knowledge base not found, skipping (stale reference)',
+      expect(logger.warn).toHaveBeenCalledWith(
         expect.objectContaining({ knowledgeBaseId: knowledgeBaseId1 }),
+        'Knowledge base not found, skipping (stale reference)',
       );
       expect(result.instructions).toBe(
         'Analyze the legal question thoroughly.',
@@ -348,9 +353,9 @@ describe('SkillActivationService', () => {
       const result = await service.activateOnThread(skillId, thread);
 
       expect(addMcpIntegrationToThreadUseCase.execute).toHaveBeenCalledTimes(2);
-      expect(Logger.prototype.warn).toHaveBeenCalledWith(
-        'MCP integration not found, skipping (stale reference)',
+      expect(logger.warn).toHaveBeenCalledWith(
         expect.objectContaining({ mcpIntegrationId: mcpIntegrationId1 }),
+        'MCP integration not found, skipping (stale reference)',
       );
       expect(result.instructions).toBe(
         'Analyze the legal question thoroughly.',
@@ -466,12 +471,12 @@ describe('SkillActivationService', () => {
 
       await service.activateOnThread(skillId, thread);
 
-      expect(Logger.prototype.warn).toHaveBeenCalledWith(
-        'Skipping non-ready source',
+      expect(logger.warn).toHaveBeenCalledWith(
         expect.objectContaining({
           sourceId: sourceId1,
           status: SourceStatus.FAILED,
         }),
+        'Skipping non-ready source',
       );
     });
   });

--- a/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/skill-activation.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SkillAccessService } from 'src/domain/skills/application/services/skill-access.service';
 import { AddSourceToThreadUseCase } from 'src/domain/threads/application/use-cases/add-source-to-thread/add-source-to-thread.use-case';
 import { AddSourceCommand } from 'src/domain/threads/application/use-cases/add-source-to-thread/add-source.command';
@@ -26,9 +27,9 @@ export interface SkillActivationResult {
 
 @Injectable()
 export class SkillActivationService {
-  private readonly logger = new Logger(SkillActivationService.name);
-
   constructor(
+    @InjectPinoLogger(SkillActivationService.name)
+    private readonly logger: PinoLogger,
     private readonly skillAccessService: SkillAccessService,
     private readonly addSourceToThreadUseCase: AddSourceToThreadUseCase,
     private readonly addMcpIntegrationToThreadUseCase: AddMcpIntegrationToThreadUseCase,
@@ -47,10 +48,13 @@ export class SkillActivationService {
     skillId: UUID,
     thread: Thread,
   ): Promise<SkillActivationResult> {
-    this.logger.log('Activating skill on thread', {
-      skillId,
-      threadId: thread.id,
-    });
+    this.logger.info(
+      {
+        skillId,
+        threadId: thread.id,
+      },
+      'Activating skill on thread',
+    );
 
     const skill = await this.skillAccessService.findAccessibleSkill(skillId);
 
@@ -72,10 +76,13 @@ export class SkillActivationService {
         new SkillUsedEvent(userId, orgId, skill.id, skill.name),
       )
       .catch((error: unknown) => {
-        this.logger.error('Failed to emit SkillUsedEvent', {
-          error: error instanceof Error ? error.message : 'Unknown error',
-          skillId: skill.id,
-        });
+        this.logger.error(
+          {
+            err: error as Error,
+            skillId: skill.id,
+          },
+          'Failed to emit SkillUsedEvent',
+        );
       });
   }
 
@@ -89,11 +96,14 @@ export class SkillActivationService {
     );
     const sources = allSources.filter((source) => {
       if (source.status !== SourceStatus.READY) {
-        this.logger.warn('Skipping non-ready source', {
-          sourceId: source.id,
-          status: source.status,
-          threadId: thread.id,
-        });
+        this.logger.warn(
+          {
+            sourceId: source.id,
+            status: source.status,
+            threadId: thread.id,
+          },
+          'Skipping non-ready source',
+        );
         return false;
       }
       return true;
@@ -105,10 +115,13 @@ export class SkillActivationService {
         );
       } catch (error) {
         if (error instanceof SourceAlreadyAssignedError) {
-          this.logger.log('Source already assigned to thread, skipping', {
-            sourceId: source.id,
-            threadId: thread.id,
-          });
+          this.logger.info(
+            {
+              sourceId: source.id,
+              threadId: thread.id,
+            },
+            'Source already assigned to thread, skipping',
+          );
           continue;
         }
         throw error;
@@ -129,11 +142,11 @@ export class SkillActivationService {
       } catch (error) {
         if (error instanceof McpIntegrationNotFoundError) {
           this.logger.warn(
-            'MCP integration not found, skipping (stale reference)',
             {
               mcpIntegrationId,
               threadId: thread.id,
             },
+            'MCP integration not found, skipping (stale reference)',
           );
           continue;
         }
@@ -159,11 +172,11 @@ export class SkillActivationService {
       } catch (error) {
         if (error instanceof KnowledgeBaseNotFoundError) {
           this.logger.warn(
-            'Knowledge base not found, skipping (stale reference)',
             {
               knowledgeBaseId,
               threadId: thread.id,
             },
+            'Knowledge base not found, skipping (stale reference)',
           );
           continue;
         }

--- a/ayunis-core-backend/src/domain/skills/application/services/skill-creator-name.service.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/skill-creator-name.service.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -40,6 +42,10 @@ describe('SkillCreatorNameService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SkillCreatorNameService,
+        {
+          provide: getLoggerToken(SkillCreatorNameService.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: FindUsersByIdsUseCase,
           useValue: mockFindUsersByIdsUseCase,

--- a/ayunis-core-backend/src/domain/skills/application/services/skill-creator-name.service.ts
+++ b/ayunis-core-backend/src/domain/skills/application/services/skill-creator-name.service.ts
@@ -1,13 +1,16 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { FindUsersByIdsUseCase } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case';
 import { FindUsersByIdsQuery } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.query';
 
 @Injectable()
 export class SkillCreatorNameService {
-  private readonly logger = new Logger(SkillCreatorNameService.name);
-
-  constructor(private readonly findUsersByIdsUseCase: FindUsersByIdsUseCase) {}
+  constructor(
+    @InjectPinoLogger(SkillCreatorNameService.name)
+    private readonly logger: PinoLogger,
+    private readonly findUsersByIdsUseCase: FindUsersByIdsUseCase,
+  ) {}
 
   async resolveOne(userId: UUID): Promise<string | null> {
     const byId = await this.resolveMany([userId]);
@@ -22,7 +25,7 @@ export class SkillCreatorNameService {
     }
 
     const uniqueIds = Array.from(new Set(userIds));
-    this.logger.log('resolveMany', { idCount: uniqueIds.length });
+    this.logger.info({ idCount: uniqueIds.length }, 'resolveMany');
 
     const users = await this.findUsersByIdsUseCase.execute(
       new FindUsersByIdsQuery(uniqueIds),

--- a/ayunis-core-backend/src/domain/skills/application/strategies/skill-share-authorization.strategy.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/strategies/skill-share-authorization.strategy.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { SkillShareAuthorizationStrategy } from './skill-share-authorization.strategy';
@@ -31,6 +33,10 @@ describe('SkillShareAuthorizationStrategy', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SkillShareAuthorizationStrategy,
+        {
+          provide: getLoggerToken(SkillShareAuthorizationStrategy.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: SkillRepository,
           useValue: mockSkillRepository,

--- a/ayunis-core-backend/src/domain/skills/application/strategies/skill-share-authorization.strategy.ts
+++ b/ayunis-core-backend/src/domain/skills/application/strategies/skill-share-authorization.strategy.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { ShareAuthorizationStrategy } from 'src/domain/shares/application/ports/share-authorization-strategy.port';
 import { SkillRepository } from '../ports/skill.repository';
@@ -9,9 +10,9 @@ import { SkillRepository } from '../ports/skill.repository';
  */
 @Injectable()
 export class SkillShareAuthorizationStrategy implements ShareAuthorizationStrategy {
-  private readonly logger = new Logger(SkillShareAuthorizationStrategy.name);
-
   constructor(
+    @InjectPinoLogger(SkillShareAuthorizationStrategy.name)
+    private readonly logger: PinoLogger,
     @Inject(SkillRepository)
     private readonly skillRepository: SkillRepository,
   ) {}
@@ -21,7 +22,7 @@ export class SkillShareAuthorizationStrategy implements ShareAuthorizationStrate
    * User must own the skill to view its shares.
    */
   async canViewShares(skillId: UUID, userId: UUID): Promise<boolean> {
-    this.logger.log('canViewShares', { skillId, userId });
+    this.logger.info({ skillId, userId }, 'canViewShares');
 
     const skill = await this.skillRepository.findOne(skillId, userId);
     return skill !== null;
@@ -32,7 +33,7 @@ export class SkillShareAuthorizationStrategy implements ShareAuthorizationStrate
    * User must own the skill to create shares for it.
    */
   async canCreateShare(skillId: UUID, userId: UUID): Promise<boolean> {
-    this.logger.log('canCreateShare', { skillId, userId });
+    this.logger.info({ skillId, userId }, 'canCreateShare');
 
     const skill = await this.skillRepository.findOne(skillId, userId);
     return skill !== null;
@@ -43,7 +44,7 @@ export class SkillShareAuthorizationStrategy implements ShareAuthorizationStrate
    * For skill shares, this is handled at the share level by checking ownerId.
    */
   canDeleteShare(shareId: UUID, userId: UUID): Promise<boolean> {
-    this.logger.log('canDeleteShare', { shareId, userId });
+    this.logger.info({ shareId, userId }, 'canDeleteShare');
 
     return Promise.resolve(true);
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/add-file-source-to-skill/add-file-source-to-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/add-file-source-to-skill/add-file-source-to-skill.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import * as fs from 'fs';
 import { randomUUID } from 'crypto';
 import type { UUID } from 'crypto';
@@ -68,6 +69,7 @@ describe('AddFileSourceToSkillUseCase', () => {
     } as unknown as ContextService;
 
     useCase = new AddFileSourceToSkillUseCase(
+      createPinoLoggerMock(),
       skillRepository,
       addSourceToSkill,
       startDocumentProcessing,

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/add-file-source-to-skill/add-file-source-to-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/add-file-source-to-skill/add-file-source-to-skill.use-case.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import type { UUID } from 'crypto';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { ContextService } from 'src/common/context/services/context.service';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
@@ -38,9 +39,9 @@ import { AddFileSourceToSkillCommand } from './add-file-source-to-skill.command'
 
 @Injectable()
 export class AddFileSourceToSkillUseCase {
-  private readonly logger = new Logger(AddFileSourceToSkillUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AddFileSourceToSkillUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillRepository: SkillRepository,
     private readonly addSourceToSkillUseCase: AddSourceToSkillUseCase,
     private readonly startDocumentProcessingUseCase: StartDocumentProcessingUseCase,
@@ -51,10 +52,13 @@ export class AddFileSourceToSkillUseCase {
 
   @HandleUnexpectedErrors(UnexpectedSkillError)
   async execute(command: AddFileSourceToSkillCommand): Promise<Skill> {
-    this.logger.log('addFileSourceToSkill', {
-      skillId: command.skillId,
-      fileName: command.file.originalname,
-    });
+    this.logger.info(
+      {
+        skillId: command.skillId,
+        fileName: command.file.originalname,
+      },
+      'addFileSourceToSkill',
+    );
 
     const detectedType = detectFileType(
       command.file.mimetype,
@@ -145,22 +149,29 @@ export class AddFileSourceToSkillUseCase {
       return await this.attachSources(skillId, sources);
     } catch (error) {
       try {
-        const orgId = this.contextService.get('orgId');
-        if (!orgId) throw new UnauthorizedAccessError();
-        await this.deleteSourcesUseCase.execute(
-          new DeleteSourcesCommand(
-            sources.map((source) => source.id),
-            orgId,
-          ),
-        );
+        await this.deleteCreatedSources(sources);
       } catch (cleanupError) {
-        this.logger.error('Failed to delete sources after attach failure', {
-          sourceIds: sources.map((source) => source.id),
-          error: cleanupError as Error,
-        });
+        this.logger.error(
+          {
+            sourceIds: sources.map((source) => source.id),
+            err: cleanupError as Error,
+          },
+          'Failed to delete sources after attach failure',
+        );
       }
       throw error;
     }
+  }
+
+  private async deleteCreatedSources(sources: Source[]): Promise<void> {
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) throw new UnauthorizedAccessError();
+    await this.deleteSourcesUseCase.execute(
+      new DeleteSourcesCommand(
+        sources.map((source) => source.id),
+        orgId,
+      ),
+    );
   }
 
   @Transactional()

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/add-source-to-skill/add-source-to-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/add-source-to-skill/add-source-to-skill.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SkillRepository } from '../../ports/skill.repository';
 import { AddSourceToSkillCommand } from './add-source-to-skill.command';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -14,18 +15,21 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class AddSourceToSkillUseCase {
-  private readonly logger = new Logger(AddSourceToSkillUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AddSourceToSkillUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillRepository: SkillRepository,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(command: AddSourceToSkillCommand): Promise<Skill> {
-    this.logger.log('Adding source to skill', {
-      skillId: command.skillId,
-      sourceId: command.sourceId,
-    });
+    this.logger.info(
+      {
+        skillId: command.skillId,
+        sourceId: command.sourceId,
+      },
+      'Adding source to skill',
+    );
     try {
       const userId = this.contextService.get('userId');
       if (!userId) {
@@ -51,9 +55,12 @@ export class AddSourceToSkillUseCase {
       return await this.skillRepository.update(updatedSkill);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error adding source to skill', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error adding source to skill',
+      );
       throw new UnexpectedSkillError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/assign-knowledge-base-to-skill/assign-knowledge-base-to-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/assign-knowledge-base-to-skill/assign-knowledge-base-to-skill.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 
@@ -7,7 +9,6 @@ jest.mock('@nestjs-cls/transactional', () => ({
       descriptor,
 }));
 
-import { Logger } from '@nestjs/common';
 import { AssignKnowledgeBaseToSkillUseCase } from './assign-knowledge-base-to-skill.use-case';
 import { AssignKnowledgeBaseToSkillCommand } from './assign-knowledge-base-to-skill.command';
 import { SkillRepository } from '../../ports/skill.repository';
@@ -56,6 +57,10 @@ describe('AssignKnowledgeBaseToSkillUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AssignKnowledgeBaseToSkillUseCase,
+        {
+          provide: getLoggerToken(AssignKnowledgeBaseToSkillUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillRepository, useValue: mockSkillRepository },
         {
           provide: GetKnowledgeBasesByIdsUseCase,
@@ -69,9 +74,6 @@ describe('AssignKnowledgeBaseToSkillUseCase', () => {
     skillRepository = module.get(SkillRepository);
     getKnowledgeBasesByIdsUseCase = module.get(GetKnowledgeBasesByIdsUseCase);
     contextService = module.get(ContextService);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/assign-knowledge-base-to-skill/assign-knowledge-base-to-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/assign-knowledge-base-to-skill/assign-knowledge-base-to-skill.use-case.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { AssignKnowledgeBaseToSkillCommand } from './assign-knowledge-base-to-skill.command';
 import { SkillRepository } from '../../ports/skill.repository';
@@ -17,9 +18,9 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 @Injectable()
 export class AssignKnowledgeBaseToSkillUseCase {
-  private readonly logger = new Logger(AssignKnowledgeBaseToSkillUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AssignKnowledgeBaseToSkillUseCase.name)
+    private readonly logger: PinoLogger,
     @Inject(SkillRepository)
     private readonly skillRepository: SkillRepository,
     private readonly getKnowledgeBasesByIdsUseCase: GetKnowledgeBasesByIdsUseCase,
@@ -28,10 +29,13 @@ export class AssignKnowledgeBaseToSkillUseCase {
 
   @Transactional()
   async execute(command: AssignKnowledgeBaseToSkillCommand): Promise<Skill> {
-    this.logger.log('Assigning knowledge base to skill', {
-      skillId: command.skillId,
-      knowledgeBaseId: command.knowledgeBaseId,
-    });
+    this.logger.info(
+      {
+        skillId: command.skillId,
+        knowledgeBaseId: command.knowledgeBaseId,
+      },
+      'Assigning knowledge base to skill',
+    );
 
     try {
       const userId = this.contextService.get('userId');
@@ -66,9 +70,12 @@ export class AssignKnowledgeBaseToSkillUseCase {
       return await this.skillRepository.update(updatedSkill);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Unexpected error assigning knowledge base', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error assigning knowledge base',
+      );
       throw new UnexpectedSkillError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/assign-mcp-integration-to-skill/assign-mcp-integration-to-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/assign-mcp-integration-to-skill/assign-mcp-integration-to-skill.use-case.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { AssignMcpIntegrationToSkillCommand } from './assign-mcp-integration-to-skill.command';
 import { SkillRepository } from '../../ports/skill.repository';
@@ -15,12 +16,13 @@ import {
 } from '../../skills.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import type { UUID } from 'crypto';
 
 @Injectable()
 export class AssignMcpIntegrationToSkillUseCase {
-  private readonly logger = new Logger(AssignMcpIntegrationToSkillUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AssignMcpIntegrationToSkillUseCase.name)
+    private readonly logger: PinoLogger,
     @Inject(SkillRepository)
     private readonly skillRepository: SkillRepository,
     @Inject(McpIntegrationsRepositoryPort)
@@ -30,10 +32,13 @@ export class AssignMcpIntegrationToSkillUseCase {
 
   @Transactional()
   async execute(command: AssignMcpIntegrationToSkillCommand): Promise<Skill> {
-    this.logger.log('Assigning MCP integration to skill', {
-      skillId: command.skillId,
-      integrationId: command.integrationId,
-    });
+    this.logger.info(
+      {
+        skillId: command.skillId,
+        integrationId: command.integrationId,
+      },
+      'Assigning MCP integration to skill',
+    );
 
     try {
       const userId = this.contextService.get('userId');
@@ -47,22 +52,7 @@ export class AssignMcpIntegrationToSkillUseCase {
         throw new SkillNotFoundError(command.skillId);
       }
 
-      const integration = await this.mcpIntegrationsRepository.findById(
-        command.integrationId,
-      );
-      if (!integration) {
-        throw new SkillMcpIntegrationNotFoundError(command.integrationId);
-      }
-
-      if (!integration.enabled) {
-        throw new SkillMcpIntegrationDisabledError(command.integrationId);
-      }
-
-      if (integration.orgId !== orgId) {
-        throw new SkillMcpIntegrationWrongOrganizationError(
-          command.integrationId,
-        );
-      }
+      await this.assertIntegrationCanBeAssigned(command.integrationId, orgId);
 
       if (skill.mcpIntegrationIds.includes(command.integrationId)) {
         throw new SkillMcpIntegrationAlreadyAssignedError(
@@ -78,10 +68,30 @@ export class AssignMcpIntegrationToSkillUseCase {
       return await this.skillRepository.update(updatedSkill);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Unexpected error assigning MCP integration', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error assigning MCP integration',
+      );
       throw new UnexpectedSkillError(error);
+    }
+  }
+
+  private async assertIntegrationCanBeAssigned(
+    integrationId: UUID,
+    orgId: UUID | undefined,
+  ): Promise<void> {
+    const integration =
+      await this.mcpIntegrationsRepository.findById(integrationId);
+    if (!integration) {
+      throw new SkillMcpIntegrationNotFoundError(integrationId);
+    }
+    if (!integration.enabled) {
+      throw new SkillMcpIntegrationDisabledError(integrationId);
+    }
+    if (integration.orgId !== orgId) {
+      throw new SkillMcpIntegrationWrongOrganizationError(integrationId);
     }
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/check-knowledge-base-skill-share-access/check-knowledge-base-skill-share-access.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/check-knowledge-base-skill-share-access/check-knowledge-base-skill-share-access.use-case.spec.ts
@@ -1,6 +1,8 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { CheckKnowledgeBaseSkillShareAccessUseCase } from './check-knowledge-base-skill-share-access.use-case';
 import { CheckKnowledgeBaseSkillShareAccessQuery } from './check-knowledge-base-skill-share-access.query';
 import { SkillRepository } from '../../ports/skill.repository';
@@ -24,6 +26,12 @@ describe('CheckKnowledgeBaseSkillShareAccessUseCase', () => {
       providers: [
         CheckKnowledgeBaseSkillShareAccessUseCase,
         {
+          provide: getLoggerToken(
+            CheckKnowledgeBaseSkillShareAccessUseCase.name,
+          ),
+          useValue: createPinoLoggerMock(),
+        },
+        {
           provide: SkillRepository,
           useValue: { findSkillsByKnowledgeBaseAndOwners: jest.fn() },
         },
@@ -37,8 +45,6 @@ describe('CheckKnowledgeBaseSkillShareAccessUseCase', () => {
     useCase = module.get(CheckKnowledgeBaseSkillShareAccessUseCase);
     skillRepository = module.get(SkillRepository);
     findSharesByScopeUseCase = module.get(FindSharesByScopeUseCase);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/check-knowledge-base-skill-share-access/check-knowledge-base-skill-share-access.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/check-knowledge-base-skill-share-access/check-knowledge-base-skill-share-access.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { FindSharesByScopeUseCase } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.use-case';
 import { FindSharesByScopeQuery } from 'src/domain/shares/application/use-cases/find-shares-by-scope/find-shares-by-scope.query';
@@ -15,11 +16,9 @@ import { CheckKnowledgeBaseSkillShareAccessQuery } from './check-knowledge-base-
  */
 @Injectable()
 export class CheckKnowledgeBaseSkillShareAccessUseCase {
-  private readonly logger = new Logger(
-    CheckKnowledgeBaseSkillShareAccessUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(CheckKnowledgeBaseSkillShareAccessUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillRepository: SkillRepository,
     private readonly findSharesByScopeUseCase: FindSharesByScopeUseCase,
   ) {}
@@ -28,9 +27,12 @@ export class CheckKnowledgeBaseSkillShareAccessUseCase {
   async execute(
     query: CheckKnowledgeBaseSkillShareAccessQuery,
   ): Promise<boolean> {
-    this.logger.log('checkKnowledgeBaseSkillShareAccess', {
-      knowledgeBaseId: query.knowledgeBaseId,
-    });
+    this.logger.info(
+      {
+        knowledgeBaseId: query.knowledgeBaseId,
+      },
+      'checkKnowledgeBaseSkillShareAccess',
+    );
 
     const ownerSkills =
       await this.skillRepository.findSkillsByKnowledgeBaseAndOwners(

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { CreateSkillWithUniqueNameUseCase } from './create-skill-with-unique-name.use-case';
 import { CreateSkillWithUniqueNameCommand } from './create-skill-with-unique-name.command';
 import type { SkillRepository } from '../../ports/skill.repository';
@@ -22,7 +23,10 @@ describe('CreateSkillWithUniqueNameUseCase', () => {
       findByNameAndOwner: jest.fn().mockResolvedValue(null),
     } as unknown as jest.Mocked<SkillRepository>;
 
-    useCase = new CreateSkillWithUniqueNameUseCase(skillRepository);
+    useCase = new CreateSkillWithUniqueNameUseCase(
+      createPinoLoggerMock(),
+      skillRepository,
+    );
   });
 
   it('should create and activate a skill with the given name when no collision exists', async () => {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill-with-unique-name/create-skill-with-unique-name.use-case.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SkillRepository } from '../../ports/skill.repository';
 import { CreateSkillWithUniqueNameCommand } from './create-skill-with-unique-name.command';
 import { Skill } from 'src/domain/skills/domain/skill.entity';
@@ -9,18 +10,21 @@ const MAX_NAME_RESOLUTION_ATTEMPTS = 100;
 
 @Injectable()
 export class CreateSkillWithUniqueNameUseCase {
-  private readonly logger = new Logger(CreateSkillWithUniqueNameUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateSkillWithUniqueNameUseCase.name)
+    private readonly logger: PinoLogger,
     @Inject(SkillRepository)
     private readonly skillRepository: SkillRepository,
   ) {}
 
   async execute(command: CreateSkillWithUniqueNameCommand): Promise<Skill> {
-    this.logger.log('Creating skill with unique name resolution', {
-      baseName: command.name,
-      userId: command.userId,
-    });
+    this.logger.info(
+      {
+        name: command.name,
+        userId: command.userId,
+      },
+      'Creating skill with unique name resolution',
+    );
 
     const name = await this.resolveUniqueName(command.name, command.userId);
 
@@ -44,13 +48,16 @@ export class CreateSkillWithUniqueNameUseCase {
       await this.skillRepository.pinSkill(created.id, command.userId);
     }
 
-    this.logger.debug('Skill created', {
-      skillId: created.id,
-      name: created.name,
-      userId: command.userId,
-      isActive: command.isActive,
-      isPinned: command.isPinned,
-    });
+    this.logger.debug(
+      {
+        skillId: created.id,
+        name: created.name,
+        userId: command.userId,
+        isActive: command.isActive,
+        isPinned: command.isPinned,
+      },
+      'Skill created',
+    );
 
     return created;
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill/create-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill/create-skill.use-case.spec.ts
@@ -1,6 +1,8 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { CreateSkillUseCase } from './create-skill.use-case';
 import { CreateSkillCommand } from './create-skill.command';
 import { SkillRepository } from '../../ports/skill.repository';
@@ -32,6 +34,10 @@ describe('CreateSkillUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateSkillUseCase,
+        {
+          provide: getLoggerToken(CreateSkillUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillRepository, useValue: mockSkillRepository },
         { provide: ContextService, useValue: mockContextService },
       ],
@@ -39,9 +45,6 @@ describe('CreateSkillUseCase', () => {
 
     useCase = module.get<CreateSkillUseCase>(CreateSkillUseCase);
     skillRepository = module.get(SkillRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill/create-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/create-skill/create-skill.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SkillRepository } from '../../ports/skill.repository';
 import { CreateSkillCommand } from './create-skill.command';
 import { Skill } from 'src/domain/skills/domain/skill.entity';
@@ -13,15 +14,15 @@ import { InvalidSkillNameError } from 'src/domain/skills/domain/skill.entity';
 
 @Injectable()
 export class CreateSkillUseCase {
-  private readonly logger = new Logger(CreateSkillUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateSkillUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillRepository: SkillRepository,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(command: CreateSkillCommand): Promise<Skill> {
-    this.logger.log('Creating skill', { name: command.name });
+    this.logger.info({ name: command.name }, 'Creating skill');
     try {
       const userId = this.contextService.get('userId');
       if (!userId) {
@@ -57,7 +58,7 @@ export class CreateSkillUseCase {
         error instanceof InvalidSkillNameError
       )
         throw error;
-      this.logger.error('Error creating skill', { error: error as Error });
+      this.logger.error({ err: error as Error }, 'Error creating skill');
       throw new UnexpectedSkillError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/delete-skill/delete-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/delete-skill/delete-skill.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 
@@ -8,7 +10,6 @@ jest.mock('@nestjs-cls/transactional', () => ({
       descriptor,
 }));
 
-import { Logger } from '@nestjs/common';
 import { DeleteSkillUseCase } from './delete-skill.use-case';
 import { DeleteSkillCommand } from './delete-skill.command';
 import { SkillRepository } from '../../ports/skill.repository';
@@ -40,6 +41,10 @@ describe('DeleteSkillUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeleteSkillUseCase,
+        {
+          provide: getLoggerToken(DeleteSkillUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillRepository, useValue: mockSkillRepository },
         { provide: ContextService, useValue: mockContextService },
       ],
@@ -47,9 +52,6 @@ describe('DeleteSkillUseCase', () => {
 
     useCase = module.get<DeleteSkillUseCase>(DeleteSkillUseCase);
     skillRepository = module.get(SkillRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/delete-skill/delete-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/delete-skill/delete-skill.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { SkillRepository } from '../../ports/skill.repository';
 import { DeleteSkillCommand } from './delete-skill.command';
@@ -9,16 +10,16 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class DeleteSkillUseCase {
-  private readonly logger = new Logger(DeleteSkillUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteSkillUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillRepository: SkillRepository,
     private readonly contextService: ContextService,
   ) {}
 
   @Transactional()
   async execute(command: DeleteSkillCommand): Promise<void> {
-    this.logger.log('Deleting skill', { skillId: command.skillId });
+    this.logger.info({ skillId: command.skillId }, 'Deleting skill');
     try {
       const userId = this.contextService.get('userId');
       if (!userId) {
@@ -33,7 +34,7 @@ export class DeleteSkillUseCase {
       await this.skillRepository.delete(command.skillId, userId);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error deleting skill', { error: error as Error });
+      this.logger.error({ err: error as Error }, 'Error deleting skill');
       throw new UnexpectedSkillError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/find-active-skills/find-active-skills.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/find-active-skills/find-active-skills.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SkillRepository } from '../../ports/skill.repository';
 import { FindActiveSkillsQuery } from './find-active-skills.query';
 import { Skill } from 'src/domain/skills/domain/skill.entity';
@@ -14,16 +15,16 @@ import { UUID } from 'crypto';
 
 @Injectable()
 export class FindActiveSkillsUseCase {
-  private readonly logger = new Logger(FindActiveSkillsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindActiveSkillsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillRepository: SkillRepository,
     private readonly findSharesByScopeUseCase: FindSharesByScopeUseCase,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(query: FindActiveSkillsQuery): Promise<Skill[]> {
-    this.logger.log('Finding active skills', query);
+    this.logger.info(query, 'Finding active skills');
     try {
       const userId = this.contextService.get('userId');
       if (!userId) {
@@ -75,9 +76,12 @@ export class FindActiveSkillsUseCase {
       return [...ownedActiveSkills, ...sharedActiveSkills];
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding active skills', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error finding active skills',
+      );
       throw new UnexpectedSkillError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/find-all-skills/find-all-skills.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/find-all-skills/find-all-skills.use-case.spec.ts
@@ -1,6 +1,8 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { FindAllSkillsUseCase } from './find-all-skills.use-case';
 import { FindAllSkillsQuery } from './find-all-skills.query';
 import { SkillRepository } from '../../ports/skill.repository';
@@ -67,6 +69,10 @@ describe('FindAllSkillsUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FindAllSkillsUseCase,
+        {
+          provide: getLoggerToken(FindAllSkillsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillRepository, useValue: mockSkillRepository },
         {
           provide: FindSharesByScopeUseCase,
@@ -79,10 +85,6 @@ describe('FindAllSkillsUseCase', () => {
     useCase = module.get<FindAllSkillsUseCase>(FindAllSkillsUseCase);
     skillRepository = module.get(SkillRepository);
     findSharesByScopeUseCase = module.get(FindSharesByScopeUseCase);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/find-all-skills/find-all-skills.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/find-all-skills/find-all-skills.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { SkillRepository } from '../../ports/skill.repository';
 import { FindAllSkillsQuery } from './find-all-skills.query';
@@ -32,16 +33,16 @@ export interface FindAllSkillsResult {
  */
 @Injectable()
 export class FindAllSkillsUseCase {
-  private readonly logger = new Logger(FindAllSkillsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindAllSkillsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillRepository: SkillRepository,
     private readonly findSharesByScopeUseCase: FindSharesByScopeUseCase,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(query: FindAllSkillsQuery): Promise<FindAllSkillsResult> {
-    this.logger.log('Finding all skills', query);
+    this.logger.info(query, 'Finding all skills');
 
     const userId = this.contextService.get('userId');
     if (!userId) {
@@ -61,16 +62,19 @@ export class FindAllSkillsUseCase {
 
     const ownedSkillIds = ownedSkills.map((s) => s.id);
 
-    this.logger.debug('Found owned skills', { count: ownedSkills.length });
+    this.logger.debug({ count: ownedSkills.length }, 'Found owned skills');
 
     // 2. Extract shared skill IDs and deduplicate against owned
     const sharedSkillIds = shares
       .map((s) => (s as SkillShare).skillId)
       .filter((id) => !ownedSkillIds.includes(id));
 
-    this.logger.debug('Found shared skills after deduplication', {
-      count: sharedSkillIds.length,
-    });
+    this.logger.debug(
+      {
+        count: sharedSkillIds.length,
+      },
+      'Found shared skills after deduplication',
+    );
 
     // 3. Fetch shared skills
     const sharedSkills =

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/find-one-skill/find-one-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/find-one-skill/find-one-skill.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SkillRepository } from '../../ports/skill.repository';
 import { FindOneSkillQuery } from './find-one-skill.query';
 import { Skill } from 'src/domain/skills/domain/skill.entity';
@@ -19,16 +20,16 @@ export interface SkillWithUserContext {
 
 @Injectable()
 export class FindOneSkillUseCase {
-  private readonly logger = new Logger(FindOneSkillUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindOneSkillUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillRepository: SkillRepository,
     private readonly findShareByEntityUseCase: FindShareByEntityUseCase,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(query: FindOneSkillQuery): Promise<SkillWithUserContext> {
-    this.logger.log('Finding skill', { id: query.id });
+    this.logger.info({ id: query.id }, 'Finding skill');
     try {
       const userId = this.contextService.get('userId');
       if (!userId) {
@@ -69,7 +70,7 @@ export class FindOneSkillUseCase {
       throw new SkillNotFoundError(query.id);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding skill', { error: error as Error });
+      this.logger.error({ err: error as Error }, 'Error finding skill');
       throw new UnexpectedSkillError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/find-skill-by-name/find-skill-by-name.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/find-skill-by-name/find-skill-by-name.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { FindSkillByNameUseCase } from './find-skill-by-name.use-case';
 import { FindSkillByNameQuery } from './find-skill-by-name.query';
 import type { SkillRepository } from '../../ports/skill.repository';
@@ -52,6 +53,7 @@ describe('FindSkillByNameUseCase', () => {
     } as unknown as jest.Mocked<ContextService>;
 
     useCase = new FindSkillByNameUseCase(
+      createPinoLoggerMock(),
       skillRepository,
       findSharesByScopeUseCase,
       contextService,

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/find-skill-by-name/find-skill-by-name.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/find-skill-by-name/find-skill-by-name.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SkillRepository } from '../../ports/skill.repository';
 import { FindSkillByNameQuery } from './find-skill-by-name.query';
 import { Skill } from 'src/domain/skills/domain/skill.entity';
@@ -13,16 +14,16 @@ import { SkillShare } from 'src/domain/shares/domain/share.entity';
 
 @Injectable()
 export class FindSkillByNameUseCase {
-  private readonly logger = new Logger(FindSkillByNameUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindSkillByNameUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillRepository: SkillRepository,
     private readonly findSharesByScopeUseCase: FindSharesByScopeUseCase,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(query: FindSkillByNameQuery): Promise<Skill> {
-    this.logger.log('Finding skill by name', { name: query.name });
+    this.logger.info({ name: query.name }, 'Finding skill by name');
     try {
       const userId = this.contextService.get('userId');
       if (!userId) {
@@ -58,9 +59,12 @@ export class FindSkillByNameUseCase {
       throw new SkillNotFoundError(query.name);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error finding skill by name', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error finding skill by name',
+      );
       throw new UnexpectedSkillError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/install-skill-from-marketplace/install-skill-from-marketplace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/install-skill-from-marketplace/install-skill-from-marketplace.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { InstallSkillFromMarketplaceUseCase } from './install-skill-from-marketplace.use-case';
 import { InstallSkillFromMarketplaceCommand } from './install-skill-from-marketplace.command';
 import type { ContextService } from 'src/common/context/services/context.service';
@@ -52,6 +53,7 @@ describe('InstallSkillFromMarketplaceUseCase', () => {
     } as unknown as jest.Mocked<EventEmitter2>;
 
     useCase = new InstallSkillFromMarketplaceUseCase(
+      createPinoLoggerMock(),
       skillInstallationService,
       contextService,
       eventEmitter,

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/install-skill-from-marketplace/install-skill-from-marketplace.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/install-skill-from-marketplace/install-skill-from-marketplace.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Skill } from 'src/domain/skills/domain/skill.entity';
 import { InstallSkillFromMarketplaceCommand } from './install-skill-from-marketplace.command';
@@ -10,16 +11,16 @@ import { MarketplaceSkillInstalledEvent } from '../../events/marketplace-skill-i
 
 @Injectable()
 export class InstallSkillFromMarketplaceUseCase {
-  private readonly logger = new Logger(InstallSkillFromMarketplaceUseCase.name);
-
   constructor(
+    @InjectPinoLogger(InstallSkillFromMarketplaceUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillInstallationService: MarketplaceSkillInstallationService,
     private readonly contextService: ContextService,
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(command: InstallSkillFromMarketplaceCommand): Promise<Skill> {
-    this.logger.log('execute', { identifier: command.identifier });
+    this.logger.info({ identifier: command.identifier }, 'execute');
 
     const userId = this.contextService.get('userId');
     const orgId = this.contextService.get('orgId');
@@ -40,11 +41,14 @@ export class InstallSkillFromMarketplaceUseCase {
           new MarketplaceSkillInstalledEvent(userId, orgId, identifier),
         )
         .catch((err: unknown) => {
-          this.logger.error('Failed to emit MarketplaceSkillInstalledEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            identifier,
-            userId,
-          });
+          this.logger.error(
+            {
+              err: err as Error,
+              identifier,
+              userId,
+            },
+            'Failed to emit MarketplaceSkillInstalledEvent',
+          );
         });
 
       return skill;
@@ -52,11 +56,14 @@ export class InstallSkillFromMarketplaceUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Failed to install marketplace skill', {
-        identifier: command.identifier,
-        userId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          identifier: command.identifier,
+          userId,
+          err: error as Error,
+        },
+        'Failed to install marketplace skill',
+      );
       throw new MarketplaceInstallFailedError(command.identifier);
     }
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-knowledge-bases/list-skill-knowledge-bases.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-knowledge-bases/list-skill-knowledge-bases.use-case.spec.ts
@@ -1,6 +1,8 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+
 import { ListSkillKnowledgeBasesUseCase } from './list-skill-knowledge-bases.use-case';
 import { ListSkillKnowledgeBasesQuery } from './list-skill-knowledge-bases.query';
 import { GetKnowledgeBasesByIdsUseCase } from 'src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.use-case';
@@ -26,6 +28,10 @@ describe('ListSkillKnowledgeBasesUseCase', () => {
       providers: [
         ListSkillKnowledgeBasesUseCase,
         {
+          provide: getLoggerToken(ListSkillKnowledgeBasesUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
+        {
           provide: GetKnowledgeBasesByIdsUseCase,
           useValue: { execute: jest.fn() },
         },
@@ -39,9 +45,6 @@ describe('ListSkillKnowledgeBasesUseCase', () => {
     useCase = module.get(ListSkillKnowledgeBasesUseCase);
     getKnowledgeBasesByIdsUseCase = module.get(GetKnowledgeBasesByIdsUseCase);
     skillAccessService = module.get(SkillAccessService);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-knowledge-bases/list-skill-knowledge-bases.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-knowledge-bases/list-skill-knowledge-bases.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ListSkillKnowledgeBasesQuery } from './list-skill-knowledge-bases.query';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
 import { GetKnowledgeBasesByIdsUseCase } from 'src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.use-case';
@@ -9,17 +10,20 @@ import { SkillAccessService } from '../../services/skill-access.service';
 
 @Injectable()
 export class ListSkillKnowledgeBasesUseCase {
-  private readonly logger = new Logger(ListSkillKnowledgeBasesUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ListSkillKnowledgeBasesUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly getKnowledgeBasesByIdsUseCase: GetKnowledgeBasesByIdsUseCase,
     private readonly skillAccessService: SkillAccessService,
   ) {}
 
   async execute(query: ListSkillKnowledgeBasesQuery): Promise<KnowledgeBase[]> {
-    this.logger.log('Listing knowledge bases for skill', {
-      skillId: query.skillId,
-    });
+    this.logger.info(
+      {
+        skillId: query.skillId,
+      },
+      'Listing knowledge bases for skill',
+    );
 
     try {
       const skill = await this.skillAccessService.findAccessibleSkill(
@@ -37,9 +41,12 @@ export class ListSkillKnowledgeBasesUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Unexpected error listing skill knowledge bases', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error listing skill knowledge bases',
+      );
       throw new UnexpectedSkillError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-mcp-integrations/list-skill-mcp-integrations.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-mcp-integrations/list-skill-mcp-integrations.use-case.spec.ts
@@ -1,6 +1,8 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger, UnauthorizedException } from '@nestjs/common';
+import { UnauthorizedException } from '@nestjs/common';
 import { ListSkillMcpIntegrationsUseCase } from './list-skill-mcp-integrations.use-case';
 import { ListSkillMcpIntegrationsQuery } from './list-skill-mcp-integrations.query';
 import { SkillRepository } from '../../ports/skill.repository';
@@ -70,6 +72,10 @@ describe('ListSkillMcpIntegrationsUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ListSkillMcpIntegrationsUseCase,
+        {
+          provide: getLoggerToken(ListSkillMcpIntegrationsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillRepository, useValue: mockSkillRepository },
         {
           provide: GetMcpIntegrationsByIdsUseCase,
@@ -88,9 +94,6 @@ describe('ListSkillMcpIntegrationsUseCase', () => {
     getMcpIntegrationsByIdsUseCase = module.get(GetMcpIntegrationsByIdsUseCase);
     contextService = module.get(ContextService);
     findShareByEntityUseCase = module.get(FindShareByEntityUseCase);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-mcp-integrations/list-skill-mcp-integrations.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-mcp-integrations/list-skill-mcp-integrations.use-case.ts
@@ -1,9 +1,5 @@
-import {
-  Inject,
-  Injectable,
-  Logger,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { ListSkillMcpIntegrationsQuery } from './list-skill-mcp-integrations.query';
 import { SkillRepository } from '../../ports/skill.repository';
@@ -20,9 +16,9 @@ import { Skill } from '../../../domain/skill.entity';
 
 @Injectable()
 export class ListSkillMcpIntegrationsUseCase {
-  private readonly logger = new Logger(ListSkillMcpIntegrationsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ListSkillMcpIntegrationsUseCase.name)
+    private readonly logger: PinoLogger,
     @Inject(SkillRepository)
     private readonly skillRepository: SkillRepository,
     private readonly getMcpIntegrationsByIdsUseCase: GetMcpIntegrationsByIdsUseCase,
@@ -33,9 +29,12 @@ export class ListSkillMcpIntegrationsUseCase {
   async execute(
     query: ListSkillMcpIntegrationsQuery,
   ): Promise<McpIntegration[]> {
-    this.logger.log('Listing MCP integrations for skill', {
-      skillId: query.skillId,
-    });
+    this.logger.info(
+      {
+        skillId: query.skillId,
+      },
+      'Listing MCP integrations for skill',
+    );
 
     try {
       const userId = this.contextService.get('userId');
@@ -62,9 +61,12 @@ export class ListSkillMcpIntegrationsUseCase {
       ) {
         throw error;
       }
-      this.logger.error('Unexpected error listing skill MCP integrations', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error listing skill MCP integrations',
+      );
       throw new UnexpectedSkillError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-sources/list-skill-sources.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-sources/list-skill-sources.use-case.spec.ts
@@ -1,6 +1,8 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger, UnauthorizedException } from '@nestjs/common';
+import { UnauthorizedException } from '@nestjs/common';
 import { ListSkillSourcesUseCase } from './list-skill-sources.use-case';
 import { ListSkillSourcesQuery } from './list-skill-sources.query';
 import { SkillRepository } from '../../ports/skill.repository';
@@ -68,6 +70,10 @@ describe('ListSkillSourcesUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ListSkillSourcesUseCase,
+        {
+          provide: getLoggerToken(ListSkillSourcesUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillRepository, useValue: mockSkillRepository },
         {
           provide: GetSourcesByIdsUseCase,
@@ -86,9 +92,6 @@ describe('ListSkillSourcesUseCase', () => {
     getSourcesByIdsUseCase = module.get(GetSourcesByIdsUseCase);
     contextService = module.get(ContextService);
     findShareByEntityUseCase = module.get(FindShareByEntityUseCase);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-sources/list-skill-sources.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/list-skill-sources/list-skill-sources.use-case.ts
@@ -1,9 +1,5 @@
-import {
-  Inject,
-  Injectable,
-  Logger,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { ListSkillSourcesQuery } from './list-skill-sources.query';
 import { SkillRepository } from '../../ports/skill.repository';
@@ -20,9 +16,9 @@ import { Skill } from '../../../domain/skill.entity';
 
 @Injectable()
 export class ListSkillSourcesUseCase {
-  private readonly logger = new Logger(ListSkillSourcesUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ListSkillSourcesUseCase.name)
+    private readonly logger: PinoLogger,
     @Inject(SkillRepository)
     private readonly skillRepository: SkillRepository,
     private readonly getSourcesByIdsUseCase: GetSourcesByIdsUseCase,
@@ -31,7 +27,7 @@ export class ListSkillSourcesUseCase {
   ) {}
 
   async execute(query: ListSkillSourcesQuery): Promise<Source[]> {
-    this.logger.log('Listing sources for skill', { skillId: query.skillId });
+    this.logger.info({ skillId: query.skillId }, 'Listing sources for skill');
 
     try {
       const userId = this.contextService.get('userId');
@@ -58,9 +54,12 @@ export class ListSkillSourcesUseCase {
       ) {
         throw error;
       }
-      this.logger.error('Unexpected error listing skill sources', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error listing skill sources',
+      );
       throw new UnexpectedSkillError(error);
     }
   }
@@ -70,19 +69,17 @@ export class ListSkillSourcesUseCase {
     userId: UUID,
   ): Promise<Skill | null> {
     const ownedSkill = await this.skillRepository.findOne(skillId, userId);
-    if (ownedSkill) {
-      return ownedSkill;
-    }
+    return ownedSkill ?? this.findSharedSkill(skillId);
+  }
 
+  private async findSharedSkill(skillId: UUID): Promise<Skill | null> {
     const share = await this.findShareByEntityUseCase.execute(
       new FindShareByEntityQuery(SharedEntityType.SKILL, skillId),
     );
-
-    if (share) {
-      const skills = await this.skillRepository.findByIds([skillId]);
-      return skills.length > 0 ? skills[0] : null;
+    if (!share) {
+      return null;
     }
-
-    return null;
+    const skills = await this.skillRepository.findByIds([skillId]);
+    return skills[0] ?? null;
   }
 }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/remove-source-from-skill/remove-source-from-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/remove-source-from-skill/remove-source-from-skill.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { SkillRepository } from '../../ports/skill.repository';
 import { RemoveSourceFromSkillCommand } from './remove-source-from-skill.command';
@@ -11,9 +12,9 @@ import { DeleteSourceCommand } from 'src/domain/sources/application/use-cases/de
 
 @Injectable()
 export class RemoveSourceFromSkillUseCase {
-  private readonly logger = new Logger(RemoveSourceFromSkillUseCase.name);
-
   constructor(
+    @InjectPinoLogger(RemoveSourceFromSkillUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillRepository: SkillRepository,
     private readonly contextService: ContextService,
     private readonly deleteSourceUseCase: DeleteSourceUseCase,
@@ -21,10 +22,13 @@ export class RemoveSourceFromSkillUseCase {
 
   @Transactional()
   async execute(command: RemoveSourceFromSkillCommand): Promise<void> {
-    this.logger.log('Removing source from skill', {
-      skillId: command.skillId,
-      sourceId: command.sourceId,
-    });
+    this.logger.info(
+      {
+        skillId: command.skillId,
+        sourceId: command.sourceId,
+      },
+      'Removing source from skill',
+    );
     try {
       const userId = this.contextService.get('userId');
       const orgId = this.contextService.get('orgId');
@@ -57,9 +61,12 @@ export class RemoveSourceFromSkillUseCase {
       ) {
         throw error;
       }
-      this.logger.error('Error removing source from skill', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error removing source from skill',
+      );
       throw new UnexpectedSkillError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/toggle-skill-active/toggle-skill-active.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/toggle-skill-active/toggle-skill-active.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 
@@ -8,7 +10,6 @@ jest.mock('@nestjs-cls/transactional', () => ({
       descriptor,
 }));
 
-import { Logger } from '@nestjs/common';
 import { ToggleSkillActiveUseCase } from './toggle-skill-active.use-case';
 import { ToggleSkillActiveCommand } from './toggle-skill-active.command';
 import { SkillRepository } from '../../ports/skill.repository';
@@ -63,6 +64,10 @@ describe('ToggleSkillActiveUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ToggleSkillActiveUseCase,
+        {
+          provide: getLoggerToken(ToggleSkillActiveUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillRepository, useValue: mockSkillRepository },
         { provide: SkillAccessService, useValue: mockSkillAccessService },
         { provide: ContextService, useValue: mockContextService },
@@ -72,9 +77,6 @@ describe('ToggleSkillActiveUseCase', () => {
     useCase = module.get<ToggleSkillActiveUseCase>(ToggleSkillActiveUseCase);
     skillRepository = module.get(SkillRepository);
     skillAccessService = module.get(SkillAccessService);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/toggle-skill-active/toggle-skill-active.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/toggle-skill-active/toggle-skill-active.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { SkillRepository } from '../../ports/skill.repository';
 import { ToggleSkillActiveCommand } from './toggle-skill-active.command';
@@ -10,9 +11,9 @@ import { SkillAccessService } from '../../services/skill-access.service';
 
 @Injectable()
 export class ToggleSkillActiveUseCase {
-  private readonly logger = new Logger(ToggleSkillActiveUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ToggleSkillActiveUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillRepository: SkillRepository,
     private readonly skillAccessService: SkillAccessService,
     private readonly contextService: ContextService,
@@ -25,7 +26,7 @@ export class ToggleSkillActiveUseCase {
     isPinned: boolean;
     isShared: boolean;
   }> {
-    this.logger.log('Toggling skill active', { skillId: command.skillId });
+    this.logger.info({ skillId: command.skillId }, 'Toggling skill active');
     try {
       // findAccessibleSkill validates userId and throws UnauthorizedAccessError
       const skill = await this.skillAccessService.findAccessibleSkill(
@@ -57,9 +58,12 @@ export class ToggleSkillActiveUseCase {
       return { skill, isActive, isPinned, isShared };
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error toggling skill active', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error toggling skill active',
+      );
       throw new UnexpectedSkillError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/toggle-skill-pinned/toggle-skill-pinned.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/toggle-skill-pinned/toggle-skill-pinned.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 
@@ -8,7 +10,6 @@ jest.mock('@nestjs-cls/transactional', () => ({
       descriptor,
 }));
 
-import { Logger } from '@nestjs/common';
 import { ToggleSkillPinnedUseCase } from './toggle-skill-pinned.use-case';
 import { ToggleSkillPinnedCommand } from './toggle-skill-pinned.command';
 import { SkillRepository } from '../../ports/skill.repository';
@@ -62,6 +63,10 @@ describe('ToggleSkillPinnedUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ToggleSkillPinnedUseCase,
+        {
+          provide: getLoggerToken(ToggleSkillPinnedUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillRepository, useValue: mockSkillRepository },
         { provide: SkillAccessService, useValue: mockSkillAccessService },
         { provide: ContextService, useValue: mockContextService },
@@ -71,9 +76,6 @@ describe('ToggleSkillPinnedUseCase', () => {
     useCase = module.get<ToggleSkillPinnedUseCase>(ToggleSkillPinnedUseCase);
     skillRepository = module.get(SkillRepository);
     skillAccessService = module.get(SkillAccessService);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/toggle-skill-pinned/toggle-skill-pinned.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/toggle-skill-pinned/toggle-skill-pinned.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { SkillRepository } from '../../ports/skill.repository';
 import { ToggleSkillPinnedCommand } from './toggle-skill-pinned.command';
@@ -10,9 +11,9 @@ import { SkillAccessService } from '../../services/skill-access.service';
 
 @Injectable()
 export class ToggleSkillPinnedUseCase {
-  private readonly logger = new Logger(ToggleSkillPinnedUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ToggleSkillPinnedUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillRepository: SkillRepository,
     private readonly skillAccessService: SkillAccessService,
     private readonly contextService: ContextService,
@@ -22,7 +23,7 @@ export class ToggleSkillPinnedUseCase {
   async execute(
     command: ToggleSkillPinnedCommand,
   ): Promise<{ skill: Skill; isPinned: boolean; isShared: boolean }> {
-    this.logger.log('Toggling skill pinned', { skillId: command.skillId });
+    this.logger.info({ skillId: command.skillId }, 'Toggling skill pinned');
     try {
       // findAccessibleSkill validates userId and throws UnauthorizedAccessError
       const skill = await this.skillAccessService.findAccessibleSkill(
@@ -53,9 +54,12 @@ export class ToggleSkillPinnedUseCase {
       return { skill, isPinned, isShared };
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error toggling skill pinned', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error toggling skill pinned',
+      );
       throw new UnexpectedSkillError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/unassign-knowledge-base-from-skill/unassign-knowledge-base-from-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/unassign-knowledge-base-from-skill/unassign-knowledge-base-from-skill.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 
@@ -7,7 +9,6 @@ jest.mock('@nestjs-cls/transactional', () => ({
       descriptor,
 }));
 
-import { Logger } from '@nestjs/common';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { UnassignKnowledgeBaseFromSkillUseCase } from './unassign-knowledge-base-from-skill.use-case';
 import { UnassignKnowledgeBaseFromSkillCommand } from './unassign-knowledge-base-from-skill.command';
@@ -46,6 +47,10 @@ describe('UnassignKnowledgeBaseFromSkillUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UnassignKnowledgeBaseFromSkillUseCase,
+        {
+          provide: getLoggerToken(UnassignKnowledgeBaseFromSkillUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillRepository, useValue: mockSkillRepository },
         { provide: ContextService, useValue: mockContextService },
       ],
@@ -54,9 +59,6 @@ describe('UnassignKnowledgeBaseFromSkillUseCase', () => {
     useCase = module.get(UnassignKnowledgeBaseFromSkillUseCase);
     skillRepository = module.get(SkillRepository);
     contextService = module.get(ContextService);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/unassign-knowledge-base-from-skill/unassign-knowledge-base-from-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/unassign-knowledge-base-from-skill/unassign-knowledge-base-from-skill.use-case.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { SkillRepository } from '../../ports/skill.repository';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -14,11 +15,9 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 @Injectable()
 export class UnassignKnowledgeBaseFromSkillUseCase {
-  private readonly logger = new Logger(
-    UnassignKnowledgeBaseFromSkillUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(UnassignKnowledgeBaseFromSkillUseCase.name)
+    private readonly logger: PinoLogger,
     @Inject(SkillRepository)
     private readonly skillRepository: SkillRepository,
     private readonly contextService: ContextService,
@@ -28,10 +27,13 @@ export class UnassignKnowledgeBaseFromSkillUseCase {
   async execute(
     command: UnassignKnowledgeBaseFromSkillCommand,
   ): Promise<Skill> {
-    this.logger.log('Unassigning knowledge base from skill', {
-      skillId: command.skillId,
-      knowledgeBaseId: command.knowledgeBaseId,
-    });
+    this.logger.info(
+      {
+        skillId: command.skillId,
+        knowledgeBaseId: command.knowledgeBaseId,
+      },
+      'Unassigning knowledge base from skill',
+    );
 
     try {
       const userId = this.contextService.get('userId');
@@ -60,9 +62,12 @@ export class UnassignKnowledgeBaseFromSkillUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Unexpected error unassigning knowledge base', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error unassigning knowledge base',
+      );
       throw new UnexpectedSkillError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/unassign-mcp-integration-from-skill/unassign-mcp-integration-from-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/unassign-mcp-integration-from-skill/unassign-mcp-integration-from-skill.use-case.ts
@@ -1,9 +1,5 @@
-import {
-  Inject,
-  Injectable,
-  Logger,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { SkillRepository } from '../../ports/skill.repository';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -18,11 +14,9 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class UnassignMcpIntegrationFromSkillUseCase {
-  private readonly logger = new Logger(
-    UnassignMcpIntegrationFromSkillUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(UnassignMcpIntegrationFromSkillUseCase.name)
+    private readonly logger: PinoLogger,
     @Inject(SkillRepository)
     private readonly skillRepository: SkillRepository,
     private readonly contextService: ContextService,
@@ -32,10 +26,13 @@ export class UnassignMcpIntegrationFromSkillUseCase {
   async execute(
     command: UnassignMcpIntegrationFromSkillCommand,
   ): Promise<Skill> {
-    this.logger.log('Unassigning MCP integration from skill', {
-      skillId: command.skillId,
-      integrationId: command.integrationId,
-    });
+    this.logger.info(
+      {
+        skillId: command.skillId,
+        integrationId: command.integrationId,
+      },
+      'Unassigning MCP integration from skill',
+    );
 
     try {
       const userId = this.contextService.get('userId');
@@ -67,9 +64,12 @@ export class UnassignMcpIntegrationFromSkillUseCase {
       ) {
         throw error;
       }
-      this.logger.error('Unexpected error unassigning MCP integration', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Unexpected error unassigning MCP integration',
+      );
       throw new UnexpectedSkillError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 
@@ -8,7 +10,6 @@ jest.mock('@nestjs-cls/transactional', () => ({
       descriptor,
 }));
 
-import { Logger } from '@nestjs/common';
 import { UpdateSkillUseCase } from './update-skill.use-case';
 import { UpdateSkillCommand } from './update-skill.command';
 import { SkillRepository } from '../../ports/skill.repository';
@@ -44,6 +45,10 @@ describe('UpdateSkillUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UpdateSkillUseCase,
+        {
+          provide: getLoggerToken(UpdateSkillUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SkillRepository, useValue: mockSkillRepository },
         { provide: ContextService, useValue: mockContextService },
       ],
@@ -51,9 +56,6 @@ describe('UpdateSkillUseCase', () => {
 
     useCase = module.get<UpdateSkillUseCase>(UpdateSkillUseCase);
     skillRepository = module.get(SkillRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.ts
+++ b/ayunis-core-backend/src/domain/skills/application/use-cases/update-skill/update-skill.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { SkillRepository } from '../../ports/skill.repository';
 import { UpdateSkillCommand } from './update-skill.command';
@@ -15,16 +16,16 @@ import { InvalidSkillNameError } from 'src/domain/skills/domain/skill.entity';
 
 @Injectable()
 export class UpdateSkillUseCase {
-  private readonly logger = new Logger(UpdateSkillUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateSkillUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly skillRepository: SkillRepository,
     private readonly contextService: ContextService,
   ) {}
 
   @Transactional()
   async execute(command: UpdateSkillCommand): Promise<Skill> {
-    this.logger.log('Updating skill', { skillId: command.skillId });
+    this.logger.info({ skillId: command.skillId }, 'Updating skill');
     try {
       const userId = this.contextService.get('userId');
       if (!userId) {
@@ -70,7 +71,7 @@ export class UpdateSkillUseCase {
         error instanceof InvalidSkillNameError
       )
         throw error;
-      this.logger.error('Error updating skill', { error: error as Error });
+      this.logger.error({ err: error as Error }, 'Error updating skill');
       throw new UnexpectedSkillError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill.repository.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { EntityManager, Repository } from 'typeorm';
 import type { TransactionHost } from '@nestjs-cls/transactional';
 import type { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
@@ -56,6 +57,7 @@ describe('LocalSkillRepository', () => {
     const mapper = {} as SkillMapper;
 
     repository = new LocalSkillRepository(
+      createPinoLoggerMock(),
       skillRepo,
       activationRepo,
       mapper,

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill.repository.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EntityManager, In, Repository } from 'typeorm';
 import { randomUUID, UUID } from 'crypto';
@@ -23,9 +24,9 @@ const SKILL_RELATIONS = [
 
 @Injectable()
 export class LocalSkillRepository implements SkillRepository {
-  private readonly logger = new Logger(LocalSkillRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalSkillRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(SkillRecord)
     private readonly skillRepository: Repository<SkillRecord>,
     @InjectRepository(SkillActivationRecord)
@@ -68,7 +69,7 @@ export class LocalSkillRepository implements SkillRepository {
   }
 
   async create(skill: Skill): Promise<Skill> {
-    this.logger.log('create', { name: skill.name, userId: skill.userId });
+    this.logger.info({ name: skill.name, userId: skill.userId }, 'create');
 
     const record = this.skillMapper.toRecord(skill);
     const saved = await this.skillRepository.save(record);
@@ -113,7 +114,7 @@ export class LocalSkillRepository implements SkillRepository {
   }
 
   async update(skill: Skill): Promise<Skill> {
-    this.logger.log('update', { id: skill.id, name: skill.name });
+    this.logger.info({ id: skill.id, name: skill.name }, 'update');
 
     const manager = this.getManager();
 
@@ -165,7 +166,7 @@ export class LocalSkillRepository implements SkillRepository {
   }
 
   async delete(skillId: UUID, userId: UUID): Promise<void> {
-    this.logger.log('delete', { skillId, userId });
+    this.logger.info({ skillId, userId }, 'delete');
 
     const result = await this.skillRepository.delete({ id: skillId, userId });
     if (result.affected === 0) {
@@ -174,7 +175,7 @@ export class LocalSkillRepository implements SkillRepository {
   }
 
   async findOne(id: UUID, userId: UUID): Promise<Skill | null> {
-    this.logger.log('findOne', { id, userId });
+    this.logger.info({ id, userId }, 'findOne');
 
     const record = await this.skillRepository.findOne({
       where: { id, userId },
@@ -186,7 +187,7 @@ export class LocalSkillRepository implements SkillRepository {
   }
 
   async findAllByOwner(userId: UUID): Promise<Skill[]> {
-    this.logger.log('findAllByOwner', { userId });
+    this.logger.info({ userId }, 'findAllByOwner');
 
     const records = await this.skillRepository.find({
       where: { userId },
@@ -197,7 +198,7 @@ export class LocalSkillRepository implements SkillRepository {
   }
 
   async findActiveByOwner(userId: UUID): Promise<Skill[]> {
-    this.logger.log('findActiveByOwner', { userId });
+    this.logger.info({ userId }, 'findActiveByOwner');
 
     const activations = await this.activationRepository.find({
       where: { userId },
@@ -216,7 +217,7 @@ export class LocalSkillRepository implements SkillRepository {
   }
 
   async findByNameAndOwner(name: string, userId: UUID): Promise<Skill | null> {
-    this.logger.log('findByNameAndOwner', { name, userId });
+    this.logger.info({ name, userId }, 'findByNameAndOwner');
 
     const record = await this.skillRepository.findOne({
       where: { name, userId },
@@ -228,7 +229,7 @@ export class LocalSkillRepository implements SkillRepository {
   }
 
   async activateSkill(skillId: UUID, userId: UUID): Promise<void> {
-    this.logger.log('activateSkill', { skillId, userId });
+    this.logger.info({ skillId, userId }, 'activateSkill');
 
     const manager = this.getManager();
 
@@ -249,14 +250,14 @@ export class LocalSkillRepository implements SkillRepository {
   }
 
   async deactivateSkill(skillId: UUID, userId: UUID): Promise<void> {
-    this.logger.log('deactivateSkill', { skillId, userId });
+    this.logger.info({ skillId, userId }, 'deactivateSkill');
 
     const manager = this.getManager();
     await manager.delete(SkillActivationRecord, { skillId, userId });
   }
 
   async deactivateAllExceptOwner(skillId: UUID, ownerId: UUID): Promise<void> {
-    this.logger.log('deactivateAllExceptOwner', { skillId, ownerId });
+    this.logger.info({ skillId, ownerId }, 'deactivateAllExceptOwner');
 
     const manager = this.getManager();
     await manager
@@ -273,11 +274,14 @@ export class LocalSkillRepository implements SkillRepository {
     ownerId: UUID,
     retainUserIds: Set<UUID>,
   ): Promise<void> {
-    this.logger.log('deactivateUsersNotInSet', {
-      skillId,
-      ownerId,
-      retainCount: retainUserIds.size,
-    });
+    this.logger.info(
+      {
+        skillId,
+        ownerId,
+        retainCount: retainUserIds.size,
+      },
+      'deactivateUsersNotInSet',
+    );
 
     const manager = this.getManager();
     const keepIds = [ownerId, ...retainUserIds];
@@ -292,7 +296,7 @@ export class LocalSkillRepository implements SkillRepository {
   }
 
   async isSkillActive(skillId: UUID, userId: UUID): Promise<boolean> {
-    this.logger.log('isSkillActive', { skillId, userId });
+    this.logger.info({ skillId, userId }, 'isSkillActive');
 
     const count = await this.activationRepository.count({
       where: { skillId, userId },
@@ -302,7 +306,7 @@ export class LocalSkillRepository implements SkillRepository {
   }
 
   async findByIds(ids: UUID[]): Promise<Skill[]> {
-    this.logger.log('findByIds', { count: ids.length });
+    this.logger.info({ count: ids.length }, 'findByIds');
 
     if (ids.length === 0) return [];
 
@@ -315,7 +319,7 @@ export class LocalSkillRepository implements SkillRepository {
   }
 
   async getActiveSkillIds(userId: UUID): Promise<Set<UUID>> {
-    this.logger.log('getActiveSkillIds', { userId });
+    this.logger.info({ userId }, 'getActiveSkillIds');
 
     const activations = await this.activationRepository.find({
       where: { userId },
@@ -326,7 +330,7 @@ export class LocalSkillRepository implements SkillRepository {
   }
 
   async pinSkill(skillId: UUID, userId: UUID): Promise<void> {
-    this.logger.log('pinSkill', { skillId, userId });
+    this.logger.info({ skillId, userId }, 'pinSkill');
 
     const manager = this.getManager();
     const result = await manager
@@ -345,7 +349,7 @@ export class LocalSkillRepository implements SkillRepository {
   }
 
   async toggleSkillPinned(skillId: UUID, userId: UUID): Promise<boolean> {
-    this.logger.log('toggleSkillPinned', { skillId, userId });
+    this.logger.info({ skillId, userId }, 'toggleSkillPinned');
 
     const manager = this.getManager();
 
@@ -364,7 +368,7 @@ export class LocalSkillRepository implements SkillRepository {
   }
 
   async isSkillPinned(skillId: UUID, userId: UUID): Promise<boolean> {
-    this.logger.log('isSkillPinned', { skillId, userId });
+    this.logger.info({ skillId, userId }, 'isSkillPinned');
 
     const manager = this.getManager();
     const count = await manager.count(SkillActivationRecord, {
@@ -375,7 +379,7 @@ export class LocalSkillRepository implements SkillRepository {
   }
 
   async getPinnedSkillIds(userId: UUID): Promise<Set<UUID>> {
-    this.logger.log('getPinnedSkillIds', { userId });
+    this.logger.info({ userId }, 'getPinnedSkillIds');
 
     const manager = this.getManager();
     const activations = await manager.find(SkillActivationRecord, {
@@ -390,10 +394,13 @@ export class LocalSkillRepository implements SkillRepository {
     knowledgeBaseId: UUID,
     ownerIds: UUID[],
   ): Promise<Skill[]> {
-    this.logger.log('findSkillsByKnowledgeBaseAndOwners', {
-      knowledgeBaseId,
-      ownerCount: ownerIds.length,
-    });
+    this.logger.info(
+      {
+        knowledgeBaseId,
+        ownerCount: ownerIds.length,
+      },
+      'findSkillsByKnowledgeBaseAndOwners',
+    );
 
     if (ownerIds.length === 0) return [];
 
@@ -419,10 +426,13 @@ export class LocalSkillRepository implements SkillRepository {
     knowledgeBaseId: UUID,
     skillIds: UUID[],
   ): Promise<void> {
-    this.logger.log('removeKnowledgeBaseFromSkills', {
-      knowledgeBaseId,
-      skillCount: skillIds.length,
-    });
+    this.logger.info(
+      {
+        knowledgeBaseId,
+        skillCount: skillIds.length,
+      },
+      'removeKnowledgeBaseFromSkills',
+    );
 
     if (skillIds.length === 0) return;
 

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skill-knowledge-bases.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skill-knowledge-bases.controller.ts
@@ -5,10 +5,10 @@ import {
   Delete,
   Param,
   ParseUUIDPipe,
-  Logger,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { AssignKnowledgeBaseToSkillUseCase } from '../../application/use-cases/assign-knowledge-base-to-skill/assign-knowledge-base-to-skill.use-case';
@@ -36,9 +36,9 @@ import { Permission } from 'src/iam/permissions/domain/value-objects/permission.
 @RequireFeature(FeatureFlag.KnowledgeBases)
 @Controller('skills')
 export class SkillKnowledgeBasesController {
-  private readonly logger = new Logger(SkillKnowledgeBasesController.name);
-
   constructor(
+    @InjectPinoLogger(SkillKnowledgeBasesController.name)
+    private readonly logger: PinoLogger,
     private readonly assignKnowledgeBaseToSkillUseCase: AssignKnowledgeBaseToSkillUseCase,
     private readonly unassignKnowledgeBaseFromSkillUseCase: UnassignKnowledgeBaseFromSkillUseCase,
     private readonly listSkillKnowledgeBasesUseCase: ListSkillKnowledgeBasesUseCase,
@@ -78,7 +78,7 @@ export class SkillKnowledgeBasesController {
     @Param('skillId', ParseUUIDPipe) skillId: UUID,
     @Param('knowledgeBaseId', ParseUUIDPipe) knowledgeBaseId: UUID,
   ): Promise<SkillResponseDto> {
-    this.logger.log('assignKnowledgeBase', { skillId, knowledgeBaseId });
+    this.logger.info({ skillId, knowledgeBaseId }, 'assignKnowledgeBase');
 
     const skill = await this.assignKnowledgeBaseToSkillUseCase.execute(
       new AssignKnowledgeBaseToSkillCommand(skillId, knowledgeBaseId),
@@ -120,7 +120,7 @@ export class SkillKnowledgeBasesController {
     @Param('skillId', ParseUUIDPipe) skillId: UUID,
     @Param('knowledgeBaseId', ParseUUIDPipe) knowledgeBaseId: UUID,
   ): Promise<SkillResponseDto> {
-    this.logger.log('unassignKnowledgeBase', { skillId, knowledgeBaseId });
+    this.logger.info({ skillId, knowledgeBaseId }, 'unassignKnowledgeBase');
 
     const skill = await this.unassignKnowledgeBaseFromSkillUseCase.execute(
       new UnassignKnowledgeBaseFromSkillCommand(skillId, knowledgeBaseId),
@@ -151,7 +151,7 @@ export class SkillKnowledgeBasesController {
   async listSkillKnowledgeBases(
     @Param('skillId', ParseUUIDPipe) skillId: UUID,
   ): Promise<KnowledgeBaseResponseDto[]> {
-    this.logger.log('listSkillKnowledgeBases', { skillId });
+    this.logger.info({ skillId }, 'listSkillKnowledgeBases');
 
     const knowledgeBases = await this.listSkillKnowledgeBasesUseCase.execute(
       new ListSkillKnowledgeBasesQuery(skillId),

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skill-mcp-integrations.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skill-mcp-integrations.controller.ts
@@ -5,10 +5,10 @@ import {
   Delete,
   Param,
   ParseUUIDPipe,
-  Logger,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import {
@@ -40,9 +40,9 @@ import { Permission } from 'src/iam/permissions/domain/value-objects/permission.
 @RequireFeature(FeatureFlag.Skills)
 @Controller('skills')
 export class SkillMcpIntegrationsController {
-  private readonly logger = new Logger(SkillMcpIntegrationsController.name);
-
   constructor(
+    @InjectPinoLogger(SkillMcpIntegrationsController.name)
+    private readonly logger: PinoLogger,
     private readonly assignMcpIntegrationToSkillUseCase: AssignMcpIntegrationToSkillUseCase,
     private readonly unassignMcpIntegrationFromSkillUseCase: UnassignMcpIntegrationFromSkillUseCase,
     private readonly listSkillMcpIntegrationsUseCase: ListSkillMcpIntegrationsUseCase,
@@ -80,7 +80,7 @@ export class SkillMcpIntegrationsController {
     @Param('skillId', ParseUUIDPipe) skillId: UUID,
     @Param('integrationId', ParseUUIDPipe) integrationId: UUID,
   ): Promise<SkillResponseDto> {
-    this.logger.log('assignMcpIntegration', { skillId, integrationId });
+    this.logger.info({ skillId, integrationId }, 'assignMcpIntegration');
 
     const skill = await this.assignMcpIntegrationToSkillUseCase.execute(
       new AssignMcpIntegrationToSkillCommand(skillId, integrationId),
@@ -123,7 +123,7 @@ export class SkillMcpIntegrationsController {
     @Param('skillId', ParseUUIDPipe) skillId: UUID,
     @Param('integrationId', ParseUUIDPipe) integrationId: UUID,
   ): Promise<SkillResponseDto> {
-    this.logger.log('unassignMcpIntegration', { skillId, integrationId });
+    this.logger.info({ skillId, integrationId }, 'unassignMcpIntegration');
 
     const skill = await this.unassignMcpIntegrationFromSkillUseCase.execute(
       new UnassignMcpIntegrationFromSkillCommand(skillId, integrationId),
@@ -154,7 +154,7 @@ export class SkillMcpIntegrationsController {
   async listSkillMcpIntegrations(
     @Param('skillId', ParseUUIDPipe) skillId: UUID,
   ): Promise<McpIntegrationResponseDto[]> {
-    this.logger.log('listSkillMcpIntegrations', { skillId });
+    this.logger.info({ skillId }, 'listSkillMcpIntegrations');
 
     const integrations = await this.listSkillMcpIntegrationsUseCase.execute(
       new ListSkillMcpIntegrationsQuery(skillId),

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skill-sources.controller.ts
@@ -5,11 +5,11 @@ import {
   Delete,
   Param,
   ParseUUIDPipe,
-  Logger,
   HttpCode,
   HttpStatus,
   UploadedFile,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { ApiTags, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import {
@@ -50,9 +50,9 @@ import { Permission } from 'src/iam/permissions/domain/value-objects/permission.
 @RequireFeature(FeatureFlag.Skills)
 @Controller('skills')
 export class SkillSourcesController {
-  private readonly logger = new Logger(SkillSourcesController.name);
-
   constructor(
+    @InjectPinoLogger(SkillSourcesController.name)
+    private readonly logger: PinoLogger,
     private readonly removeSourceFromSkillUseCase: RemoveSourceFromSkillUseCase,
     private readonly listSkillSourcesUseCase: ListSkillSourcesUseCase,
     private readonly skillDtoMapper: SkillDtoMapper,
@@ -79,7 +79,7 @@ export class SkillSourcesController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Param('id', ParseUUIDPipe) skillId: UUID,
   ): Promise<SkillSourceResponseDto[]> {
-    this.logger.log('getSkillSources', { skillId, userId });
+    this.logger.info({ skillId, userId }, 'getSkillSources');
 
     const sources = await this.listSkillSourcesUseCase.execute(
       new ListSkillSourcesQuery(skillId),
@@ -100,11 +100,14 @@ export class SkillSourcesController {
       throw new MissingFileError();
     }
 
-    this.logger.log('addFileSource', {
-      skillId,
-      userId,
-      fileName: file.originalname,
-    });
+    this.logger.info(
+      {
+        skillId,
+        userId,
+        fileName: file.originalname,
+      },
+      'addFileSource',
+    );
     try {
       const updatedSkill = await this.addFileSourceToSkillUseCase.execute(
         new AddFileSourceToSkillCommand({ skillId, file }),
@@ -112,7 +115,7 @@ export class SkillSourcesController {
 
       return await this.toSkillDtoWithCreator(updatedSkill, skillId);
     } catch (error: unknown) {
-      this.logger.error('addFileSource', { error: error as Error });
+      this.logger.error({ err: error as Error }, 'addFileSource');
       throw error;
     } finally {
       removeUploadedFile(file.path);
@@ -159,7 +162,7 @@ export class SkillSourcesController {
     @Param('id', ParseUUIDPipe) skillId: UUID,
     @Param('sourceId', ParseUUIDPipe) sourceId: UUID,
   ): Promise<void> {
-    this.logger.log('removeSource', { skillId, sourceId, userId });
+    this.logger.info({ skillId, sourceId, userId }, 'removeSource');
 
     await this.removeSourceFromSkillUseCase.execute(
       new RemoveSourceFromSkillCommand({ skillId, sourceId }),

--- a/ayunis-core-backend/src/domain/skills/presenters/http/skills.controller.ts
+++ b/ayunis-core-backend/src/domain/skills/presenters/http/skills.controller.ts
@@ -9,10 +9,10 @@ import {
   Param,
   Body,
   ParseUUIDPipe,
-  Logger,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import {
   ApiTags,
@@ -66,9 +66,9 @@ import { Permission } from 'src/iam/permissions/domain/value-objects/permission.
 @RequireFeature(FeatureFlag.Skills)
 @Controller('skills')
 export class SkillsController {
-  private readonly logger = new Logger(SkillsController.name);
-
   constructor(
+    @InjectPinoLogger(SkillsController.name)
+    private readonly logger: PinoLogger,
     private readonly installSkillFromMarketplaceUseCase: InstallSkillFromMarketplaceUseCase,
     private readonly createSkillUseCase: CreateSkillUseCase,
     private readonly updateSkillUseCase: UpdateSkillUseCase,
@@ -100,10 +100,13 @@ export class SkillsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() dto: InstallSkillFromMarketplaceDto,
   ): Promise<SkillResponseDto> {
-    this.logger.log('installFromMarketplace', {
-      userId,
-      identifier: dto.identifier,
-    });
+    this.logger.info(
+      {
+        userId,
+        identifier: dto.identifier,
+      },
+      'installFromMarketplace',
+    );
 
     const skill = await this.installSkillFromMarketplaceUseCase.execute(
       new InstallSkillFromMarketplaceCommand(dto.identifier),
@@ -136,7 +139,7 @@ export class SkillsController {
   ): Promise<SkillResponseDto> {
     const isActive = dto.isActive ?? true;
 
-    this.logger.log('create', { userId, name: dto.name });
+    this.logger.info({ userId, name: dto.name }, 'create');
 
     try {
       const skill = await this.createSkillUseCase.execute(
@@ -171,7 +174,7 @@ export class SkillsController {
   async findAll(
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<SkillResponseDto[]> {
-    this.logger.log('findAll', { userId });
+    this.logger.info({ userId }, 'findAll');
 
     const {
       skills: results,
@@ -216,7 +219,7 @@ export class SkillsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<SkillResponseDto> {
-    this.logger.log('findOne', { id, userId });
+    this.logger.info({ id, userId }, 'findOne');
 
     const { skill, isActive, isShared, isPinned } =
       await this.findOneSkillUseCase.execute(new FindOneSkillQuery(id));
@@ -258,7 +261,7 @@ export class SkillsController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() dto: UpdateSkillDto,
   ): Promise<SkillResponseDto> {
-    this.logger.log('update', { id, userId, name: dto.name });
+    this.logger.info({ id, userId, name: dto.name }, 'update');
 
     try {
       const skill = await this.updateSkillUseCase.execute(
@@ -301,7 +304,7 @@ export class SkillsController {
   @ApiResponse({ status: 404, description: 'Skill not found' })
   @HttpCode(HttpStatus.NO_CONTENT)
   async delete(@Param('id', ParseUUIDPipe) id: UUID): Promise<void> {
-    this.logger.log('delete', { id });
+    this.logger.info({ id }, 'delete');
 
     await this.deleteSkillUseCase.execute(
       new DeleteSkillCommand({ skillId: id }),
@@ -326,7 +329,7 @@ export class SkillsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<SkillResponseDto> {
-    this.logger.log('toggleActive', { id, userId });
+    this.logger.info({ id, userId }, 'toggleActive');
 
     const { skill, isActive, isShared, isPinned } =
       await this.toggleSkillActiveUseCase.execute(
@@ -363,7 +366,7 @@ export class SkillsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<SkillResponseDto> {
-    this.logger.log('togglePinned', { id, userId });
+    this.logger.info({ id, userId }, 'togglePinned');
 
     const { skill, isPinned, isShared } =
       await this.toggleSkillPinnedUseCase.execute(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only changes with no intended business-logic changes; risk is limited to log shape/context in production and test wiring if a provider token is missed.
> 
> **Overview**
> **Migrates structured logging** from `@nestjs/common` `Logger` to **`nestjs-pino`** (`InjectPinoLogger` / `PinoLogger`) across the **knowledge-bases**, **skills**, **skill-templates**, and **marketplace** bounded contexts—controllers, use cases, listeners, repositories, and HTTP clients.
> 
> Log calls are updated to Pino style: **`info`/`debug`/`warn`** with **context first and message second**, and errors logged with **`err`** instead of `error` (including `Unexpected*Error` metadata). Unit tests register **`getLoggerToken(...)`** with **`createPinoLoggerMock()`** and drop **`Logger.prototype` spies**.
> 
> A few **small refactors** ride along with the same files (e.g. **`assertSourceCapacity`** for add-document/add-URL use cases, **`processDocumentUpload`** on the knowledge-bases controller, **`resolveResults`** in query-knowledge-base, and **`UpdateSkillTemplateUseCase`** split into private helpers). **`SkillAccessService`** drops its logger entirely rather than switching to Pino.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9d9a0ac57ac70d84bfdf3b4607e0f0e3166eb98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->