### PR TITLE
wip(logging): migrate artifacts and workspace logging (AYC-753)

### DIFF
--- a/ayunis-core-backend/src/domain/artifacts/application/helpers/add-version-with-retry.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/helpers/add-version-with-retry.ts
@@ -1,4 +1,4 @@
-import type { Logger } from '@nestjs/common';
+import type { PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import type { ArtifactsRepository } from '../ports/artifacts-repository.port';
 import type { ArtifactVersion } from '../../domain/artifact-version.entity';
@@ -14,7 +14,7 @@ const MAX_VERSION_RETRIES = 3;
  */
 export async function addVersionWithRetry(params: {
   repository: ArtifactsRepository;
-  logger: Logger;
+  logger: PinoLogger;
   artifactId: string;
   buildVersion: () => Promise<{
     version: ArtifactVersion;
@@ -34,10 +34,14 @@ export async function addVersionWithRetry(params: {
         error instanceof ArtifactVersionConflictError &&
         attempt < MAX_VERSION_RETRIES
       ) {
-        logger.warn(`Version conflict on attempt ${attempt}, retrying`, {
-          artifactId,
-          versionNumber: updateParams.version.versionNumber,
-        });
+        logger.warn(
+          {
+            artifactId,
+            versionNumber: updateParams.version.versionNumber,
+            attempt,
+          },
+          'Version conflict, retrying',
+        );
         continue;
       }
 

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { ApplyEditsToArtifactUseCase } from './apply-edits-to-artifact.use-case';
 import { ApplyEditsToArtifactCommand } from './apply-edits-to-artifact.command';
@@ -54,13 +55,15 @@ describe('ApplyEditsToArtifactUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ApplyEditsToArtifactUseCase,
+        {
+          provide: getLoggerToken(ApplyEditsToArtifactUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ArtifactsRepository, useValue: mockRepository },
         { provide: ContextService, useValue: mockContextService },
         { provide: UpdateArtifactUseCase, useValue: mockUpdateUseCase },
       ],
-    })
-      .setLogger(new Logger())
-      .compile();
+    }).compile();
 
     useCase = module.get<ApplyEditsToArtifactUseCase>(
       ApplyEditsToArtifactUseCase,

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/apply-edits-to-artifact/apply-edits-to-artifact.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { ApplyEditsToArtifactCommand } from './apply-edits-to-artifact.command';
 import {
@@ -20,9 +21,9 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 @Injectable()
 export class ApplyEditsToArtifactUseCase {
-  private readonly logger = new Logger(ApplyEditsToArtifactUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ApplyEditsToArtifactUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly artifactsRepository: ArtifactsRepository,
     private readonly contextService: ContextService,
     private readonly updateArtifactUseCase: UpdateArtifactUseCase,
@@ -32,10 +33,13 @@ export class ApplyEditsToArtifactUseCase {
   async execute(
     command: ApplyEditsToArtifactCommand,
   ): Promise<ArtifactVersion> {
-    this.logger.log('Applying edits to artifact', {
-      artifactId: command.artifactId,
-      editCount: command.edits.length,
-    });
+    this.logger.info(
+      {
+        artifactId: command.artifactId,
+        editCount: command.edits.length,
+      },
+      'Applying edits to artifact',
+    );
 
     const userId = this.contextService.get('userId');
     if (!userId) {

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.spec.ts
@@ -4,9 +4,10 @@ jest.mock('@nestjs-cls/transactional', () => ({
       descriptor,
 }));
 
+import { getLoggerToken, type PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import type { UUID } from 'crypto';
 import { CreateArtifactUseCase } from './create-artifact.use-case';
@@ -36,6 +37,7 @@ describe('CreateArtifactUseCase', () => {
   let artifactsRepository: jest.Mocked<ArtifactsRepository>;
   let findThreadUseCase: jest.Mocked<FindThreadUseCase>;
   let findLetterheadUseCase: jest.Mocked<FindLetterheadUseCase>;
+  let logger: jest.Mocked<PinoLogger>;
 
   const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
   const mockThreadId = '223e4567-e89b-12d3-a456-426614174000' as UUID;
@@ -69,6 +71,10 @@ describe('CreateArtifactUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateArtifactUseCase,
+        {
+          provide: getLoggerToken(CreateArtifactUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ArtifactsRepository, useValue: mockRepository },
         { provide: ContextService, useValue: mockContextService },
         { provide: FindThreadUseCase, useValue: mockFindThreadUseCase },
@@ -83,8 +89,7 @@ describe('CreateArtifactUseCase', () => {
     artifactsRepository = module.get(ArtifactsRepository);
     findThreadUseCase = module.get(FindThreadUseCase);
     findLetterheadUseCase = module.get(FindLetterheadUseCase);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    logger = module.get(getLoggerToken(CreateArtifactUseCase.name));
   });
 
   afterEach(() => {
@@ -118,6 +123,10 @@ describe('CreateArtifactUseCase', () => {
       '<h1>Budget Report</h1><p>Q1 2026 expenses...</p>',
     );
     expect(result.versions[0].authorType).toBe(AuthorType.ASSISTANT);
+    expect(logger.info).toHaveBeenCalledWith(
+      { type: ArtifactType.DOCUMENT },
+      'Creating artifact',
+    );
   });
 
   it('should create an artifact with letterheadId when provided', async () => {
@@ -186,6 +195,10 @@ describe('CreateArtifactUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateArtifactUseCase,
+        {
+          provide: getLoggerToken(CreateArtifactUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ArtifactsRepository, useValue: artifactsRepository },
         { provide: ContextService, useValue: mockContextService },
         { provide: FindThreadUseCase, useValue: findThreadUseCase },

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case.ts
@@ -1,5 +1,6 @@
 import type { UUID } from 'crypto';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { CreateArtifactCommand } from './create-artifact.command';
@@ -28,9 +29,9 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 @Injectable()
 export class CreateArtifactUseCase {
-  private readonly logger = new Logger(CreateArtifactUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateArtifactUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly artifactsRepository: ArtifactsRepository,
     private readonly contextService: ContextService,
     private readonly findThreadUseCase: FindThreadUseCase,
@@ -40,10 +41,7 @@ export class CreateArtifactUseCase {
   @HandleUnexpectedErrors(UnexpectedArtifactError)
   @Transactional()
   async execute(command: CreateArtifactCommand): Promise<Artifact> {
-    this.logger.log('Creating artifact', {
-      title: command.title,
-      type: command.type,
-    });
+    this.logger.info({ type: command.type }, 'Creating artifact');
 
     const userId = this.resolveUserId();
     const content = prepareContentForWrite(command.type, command.content);

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Readable } from 'stream';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import type { UUID } from 'crypto';
@@ -97,6 +98,10 @@ describe('ExportArtifactUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ExportArtifactUseCase,
+        {
+          provide: getLoggerToken(ExportArtifactUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ArtifactsRepository, useValue: mockRepository },
         { provide: DocumentExportPort, useValue: mockExportPort },
         { provide: SpreadsheetExportPort, useValue: mockSpreadsheetExportPort },
@@ -114,9 +119,6 @@ describe('ExportArtifactUseCase', () => {
     findLetterheadUseCase = module.get(FindLetterheadUseCase);
     downloadObjectUseCase = module.get(DownloadObjectUseCase);
     getThreadPiiMasksUseCase = module.get(GetThreadPiiMasksUseCase);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
   });
 
   afterEach(() => {
@@ -425,6 +427,10 @@ describe('ExportArtifactUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ExportArtifactUseCase,
+        {
+          provide: getLoggerToken(ExportArtifactUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ArtifactsRepository, useValue: artifactsRepository },
         { provide: DocumentExportPort, useValue: documentExportPort },
         { provide: SpreadsheetExportPort, useValue: spreadsheetExportPort },

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case.ts
@@ -1,5 +1,6 @@
 import type { UUID } from 'crypto';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import {
   DocumentExportPort,
@@ -51,9 +52,9 @@ export interface ExportResult {
 
 @Injectable()
 export class ExportArtifactUseCase {
-  private readonly logger = new Logger(ExportArtifactUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ExportArtifactUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly artifactsRepository: ArtifactsRepository,
     private readonly documentExportPort: DocumentExportPort,
     private readonly spreadsheetExportPort: SpreadsheetExportPort,
@@ -65,10 +66,13 @@ export class ExportArtifactUseCase {
 
   @HandleUnexpectedErrors(UnexpectedArtifactError)
   async execute(command: ExportArtifactCommand): Promise<ExportResult> {
-    this.logger.log('Exporting artifact', {
-      artifactId: command.artifactId,
-      format: command.format,
-    });
+    this.logger.info(
+      {
+        artifactId: command.artifactId,
+        format: command.format,
+      },
+      'Exporting artifact',
+    );
 
     const userId = this.contextService.get('userId');
     if (!userId) {
@@ -254,9 +258,9 @@ export class ExportArtifactUseCase {
       if (error instanceof ArtifactExportTimeoutError || !letterheadConfig) {
         throw error;
       }
-      const reason = error instanceof Error ? error.message : 'Unknown error';
       this.logger.warn(
-        `Letterhead compositing failed, exporting without letterhead: ${reason}`,
+        { err: error as Error },
+        'Letterhead compositing failed, exporting without letterhead',
       );
       buffer = await this.documentExportPort.exportToPdf(content);
     }
@@ -280,9 +284,9 @@ export class ExportArtifactUseCase {
       );
       return await this.downloadLetterheadPdfs(letterhead);
     } catch (error) {
-      const reason = error instanceof Error ? error.message : 'Unknown error';
       this.logger.warn(
-        `Failed to resolve letterhead ${artifact.letterheadId}, exporting without background: ${reason}`,
+        { err: error as Error, letterheadId: artifact.letterheadId },
+        'Failed to resolve letterhead, exporting without background',
       );
       return undefined;
     }

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import type { UUID } from 'crypto';
 import { RevertArtifactUseCase } from './revert-artifact.use-case';
@@ -67,6 +68,10 @@ describe('RevertArtifactUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RevertArtifactUseCase,
+        {
+          provide: getLoggerToken(RevertArtifactUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ArtifactsRepository, useValue: mockRepository },
         { provide: ContextService, useValue: mockContextService },
       ],
@@ -74,9 +79,6 @@ describe('RevertArtifactUseCase', () => {
 
     useCase = module.get<RevertArtifactUseCase>(RevertArtifactUseCase);
     artifactsRepository = module.get(ArtifactsRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
   });
 
   afterEach(() => {
@@ -275,6 +277,10 @@ describe('RevertArtifactUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RevertArtifactUseCase,
+        {
+          provide: getLoggerToken(RevertArtifactUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ArtifactsRepository, useValue: artifactsRepository },
         { provide: ContextService, useValue: mockContextService },
       ],

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case.ts
@@ -1,5 +1,6 @@
 import type { UUID } from 'crypto';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { RevertArtifactCommand } from './revert-artifact.command';
 import {
@@ -17,19 +18,22 @@ import { addVersionWithRetry } from '../../helpers/add-version-with-retry';
 
 @Injectable()
 export class RevertArtifactUseCase {
-  private readonly logger = new Logger(RevertArtifactUseCase.name);
-
   constructor(
+    @InjectPinoLogger(RevertArtifactUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly artifactsRepository: ArtifactsRepository,
     private readonly contextService: ContextService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedArtifactError)
   async execute(command: RevertArtifactCommand): Promise<ArtifactVersion> {
-    this.logger.log('Reverting artifact', {
-      artifactId: command.artifactId,
-      targetVersion: command.versionNumber,
-    });
+    this.logger.info(
+      {
+        artifactId: command.artifactId,
+        targetVersion: command.versionNumber,
+      },
+      'Reverting artifact',
+    );
 
     const userId = this.contextService.get('userId');
     if (!userId) {

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import type { UUID } from 'crypto';
 import { UpdateArtifactUseCase } from './update-artifact.use-case';
@@ -62,6 +63,10 @@ describe('UpdateArtifactUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UpdateArtifactUseCase,
+        {
+          provide: getLoggerToken(UpdateArtifactUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ArtifactsRepository, useValue: mockRepository },
         { provide: ContextService, useValue: mockContextService },
         {
@@ -74,9 +79,6 @@ describe('UpdateArtifactUseCase', () => {
     useCase = module.get<UpdateArtifactUseCase>(UpdateArtifactUseCase);
     artifactsRepository = module.get(ArtifactsRepository);
     findLetterheadUseCase = module.get(FindLetterheadUseCase);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
   });
 
   afterEach(() => {
@@ -430,6 +432,10 @@ describe('UpdateArtifactUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UpdateArtifactUseCase,
+        {
+          provide: getLoggerToken(UpdateArtifactUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: ArtifactsRepository, useValue: artifactsRepository },
         { provide: ContextService, useValue: mockContextService },
         {

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case.ts
@@ -1,5 +1,6 @@
 import type { UUID } from 'crypto';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ArtifactsRepository } from '../../ports/artifacts-repository.port';
 import { UpdateArtifactCommand } from './update-artifact.command';
 import {
@@ -26,9 +27,9 @@ import { FindLetterheadQuery } from 'src/domain/letterheads/application/use-case
 
 @Injectable()
 export class UpdateArtifactUseCase {
-  private readonly logger = new Logger(UpdateArtifactUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateArtifactUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly artifactsRepository: ArtifactsRepository,
     private readonly contextService: ContextService,
     private readonly findLetterheadUseCase: FindLetterheadUseCase,
@@ -38,7 +39,7 @@ export class UpdateArtifactUseCase {
   async execute(
     command: UpdateArtifactCommand,
   ): Promise<ArtifactVersion | void> {
-    this.logger.log('Updating artifact', { artifactId: command.artifactId });
+    this.logger.info({ artifactId: command.artifactId }, 'Updating artifact');
 
     const userId = this.resolveUserId();
 

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { HtmlDocumentExportService } from './html-document-export.service';
 import type { PdfLetterheadCompositor } from './pdf-letterhead-compositor';
 import type { LetterheadConfig } from '../../application/ports/document-export.port';
@@ -67,7 +68,7 @@ describe('HtmlDocumentExportService', () => {
     compositor = {
       composite: jest.fn().mockResolvedValue(Buffer.from('%PDF-composited')),
     } as unknown as jest.Mocked<PdfLetterheadCompositor>;
-    service = new HtmlDocumentExportService(compositor);
+    service = new HtmlDocumentExportService(createPinoLoggerMock(), compositor);
   });
 
   afterAll(async () => {

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   DocumentExportPort,
   LetterheadConfig,
@@ -51,10 +52,11 @@ const PDF_CSS = `
 export class HtmlDocumentExportService
   implements DocumentExportPort, OnModuleDestroy
 {
-  private readonly logger = new Logger(HtmlDocumentExportService.name);
   private readonly chromium = new LazyChromiumBrowser();
 
   constructor(
+    @InjectPinoLogger(HtmlDocumentExportService.name)
+    private readonly logger: PinoLogger,
     private readonly pdfLetterheadCompositor: PdfLetterheadCompositor,
   ) {}
 
@@ -63,7 +65,7 @@ export class HtmlDocumentExportService
   }
 
   async exportToDocx(html: string): Promise<Buffer> {
-    this.logger.log('Exporting HTML to DOCX');
+    this.logger.info('Exporting HTML to DOCX');
 
     const sanitized = sanitizeHtmlContent(html);
     return convertHtmlToDocx(sanitized);
@@ -73,7 +75,7 @@ export class HtmlDocumentExportService
     html: string,
     letterhead?: LetterheadConfig,
   ): Promise<Buffer> {
-    this.logger.log('Exporting HTML to PDF');
+    this.logger.info('Exporting HTML to PDF');
 
     const wrappedHtml = this.wrapHtmlForPdf(html, letterhead);
     const browser = await this.chromium.get();

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/pdf-letterhead-compositor.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/pdf-letterhead-compositor.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { PDFDocument, rgb } from 'pdf-lib';
 import { PdfLetterheadCompositor } from './pdf-letterhead-compositor';
 
@@ -26,7 +27,7 @@ describe('PdfLetterheadCompositor', () => {
   let compositor: PdfLetterheadCompositor;
 
   beforeEach(() => {
-    compositor = new PdfLetterheadCompositor();
+    compositor = new PdfLetterheadCompositor(createPinoLoggerMock());
   });
 
   it('should composite a single-page content PDF with first-page background', async () => {

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/pdf-letterhead-compositor.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/pdf-letterhead-compositor.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { PDFDocument } from 'pdf-lib';
 
 /**
@@ -10,7 +11,10 @@ import { PDFDocument } from 'pdf-lib';
  */
 @Injectable()
 export class PdfLetterheadCompositor {
-  private readonly logger = new Logger(PdfLetterheadCompositor.name);
+  constructor(
+    @InjectPinoLogger(PdfLetterheadCompositor.name)
+    private readonly logger: PinoLogger,
+  ) {}
 
   /**
    * Composite content pages onto letterhead backgrounds.
@@ -25,7 +29,7 @@ export class PdfLetterheadCompositor {
     firstPagePdf: Buffer,
     continuationPagePdf?: Buffer,
   ): Promise<Buffer> {
-    this.logger.log('Compositing PDF with letterhead background');
+    this.logger.info('Compositing PDF with letterhead background');
 
     const contentDoc = await PDFDocument.load(contentPdf);
     const firstBgDoc = await PDFDocument.load(firstPagePdf);
@@ -58,8 +62,9 @@ export class PdfLetterheadCompositor {
     }
 
     const outputBytes = await outputDoc.save();
-    this.logger.log(
-      `Composited ${contentPageCount} page(s) with letterhead background`,
+    this.logger.info(
+      { pageCount: contentPageCount },
+      'Composited PDF with letterhead background',
     );
     return Buffer.from(outputBytes);
   }

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/xlsx-spreadsheet-export.service.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/xlsx-spreadsheet-export.service.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import * as XLSX from 'xlsx';
 import * as ExcelJS from 'exceljs';
 import type { SpreadsheetExportInput } from '../../application/ports/spreadsheet-export.port';
@@ -11,7 +12,7 @@ describe('XlsxSpreadsheetExportService', () => {
   let service: XlsxSpreadsheetExportService;
 
   beforeEach(() => {
-    service = new XlsxSpreadsheetExportService();
+    service = new XlsxSpreadsheetExportService(createPinoLoggerMock());
   });
 
   function createExportInput(

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/xlsx-spreadsheet-export.service.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/xlsx-spreadsheet-export.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import * as ExcelJS from 'exceljs';
 import {
   SpreadsheetExportPort,
@@ -123,7 +124,12 @@ function toCsvField(cell: EvaluatedCell): string {
 
 @Injectable()
 export class XlsxSpreadsheetExportService extends SpreadsheetExportPort {
-  private readonly logger = new Logger(XlsxSpreadsheetExportService.name);
+  constructor(
+    @InjectPinoLogger(XlsxSpreadsheetExportService.name)
+    private readonly logger: PinoLogger,
+  ) {
+    super();
+  }
 
   async exportToXlsx(data: SpreadsheetExportInput): Promise<Buffer> {
     const workbook = new ExcelJS.Workbook();
@@ -170,9 +176,10 @@ export class XlsxSpreadsheetExportService extends SpreadsheetExportPort {
         data.formulaCells,
       ).evaluateForExport();
     } catch (error) {
-      this.logger.warn('Spreadsheet evaluation failed, exporting raw values', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.warn(
+        { err: error as Error },
+        'Spreadsheet evaluation failed, exporting raw values',
+      );
       return {
         values: data.grid.rows,
         liveFormulaCells: data.grid.rows.map((row) => row.map(() => false)),

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/local-artifacts.repository.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/local-artifacts.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -17,9 +18,9 @@ import { isUniqueConstraintViolation } from './unique-constraint.util';
 
 @Injectable()
 export class LocalArtifactsRepository extends ArtifactsRepository {
-  private readonly logger = new Logger(LocalArtifactsRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalArtifactsRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(ArtifactRecord)
     private readonly artifactRepo: Repository<ArtifactRecord>,
     @InjectRepository(DocumentArtifactRecord)
@@ -33,11 +34,13 @@ export class LocalArtifactsRepository extends ArtifactsRepository {
   }
 
   async create(artifact: Artifact): Promise<Artifact> {
-    this.logger.log('create', {
-      id: artifact.id,
-      title: artifact.title,
-      type: artifact.type,
-    });
+    this.logger.info(
+      {
+        id: artifact.id,
+        type: artifact.type,
+      },
+      'create',
+    );
     const record = this.artifactMapper.toRecord(artifact);
     const saved = await this.artifactRepo.save(record);
     return this.artifactMapper.toDomain(saved);
@@ -68,10 +71,13 @@ export class LocalArtifactsRepository extends ArtifactsRepository {
   }
 
   async addVersion(version: ArtifactVersion): Promise<ArtifactVersion> {
-    this.logger.log('addVersion', {
-      artifactId: version.artifactId,
-      versionNumber: version.versionNumber,
-    });
+    this.logger.info(
+      {
+        artifactId: version.artifactId,
+        versionNumber: version.versionNumber,
+      },
+      'addVersion',
+    );
     const record = this.versionMapper.toRecord(version);
     const saved = await this.versionRepo.save(record);
     return this.versionMapper.toDomain(saved);
@@ -105,12 +111,7 @@ export class LocalArtifactsRepository extends ArtifactsRepository {
   }): Promise<ArtifactVersion> {
     const { version, expectedCurrentVersionNumber, letterheadId } = params;
 
-    this.logger.log('addVersionAndUpdateArtifact', {
-      artifactId: version.artifactId,
-      versionNumber: version.versionNumber,
-      expectedCurrentVersionNumber,
-      shouldUpdateLetterhead: letterheadId !== undefined,
-    });
+    this.logVersionUpdate(params);
 
     try {
       const record = this.versionMapper.toRecord(version);
@@ -152,6 +153,22 @@ export class LocalArtifactsRepository extends ArtifactsRepository {
       }
       throw error;
     }
+  }
+
+  private logVersionUpdate(params: {
+    version: ArtifactVersion;
+    expectedCurrentVersionNumber: number;
+    letterheadId?: UUID | null;
+  }): void {
+    this.logger.info(
+      {
+        artifactId: params.version.artifactId,
+        versionNumber: params.version.versionNumber,
+        expectedCurrentVersionNumber: params.expectedCurrentVersionNumber,
+        shouldUpdateLetterhead: params.letterheadId !== undefined,
+      },
+      'addVersionAndUpdateArtifact',
+    );
   }
 
   async delete(id: UUID): Promise<void> {

--- a/ayunis-core-backend/src/domain/artifacts/presenters/http/artifacts.controller.ts
+++ b/ayunis-core-backend/src/domain/artifacts/presenters/http/artifacts.controller.ts
@@ -7,11 +7,11 @@ import {
   Body,
   Query,
   ParseUUIDPipe,
-  Logger,
   Res,
   StreamableFile,
   HttpStatus,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -49,9 +49,9 @@ import { ArtifactDtoMapper } from './mappers/artifact-dto.mapper';
 @ApiTags('artifacts')
 @Controller('artifacts')
 export class ArtifactsController {
-  private readonly logger = new Logger(ArtifactsController.name);
-
   constructor(
+    @InjectPinoLogger(ArtifactsController.name)
+    private readonly logger: PinoLogger,
     private readonly createArtifactUseCase: CreateArtifactUseCase,
     private readonly updateArtifactUseCase: UpdateArtifactUseCase,
     private readonly findArtifactsByThreadUseCase: FindArtifactsByThreadUseCase,
@@ -70,7 +70,7 @@ export class ArtifactsController {
   })
   @ApiResponse({ status: 400, description: 'Invalid input data' })
   async create(@Body() dto: CreateArtifactDto): Promise<ArtifactResponseDto> {
-    this.logger.log('create', { title: dto.title, threadId: dto.threadId });
+    this.logger.info({ threadId: dto.threadId }, 'create');
     const artifact = await this.createArtifactUseCase.execute(
       new CreateArtifactCommand({
         threadId: dto.threadId,
@@ -106,7 +106,7 @@ export class ArtifactsController {
     @Body() dto: UpdateArtifactDto,
     @Res({ passthrough: true }) res: Response,
   ): Promise<ArtifactVersionResponseDto | void> {
-    this.logger.log('update', { artifactId: id });
+    this.logger.info({ artifactId: id }, 'update');
     const result = await this.updateArtifactUseCase.execute(
       new UpdateArtifactCommand({
         artifactId: id,
@@ -138,7 +138,7 @@ export class ArtifactsController {
   async findOne(
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<ArtifactResponseDto> {
-    this.logger.log('findOne', { id });
+    this.logger.info({ id }, 'findOne');
     const artifact = await this.findArtifactWithVersionsUseCase.execute(
       new FindArtifactWithVersionsQuery({ artifactId: id }),
     );
@@ -161,7 +161,7 @@ export class ArtifactsController {
   async findByThread(
     @Param('threadId', ParseUUIDPipe) threadId: UUID,
   ): Promise<ArtifactResponseDto[]> {
-    this.logger.log('findByThread', { threadId });
+    this.logger.info({ threadId }, 'findByThread');
     const artifacts = await this.findArtifactsByThreadUseCase.execute(
       new FindArtifactsByThreadQuery({ threadId }),
     );
@@ -186,10 +186,13 @@ export class ArtifactsController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() dto: RevertArtifactDto,
   ): Promise<ArtifactVersionResponseDto> {
-    this.logger.log('revert', {
-      artifactId: id,
-      versionNumber: dto.versionNumber,
-    });
+    this.logger.info(
+      {
+        artifactId: id,
+        versionNumber: dto.versionNumber,
+      },
+      'revert',
+    );
     const version = await this.revertArtifactUseCase.execute(
       new RevertArtifactCommand({
         artifactId: id,
@@ -230,7 +233,7 @@ export class ArtifactsController {
     @Query() query: ExportArtifactQueryDto,
     @Res({ passthrough: true }) res: Response,
   ): Promise<StreamableFile> {
-    this.logger.log('export', { artifactId: id, format: query.format });
+    this.logger.info({ artifactId: id, format: query.format }, 'export');
     const result = await this.exportArtifactUseCase.execute(
       new ExportArtifactCommand({
         artifactId: id,

--- a/ayunis-core-backend/src/domain/favorites/application/services/favorite-reference-resolver.service.spec.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/services/favorite-reference-resolver.service.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import type { FindThreadsByIdsUseCase } from 'src/domain/threads/application/use-cases/find-threads-by-ids/find-threads-by-ids.use-case';
 import { ThreadNotFoundError } from 'src/domain/threads/application/threads.errors';
@@ -80,6 +81,7 @@ function createResolver(params: {
   threads?: unknown[];
 }): FavoriteReferenceResolver {
   return new FavoriteReferenceResolver(
+    createPinoLoggerMock(),
     {
       execute: jest.fn().mockResolvedValue(params.workspaces ?? []),
     } as unknown as FindWorkspacesByIdsUseCase,

--- a/ayunis-core-backend/src/domain/favorites/application/services/favorite-reference-resolver.service.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/services/favorite-reference-resolver.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { ThreadNotFoundError } from 'src/domain/threads/application/threads.errors';
 import { FindThreadsByIdsQuery } from 'src/domain/threads/application/use-cases/find-threads-by-ids/find-threads-by-ids.query';
@@ -14,9 +15,9 @@ import type { FavoriteResult } from '../use-cases/find-favorites/favorite.result
 
 @Injectable()
 export class FavoriteReferenceResolver {
-  private readonly logger = new Logger(FavoriteReferenceResolver.name);
-
   constructor(
+    @InjectPinoLogger(FavoriteReferenceResolver.name)
+    private readonly logger: PinoLogger,
     private readonly findWorkspacesByIdsUseCase: FindWorkspacesByIdsUseCase,
     private readonly findThreadsByIdsUseCase: FindThreadsByIdsUseCase,
   ) {}
@@ -47,11 +48,14 @@ export class FavoriteReferenceResolver {
     return favorites.flatMap((favorite) => {
       const result = this.resolve(favorite, workspacesById, threadsById);
       if (!result) {
-        this.logger.warn('Ignoring stale favorite reference', {
-          favoriteId: favorite.id,
-          referenceType: favorite.referenceType,
-          referenceId: favorite.referenceId,
-        });
+        this.logger.warn(
+          {
+            favoriteId: favorite.id,
+            referenceType: favorite.referenceType,
+            referenceId: favorite.referenceId,
+          },
+          'Ignoring stale favorite reference',
+        );
       }
       return result ? [result] : [];
     });

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/add-favorite/add-favorite.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/add-favorite/add-favorite.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import type { FavoritesRepository } from '../../ports/favorites-repository.port';
 import { FavoriteReferenceType } from '../../../domain/value-objects/favorite-reference-type.enum';
@@ -10,7 +11,7 @@ const WORKSPACE_ID = '22222222-2222-4222-8222-222222222222' as UUID;
 describe('AddFavoriteUseCase', () => {
   it('appends the reference for the user', async () => {
     const repository = createRepository();
-    const useCase = new AddFavoriteUseCase(repository);
+    const useCase = new AddFavoriteUseCase(createPinoLoggerMock(), repository);
 
     await useCase.execute(
       new AddFavoriteCommand(

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/add-favorite/add-favorite.use-case.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/add-favorite/add-favorite.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnexpectedFavoriteError } from '../../favorites.errors';
 import { FavoritesRepository } from '../../ports/favorites-repository.port';
@@ -6,17 +7,22 @@ import { AddFavoriteCommand } from './add-favorite.command';
 
 @Injectable()
 export class AddFavoriteUseCase {
-  private readonly logger = new Logger(AddFavoriteUseCase.name);
-
-  constructor(private readonly favoritesRepository: FavoritesRepository) {}
+  constructor(
+    @InjectPinoLogger(AddFavoriteUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly favoritesRepository: FavoritesRepository,
+  ) {}
 
   @HandleUnexpectedErrors(UnexpectedFavoriteError)
   async execute(command: AddFavoriteCommand): Promise<void> {
-    this.logger.log('Adding favorite', {
-      userId: command.userId,
-      referenceType: command.referenceType,
-      referenceId: command.referenceId,
-    });
+    this.logger.info(
+      {
+        userId: command.userId,
+        referenceType: command.referenceType,
+        referenceId: command.referenceId,
+      },
+      'Adding favorite',
+    );
 
     await this.favoritesRepository.append(
       command.userId,

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/find-favorites/find-favorites.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/find-favorites/find-favorites.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import type { ContextService } from 'src/common/context/services/context.service';
 import type { FavoriteReferenceResolver } from '../../services/favorite-reference-resolver.service';
@@ -27,7 +28,12 @@ describe('FindFavoritesUseCase', () => {
     const context = {
       get: jest.fn().mockReturnValue(USER_ID),
     } as unknown as ContextService;
-    const useCase = new FindFavoritesUseCase(repository, resolver, context);
+    const useCase = new FindFavoritesUseCase(
+      createPinoLoggerMock(),
+      repository,
+      resolver,
+      context,
+    );
 
     await expect(useCase.execute()).resolves.toBe(resolved);
     expect(resolver.resolveAll).toHaveBeenCalledWith([favorite], USER_ID);

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/find-favorites/find-favorites.use-case.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/find-favorites/find-favorites.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
@@ -10,9 +11,9 @@ import type { FavoriteResult } from './favorite.result';
 
 @Injectable()
 export class FindFavoritesUseCase {
-  private readonly logger = new Logger(FindFavoritesUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindFavoritesUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly favoritesRepository: FavoritesRepository,
     private readonly favoriteReferenceResolver: FavoriteReferenceResolver,
     private readonly contextService: ContextService,
@@ -20,7 +21,7 @@ export class FindFavoritesUseCase {
 
   @HandleUnexpectedErrors(UnexpectedFavoriteError)
   async execute(): Promise<FavoriteResult[]> {
-    this.logger.log('Finding favorites');
+    this.logger.info('Finding favorites');
     const userId = this.requireUserId();
     const favorites = await this.favoritesRepository.findAllByUserId(userId);
     return this.favoriteReferenceResolver.resolveAll(favorites, userId);

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/remove-favorite-reference/remove-favorite-reference.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/remove-favorite-reference/remove-favorite-reference.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import type { FavoritesRepository } from '../../ports/favorites-repository.port';
 import { FavoriteReferenceType } from '../../../domain/value-objects/favorite-reference-type.enum';
@@ -9,7 +10,10 @@ const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111' as UUID;
 describe('RemoveFavoriteReferenceUseCase', () => {
   it('removes the deleted reference from every user favorite list', async () => {
     const repository = createRepository();
-    const useCase = new RemoveFavoriteReferenceUseCase(repository);
+    const useCase = new RemoveFavoriteReferenceUseCase(
+      createPinoLoggerMock(),
+      repository,
+    );
 
     await useCase.execute(
       new RemoveFavoriteReferenceCommand(

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/remove-favorite-reference/remove-favorite-reference.use-case.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/remove-favorite-reference/remove-favorite-reference.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { FavoritesRepository } from '../../ports/favorites-repository.port';
 import { UnexpectedFavoriteError } from '../../favorites.errors';
@@ -6,16 +7,21 @@ import { RemoveFavoriteReferenceCommand } from './remove-favorite-reference.comm
 
 @Injectable()
 export class RemoveFavoriteReferenceUseCase {
-  private readonly logger = new Logger(RemoveFavoriteReferenceUseCase.name);
-
-  constructor(private readonly favoritesRepository: FavoritesRepository) {}
+  constructor(
+    @InjectPinoLogger(RemoveFavoriteReferenceUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly favoritesRepository: FavoritesRepository,
+  ) {}
 
   @HandleUnexpectedErrors(UnexpectedFavoriteError)
   async execute(command: RemoveFavoriteReferenceCommand): Promise<void> {
-    this.logger.log('Removing favorite reference', {
-      referenceType: command.referenceType,
-      referenceId: command.referenceId,
-    });
+    this.logger.info(
+      {
+        referenceType: command.referenceType,
+        referenceId: command.referenceId,
+      },
+      'Removing favorite reference',
+    );
     await this.favoritesRepository.removeByReference(
       command.referenceType,
       command.referenceId,

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/reorder-favorites/reorder-favorites.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/reorder-favorites/reorder-favorites.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import type { UUID } from 'crypto';
 import type { ContextService } from 'src/common/context/services/context.service';
@@ -17,6 +18,7 @@ describe('ReorderFavoritesUseCase', () => {
     const second = createFavorite(SECOND_FAVORITE_ID, 1);
     const repository = createRepository([first, second]);
     const useCase = new ReorderFavoritesUseCase(
+      createPinoLoggerMock(),
       repository,
       createContextService(),
     );

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/reorder-favorites/reorder-favorites.use-case.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/reorder-favorites/reorder-favorites.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
@@ -10,18 +11,21 @@ import { ReorderFavoritesCommand } from './reorder-favorites.command';
 
 @Injectable()
 export class ReorderFavoritesUseCase {
-  private readonly logger = new Logger(ReorderFavoritesUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ReorderFavoritesUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly favoritesRepository: FavoritesRepository,
     private readonly contextService: ContextService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedFavoriteError)
   async execute(command: ReorderFavoritesCommand): Promise<Favorite[]> {
-    this.logger.log('Reordering favorites', {
-      count: command.favoriteIds.length,
-    });
+    this.logger.info(
+      {
+        count: command.favoriteIds.length,
+      },
+      'Reordering favorites',
+    );
     const userId = this.requireUserId();
     const current = await this.favoritesRepository.findAllByUserId(userId);
     const currentById = new Map(

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/toggle-favorite/toggle-favorite.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/toggle-favorite/toggle-favorite.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import type { ContextService } from 'src/common/context/services/context.service';
 import type { FavoriteReferenceResolver } from '../../services/favorite-reference-resolver.service';
@@ -75,7 +76,12 @@ function setup(current: Favorite[] = []) {
   return {
     repository,
     resolver,
-    useCase: new ToggleFavoriteUseCase(repository, resolver, context),
+    useCase: new ToggleFavoriteUseCase(
+      createPinoLoggerMock(),
+      repository,
+      resolver,
+      context,
+    ),
   };
 }
 

--- a/ayunis-core-backend/src/domain/favorites/application/use-cases/toggle-favorite/toggle-favorite.use-case.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/use-cases/toggle-favorite/toggle-favorite.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
@@ -11,9 +12,9 @@ import { ToggleFavoriteCommand } from './toggle-favorite.command';
 
 @Injectable()
 export class ToggleFavoriteUseCase {
-  private readonly logger = new Logger(ToggleFavoriteUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ToggleFavoriteUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly favoritesRepository: FavoritesRepository,
     private readonly favoriteReferenceResolver: FavoriteReferenceResolver,
     private readonly contextService: ContextService,
@@ -21,10 +22,13 @@ export class ToggleFavoriteUseCase {
 
   @HandleUnexpectedErrors(UnexpectedFavoriteError)
   async execute(command: ToggleFavoriteCommand): Promise<void> {
-    this.logger.log('Toggling favorite', {
-      referenceType: command.referenceType,
-      referenceId: command.referenceId,
-    });
+    this.logger.info(
+      {
+        referenceType: command.referenceType,
+        referenceId: command.referenceId,
+      },
+      'Toggling favorite',
+    );
     const userId = this.requireUserId();
     const current = await this.favoritesRepository.findAllByUserId(userId);
     const existing = current.find(

--- a/ayunis-core-backend/src/domain/favorites/presenters/http/favorites.controller.ts
+++ b/ayunis-core-backend/src/domain/favorites/presenters/http/favorites.controller.ts
@@ -4,9 +4,9 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Logger,
   Patch,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiExtraModels,
   ApiOperation,
@@ -37,9 +37,9 @@ import { ToggleFavoriteDto } from './dtos/toggle-favorite.dto';
 @RequireFeature(FeatureFlag.Workspaces)
 @Controller('favorites')
 export class FavoritesController {
-  private readonly logger = new Logger(FavoritesController.name);
-
   constructor(
+    @InjectPinoLogger(FavoritesController.name)
+    private readonly logger: PinoLogger,
     private readonly findFavoritesUseCase: FindFavoritesUseCase,
     private readonly toggleFavoriteUseCase: ToggleFavoriteUseCase,
     private readonly reorderFavoritesUseCase: ReorderFavoritesUseCase,
@@ -61,7 +61,7 @@ export class FavoritesController {
     },
   })
   async findAll(): Promise<FavoriteResponseDto[]> {
-    this.logger.log('findAll');
+    this.logger.info('findAll');
     return this.findFavoritesUseCase.execute();
   }
 
@@ -70,7 +70,7 @@ export class FavoritesController {
   @ApiOperation({ summary: 'Favorite or unfavorite an authorized reference' })
   @ApiResponse({ status: 204, description: 'The favorite was toggled' })
   async toggle(@Body() dto: ToggleFavoriteDto): Promise<void> {
-    this.logger.log('toggle', dto);
+    this.logger.info(dto, 'toggle');
     await this.toggleFavoriteUseCase.execute(
       new ToggleFavoriteCommand(dto.referenceType, dto.referenceId),
     );
@@ -81,7 +81,7 @@ export class FavoritesController {
   @ApiOperation({ summary: 'Reorder the current user favorites' })
   @ApiResponse({ status: 204, description: 'The favorites were reordered' })
   async reorder(@Body() dto: ReorderFavoritesDto): Promise<void> {
-    this.logger.log('reorder', { count: dto.favoriteIds.length });
+    this.logger.info({ count: dto.favoriteIds.length }, 'reorder');
     await this.reorderFavoritesUseCase.execute(
       new ReorderFavoritesCommand(dto.favoriteIds),
     );

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { PDFDocument } from 'pdf-lib';
 import { CreateLetterheadUseCase } from './create-letterhead.use-case';
@@ -61,6 +62,10 @@ describe('CreateLetterheadUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateLetterheadUseCase,
+        {
+          provide: getLoggerToken(CreateLetterheadUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         LetterheadPdfService,
         { provide: LetterheadsRepository, useValue: mockRepository },
         { provide: ContextService, useValue: mockContextService },
@@ -73,8 +78,6 @@ describe('CreateLetterheadUseCase', () => {
     uploadObjectUseCase = module.get(UploadObjectUseCase);
 
     letterheadsRepository.save.mockImplementation(async (l) => l);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
   });
 
   afterEach(() => {
@@ -178,6 +181,10 @@ describe('CreateLetterheadUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateLetterheadUseCase,
+        {
+          provide: getLoggerToken(CreateLetterheadUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         LetterheadPdfService,
         { provide: LetterheadsRepository, useValue: letterheadsRepository },
         { provide: ContextService, useValue: mockContextService },

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.use-case.ts
@@ -1,5 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { randomUUID } from 'crypto';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { randomUUID, type UUID } from 'crypto';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -13,9 +14,9 @@ import { CreateLetterheadCommand } from './create-letterhead.command';
 
 @Injectable()
 export class CreateLetterheadUseCase {
-  private readonly logger = new Logger(CreateLetterheadUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateLetterheadUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly letterheadsRepository: LetterheadsRepository,
     private readonly contextService: ContextService,
     private readonly uploadObjectUseCase: UploadObjectUseCase,
@@ -23,54 +24,42 @@ export class CreateLetterheadUseCase {
   ) {}
 
   async execute(command: CreateLetterheadCommand): Promise<Letterhead> {
-    this.logger.log('Creating letterhead', { name: command.name });
+    this.logger.info('Creating letterhead');
 
     try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedAccessError();
+      return await this.createLetterhead(command);
+    } catch (error) {
+      if (error instanceof ApplicationError) {
+        throw error;
       }
+      this.logger.error({ err: error as Error }, 'Error creating letterhead');
+      throw new UnexpectedLetterheadError('Error creating letterhead', {
+        error: error as Error,
+      });
+    }
+  }
 
-      await this.letterheadPdfService.validateSinglePagePdf(
-        command.firstPagePdfBuffer,
-        'first page',
-      );
-
-      if (command.continuationPagePdfBuffer) {
-        await this.letterheadPdfService.validateSinglePagePdf(
-          command.continuationPagePdfBuffer,
-          'continuation page',
-        );
-      }
-
-      const letterheadId = randomUUID();
-
-      const firstPagePath = this.letterheadPdfService.buildStoragePath(
-        orgId,
-        letterheadId,
-        'first-page.pdf',
-      );
-
-      await this.uploadObjectUseCase.execute(
-        new UploadObjectCommand(firstPagePath, command.firstPagePdfBuffer),
-      );
-
-      let continuationPagePath: string | null = null;
-      if (command.continuationPagePdfBuffer) {
-        continuationPagePath = this.letterheadPdfService.buildStoragePath(
-          orgId,
-          letterheadId,
-          'continuation.pdf',
-        );
-        await this.uploadObjectUseCase.execute(
-          new UploadObjectCommand(
-            continuationPagePath,
-            command.continuationPagePdfBuffer,
-          ),
-        );
-      }
-
-      const letterhead = new Letterhead({
+  private async createLetterhead(
+    command: CreateLetterheadCommand,
+  ): Promise<Letterhead> {
+    const orgId = this.resolveOrgId();
+    await this.validatePdfs(command);
+    const letterheadId = randomUUID();
+    const firstPagePath = this.letterheadPdfService.buildStoragePath(
+      orgId,
+      letterheadId,
+      'first-page.pdf',
+    );
+    await this.uploadObjectUseCase.execute(
+      new UploadObjectCommand(firstPagePath, command.firstPagePdfBuffer),
+    );
+    const continuationPagePath = await this.uploadContinuationPage(
+      orgId,
+      letterheadId,
+      command.continuationPagePdfBuffer,
+    );
+    return this.letterheadsRepository.save(
+      new Letterhead({
         id: letterheadId,
         orgId,
         name: command.name,
@@ -79,19 +68,43 @@ export class CreateLetterheadUseCase {
         continuationPageStoragePath: continuationPagePath,
         firstPageMargins: command.firstPageMargins,
         continuationPageMargins: command.continuationPageMargins,
-      });
+      }),
+    );
+  }
 
-      return await this.letterheadsRepository.save(letterhead);
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error creating letterhead', {
-        error: error as Error,
-      });
-      throw new UnexpectedLetterheadError('Error creating letterhead', {
-        error: error as Error,
-      });
+  private resolveOrgId(): UUID {
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) throw new UnauthorizedAccessError();
+    return orgId;
+  }
+
+  private async validatePdfs(command: CreateLetterheadCommand): Promise<void> {
+    await this.letterheadPdfService.validateSinglePagePdf(
+      command.firstPagePdfBuffer,
+      'first page',
+    );
+    if (command.continuationPagePdfBuffer) {
+      await this.letterheadPdfService.validateSinglePagePdf(
+        command.continuationPagePdfBuffer,
+        'continuation page',
+      );
     }
+  }
+
+  private async uploadContinuationPage(
+    orgId: UUID,
+    letterheadId: UUID,
+    buffer: Buffer | null | undefined,
+  ): Promise<string | null> {
+    if (!buffer) return null;
+    const path = this.letterheadPdfService.buildStoragePath(
+      orgId,
+      letterheadId,
+      'continuation.pdf',
+    );
+    await this.uploadObjectUseCase.execute(
+      new UploadObjectCommand(path, buffer),
+    );
+    return path;
   }
 }

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/delete-letterhead/delete-letterhead.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/delete-letterhead/delete-letterhead.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { DeleteLetterheadUseCase } from './delete-letterhead.use-case';
 import { DeleteLetterheadCommand } from './delete-letterhead.command';
@@ -41,6 +42,10 @@ describe('DeleteLetterheadUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeleteLetterheadUseCase,
+        {
+          provide: getLoggerToken(DeleteLetterheadUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: LetterheadsRepository, useValue: mockRepository },
         { provide: ContextService, useValue: mockContextService },
         { provide: DeleteObjectUseCase, useValue: mockDeleteObjectUseCase },
@@ -50,8 +55,6 @@ describe('DeleteLetterheadUseCase', () => {
     useCase = module.get(DeleteLetterheadUseCase);
     letterheadsRepository = module.get(LetterheadsRepository);
     deleteObjectUseCase = module.get(DeleteObjectUseCase);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
   });
 
   afterEach(() => {
@@ -126,6 +129,10 @@ describe('DeleteLetterheadUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeleteLetterheadUseCase,
+        {
+          provide: getLoggerToken(DeleteLetterheadUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: LetterheadsRepository, useValue: letterheadsRepository },
         { provide: ContextService, useValue: mockContextService },
         { provide: DeleteObjectUseCase, useValue: deleteObjectUseCase },

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/delete-letterhead/delete-letterhead.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/delete-letterhead/delete-letterhead.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -13,18 +14,21 @@ import { DeleteLetterheadCommand } from './delete-letterhead.command';
 
 @Injectable()
 export class DeleteLetterheadUseCase {
-  private readonly logger = new Logger(DeleteLetterheadUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteLetterheadUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly letterheadsRepository: LetterheadsRepository,
     private readonly contextService: ContextService,
     private readonly deleteObjectUseCase: DeleteObjectUseCase,
   ) {}
 
   async execute(command: DeleteLetterheadCommand): Promise<void> {
-    this.logger.log('Deleting letterhead', {
-      letterheadId: command.letterheadId,
-    });
+    this.logger.info(
+      {
+        letterheadId: command.letterheadId,
+      },
+      'Deleting letterhead',
+    );
 
     try {
       const orgId = this.contextService.get('orgId');
@@ -57,9 +61,7 @@ export class DeleteLetterheadUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error deleting letterhead', {
-        error: error as Error,
-      });
+      this.logger.error({ err: error as Error }, 'Error deleting letterhead');
       throw new UnexpectedLetterheadError('Error deleting letterhead', {
         error: error as Error,
       });

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-all-letterheads/find-all-letterheads.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-all-letterheads/find-all-letterheads.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { FindAllLetterheadsUseCase } from './find-all-letterheads.use-case';
 import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
@@ -32,6 +33,10 @@ describe('FindAllLetterheadsUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FindAllLetterheadsUseCase,
+        {
+          provide: getLoggerToken(FindAllLetterheadsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: LetterheadsRepository, useValue: mockRepository },
         { provide: ContextService, useValue: mockContextService },
       ],
@@ -39,8 +44,6 @@ describe('FindAllLetterheadsUseCase', () => {
 
     useCase = module.get(FindAllLetterheadsUseCase);
     letterheadsRepository = module.get(LetterheadsRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
   });
 
   afterEach(() => {
@@ -92,6 +95,10 @@ describe('FindAllLetterheadsUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FindAllLetterheadsUseCase,
+        {
+          provide: getLoggerToken(FindAllLetterheadsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: LetterheadsRepository, useValue: letterheadsRepository },
         { provide: ContextService, useValue: mockContextService },
       ],

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-all-letterheads/find-all-letterheads.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-all-letterheads/find-all-letterheads.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -8,15 +9,15 @@ import { Letterhead } from 'src/domain/letterheads/domain/letterhead.entity';
 
 @Injectable()
 export class FindAllLetterheadsUseCase {
-  private readonly logger = new Logger(FindAllLetterheadsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindAllLetterheadsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly letterheadsRepository: LetterheadsRepository,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(): Promise<Letterhead[]> {
-    this.logger.log('Finding all letterheads');
+    this.logger.info('Finding all letterheads');
 
     try {
       const orgId = this.contextService.get('orgId');
@@ -29,9 +30,10 @@ export class FindAllLetterheadsUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error finding all letterheads', {
-        error: error as Error,
-      });
+      this.logger.error(
+        { err: error as Error },
+        'Error finding all letterheads',
+      );
       throw new UnexpectedLetterheadError('Error finding all letterheads', {
         error: error as Error,
       });

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { FindLetterheadUseCase } from './find-letterhead.use-case';
 import { FindLetterheadQuery } from './find-letterhead.query';
@@ -35,6 +36,10 @@ describe('FindLetterheadUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FindLetterheadUseCase,
+        {
+          provide: getLoggerToken(FindLetterheadUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: LetterheadsRepository, useValue: mockRepository },
         { provide: ContextService, useValue: mockContextService },
       ],
@@ -42,8 +47,6 @@ describe('FindLetterheadUseCase', () => {
 
     useCase = module.get(FindLetterheadUseCase);
     letterheadsRepository = module.get(LetterheadsRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
   });
 
   afterEach(() => {
@@ -92,6 +95,10 @@ describe('FindLetterheadUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FindLetterheadUseCase,
+        {
+          provide: getLoggerToken(FindLetterheadUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: LetterheadsRepository, useValue: letterheadsRepository },
         { provide: ContextService, useValue: mockContextService },
       ],

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/find-letterhead/find-letterhead.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -12,17 +13,20 @@ import { FindLetterheadQuery } from './find-letterhead.query';
 
 @Injectable()
 export class FindLetterheadUseCase {
-  private readonly logger = new Logger(FindLetterheadUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindLetterheadUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly letterheadsRepository: LetterheadsRepository,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(query: FindLetterheadQuery): Promise<Letterhead> {
-    this.logger.log('Finding letterhead', {
-      letterheadId: query.letterheadId,
-    });
+    this.logger.info(
+      {
+        letterheadId: query.letterheadId,
+      },
+      'Finding letterhead',
+    );
 
     try {
       const orgId = this.contextService.get('orgId');
@@ -44,9 +48,7 @@ export class FindLetterheadUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error finding letterhead', {
-        error: error as Error,
-      });
+      this.logger.error({ err: error as Error }, 'Error finding letterhead');
       throw new UnexpectedLetterheadError('Error finding letterhead', {
         error: error as Error,
       });

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { PDFDocument } from 'pdf-lib';
 import { UpdateLetterheadUseCase } from './update-letterhead.use-case';
@@ -83,6 +84,10 @@ describe('UpdateLetterheadUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UpdateLetterheadUseCase,
+        {
+          provide: getLoggerToken(UpdateLetterheadUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         LetterheadPdfService,
         { provide: LetterheadsRepository, useValue: mockRepository },
         { provide: ContextService, useValue: mockContextService },
@@ -97,8 +102,6 @@ describe('UpdateLetterheadUseCase', () => {
     deleteObjectUseCase = module.get(DeleteObjectUseCase);
 
     letterheadsRepository.save.mockImplementation(async (l) => l);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
   });
 
   afterEach(() => {
@@ -236,6 +239,10 @@ describe('UpdateLetterheadUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UpdateLetterheadUseCase,
+        {
+          provide: getLoggerToken(UpdateLetterheadUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         LetterheadPdfService,
         { provide: LetterheadsRepository, useValue: letterheadsRepository },
         { provide: ContextService, useValue: mockContextService },

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.use-case.ts
@@ -1,4 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ContextService } from 'src/common/context/services/context.service';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -17,9 +19,9 @@ import { UpdateLetterheadCommand } from './update-letterhead.command';
 
 @Injectable()
 export class UpdateLetterheadUseCase {
-  private readonly logger = new Logger(UpdateLetterheadUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateLetterheadUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly letterheadsRepository: LetterheadsRepository,
     private readonly contextService: ContextService,
     private readonly uploadObjectUseCase: UploadObjectUseCase,
@@ -28,98 +30,135 @@ export class UpdateLetterheadUseCase {
   ) {}
 
   async execute(command: UpdateLetterheadCommand): Promise<Letterhead> {
-    this.logger.log('Updating letterhead', {
-      letterheadId: command.letterheadId,
-    });
+    this.logger.info(
+      { letterheadId: command.letterheadId },
+      'Updating letterhead',
+    );
 
     try {
-      const orgId = this.contextService.get('orgId');
-      if (!orgId) {
-        throw new UnauthorizedAccessError();
-      }
-
-      const existing = await this.letterheadsRepository.findById(
-        orgId,
-        command.letterheadId,
-      );
-      if (!existing) {
-        throw new LetterheadNotFoundError(command.letterheadId);
-      }
-
-      let firstPageStoragePath = existing.firstPageStoragePath;
-      if (command.firstPagePdfBuffer) {
-        await this.letterheadPdfService.validateSinglePagePdf(
-          command.firstPagePdfBuffer,
-          'first page',
-        );
-        firstPageStoragePath = this.letterheadPdfService.buildStoragePath(
-          orgId,
-          existing.id,
-          'first-page.pdf',
-        );
-        await this.uploadObjectUseCase.execute(
-          new UploadObjectCommand(
-            firstPageStoragePath,
-            command.firstPagePdfBuffer,
-          ),
-        );
-      }
-
-      let continuationPageStoragePath = existing.continuationPageStoragePath;
-      if (command.continuationPagePdfBuffer) {
-        await this.letterheadPdfService.validateSinglePagePdf(
-          command.continuationPagePdfBuffer,
-          'continuation page',
-        );
-        continuationPageStoragePath =
-          this.letterheadPdfService.buildStoragePath(
-            orgId,
-            existing.id,
-            'continuation.pdf',
-          );
-        await this.uploadObjectUseCase.execute(
-          new UploadObjectCommand(
-            continuationPageStoragePath,
-            command.continuationPagePdfBuffer,
-          ),
-        );
-      } else if (command.removeContinuationPage) {
-        if (existing.continuationPageStoragePath) {
-          await this.deleteObjectUseCase.execute(
-            new DeleteObjectCommand(existing.continuationPageStoragePath),
-          );
-        }
-        continuationPageStoragePath = null;
-      }
-
-      const updated = new Letterhead({
-        id: existing.id,
-        orgId: existing.orgId,
-        name: command.name ?? existing.name,
-        description:
-          command.description !== undefined
-            ? command.description
-            : existing.description,
-        firstPageStoragePath,
-        continuationPageStoragePath,
-        firstPageMargins: command.firstPageMargins ?? existing.firstPageMargins,
-        continuationPageMargins:
-          command.continuationPageMargins ?? existing.continuationPageMargins,
-        createdAt: existing.createdAt,
-        updatedAt: new Date(),
-      });
-
-      return await this.letterheadsRepository.save(updated);
+      return await this.updateLetterhead(command);
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error updating letterhead', {
-        error: error as Error,
-      });
+      this.logger.error({ err: error as Error }, 'Error updating letterhead');
       throw new UnexpectedLetterheadError('Error updating letterhead', {
         error: error as Error,
       });
     }
+  }
+
+  private async updateLetterhead(
+    command: UpdateLetterheadCommand,
+  ): Promise<Letterhead> {
+    const orgId = this.resolveOrgId();
+    const existing = await this.letterheadsRepository.findById(
+      orgId,
+      command.letterheadId,
+    );
+    if (!existing) throw new LetterheadNotFoundError(command.letterheadId);
+    const firstPageStoragePath = await this.replaceFirstPage(
+      orgId,
+      existing,
+      command.firstPagePdfBuffer,
+    );
+    const continuationPageStoragePath = await this.resolveContinuationPage(
+      orgId,
+      existing,
+      command,
+    );
+    return this.letterheadsRepository.save(
+      this.buildUpdatedLetterhead(
+        existing,
+        command,
+        firstPageStoragePath,
+        continuationPageStoragePath,
+      ),
+    );
+  }
+
+  private resolveOrgId(): UUID {
+    const orgId = this.contextService.get('orgId');
+    if (!orgId) throw new UnauthorizedAccessError();
+    return orgId;
+  }
+
+  private async replaceFirstPage(
+    orgId: UUID,
+    existing: Letterhead,
+    buffer?: Buffer,
+  ): Promise<string> {
+    if (!buffer) return existing.firstPageStoragePath;
+    await this.letterheadPdfService.validateSinglePagePdf(buffer, 'first page');
+    return this.uploadPdf(orgId, existing.id, 'first-page.pdf', buffer);
+  }
+
+  private async resolveContinuationPage(
+    orgId: UUID,
+    existing: Letterhead,
+    command: UpdateLetterheadCommand,
+  ): Promise<string | null> {
+    if (command.continuationPagePdfBuffer) {
+      await this.letterheadPdfService.validateSinglePagePdf(
+        command.continuationPagePdfBuffer,
+        'continuation page',
+      );
+      return this.uploadPdf(
+        orgId,
+        existing.id,
+        'continuation.pdf',
+        command.continuationPagePdfBuffer,
+      );
+    }
+    if (!command.removeContinuationPage) {
+      return existing.continuationPageStoragePath;
+    }
+    if (existing.continuationPageStoragePath) {
+      await this.deleteObjectUseCase.execute(
+        new DeleteObjectCommand(existing.continuationPageStoragePath),
+      );
+    }
+    return null;
+  }
+
+  private async uploadPdf(
+    orgId: UUID,
+    letterheadId: UUID,
+    fileName: string,
+    buffer: Buffer,
+  ): Promise<string> {
+    const path = this.letterheadPdfService.buildStoragePath(
+      orgId,
+      letterheadId,
+      fileName,
+    );
+    await this.uploadObjectUseCase.execute(
+      new UploadObjectCommand(path, buffer),
+    );
+    return path;
+  }
+
+  private buildUpdatedLetterhead(
+    existing: Letterhead,
+    command: UpdateLetterheadCommand,
+    firstPageStoragePath: string,
+    continuationPageStoragePath: string | null,
+  ): Letterhead {
+    return new Letterhead({
+      id: existing.id,
+      orgId: existing.orgId,
+      name: command.name ?? existing.name,
+      description:
+        command.description !== undefined
+          ? command.description
+          : existing.description,
+      firstPageStoragePath,
+      continuationPageStoragePath,
+      firstPageMargins: command.firstPageMargins ?? existing.firstPageMargins,
+      continuationPageMargins:
+        command.continuationPageMargins ?? existing.continuationPageMargins,
+      createdAt: existing.createdAt,
+      updatedAt: new Date(),
+    });
   }
 }

--- a/ayunis-core-backend/src/domain/letterheads/infrastructure/persistence/local/local-letterheads.repository.ts
+++ b/ayunis-core-backend/src/domain/letterheads/infrastructure/persistence/local/local-letterheads.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { UUID } from 'crypto';
@@ -11,9 +12,9 @@ import { LetterheadMapper } from './mappers/letterhead.mapper';
 
 @Injectable()
 export class LocalLetterheadsRepository extends LetterheadsRepository {
-  private readonly logger = new Logger(LocalLetterheadsRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalLetterheadsRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(LetterheadRecord)
     private readonly repo: Repository<LetterheadRecord>,
     private readonly mapper: LetterheadMapper,
@@ -35,7 +36,7 @@ export class LocalLetterheadsRepository extends LetterheadsRepository {
   }
 
   async save(letterhead: Letterhead): Promise<Letterhead> {
-    this.logger.log(`Saving letterhead ${letterhead.id}`);
+    this.logger.info({ letterheadId: letterhead.id }, 'Saving letterhead');
     const record = this.mapper.toRecord(letterhead);
     const saved = await this.repo.save(record);
     return this.mapper.toDomain(saved);

--- a/ayunis-core-backend/src/domain/letterheads/presenters/http/letterheads.controller.ts
+++ b/ayunis-core-backend/src/domain/letterheads/presenters/http/letterheads.controller.ts
@@ -8,7 +8,6 @@ import {
   Body,
   Res,
   ParseUUIDPipe,
-  Logger,
   UseInterceptors,
   UploadedFiles,
   BadRequestException,
@@ -17,6 +16,7 @@ import {
   HttpStatus,
   StreamableFile,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
 import {
   ApiTags,
@@ -101,9 +101,9 @@ function parseMargins(value: unknown, label: string): PageMargins {
 @ApiTags('letterheads')
 @Controller('letterheads')
 export class LetterheadsController {
-  private readonly logger = new Logger(LetterheadsController.name);
-
   constructor(
+    @InjectPinoLogger(LetterheadsController.name)
+    private readonly logger: PinoLogger,
     private readonly createLetterheadUseCase: CreateLetterheadUseCase,
     private readonly findAllLetterheadsUseCase: FindAllLetterheadsUseCase,
     private readonly findLetterheadUseCase: FindLetterheadUseCase,
@@ -136,7 +136,7 @@ export class LetterheadsController {
     @Body() dto: CreateLetterheadDto,
     @UploadedFiles() files: UploadedFileFields,
   ): Promise<LetterheadResponseDto> {
-    this.logger.log('create', { name: dto.name });
+    this.logger.info('create');
 
     const firstPageFile = files.firstPagePdf?.[0];
     if (!firstPageFile) {
@@ -174,7 +174,7 @@ export class LetterheadsController {
     type: [LetterheadResponseDto],
   })
   async findAll(): Promise<LetterheadResponseDto[]> {
-    this.logger.log('findAll');
+    this.logger.info('findAll');
     const letterheads = await this.findAllLetterheadsUseCase.execute();
     return letterheads.map((l) => this.letterheadDtoMapper.toDto(l));
   }
@@ -196,7 +196,7 @@ export class LetterheadsController {
   async findOne(
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<LetterheadResponseDto> {
-    this.logger.log('findOne', { id });
+    this.logger.info({ id }, 'findOne');
     const letterhead = await this.findLetterheadUseCase.execute(
       new FindLetterheadQuery({ letterheadId: id }),
     );
@@ -301,30 +301,35 @@ export class LetterheadsController {
     @Body() dto: UpdateLetterheadDto,
     @UploadedFiles() files: UploadedFileFields,
   ): Promise<LetterheadResponseDto> {
-    this.logger.log('update', { id });
+    this.logger.info({ id }, 'update');
 
+    const letterhead = await this.updateLetterheadUseCase.execute(
+      this.toUpdateCommand(id, dto, files),
+    );
+    return this.letterheadDtoMapper.toDto(letterhead);
+  }
+
+  private toUpdateCommand(
+    id: UUID,
+    dto: UpdateLetterheadDto,
+    files: UploadedFileFields,
+  ): UpdateLetterheadCommand {
     const firstPageMargins = dto.firstPageMargins
       ? parseMargins(dto.firstPageMargins, 'firstPageMargins')
       : undefined;
     const continuationPageMargins = dto.continuationPageMargins
       ? parseMargins(dto.continuationPageMargins, 'continuationPageMargins')
       : undefined;
-
-    const removeContinuationPage = dto.removeContinuationPage === 'true';
-
-    const letterhead = await this.updateLetterheadUseCase.execute(
-      new UpdateLetterheadCommand({
-        letterheadId: id,
-        name: dto.name,
-        description: dto.description,
-        firstPagePdfBuffer: files.firstPagePdf?.[0]?.buffer,
-        continuationPagePdfBuffer: files.continuationPagePdf?.[0]?.buffer,
-        removeContinuationPage,
-        firstPageMargins,
-        continuationPageMargins,
-      }),
-    );
-    return this.letterheadDtoMapper.toDto(letterhead);
+    return new UpdateLetterheadCommand({
+      letterheadId: id,
+      name: dto.name,
+      description: dto.description,
+      firstPagePdfBuffer: files.firstPagePdf?.[0]?.buffer,
+      continuationPagePdfBuffer: files.continuationPagePdf?.[0]?.buffer,
+      removeContinuationPage: dto.removeContinuationPage === 'true',
+      firstPageMargins,
+      continuationPageMargins,
+    });
   }
 
   @Delete(':id')
@@ -340,7 +345,7 @@ export class LetterheadsController {
   @ApiResponse({ status: 204, description: 'Letterhead deleted' })
   @ApiResponse({ status: 404, description: 'Letterhead not found' })
   async remove(@Param('id', ParseUUIDPipe) id: UUID): Promise<void> {
-    this.logger.log('delete', { id });
+    this.logger.info({ id }, 'delete');
     await this.deleteLetterheadUseCase.execute(
       new DeleteLetterheadCommand({ letterheadId: id }),
     );

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/create-workspace/create-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/create-workspace/create-workspace.use-case.spec.ts
@@ -1,5 +1,6 @@
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { AddFavoriteUseCase } from 'src/domain/favorites/application/use-cases/add-favorite/add-favorite.use-case';
@@ -34,6 +35,10 @@ describe('CreateWorkspaceUseCase', () => {
     const module = await Test.createTestingModule({
       providers: [
         CreateWorkspaceUseCase,
+        {
+          provide: getLoggerToken(CreateWorkspaceUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: WorkspacesRepository, useValue: repository },
         { provide: AddFavoriteUseCase, useValue: addFavoriteUseCase },
         { provide: ContextService, useValue: contextService },
@@ -41,10 +46,6 @@ describe('CreateWorkspaceUseCase', () => {
     }).compile();
     useCase = module.get(CreateWorkspaceUseCase);
   }
-
-  beforeAll(() => {
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-  });
 
   beforeEach(async () => {
     await setup();

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/create-workspace/create-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/create-workspace/create-workspace.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -14,9 +15,9 @@ import { CreateWorkspaceCommand } from './create-workspace.command';
 
 @Injectable()
 export class CreateWorkspaceUseCase {
-  private readonly logger = new Logger(CreateWorkspaceUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateWorkspaceUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
     private readonly contextService: ContextService,
     private readonly addFavoriteUseCase: AddFavoriteUseCase,
@@ -24,7 +25,7 @@ export class CreateWorkspaceUseCase {
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(command: CreateWorkspaceCommand): Promise<Workspace> {
-    this.logger.log('Creating workspace');
+    this.logger.info('Creating workspace');
 
     assertValidWorkspaceFields({
       name: command.name,

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/delete-workspace/delete-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/delete-workspace/delete-workspace.use-case.spec.ts
@@ -1,5 +1,6 @@
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ContextService } from 'src/common/context/services/context.service';
 import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
@@ -21,17 +22,16 @@ describe('DeleteWorkspaceUseCase', () => {
   let repository: jest.Mocked<WorkspacesRepository>;
   let eventEmitter: { emitAsync: jest.Mock };
 
-  beforeAll(() => {
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
-  });
-
   beforeEach(async () => {
     repository = createMockWorkspacesRepository();
     eventEmitter = { emitAsync: jest.fn().mockResolvedValue([]) };
     const module = await Test.createTestingModule({
       providers: [
         DeleteWorkspaceUseCase,
+        {
+          provide: getLoggerToken(DeleteWorkspaceUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: WorkspacesRepository, useValue: repository },
         { provide: ContextService, useValue: createMockContextService() },
         { provide: EventEmitter2, useValue: eventEmitter },

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/delete-workspace/delete-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/delete-workspace/delete-workspace.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
@@ -15,9 +16,9 @@ import { DeleteWorkspaceCommand } from './delete-workspace.command';
 
 @Injectable()
 export class DeleteWorkspaceUseCase {
-  private readonly logger = new Logger(DeleteWorkspaceUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteWorkspaceUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
     private readonly contextService: ContextService,
     private readonly eventEmitter: EventEmitter2,
@@ -25,7 +26,7 @@ export class DeleteWorkspaceUseCase {
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(command: DeleteWorkspaceCommand): Promise<void> {
-    this.logger.log('Deleting workspace', { workspaceId: command.id });
+    this.logger.info({ workspaceId: command.id }, 'Deleting workspace');
 
     const userId = this.resolveUserId();
     const workspace = await this.workspacesRepository.findById(

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.spec.ts
@@ -1,5 +1,6 @@
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
@@ -20,16 +21,16 @@ describe('FindAllWorkspacesUseCase', () => {
     const module = await Test.createTestingModule({
       providers: [
         FindAllWorkspacesUseCase,
+        {
+          provide: getLoggerToken(FindAllWorkspacesUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: WorkspacesRepository, useValue: repository },
         { provide: ContextService, useValue: contextService },
       ],
     }).compile();
     useCase = module.get(FindAllWorkspacesUseCase);
   }
-
-  beforeAll(() => {
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-  });
 
   beforeEach(async () => {
     await setup();

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -16,16 +17,16 @@ export interface WorkspaceListItem {
 
 @Injectable()
 export class FindAllWorkspacesUseCase {
-  private readonly logger = new Logger(FindAllWorkspacesUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindAllWorkspacesUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
     private readonly contextService: ContextService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(): Promise<WorkspaceListItem[]> {
-    this.logger.log('Finding all workspaces');
+    this.logger.info('Finding all workspaces');
 
     const workspaces = await this.workspacesRepository.findAllByUserId(
       this.resolveUserId(),

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspace/find-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspace/find-workspace.use-case.spec.ts
@@ -1,5 +1,6 @@
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { ContextService } from 'src/common/context/services/context.service';
 import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
 import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
@@ -17,15 +18,15 @@ describe('FindWorkspaceUseCase', () => {
   let useCase: FindWorkspaceUseCase;
   let repository: jest.Mocked<WorkspacesRepository>;
 
-  beforeAll(() => {
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-  });
-
   beforeEach(async () => {
     repository = createMockWorkspacesRepository();
     const module = await Test.createTestingModule({
       providers: [
         FindWorkspaceUseCase,
+        {
+          provide: getLoggerToken(FindWorkspaceUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: WorkspacesRepository, useValue: repository },
         { provide: ContextService, useValue: createMockContextService() },
       ],

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspace/find-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspace/find-workspace.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -13,16 +14,16 @@ import { FindWorkspaceQuery } from './find-workspace.query';
 
 @Injectable()
 export class FindWorkspaceUseCase {
-  private readonly logger = new Logger(FindWorkspaceUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindWorkspaceUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
     private readonly contextService: ContextService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(query: FindWorkspaceQuery): Promise<Workspace> {
-    this.logger.log('Finding workspace', { workspaceId: query.id });
+    this.logger.info({ workspaceId: query.id }, 'Finding workspace');
 
     const workspace = await this.workspacesRepository.findById(
       this.resolveUserId(),

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import type { WorkspacesRepository } from '../../ports/workspaces-repository.port';
 import { FindWorkspacesByIdsQuery } from './find-workspaces-by-ids.query';
@@ -12,7 +13,10 @@ describe('FindWorkspacesByIdsUseCase', () => {
     const repository = {
       findAllByIds: jest.fn().mockResolvedValue(workspaces),
     } as unknown as WorkspacesRepository;
-    const useCase = new FindWorkspacesByIdsUseCase(repository);
+    const useCase = new FindWorkspacesByIdsUseCase(
+      createPinoLoggerMock(),
+      repository,
+    );
 
     await expect(
       useCase.execute(new FindWorkspacesByIdsQuery(USER_ID, [WORKSPACE_ID])),

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import type { Workspace } from '../../../domain/workspace.entity';
 import { UnexpectedWorkspaceError } from '../../workspaces.errors';
@@ -7,16 +8,21 @@ import type { FindWorkspacesByIdsQuery } from './find-workspaces-by-ids.query';
 
 @Injectable()
 export class FindWorkspacesByIdsUseCase {
-  private readonly logger = new Logger(FindWorkspacesByIdsUseCase.name);
-
-  constructor(private readonly workspacesRepository: WorkspacesRepository) {}
+  constructor(
+    @InjectPinoLogger(FindWorkspacesByIdsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly workspacesRepository: WorkspacesRepository,
+  ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(query: FindWorkspacesByIdsQuery): Promise<Workspace[]> {
-    this.logger.debug('Finding workspaces by ids', {
-      userId: query.userId,
-      count: query.ids.length,
-    });
+    this.logger.debug(
+      {
+        userId: query.userId,
+        count: query.ids.length,
+      },
+      'Finding workspaces by ids',
+    );
     return this.workspacesRepository.findAllByIds(query.userId, query.ids);
   }
 }

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace/update-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace/update-workspace.use-case.spec.ts
@@ -1,5 +1,6 @@
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { ContextService } from 'src/common/context/services/context.service';
 import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
 import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
@@ -21,15 +22,15 @@ describe('UpdateWorkspaceUseCase', () => {
   let useCase: UpdateWorkspaceUseCase;
   let repository: jest.Mocked<WorkspacesRepository>;
 
-  beforeAll(() => {
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-  });
-
   beforeEach(async () => {
     repository = createMockWorkspacesRepository();
     const module = await Test.createTestingModule({
       providers: [
         UpdateWorkspaceUseCase,
+        {
+          provide: getLoggerToken(UpdateWorkspaceUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: WorkspacesRepository, useValue: repository },
         { provide: ContextService, useValue: createMockContextService() },
       ],

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace/update-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace/update-workspace.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -14,16 +15,16 @@ import { UpdateWorkspaceCommand } from './update-workspace.command';
 
 @Injectable()
 export class UpdateWorkspaceUseCase {
-  private readonly logger = new Logger(UpdateWorkspaceUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateWorkspaceUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
     private readonly contextService: ContextService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(command: UpdateWorkspaceCommand): Promise<Workspace> {
-    this.logger.log('Updating workspace', { workspaceId: command.id });
+    this.logger.info({ workspaceId: command.id }, 'Updating workspace');
 
     const workspace = await this.workspacesRepository.findById(
       this.resolveUserId(),

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/workspaces.controller.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/workspaces.controller.ts
@@ -5,12 +5,12 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   ParseUUIDPipe,
   Patch,
   Post,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import type { UUID } from 'crypto';
 import { RequireFeature } from 'src/common/guards/feature.guard';
@@ -33,9 +33,9 @@ import { WorkspaceDtoMapper } from './mappers/workspace-dto.mapper';
 @Controller('workspaces')
 @RequireFeature(FeatureFlag.Workspaces)
 export class WorkspacesController {
-  private readonly logger = new Logger(WorkspacesController.name);
-
   constructor(
+    @InjectPinoLogger(WorkspacesController.name)
+    private readonly logger: PinoLogger,
     private readonly createWorkspaceUseCase: CreateWorkspaceUseCase,
     private readonly findAllWorkspacesUseCase: FindAllWorkspacesUseCase,
     private readonly findWorkspaceUseCase: FindWorkspaceUseCase,
@@ -52,7 +52,7 @@ export class WorkspacesController {
     type: WorkspaceResponseDto,
   })
   async create(@Body() dto: CreateWorkspaceDto): Promise<WorkspaceResponseDto> {
-    this.logger.log('create');
+    this.logger.info('create');
     const workspace = await this.createWorkspaceUseCase.execute(
       new CreateWorkspaceCommand({
         name: dto.name,
@@ -72,7 +72,7 @@ export class WorkspacesController {
     type: [WorkspaceResponseDto],
   })
   async findAll(): Promise<WorkspaceResponseDto[]> {
-    this.logger.log('findAll');
+    this.logger.info('findAll');
     const items = await this.findAllWorkspacesUseCase.execute();
     return items.map((item) => this.workspaceDtoMapper.toListItemDto(item));
   }
@@ -94,7 +94,7 @@ export class WorkspacesController {
   async findOne(
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<WorkspaceResponseDto> {
-    this.logger.log('findOne', { id });
+    this.logger.info({ id }, 'findOne');
     const workspace = await this.findWorkspaceUseCase.execute(
       new FindWorkspaceQuery(id),
     );
@@ -119,7 +119,7 @@ export class WorkspacesController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() dto: UpdateWorkspaceDto,
   ): Promise<WorkspaceResponseDto> {
-    this.logger.log('update', { id });
+    this.logger.info({ id }, 'update');
     const workspace = await this.updateWorkspaceUseCase.execute(
       new UpdateWorkspaceCommand({
         id,
@@ -146,7 +146,7 @@ export class WorkspacesController {
   @ApiResponse({ status: 204, description: 'The workspace was deleted' })
   @ApiResponse({ status: 404, description: 'Workspace not found' })
   async remove(@Param('id', ParseUUIDPipe) id: UUID): Promise<void> {
-    this.logger.log('remove', { id });
+    this.logger.info({ id }, 'remove');
     await this.deleteWorkspaceUseCase.execute(new DeleteWorkspaceCommand(id));
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability and DI-only changes with broad test updates; letterhead use-case refactors are structural but warrant a quick sanity check on create/update flows.
> 
> **Overview**
> **Migrates domain logging from Nest’s `Logger` to `nestjs-pino` (`PinoLogger`)** across artifacts (use cases, export services, repository, controller), favorites, letterheads, and workspaces.
> 
> Classes now take **`@InjectPinoLogger(ClassName.name)`** instead of `private readonly logger = new Logger(...)`. Calls move from **`log`/`warn`/`error` with message-first or ad-hoc objects** to Pino’s **`info`/`warn`/`error` with bindings first and a string message second** (e.g. version-conflict retries in `addVersionWithRetry`, export fallbacks using `{ err }` instead of inlined error text).
> 
> **Tests** drop `Logger.prototype` spies and **`.setLogger(new Logger())`** in favor of **`getLoggerToken(...)`** and **`createPinoLoggerMock()`**; export/infrastructure specs pass a mock logger into constructors that now require it. One create-artifact spec asserts **`logger.info`** is called with the new shape.
> 
> **Minor non-logging edits:** letterhead create/update use cases are split into private helpers; `LocalArtifactsRepository` extracts `logVersionUpdate`; `LetterheadsController` extracts `toUpdateCommand` for update—behavior should be unchanged aside from log field tweaks (e.g. less title/name in controller logs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38957c1a50e3210256400739cd4d1ea939e8545b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->