### PR TITLE
wip(logging): migrate remaining domain logging (AYC-754)

### DIFF
--- a/ayunis-core-backend/src/domain/academy/application/use-cases/create-chapter/create-chapter.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/create-chapter/create-chapter.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyChapter } from 'src/domain/academy/domain/academy-chapter.entity';
@@ -7,12 +8,14 @@ import { CreateChapterCommand } from './create-chapter.command';
 
 @Injectable()
 export class CreateChapterUseCase {
-  private readonly logger = new Logger(CreateChapterUseCase.name);
-
-  constructor(private readonly chapterRepository: AcademyChapterRepository) {}
+  constructor(
+    @InjectPinoLogger(CreateChapterUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly chapterRepository: AcademyChapterRepository,
+  ) {}
 
   async execute(command: CreateChapterCommand): Promise<AcademyChapter> {
-    this.logger.log('Creating academy chapter', { title: command.title });
+    this.logger.info({ title: command.title }, 'Creating academy chapter');
     try {
       const maxPosition = await this.chapterRepository.findMaxPosition();
       const chapter = new AcademyChapter({
@@ -23,9 +26,12 @@ export class CreateChapterUseCase {
       return await this.chapterRepository.create(chapter);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error creating academy chapter', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error creating academy chapter',
+      );
       throw new UnexpectedAcademyError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/create-course-module/create-course-module.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/create-course-module/create-course-module.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { CreateCourseModuleUseCase } from './create-course-module.use-case';
 import { CreateCourseModuleCommand } from './create-course-module.command';
@@ -32,6 +33,10 @@ describe('CreateCourseModuleUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(CreateCourseModuleUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         CreateCourseModuleUseCase,
         { provide: AcademyChapterRepository, useValue: mockChapterRepository },
         {
@@ -44,9 +49,6 @@ describe('CreateCourseModuleUseCase', () => {
     useCase = module.get<CreateCourseModuleUseCase>(CreateCourseModuleUseCase);
     chapterRepository = module.get(AcademyChapterRepository);
     courseModuleRepository = module.get(AcademyCourseModuleRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/create-course-module/create-course-module.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/create-course-module/create-course-module.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyCourseModuleRepository } from '../../ports/academy-course-module.repository';
@@ -11,9 +12,9 @@ import { CreateCourseModuleCommand } from './create-course-module.command';
 
 @Injectable()
 export class CreateCourseModuleUseCase {
-  private readonly logger = new Logger(CreateCourseModuleUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateCourseModuleUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly chapterRepository: AcademyChapterRepository,
     private readonly courseModuleRepository: AcademyCourseModuleRepository,
   ) {}
@@ -21,10 +22,13 @@ export class CreateCourseModuleUseCase {
   async execute(
     command: CreateCourseModuleCommand,
   ): Promise<AcademyCourseModule> {
-    this.logger.log('Creating academy module', {
-      chapterId: command.chapterId,
-      title: command.title,
-    });
+    this.logger.info(
+      {
+        chapterId: command.chapterId,
+        title: command.title,
+      },
+      'Creating academy module',
+    );
     try {
       const chapter = await this.chapterRepository.findOne(command.chapterId);
       if (!chapter) {
@@ -43,9 +47,12 @@ export class CreateCourseModuleUseCase {
       return await this.courseModuleRepository.create(courseModule);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error creating academy module', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error creating academy module',
+      );
       throw new UnexpectedAcademyError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/create-quiz-question/create-quiz-question.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/create-quiz-question/create-quiz-question.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { CreateQuizQuestionUseCase } from './create-quiz-question.use-case';
 import { CreateQuizQuestionCommand } from './create-quiz-question.command';
@@ -38,6 +39,10 @@ describe('CreateQuizQuestionUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(CreateQuizQuestionUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         CreateQuizQuestionUseCase,
         { provide: AcademyChapterRepository, useValue: mockChapterRepository },
         {
@@ -50,9 +55,6 @@ describe('CreateQuizQuestionUseCase', () => {
     useCase = module.get<CreateQuizQuestionUseCase>(CreateQuizQuestionUseCase);
     chapterRepository = module.get(AcademyChapterRepository);
     quizQuestionRepository = module.get(AcademyQuizQuestionRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/create-quiz-question/create-quiz-question.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/create-quiz-question/create-quiz-question.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
@@ -12,9 +13,9 @@ import { CreateQuizQuestionCommand } from './create-quiz-question.command';
 
 @Injectable()
 export class CreateQuizQuestionUseCase {
-  private readonly logger = new Logger(CreateQuizQuestionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateQuizQuestionUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly chapterRepository: AcademyChapterRepository,
     private readonly quizQuestionRepository: AcademyQuizQuestionRepository,
   ) {}
@@ -22,9 +23,12 @@ export class CreateQuizQuestionUseCase {
   async execute(
     command: CreateQuizQuestionCommand,
   ): Promise<AcademyQuizQuestion> {
-    this.logger.log('Creating academy quiz question', {
-      chapterId: command.chapterId,
-    });
+    this.logger.info(
+      {
+        chapterId: command.chapterId,
+      },
+      'Creating academy quiz question',
+    );
     try {
       assertValidQuizOptions(command.options);
       const chapter = await this.chapterRepository.findOne(command.chapterId);
@@ -43,9 +47,12 @@ export class CreateQuizQuestionUseCase {
       return await this.quizQuestionRepository.create(quizQuestion);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error creating academy quiz question', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error creating academy quiz question',
+      );
       throw new UnexpectedAcademyError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/delete-chapter/delete-chapter.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/delete-chapter/delete-chapter.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { UnexpectedAcademyError } from '../../academy.errors';
@@ -6,21 +7,29 @@ import { DeleteChapterCommand } from './delete-chapter.command';
 
 @Injectable()
 export class DeleteChapterUseCase {
-  private readonly logger = new Logger(DeleteChapterUseCase.name);
-
-  constructor(private readonly chapterRepository: AcademyChapterRepository) {}
+  constructor(
+    @InjectPinoLogger(DeleteChapterUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly chapterRepository: AcademyChapterRepository,
+  ) {}
 
   async execute(command: DeleteChapterCommand): Promise<void> {
-    this.logger.log('Deleting academy chapter', {
-      chapterId: command.chapterId,
-    });
+    this.logger.info(
+      {
+        chapterId: command.chapterId,
+      },
+      'Deleting academy chapter',
+    );
     try {
       await this.chapterRepository.delete(command.chapterId);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error deleting academy chapter', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error deleting academy chapter',
+      );
       throw new UnexpectedAcademyError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/delete-course-module/delete-course-module.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/delete-course-module/delete-course-module.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AcademyCourseModuleRepository } from '../../ports/academy-course-module.repository';
 import { UnexpectedAcademyError } from '../../academy.errors';
@@ -6,23 +7,29 @@ import { DeleteCourseModuleCommand } from './delete-course-module.command';
 
 @Injectable()
 export class DeleteCourseModuleUseCase {
-  private readonly logger = new Logger(DeleteCourseModuleUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteCourseModuleUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly courseModuleRepository: AcademyCourseModuleRepository,
   ) {}
 
   async execute(command: DeleteCourseModuleCommand): Promise<void> {
-    this.logger.log('Deleting academy module', {
-      courseModuleId: command.courseModuleId,
-    });
+    this.logger.info(
+      {
+        courseModuleId: command.courseModuleId,
+      },
+      'Deleting academy module',
+    );
     try {
       await this.courseModuleRepository.delete(command.courseModuleId);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error deleting academy module', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error deleting academy module',
+      );
       throw new UnexpectedAcademyError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/delete-quiz-question/delete-quiz-question.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/delete-quiz-question/delete-quiz-question.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
 import { UnexpectedAcademyError } from '../../academy.errors';
@@ -6,23 +7,29 @@ import { DeleteQuizQuestionCommand } from './delete-quiz-question.command';
 
 @Injectable()
 export class DeleteQuizQuestionUseCase {
-  private readonly logger = new Logger(DeleteQuizQuestionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteQuizQuestionUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly quizQuestionRepository: AcademyQuizQuestionRepository,
   ) {}
 
   async execute(command: DeleteQuizQuestionCommand): Promise<void> {
-    this.logger.log('Deleting academy quiz question', {
-      quizQuestionId: command.quizQuestionId,
-    });
+    this.logger.info(
+      {
+        quizQuestionId: command.quizQuestionId,
+      },
+      'Deleting academy quiz question',
+    );
     try {
       await this.quizQuestionRepository.delete(command.quizQuestionId);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error deleting academy quiz question', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error deleting academy quiz question',
+      );
       throw new UnexpectedAcademyError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-certificate/get-academy-certificate.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-certificate/get-academy-certificate.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { GetAcademyCertificateUseCase } from './get-academy-certificate.use-case';
 import { GetAcademyCertificateQuery } from './get-academy-certificate.query';
@@ -34,9 +35,6 @@ describe('GetAcademyCertificateUseCase', () => {
   });
 
   beforeEach(async () => {
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
-
     completionRepository = {
       findByUser: jest.fn(),
       findByUsers: jest.fn(),
@@ -51,6 +49,10 @@ describe('GetAcademyCertificateUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(GetAcademyCertificateUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         GetAcademyCertificateUseCase,
         {
           provide: AcademyCompletionRepository,

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-certificate/get-academy-certificate.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-certificate/get-academy-certificate.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { FindUserByIdUseCase } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case';
 import { FindUserByIdQuery } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.query';
@@ -28,9 +29,9 @@ const CERTIFICATE_DATE_FORMAT = new Intl.DateTimeFormat('de-DE', {
 
 @Injectable()
 export class GetAcademyCertificateUseCase {
-  private readonly logger = new Logger(GetAcademyCertificateUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetAcademyCertificateUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly completionRepository: AcademyCompletionRepository,
     private readonly findUserByIdUseCase: FindUserByIdUseCase,
     private readonly certificateRenderer: CertificateRendererPort,
@@ -40,7 +41,7 @@ export class GetAcademyCertificateUseCase {
   async execute(
     query: GetAcademyCertificateQuery,
   ): Promise<AcademyCertificateFile> {
-    this.logger.log('Getting academy certificate', { userId: query.userId });
+    this.logger.info({ userId: query.userId }, 'Getting academy certificate');
 
     const completion = await this.completionRepository.findByUser(query.userId);
     if (!completion) {

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-completion/get-academy-completion.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-completion/get-academy-completion.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { GetAcademyCompletionUseCase } from './get-academy-completion.use-case';
 import { GetAcademyCompletionQuery } from './get-academy-completion.query';
@@ -17,6 +18,10 @@ describe('GetAcademyCompletionUseCase', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(GetAcademyCompletionUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         GetAcademyCompletionUseCase,
         {
           provide: AcademyCompletionRepository,
@@ -27,8 +32,6 @@ describe('GetAcademyCompletionUseCase', () => {
 
     useCase = module.get(GetAcademyCompletionUseCase);
     completionRepository = module.get(AcademyCompletionRepository);
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-completion/get-academy-completion.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-completion/get-academy-completion.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyCompletionRepository } from '../../ports/academy-completion.repository';
 import { UnexpectedAcademyError } from '../../academy.errors';
@@ -13,9 +14,9 @@ import { GetAcademyCompletionQuery } from './get-academy-completion.query';
  */
 @Injectable()
 export class GetAcademyCompletionUseCase {
-  private readonly logger = new Logger(GetAcademyCompletionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetAcademyCompletionUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly completionRepository: AcademyCompletionRepository,
   ) {}
 
@@ -23,7 +24,7 @@ export class GetAcademyCompletionUseCase {
   async execute(
     query: GetAcademyCompletionQuery,
   ): Promise<AcademyCompletionView> {
-    this.logger.debug('Getting academy completion', { userId: query.userId });
+    this.logger.debug({ userId: query.userId }, 'Getting academy completion');
 
     const completion = await this.completionRepository.findByUser(query.userId);
     if (!completion) {

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-completions/get-academy-completions.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-completions/get-academy-completions.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { AcademyCompletionRepository } from 'src/domain/academy/application/ports/academy-completion.repository';
@@ -15,9 +16,9 @@ import { GetAcademyCompletionsQuery } from './get-academy-completions.query';
  */
 @Injectable()
 export class GetAcademyCompletionsUseCase {
-  private readonly logger = new Logger(GetAcademyCompletionsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetAcademyCompletionsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly completionRepository: AcademyCompletionRepository,
   ) {}
 
@@ -25,9 +26,12 @@ export class GetAcademyCompletionsUseCase {
   async execute(
     query: GetAcademyCompletionsQuery,
   ): Promise<ReadonlyMap<UUID, AcademyCompletionView>> {
-    this.logger.debug('Getting academy completions', {
-      userCount: query.userIds.length,
-    });
+    this.logger.debug(
+      {
+        userCount: query.userIds.length,
+      },
+      'Getting academy completions',
+    );
 
     const completions = await this.completionRepository.findByUsers(
       query.userIds,

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-content/get-academy-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-content/get-academy-content.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyChapter } from 'src/domain/academy/domain/academy-chapter.entity';
@@ -7,20 +8,25 @@ import { GetAcademyContentQuery } from './get-academy-content.query';
 
 @Injectable()
 export class GetAcademyContentUseCase {
-  private readonly logger = new Logger(GetAcademyContentUseCase.name);
-
-  constructor(private readonly chapterRepository: AcademyChapterRepository) {}
+  constructor(
+    @InjectPinoLogger(GetAcademyContentUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly chapterRepository: AcademyChapterRepository,
+  ) {}
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async execute(_query: GetAcademyContentQuery): Promise<AcademyChapter[]> {
-    this.logger.log('Getting academy content');
+    this.logger.info('Getting academy content');
     try {
       return await this.chapterRepository.findAllWithCourseModules();
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting academy content', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error getting academy content',
+      );
       throw new UnexpectedAcademyError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-management-content/get-academy-management-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-management-content/get-academy-management-content.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyChapter } from 'src/domain/academy/domain/academy-chapter.entity';
@@ -13,22 +14,27 @@ import { GetAcademyManagementContentQuery } from './get-academy-management-conte
  */
 @Injectable()
 export class GetAcademyManagementContentUseCase {
-  private readonly logger = new Logger(GetAcademyManagementContentUseCase.name);
-
-  constructor(private readonly chapterRepository: AcademyChapterRepository) {}
+  constructor(
+    @InjectPinoLogger(GetAcademyManagementContentUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly chapterRepository: AcademyChapterRepository,
+  ) {}
 
   async execute(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _query: GetAcademyManagementContentQuery,
   ): Promise<AcademyChapter[]> {
-    this.logger.log('Getting academy management content');
+    this.logger.info('Getting academy management content');
     try {
       return await this.chapterRepository.findAllWithQuizContent();
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting academy management content', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error getting academy management content',
+      );
       throw new UnexpectedAcademyError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-progress/get-academy-progress.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-progress/get-academy-progress.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { GetAcademyProgressUseCase } from './get-academy-progress.use-case';
 import { GetAcademyProgressQuery } from './get-academy-progress.query';
@@ -21,6 +22,10 @@ describe('GetAcademyProgressUseCase', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(GetAcademyProgressUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         GetAcademyProgressUseCase,
         {
           provide: AcademyChapterProgressRepository,
@@ -36,8 +41,6 @@ describe('GetAcademyProgressUseCase', () => {
     useCase = module.get(GetAcademyProgressUseCase);
     progressRepository = module.get(AcademyChapterProgressRepository);
     completionRepository = module.get(AcademyCompletionRepository);
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-progress/get-academy-progress.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-progress/get-academy-progress.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AcademyChapterProgressRepository } from '../../ports/academy-chapter-progress.repository';
@@ -31,15 +32,15 @@ export interface AcademyProgressView {
 
 @Injectable()
 export class GetAcademyProgressUseCase {
-  private readonly logger = new Logger(GetAcademyProgressUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetAcademyProgressUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly progressRepository: AcademyChapterProgressRepository,
     private readonly completionRepository: AcademyCompletionRepository,
   ) {}
 
   async execute(query: GetAcademyProgressQuery): Promise<AcademyProgressView> {
-    this.logger.log('Getting academy progress', { userId: query.userId });
+    this.logger.info({ userId: query.userId }, 'Getting academy progress');
     try {
       const progress = await this.progressRepository.findAllByUser(
         query.userId,
@@ -64,9 +65,12 @@ export class GetAcademyProgressUseCase {
       };
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting academy progress', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error getting academy progress',
+      );
       throw new UnexpectedAcademyError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-chapter-quiz/get-chapter-quiz.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-chapter-quiz/get-chapter-quiz.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import type { UUID } from 'crypto';
 import { GetChapterQuizUseCase } from './get-chapter-quiz.use-case';
@@ -45,6 +46,10 @@ describe('GetChapterQuizUseCase', () => {
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(GetChapterQuizUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         GetChapterQuizUseCase,
         { provide: AcademyChapterRepository, useValue: { findOne: jest.fn() } },
         {
@@ -57,8 +62,6 @@ describe('GetChapterQuizUseCase', () => {
     useCase = module.get(GetChapterQuizUseCase);
     chapterRepository = module.get(AcademyChapterRepository);
     quizQuestionRepository = module.get(AcademyQuizQuestionRepository);
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-chapter-quiz/get-chapter-quiz.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-chapter-quiz/get-chapter-quiz.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
@@ -13,15 +14,15 @@ import { GetChapterQuizQuery } from './get-chapter-quiz.query';
 
 @Injectable()
 export class GetChapterQuizUseCase {
-  private readonly logger = new Logger(GetChapterQuizUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetChapterQuizUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly chapterRepository: AcademyChapterRepository,
     private readonly quizQuestionRepository: AcademyQuizQuestionRepository,
   ) {}
 
   async execute(query: GetChapterQuizQuery): Promise<AcademyQuizQuestion[]> {
-    this.logger.log('Getting chapter quiz', { chapterId: query.chapterId });
+    this.logger.info({ chapterId: query.chapterId }, 'Getting chapter quiz');
     try {
       const chapter = await this.chapterRepository.findOne(query.chapterId);
       if (!chapter) {
@@ -39,9 +40,12 @@ export class GetChapterQuizUseCase {
       return this.drawRandom(pool, DRAWN_QUESTION_COUNT);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting chapter quiz', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error getting chapter quiz',
+      );
       throw new UnexpectedAcademyError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-chapters/reorder-chapters.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-chapters/reorder-chapters.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { ReorderChaptersUseCase } from './reorder-chapters.use-case';
 import { ReorderChaptersCommand } from './reorder-chapters.command';
@@ -19,6 +20,10 @@ describe('ReorderChaptersUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(ReorderChaptersUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         ReorderChaptersUseCase,
         { provide: AcademyChapterRepository, useValue: mockRepository },
       ],
@@ -26,9 +31,6 @@ describe('ReorderChaptersUseCase', () => {
 
     useCase = module.get<ReorderChaptersUseCase>(ReorderChaptersUseCase);
     repository = module.get(AcademyChapterRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-chapters/reorder-chapters.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-chapters/reorder-chapters.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { UnexpectedAcademyError } from '../../academy.errors';
@@ -7,23 +8,31 @@ import { ReorderChaptersCommand } from './reorder-chapters.command';
 
 @Injectable()
 export class ReorderChaptersUseCase {
-  private readonly logger = new Logger(ReorderChaptersUseCase.name);
-
-  constructor(private readonly chapterRepository: AcademyChapterRepository) {}
+  constructor(
+    @InjectPinoLogger(ReorderChaptersUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly chapterRepository: AcademyChapterRepository,
+  ) {}
 
   async execute(command: ReorderChaptersCommand): Promise<void> {
-    this.logger.log('Reordering academy chapters', {
-      count: command.chapterIds.length,
-    });
+    this.logger.info(
+      {
+        count: command.chapterIds.length,
+      },
+      'Reordering academy chapters',
+    );
     try {
       const currentIds = await this.chapterRepository.findAllIds();
       assertSameIdSet(currentIds, command.chapterIds);
       await this.chapterRepository.updatePositions(command.chapterIds);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error reordering academy chapters', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error reordering academy chapters',
+      );
       throw new UnexpectedAcademyError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-course-modules/reorder-course-modules.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-course-modules/reorder-course-modules.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { ReorderCourseModulesUseCase } from './reorder-course-modules.use-case';
 import { ReorderCourseModulesCommand } from './reorder-course-modules.command';
@@ -34,6 +35,10 @@ describe('ReorderCourseModulesUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(ReorderCourseModulesUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         ReorderCourseModulesUseCase,
         { provide: AcademyChapterRepository, useValue: mockChapterRepository },
         {
@@ -48,9 +53,6 @@ describe('ReorderCourseModulesUseCase', () => {
     );
     chapterRepository = module.get(AcademyChapterRepository);
     courseModuleRepository = module.get(AcademyCourseModuleRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-course-modules/reorder-course-modules.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/reorder-course-modules/reorder-course-modules.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyCourseModuleRepository } from '../../ports/academy-course-module.repository';
@@ -11,18 +12,21 @@ import { ReorderCourseModulesCommand } from './reorder-course-modules.command';
 
 @Injectable()
 export class ReorderCourseModulesUseCase {
-  private readonly logger = new Logger(ReorderCourseModulesUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ReorderCourseModulesUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly chapterRepository: AcademyChapterRepository,
     private readonly courseModuleRepository: AcademyCourseModuleRepository,
   ) {}
 
   async execute(command: ReorderCourseModulesCommand): Promise<void> {
-    this.logger.log('Reordering academy modules', {
-      chapterId: command.chapterId,
-      count: command.courseModuleIds.length,
-    });
+    this.logger.info(
+      {
+        chapterId: command.chapterId,
+        count: command.courseModuleIds.length,
+      },
+      'Reordering academy modules',
+    );
     try {
       const chapter = await this.chapterRepository.findOne(command.chapterId);
       if (!chapter) {
@@ -38,9 +42,12 @@ export class ReorderCourseModulesUseCase {
       );
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error reordering academy modules', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error reordering academy modules',
+      );
       throw new UnexpectedAcademyError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/submit-chapter-quiz/submit-chapter-quiz.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/submit-chapter-quiz/submit-chapter-quiz.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import type { UUID } from 'crypto';
 import { SubmitChapterQuizUseCase } from './submit-chapter-quiz.use-case';
@@ -65,6 +66,10 @@ describe('SubmitChapterQuizUseCase', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(SubmitChapterQuizUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         SubmitChapterQuizUseCase,
         {
           provide: AcademyChapterRepository,
@@ -101,8 +106,6 @@ describe('SubmitChapterQuizUseCase', () => {
     progressRepository.upsert.mockImplementation(async (p) => p);
     completionRepository.findByUser.mockResolvedValue(null);
     completionRepository.upsert.mockImplementation(async (c) => c);
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/submit-chapter-quiz/submit-chapter-quiz.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/submit-chapter-quiz/submit-chapter-quiz.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
@@ -33,9 +34,9 @@ export interface QuizAttemptResult {
 
 @Injectable()
 export class SubmitChapterQuizUseCase {
-  private readonly logger = new Logger(SubmitChapterQuizUseCase.name);
-
   constructor(
+    @InjectPinoLogger(SubmitChapterQuizUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly chapterRepository: AcademyChapterRepository,
     private readonly quizQuestionRepository: AcademyQuizQuestionRepository,
     private readonly progressRepository: AcademyChapterProgressRepository,
@@ -43,10 +44,13 @@ export class SubmitChapterQuizUseCase {
   ) {}
 
   async execute(command: SubmitChapterQuizCommand): Promise<QuizAttemptResult> {
-    this.logger.log('Submitting chapter quiz', {
-      userId: command.userId,
-      chapterId: command.chapterId,
-    });
+    this.logger.info(
+      {
+        userId: command.userId,
+        chapterId: command.chapterId,
+      },
+      'Submitting chapter quiz',
+    );
     try {
       const chapter = await this.loadQuizChapter(command.chapterId);
       const pool = await this.quizQuestionRepository.findAllByChapter(
@@ -63,9 +67,12 @@ export class SubmitChapterQuizUseCase {
       return { ...grade, academyCompleted };
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error submitting chapter quiz', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error submitting chapter quiz',
+      );
       throw new UnexpectedAcademyError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-chapter/update-chapter.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-chapter/update-chapter.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AcademyChapterRepository } from '../../ports/academy-chapter.repository';
 import { AcademyChapter } from 'src/domain/academy/domain/academy-chapter.entity';
@@ -10,14 +11,19 @@ import { UpdateChapterCommand } from './update-chapter.command';
 
 @Injectable()
 export class UpdateChapterUseCase {
-  private readonly logger = new Logger(UpdateChapterUseCase.name);
-
-  constructor(private readonly chapterRepository: AcademyChapterRepository) {}
+  constructor(
+    @InjectPinoLogger(UpdateChapterUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly chapterRepository: AcademyChapterRepository,
+  ) {}
 
   async execute(command: UpdateChapterCommand): Promise<AcademyChapter> {
-    this.logger.log('Updating academy chapter', {
-      chapterId: command.chapterId,
-    });
+    this.logger.info(
+      {
+        chapterId: command.chapterId,
+      },
+      'Updating academy chapter',
+    );
     try {
       const existing = await this.chapterRepository.findOne(command.chapterId);
       if (!existing) {
@@ -50,9 +56,12 @@ export class UpdateChapterUseCase {
       });
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error updating academy chapter', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error updating academy chapter',
+      );
       throw new UnexpectedAcademyError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-course-module/update-course-module.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-course-module/update-course-module.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { UpdateCourseModuleUseCase } from './update-course-module.use-case';
 import { UpdateCourseModuleCommand } from './update-course-module.command';
@@ -20,6 +21,10 @@ describe('UpdateCourseModuleUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(UpdateCourseModuleUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         UpdateCourseModuleUseCase,
         {
           provide: AcademyCourseModuleRepository,
@@ -30,9 +35,6 @@ describe('UpdateCourseModuleUseCase', () => {
 
     useCase = module.get<UpdateCourseModuleUseCase>(UpdateCourseModuleUseCase);
     courseModuleRepository = module.get(AcademyCourseModuleRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-course-module/update-course-module.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-course-module/update-course-module.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AcademyCourseModuleRepository } from '../../ports/academy-course-module.repository';
 import { AcademyCourseModule } from 'src/domain/academy/domain/academy-course-module.entity';
@@ -10,18 +11,21 @@ import { UpdateCourseModuleCommand } from './update-course-module.command';
 
 @Injectable()
 export class UpdateCourseModuleUseCase {
-  private readonly logger = new Logger(UpdateCourseModuleUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateCourseModuleUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly courseModuleRepository: AcademyCourseModuleRepository,
   ) {}
 
   async execute(
     command: UpdateCourseModuleCommand,
   ): Promise<AcademyCourseModule> {
-    this.logger.log('Updating academy module', {
-      courseModuleId: command.courseModuleId,
-    });
+    this.logger.info(
+      {
+        courseModuleId: command.courseModuleId,
+      },
+      'Updating academy module',
+    );
     try {
       const existing = await this.courseModuleRepository.findOne(
         command.courseModuleId,
@@ -45,9 +49,12 @@ export class UpdateCourseModuleUseCase {
       return await this.courseModuleRepository.update(updated);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error updating academy module', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error updating academy module',
+      );
       throw new UnexpectedAcademyError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-quiz-question/update-quiz-question.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-quiz-question/update-quiz-question.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { UpdateQuizQuestionUseCase } from './update-quiz-question.use-case';
 import { UpdateQuizQuestionCommand } from './update-quiz-question.command';
@@ -35,6 +36,10 @@ describe('UpdateQuizQuestionUseCase', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        {
+          provide: getLoggerToken(UpdateQuizQuestionUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         UpdateQuizQuestionUseCase,
         {
           provide: AcademyQuizQuestionRepository,
@@ -45,9 +50,6 @@ describe('UpdateQuizQuestionUseCase', () => {
 
     useCase = module.get<UpdateQuizQuestionUseCase>(UpdateQuizQuestionUseCase);
     quizQuestionRepository = module.get(AcademyQuizQuestionRepository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/update-quiz-question/update-quiz-question.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/update-quiz-question/update-quiz-question.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AcademyQuizQuestionRepository } from '../../ports/academy-quiz-question.repository';
 import { AcademyQuizQuestion } from 'src/domain/academy/domain/academy-quiz-question.entity';
@@ -11,18 +12,21 @@ import { UpdateQuizQuestionCommand } from './update-quiz-question.command';
 
 @Injectable()
 export class UpdateQuizQuestionUseCase {
-  private readonly logger = new Logger(UpdateQuizQuestionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateQuizQuestionUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly quizQuestionRepository: AcademyQuizQuestionRepository,
   ) {}
 
   async execute(
     command: UpdateQuizQuestionCommand,
   ): Promise<AcademyQuizQuestion> {
-    this.logger.log('Updating academy quiz question', {
-      quizQuestionId: command.quizQuestionId,
-    });
+    this.logger.info(
+      {
+        quizQuestionId: command.quizQuestionId,
+      },
+      'Updating academy quiz question',
+    );
     try {
       assertValidQuizOptions(command.options);
       const existing = await this.quizQuestionRepository.findOne(
@@ -43,9 +47,12 @@ export class UpdateQuizQuestionUseCase {
       return await this.quizQuestionRepository.update(updated);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error updating academy quiz question', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error updating academy quiz question',
+      );
       throw new UnexpectedAcademyError(error);
     }
   }

--- a/ayunis-core-backend/src/domain/academy/infrastructure/certificate/puppeteer-certificate-renderer.service.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/certificate/puppeteer-certificate-renderer.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { LazyChromiumBrowser } from 'src/common/puppeteer/lazy-chromium-browser';
 import {
   CertificateRendererPort,
@@ -10,9 +11,11 @@ import { buildCertificateHtml } from './certificate-template';
 export class PuppeteerCertificateRendererService
   implements CertificateRendererPort, OnModuleDestroy
 {
-  private readonly logger = new Logger(
-    PuppeteerCertificateRendererService.name,
-  );
+  constructor(
+    @InjectPinoLogger(PuppeteerCertificateRendererService.name)
+    private readonly logger: PinoLogger,
+  ) {}
+
   private readonly chromium = new LazyChromiumBrowser();
 
   async onModuleDestroy(): Promise<void> {
@@ -20,7 +23,7 @@ export class PuppeteerCertificateRendererService
   }
 
   async render(input: CertificateRenderInput): Promise<Buffer> {
-    this.logger.log('Rendering academy certificate PDF');
+    this.logger.info('Rendering academy certificate PDF');
 
     const html = buildCertificateHtml(input);
     const browser = await this.chromium.get();

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-chapter-progress.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-chapter-progress.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { UUID } from 'crypto';
@@ -10,11 +11,9 @@ import { AcademyMapper } from './mappers/academy.mapper';
 
 @Injectable()
 export class LocalAcademyChapterProgressRepository implements AcademyChapterProgressRepository {
-  private readonly logger = new Logger(
-    LocalAcademyChapterProgressRepository.name,
-  );
-
   constructor(
+    @InjectPinoLogger(LocalAcademyChapterProgressRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(AcademyChapterProgressRecord)
     private readonly repository: Repository<AcademyChapterProgressRecord>,
     private readonly mapper: AcademyMapper,
@@ -24,7 +23,7 @@ export class LocalAcademyChapterProgressRepository implements AcademyChapterProg
     userId: UUID,
     chapterId: UUID,
   ): Promise<AcademyChapterProgress | null> {
-    this.logger.log('findByUserAndChapter', { userId, chapterId });
+    this.logger.info({ userId, chapterId }, 'findByUserAndChapter');
     const record = await this.repository.findOne({
       where: { userId, chapterId },
     });
@@ -33,7 +32,7 @@ export class LocalAcademyChapterProgressRepository implements AcademyChapterProg
   }
 
   async findAllByUser(userId: UUID): Promise<AcademyChapterProgress[]> {
-    this.logger.log('findAllByUser', { userId });
+    this.logger.info({ userId }, 'findAllByUser');
     const records = await this.repository.find({ where: { userId } });
     return records.map((record) => this.mapper.chapterProgressToDomain(record));
   }
@@ -41,10 +40,13 @@ export class LocalAcademyChapterProgressRepository implements AcademyChapterProg
   async upsert(
     progress: AcademyChapterProgress,
   ): Promise<AcademyChapterProgress> {
-    this.logger.log('upsert', {
-      userId: progress.userId,
-      chapterId: progress.chapterId,
-    });
+    this.logger.info(
+      {
+        userId: progress.userId,
+        chapterId: progress.chapterId,
+      },
+      'upsert',
+    );
     const record = this.mapper.chapterProgressToRecord(progress);
     const saved = await this.repository.save(record);
     return this.mapper.chapterProgressToDomain(saved);

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-chapter.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-chapter.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import type { UUID } from 'crypto';
@@ -11,9 +12,9 @@ import { ChapterNotFoundError } from 'src/domain/academy/application/academy.err
 
 @Injectable()
 export class LocalAcademyChapterRepository implements AcademyChapterRepository {
-  private readonly logger = new Logger(LocalAcademyChapterRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalAcademyChapterRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(AcademyChapterRecord)
     private readonly repository: Repository<AcademyChapterRecord>,
     private readonly dataSource: DataSource,
@@ -21,7 +22,7 @@ export class LocalAcademyChapterRepository implements AcademyChapterRepository {
   ) {}
 
   async findAllWithCourseModules(): Promise<AcademyChapter[]> {
-    this.logger.log('findAllWithCourseModules');
+    this.logger.info('findAllWithCourseModules');
     const records = await this.repository.find({
       relations: { courseModules: true },
       order: {
@@ -34,7 +35,7 @@ export class LocalAcademyChapterRepository implements AcademyChapterRepository {
   }
 
   async findAllWithQuizContent(): Promise<AcademyChapter[]> {
-    this.logger.log('findAllWithQuizContent');
+    this.logger.info('findAllWithQuizContent');
     const records = await this.repository.find({
       relations: { courseModules: true, quizQuestions: true },
       order: {
@@ -48,7 +49,7 @@ export class LocalAcademyChapterRepository implements AcademyChapterRepository {
   }
 
   async findOne(id: UUID): Promise<AcademyChapter | null> {
-    this.logger.log('findOne', { id });
+    this.logger.info({ id }, 'findOne');
     const record = await this.repository.findOne({
       where: { id },
       relations: { courseModules: true },
@@ -59,13 +60,13 @@ export class LocalAcademyChapterRepository implements AcademyChapterRepository {
   }
 
   async findAllIds(): Promise<UUID[]> {
-    this.logger.log('findAllIds');
+    this.logger.info('findAllIds');
     const records = await this.repository.find({ select: { id: true } });
     return records.map((record) => record.id);
   }
 
   async findQuizEnabledIds(): Promise<UUID[]> {
-    this.logger.log('findQuizEnabledIds');
+    this.logger.info('findQuizEnabledIds');
     const records = await this.repository.find({
       where: { quizEnabled: true },
       select: { id: true },
@@ -74,26 +75,26 @@ export class LocalAcademyChapterRepository implements AcademyChapterRepository {
   }
 
   async findMaxPosition(): Promise<number | null> {
-    this.logger.log('findMaxPosition');
+    this.logger.info('findMaxPosition');
     return this.repository.maximum('position');
   }
 
   async create(chapter: AcademyChapter): Promise<AcademyChapter> {
-    this.logger.log('create', { title: chapter.title });
+    this.logger.info({ title: chapter.title }, 'create');
     const record = this.mapper.chapterToRecord(chapter);
     const saved = await this.repository.save(record);
     return this.mapper.chapterToDomain(saved);
   }
 
   async update(chapter: AcademyChapter): Promise<AcademyChapter> {
-    this.logger.log('update', { id: chapter.id });
+    this.logger.info({ id: chapter.id }, 'update');
     const record = this.mapper.chapterToRecord(chapter);
     const saved = await this.repository.save(record);
     return this.mapper.chapterToDomain(saved);
   }
 
   async delete(id: UUID): Promise<void> {
-    this.logger.log('delete', { id });
+    this.logger.info({ id }, 'delete');
     const result = await this.repository.delete({ id });
     if (result.affected === 0) {
       throw new ChapterNotFoundError(id);
@@ -101,7 +102,7 @@ export class LocalAcademyChapterRepository implements AcademyChapterRepository {
   }
 
   async updatePositions(orderedIds: UUID[]): Promise<void> {
-    this.logger.log('updatePositions', { count: orderedIds.length });
+    this.logger.info({ count: orderedIds.length }, 'updatePositions');
     await this.dataSource.transaction(async (manager) => {
       for (const [index, id] of orderedIds.entries()) {
         await manager.update(AcademyChapterRecord, { id }, { position: index });

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-completion.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-completion.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import type { UUID } from 'crypto';
@@ -17,23 +18,23 @@ const MAX_BATCH_SIZE = 500;
 
 @Injectable()
 export class LocalAcademyCompletionRepository implements AcademyCompletionRepository {
-  private readonly logger = new Logger(LocalAcademyCompletionRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalAcademyCompletionRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(AcademyCompletionRecord)
     private readonly repository: Repository<AcademyCompletionRecord>,
     private readonly mapper: AcademyMapper,
   ) {}
 
   async findByUser(userId: UUID): Promise<AcademyCompletion | null> {
-    this.logger.debug('findByUser', { userId });
+    this.logger.debug({ userId }, 'findByUser');
     const record = await this.repository.findOne({ where: { userId } });
     if (!record) return null;
     return this.mapper.completionToDomain(record);
   }
 
   async findByUsers(userIds: UUID[]): Promise<AcademyCompletion[]> {
-    this.logger.debug('findByUsers', { userCount: userIds.length });
+    this.logger.debug({ userCount: userIds.length }, 'findByUsers');
     if (userIds.length === 0) {
       return [];
     }
@@ -55,7 +56,7 @@ export class LocalAcademyCompletionRepository implements AcademyCompletionReposi
   }
 
   async upsert(completion: AcademyCompletion): Promise<AcademyCompletion> {
-    this.logger.log('upsert', { userId: completion.userId });
+    this.logger.info({ userId: completion.userId }, 'upsert');
     const record = this.mapper.completionToRecord(completion);
     const saved = await this.repository.save(record);
     return this.mapper.completionToDomain(saved);

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-course-module.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-course-module.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import type { UUID } from 'crypto';
@@ -11,9 +12,9 @@ import { CourseModuleNotFoundError } from 'src/domain/academy/application/academ
 
 @Injectable()
 export class LocalAcademyCourseModuleRepository implements AcademyCourseModuleRepository {
-  private readonly logger = new Logger(LocalAcademyCourseModuleRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalAcademyCourseModuleRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(AcademyCourseModuleRecord)
     private readonly repository: Repository<AcademyCourseModuleRecord>,
     private readonly dataSource: DataSource,
@@ -21,14 +22,14 @@ export class LocalAcademyCourseModuleRepository implements AcademyCourseModuleRe
   ) {}
 
   async findOne(id: UUID): Promise<AcademyCourseModule | null> {
-    this.logger.log('findOne', { id });
+    this.logger.info({ id }, 'findOne');
     const record = await this.repository.findOne({ where: { id } });
     if (!record) return null;
     return this.mapper.courseModuleToDomain(record);
   }
 
   async findIdsByChapterId(chapterId: UUID): Promise<UUID[]> {
-    this.logger.log('findIdsByChapterId', { chapterId });
+    this.logger.info({ chapterId }, 'findIdsByChapterId');
     const records = await this.repository.find({
       select: { id: true },
       where: { chapterId },
@@ -37,14 +38,14 @@ export class LocalAcademyCourseModuleRepository implements AcademyCourseModuleRe
   }
 
   async findMaxPosition(chapterId: UUID): Promise<number | null> {
-    this.logger.log('findMaxPosition', { chapterId });
+    this.logger.info({ chapterId }, 'findMaxPosition');
     return this.repository.maximum('position', { chapterId });
   }
 
   async create(
     courseModule: AcademyCourseModule,
   ): Promise<AcademyCourseModule> {
-    this.logger.log('create', { title: courseModule.title });
+    this.logger.info({ title: courseModule.title }, 'create');
     const record = this.mapper.courseModuleToRecord(courseModule);
     const saved = await this.repository.save(record);
     return this.mapper.courseModuleToDomain(saved);
@@ -53,14 +54,14 @@ export class LocalAcademyCourseModuleRepository implements AcademyCourseModuleRe
   async update(
     courseModule: AcademyCourseModule,
   ): Promise<AcademyCourseModule> {
-    this.logger.log('update', { id: courseModule.id });
+    this.logger.info({ id: courseModule.id }, 'update');
     const record = this.mapper.courseModuleToRecord(courseModule);
     const saved = await this.repository.save(record);
     return this.mapper.courseModuleToDomain(saved);
   }
 
   async delete(id: UUID): Promise<void> {
-    this.logger.log('delete', { id });
+    this.logger.info({ id }, 'delete');
     const result = await this.repository.delete({ id });
     if (result.affected === 0) {
       throw new CourseModuleNotFoundError(id);
@@ -68,10 +69,13 @@ export class LocalAcademyCourseModuleRepository implements AcademyCourseModuleRe
   }
 
   async updatePositions(chapterId: UUID, orderedIds: UUID[]): Promise<void> {
-    this.logger.log('updatePositions', {
-      chapterId,
-      count: orderedIds.length,
-    });
+    this.logger.info(
+      {
+        chapterId,
+        count: orderedIds.length,
+      },
+      'updatePositions',
+    );
     await this.dataSource.transaction(async (manager) => {
       for (const [index, id] of orderedIds.entries()) {
         await manager.update(

--- a/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-quiz-question.repository.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/persistence/local/local-academy-quiz-question.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { UUID } from 'crypto';
@@ -11,23 +12,23 @@ import { QuizQuestionNotFoundError } from 'src/domain/academy/application/academ
 
 @Injectable()
 export class LocalAcademyQuizQuestionRepository implements AcademyQuizQuestionRepository {
-  private readonly logger = new Logger(LocalAcademyQuizQuestionRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalAcademyQuizQuestionRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(AcademyQuizQuestionRecord)
     private readonly repository: Repository<AcademyQuizQuestionRecord>,
     private readonly mapper: AcademyMapper,
   ) {}
 
   async findOne(id: UUID): Promise<AcademyQuizQuestion | null> {
-    this.logger.log('findOne', { id });
+    this.logger.info({ id }, 'findOne');
     const record = await this.repository.findOne({ where: { id } });
     if (!record) return null;
     return this.mapper.quizQuestionToDomain(record);
   }
 
   async findAllByChapter(chapterId: UUID): Promise<AcademyQuizQuestion[]> {
-    this.logger.log('findAllByChapter', { chapterId });
+    this.logger.info({ chapterId }, 'findAllByChapter');
     const records = await this.repository.find({
       where: { chapterId },
       order: { position: 'ASC', createdAt: 'ASC' },
@@ -36,14 +37,14 @@ export class LocalAcademyQuizQuestionRepository implements AcademyQuizQuestionRe
   }
 
   async findMaxPosition(chapterId: UUID): Promise<number | null> {
-    this.logger.log('findMaxPosition', { chapterId });
+    this.logger.info({ chapterId }, 'findMaxPosition');
     return this.repository.maximum('position', { chapterId });
   }
 
   async create(
     quizQuestion: AcademyQuizQuestion,
   ): Promise<AcademyQuizQuestion> {
-    this.logger.log('create', { chapterId: quizQuestion.chapterId });
+    this.logger.info({ chapterId: quizQuestion.chapterId }, 'create');
     const record = this.mapper.quizQuestionToRecord(quizQuestion);
     const saved = await this.repository.save(record);
     return this.mapper.quizQuestionToDomain(saved);
@@ -52,14 +53,14 @@ export class LocalAcademyQuizQuestionRepository implements AcademyQuizQuestionRe
   async update(
     quizQuestion: AcademyQuizQuestion,
   ): Promise<AcademyQuizQuestion> {
-    this.logger.log('update', { id: quizQuestion.id });
+    this.logger.info({ id: quizQuestion.id }, 'update');
     const record = this.mapper.quizQuestionToRecord(quizQuestion);
     const saved = await this.repository.save(record);
     return this.mapper.quizQuestionToDomain(saved);
   }
 
   async delete(id: UUID): Promise<void> {
-    this.logger.log('delete', { id });
+    this.logger.info({ id }, 'delete');
     const result = await this.repository.delete({ id });
     if (result.affected === 0) {
       throw new QuizQuestionNotFoundError(id);

--- a/ayunis-core-backend/src/domain/academy/presenters/http/academy-certificate.controller.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/academy-certificate.controller.ts
@@ -3,10 +3,10 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Logger,
   Res,
   StreamableFile,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import type { Response } from 'express';
 import {
@@ -31,9 +31,9 @@ import { GetAcademyCertificateQuery } from '../../application/use-cases/get-acad
 @Controller('academy/certificate')
 @RequireAddon(AddonType.AYUNIS_CORE_ACADEMY)
 export class AcademyCertificateController {
-  private readonly logger = new Logger(AcademyCertificateController.name);
-
   constructor(
+    @InjectPinoLogger(AcademyCertificateController.name)
+    private readonly logger: PinoLogger,
     private readonly getAcademyCertificateUseCase: GetAcademyCertificateUseCase,
   ) {}
 
@@ -64,7 +64,7 @@ export class AcademyCertificateController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Res({ passthrough: true }) res: Response,
   ): Promise<StreamableFile> {
-    this.logger.log('Getting academy certificate');
+    this.logger.info('Getting academy certificate');
     const certificate = await this.getAcademyCertificateUseCase.execute(
       new GetAcademyCertificateQuery({ userId }),
     );

--- a/ayunis-core-backend/src/domain/academy/presenters/http/academy-chapters.controller.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/academy-chapters.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, HttpCode, HttpStatus, Logger } from '@nestjs/common';
+import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiInternalServerErrorResponse,
   ApiOkResponse,
@@ -17,9 +18,9 @@ import { AcademyResponseDtoMapper } from './mappers/academy-response-dto.mapper'
 @Controller('academy/chapters')
 @RequireAddon(AddonType.AYUNIS_CORE_ACADEMY)
 export class AcademyChaptersController {
-  private readonly logger = new Logger(AcademyChaptersController.name);
-
   constructor(
+    @InjectPinoLogger(AcademyChaptersController.name)
+    private readonly logger: PinoLogger,
     private readonly getAcademyContentUseCase: GetAcademyContentUseCase,
     private readonly responseMapper: AcademyResponseDtoMapper,
   ) {}
@@ -40,7 +41,7 @@ export class AcademyChaptersController {
   })
   @ApiInternalServerErrorResponse({ description: 'Internal server error' })
   async getChapters(): Promise<AcademyChapterResponseDto[]> {
-    this.logger.log('Getting academy chapters');
+    this.logger.info('Getting academy chapters');
     const chapters = await this.getAcademyContentUseCase.execute(
       new GetAcademyContentQuery(),
     );

--- a/ayunis-core-backend/src/domain/academy/presenters/http/academy-quiz.controller.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/academy-quiz.controller.ts
@@ -4,11 +4,11 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   ParseUUIDPipe,
   Post,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import {
   ApiInternalServerErrorResponse,
@@ -40,9 +40,9 @@ import { AcademyResponseDtoMapper } from './mappers/academy-response-dto.mapper'
 @Controller('academy')
 @RequireAddon(AddonType.AYUNIS_CORE_ACADEMY)
 export class AcademyQuizController {
-  private readonly logger = new Logger(AcademyQuizController.name);
-
   constructor(
+    @InjectPinoLogger(AcademyQuizController.name)
+    private readonly logger: PinoLogger,
     private readonly getChapterQuizUseCase: GetChapterQuizUseCase,
     private readonly submitChapterQuizUseCase: SubmitChapterQuizUseCase,
     private readonly getAcademyProgressUseCase: GetAcademyProgressUseCase,
@@ -65,7 +65,7 @@ export class AcademyQuizController {
   async getChapterQuiz(
     @Param('chapterId', ParseUUIDPipe) chapterId: UUID,
   ): Promise<QuizQuestionForTakingResponseDto[]> {
-    this.logger.log(`Getting quiz for chapter ${chapterId}`);
+    this.logger.info({ chapterId }, 'Getting quiz for chapter');
     const questions = await this.getChapterQuizUseCase.execute(
       new GetChapterQuizQuery({ chapterId }),
     );
@@ -90,7 +90,7 @@ export class AcademyQuizController {
     @Body() dto: SubmitQuizRequestDto,
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<QuizResultResponseDto> {
-    this.logger.log(`Submitting quiz for chapter ${chapterId}`);
+    this.logger.info({ chapterId }, 'Submitting quiz for chapter');
     const result = await this.submitChapterQuizUseCase.execute(
       new SubmitChapterQuizCommand({ userId, chapterId, answers: dto.answers }),
     );
@@ -112,7 +112,7 @@ export class AcademyQuizController {
   async getProgress(
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<AcademyProgressResponseDto> {
-    this.logger.log('Getting academy progress');
+    this.logger.info('Getting academy progress');
     const progress = await this.getAcademyProgressUseCase.execute(
       new GetAcademyProgressQuery({ userId }),
     );

--- a/ayunis-core-backend/src/domain/academy/presenters/http/super-admin-academy-chapters.controller.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/super-admin-academy-chapters.controller.ts
@@ -5,12 +5,12 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   ParseUUIDPipe,
   Post,
   Put,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiBody,
   ApiCreatedResponse,
@@ -46,11 +46,9 @@ import { AcademyResponseDtoMapper } from './mappers/academy-response-dto.mapper'
 @Controller('super-admin/academy/chapters')
 @SystemRoles(SystemRole.SUPER_ADMIN)
 export class SuperAdminAcademyChaptersController {
-  private readonly logger = new Logger(
-    SuperAdminAcademyChaptersController.name,
-  );
-
   constructor(
+    @InjectPinoLogger(SuperAdminAcademyChaptersController.name)
+    private readonly logger: PinoLogger,
     private readonly getAcademyManagementContentUseCase: GetAcademyManagementContentUseCase,
     private readonly createChapterUseCase: CreateChapterUseCase,
     private readonly updateChapterUseCase: UpdateChapterUseCase,
@@ -75,7 +73,7 @@ export class SuperAdminAcademyChaptersController {
   })
   @ApiInternalServerErrorResponse({ description: 'Internal server error' })
   async getChapters(): Promise<SuperAdminAcademyChapterResponseDto[]> {
-    this.logger.log('Getting academy chapters');
+    this.logger.info('Getting academy chapters');
     const chapters = await this.getAcademyManagementContentUseCase.execute(
       new GetAcademyManagementContentQuery(),
     );
@@ -101,7 +99,7 @@ export class SuperAdminAcademyChaptersController {
   async createChapter(
     @Body() dto: CreateChapterRequestDto,
   ): Promise<AcademyChapterResponseDto> {
-    this.logger.log(`Creating academy chapter: ${dto.title}`);
+    this.logger.info({ title: dto.title }, 'Creating academy chapter');
     const chapter = await this.createChapterUseCase.execute(
       new CreateChapterCommand({
         title: dto.title,
@@ -135,7 +133,10 @@ export class SuperAdminAcademyChaptersController {
   })
   @ApiInternalServerErrorResponse({ description: 'Internal server error' })
   async reorderChapters(@Body() dto: ReorderChaptersRequestDto): Promise<void> {
-    this.logger.log(`Reordering ${dto.chapterIds.length} academy chapters`);
+    this.logger.info(
+      { chapterCount: dto.chapterIds.length },
+      'Reordering academy chapters',
+    );
     await this.reorderChaptersUseCase.execute(
       new ReorderChaptersCommand({ chapterIds: dto.chapterIds }),
     );
@@ -166,7 +167,7 @@ export class SuperAdminAcademyChaptersController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() dto: UpdateChapterRequestDto,
   ): Promise<AcademyChapterResponseDto> {
-    this.logger.log(`Updating academy chapter ${id}`);
+    this.logger.info({ chapterId: id }, 'Updating academy chapter');
     const chapter = await this.updateChapterUseCase.execute(
       new UpdateChapterCommand({
         chapterId: id,
@@ -200,7 +201,7 @@ export class SuperAdminAcademyChaptersController {
   })
   @ApiInternalServerErrorResponse({ description: 'Internal server error' })
   async deleteChapter(@Param('id', ParseUUIDPipe) id: UUID): Promise<void> {
-    this.logger.log(`Deleting academy chapter ${id}`);
+    this.logger.info({ chapterId: id }, 'Deleting academy chapter');
     await this.deleteChapterUseCase.execute(
       new DeleteChapterCommand({ chapterId: id }),
     );

--- a/ayunis-core-backend/src/domain/academy/presenters/http/super-admin-academy-course-modules.controller.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/super-admin-academy-course-modules.controller.ts
@@ -4,12 +4,12 @@ import {
   Delete,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   ParseUUIDPipe,
   Post,
   Put,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiBody,
   ApiCreatedResponse,
@@ -42,11 +42,9 @@ import { AcademyResponseDtoMapper } from './mappers/academy-response-dto.mapper'
 @Controller('super-admin/academy')
 @SystemRoles(SystemRole.SUPER_ADMIN)
 export class SuperAdminAcademyCourseModulesController {
-  private readonly logger = new Logger(
-    SuperAdminAcademyCourseModulesController.name,
-  );
-
   constructor(
+    @InjectPinoLogger(SuperAdminAcademyCourseModulesController.name)
+    private readonly logger: PinoLogger,
     private readonly createCourseModuleUseCase: CreateCourseModuleUseCase,
     private readonly updateCourseModuleUseCase: UpdateCourseModuleUseCase,
     private readonly deleteCourseModuleUseCase: DeleteCourseModuleUseCase,
@@ -79,7 +77,7 @@ export class SuperAdminAcademyCourseModulesController {
     @Param('chapterId', ParseUUIDPipe) chapterId: UUID,
     @Body() dto: CreateCourseModuleRequestDto,
   ): Promise<CourseModuleResponseDto> {
-    this.logger.log(`Creating academy module in chapter ${chapterId}`);
+    this.logger.info({ chapterId }, 'Creating academy module');
     const courseModule = await this.createCourseModuleUseCase.execute(
       new CreateCourseModuleCommand({
         chapterId,
@@ -121,8 +119,9 @@ export class SuperAdminAcademyCourseModulesController {
     @Param('chapterId', ParseUUIDPipe) chapterId: UUID,
     @Body() dto: ReorderCourseModulesRequestDto,
   ): Promise<void> {
-    this.logger.log(
-      `Reordering ${dto.courseModuleIds.length} modules of chapter ${chapterId}`,
+    this.logger.info(
+      { chapterId, courseModuleCount: dto.courseModuleIds.length },
+      'Reordering academy modules',
     );
     await this.reorderCourseModulesUseCase.execute(
       new ReorderCourseModulesCommand({
@@ -157,7 +156,7 @@ export class SuperAdminAcademyCourseModulesController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() dto: UpdateCourseModuleRequestDto,
   ): Promise<CourseModuleResponseDto> {
-    this.logger.log(`Updating academy module ${id}`);
+    this.logger.info({ courseModuleId: id }, 'Updating academy module');
     const courseModule = await this.updateCourseModuleUseCase.execute(
       new UpdateCourseModuleCommand({
         courseModuleId: id,
@@ -191,7 +190,7 @@ export class SuperAdminAcademyCourseModulesController {
   async deleteCourseModule(
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<void> {
-    this.logger.log(`Deleting academy module ${id}`);
+    this.logger.info({ courseModuleId: id }, 'Deleting academy module');
     await this.deleteCourseModuleUseCase.execute(
       new DeleteCourseModuleCommand({ courseModuleId: id }),
     );

--- a/ayunis-core-backend/src/domain/academy/presenters/http/super-admin-academy-quiz-questions.controller.ts
+++ b/ayunis-core-backend/src/domain/academy/presenters/http/super-admin-academy-quiz-questions.controller.ts
@@ -4,12 +4,12 @@ import {
   Delete,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   ParseUUIDPipe,
   Post,
   Put,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import {
   ApiBody,
@@ -39,11 +39,9 @@ import { AcademyResponseDtoMapper } from './mappers/academy-response-dto.mapper'
 @Controller('super-admin/academy')
 @SystemRoles(SystemRole.SUPER_ADMIN)
 export class SuperAdminAcademyQuizQuestionsController {
-  private readonly logger = new Logger(
-    SuperAdminAcademyQuizQuestionsController.name,
-  );
-
   constructor(
+    @InjectPinoLogger(SuperAdminAcademyQuizQuestionsController.name)
+    private readonly logger: PinoLogger,
     private readonly createQuizQuestionUseCase: CreateQuizQuestionUseCase,
     private readonly updateQuizQuestionUseCase: UpdateQuizQuestionUseCase,
     private readonly deleteQuizQuestionUseCase: DeleteQuizQuestionUseCase,
@@ -79,7 +77,7 @@ export class SuperAdminAcademyQuizQuestionsController {
     @Param('chapterId', ParseUUIDPipe) chapterId: UUID,
     @Body() dto: CreateQuizQuestionRequestDto,
   ): Promise<QuizQuestionResponseDto> {
-    this.logger.log(`Creating academy quiz question in chapter ${chapterId}`);
+    this.logger.info({ chapterId }, 'Creating academy quiz question');
     const quizQuestion = await this.createQuizQuestionUseCase.execute(
       new CreateQuizQuestionCommand({
         chapterId,
@@ -122,7 +120,7 @@ export class SuperAdminAcademyQuizQuestionsController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() dto: UpdateQuizQuestionRequestDto,
   ): Promise<QuizQuestionResponseDto> {
-    this.logger.log(`Updating academy quiz question ${id}`);
+    this.logger.info({ quizQuestionId: id }, 'Updating academy quiz question');
     const quizQuestion = await this.updateQuizQuestionUseCase.execute(
       new UpdateQuizQuestionCommand({
         quizQuestionId: id,
@@ -158,7 +156,7 @@ export class SuperAdminAcademyQuizQuestionsController {
   async deleteQuizQuestion(
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<void> {
-    this.logger.log(`Deleting academy quiz question ${id}`);
+    this.logger.info({ quizQuestionId: id }, 'Deleting academy quiz question');
     await this.deleteQuizQuestionUseCase.execute(
       new DeleteQuizQuestionCommand({ quizQuestionId: id }),
     );

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/add-global-pii-whitelist-word/add-global-pii-whitelist-word.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/add-global-pii-whitelist-word/add-global-pii-whitelist-word.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
 import { GlobalAnonymizationWhitelistWord } from 'src/domain/anonymization-settings/domain/global-anonymization-whitelist-word.entity';
@@ -17,7 +18,10 @@ describe('AddGlobalPiiWhitelistWordUseCase', () => {
     delete: jest.fn(),
   };
 
-  const useCase = new AddGlobalPiiWhitelistWordUseCase(repository);
+  const useCase = new AddGlobalPiiWhitelistWordUseCase(
+    createPinoLoggerMock(),
+    repository,
+  );
   const superAdminId = randomUUID();
 
   beforeEach(() => {

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/add-global-pii-whitelist-word/add-global-pii-whitelist-word.use-case.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/add-global-pii-whitelist-word/add-global-pii-whitelist-word.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GlobalAnonymizationWhitelistRepository } from '../../ports/global-anonymization-whitelist.repository';
 import {
@@ -11,9 +12,9 @@ import type { AddGlobalPiiWhitelistWordCommand } from './add-global-pii-whitelis
 
 @Injectable()
 export class AddGlobalPiiWhitelistWordUseCase {
-  private readonly logger = new Logger(AddGlobalPiiWhitelistWordUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AddGlobalPiiWhitelistWordUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: GlobalAnonymizationWhitelistRepository,
   ) {}
 
@@ -21,9 +22,12 @@ export class AddGlobalPiiWhitelistWordUseCase {
   async execute(
     command: AddGlobalPiiWhitelistWordCommand,
   ): Promise<GlobalAnonymizationWhitelistWord> {
-    this.logger.log('Adding global PII whitelist word', {
-      category: command.category,
-    });
+    this.logger.info(
+      {
+        category: command.category,
+      },
+      'Adding global PII whitelist word',
+    );
 
     const word = command.word.trim();
     if (word.length === 0) {

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { AnonymizeTextForOrgUseCase } from './anonymize-text-for-org.use-case';
 import { AnonymizeTextForOrgCommand } from './anonymize-text-for-org.command';
@@ -27,6 +27,7 @@ describe('AnonymizeTextForOrgUseCase', () => {
       replacements: [],
     });
     useCase = new AnonymizeTextForOrgUseCase(
+      createPinoLoggerMock(),
       {
         findByOrgId,
         replaceForOrg: jest.fn(),
@@ -36,8 +37,6 @@ describe('AnonymizeTextForOrgUseCase', () => {
       } as unknown as GetGlobalPiiWhitelistUseCase,
       { execute: anonymizeExecute } as unknown as AnonymizeTextUseCase,
     );
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   it('passes the org whitelist to the anonymization use case', async () => {

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/anonymize-text-for-org/anonymize-text-for-org.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
 import { AnonymizeTextCommand } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command';
@@ -17,9 +18,9 @@ import type { AnonymizeTextForOrgCommand } from './anonymize-text-for-org.comman
  */
 @Injectable()
 export class AnonymizeTextForOrgUseCase {
-  private readonly logger = new Logger(AnonymizeTextForOrgUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AnonymizeTextForOrgUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: AnonymizationWhitelistRepository,
     private readonly getGlobalPiiWhitelistUseCase: GetGlobalPiiWhitelistUseCase,
     private readonly anonymizeTextUseCase: AnonymizeTextUseCase,
@@ -28,7 +29,7 @@ export class AnonymizeTextForOrgUseCase {
   async execute(
     command: AnonymizeTextForOrgCommand,
   ): Promise<AnonymizationResult> {
-    this.logger.debug('Anonymizing text for org', { orgId: command.orgId });
+    this.logger.debug({ orgId: command.orgId }, 'Anonymizing text for org');
 
     try {
       const entries = await this.repository.findByOrgId(command.orgId);
@@ -46,10 +47,13 @@ export class AnonymizeTextForOrgUseCase {
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
 
-      this.logger.error('Failed to anonymize text for org', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          orgId: command.orgId,
+        },
+        'Failed to anonymize text for org',
+      );
 
       throw new UnexpectedAnonymizationSettingsError('anonymize', {
         orgId: command.orgId,

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/delete-global-pii-whitelist-word/delete-global-pii-whitelist-word.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/delete-global-pii-whitelist-word/delete-global-pii-whitelist-word.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import type { GlobalAnonymizationWhitelistRepository } from '../../ports/global-anonymization-whitelist.repository';
 import { GlobalWhitelistWordNotFoundError } from '../../anonymization-settings.errors';
@@ -12,7 +13,10 @@ describe('DeleteGlobalPiiWhitelistWordUseCase', () => {
     delete: jest.fn(),
   };
 
-  const useCase = new DeleteGlobalPiiWhitelistWordUseCase(repository);
+  const useCase = new DeleteGlobalPiiWhitelistWordUseCase(
+    createPinoLoggerMock(),
+    repository,
+  );
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/delete-global-pii-whitelist-word/delete-global-pii-whitelist-word.use-case.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/delete-global-pii-whitelist-word/delete-global-pii-whitelist-word.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GlobalAnonymizationWhitelistRepository } from '../../ports/global-anonymization-whitelist.repository';
 import {
@@ -9,19 +10,20 @@ import type { DeleteGlobalPiiWhitelistWordCommand } from './delete-global-pii-wh
 
 @Injectable()
 export class DeleteGlobalPiiWhitelistWordUseCase {
-  private readonly logger = new Logger(
-    DeleteGlobalPiiWhitelistWordUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(DeleteGlobalPiiWhitelistWordUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: GlobalAnonymizationWhitelistRepository,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedGlobalAnonymizationWhitelistError)
   async execute(command: DeleteGlobalPiiWhitelistWordCommand): Promise<void> {
-    this.logger.log('Deleting global PII whitelist word', {
-      wordId: command.wordId,
-    });
+    this.logger.info(
+      {
+        wordId: command.wordId,
+      },
+      'Deleting global PII whitelist word',
+    );
 
     const deleted = await this.repository.delete(command.wordId);
     if (!deleted) {

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/get-global-pii-whitelist/get-global-pii-whitelist.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/get-global-pii-whitelist/get-global-pii-whitelist.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { PiiCategory } from 'src/common/anonymization/domain/pii-category.enum';
 import { GlobalAnonymizationWhitelistWord } from 'src/domain/anonymization-settings/domain/global-anonymization-whitelist-word.entity';
@@ -13,7 +14,10 @@ describe('GetGlobalPiiWhitelistUseCase', () => {
     delete: jest.fn(),
   };
 
-  const useCase = new GetGlobalPiiWhitelistUseCase(repository);
+  const useCase = new GetGlobalPiiWhitelistUseCase(
+    createPinoLoggerMock(),
+    repository,
+  );
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/get-global-pii-whitelist/get-global-pii-whitelist.use-case.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/get-global-pii-whitelist/get-global-pii-whitelist.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { GlobalAnonymizationWhitelistRepository } from '../../ports/global-anonymization-whitelist.repository';
 import { UnexpectedGlobalAnonymizationWhitelistError } from '../../anonymization-settings.errors';
@@ -6,9 +7,9 @@ import type { GlobalAnonymizationWhitelistWord } from 'src/domain/anonymization-
 
 @Injectable()
 export class GetGlobalPiiWhitelistUseCase {
-  private readonly logger = new Logger(GetGlobalPiiWhitelistUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetGlobalPiiWhitelistUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: GlobalAnonymizationWhitelistRepository,
   ) {}
 

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/get-pii-whitelist/get-pii-whitelist.use-case.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/get-pii-whitelist/get-pii-whitelist.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AnonymizationWhitelistRepository } from '../../ports/anonymization-whitelist.repository';
 import { UnexpectedAnonymizationSettingsError } from '../../anonymization-settings.errors';
@@ -7,24 +8,29 @@ import type { AnonymizationWhitelistEntry } from 'src/domain/anonymization-setti
 
 @Injectable()
 export class GetPiiWhitelistUseCase {
-  private readonly logger = new Logger(GetPiiWhitelistUseCase.name);
-
-  constructor(private readonly repository: AnonymizationWhitelistRepository) {}
+  constructor(
+    @InjectPinoLogger(GetPiiWhitelistUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: AnonymizationWhitelistRepository,
+  ) {}
 
   async execute(
     query: GetPiiWhitelistQuery,
   ): Promise<AnonymizationWhitelistEntry[]> {
-    this.logger.debug('Getting PII whitelist', { orgId: query.orgId });
+    this.logger.debug({ orgId: query.orgId }, 'Getting PII whitelist');
 
     try {
       return await this.repository.findByOrgId(query.orgId);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
 
-      this.logger.error('Failed to get PII whitelist', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: query.orgId,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          orgId: query.orgId,
+        },
+        'Failed to get PII whitelist',
+      );
 
       throw new UnexpectedAnonymizationSettingsError('get', {
         orgId: query.orgId,

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/update-pii-whitelist/update-pii-whitelist.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/update-pii-whitelist/update-pii-whitelist.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { UpdatePiiWhitelistUseCase } from './update-pii-whitelist.use-case';
 import { UpdatePiiWhitelistCommand } from './update-pii-whitelist.command';
@@ -26,9 +26,7 @@ describe('UpdatePiiWhitelistUseCase', () => {
       findByOrgId: jest.fn(),
       replaceForOrg,
     } as unknown as AnonymizationWhitelistRepository;
-    useCase = new UpdatePiiWhitelistUseCase(repository);
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    useCase = new UpdatePiiWhitelistUseCase(createPinoLoggerMock(), repository);
   });
 
   it('replaces the whitelist with validated entries', async () => {

--- a/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/update-pii-whitelist/update-pii-whitelist.use-case.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/application/use-cases/update-pii-whitelist/update-pii-whitelist.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AnonymizationWhitelistRepository } from '../../ports/anonymization-whitelist.repository';
 import {
@@ -16,17 +17,22 @@ import type { UUID } from 'crypto';
 
 @Injectable()
 export class UpdatePiiWhitelistUseCase {
-  private readonly logger = new Logger(UpdatePiiWhitelistUseCase.name);
-
-  constructor(private readonly repository: AnonymizationWhitelistRepository) {}
+  constructor(
+    @InjectPinoLogger(UpdatePiiWhitelistUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: AnonymizationWhitelistRepository,
+  ) {}
 
   async execute(
     command: UpdatePiiWhitelistCommand,
   ): Promise<AnonymizationWhitelistEntry[]> {
-    this.logger.debug('Updating PII whitelist', {
-      orgId: command.orgId,
-      entryCount: command.entries.length,
-    });
+    this.logger.debug(
+      {
+        orgId: command.orgId,
+        entryCount: command.entries.length,
+      },
+      'Updating PII whitelist',
+    );
 
     try {
       this.validateEntries(command.entries);
@@ -37,10 +43,13 @@ export class UpdatePiiWhitelistUseCase {
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
 
-      this.logger.error('Failed to update PII whitelist', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          orgId: command.orgId,
+        },
+        'Failed to update PII whitelist',
+      );
 
       throw new UnexpectedAnonymizationSettingsError('update', {
         orgId: command.orgId,

--- a/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/anonymization-whitelist.repository.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/anonymization-whitelist.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { UUID } from 'crypto';
@@ -9,11 +10,9 @@ import { AnonymizationWhitelistEntryMapper } from './mappers/anonymization-white
 
 @Injectable()
 export class PostgresAnonymizationWhitelistRepository extends AnonymizationWhitelistRepository {
-  private readonly logger = new Logger(
-    PostgresAnonymizationWhitelistRepository.name,
-  );
-
   constructor(
+    @InjectPinoLogger(PostgresAnonymizationWhitelistRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(AnonymizationWhitelistEntryRecord)
     private readonly repository: Repository<AnonymizationWhitelistEntryRecord>,
   ) {
@@ -21,7 +20,7 @@ export class PostgresAnonymizationWhitelistRepository extends AnonymizationWhite
   }
 
   async findByOrgId(orgId: UUID): Promise<AnonymizationWhitelistEntry[]> {
-    this.logger.debug('findByOrgId', { orgId });
+    this.logger.debug({ orgId }, 'findByOrgId');
 
     const records = await this.repository.find({
       where: { orgId },
@@ -37,7 +36,7 @@ export class PostgresAnonymizationWhitelistRepository extends AnonymizationWhite
     orgId: UUID,
     entries: AnonymizationWhitelistEntry[],
   ): Promise<AnonymizationWhitelistEntry[]> {
-    this.logger.debug('replaceForOrg', { orgId, entryCount: entries.length });
+    this.logger.debug({ orgId, entryCount: entries.length }, 'replaceForOrg');
 
     await this.repository.manager.transaction(async (manager) => {
       await manager.delete(AnonymizationWhitelistEntryRecord, { orgId });

--- a/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/global-anonymization-whitelist.repository.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/infrastructure/persistence/postgres/global-anonymization-whitelist.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { UUID } from 'crypto';
@@ -10,11 +11,9 @@ import { GlobalAnonymizationWhitelistWordMapper } from './mappers/global-anonymi
 
 @Injectable()
 export class PostgresGlobalAnonymizationWhitelistRepository extends GlobalAnonymizationWhitelistRepository {
-  private readonly logger = new Logger(
-    PostgresGlobalAnonymizationWhitelistRepository.name,
-  );
-
   constructor(
+    @InjectPinoLogger(PostgresGlobalAnonymizationWhitelistRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(GlobalAnonymizationWhitelistWordRecord)
     private readonly repository: Repository<GlobalAnonymizationWhitelistWordRecord>,
   ) {
@@ -38,7 +37,7 @@ export class PostgresGlobalAnonymizationWhitelistRepository extends GlobalAnonym
     category: PiiCategory,
     word: string,
   ): Promise<GlobalAnonymizationWhitelistWord | null> {
-    this.logger.debug('findByCategoryAndWord', { category });
+    this.logger.debug({ category }, 'findByCategoryAndWord');
 
     const record = await this.repository.findOne({
       where: { category, wordLowercase: word.trim().toLowerCase() },
@@ -52,7 +51,7 @@ export class PostgresGlobalAnonymizationWhitelistRepository extends GlobalAnonym
   async create(
     word: GlobalAnonymizationWhitelistWord,
   ): Promise<GlobalAnonymizationWhitelistWord> {
-    this.logger.debug('create', { category: word.category });
+    this.logger.debug({ category: word.category }, 'create');
 
     const record = await this.repository.save(
       GlobalAnonymizationWhitelistWordMapper.toRecord(word),
@@ -68,7 +67,7 @@ export class PostgresGlobalAnonymizationWhitelistRepository extends GlobalAnonym
   }
 
   async delete(id: UUID): Promise<boolean> {
-    this.logger.debug('delete', { id });
+    this.logger.debug({ id }, 'delete');
 
     const result = await this.repository.delete({ id });
     return (result.affected ?? 0) > 0;

--- a/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/anonymization-settings.controller.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/anonymization-settings.controller.ts
@@ -1,4 +1,5 @@
-import { Body, Controller, Get, Logger, Put } from '@nestjs/common';
+import { Body, Controller, Get, Put } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiExtraModels,
   ApiOperation,
@@ -25,9 +26,9 @@ import type { AnonymizationWhitelistEntry } from '../../domain/anonymization-whi
 @Controller('anonymization-settings')
 @ApiExtraModels(PiiWhitelistResponseDto)
 export class AnonymizationSettingsController {
-  private readonly logger = new Logger(AnonymizationSettingsController.name);
-
   constructor(
+    @InjectPinoLogger(AnonymizationSettingsController.name)
+    private readonly logger: PinoLogger,
     private readonly getPiiWhitelistUseCase: GetPiiWhitelistUseCase,
     private readonly updatePiiWhitelistUseCase: UpdatePiiWhitelistUseCase,
   ) {}
@@ -43,7 +44,7 @@ export class AnonymizationSettingsController {
   async get(
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
   ): Promise<PiiWhitelistResponseDto> {
-    this.logger.log(`Getting PII whitelist for org ${orgId}`);
+    this.logger.info({ orgId }, 'Getting PII whitelist for org');
 
     const entries = await this.getPiiWhitelistUseCase.execute(
       new GetPiiWhitelistQuery(orgId),
@@ -67,7 +68,7 @@ export class AnonymizationSettingsController {
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
     @Body() dto: UpdatePiiWhitelistRequestDto,
   ): Promise<PiiWhitelistResponseDto> {
-    this.logger.log(`Updating PII whitelist for org ${orgId}`);
+    this.logger.info({ orgId }, 'Updating PII whitelist for org');
 
     const entries = await this.updatePiiWhitelistUseCase.execute(
       new UpdatePiiWhitelistCommand(

--- a/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/super-admin-anonymization-whitelist.controller.ts
+++ b/ayunis-core-backend/src/domain/anonymization-settings/presenters/http/super-admin-anonymization-whitelist.controller.ts
@@ -5,10 +5,10 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   Post,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import {
   ApiBadRequestResponse,
@@ -40,11 +40,9 @@ import { GlobalPiiWhitelistWordDto } from './dtos/global-pii-whitelist-word.dto'
 @Controller('super-admin/anonymization-whitelist')
 @SystemRoles(SystemRole.SUPER_ADMIN)
 export class SuperAdminAnonymizationWhitelistController {
-  private readonly logger = new Logger(
-    SuperAdminAnonymizationWhitelistController.name,
-  );
-
   constructor(
+    @InjectPinoLogger(SuperAdminAnonymizationWhitelistController.name)
+    private readonly logger: PinoLogger,
     private readonly getGlobalPiiWhitelistUseCase: GetGlobalPiiWhitelistUseCase,
     private readonly addGlobalPiiWhitelistWordUseCase: AddGlobalPiiWhitelistWordUseCase,
     private readonly deleteGlobalPiiWhitelistWordUseCase: DeleteGlobalPiiWhitelistWordUseCase,
@@ -55,7 +53,7 @@ export class SuperAdminAnonymizationWhitelistController {
   @ApiResponse({ status: HttpStatus.OK, type: [GlobalPiiWhitelistWordDto] })
   @ApiUnauthorizedResponse({ description: 'Not authorized as super admin' })
   async list(): Promise<GlobalPiiWhitelistWordDto[]> {
-    this.logger.log('list');
+    this.logger.info('list');
 
     const words = await this.getGlobalPiiWhitelistUseCase.execute();
     return words.map((word) => this.toDto(word));
@@ -75,7 +73,7 @@ export class SuperAdminAnonymizationWhitelistController {
     @Body() dto: AddGlobalPiiWhitelistWordRequestDto,
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<GlobalPiiWhitelistWordDto> {
-    this.logger.log('add', { category: dto.category });
+    this.logger.info({ category: dto.category }, 'add');
 
     const word = await this.addGlobalPiiWhitelistWordUseCase.execute(
       new AddGlobalPiiWhitelistWordCommand(dto.category, dto.word, userId),
@@ -93,7 +91,7 @@ export class SuperAdminAnonymizationWhitelistController {
   @ApiNotFoundResponse({ description: 'Word not found' })
   @ApiUnauthorizedResponse({ description: 'Not authorized as super admin' })
   async remove(@Param('wordId') wordId: UUID): Promise<void> {
-    this.logger.log('remove', { wordId });
+    this.logger.info({ wordId }, 'remove');
 
     await this.deleteGlobalPiiWhitelistWordUseCase.execute(
       new DeleteGlobalPiiWhitelistWordCommand(wordId),

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/delete-org-system-prompt/delete-org-system-prompt.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/delete-org-system-prompt/delete-org-system-prompt.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { DeleteOrgSystemPromptUseCase } from './delete-org-system-prompt.use-case';
 import type { OrgSystemPromptsRepository } from '../../ports/org-system-prompts.repository';
 import { randomUUID } from 'crypto';
@@ -22,6 +23,7 @@ describe('DeleteOrgSystemPromptUseCase', () => {
     };
 
     useCase = new DeleteOrgSystemPromptUseCase(
+      createPinoLoggerMock(),
       repository,
       contextService as unknown as ContextService,
     );

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/delete-org-system-prompt/delete-org-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/delete-org-system-prompt/delete-org-system-prompt.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OrgSystemPromptsRepository } from '../../ports/org-system-prompts.repository';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -7,9 +8,9 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class DeleteOrgSystemPromptUseCase {
-  private readonly logger = new Logger(DeleteOrgSystemPromptUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteOrgSystemPromptUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly orgSystemPromptsRepository: OrgSystemPromptsRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -19,15 +20,18 @@ export class DeleteOrgSystemPromptUseCase {
     if (!orgId) {
       throw new UnauthorizedAccessError();
     }
-    this.logger.log('execute', { orgId });
+    this.logger.info({ orgId }, 'execute');
 
     try {
       await this.orgSystemPromptsRepository.deleteByOrgId(orgId);
 
-      this.logger.debug('Org system prompt deleted', { orgId });
+      this.logger.debug({ orgId }, 'Org system prompt deleted');
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to delete org system prompt', error);
+      this.logger.error(
+        { err: error as Error },
+        'Failed to delete org system prompt',
+      );
       throw new UnexpectedChatSettingsError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/delete-user-system-prompt/delete-user-system-prompt.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/delete-user-system-prompt/delete-user-system-prompt.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { DeleteUserSystemPromptUseCase } from './delete-user-system-prompt.use-case';
 import type { UserSystemPromptsRepository } from '../../ports/user-system-prompts.repository';
 import { randomUUID } from 'crypto';
@@ -22,6 +23,7 @@ describe('DeleteUserSystemPromptUseCase', () => {
     };
 
     useCase = new DeleteUserSystemPromptUseCase(
+      createPinoLoggerMock(),
       repository,
       contextService as unknown as ContextService,
     );

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/delete-user-system-prompt/delete-user-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/delete-user-system-prompt/delete-user-system-prompt.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UserSystemPromptsRepository } from '../../ports/user-system-prompts.repository';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -7,9 +8,9 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class DeleteUserSystemPromptUseCase {
-  private readonly logger = new Logger(DeleteUserSystemPromptUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteUserSystemPromptUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly userSystemPromptsRepository: UserSystemPromptsRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -19,15 +20,18 @@ export class DeleteUserSystemPromptUseCase {
     if (!userId) {
       throw new UnauthorizedAccessError();
     }
-    this.logger.log('execute', { userId });
+    this.logger.info({ userId }, 'execute');
 
     try {
       await this.userSystemPromptsRepository.deleteByUserId(userId);
 
-      this.logger.debug('User system prompt deleted', { userId });
+      this.logger.debug({ userId }, 'User system prompt deleted');
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to delete user system prompt', error);
+      this.logger.error(
+        { err: error as Error },
+        'Failed to delete user system prompt',
+      );
       throw new UnexpectedChatSettingsError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { GeneratePersonalizedSystemPromptUseCase } from './generate-personalized-system-prompt.use-case';
 import { GeneratePersonalizedSystemPromptCommand } from './generate-personalized-system-prompt.command';
 import { PersonalizedSystemPromptGenerationError } from '../../chat-settings.errors';
@@ -72,6 +73,7 @@ describe('GeneratePersonalizedSystemPromptUseCase', () => {
     };
 
     useCase = new GeneratePersonalizedSystemPromptUseCase(
+      createPinoLoggerMock(),
       getInferenceUseCase as unknown as GetInferenceUseCase,
       getDefaultModelUseCase as unknown as GetDefaultModelUseCase,
       upsertUserSystemPromptUseCase as unknown as UpsertUserSystemPromptUseCase,

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/generate-personalized-system-prompt/generate-personalized-system-prompt.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GeneratePersonalizedSystemPromptCommand } from './generate-personalized-system-prompt.command';
 import { GetInferenceUseCase } from 'src/domain/models/application/use-cases/get-inference/get-inference.use-case';
 import { GetInferenceCommand } from 'src/domain/models/application/use-cases/get-inference/get-inference.command';
@@ -31,11 +32,9 @@ export interface GeneratePersonalizedSystemPromptResult {
 
 @Injectable()
 export class GeneratePersonalizedSystemPromptUseCase {
-  private readonly logger = new Logger(
-    GeneratePersonalizedSystemPromptUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(GeneratePersonalizedSystemPromptUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly getInferenceUseCase: GetInferenceUseCase,
     private readonly getDefaultModelUseCase: GetDefaultModelUseCase,
     private readonly upsertUserSystemPromptUseCase: UpsertUserSystemPromptUseCase,
@@ -55,7 +54,7 @@ export class GeneratePersonalizedSystemPromptUseCase {
       throw new UnauthorizedAccessError();
     }
 
-    this.logger.log('execute', { userId });
+    this.logger.info({ userId }, 'execute');
 
     try {
       const permittedModel = await this.getDefaultModelUseCase.execute(
@@ -84,10 +83,13 @@ export class GeneratePersonalizedSystemPromptUseCase {
       return { systemPrompt, welcomeMessage };
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to generate personalized system prompt', {
-        userId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          userId,
+          err: error as Error,
+        },
+        'Failed to generate personalized system prompt',
+      );
       throw new PersonalizedSystemPromptGenerationError(
         error instanceof Error ? error : undefined,
       );
@@ -153,9 +155,10 @@ export class GeneratePersonalizedSystemPromptUseCase {
         model,
       );
     } catch (error) {
-      this.logger.warn('Welcome message generation failed, using fallback', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.warn(
+        { err: error as Error },
+        'Welcome message generation failed, using fallback',
+      );
       return '';
     }
   }

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-org-chat-settings/get-org-chat-settings.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-org-chat-settings/get-org-chat-settings.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { GetOrgChatSettingsUseCase } from './get-org-chat-settings.use-case';
 import type { OrgChatSettingsRepository } from '../../ports/org-chat-settings.repository';
 import { OrgChatSettings } from 'src/domain/chat-settings/domain/org-chat-settings.entity';
@@ -23,6 +24,7 @@ describe('GetOrgChatSettingsUseCase', () => {
     };
 
     useCase = new GetOrgChatSettingsUseCase(
+      createPinoLoggerMock(),
       repository,
       contextService as unknown as ContextService,
     );

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-org-chat-settings/get-org-chat-settings.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-org-chat-settings/get-org-chat-settings.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OrgChatSettings } from 'src/domain/chat-settings/domain/org-chat-settings.entity';
 import { OrgChatSettingsRepository } from '../../ports/org-chat-settings.repository';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -8,9 +9,9 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetOrgChatSettingsUseCase {
-  private readonly logger = new Logger(GetOrgChatSettingsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetOrgChatSettingsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly orgChatSettingsRepository: OrgChatSettingsRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -20,7 +21,7 @@ export class GetOrgChatSettingsUseCase {
     if (!orgId) {
       throw new UnauthorizedAccessError();
     }
-    this.logger.log('execute', { orgId });
+    this.logger.info({ orgId }, 'execute');
 
     try {
       const orgChatSettings =
@@ -30,9 +31,12 @@ export class GetOrgChatSettingsUseCase {
       return orgChatSettings ?? new OrgChatSettings({ orgId });
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get org chat settings', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Failed to get org chat settings',
+      );
       throw new UnexpectedChatSettingsError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-org-system-prompt/get-org-system-prompt.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-org-system-prompt/get-org-system-prompt.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { GetOrgSystemPromptUseCase } from './get-org-system-prompt.use-case';
 import type { OrgSystemPromptsRepository } from '../../ports/org-system-prompts.repository';
 import { OrgSystemPrompt } from 'src/domain/chat-settings/domain/org-system-prompt.entity';
@@ -24,6 +25,7 @@ describe('GetOrgSystemPromptUseCase', () => {
     };
 
     useCase = new GetOrgSystemPromptUseCase(
+      createPinoLoggerMock(),
       repository,
       contextService as unknown as ContextService,
     );

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-org-system-prompt/get-org-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-org-system-prompt/get-org-system-prompt.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OrgSystemPrompt } from 'src/domain/chat-settings/domain/org-system-prompt.entity';
 import { OrgSystemPromptsRepository } from '../../ports/org-system-prompts.repository';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -8,9 +9,9 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetOrgSystemPromptUseCase {
-  private readonly logger = new Logger(GetOrgSystemPromptUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetOrgSystemPromptUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly orgSystemPromptsRepository: OrgSystemPromptsRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -20,22 +21,25 @@ export class GetOrgSystemPromptUseCase {
     if (!orgId) {
       throw new UnauthorizedAccessError();
     }
-    this.logger.log('execute', { orgId });
+    this.logger.info({ orgId }, 'execute');
 
     try {
       const orgSystemPrompt =
         await this.orgSystemPromptsRepository.findByOrgId(orgId);
 
       if (orgSystemPrompt) {
-        this.logger.debug('Org system prompt found', { orgId });
+        this.logger.debug({ orgId }, 'Org system prompt found');
       } else {
-        this.logger.debug('No org system prompt found', { orgId });
+        this.logger.debug({ orgId }, 'No org system prompt found');
       }
 
       return orgSystemPrompt;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get org system prompt', error);
+      this.logger.error(
+        { err: error as Error },
+        'Failed to get org system prompt',
+      );
       throw new UnexpectedChatSettingsError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-user-system-prompt/get-user-system-prompt.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-user-system-prompt/get-user-system-prompt.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { GetUserSystemPromptUseCase } from './get-user-system-prompt.use-case';
 import type { UserSystemPromptsRepository } from '../../ports/user-system-prompts.repository';
 import { UserSystemPrompt } from 'src/domain/chat-settings/domain/user-system-prompt.entity';
@@ -23,6 +24,7 @@ describe('GetUserSystemPromptUseCase', () => {
     };
 
     useCase = new GetUserSystemPromptUseCase(
+      createPinoLoggerMock(),
       repository,
       contextService as unknown as ContextService,
     );

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-user-system-prompt/get-user-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/get-user-system-prompt/get-user-system-prompt.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UserSystemPrompt } from 'src/domain/chat-settings/domain/user-system-prompt.entity';
 import { UserSystemPromptsRepository } from '../../ports/user-system-prompts.repository';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -8,9 +9,9 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetUserSystemPromptUseCase {
-  private readonly logger = new Logger(GetUserSystemPromptUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetUserSystemPromptUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly userSystemPromptsRepository: UserSystemPromptsRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -20,22 +21,25 @@ export class GetUserSystemPromptUseCase {
     if (!userId) {
       throw new UnauthorizedAccessError();
     }
-    this.logger.log('execute', { userId });
+    this.logger.info({ userId }, 'execute');
 
     try {
       const userSystemPrompt =
         await this.userSystemPromptsRepository.findByUserId(userId);
 
       if (userSystemPrompt) {
-        this.logger.debug('User system prompt found', { userId });
+        this.logger.debug({ userId }, 'User system prompt found');
       } else {
-        this.logger.debug('No user system prompt found', { userId });
+        this.logger.debug({ userId }, 'No user system prompt found');
       }
 
       return userSystemPrompt;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get user system prompt', error);
+      this.logger.error(
+        { err: error as Error },
+        'Failed to get user system prompt',
+      );
       throw new UnexpectedChatSettingsError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-chat-settings/upsert-org-chat-settings.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-chat-settings/upsert-org-chat-settings.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { UpsertOrgChatSettingsUseCase } from './upsert-org-chat-settings.use-case';
 import { UpsertOrgChatSettingsCommand } from './upsert-org-chat-settings.command';
 import type { OrgChatSettingsRepository } from '../../ports/org-chat-settings.repository';
@@ -24,6 +25,7 @@ describe('UpsertOrgChatSettingsUseCase', () => {
     };
 
     useCase = new UpsertOrgChatSettingsUseCase(
+      createPinoLoggerMock(),
       repository,
       contextService as unknown as ContextService,
     );

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-chat-settings/upsert-org-chat-settings.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-chat-settings/upsert-org-chat-settings.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UpsertOrgChatSettingsCommand } from './upsert-org-chat-settings.command';
 import { OrgChatSettings } from 'src/domain/chat-settings/domain/org-chat-settings.entity';
 import { OrgChatSettingsRepository } from '../../ports/org-chat-settings.repository';
@@ -9,9 +10,9 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class UpsertOrgChatSettingsUseCase {
-  private readonly logger = new Logger(UpsertOrgChatSettingsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpsertOrgChatSettingsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly orgChatSettingsRepository: OrgChatSettingsRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -23,7 +24,7 @@ export class UpsertOrgChatSettingsUseCase {
     if (!orgId) {
       throw new UnauthorizedAccessError();
     }
-    this.logger.log('execute', { orgId });
+    this.logger.info({ orgId }, 'execute');
 
     try {
       const orgChatSettings = new OrgChatSettings({
@@ -34,17 +35,23 @@ export class UpsertOrgChatSettingsUseCase {
       const result =
         await this.orgChatSettingsRepository.upsert(orgChatSettings);
 
-      this.logger.debug('Org chat settings upserted', {
-        orgId,
-        id: result.id,
-      });
+      this.logger.debug(
+        {
+          orgId,
+          id: result.id,
+        },
+        'Org chat settings upserted',
+      );
 
       return result;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to upsert org chat settings', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Failed to upsert org chat settings',
+      );
       throw new UnexpectedChatSettingsError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-system-prompt/upsert-org-system-prompt.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-system-prompt/upsert-org-system-prompt.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { UpsertOrgSystemPromptUseCase } from './upsert-org-system-prompt.use-case';
 import { UpsertOrgSystemPromptCommand } from './upsert-org-system-prompt.command';
 import type { OrgSystemPromptsRepository } from '../../ports/org-system-prompts.repository';
@@ -24,6 +25,7 @@ describe('UpsertOrgSystemPromptUseCase', () => {
     };
 
     useCase = new UpsertOrgSystemPromptUseCase(
+      createPinoLoggerMock(),
       repository,
       contextService as unknown as ContextService,
     );

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-system-prompt/upsert-org-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-org-system-prompt/upsert-org-system-prompt.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UpsertOrgSystemPromptCommand } from './upsert-org-system-prompt.command';
 import { OrgSystemPrompt } from 'src/domain/chat-settings/domain/org-system-prompt.entity';
 import { OrgSystemPromptsRepository } from '../../ports/org-system-prompts.repository';
@@ -9,9 +10,9 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class UpsertOrgSystemPromptUseCase {
-  private readonly logger = new Logger(UpsertOrgSystemPromptUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpsertOrgSystemPromptUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly orgSystemPromptsRepository: OrgSystemPromptsRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -23,7 +24,7 @@ export class UpsertOrgSystemPromptUseCase {
     if (!orgId) {
       throw new UnauthorizedAccessError();
     }
-    this.logger.log('execute', { orgId });
+    this.logger.info({ orgId }, 'execute');
 
     try {
       const orgSystemPrompt = new OrgSystemPrompt({
@@ -34,15 +35,21 @@ export class UpsertOrgSystemPromptUseCase {
       const result =
         await this.orgSystemPromptsRepository.upsert(orgSystemPrompt);
 
-      this.logger.debug('Org system prompt upserted', {
-        orgId,
-        id: result.id,
-      });
+      this.logger.debug(
+        {
+          orgId,
+          id: result.id,
+        },
+        'Org system prompt upserted',
+      );
 
       return result;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to upsert org system prompt', error);
+      this.logger.error(
+        { err: error as Error },
+        'Failed to upsert org system prompt',
+      );
       throw new UnexpectedChatSettingsError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-user-system-prompt/upsert-user-system-prompt.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-user-system-prompt/upsert-user-system-prompt.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { UpsertUserSystemPromptUseCase } from './upsert-user-system-prompt.use-case';
 import { UpsertUserSystemPromptCommand } from './upsert-user-system-prompt.command';
 import type { UserSystemPromptsRepository } from '../../ports/user-system-prompts.repository';
@@ -24,6 +25,7 @@ describe('UpsertUserSystemPromptUseCase', () => {
     };
 
     useCase = new UpsertUserSystemPromptUseCase(
+      createPinoLoggerMock(),
       repository,
       contextService as unknown as ContextService,
     );

--- a/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-user-system-prompt/upsert-user-system-prompt.use-case.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/application/use-cases/upsert-user-system-prompt/upsert-user-system-prompt.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UpsertUserSystemPromptCommand } from './upsert-user-system-prompt.command';
 import { UserSystemPrompt } from 'src/domain/chat-settings/domain/user-system-prompt.entity';
 import { UserSystemPromptsRepository } from '../../ports/user-system-prompts.repository';
@@ -9,9 +10,9 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class UpsertUserSystemPromptUseCase {
-  private readonly logger = new Logger(UpsertUserSystemPromptUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpsertUserSystemPromptUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly userSystemPromptsRepository: UserSystemPromptsRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -23,7 +24,7 @@ export class UpsertUserSystemPromptUseCase {
     if (!userId) {
       throw new UnauthorizedAccessError();
     }
-    this.logger.log('execute', { userId });
+    this.logger.info({ userId }, 'execute');
 
     try {
       const userSystemPrompt = new UserSystemPrompt({
@@ -34,15 +35,21 @@ export class UpsertUserSystemPromptUseCase {
       const result =
         await this.userSystemPromptsRepository.upsert(userSystemPrompt);
 
-      this.logger.debug('User system prompt upserted', {
-        userId,
-        id: result.id,
-      });
+      this.logger.debug(
+        {
+          userId,
+          id: result.id,
+        },
+        'User system prompt upserted',
+      );
 
       return result;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to upsert user system prompt', error);
+      this.logger.error(
+        { err: error as Error },
+        'Failed to upsert user system prompt',
+      );
       throw new UnexpectedChatSettingsError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/domain/chat-settings/infrastructure/persistence/local-org-chat-settings/local-org-chat-settings.repository.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/infrastructure/persistence/local-org-chat-settings/local-org-chat-settings.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UUID } from 'crypto';
@@ -9,9 +10,9 @@ import { OrgChatSettingsMapper } from './mappers/org-chat-settings.mapper';
 
 @Injectable()
 export class LocalOrgChatSettingsRepository extends OrgChatSettingsRepository {
-  private readonly logger = new Logger(LocalOrgChatSettingsRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalOrgChatSettingsRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(OrgChatSettingsRecord)
     private readonly repository: Repository<OrgChatSettingsRecord>,
     private readonly mapper: OrgChatSettingsMapper,
@@ -20,12 +21,12 @@ export class LocalOrgChatSettingsRepository extends OrgChatSettingsRepository {
   }
 
   async findByOrgId(orgId: UUID): Promise<OrgChatSettings | null> {
-    this.logger.log('findByOrgId', { orgId });
+    this.logger.info({ orgId }, 'findByOrgId');
 
     const record = await this.repository.findOne({ where: { orgId } });
 
     if (!record) {
-      this.logger.debug('No org chat settings found', { orgId });
+      this.logger.debug({ orgId }, 'No org chat settings found');
       return null;
     }
 
@@ -33,7 +34,7 @@ export class LocalOrgChatSettingsRepository extends OrgChatSettingsRepository {
   }
 
   async upsert(orgChatSettings: OrgChatSettings): Promise<OrgChatSettings> {
-    this.logger.log('upsert', { orgId: orgChatSettings.orgId });
+    this.logger.info({ orgId: orgChatSettings.orgId }, 'upsert');
 
     const record = this.mapper.toRecord(orgChatSettings);
 
@@ -48,10 +49,13 @@ export class LocalOrgChatSettingsRepository extends OrgChatSettingsRepository {
       where: { orgId: orgChatSettings.orgId },
     });
 
-    this.logger.debug('Org chat settings upserted', {
-      orgId: orgChatSettings.orgId,
-      id: savedRecord.id,
-    });
+    this.logger.debug(
+      {
+        orgId: orgChatSettings.orgId,
+        id: savedRecord.id,
+      },
+      'Org chat settings upserted',
+    );
 
     return this.mapper.toDomain(savedRecord);
   }

--- a/ayunis-core-backend/src/domain/chat-settings/infrastructure/persistence/local-org-system-prompts/local-org-system-prompts.repository.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/infrastructure/persistence/local-org-system-prompts/local-org-system-prompts.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UUID } from 'crypto';
@@ -9,9 +10,9 @@ import { OrgSystemPromptMapper } from './mappers/org-system-prompt.mapper';
 
 @Injectable()
 export class LocalOrgSystemPromptsRepository extends OrgSystemPromptsRepository {
-  private readonly logger = new Logger(LocalOrgSystemPromptsRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalOrgSystemPromptsRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(OrgSystemPromptRecord)
     private readonly repository: Repository<OrgSystemPromptRecord>,
     private readonly mapper: OrgSystemPromptMapper,
@@ -20,12 +21,12 @@ export class LocalOrgSystemPromptsRepository extends OrgSystemPromptsRepository 
   }
 
   async findByOrgId(orgId: UUID): Promise<OrgSystemPrompt | null> {
-    this.logger.log('findByOrgId', { orgId });
+    this.logger.info({ orgId }, 'findByOrgId');
 
     const record = await this.repository.findOne({ where: { orgId } });
 
     if (!record) {
-      this.logger.debug('No org system prompt found', { orgId });
+      this.logger.debug({ orgId }, 'No org system prompt found');
       return null;
     }
 
@@ -33,7 +34,7 @@ export class LocalOrgSystemPromptsRepository extends OrgSystemPromptsRepository 
   }
 
   async upsert(orgSystemPrompt: OrgSystemPrompt): Promise<OrgSystemPrompt> {
-    this.logger.log('upsert', { orgId: orgSystemPrompt.orgId });
+    this.logger.info({ orgId: orgSystemPrompt.orgId }, 'upsert');
 
     const record = this.mapper.toRecord(orgSystemPrompt);
 
@@ -48,19 +49,22 @@ export class LocalOrgSystemPromptsRepository extends OrgSystemPromptsRepository 
       where: { orgId: orgSystemPrompt.orgId },
     });
 
-    this.logger.debug('Org system prompt upserted', {
-      orgId: orgSystemPrompt.orgId,
-      id: savedRecord.id,
-    });
+    this.logger.debug(
+      {
+        orgId: orgSystemPrompt.orgId,
+        id: savedRecord.id,
+      },
+      'Org system prompt upserted',
+    );
 
     return this.mapper.toDomain(savedRecord);
   }
 
   async deleteByOrgId(orgId: UUID): Promise<void> {
-    this.logger.log('deleteByOrgId', { orgId });
+    this.logger.info({ orgId }, 'deleteByOrgId');
 
     await this.repository.delete({ orgId });
 
-    this.logger.debug('Org system prompt deleted', { orgId });
+    this.logger.debug({ orgId }, 'Org system prompt deleted');
   }
 }

--- a/ayunis-core-backend/src/domain/chat-settings/infrastructure/persistence/local-user-system-prompts/local-user-system-prompts.repository.ts
+++ b/ayunis-core-backend/src/domain/chat-settings/infrastructure/persistence/local-user-system-prompts/local-user-system-prompts.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UUID } from 'crypto';
@@ -9,9 +10,9 @@ import { UserSystemPromptMapper } from './mappers/user-system-prompt.mapper';
 
 @Injectable()
 export class LocalUserSystemPromptsRepository extends UserSystemPromptsRepository {
-  private readonly logger = new Logger(LocalUserSystemPromptsRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalUserSystemPromptsRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(UserSystemPromptRecord)
     private readonly repository: Repository<UserSystemPromptRecord>,
     private readonly mapper: UserSystemPromptMapper,
@@ -20,12 +21,12 @@ export class LocalUserSystemPromptsRepository extends UserSystemPromptsRepositor
   }
 
   async findByUserId(userId: UUID): Promise<UserSystemPrompt | null> {
-    this.logger.log('findByUserId', { userId });
+    this.logger.info({ userId }, 'findByUserId');
 
     const record = await this.repository.findOne({ where: { userId } });
 
     if (!record) {
-      this.logger.debug('No user system prompt found', { userId });
+      this.logger.debug({ userId }, 'No user system prompt found');
       return null;
     }
 
@@ -33,7 +34,7 @@ export class LocalUserSystemPromptsRepository extends UserSystemPromptsRepositor
   }
 
   async upsert(userSystemPrompt: UserSystemPrompt): Promise<UserSystemPrompt> {
-    this.logger.log('upsert', { userId: userSystemPrompt.userId });
+    this.logger.info({ userId: userSystemPrompt.userId }, 'upsert');
 
     const record = this.mapper.toRecord(userSystemPrompt);
 
@@ -48,19 +49,22 @@ export class LocalUserSystemPromptsRepository extends UserSystemPromptsRepositor
       where: { userId: userSystemPrompt.userId },
     });
 
-    this.logger.debug('User system prompt upserted', {
-      userId: userSystemPrompt.userId,
-      id: savedRecord.id,
-    });
+    this.logger.debug(
+      {
+        userId: userSystemPrompt.userId,
+        id: savedRecord.id,
+      },
+      'User system prompt upserted',
+    );
 
     return this.mapper.toDomain(savedRecord);
   }
 
   async deleteByUserId(userId: UUID): Promise<void> {
-    this.logger.log('deleteByUserId', { userId });
+    this.logger.info({ userId }, 'deleteByUserId');
 
     await this.repository.delete({ userId });
 
-    this.logger.debug('User system prompt deleted', { userId });
+    this.logger.debug({ userId }, 'User system prompt deleted');
   }
 }

--- a/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/assert-crawl-domain-access/assert-crawl-domain-access.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/assert-crawl-domain-access/assert-crawl-domain-access.use-case.spec.ts
@@ -1,4 +1,5 @@
 import type { UUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { AssertCrawlDomainAccessUseCase } from './assert-crawl-domain-access.use-case';
 import { AssertCrawlDomainAccessCommand } from './assert-crawl-domain-access.command';
 import type { CrawlDomainGrantRepository } from '../../ports/crawl-domain-grant.repository';
@@ -23,6 +24,7 @@ function repoReturning(
 describe('AssertCrawlDomainAccessUseCase', () => {
   it('allows when no grant exists for the host', async () => {
     const useCase = new AssertCrawlDomainAccessUseCase(
+      createPinoLoggerMock(),
       repoReturning(() => null),
     );
     await expect(
@@ -41,6 +43,7 @@ describe('AssertCrawlDomainAccessUseCase', () => {
       domain: 'intranet.customer.de',
     });
     const useCase = new AssertCrawlDomainAccessUseCase(
+      createPinoLoggerMock(),
       repoReturning(() => grant),
     );
     await expect(
@@ -53,14 +56,17 @@ describe('AssertCrawlDomainAccessUseCase', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('blocks with a 404 access-denied error when the host is granted to another org', async () => {
+  it('logs blocked cross-org crawls with object-first metadata', async () => {
     const grant = new CrawlDomainGrant({
       orgId: ORG_A,
       domain: 'intranet.customer.de',
     });
+    const logger = createPinoLoggerMock();
     const useCase = new AssertCrawlDomainAccessUseCase(
+      logger,
       repoReturning(() => grant),
     );
+
     await expect(
       useCase.execute(
         new AssertCrawlDomainAccessCommand(
@@ -69,10 +75,15 @@ describe('AssertCrawlDomainAccessUseCase', () => {
         ),
       ),
     ).rejects.toBeInstanceOf(CrawlDomainAccessDeniedError);
+    expect(logger.warn).toHaveBeenCalledWith(
+      { domain: 'intranet.customer.de', orgId: ORG_B },
+      'Blocked cross-org crawl of a restricted domain',
+    );
   });
 
   it('does not block a different host under the same registrable domain (exact-host match)', async () => {
     const useCase = new AssertCrawlDomainAccessUseCase(
+      createPinoLoggerMock(),
       repoReturning((domain) =>
         domain === 'intranet.customer.de'
           ? new CrawlDomainGrant({
@@ -91,7 +102,10 @@ describe('AssertCrawlDomainAccessUseCase', () => {
 
   it('queries the repository with the exact lowercased host (no port)', async () => {
     const repo = repoReturning(() => null);
-    const useCase = new AssertCrawlDomainAccessUseCase(repo);
+    const useCase = new AssertCrawlDomainAccessUseCase(
+      createPinoLoggerMock(),
+      repo,
+    );
     await useCase.execute(
       new AssertCrawlDomainAccessCommand(
         'https://Intranet.Customer.DE:8443/x',

--- a/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/assert-crawl-domain-access/assert-crawl-domain-access.use-case.ts
+++ b/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/assert-crawl-domain-access/assert-crawl-domain-access.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { CrawlDomainGrantRepository } from '../../ports/crawl-domain-grant.repository';
 import {
@@ -18,9 +19,9 @@ import { InvalidCrawlDomainError } from 'src/domain/crawl-domain-grants/domain/c
  */
 @Injectable()
 export class AssertCrawlDomainAccessUseCase {
-  private readonly logger = new Logger(AssertCrawlDomainAccessUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AssertCrawlDomainAccessUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly crawlDomainGrantRepository: CrawlDomainGrantRepository,
   ) {}
 
@@ -35,17 +36,23 @@ export class AssertCrawlDomainAccessUseCase {
 
       const grant = await this.crawlDomainGrantRepository.findByDomain(host);
       if (grant && grant.orgId !== command.orgId) {
-        this.logger.warn('Blocked cross-org crawl of a restricted domain', {
-          host,
-          orgId: command.orgId,
-        });
+        this.logger.warn(
+          {
+            domain: host,
+            orgId: command.orgId,
+          },
+          'Blocked cross-org crawl of a restricted domain',
+        );
         throw new CrawlDomainAccessDeniedError({ domain: host });
       }
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error asserting crawl domain access', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error asserting crawl domain access',
+      );
       throw new UnexpectedCrawlDomainGrantError('assert', {
         error: error as Error,
       });

--- a/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/grant-crawl-domain/grant-crawl-domain.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/grant-crawl-domain/grant-crawl-domain.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { GrantCrawlDomainUseCase } from './grant-crawl-domain.use-case';
 import { GrantCrawlDomainCommand } from './grant-crawl-domain.command';
@@ -26,7 +27,7 @@ function makeRepo(
 describe('GrantCrawlDomainUseCase', () => {
   it('normalizes the input to a host and creates the grant when the domain is free', async () => {
     const repo = makeRepo(null);
-    const useCase = new GrantCrawlDomainUseCase(repo);
+    const useCase = new GrantCrawlDomainUseCase(createPinoLoggerMock(), repo);
 
     const result = await useCase.execute(
       new GrantCrawlDomainCommand(ORG_A, 'https://Intranet.Customer.DE/wiki'),
@@ -43,7 +44,7 @@ describe('GrantCrawlDomainUseCase', () => {
       domain: 'intranet.customer.de',
     });
     const repo = makeRepo(existing);
-    const useCase = new GrantCrawlDomainUseCase(repo);
+    const useCase = new GrantCrawlDomainUseCase(createPinoLoggerMock(), repo);
 
     const result = await useCase.execute(
       new GrantCrawlDomainCommand(ORG_A, 'intranet.customer.de'),
@@ -58,7 +59,10 @@ describe('GrantCrawlDomainUseCase', () => {
       orgId: ORG_A,
       domain: 'intranet.customer.de',
     });
-    const useCase = new GrantCrawlDomainUseCase(makeRepo(existing));
+    const useCase = new GrantCrawlDomainUseCase(
+      createPinoLoggerMock(),
+      makeRepo(existing),
+    );
 
     await expect(
       useCase.execute(
@@ -68,7 +72,10 @@ describe('GrantCrawlDomainUseCase', () => {
   });
 
   it('rejects an unparseable domain with a 400', async () => {
-    const useCase = new GrantCrawlDomainUseCase(makeRepo(null));
+    const useCase = new GrantCrawlDomainUseCase(
+      createPinoLoggerMock(),
+      makeRepo(null),
+    );
 
     await expect(
       useCase.execute(new GrantCrawlDomainCommand(ORG_A, 'not a domain')),

--- a/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/grant-crawl-domain/grant-crawl-domain.use-case.ts
+++ b/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/grant-crawl-domain/grant-crawl-domain.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { CrawlDomainGrant } from 'src/domain/crawl-domain-grants/domain/crawl-domain-grant.entity';
 import { normalizeHost } from 'src/domain/crawl-domain-grants/domain/crawl-domain.util';
@@ -13,17 +14,20 @@ import { GrantCrawlDomainCommand } from './grant-crawl-domain.command';
 
 @Injectable()
 export class GrantCrawlDomainUseCase {
-  private readonly logger = new Logger(GrantCrawlDomainUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GrantCrawlDomainUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly crawlDomainGrantRepository: CrawlDomainGrantRepository,
   ) {}
 
   async execute(command: GrantCrawlDomainCommand): Promise<CrawlDomainGrant> {
-    this.logger.log('Granting crawl domain', {
-      orgId: command.orgId,
-      domain: command.domain,
-    });
+    this.logger.info(
+      {
+        orgId: command.orgId,
+        domain: command.domain,
+      },
+      'Granting crawl domain',
+    );
 
     try {
       const domain = this.normalize(command.domain);
@@ -42,9 +46,12 @@ export class GrantCrawlDomainUseCase {
       return await this.crawlDomainGrantRepository.create(grant);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error granting crawl domain', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error granting crawl domain',
+      );
       throw new UnexpectedCrawlDomainGrantError('grant', {
         error: error as Error,
       });

--- a/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/list-org-crawl-domains/list-org-crawl-domains.use-case.ts
+++ b/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/list-org-crawl-domains/list-org-crawl-domains.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { CrawlDomainGrant } from 'src/domain/crawl-domain-grants/domain/crawl-domain-grant.entity';
 import { CrawlDomainGrantRepository } from '../../ports/crawl-domain-grant.repository';
@@ -7,22 +8,25 @@ import { ListOrgCrawlDomainsQuery } from './list-org-crawl-domains.query';
 
 @Injectable()
 export class ListOrgCrawlDomainsUseCase {
-  private readonly logger = new Logger(ListOrgCrawlDomainsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ListOrgCrawlDomainsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly crawlDomainGrantRepository: CrawlDomainGrantRepository,
   ) {}
 
   async execute(query: ListOrgCrawlDomainsQuery): Promise<CrawlDomainGrant[]> {
-    this.logger.log('Listing crawl domains', { orgId: query.orgId });
+    this.logger.info({ orgId: query.orgId }, 'Listing crawl domains');
 
     try {
       return await this.crawlDomainGrantRepository.findAllByOrgId(query.orgId);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error listing crawl domains', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error listing crawl domains',
+      );
       throw new UnexpectedCrawlDomainGrantError('list', {
         error: error as Error,
       });

--- a/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/revoke-crawl-domain/revoke-crawl-domain.use-case.ts
+++ b/ayunis-core-backend/src/domain/crawl-domain-grants/application/use-cases/revoke-crawl-domain/revoke-crawl-domain.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { CrawlDomainGrantRepository } from '../../ports/crawl-domain-grant.repository';
 import {
@@ -9,17 +10,20 @@ import { RevokeCrawlDomainCommand } from './revoke-crawl-domain.command';
 
 @Injectable()
 export class RevokeCrawlDomainUseCase {
-  private readonly logger = new Logger(RevokeCrawlDomainUseCase.name);
-
   constructor(
+    @InjectPinoLogger(RevokeCrawlDomainUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly crawlDomainGrantRepository: CrawlDomainGrantRepository,
   ) {}
 
   async execute(command: RevokeCrawlDomainCommand): Promise<void> {
-    this.logger.log('Revoking crawl domain', {
-      orgId: command.orgId,
-      grantId: command.grantId,
-    });
+    this.logger.info(
+      {
+        orgId: command.orgId,
+        grantId: command.grantId,
+      },
+      'Revoking crawl domain',
+    );
 
     try {
       const grant = await this.crawlDomainGrantRepository.findById(
@@ -34,9 +38,12 @@ export class RevokeCrawlDomainUseCase {
       await this.crawlDomainGrantRepository.delete(command.grantId);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error revoking crawl domain', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error revoking crawl domain',
+      );
       throw new UnexpectedCrawlDomainGrantError('revoke', {
         error: error as Error,
       });

--- a/ayunis-core-backend/src/domain/crawl-domain-grants/infrastructure/persistence/postgres/crawl-domain-grant.repository.ts
+++ b/ayunis-core-backend/src/domain/crawl-domain-grants/infrastructure/persistence/postgres/crawl-domain-grant.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { UUID } from 'crypto';
@@ -9,9 +10,9 @@ import { CrawlDomainGrantMapper } from './mappers/crawl-domain-grant.mapper';
 
 @Injectable()
 export class PostgresCrawlDomainGrantRepository extends CrawlDomainGrantRepository {
-  private readonly logger = new Logger(PostgresCrawlDomainGrantRepository.name);
-
   constructor(
+    @InjectPinoLogger(PostgresCrawlDomainGrantRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(CrawlDomainGrantRecord)
     private readonly repository: Repository<CrawlDomainGrantRecord>,
   ) {
@@ -37,7 +38,7 @@ export class PostgresCrawlDomainGrantRepository extends CrawlDomainGrantReposito
   }
 
   async create(grant: CrawlDomainGrant): Promise<CrawlDomainGrant> {
-    this.logger.debug('create', { orgId: grant.orgId, domain: grant.domain });
+    this.logger.debug({ orgId: grant.orgId, domain: grant.domain }, 'create');
 
     const record = CrawlDomainGrantMapper.toRecord(grant);
     await this.repository.save(record);

--- a/ayunis-core-backend/src/domain/crawl-domain-grants/presenters/http/super-admin-crawl-domains.controller.ts
+++ b/ayunis-core-backend/src/domain/crawl-domain-grants/presenters/http/super-admin-crawl-domains.controller.ts
@@ -5,10 +5,10 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   Post,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -37,9 +37,9 @@ import { CrawlDomainGrantResponseDto } from './dtos/crawl-domain-grant-response.
 @Controller('super-admin/crawl-domains')
 @SystemRoles(SystemRole.SUPER_ADMIN)
 export class SuperAdminCrawlDomainsController {
-  private readonly logger = new Logger(SuperAdminCrawlDomainsController.name);
-
   constructor(
+    @InjectPinoLogger(SuperAdminCrawlDomainsController.name)
+    private readonly logger: PinoLogger,
     private readonly listOrgCrawlDomainsUseCase: ListOrgCrawlDomainsUseCase,
     private readonly grantCrawlDomainUseCase: GrantCrawlDomainUseCase,
     private readonly revokeCrawlDomainUseCase: RevokeCrawlDomainUseCase,
@@ -55,7 +55,7 @@ export class SuperAdminCrawlDomainsController {
   async list(
     @Param('orgId') orgId: UUID,
   ): Promise<CrawlDomainGrantResponseDto[]> {
-    this.logger.log('list', { orgId });
+    this.logger.info({ orgId }, 'list');
 
     const grants = await this.listOrgCrawlDomainsUseCase.execute(
       new ListOrgCrawlDomainsQuery(orgId),
@@ -81,7 +81,7 @@ export class SuperAdminCrawlDomainsController {
     @Param('orgId') orgId: UUID,
     @Body() dto: GrantCrawlDomainRequestDto,
   ): Promise<CrawlDomainGrantResponseDto> {
-    this.logger.log('grant', { orgId, domain: dto.domain });
+    this.logger.info({ orgId, domain: dto.domain }, 'grant');
 
     const grant = await this.grantCrawlDomainUseCase.execute(
       new GrantCrawlDomainCommand(orgId, dto.domain),
@@ -104,7 +104,7 @@ export class SuperAdminCrawlDomainsController {
     @Param('orgId') orgId: UUID,
     @Param('grantId') grantId: UUID,
   ): Promise<void> {
-    this.logger.log('revoke', { orgId, grantId });
+    this.logger.info({ orgId, grantId }, 'revoke');
 
     await this.revokeCrawlDomainUseCase.execute(
       new RevokeCrawlDomainCommand(orgId, grantId),

--- a/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { AnonymizeTextForThreadUseCase } from './anonymize-text-for-thread.use-case';
 import { AnonymizeTextForThreadCommand } from './anonymize-text-for-thread.command';
@@ -38,6 +38,7 @@ describe('AnonymizeTextForThreadUseCase', () => {
       ],
     });
     useCase = new AnonymizeTextForThreadUseCase(
+      createPinoLoggerMock(),
       { findByThreadId, saveMany },
       { execute: whitelistExecute } as unknown as GetPiiWhitelistUseCase,
       {
@@ -45,8 +46,6 @@ describe('AnonymizeTextForThreadUseCase', () => {
       } as unknown as GetGlobalPiiWhitelistUseCase,
       { execute: anonymizeExecute } as unknown as AnonymizeTextUseCase,
     );
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   const command = () =>

--- a/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/anonymize-text-for-thread/anonymize-text-for-thread.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AnonymizeTextUseCase } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.use-case';
 import { AnonymizeTextCommand } from 'src/common/anonymization/application/use-cases/anonymize-text/anonymize-text.command';
@@ -27,9 +28,9 @@ export interface ThreadAnonymizationResult extends AnonymizationResult {
  */
 @Injectable()
 export class AnonymizeTextForThreadUseCase {
-  private readonly logger = new Logger(AnonymizeTextForThreadUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AnonymizeTextForThreadUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: ThreadPiiMaskRepository,
     private readonly getPiiWhitelistUseCase: GetPiiWhitelistUseCase,
     private readonly getGlobalPiiWhitelistUseCase: GetGlobalPiiWhitelistUseCase,
@@ -39,10 +40,8 @@ export class AnonymizeTextForThreadUseCase {
   async execute(
     command: AnonymizeTextForThreadCommand,
   ): Promise<ThreadAnonymizationResult> {
-    this.logger.debug('Anonymizing text for thread', {
-      orgId: command.orgId,
-      threadId: command.threadId,
-    });
+    const logContext = { orgId: command.orgId, threadId: command.threadId };
+    this.logger.debug(logContext, 'Anonymizing text for thread');
 
     try {
       const entries = await this.getPiiWhitelistUseCase.execute(
@@ -76,13 +75,10 @@ export class AnonymizeTextForThreadUseCase {
       return { ...result, masks: [...existing, ...created] };
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-
-      this.logger.error('Failed to anonymize text for thread', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-        threadId: command.threadId,
-      });
-
+      this.logger.error(
+        { err: error as Error, ...logContext },
+        'Failed to anonymize text for thread',
+      );
       throw new UnexpectedThreadPiiMasksError('anonymize', {
         orgId: command.orgId,
         threadId: command.threadId,

--- a/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/get-thread-pii-masks/get-thread-pii-masks.use-case.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/application/use-cases/get-thread-pii-masks/get-thread-pii-masks.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ThreadPiiMaskRepository } from '../../ports/thread-pii-mask.repository';
 import { UnexpectedThreadPiiMasksError } from '../../thread-pii-masks.errors';
@@ -7,24 +8,32 @@ import type { GetThreadPiiMasksQuery } from './get-thread-pii-masks.query';
 
 @Injectable()
 export class GetThreadPiiMasksUseCase {
-  private readonly logger = new Logger(GetThreadPiiMasksUseCase.name);
-
-  constructor(private readonly repository: ThreadPiiMaskRepository) {}
+  constructor(
+    @InjectPinoLogger(GetThreadPiiMasksUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: ThreadPiiMaskRepository,
+  ) {}
 
   async execute(query: GetThreadPiiMasksQuery): Promise<ThreadPiiMask[]> {
-    this.logger.debug('Getting thread PII masks', {
-      threadId: query.threadId,
-    });
+    this.logger.debug(
+      {
+        threadId: query.threadId,
+      },
+      'Getting thread PII masks',
+    );
 
     try {
       return await this.repository.findByThreadId(query.threadId);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
 
-      this.logger.error('Failed to get thread PII masks', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        threadId: query.threadId,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          threadId: query.threadId,
+        },
+        'Failed to get thread PII masks',
+      );
 
       throw new UnexpectedThreadPiiMasksError('get', {
         threadId: query.threadId,

--- a/ayunis-core-backend/src/domain/thread-pii-masks/infrastructure/persistence/postgres/thread-pii-mask.repository.ts
+++ b/ayunis-core-backend/src/domain/thread-pii-masks/infrastructure/persistence/postgres/thread-pii-mask.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { UUID } from 'crypto';
@@ -9,9 +10,9 @@ import { ThreadPiiMaskMapper } from './mappers/thread-pii-mask.mapper';
 
 @Injectable()
 export class PostgresThreadPiiMaskRepository extends ThreadPiiMaskRepository {
-  private readonly logger = new Logger(PostgresThreadPiiMaskRepository.name);
-
   constructor(
+    @InjectPinoLogger(PostgresThreadPiiMaskRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(ThreadPiiMaskRecord)
     private readonly repository: Repository<ThreadPiiMaskRecord>,
   ) {
@@ -19,7 +20,7 @@ export class PostgresThreadPiiMaskRepository extends ThreadPiiMaskRepository {
   }
 
   async findByThreadId(threadId: UUID): Promise<ThreadPiiMask[]> {
-    this.logger.debug('findByThreadId', { threadId });
+    this.logger.debug({ threadId }, 'findByThreadId');
 
     const records = await this.repository.find({
       where: { threadId },
@@ -30,7 +31,7 @@ export class PostgresThreadPiiMaskRepository extends ThreadPiiMaskRepository {
   }
 
   async saveMany(masks: ThreadPiiMask[]): Promise<void> {
-    this.logger.debug('saveMany', { count: masks.length });
+    this.logger.debug({ count: masks.length }, 'saveMany');
 
     if (masks.length === 0) {
       return;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only refactor with no business-logic changes; main risk is mis-wired DI or log field renames affecting dashboards/alerts.
> 
> **Overview**
> Continues the **nestjs-pino** rollout across remaining **domain** areas: **academy**, **anonymization-settings**, **chat-settings**, and **crawl-domain-grants** (use cases, HTTP controllers, repositories, and certificate rendering).
> 
> Classes drop `new Logger(...)` in favor of **`@InjectPinoLogger(ClassName.name)`** and **`PinoLogger`**. Log calls move to Pino’s **object-first** style (`info`/`debug`/`warn` instead of `log` where applicable), with errors logged as **`{ err: error }`** rather than `{ error: ... }`. Controllers favor structured fields (e.g. `chapterId`) over string interpolation.
> 
> **Unit tests** register **`getLoggerToken(UseCase.name)`** with **`createPinoLoggerMock()`** in Nest testing modules, or pass the mock into manually constructed use cases; **`Logger.prototype` spies** are removed.
> 
> **`AssertCrawlDomainAccessUseCase`** now logs blocked cross-org crawls with **`domain`** (not `host`) in the warn metadata, with a spec asserting that shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 913af36f000eb57ace0eb2b237157d0b353ade29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->