### PR TITLE
wip(logging): migrate authentication users and hashing logging (AYC-755)

### DIFF
--- a/ayunis-core-backend/src/iam/authentication/application/guards/jwt-auth.guard.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/guards/jwt-auth.guard.ts
@@ -1,4 +1,5 @@
-import { ExecutionContext, Injectable, Logger } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { IS_PUBLIC_KEY } from 'src/common/guards/public.guard';
@@ -11,9 +12,9 @@ import { RefreshTokenReuseError } from 'src/iam/sessions/application/sessions.er
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
-  private readonly logger = new Logger(JwtAuthGuard.name);
-
   constructor(
+    @InjectPinoLogger(JwtAuthGuard.name)
+    private readonly logger: PinoLogger,
     private reflector: Reflector,
     private refreshTokenUseCase: RefreshTokenUseCase,
     private configService: ConfigService,
@@ -86,9 +87,12 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
         // client stops presenting the compromised token.
         clearCookies(response, this.configService);
       }
-      this.logger.debug('JwtAuthGuard canActivate: token refresh failed', {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      this.logger.debug(
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+        'JwtAuthGuard canActivate: token refresh failed',
+      );
       return false;
     }
   }

--- a/ayunis-core-backend/src/iam/authentication/application/guards/local-auth.guard.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/guards/local-auth.guard.ts
@@ -1,9 +1,15 @@
-import { ExecutionContext, Injectable, Logger } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
 export class LocalAuthGuard extends AuthGuard('local') {
-  private readonly logger = new Logger(LocalAuthGuard.name);
+  constructor(
+    @InjectPinoLogger(LocalAuthGuard.name)
+    private readonly logger: PinoLogger,
+  ) {
+    super();
+  }
 
   canActivate(context: ExecutionContext) {
     this.logger.debug('LocalAuthGuard canActivate');

--- a/ayunis-core-backend/src/iam/authentication/application/strategies/api-key.strategy.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/strategies/api-key.strategy.spec.ts
@@ -1,6 +1,7 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import type { UUID } from 'crypto';
 import { ApiKeyStrategy } from './api-key.strategy';
 import { ValidateApiKeyUseCase } from 'src/iam/api-keys/application/use-cases/validate-api-key/validate-api-key.use-case';
@@ -26,13 +27,15 @@ describe('ApiKeyStrategy', () => {
       providers: [
         ApiKeyStrategy,
         { provide: ValidateApiKeyUseCase, useValue: mockValidateApiKey },
+        {
+          provide: getLoggerToken(ApiKeyStrategy.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
     strategy = module.get(ApiKeyStrategy);
     validateApiKey = module.get(ValidateApiKeyUseCase);
-
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
   });
 
   it('returns the principal on a valid token', async () => {

--- a/ayunis-core-backend/src/iam/authentication/application/strategies/api-key.strategy.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/strategies/api-key.strategy.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-http-bearer';
 import type { UUID } from 'crypto';
@@ -18,9 +19,11 @@ export interface ApiKeyPrincipal {
 
 @Injectable()
 export class ApiKeyStrategy extends PassportStrategy(Strategy, 'api-key') {
-  private readonly logger = new Logger(ApiKeyStrategy.name);
-
-  constructor(private readonly validateApiKey: ValidateApiKeyUseCase) {
+  constructor(
+    @InjectPinoLogger(ApiKeyStrategy.name)
+    private readonly logger: PinoLogger,
+    private readonly validateApiKey: ValidateApiKeyUseCase,
+  ) {
     super();
   }
 
@@ -35,7 +38,7 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, 'api-key') {
         error instanceof ApiKeyNotFoundError ||
         error instanceof ApiKeyExpiredError
       ) {
-        this.logger.debug('API key validation failed', { code: error.code });
+        this.logger.debug({ code: error.code }, 'API key validation failed');
         return false;
       }
       throw error;

--- a/ayunis-core-backend/src/iam/authentication/application/strategies/jwt.strategy.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/strategies/jwt.strategy.spec.ts
@@ -1,6 +1,7 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import type { UUID } from 'crypto';
 import { JwtStrategy } from './jwt.strategy';
@@ -30,13 +31,14 @@ describe('JwtStrategy', () => {
           useValue: { get: jest.fn().mockReturnValue('access_token') },
         },
         { provide: JWT_SECRET, useValue: 'super-secret' },
+        {
+          provide: getLoggerToken(JwtStrategy.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
     strategy = module.get(JwtStrategy);
-
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/iam/authentication/application/strategies/jwt.strategy.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/strategies/jwt.strategy.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
@@ -22,9 +23,9 @@ interface JwtPayload {
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  private readonly logger = new Logger(JwtStrategy.name);
-
   constructor(
+    @InjectPinoLogger(JwtStrategy.name)
+    private readonly logger: PinoLogger,
     configService: ConfigService,
     @Inject(JWT_SECRET) secret: string,
   ) {
@@ -38,7 +39,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         const token = req.cookies[cookieName] as string;
 
         if (!token) {
-          this.logger.debug(`No JWT token found in cookie: ${cookieName}`);
+          this.logger.debug({ cookieName }, 'No JWT token found in cookie');
         }
 
         return token;

--- a/ayunis-core-backend/src/iam/authentication/application/strategies/local.strategy.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/strategies/local.strategy.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { PassportStrategy } from '@nestjs/passport';
 import { ValidateUserUseCase } from 'src/iam/users/application/use-cases/validate-user/validate-user.use-case';
 import { ValidateUserQuery } from 'src/iam/users/application/use-cases/validate-user/validate-user.query';
@@ -11,9 +12,11 @@ import {
 
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {
-  private readonly logger = new Logger(LocalStrategy.name);
-
-  constructor(private validateUserUseCase: ValidateUserUseCase) {
+  constructor(
+    @InjectPinoLogger(LocalStrategy.name)
+    private readonly logger: PinoLogger,
+    private validateUserUseCase: ValidateUserUseCase,
+  ) {
     super({ usernameField: 'email' });
   }
 
@@ -22,9 +25,12 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
       const user = await this.validateUserUseCase.execute(
         new ValidateUserQuery(username, password),
       );
-      this.logger.debug('LocalStrategy - user', {
-        user,
-      });
+      this.logger.debug(
+        {
+          userId: user.id,
+        },
+        'LocalStrategy - user',
+      );
       return new ActiveUser({
         id: user.id,
         email: user.email,
@@ -39,10 +45,13 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
         error instanceof UserNotFoundError ||
         error instanceof UserAuthenticationFailedError
       ) {
-        this.logger.warn('Invalid credentials', {
-          error,
-          username,
-        });
+        this.logger.warn(
+          {
+            err: error as Error,
+            email: username,
+          },
+          'Invalid credentials',
+        );
         return null;
       }
       throw error;

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/get-current-user/get-current-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/get-current-user/get-current-user.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetCurrentUserUseCase } from './get-current-user.use-case';
@@ -23,6 +25,10 @@ describe('GetCurrentUserUseCase', () => {
         GetCurrentUserUseCase,
         { provide: JwtService, useValue: mockJwtService },
         { provide: FindUserByIdUseCase, useValue: mockFindUserByIdUseCase },
+        {
+          provide: getLoggerToken(GetCurrentUserUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/get-current-user/get-current-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/get-current-user/get-current-user.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { JwtService } from '@nestjs/jwt';
 import { GetCurrentUserCommand } from './get-current-user.command';
 import { ActiveUser } from '../../../domain/active-user.entity';
@@ -22,18 +23,20 @@ interface JwtPayload {
 
 @Injectable()
 export class GetCurrentUserUseCase {
-  private readonly logger = new Logger(GetCurrentUserUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetCurrentUserUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly jwtService: JwtService,
     private readonly findUserByIdUseCase: FindUserByIdUseCase,
   ) {}
 
   async execute(command: GetCurrentUserCommand): Promise<ActiveUser> {
-    this.logger.log('getCurrentUser');
+    this.logger.info('getCurrentUser');
 
     try {
-      const payload = this.jwtService.verify<JwtPayload>(command.accessToken);
+      const payload = this.jwtService.verify<Partial<JwtPayload>>(
+        command.accessToken,
+      );
 
       if (
         !payload.sub ||
@@ -45,12 +48,15 @@ export class GetCurrentUserUseCase {
         throw new InvalidTokenError('Invalid token payload');
       }
 
-      this.logger.debug('Token verified successfully', {
-        userId: payload.sub,
-        email: payload.email,
-        role: payload.role,
-        name: payload.name,
-      });
+      this.logger.debug(
+        {
+          userId: payload.sub,
+          email: payload.email,
+          role: payload.role,
+          name: payload.name,
+        },
+        'Token verified successfully',
+      );
 
       const user = await this.findUserByIdUseCase.execute(
         new FindUserByIdQuery(payload.sub),
@@ -69,7 +75,7 @@ export class GetCurrentUserUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Token verification failed', { error });
+      this.logger.error({ err: error as Error }, 'Token verification failed');
       throw new InvalidTokenError('Unable to verify access token');
     }
   }

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/login/login.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/login/login.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { LoginUseCase } from './login.use-case';
@@ -27,6 +29,10 @@ describe('LoginUseCase', () => {
         LoginUseCase,
         { provide: AUTHENTICATION_REPOSITORY, useValue: mockAuthRepository },
         { provide: CreateSessionUseCase, useValue: mockCreateSessionUseCase },
+        {
+          provide: getLoggerToken(LoginUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/login/login.use-case.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/login/login.use-case.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { AuthenticationRepository } from '../../ports/authentication.repository';
 import { AUTHENTICATION_REPOSITORY } from '../../tokens/authentication-repository.token';
 import { LoginCommand } from './login.command';
@@ -10,9 +11,9 @@ import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-
 
 @Injectable()
 export class LoginUseCase {
-  private readonly logger = new Logger(LoginUseCase.name);
-
   constructor(
+    @InjectPinoLogger(LoginUseCase.name)
+    private readonly logger: PinoLogger,
     @Inject(AUTHENTICATION_REPOSITORY)
     private readonly authRepository: AuthenticationRepository,
     private readonly createSessionUseCase: CreateSessionUseCase,
@@ -20,10 +21,13 @@ export class LoginUseCase {
 
   @HandleUnexpectedErrors(UnexpectedAuthenticationError)
   async execute(command: LoginCommand): Promise<AuthTokens> {
-    this.logger.log('login', {
-      userId: command.user.id,
-      email: command.user.email,
-    });
+    this.logger.info(
+      {
+        userId: command.user.id,
+        email: command.user.email,
+      },
+      'login',
+    );
 
     const accessToken = await this.authRepository.generateAccessToken(
       command.user,

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/refresh-token/refresh-token.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/refresh-token/refresh-token.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { RefreshTokenUseCase } from './refresh-token.use-case';
@@ -53,6 +55,10 @@ describe('RefreshTokenUseCase', () => {
         { provide: FindUserByIdUseCase, useValue: mockFindUserByIdUseCase },
         { provide: RotateSessionUseCase, useValue: mockRotateSessionUseCase },
         { provide: CreateSessionUseCase, useValue: mockCreateSessionUseCase },
+        {
+          provide: getLoggerToken(RefreshTokenUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/refresh-token/refresh-token.use-case.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/refresh-token/refresh-token.use-case.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { AuthenticationRepository } from '../../ports/authentication.repository';
 import { AUTHENTICATION_REPOSITORY } from '../../tokens/authentication-repository.token';
 import { JwtService } from '@nestjs/jwt';
@@ -28,9 +29,9 @@ interface RefreshTokenPayload {
 
 @Injectable()
 export class RefreshTokenUseCase {
-  private readonly logger = new Logger(RefreshTokenUseCase.name);
-
   constructor(
+    @InjectPinoLogger(RefreshTokenUseCase.name)
+    private readonly logger: PinoLogger,
     @Inject(AUTHENTICATION_REPOSITORY)
     private readonly authRepository: AuthenticationRepository,
     private readonly jwtService: JwtService,
@@ -41,7 +42,7 @@ export class RefreshTokenUseCase {
 
   @HandleUnexpectedErrors(UnexpectedAuthenticationError)
   async execute(command: RefreshTokenCommand): Promise<AuthTokens> {
-    this.logger.log('refreshToken');
+    this.logger.info('refreshToken');
     const rotated = this.isJwt(command.refreshToken)
       ? await this.migrateLegacyToken(command.refreshToken)
       : await this.rotate(command.refreshToken);
@@ -90,7 +91,10 @@ export class RefreshTokenUseCase {
     try {
       return this.jwtService.verify<RefreshTokenPayload>(token);
     } catch (error: unknown) {
-      this.logger.warn('Legacy refresh token verification failed', { error });
+      this.logger.warn(
+        { err: error as Error },
+        'Legacy refresh token verification failed',
+      );
       throw new InvalidTokenError('Unable to verify refresh token');
     }
   }

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/register-user/register-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/register-user/register-user.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 
@@ -75,6 +77,10 @@ describe('RegisterUserUseCase', () => {
         {
           provide: ConfigService,
           useValue: { get: jest.fn().mockReturnValue(false) },
+        },
+        {
+          provide: getLoggerToken(RegisterUserUseCase.name),
+          useValue: createPinoLoggerMock(),
         },
       ],
     }).compile();

--- a/ayunis-core-backend/src/iam/authentication/application/use-cases/register-user/register-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/authentication/application/use-cases/register-user/register-user.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { CreateAdminUserUseCase } from '../../../../users/application/use-cases/create-admin-user/create-admin-user.use-case';
 import { CreateAdminUserCommand } from '../../../../users/application/use-cases/create-admin-user/create-admin-user.command';
 import { IsValidPasswordUseCase } from '../../../../users/application/use-cases/is-valid-password/is-valid-password.use-case';
@@ -27,12 +28,14 @@ import { FindUserByEmailUseCase } from 'src/iam/users/application/use-cases/find
 import { FindUserByEmailQuery } from 'src/iam/users/application/use-cases/find-user-by-email/find-user-by-email.query';
 import { UserAlreadyExistsError } from 'src/iam/users/application/users.errors';
 import { Transactional } from '@nestjs-cls/transactional';
+import type { UUID } from 'crypto';
+import type { User } from 'src/iam/users/domain/user.entity';
 
 @Injectable()
 export class RegisterUserUseCase {
-  private readonly logger = new Logger(RegisterUserUseCase.name);
-
   constructor(
+    @InjectPinoLogger(RegisterUserUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly findUserByEmailUseCase: FindUserByEmailUseCase,
     private readonly createAdminUserUseCase: CreateAdminUserUseCase,
     private readonly isValidPasswordUseCase: IsValidPasswordUseCase,
@@ -45,110 +48,125 @@ export class RegisterUserUseCase {
 
   @Transactional()
   async execute(command: RegisterUserCommand): Promise<ActiveUser> {
-    this.logger.log('register', {
-      email: command.email,
-      orgName: command.orgName,
-    });
-
+    this.logger.info(
+      { email: command.email, org: { name: command.orgName } },
+      'register',
+    );
     try {
-      const disableRegistration = this.configService.get<boolean>(
-        'app.disableRegistration',
-      );
-      if (disableRegistration) {
-        throw new RegistrationDisabledError();
-      }
-
-      const existingUser = await this.findUserByEmailUseCase.execute(
-        new FindUserByEmailQuery(command.email),
-      );
-      if (existingUser) {
-        throw new UserAlreadyExistsError(existingUser.id);
-      }
-
-      const isValidPassword = await this.isValidPasswordUseCase.execute(
-        new IsValidPasswordQuery(command.password),
-      );
-      if (!isValidPassword) {
-        this.logger.warn('Invalid password during registration', {
-          email: command.email,
-        });
-        throw new InvalidPasswordError(
-          'Password does not meet security requirements',
-        );
-      }
-
-      this.logger.debug('Creating organization');
-      const org = await this.createOrgUseCase.execute(
-        new CreateOrgCommand(command.orgName),
-      );
-
-      this.logger.debug('Creating trial for organization', { orgId: org.id });
-      const trialMaxMessages = this.configService.get<number>(
-        'subscriptions.trialMaxMessages',
-      )!;
-      await this.createTrialUseCase.execute(
-        new CreateTrialCommand(org.id, trialMaxMessages),
-      );
-
-      // Only send confirmation email if email config is available
-      const shouldConfirmEmail =
-        this.configService.get<boolean>('emails.hasConfig');
-
-      this.logger.debug('Creating admin user', { orgId: org.id });
-      const user = await this.createAdminUserUseCase.execute(
-        new CreateAdminUserCommand({
-          email: command.email,
-          password: command.password,
-          orgId: org.id,
-          name: command.userName,
-          emailVerified: shouldConfirmEmail ? false : true,
-          hasAcceptedMarketing: command.hasAcceptedMarketing,
-          department: command.department,
-        }),
-      );
-
-      this.logger.debug('Creating legal acceptance', {
-        userId: user.id,
-        orgId: org.id,
-      });
-      await this.createLegalAcceptanceUseCase.execute(
-        new CreateTosAcceptanceCommand({
-          userId: user.id,
-          orgId: org.id,
-        }),
-      );
-      await this.createLegalAcceptanceUseCase.execute(
-        new CreatePrivacyPolicyAcceptanceCommand({
-          userId: user.id,
-          orgId: org.id,
-        }),
-      );
-
-      if (shouldConfirmEmail) {
-        await this.sendConfirmationEmailUseCase.execute(
-          new SendConfirmationEmailCommand(user),
-        );
-      }
-
-      this.logger.debug('Registration successful, logging in user', {
-        userId: user.id,
-      });
-
-      return new ActiveUser({
-        id: user.id,
-        email: user.email,
-        emailVerified: user.emailVerified,
-        role: user.role,
-        systemRole: user.systemRole,
-        orgId: user.orgId,
-        name: user.name,
-      });
+      return await this.register(command);
     } catch (error: unknown) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Unexpected authentication error', { error });
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error(
+        { err: error as Error },
+        'Unexpected authentication error',
+      );
       throw new UnexpectedAuthenticationError(error);
     }
+  }
+
+  private async register(command: RegisterUserCommand): Promise<ActiveUser> {
+    await this.assertRegistrationAllowed(command);
+    const orgId = await this.createOrganizationWithTrial(command.orgName);
+    const shouldConfirmEmail =
+      this.configService.get<boolean>('emails.hasConfig');
+    const user = await this.createAdminUser(
+      command,
+      orgId,
+      !!shouldConfirmEmail,
+    );
+    await this.createLegalAcceptances(user.id, orgId);
+    if (shouldConfirmEmail) {
+      await this.sendConfirmationEmailUseCase.execute(
+        new SendConfirmationEmailCommand(user),
+      );
+    }
+    this.logger.debug(
+      { userId: user.id },
+      'Registration successful, logging in user',
+    );
+    return this.toActiveUser(user);
+  }
+
+  private async assertRegistrationAllowed(
+    command: RegisterUserCommand,
+  ): Promise<void> {
+    if (this.configService.get<boolean>('app.disableRegistration')) {
+      throw new RegistrationDisabledError();
+    }
+    const existingUser = await this.findUserByEmailUseCase.execute(
+      new FindUserByEmailQuery(command.email),
+    );
+    if (existingUser) throw new UserAlreadyExistsError(existingUser.id);
+
+    const isValidPassword = await this.isValidPasswordUseCase.execute(
+      new IsValidPasswordQuery(command.password),
+    );
+    if (isValidPassword) return;
+    this.logger.warn(
+      { email: command.email },
+      'Invalid password during registration',
+    );
+    throw new InvalidPasswordError(
+      'Password does not meet security requirements',
+    );
+  }
+
+  private async createOrganizationWithTrial(orgName: string): Promise<UUID> {
+    this.logger.debug('Creating organization');
+    const org = await this.createOrgUseCase.execute(
+      new CreateOrgCommand(orgName),
+    );
+    this.logger.debug({ orgId: org.id }, 'Creating trial for organization');
+    const maxMessages = this.configService.get<number>(
+      'subscriptions.trialMaxMessages',
+    )!;
+    await this.createTrialUseCase.execute(
+      new CreateTrialCommand(org.id, maxMessages),
+    );
+    return org.id;
+  }
+
+  private async createAdminUser(
+    command: RegisterUserCommand,
+    orgId: UUID,
+    shouldConfirmEmail: boolean,
+  ): Promise<User> {
+    this.logger.debug({ orgId }, 'Creating admin user');
+    return this.createAdminUserUseCase.execute(
+      new CreateAdminUserCommand({
+        email: command.email,
+        password: command.password,
+        orgId,
+        name: command.userName,
+        emailVerified: !shouldConfirmEmail,
+        hasAcceptedMarketing: command.hasAcceptedMarketing,
+        department: command.department,
+      }),
+    );
+  }
+
+  private async createLegalAcceptances(
+    userId: UUID,
+    orgId: UUID,
+  ): Promise<void> {
+    this.logger.debug({ userId, orgId }, 'Creating legal acceptance');
+    await this.createLegalAcceptanceUseCase.execute(
+      new CreateTosAcceptanceCommand({ userId, orgId }),
+    );
+    await this.createLegalAcceptanceUseCase.execute(
+      new CreatePrivacyPolicyAcceptanceCommand({ userId, orgId }),
+    );
+  }
+
+  private toActiveUser(user: User): ActiveUser {
+    return new ActiveUser({
+      id: user.id,
+      email: user.email,
+      emailVerified: user.emailVerified,
+      role: user.role,
+      systemRole: user.systemRole,
+      orgId: user.orgId,
+      name: user.name,
+    });
   }
 }

--- a/ayunis-core-backend/src/iam/authentication/authentication.module.ts
+++ b/ayunis-core-backend/src/iam/authentication/authentication.module.ts
@@ -2,6 +2,7 @@ import { DynamicModule, Module, Provider } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { getLoggerToken, PinoLogger } from 'nestjs-pino';
 
 import { JwtConfigModule } from './jwt.module';
 import { JwtStrategy } from './application/strategies/jwt.strategy';
@@ -63,7 +64,11 @@ function createAuthenticationRepositoryProvider(
 ): Provider {
   return {
     provide: AUTHENTICATION_REPOSITORY,
-    useFactory: (configService: ConfigService, jwtService: JwtService) => {
+    useFactory: (
+      logger: PinoLogger,
+      configService: ConfigService,
+      jwtService: JwtService,
+    ) => {
       const provider =
         options?.provider ??
         configService.get<AuthProvider>('auth.provider', AuthProvider.LOCAL);
@@ -73,9 +78,17 @@ function createAuthenticationRepositoryProvider(
         throw new Error('Cloud authentication repository not implemented');
       }
 
-      return new LocalAuthenticationRepository(jwtService, configService);
+      return new LocalAuthenticationRepository(
+        logger,
+        jwtService,
+        configService,
+      );
     },
-    inject: [ConfigService, JwtService],
+    inject: [
+      getLoggerToken(LocalAuthenticationRepository.name),
+      ConfigService,
+      JwtService,
+    ],
   };
 }
 

--- a/ayunis-core-backend/src/iam/authentication/infrastructure/repositories/local/local-authentication.repository.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/infrastructure/repositories/local/local-authentication.repository.spec.ts
@@ -1,6 +1,7 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { LocalAuthenticationRepository } from './local-authentication.repository';
@@ -29,16 +30,16 @@ describe('LocalAuthenticationRepository', () => {
         LocalAuthenticationRepository,
         { provide: JwtService, useValue: { sign: jest.fn() } },
         { provide: ConfigService, useValue: { get: jest.fn() } },
+        {
+          provide: getLoggerToken(LocalAuthenticationRepository.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
     repository = module.get(LocalAuthenticationRepository);
     jwtService = module.get(JwtService);
     configService = module.get(ConfigService);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/iam/authentication/infrastructure/repositories/local/local-authentication.repository.ts
+++ b/ayunis-core-backend/src/iam/authentication/infrastructure/repositories/local/local-authentication.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { AuthenticationRepository } from 'src/iam/authentication/application/ports/authentication.repository';
@@ -13,22 +14,25 @@ interface JwtConfig {
 
 @Injectable()
 export class LocalAuthenticationRepository extends AuthenticationRepository {
-  private readonly logger = new Logger(LocalAuthenticationRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalAuthenticationRepository.name)
+    private readonly logger: PinoLogger,
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
   ) {
     super();
-    this.logger.log('constructor');
+    this.logger.info('constructor');
   }
 
   generateAccessToken(user: ActiveUser): Promise<string> {
-    this.logger.log('generateAccessToken', {
-      userId: user.id,
-      email: user.email,
-      name: user.name,
-    });
+    this.logger.info(
+      {
+        userId: user.id,
+        email: user.email,
+        name: user.name,
+      },
+      'generateAccessToken',
+    );
     try {
       return Promise.resolve(this.signAccessToken(user));
     } catch (error) {

--- a/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.spec.ts
+++ b/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { AuthenticationController } from './authentication.controller';
@@ -87,6 +89,10 @@ describe('AuthenticationController', () => {
         {
           provide: MeResponseDtoMapper,
           useValue: { toDto: (u: any) => ({ email: u.email, role: u.role }) },
+        },
+        {
+          provide: getLoggerToken(AuthenticationController.name),
+          useValue: createPinoLoggerMock(),
         },
       ],
     }).compile();

--- a/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.ts
+++ b/ayunis-core-backend/src/iam/authentication/presenters/http/authentication.controller.ts
@@ -3,13 +3,13 @@ import {
   Controller,
   HttpCode,
   HttpStatus,
-  Logger,
   Post,
   Get,
   Req,
   Res,
   UseGuards,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -60,8 +60,9 @@ import { SessionAuthenticationMethod } from 'src/iam/sessions/domain/value-objec
 @ApiTags('Authentication')
 @Controller('auth')
 export class AuthenticationController {
-  private readonly logger = new Logger(AuthenticationController.name);
   constructor(
+    @InjectPinoLogger(AuthenticationController.name)
+    private readonly logger: PinoLogger,
     private readonly loginUseCase: LoginUseCase,
     private readonly refreshTokenUseCase: RefreshTokenUseCase,
     private readonly registerUserUseCase: RegisterUserUseCase,
@@ -103,7 +104,7 @@ export class AuthenticationController {
     type: ErrorResponseDto,
   })
   async login(@Req() req: Request, @Res() res: Response) {
-    this.logger.log('login');
+    this.logger.info('login');
     const user = req.user as ActiveUser;
 
     const mfaRequirement = await this.checkMfaLoginRequirementUseCase.execute(
@@ -222,7 +223,7 @@ export class AuthenticationController {
     type: ErrorResponseDto,
   })
   async refresh(@Req() req: Request, @Res() res: Response) {
-    this.logger.log('refresh');
+    this.logger.info('refresh');
     const refreshTokenName = this.configService.get<string>(
       'auth.cookie.refreshTokenName',
     );
@@ -258,7 +259,10 @@ export class AuthenticationController {
       // Any refresh failure (expired, reuse/theft, unknown) leaves the browser
       // holding a useless refresh cookie — clear it so the client logs out
       // cleanly instead of retrying a doomed token.
-      this.logger.warn('Refresh failed; clearing cookies', error);
+      this.logger.warn(
+        { err: error as Error },
+        'Refresh failed; clearing cookies',
+      );
       clearCookies(res, this.configService);
       return res
         .status(HttpStatus.UNAUTHORIZED)
@@ -288,7 +292,7 @@ export class AuthenticationController {
     type: ErrorResponseDto,
   })
   async me(@Req() req: Request, @Res() res: Response) {
-    this.logger.log('me');
+    this.logger.info('me');
 
     const accessTokenName = this.configService.get<string>(
       'auth.cookie.accessTokenName',
@@ -335,7 +339,10 @@ export class AuthenticationController {
         new GetCurrentUserCommand(accessToken),
       );
     } catch (error) {
-      this.logger.debug('Access token verification failed', error);
+      this.logger.debug(
+        { err: error as Error },
+        'Access token verification failed',
+      );
       return null;
     }
   }
@@ -359,7 +366,10 @@ export class AuthenticationController {
       );
       return res.json(this.meResponseDtoMapper.toDto(user));
     } catch (error) {
-      this.logger.error('Token refresh failed during me request', error);
+      this.logger.error(
+        { err: error as Error },
+        'Token refresh failed during me request',
+      );
       // Clear the now-useless refresh cookie so the client logs out cleanly.
       clearCookies(res, this.configService);
       return res.status(HttpStatus.UNAUTHORIZED).json({

--- a/ayunis-core-backend/src/iam/authentication/presenters/http/mfa-login.controller.ts
+++ b/ayunis-core-backend/src/iam/authentication/presenters/http/mfa-login.controller.ts
@@ -3,11 +3,11 @@ import {
   Controller,
   HttpCode,
   HttpStatus,
-  Logger,
   Post,
   Req,
   Res,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { ConfigService } from '@nestjs/config';
@@ -48,9 +48,9 @@ import {
 @ApiTags('Authentication')
 @Controller('auth/mfa')
 export class MfaLoginController {
-  private readonly logger = new Logger(MfaLoginController.name);
-
   constructor(
+    @InjectPinoLogger(MfaLoginController.name)
+    private readonly logger: PinoLogger,
     private readonly mfaPendingJwtService: MfaPendingJwtService,
     private readonly verifyMfaCodeUseCase: VerifyMfaCodeUseCase,
     private readonly setupTotpUseCase: SetupTotpUseCase,
@@ -76,7 +76,7 @@ export class MfaLoginController {
     @Body() dto: MfaCodeRequestDto,
   ) {
     const payload = this.readPendingToken(req);
-    this.logger.log('verify', { userId: payload.sub });
+    this.logger.info({ userId: payload.sub }, 'verify');
 
     await this.verifyMfaCodeUseCase.execute(
       new VerifyMfaCodeCommand(payload.sub, dto.code),
@@ -101,7 +101,7 @@ export class MfaLoginController {
     if (!payload.enrollmentRequired) {
       throw new MfaEnrollmentNotAllowedError();
     }
-    this.logger.log('setup', { userId: payload.sub });
+    this.logger.info({ userId: payload.sub }, 'setup');
 
     const user = await this.findUserByIdUseCase.execute(
       new FindUserByIdQuery(payload.sub),
@@ -131,7 +131,7 @@ export class MfaLoginController {
     if (!payload.enrollmentRequired) {
       throw new MfaEnrollmentNotAllowedError();
     }
-    this.logger.log('confirmSetup', { userId: payload.sub });
+    this.logger.info({ userId: payload.sub }, 'confirmSetup');
 
     const recoveryCodes = await this.confirmTotpUseCase.execute(
       new ConfirmTotpCommand(payload.sub, dto.code),

--- a/ayunis-core-backend/src/iam/hashing/application/use-cases/compare-hash/compare-hash.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/hashing/application/use-cases/compare-hash/compare-hash.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { CompareHashUseCase } from './compare-hash.use-case';
@@ -20,6 +22,10 @@ describe('CompareHashUseCase', () => {
         {
           provide: HashingHandler,
           useValue: mockHashingHandler,
+        },
+        {
+          provide: getLoggerToken(CompareHashUseCase.name),
+          useValue: createPinoLoggerMock(),
         },
       ],
     }).compile();

--- a/ayunis-core-backend/src/iam/hashing/application/use-cases/compare-hash/compare-hash.use-case.ts
+++ b/ayunis-core-backend/src/iam/hashing/application/use-cases/compare-hash/compare-hash.use-case.ts
@@ -1,29 +1,35 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HashingHandler } from '../../ports/hashing.handler';
 import { CompareHashCommand } from './compare-hash.command';
 import { ComparisonFailedError, HashingError } from '../../hashing.errors';
 
 @Injectable()
 export class CompareHashUseCase {
-  private readonly logger = new Logger(CompareHashUseCase.name);
-
-  constructor(private readonly hashingHandler: HashingHandler) {}
+  constructor(
+    @InjectPinoLogger(CompareHashUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly hashingHandler: HashingHandler,
+  ) {}
 
   async execute(command: CompareHashCommand): Promise<boolean> {
-    this.logger.log('compare');
+    this.logger.info('compare');
     try {
       this.logger.debug('Comparing plaintext with hash');
       const isMatch = await this.hashingHandler.compare(
         command.plainText,
         command.hash,
       );
-      this.logger.debug('Comparison completed', { isMatch });
+      this.logger.debug({ isMatch }, 'Comparison completed');
       return isMatch;
     } catch (error) {
       if (!(error instanceof HashingError)) {
-        this.logger.error('Failed to compare hash', {
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
+        this.logger.error(
+          {
+            error: error instanceof Error ? error.message : 'Unknown error',
+          },
+          'Failed to compare hash',
+        );
         throw new ComparisonFailedError(
           error instanceof Error ? error.message : 'Unknown error',
         );

--- a/ayunis-core-backend/src/iam/hashing/application/use-cases/hash-text/hash-text.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/hashing/application/use-cases/hash-text/hash-text.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { HashTextUseCase } from './hash-text.use-case';
@@ -20,6 +22,10 @@ describe('HashTextUseCase', () => {
         {
           provide: HashingHandler,
           useValue: mockHashingHandler,
+        },
+        {
+          provide: getLoggerToken(HashTextUseCase.name),
+          useValue: createPinoLoggerMock(),
         },
       ],
     }).compile();

--- a/ayunis-core-backend/src/iam/hashing/application/use-cases/hash-text/hash-text.use-case.ts
+++ b/ayunis-core-backend/src/iam/hashing/application/use-cases/hash-text/hash-text.use-case.ts
@@ -1,16 +1,19 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HashingHandler } from '../../ports/hashing.handler';
 import { HashTextCommand } from './hash-text.command';
 import { HashingFailedError, HashingError } from '../../hashing.errors';
 
 @Injectable()
 export class HashTextUseCase {
-  private readonly logger = new Logger(HashTextUseCase.name);
-
-  constructor(private readonly hashingHandler: HashingHandler) {}
+  constructor(
+    @InjectPinoLogger(HashTextUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly hashingHandler: HashingHandler,
+  ) {}
 
   async execute(command: HashTextCommand): Promise<string> {
-    this.logger.log('hash');
+    this.logger.info('hash');
     try {
       this.logger.debug('Hashing plaintext data');
       const hashedData = await this.hashingHandler.hash(command.plainText);
@@ -18,9 +21,12 @@ export class HashTextUseCase {
       return hashedData;
     } catch (error) {
       if (!(error instanceof HashingError)) {
-        this.logger.error('Failed to hash data', {
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
+        this.logger.error(
+          {
+            error: error instanceof Error ? error.message : 'Unknown error',
+          },
+          'Failed to hash data',
+        );
         throw new HashingFailedError(
           error instanceof Error ? error.message : 'Unknown error',
         );

--- a/ayunis-core-backend/src/iam/hashing/infrastructure/handlers/bcrypt.handler.spec.ts
+++ b/ayunis-core-backend/src/iam/hashing/infrastructure/handlers/bcrypt.handler.spec.ts
@@ -1,14 +1,20 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { getLoggerToken } from 'nestjs-pino';
 import { BcryptHandler } from './bcrypt.handler';
 
 describe('BcryptHandler', () => {
   const build = async (configuredRounds: number | undefined) => {
+    const logger = createPinoLoggerMock();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         BcryptHandler,
+        {
+          provide: getLoggerToken(BcryptHandler.name),
+          useValue: logger,
+        },
         {
           provide: ConfigService,
           useValue: {
@@ -20,15 +26,19 @@ describe('BcryptHandler', () => {
       ],
     }).compile();
 
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    return module.get(BcryptHandler);
+    return { handler: module.get(BcryptHandler), logger };
   };
 
   afterEach(() => jest.clearAllMocks());
 
+  it('should log configured salt rounds as structured metadata', async () => {
+    const { logger } = await build(12);
+
+    expect(logger.info).toHaveBeenCalledWith({ saltRounds: 12 }, 'constructor');
+  });
+
   it('should hash using the configured salt rounds', async () => {
-    const handler = await build(12);
+    const { handler } = await build(12);
 
     const hash = await handler.hash('correct horse battery staple');
 
@@ -37,7 +47,7 @@ describe('BcryptHandler', () => {
   });
 
   it('should default to 10 rounds when config is absent', async () => {
-    const handler = await build(undefined);
+    const { handler } = await build(undefined);
 
     const hash = await handler.hash('correct horse battery staple');
 
@@ -45,7 +55,7 @@ describe('BcryptHandler', () => {
   });
 
   it('should round-trip compare a hashed value', async () => {
-    const handler = await build(10);
+    const { handler } = await build(10);
     const hash = await handler.hash('s3cret');
 
     await expect(handler.compare('s3cret', hash)).resolves.toBe(true);

--- a/ayunis-core-backend/src/iam/hashing/infrastructure/handlers/bcrypt.handler.ts
+++ b/ayunis-core-backend/src/iam/hashing/infrastructure/handlers/bcrypt.handler.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import * as bcrypt from 'bcrypt';
 import { HashingHandler } from '../../application/ports/hashing.handler';
@@ -10,19 +11,22 @@ import {
 
 @Injectable()
 export class BcryptHandler implements HashingHandler {
-  private readonly logger = new Logger(BcryptHandler.name);
   private readonly saltRounds: number;
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    @InjectPinoLogger(BcryptHandler.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {
     this.saltRounds = this.configService.get<number>(
       'auth.local.passwordHashRounds',
       10,
     );
-    this.logger.log('constructor', { saltRounds: this.saltRounds });
+    this.logger.info({ saltRounds: this.saltRounds }, 'constructor');
   }
 
   async hash(plainText: string): Promise<string> {
-    this.logger.log('hash');
+    this.logger.info('hash');
 
     if (!plainText) {
       this.logger.warn('Attempted to hash empty string');
@@ -30,14 +34,20 @@ export class BcryptHandler implements HashingHandler {
     }
 
     try {
-      this.logger.debug('Hashing using bcrypt', {
-        saltRounds: this.saltRounds,
-      });
+      this.logger.debug(
+        {
+          saltRounds: this.saltRounds,
+        },
+        'Hashing using bcrypt',
+      );
       return await bcrypt.hash(plainText, this.saltRounds);
     } catch (error) {
-      this.logger.error('Bcrypt hashing failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Bcrypt hashing failed',
+      );
       throw new HashingFailedError(
         error instanceof Error ? error.message : 'Unknown error',
       );
@@ -45,7 +55,7 @@ export class BcryptHandler implements HashingHandler {
   }
 
   async compare(plainText: string, hash: string): Promise<boolean> {
-    this.logger.log('compare');
+    this.logger.info('compare');
 
     if (!hash) {
       this.logger.warn('Attempted to compare with empty hash');
@@ -56,9 +66,12 @@ export class BcryptHandler implements HashingHandler {
       this.logger.debug('Comparing using bcrypt');
       return await bcrypt.compare(plainText, hash);
     } catch (error) {
-      this.logger.error('Bcrypt comparison failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Bcrypt comparison failed',
+      );
       throw new ComparisonFailedError(
         error instanceof Error ? error.message : 'Unknown error',
       );

--- a/ayunis-core-backend/src/iam/users/application/services/email-confirmation-jwt.service.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/services/email-confirmation-jwt.service.spec.ts
@@ -1,6 +1,7 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import type { UUID } from 'crypto';
@@ -27,16 +28,16 @@ describe('EmailConfirmationJwtService', () => {
           useValue: { sign: jest.fn(), verify: jest.fn(), decode: jest.fn() },
         },
         { provide: ConfigService, useValue: { get: jest.fn() } },
+        {
+          provide: getLoggerToken(EmailConfirmationJwtService.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
     service = module.get(EmailConfirmationJwtService);
     jwtService = module.get(JwtService);
     configService = module.get(ConfigService);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/iam/users/application/services/email-confirmation-jwt.service.ts
+++ b/ayunis-core-backend/src/iam/users/application/services/email-confirmation-jwt.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { UUID } from 'crypto';
@@ -21,9 +22,9 @@ export interface EmailConfirmationJwtPayload {
 
 @Injectable()
 export class EmailConfirmationJwtService {
-  private readonly logger = new Logger(EmailConfirmationJwtService.name);
-
   constructor(
+    @InjectPinoLogger(EmailConfirmationJwtService.name)
+    private readonly logger: PinoLogger,
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
   ) {}
@@ -32,10 +33,13 @@ export class EmailConfirmationJwtService {
     userId: UUID;
     email: string;
   }): string {
-    this.logger.log('generateEmailConfirmationToken', {
-      userId: params.userId,
-      email: params.email,
-    });
+    this.logger.info(
+      {
+        userId: params.userId,
+        email: params.email,
+      },
+      'generateEmailConfirmationToken',
+    );
 
     const payload: EmailConfirmationJwtPayload = {
       userId: params.userId,
@@ -52,7 +56,7 @@ export class EmailConfirmationJwtService {
   }
 
   verifyEmailConfirmationToken(token: string): EmailConfirmationJwtPayload {
-    this.logger.log('verifyEmailConfirmationToken');
+    this.logger.info('verifyEmailConfirmationToken');
 
     try {
       const payload =
@@ -66,10 +70,13 @@ export class EmailConfirmationJwtService {
         throw new InvalidEmailConfirmationTokenError('Invalid token payload');
       }
 
-      this.logger.debug('Email confirmation token verified successfully', {
-        userId: payload.userId,
-        email: payload.email,
-      });
+      this.logger.debug(
+        {
+          userId: payload.userId,
+          email: payload.email,
+        },
+        'Email confirmation token verified successfully',
+      );
 
       return {
         userId: payload.userId,
@@ -77,9 +84,12 @@ export class EmailConfirmationJwtService {
         type: EMAIL_CONFIRMATION_TOKEN_TYPE,
       };
     } catch (error: unknown) {
-      this.logger.error('Email confirmation token verification failed', {
-        error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Email confirmation token verification failed',
+      );
 
       if (error instanceof InvalidEmailConfirmationTokenError) {
         throw error;

--- a/ayunis-core-backend/src/iam/users/application/services/password-set-token.service.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/services/password-set-token.service.spec.ts
@@ -1,6 +1,7 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PasswordSetTokenService } from './password-set-token.service';
 import { PasswordSetTokensRepository } from '../ports/password-set-tokens.repository';
@@ -30,15 +31,15 @@ describe('PasswordSetTokenService', () => {
             get: jest.fn((_key: string, fallback: string) => fallback),
           },
         },
+        {
+          provide: getLoggerToken(PasswordSetTokenService.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
     service = module.get(PasswordSetTokenService);
     configService = module.get(ConfigService);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/iam/users/application/services/password-set-token.service.ts
+++ b/ayunis-core-backend/src/iam/users/application/services/password-set-token.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { randomBytes, type UUID } from 'crypto';
 import { InvalidTokenError } from 'src/iam/authentication/application/authentication.errors';
@@ -15,9 +16,9 @@ import { PasswordSetTokensRepository } from '../ports/password-set-tokens.reposi
  */
 @Injectable()
 export class PasswordSetTokenService {
-  private readonly logger = new Logger(PasswordSetTokenService.name);
-
   constructor(
+    @InjectPinoLogger(PasswordSetTokenService.name)
+    private readonly logger: PinoLogger,
     private readonly configService: ConfigService,
     private readonly passwordSetTokensRepository: PasswordSetTokensRepository,
   ) {}
@@ -26,10 +27,13 @@ export class PasswordSetTokenService {
     userId: UUID;
     purpose: PasswordSetTokenPurpose;
   }): Promise<string> {
-    this.logger.log('issue', {
-      userId: params.userId,
-      purpose: params.purpose,
-    });
+    this.logger.info(
+      {
+        userId: params.userId,
+        purpose: params.purpose,
+      },
+      'issue',
+    );
 
     const plaintext = randomBytes(32).toString('base64url');
     const token = new PasswordSetToken({

--- a/ayunis-core-backend/src/iam/users/application/use-cases/admin-trigger-password-reset/admin-trigger-password-reset.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/admin-trigger-password-reset/admin-trigger-password-reset.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -44,6 +46,10 @@ describe('AdminTriggerPasswordResetUseCase', () => {
         {
           provide: TriggerPasswordResetUseCase,
           useValue: triggerPasswordResetUseCase,
+        },
+        {
+          provide: getLoggerToken(AdminTriggerPasswordResetUseCase.name),
+          useValue: createPinoLoggerMock(),
         },
       ],
     }).compile();

--- a/ayunis-core-backend/src/iam/users/application/use-cases/admin-trigger-password-reset/admin-trigger-password-reset.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/admin-trigger-password-reset/admin-trigger-password-reset.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { AdminTriggerPasswordResetCommand } from './admin-trigger-password-reset.command';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UsersRepository } from '../../ports/users.repository';
@@ -12,16 +13,16 @@ import {
 
 @Injectable()
 export class AdminTriggerPasswordResetUseCase {
-  private readonly logger = new Logger(AdminTriggerPasswordResetUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AdminTriggerPasswordResetUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly contextService: ContextService,
     private readonly usersRepository: UsersRepository,
     private readonly triggerPasswordResetUseCase: TriggerPasswordResetUseCase,
   ) {}
 
   async execute(command: AdminTriggerPasswordResetCommand): Promise<void> {
-    this.logger.log('adminTriggerPasswordReset', { userId: command.userId });
+    this.logger.info({ userId: command.userId }, 'adminTriggerPasswordReset');
 
     const requestUserOrgId = this.contextService.get('orgId');
     if (!requestUserOrgId) {
@@ -30,7 +31,7 @@ export class AdminTriggerPasswordResetUseCase {
 
     const targetUser = await this.usersRepository.findOneById(command.userId);
     if (!targetUser) {
-      this.logger.error('User not found', { userId: command.userId });
+      this.logger.error({ userId: command.userId }, 'User not found');
       throw new UserNotFoundError(command.userId);
     }
 
@@ -49,9 +50,12 @@ export class AdminTriggerPasswordResetUseCase {
       new TriggerPasswordResetCommand(targetUser.email),
     );
 
-    this.logger.log('Password reset triggered for user', {
-      userId: command.userId,
-      email: targetUser.email,
-    });
+    this.logger.info(
+      {
+        userId: command.userId,
+        email: targetUser.email,
+      },
+      'Password reset triggered for user',
+    );
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/admin-update-user/admin-update-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/admin-update-user/admin-update-user.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -66,6 +68,10 @@ describe('AdminUpdateUserUseCase', () => {
         {
           provide: SendConfirmationEmailUseCase,
           useValue: mockSendConfirmationEmailUseCase,
+        },
+        {
+          provide: getLoggerToken(AdminUpdateUserUseCase.name),
+          useValue: createPinoLoggerMock(),
         },
       ],
     }).compile();

--- a/ayunis-core-backend/src/iam/users/application/use-cases/admin-update-user/admin-update-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/admin-update-user/admin-update-user.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -18,9 +19,9 @@ import { SendConfirmationEmailCommand } from '../send-confirmation-email/send-co
 
 @Injectable()
 export class AdminUpdateUserUseCase {
-  private readonly logger = new Logger(AdminUpdateUserUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AdminUpdateUserUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly contextService: ContextService,
     private readonly usersRepository: UsersRepository,
     private readonly eventEmitter: EventEmitter2,
@@ -28,11 +29,14 @@ export class AdminUpdateUserUseCase {
   ) {}
 
   async execute(command: AdminUpdateUserCommand): Promise<User> {
-    this.logger.log('adminUpdateUser', {
-      userId: command.userId,
-      hasName: command.name !== undefined,
-      hasEmail: command.email !== undefined,
-    });
+    this.logger.info(
+      {
+        userId: command.userId,
+        hasName: command.name !== undefined,
+        hasEmail: command.email !== undefined,
+      },
+      'adminUpdateUser',
+    );
 
     this.assertHasFieldsToUpdate(command);
     const requesterOrgId = this.readRequesterOrgId();
@@ -55,10 +59,13 @@ export class AdminUpdateUserUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Failed to update user', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        userId: command.userId,
-      });
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          userId: command.userId,
+        },
+        'Failed to update user',
+      );
       throw new UserUnexpectedError(error as Error);
     }
   }
@@ -129,11 +136,11 @@ export class AdminUpdateUserUseCase {
       );
     } catch (error) {
       this.logger.error(
-        'Failed to send confirmation email after admin update',
         {
           error: error instanceof Error ? error.message : 'Unknown error',
           userId: user.id,
         },
+        'Failed to send confirmation email after admin update',
       );
     }
   }
@@ -145,10 +152,13 @@ export class AdminUpdateUserUseCase {
         new UserUpdatedEvent(user.id, user.orgId, user),
       )
       .catch((err: unknown) => {
-        this.logger.error('Failed to emit UserUpdatedEvent', {
-          error: err instanceof Error ? err.message : 'Unknown error',
-          userId: user.id,
-        });
+        this.logger.error(
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            userId: user.id,
+          },
+          'Failed to emit UserUpdatedEvent',
+        );
       });
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/confirm-email/confirm-email.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/confirm-email/confirm-email.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ConfirmEmailUseCase } from './confirm-email.use-case';
@@ -62,6 +64,10 @@ describe('ConfirmEmailUseCase', () => {
           useValue: mockJwtService,
         },
         { provide: EventEmitter2, useValue: mockEventEmitter },
+        {
+          provide: getLoggerToken(ConfirmEmailUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/confirm-email/confirm-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/confirm-email/confirm-email.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ConfirmEmailCommand } from './confirm-email.command';
 import { UsersRepository } from '../../ports/users.repository';
@@ -14,79 +15,90 @@ import {
 } from '../../services/email-confirmation-jwt.service';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UserUpdatedEvent } from '../../events/user-updated.event';
+import type { User } from '../../../domain/user.entity';
 
 @Injectable()
 export class ConfirmEmailUseCase {
-  private readonly logger = new Logger(ConfirmEmailUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ConfirmEmailUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly usersRepository: UsersRepository,
     private readonly emailConfirmationJwtService: EmailConfirmationJwtService,
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(command: ConfirmEmailCommand): Promise<void> {
-    this.logger.log('execute', { hasToken: !!command.token });
-
-    // Verify and decode the JWT token
-    let payload: EmailConfirmationJwtPayload;
+    this.logger.info({ hasToken: !!command.token }, 'execute');
+    const payload = this.verifyToken(command.token);
     try {
-      payload = this.emailConfirmationJwtService.verifyEmailConfirmationToken(
-        command.token,
-      );
-    } catch (error: unknown) {
-      this.logger.error('Invalid email confirmation token', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-      throw new InvalidEmailConfirmationTokenError('Token verification failed');
-    }
-
-    try {
-      // Find the user in the database
-      const user = await this.usersRepository.findOneById(payload.userId);
-      if (!user) {
-        this.logger.error('User not found', { userId: payload.userId });
-        throw new UserNotFoundError(payload.userId);
-      }
-
-      // Verify the email matches
-      if (user.email !== payload.email) {
-        this.logger.error('Email mismatch', {
-          userId: payload.userId,
-          payloadEmail: payload.email,
-          userEmail: user.email,
-        });
-        throw new UserEmailMismatchError(payload.userId);
-      }
-
-      // Confirm the email
-      user.emailVerified = true;
-      await this.usersRepository.update(user);
-
-      this.logger.debug('Email confirmed successfully', {
-        userId: user.id,
-        email: user.email,
-      });
-
-      this.eventEmitter
-        .emitAsync(
-          UserUpdatedEvent.EVENT_NAME,
-          new UserUpdatedEvent(user.id, user.orgId, user),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit UserUpdatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            userId: user.id,
-          });
-        });
+      await this.confirmEmail(payload);
     } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to confirm email', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Failed to confirm email',
+      );
       throw new UserUnexpectedError(error as Error);
     }
+  }
+
+  private verifyToken(token: string): EmailConfirmationJwtPayload {
+    try {
+      return this.emailConfirmationJwtService.verifyEmailConfirmationToken(
+        token,
+      );
+    } catch (error: unknown) {
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Invalid email confirmation token',
+      );
+      throw new InvalidEmailConfirmationTokenError('Token verification failed');
+    }
+  }
+
+  private async confirmEmail(
+    payload: EmailConfirmationJwtPayload,
+  ): Promise<void> {
+    const user = await this.usersRepository.findOneById(payload.userId);
+    if (!user) {
+      this.logger.error({ userId: payload.userId }, 'User not found');
+      throw new UserNotFoundError(payload.userId);
+    }
+    if (user.email !== payload.email) {
+      this.logger.error(
+        { userId: payload.userId, email: payload.email, userEmail: user.email },
+        'Email mismatch',
+      );
+      throw new UserEmailMismatchError(payload.userId);
+    }
+
+    user.emailVerified = true;
+    await this.usersRepository.update(user);
+    this.logger.debug(
+      { userId: user.id, email: user.email },
+      'Email confirmed successfully',
+    );
+    this.emitUserUpdated(user);
+  }
+
+  private emitUserUpdated(user: User): void {
+    this.eventEmitter
+      .emitAsync(
+        UserUpdatedEvent.EVENT_NAME,
+        new UserUpdatedEvent(user.id, user.orgId, user),
+      )
+      .catch((err: unknown) => {
+        this.logger.error(
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            userId: user.id,
+          },
+          'Failed to emit UserUpdatedEvent',
+        );
+      });
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-admin-user/create-admin-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-admin-user/create-admin-user.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { CreateAdminUserUseCase } from './create-admin-user.use-case';
@@ -34,6 +36,10 @@ describe('CreateAdminUserUseCase', () => {
         { provide: UsersRepository, useValue: mockUsersRepository },
         { provide: HashTextUseCase, useValue: mockHashTextUseCase },
         { provide: CreateUserUseCase, useValue: mockCreateUserUseCase },
+        {
+          provide: getLoggerToken(CreateAdminUserUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-admin-user/create-admin-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-admin-user/create-admin-user.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { CreateAdminUserCommand } from './create-admin-user.command';
 import { User } from 'src/iam/users/domain/user.entity';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
@@ -7,15 +8,20 @@ import { CreateUserCommand } from '../create-user/create-user.command';
 
 @Injectable()
 export class CreateAdminUserUseCase {
-  private readonly logger = new Logger(CreateAdminUserUseCase.name);
-
-  constructor(private readonly createUserUseCase: CreateUserUseCase) {}
+  constructor(
+    @InjectPinoLogger(CreateAdminUserUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly createUserUseCase: CreateUserUseCase,
+  ) {}
 
   async execute(command: CreateAdminUserCommand): Promise<User> {
-    this.logger.log('createAdmin', {
-      email: command.email,
-      orgId: command.orgId,
-    });
+    this.logger.info(
+      {
+        email: command.email,
+        orgId: command.orgId,
+      },
+      'createAdmin',
+    );
 
     const createUserCommand = new CreateUserCommand({
       email: command.email,

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-regular-user/create-regular-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-regular-user/create-regular-user.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { CreateRegularUserUseCase } from './create-regular-user.use-case';
@@ -34,6 +36,10 @@ describe('CreateRegularUserUseCase', () => {
         { provide: UsersRepository, useValue: mockUsersRepository },
         { provide: HashTextUseCase, useValue: mockHashTextUseCase },
         { provide: CreateUserUseCase, useValue: mockCreateUserUseCase },
+        {
+          provide: getLoggerToken(CreateRegularUserUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-regular-user/create-regular-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-regular-user/create-regular-user.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { CreateRegularUserCommand } from './create-regular-user.command';
 import { User } from 'src/iam/users/domain/user.entity';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
@@ -7,16 +8,21 @@ import { CreateUserCommand } from '../create-user/create-user.command';
 
 @Injectable()
 export class CreateRegularUserUseCase {
-  private readonly logger = new Logger(CreateRegularUserUseCase.name);
-
-  constructor(private readonly createUserUseCase: CreateUserUseCase) {}
+  constructor(
+    @InjectPinoLogger(CreateRegularUserUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly createUserUseCase: CreateUserUseCase,
+  ) {}
 
   async execute(command: CreateRegularUserCommand): Promise<User> {
-    this.logger.log('createUser', {
-      email: command.email,
-      orgId: command.orgId,
-      name: command.name,
-    });
+    this.logger.info(
+      {
+        email: command.email,
+        orgId: command.orgId,
+        name: command.name,
+      },
+      'createUser',
+    );
 
     const createUserCommand = new CreateUserCommand({
       email: command.email,

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { CreateUserUseCase } from './create-user.use-case';
 import { CreateUserCommand } from './create-user.command';
 import { UserCreatedEvent } from '../../events/user-created.event';
@@ -54,6 +55,7 @@ describe('CreateUserUseCase', () => {
     } as unknown as jest.Mocked<EventEmitter2>;
 
     useCase = new CreateUserUseCase(
+      createPinoLoggerMock(),
       usersRepository,
       hashTextUseCase,
       configService,

--- a/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/create-user/create-user.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UsersRepository } from '../../ports/users.repository';
 import { CreateUserCommand } from './create-user.command';
@@ -17,9 +18,9 @@ import { UserCreatedEvent } from '../../events/user-created.event';
 
 @Injectable()
 export class CreateUserUseCase {
-  private readonly logger = new Logger(CreateUserUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateUserUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly usersRepository: UsersRepository,
     private readonly hashTextUseCase: HashTextUseCase,
     private readonly configService: ConfigService,
@@ -27,92 +28,107 @@ export class CreateUserUseCase {
   ) {}
 
   async execute(command: CreateUserCommand): Promise<User> {
-    this.logger.log('createUser', {
-      email: command.email,
-      orgId: command.orgId,
-      role: command.role,
-      name: command.name,
-      hasAcceptedMarketing: command.hasAcceptedMarketing,
-    });
-
-    const emailProvider = command.email.split('@')[1];
-    const emailProviderBlacklist = this.configService.get<string[]>(
-      'auth.emailProviderBlacklist',
-    )!;
-    if (emailProviderBlacklist.includes(emailProvider)) {
-      throw new UserEmailProviderBlacklistedError(emailProvider);
-    }
-
-    try {
-      this.logger.debug('Checking if user already exists');
-      const existingUser = await this.usersRepository.findOneByEmail(
-        command.email,
-      );
-
-      if (existingUser) {
-        this.logger.warn('User already exists', { email: command.email });
-        throw new UserAlreadyExistsError('User already exists');
-      }
-
-      this.logger.debug('Hashing password');
-      let passwordHash: string;
-      try {
-        passwordHash = await this.hashTextUseCase.execute(
-          new HashTextCommand(command.password),
-        );
-      } catch (error) {
-        if (error instanceof HashingError) {
-          // Already logged in hashing use case
-          throw error;
-        }
-        this.logger.error('Password hashing failed', {
-          error: error instanceof Error ? error.message : 'Unknown error',
-          email: command.email,
-        });
-        throw new UserInvalidInputError('Password hashing failed');
-      }
-
-      this.logger.debug('Creating new user');
-      const user = new User({
+    this.logger.info(
+      {
         email: command.email,
-        emailVerified: command.emailVerified,
-        passwordHash,
         orgId: command.orgId,
         role: command.role,
         name: command.name,
         hasAcceptedMarketing: command.hasAcceptedMarketing,
-        department: command.department,
-      });
-
-      const createdUser = await this.usersRepository.create(user);
-      this.logger.debug('User created successfully', {
-        userId: createdUser.id,
-        role: command.role,
-      });
-
-      this.eventEmitter
-        .emitAsync(
-          UserCreatedEvent.EVENT_NAME,
-          new UserCreatedEvent(createdUser.id, command.orgId, createdUser),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit UserCreatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            userId: createdUser.id,
-          });
-        });
-
-      return createdUser;
+      },
+      'createUser',
+    );
+    this.assertEmailProviderAllowed(command.email);
+    try {
+      return await this.createUser(command);
     } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('User creation failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        email: command.email,
-        role: command.role,
-      });
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          email: command.email,
+          role: command.role,
+        },
+        'User creation failed',
+      );
       throw new UserInvalidInputError('User creation failed');
     }
+  }
+
+  private assertEmailProviderAllowed(email: string): void {
+    const provider = email.split('@')[1];
+    const blacklist = this.configService.get<string[]>(
+      'auth.emailProviderBlacklist',
+    )!;
+    if (blacklist.includes(provider)) {
+      throw new UserEmailProviderBlacklistedError(provider);
+    }
+  }
+
+  private async createUser(command: CreateUserCommand): Promise<User> {
+    this.logger.debug('Checking if user already exists');
+    const existingUser = await this.usersRepository.findOneByEmail(
+      command.email,
+    );
+    if (existingUser) {
+      this.logger.warn({ email: command.email }, 'User already exists');
+      throw new UserAlreadyExistsError('User already exists');
+    }
+
+    const passwordHash = await this.hashPassword(command);
+    this.logger.debug('Creating new user');
+    const user = new User({
+      email: command.email,
+      emailVerified: command.emailVerified,
+      passwordHash,
+      orgId: command.orgId,
+      role: command.role,
+      name: command.name,
+      hasAcceptedMarketing: command.hasAcceptedMarketing,
+      department: command.department,
+    });
+    const createdUser = await this.usersRepository.create(user);
+    this.logger.debug(
+      { userId: createdUser.id, role: command.role },
+      'User created successfully',
+    );
+    this.emitUserCreated(createdUser, command);
+    return createdUser;
+  }
+
+  private async hashPassword(command: CreateUserCommand): Promise<string> {
+    this.logger.debug('Hashing password');
+    try {
+      return await this.hashTextUseCase.execute(
+        new HashTextCommand(command.password),
+      );
+    } catch (error) {
+      if (error instanceof HashingError) throw error;
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          email: command.email,
+        },
+        'Password hashing failed',
+      );
+      throw new UserInvalidInputError('Password hashing failed');
+    }
+  }
+
+  private emitUserCreated(user: User, command: CreateUserCommand): void {
+    this.eventEmitter
+      .emitAsync(
+        UserCreatedEvent.EVENT_NAME,
+        new UserCreatedEvent(user.id, command.orgId, user),
+      )
+      .catch((err: unknown) => {
+        this.logger.error(
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            userId: user.id,
+          },
+          'Failed to emit UserCreatedEvent',
+        );
+      });
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 
@@ -62,6 +64,10 @@ describe('DeleteUserUseCase', () => {
           useValue: mockDeleteInviteByEmailUseCase,
         },
         { provide: ContextService, useValue: mockContextService },
+        {
+          provide: getLoggerToken(DeleteUserUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/delete-user/delete-user.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
 import { UsersRepository } from '../../ports/users.repository';
@@ -18,9 +19,9 @@ import type { User } from 'src/iam/users/domain/user.entity';
 
 @Injectable()
 export class DeleteUserUseCase {
-  private readonly logger = new Logger(DeleteUserUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteUserUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly contextService: ContextService,
     private readonly usersRepository: UsersRepository,
     private readonly eventEmitter: EventEmitter2,
@@ -28,7 +29,7 @@ export class DeleteUserUseCase {
   ) {}
 
   async execute(command: DeleteUserCommand): Promise<void> {
-    this.logger.log('deleteUser', { userId: command.userId });
+    this.logger.info({ userId: command.userId }, 'deleteUser');
     const requestingUserId = this.contextService.get('userId');
     if (!requestingUserId) {
       throw new UserUnauthorizedError('User not authenticated');
@@ -36,7 +37,7 @@ export class DeleteUserUseCase {
 
     const userToDelete = await this.usersRepository.findOneById(command.userId);
     if (!userToDelete) {
-      this.logger.error('User not found', { userId: command.userId });
+      this.logger.error({ userId: command.userId }, 'User not found');
       throw new UserNotFoundError(command.userId);
     }
     this.assertAllowedToDelete(command, userToDelete);
@@ -116,10 +117,13 @@ export class DeleteUserUseCase {
         new UserDeletedEvent(user.id, user.orgId, user.email),
       )
       .catch((err: unknown) => {
-        this.logger.error('Failed to emit UserDeletedEvent', {
-          error: err instanceof Error ? err.message : 'Unknown error',
-          userId: user.id,
-        });
+        this.logger.error(
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            userId: user.id,
+          },
+          'Failed to emit UserDeletedEvent',
+        );
       });
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/demote-from-super-admin/demote-from-super-admin.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/demote-from-super-admin/demote-from-super-admin.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 
@@ -37,6 +39,10 @@ describe('DemoteFromSuperAdminUseCase', () => {
       providers: [
         DemoteFromSuperAdminUseCase,
         { provide: UsersRepository, useValue: mockUsersRepository },
+        {
+          provide: getLoggerToken(DemoteFromSuperAdminUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/demote-from-super-admin/demote-from-super-admin.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/demote-from-super-admin/demote-from-super-admin.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { UsersRepository } from '../../ports/users.repository';
 import { DemoteFromSuperAdminCommand } from './demote-from-super-admin.command';
@@ -14,16 +15,21 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class DemoteFromSuperAdminUseCase {
-  private readonly logger = new Logger(DemoteFromSuperAdminUseCase.name);
-
-  constructor(private readonly usersRepository: UsersRepository) {}
+  constructor(
+    @InjectPinoLogger(DemoteFromSuperAdminUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly usersRepository: UsersRepository,
+  ) {}
 
   @Transactional()
   async execute(command: DemoteFromSuperAdminCommand): Promise<void> {
-    this.logger.log('execute', {
-      userId: command.userId,
-      requestingUserId: command.requestingUserId,
-    });
+    this.logger.info(
+      {
+        userId: command.userId,
+        requestingUserId: command.requestingUserId,
+      },
+      'execute',
+    );
 
     try {
       if (command.userId === command.requestingUserId) {
@@ -52,9 +58,12 @@ export class DemoteFromSuperAdminUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error demoting user from super admin', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Error demoting user from super admin',
+      );
       throw new UserUnexpectedError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/export-users/export-users.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/export-users/export-users.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { ExportUsersUseCase } from './export-users.use-case';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
 import type { UUID } from 'crypto';
@@ -30,7 +31,10 @@ describe('ExportUsersUseCase', () => {
       ]),
     };
 
-    const csv = await new ExportUsersUseCase(repository).execute();
+    const csv = await new ExportUsersUseCase(
+      createPinoLoggerMock(),
+      repository,
+    ).execute();
 
     expect(repository.findSubscribedOrgUsers).toHaveBeenCalledTimes(1);
     expect(csv).toBe(
@@ -58,7 +62,10 @@ describe('ExportUsersUseCase', () => {
       ]),
     };
 
-    const csv = await new ExportUsersUseCase(repository).execute();
+    const csv = await new ExportUsersUseCase(
+      createPinoLoggerMock(),
+      repository,
+    ).execute();
     const dataRow = csv.split('\n')[1];
 
     expect(dataRow).toBe(

--- a/ayunis-core-backend/src/iam/users/application/use-cases/export-users/export-users.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/export-users/export-users.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { convertCSVToString } from 'src/common/util/csv';
 import {
   UserExportRow,
@@ -8,12 +9,14 @@ import { UserError, UserUnexpectedError } from '../../users.errors';
 
 @Injectable()
 export class ExportUsersUseCase {
-  private readonly logger = new Logger(ExportUsersUseCase.name);
-
-  constructor(private readonly usersExportRepository: UsersExportRepository) {}
+  constructor(
+    @InjectPinoLogger(ExportUsersUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly usersExportRepository: UsersExportRepository,
+  ) {}
 
   async execute(): Promise<string> {
-    this.logger.log('Exporting users for subscribed organizations');
+    this.logger.info('Exporting users for subscribed organizations');
 
     try {
       const rows = await this.usersExportRepository.findSubscribedOrgUsers();
@@ -36,9 +39,12 @@ export class ExportUsersUseCase {
       if (error instanceof UserError) {
         throw error;
       }
-      this.logger.error('Error exporting users', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error exporting users',
+      );
       throw new UserUnexpectedError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-all-user-ids-by-org-id/find-all-user-ids-by-org-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-all-user-ids-by-org-id/find-all-user-ids-by-org-id.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { UsersRepository } from '../../ports/users.repository';
 import { FindAllUserIdsByOrgIdQuery } from './find-all-user-ids-by-org-id.query';
@@ -9,12 +10,14 @@ import { FindAllUserIdsByOrgIdQuery } from './find-all-user-ids-by-org-id.query'
  */
 @Injectable()
 export class FindAllUserIdsByOrgIdUseCase {
-  private readonly logger = new Logger(FindAllUserIdsByOrgIdUseCase.name);
-
-  constructor(private readonly usersRepository: UsersRepository) {}
+  constructor(
+    @InjectPinoLogger(FindAllUserIdsByOrgIdUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly usersRepository: UsersRepository,
+  ) {}
 
   async execute(query: FindAllUserIdsByOrgIdQuery): Promise<UUID[]> {
-    this.logger.log('execute', { orgId: query.orgId });
+    this.logger.info({ orgId: query.orgId }, 'execute');
     return this.usersRepository.findAllIdsByOrgId(query.orgId);
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-all-user-summaries-by-org-id/find-all-user-summaries-by-org-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-all-user-summaries-by-org-id/find-all-user-summaries-by-org-id.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import type { UserSummary } from 'src/iam/users/domain/user-summary';
 import { UsersRepository } from 'src/iam/users/application/ports/users.repository';
@@ -17,15 +18,17 @@ import { FindAllUserSummariesByOrgIdQuery } from './find-all-user-summaries-by-o
  */
 @Injectable()
 export class FindAllUserSummariesByOrgIdUseCase {
-  private readonly logger = new Logger(FindAllUserSummariesByOrgIdUseCase.name);
-
-  constructor(private readonly usersRepository: UsersRepository) {}
+  constructor(
+    @InjectPinoLogger(FindAllUserSummariesByOrgIdUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly usersRepository: UsersRepository,
+  ) {}
 
   @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(
     query: FindAllUserSummariesByOrgIdQuery,
   ): Promise<UserSummary[]> {
-    this.logger.log('execute', { orgId: query.orgId });
+    this.logger.info({ orgId: query.orgId }, 'execute');
     return this.usersRepository.findAllSummariesByOrgId(query.orgId, {
       search: query.search,
     });

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-super-admins/find-super-admins.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-super-admins/find-super-admins.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { FindSuperAdminsUseCase } from './find-super-admins.use-case';
@@ -20,6 +22,10 @@ describe('FindSuperAdminsUseCase', () => {
       providers: [
         FindSuperAdminsUseCase,
         { provide: UsersRepository, useValue: mockUsersRepository },
+        {
+          provide: getLoggerToken(FindSuperAdminsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-super-admins/find-super-admins.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-super-admins/find-super-admins.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UsersRepository } from '../../ports/users.repository';
 import { User } from 'src/iam/users/domain/user.entity';
 import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum';
@@ -6,20 +7,25 @@ import { UserUnexpectedError } from '../../users.errors';
 
 @Injectable()
 export class FindSuperAdminsUseCase {
-  private readonly logger = new Logger(FindSuperAdminsUseCase.name);
-
-  constructor(private readonly usersRepository: UsersRepository) {}
+  constructor(
+    @InjectPinoLogger(FindSuperAdminsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly usersRepository: UsersRepository,
+  ) {}
 
   async execute(): Promise<User[]> {
-    this.logger.log('execute');
+    this.logger.info('execute');
     try {
       return await this.usersRepository.findManyBySystemRole(
         SystemRole.SUPER_ADMIN,
       );
     } catch (error) {
-      this.logger.error('Error finding super admins', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Error finding super admins',
+      );
       throw new UserUnexpectedError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { FindUserByIdUseCase } from './find-user-by-id.use-case';
@@ -20,6 +22,10 @@ describe('FindUserByIdUseCase', () => {
       providers: [
         FindUserByIdUseCase,
         { provide: UsersRepository, useValue: mockUsersRepository },
+        {
+          provide: getLoggerToken(FindUserByIdUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UsersRepository } from '../../ports/users.repository';
 import { FindUserByIdQuery } from './find-user-by-id.query';
 import { User } from 'src/iam/users/domain/user.entity';
@@ -10,12 +11,14 @@ import {
 
 @Injectable()
 export class FindUserByIdUseCase {
-  private readonly logger = new Logger(FindUserByIdUseCase.name);
-
-  constructor(private readonly usersRepository: UsersRepository) {}
+  constructor(
+    @InjectPinoLogger(FindUserByIdUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly usersRepository: UsersRepository,
+  ) {}
 
   async execute(query: FindUserByIdQuery): Promise<User> {
-    this.logger.log('findOneById', { id: query.id });
+    this.logger.info({ id: query.id }, 'findOneById');
     try {
       const user = await this.usersRepository.findOneById(query.id);
       if (!user) {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { FindUsersByIdsUseCase } from './find-users-by-ids.use-case';
@@ -39,6 +41,10 @@ describe('FindUsersByIdsUseCase', () => {
         FindUsersByIdsUseCase,
         { provide: UsersRepository, useValue: mockUsersRepository },
         { provide: ContextService, useValue: mockContextService },
+        {
+          provide: getLoggerToken(FindUsersByIdsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UsersRepository } from '../../ports/users.repository';
 import { FindUsersByIdsQuery } from './find-users-by-ids.query';
 import { User } from 'src/iam/users/domain/user.entity';
@@ -8,9 +9,9 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 @Injectable()
 export class FindUsersByIdsUseCase {
-  private readonly logger = new Logger(FindUsersByIdsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindUsersByIdsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly usersRepository: UsersRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -22,7 +23,7 @@ export class FindUsersByIdsUseCase {
       throw new UnauthorizedAccessError();
     }
 
-    this.logger.log('execute', { idCount: query.ids.length, orgId });
+    this.logger.info({ idCount: query.ids.length, orgId }, 'execute');
 
     try {
       return await this.usersRepository.findManyByIdsAndOrgId(query.ids, orgId);

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { FindUsersByOrgIdUseCase } from './find-users-by-org-id.use-case';
@@ -33,6 +35,10 @@ describe('FindUsersByOrgIdUseCase', () => {
         {
           provide: HasPermissionUseCase,
           useValue: { execute: jest.fn().mockResolvedValue(false) },
+        },
+        {
+          provide: getLoggerToken(FindUsersByOrgIdUseCase.name),
+          useValue: createPinoLoggerMock(),
         },
       ],
     }).compile();

--- a/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/find-users-by-org-id/find-users-by-org-id.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UsersRepository } from '../../ports/users.repository';
 import { FindUsersByOrgIdQuery } from './find-users-by-org-id.query';
 import { User } from 'src/iam/users/domain/user.entity';
@@ -12,21 +13,24 @@ import { Permission } from 'src/iam/permissions/domain/value-objects/permission.
 
 @Injectable()
 export class FindUsersByOrgIdUseCase {
-  private readonly logger = new Logger(FindUsersByOrgIdUseCase.name);
-
   constructor(
+    @InjectPinoLogger(FindUsersByOrgIdUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly usersRepository: UsersRepository,
     private readonly contextService: ContextService,
     private readonly hasPermissionUseCase: HasPermissionUseCase,
   ) {}
 
   async execute(query: FindUsersByOrgIdQuery): Promise<Paginated<User>> {
-    this.logger.log('findManyByOrgId', {
-      orgId: query.orgId,
-      limit: query.limit,
-      offset: query.offset,
-      search: query.search,
-    });
+    this.logger.info(
+      {
+        orgId: query.orgId,
+        limit: query.limit,
+        offset: query.offset,
+        hasSearch: query.search !== undefined,
+      },
+      'findManyByOrgId',
+    );
     const systemRole = this.contextService.get('systemRole');
     const orgRole = this.contextService.get('role');
     // Listing org users is allowed for super-admins, org admins (admins hold

--- a/ayunis-core-backend/src/iam/users/application/use-cases/get-org-admins/get-org-admins.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/get-org-admins/get-org-admins.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetOrgAdminsUseCase } from './get-org-admins.use-case';
@@ -23,6 +25,10 @@ describe('GetOrgAdminsUseCase', () => {
       providers: [
         GetOrgAdminsUseCase,
         { provide: UsersRepository, useValue: mockUsersRepository },
+        {
+          provide: getLoggerToken(GetOrgAdminsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/get-org-admins/get-org-admins.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/get-org-admins/get-org-admins.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UsersRepository } from '../../ports/users.repository';
 import { User } from '../../../domain/user.entity';
@@ -7,13 +8,15 @@ import { UserUnexpectedError } from '../../users.errors';
 
 @Injectable()
 export class GetOrgAdminsUseCase {
-  private readonly logger = new Logger(GetOrgAdminsUseCase.name);
-
-  constructor(private readonly usersRepository: UsersRepository) {}
+  constructor(
+    @InjectPinoLogger(GetOrgAdminsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly usersRepository: UsersRepository,
+  ) {}
 
   @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(query: GetOrgAdminsQuery): Promise<User[]> {
-    this.logger.log('execute', { orgId: query.orgId });
+    this.logger.info({ orgId: query.orgId }, 'execute');
     return this.usersRepository.findAdminsByOrgId(query.orgId);
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/is-valid-password/is-valid-password.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/is-valid-password/is-valid-password.use-case.ts
@@ -1,11 +1,9 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { UsersRepository } from '../../ports/users.repository';
 import { IsValidPasswordQuery } from './is-valid-password.query';
 
 @Injectable()
 export class IsValidPasswordUseCase {
-  private readonly logger = new Logger(IsValidPasswordUseCase.name);
-
   constructor(private readonly usersRepository: UsersRepository) {}
 
   async execute(query: IsValidPasswordQuery): Promise<boolean> {

--- a/ayunis-core-backend/src/iam/users/application/use-cases/promote-to-super-admin/promote-to-super-admin.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/promote-to-super-admin/promote-to-super-admin.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 
@@ -31,6 +33,10 @@ describe('PromoteToSuperAdminUseCase', () => {
       providers: [
         PromoteToSuperAdminUseCase,
         { provide: UsersRepository, useValue: mockUsersRepository },
+        {
+          provide: getLoggerToken(PromoteToSuperAdminUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/promote-to-super-admin/promote-to-super-admin.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/promote-to-super-admin/promote-to-super-admin.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Transactional } from '@nestjs-cls/transactional';
 import { UsersRepository } from '../../ports/users.repository';
 import { PromoteToSuperAdminCommand } from './promote-to-super-admin.command';
@@ -9,13 +10,15 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class PromoteToSuperAdminUseCase {
-  private readonly logger = new Logger(PromoteToSuperAdminUseCase.name);
-
-  constructor(private readonly usersRepository: UsersRepository) {}
+  constructor(
+    @InjectPinoLogger(PromoteToSuperAdminUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly usersRepository: UsersRepository,
+  ) {}
 
   @Transactional()
   async execute(command: PromoteToSuperAdminCommand): Promise<User> {
-    this.logger.log('execute');
+    this.logger.info('execute');
 
     try {
       const user = await this.usersRepository.findOneByEmail(command.email);
@@ -34,9 +37,12 @@ export class PromoteToSuperAdminUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error promoting user to super admin', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Error promoting user to super admin',
+      );
       throw new UserUnexpectedError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/resend-email-confirmation/resend-email-confirmation.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/resend-email-confirmation/resend-email-confirmation.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ResendEmailConfirmationCommand } from './resend-email-confirmation.command';
 import { UsersRepository } from '../../ports/users.repository';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -11,21 +12,21 @@ import { SendConfirmationEmailCommand } from '../send-confirmation-email/send-co
 
 @Injectable()
 export class ResendEmailConfirmationUseCase {
-  private readonly logger = new Logger(ResendEmailConfirmationUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ResendEmailConfirmationUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly usersRepository: UsersRepository,
     private readonly sendConfirmationEmailUseCase: SendConfirmationEmailUseCase,
   ) {}
 
   async execute(command: ResendEmailConfirmationCommand): Promise<void> {
     try {
-      this.logger.log('execute', { email: command.email });
+      this.logger.info({ email: command.email }, 'execute');
 
       // Find the user by email
       const user = await this.usersRepository.findOneByEmail(command.email);
       if (!user) {
-        this.logger.error('User not found', { email: command.email });
+        this.logger.error({ email: command.email }, 'User not found');
         return; // Silently return without error for security reasons
       }
 
@@ -33,16 +34,22 @@ export class ResendEmailConfirmationUseCase {
         .execute(new SendConfirmationEmailCommand(user))
         .catch((error) => {
           if (error instanceof UserEmailAlreadyVerifiedError) return; // Silently return without error for security reasons
-          this.logger.error('Error resending email confirmation', {
-            error: error instanceof Error ? error.message : 'Unknown error',
-          });
+          this.logger.error(
+            {
+              error: error instanceof Error ? error.message : 'Unknown error',
+            },
+            'Error resending email confirmation',
+          );
           throw new UserUnexpectedError(error as Error);
         });
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error resending email confirmation', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Error resending email confirmation',
+      );
       throw new UserUnexpectedError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/reset-password/reset-password.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/reset-password/reset-password.use-case.spec.ts
@@ -1,6 +1,7 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import type { UUID } from 'crypto';
 import { ResetPasswordUseCase } from './reset-password.use-case';
 import { ResetPasswordCommand } from './reset-password.command';
@@ -77,15 +78,14 @@ describe('ResetPasswordUseCase', () => {
           provide: RevokeAllSessionsForUserUseCase,
           useValue: mockRevokeAllSessionsForUserUseCase,
         },
+        {
+          provide: getLoggerToken(ResetPasswordUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
     useCase = module.get(ResetPasswordUseCase);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/iam/users/application/use-cases/reset-password/reset-password.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/reset-password/reset-password.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UsersRepository } from 'src/iam/users/application/ports/users.repository';
 import { ResetPasswordCommand } from './reset-password.command';
 import { InvalidTokenError } from 'src/iam/authentication/application/authentication.errors';
@@ -18,9 +19,9 @@ import { RevokeAllSessionsForUserCommand } from 'src/iam/sessions/application/us
 
 @Injectable()
 export class ResetPasswordUseCase {
-  private readonly logger = new Logger(ResetPasswordUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ResetPasswordUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly passwordSetTokenService: PasswordSetTokenService,
     private readonly passwordSetTokensRepository: PasswordSetTokensRepository,
     private readonly hashTextUseCase: HashTextUseCase,
@@ -31,7 +32,7 @@ export class ResetPasswordUseCase {
 
   @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: ResetPasswordCommand): Promise<void> {
-    this.logger.log('resetPassword', { hasToken: !!command.resetToken });
+    this.logger.info({ hasToken: !!command.resetToken }, 'resetPassword');
 
     // Look up (read-only) before consuming, so a weak-password attempt does
     // not burn the link.
@@ -44,9 +45,12 @@ export class ResetPasswordUseCase {
 
     const user = await this.usersRepository.findOneById(token.userId);
     if (!user) {
-      this.logger.error('User not found during password reset', {
-        userId: token.userId,
-      });
+      this.logger.error(
+        {
+          userId: token.userId,
+        },
+        'User not found during password reset',
+      );
       throw new InvalidTokenError('Invalid token - user not found');
     }
     if (
@@ -73,7 +77,7 @@ export class ResetPasswordUseCase {
       new RevokeAllSessionsForUserCommand(user.id),
     );
 
-    this.logger.debug('Password reset successfully', { userId: user.id });
+    this.logger.debug({ userId: user.id }, 'Password reset successfully');
   }
 
   private assertPasswordsAcceptable(command: ResetPasswordCommand): void {
@@ -91,9 +95,12 @@ export class ResetPasswordUseCase {
       new IsValidPasswordQuery(password),
     );
     if (!isValid) {
-      this.logger.warn('Password does not meet security requirements', {
-        userId,
-      });
+      this.logger.warn(
+        {
+          userId,
+        },
+        'Password does not meet security requirements',
+      );
       throw new InvalidPasswordError(
         'Password does not meet security requirements',
       );
@@ -106,7 +113,7 @@ export class ResetPasswordUseCase {
       new Date(),
     );
     if (!consumed) {
-      this.logger.warn('Token already used', { userId: token.userId });
+      this.logger.warn({ userId: token.userId }, 'Token already used');
       throw new InvalidTokenError('Token already used');
     }
   }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/send-confirmation-email/send-confirmation-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/send-confirmation-email/send-confirmation-email.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SendConfirmationEmailCommand } from './send-confirmation-email.command';
 import { SendEmailCommand } from 'src/common/emails/application/use-cases/send-email/send-email.command';
 import { EmailConfirmationJwtService } from '../../services/email-confirmation-jwt.service';
@@ -12,12 +13,13 @@ import { ApplicationError } from 'src/common/errors/base.error';
 import { EmailConfirmationTemplate } from 'src/common/email-templates/domain/email-template.entity';
 import { RenderTemplateUseCase } from 'src/common/email-templates/application/use-cases/render-template/render-template.use-case';
 import { RenderTemplateCommand } from 'src/common/email-templates/application/use-cases/render-template/render-template.command';
+import type { User } from 'src/iam/users/domain/user.entity';
 
 @Injectable()
 export class SendConfirmationEmailUseCase {
-  private readonly logger = new Logger(SendConfirmationEmailUseCase.name);
-
   constructor(
+    @InjectPinoLogger(SendConfirmationEmailUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly emailConfirmationJwtService: EmailConfirmationJwtService,
     private readonly sendEmailUseCase: SendEmailUseCase,
     private readonly configService: ConfigService,
@@ -26,71 +28,77 @@ export class SendConfirmationEmailUseCase {
 
   async execute(command: SendConfirmationEmailCommand): Promise<void> {
     try {
-      const user = command.user;
-      // Check if email is already verified
-      if (user.emailVerified) {
-        this.logger.debug('Email already verified, skipping resend', {
-          userId: user.id,
-          email: user.email,
-        });
-        throw new UserEmailAlreadyVerifiedError('Email already verified', {
-          userId: user.id,
-          email: user.email,
-        });
-      }
-
-      // Generate new confirmation token
-      this.logger.debug('Generating new email confirmation token', {
-        userId: user.id,
-      });
-      const confirmationToken =
-        this.emailConfirmationJwtService.generateEmailConfirmationToken({
-          userId: user.id,
-          email: user.email,
-        });
-
-      // Build confirmation link
-      const frontendBaseUrl = this.configService.get<string>(
-        'app.frontend.baseUrl',
-      );
-      const emailConfirmEndpoint = this.configService.get<string>(
-        'app.frontend.emailConfirmEndpoint',
-      );
-      const confirmationLink = `${frontendBaseUrl}${emailConfirmEndpoint}?token=${confirmationToken}`;
-
-      // Send email
-      this.logger.debug('Resending email confirmation email', {
-        userId: user.id,
-        email: user.email,
-      });
-      const template = new EmailConfirmationTemplate({
-        confirmationUrl: confirmationLink,
-        userEmail: user.email,
-        currentYear: new Date().getFullYear().toString(),
-        companyName: 'Ayunis',
-      });
-      const emailContent = this.renderTemplateUseCase.execute(
-        new RenderTemplateCommand(template),
-      );
-      await this.sendEmailUseCase.execute(
-        new SendEmailCommand({
-          to: user.email,
-          subject: 'Ayunis Core – Bestätigen Sie Ihre E-Mail-Adresse',
-          html: emailContent.html,
-          text: emailContent.text,
-        }),
-      );
-
-      this.logger.debug('Email confirmation resent successfully', {
-        userId: user.id,
-        email: user.email,
-      });
+      await this.sendConfirmationEmail(command.user);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error sending email confirmation', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Error sending email confirmation',
+      );
       throw new UserUnexpectedError(error as Error);
     }
+  }
+
+  private async sendConfirmationEmail(user: User): Promise<void> {
+    this.assertEmailUnverified(user);
+    const confirmationLink = this.buildConfirmationLink(user);
+    this.logger.debug(
+      { userId: user.id, email: user.email },
+      'Resending email confirmation email',
+    );
+    const template = new EmailConfirmationTemplate({
+      confirmationUrl: confirmationLink,
+      userEmail: user.email,
+      currentYear: new Date().getFullYear().toString(),
+      companyName: 'Ayunis',
+    });
+    const emailContent = this.renderTemplateUseCase.execute(
+      new RenderTemplateCommand(template),
+    );
+    await this.sendEmailUseCase.execute(
+      new SendEmailCommand({
+        to: user.email,
+        subject: 'Ayunis Core – Bestätigen Sie Ihre E-Mail-Adresse',
+        html: emailContent.html,
+        text: emailContent.text,
+      }),
+    );
+    this.logger.debug(
+      { userId: user.id, email: user.email },
+      'Email confirmation resent successfully',
+    );
+  }
+
+  private assertEmailUnverified(user: User): void {
+    if (!user.emailVerified) return;
+    this.logger.debug(
+      { userId: user.id, email: user.email },
+      'Email already verified, skipping resend',
+    );
+    throw new UserEmailAlreadyVerifiedError('Email already verified', {
+      userId: user.id,
+      email: user.email,
+    });
+  }
+
+  private buildConfirmationLink(user: User): string {
+    this.logger.debug(
+      { userId: user.id },
+      'Generating new email confirmation token',
+    );
+    const token =
+      this.emailConfirmationJwtService.generateEmailConfirmationToken({
+        userId: user.id,
+        email: user.email,
+      });
+    const frontendBaseUrl = this.configService.get<string>(
+      'app.frontend.baseUrl',
+    );
+    const endpoint = this.configService.get<string>(
+      'app.frontend.emailConfirmEndpoint',
+    );
+    return `${frontendBaseUrl}${endpoint}?token=${token}`;
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/send-password-reset-email/send-password-reset-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/send-password-reset-email/send-password-reset-email.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SendPasswordResetEmailCommand } from './send-password-reset-email.command';
 import { SendEmailCommand } from 'src/common/emails/application/use-cases/send-email/send-email.command';
 import { SendEmailUseCase } from 'src/common/emails/application/use-cases/send-email/send-email.use-case';
@@ -11,89 +12,92 @@ import { PasswordResetEmailSendingFailedError } from '../../users.errors';
 
 @Injectable()
 export class SendPasswordResetEmailUseCase {
-  private readonly logger = new Logger(SendPasswordResetEmailUseCase.name);
-
   constructor(
+    @InjectPinoLogger(SendPasswordResetEmailUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly sendEmailUseCase: SendEmailUseCase,
     private readonly configService: ConfigService,
     private readonly renderTemplateUseCase: RenderTemplateUseCase,
   ) {}
 
   async execute(command: SendPasswordResetEmailCommand): Promise<void> {
+    this.logger.info(
+      { email: command.userEmail, hasUserName: !!command.userName },
+      'execute',
+    );
     try {
-      this.logger.log('execute', {
-        email: command.userEmail,
-        hasUserName: !!command.userName,
-      });
-
-      // Build password reset link
-      const frontendBaseUrl = this.configService.get<string>(
-        'app.frontend.baseUrl',
-      );
-      const passwordResetEndpoint = this.configService.get<string>(
-        'app.frontend.passwordResetEndpoint',
-      );
-      const forgotPasswordEndpoint = this.configService.get<string>(
-        'app.frontend.forgotPasswordEndpoint',
-      );
-      const resetUrl = `${frontendBaseUrl}${passwordResetEndpoint}?token=${command.resetToken}`;
-      const forgotPasswordUrl = `${frontendBaseUrl}${forgotPasswordEndpoint}`;
-      const emailAssetsPath = this.configService.get<string>(
-        'app.frontend.emailAssetsPath',
-      );
-      const assetBase = `${frontendBaseUrl}${emailAssetsPath}`;
-
-      // Create password reset email template
-      this.logger.debug('Creating password reset email template', {
-        email: command.userEmail,
-      });
-      const template = new PasswordResetTemplate({
-        resetUrl,
-        forgotPasswordUrl,
-        userEmail: command.userEmail,
-        companyName: 'Ayunis',
-        productName: 'Ayunis Core',
-        currentYear: new Date().getFullYear().toString(),
-        userName: command.userName,
-        logoUrl: `${assetBase}/logo.png`,
-        teamUrl: `${assetBase}/team.png`,
-      });
-
-      // Render email content
-      const emailContent = this.renderTemplateUseCase.execute(
-        new RenderTemplateCommand(template),
-      );
-
-      // Send the password reset email
-      this.logger.debug('Sending password reset email', {
-        email: command.userEmail,
-      });
-      await this.sendEmailUseCase.execute(
-        new SendEmailCommand({
-          to: command.userEmail,
-          subject: 'Passwort zurücksetzen für Ayunis Core',
-          html: emailContent.html,
-          text: emailContent.text,
-        }),
-      );
-
-      this.logger.debug('Password reset email sent successfully', {
-        email: command.userEmail,
-      });
+      await this.sendPasswordResetEmail(command);
     } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error sending password reset email', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        email: command.userEmail,
-      });
-      throw new PasswordResetEmailSendingFailedError(
-        error instanceof Error ? error.message : 'Unknown error',
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error(
         {
+          error: error instanceof Error ? error.message : 'Unknown error',
           email: command.userEmail,
         },
+        'Error sending password reset email',
+      );
+      throw new PasswordResetEmailSendingFailedError(
+        error instanceof Error ? error.message : 'Unknown error',
+        { email: command.userEmail },
       );
     }
+  }
+
+  private async sendPasswordResetEmail(
+    command: SendPasswordResetEmailCommand,
+  ): Promise<void> {
+    const template = this.buildTemplate(command);
+    const emailContent = this.renderTemplateUseCase.execute(
+      new RenderTemplateCommand(template),
+    );
+    this.logger.debug(
+      { email: command.userEmail },
+      'Sending password reset email',
+    );
+    await this.sendEmailUseCase.execute(
+      new SendEmailCommand({
+        to: command.userEmail,
+        subject: 'Passwort zurücksetzen für Ayunis Core',
+        html: emailContent.html,
+        text: emailContent.text,
+      }),
+    );
+    this.logger.debug(
+      { email: command.userEmail },
+      'Password reset email sent successfully',
+    );
+  }
+
+  private buildTemplate(
+    command: SendPasswordResetEmailCommand,
+  ): PasswordResetTemplate {
+    const frontendBaseUrl = this.configService.get<string>(
+      'app.frontend.baseUrl',
+    );
+    const passwordResetEndpoint = this.configService.get<string>(
+      'app.frontend.passwordResetEndpoint',
+    );
+    const forgotPasswordEndpoint = this.configService.get<string>(
+      'app.frontend.forgotPasswordEndpoint',
+    );
+    const emailAssetsPath = this.configService.get<string>(
+      'app.frontend.emailAssetsPath',
+    );
+    const assetBase = `${frontendBaseUrl}${emailAssetsPath}`;
+    this.logger.debug(
+      { email: command.userEmail },
+      'Creating password reset email template',
+    );
+    return new PasswordResetTemplate({
+      resetUrl: `${frontendBaseUrl}${passwordResetEndpoint}?token=${command.resetToken}`,
+      forgotPasswordUrl: `${frontendBaseUrl}${forgotPasswordEndpoint}`,
+      userEmail: command.userEmail,
+      companyName: 'Ayunis',
+      productName: 'Ayunis Core',
+      currentYear: new Date().getFullYear().toString(),
+      userName: command.userName,
+      logoUrl: `${assetBase}/logo.png`,
+      teamUrl: `${assetBase}/team.png`,
+    });
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/send-set-initial-password-email/send-set-initial-password-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/send-set-initial-password-email/send-set-initial-password-email.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { SetInitialPasswordTemplate } from 'src/common/email-templates/domain/email-template.entity';
@@ -13,9 +14,9 @@ import { PasswordResetEmailSendingFailedError } from '../../users.errors';
 
 @Injectable()
 export class SendSetInitialPasswordEmailUseCase {
-  private readonly logger = new Logger(SendSetInitialPasswordEmailUseCase.name);
-
   constructor(
+    @InjectPinoLogger(SendSetInitialPasswordEmailUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly sendEmailUseCase: SendEmailUseCase,
     private readonly configService: ConfigService,
     private readonly renderTemplateUseCase: RenderTemplateUseCase,
@@ -23,63 +24,73 @@ export class SendSetInitialPasswordEmailUseCase {
   ) {}
 
   async execute(command: SendSetInitialPasswordEmailCommand): Promise<void> {
+    this.logger.info({ email: command.userEmail }, 'execute');
     try {
-      this.logger.log('execute', { email: command.userEmail });
-
-      const org = await this.findOrgByIdUseCase.execute(
-        new FindOrgByIdQuery(command.orgId),
-      );
-
-      const frontendBaseUrl = this.configService.get<string>(
-        'app.frontend.baseUrl',
-      );
-      const accountActivateEndpoint = this.configService.get<string>(
-        'app.frontend.accountActivateEndpoint',
-      );
-      const emailAssetsPath = this.configService.get<string>(
-        'app.frontend.emailAssetsPath',
-      );
-      const resetUrl = `${frontendBaseUrl}${accountActivateEndpoint}?token=${command.resetToken}`;
-      const assetBase = `${frontendBaseUrl}${emailAssetsPath}`;
-
-      const template = new SetInitialPasswordTemplate({
-        resetUrl,
-        userEmail: command.userEmail,
-        invitingCompanyName: org.name,
-        userName: command.userName,
-        productName: 'Ayunis Core',
-        currentYear: new Date().getFullYear().toString(),
-        logoUrl: `${assetBase}/logo.png`,
-        teamUrl: `${assetBase}/team.png`,
-        bannerUrl: `${assetBase}/banner-welcome.png`,
-      });
-
-      const emailContent = this.renderTemplateUseCase.execute(
-        new RenderTemplateCommand(template),
-      );
-
-      await this.sendEmailUseCase.execute(
-        new SendEmailCommand({
-          to: command.userEmail,
-          subject: `Ihr Konto bei ${org.name} – Passwort festlegen`,
-          html: emailContent.html,
-          text: emailContent.text,
-        }),
-      );
-
-      this.logger.debug('Set-initial-password email sent', {
-        email: command.userEmail,
-      });
+      await this.sendInitialPasswordEmail(command);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error sending set-initial-password email', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        email: command.userEmail,
-      });
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          email: command.userEmail,
+        },
+        'Error sending set-initial-password email',
+      );
       throw new PasswordResetEmailSendingFailedError(
         error instanceof Error ? error.message : 'Unknown error',
         { email: command.userEmail },
       );
     }
+  }
+
+  private async sendInitialPasswordEmail(
+    command: SendSetInitialPasswordEmailCommand,
+  ): Promise<void> {
+    const org = await this.findOrgByIdUseCase.execute(
+      new FindOrgByIdQuery(command.orgId),
+    );
+    const template = this.buildTemplate(command, org.name);
+    const emailContent = this.renderTemplateUseCase.execute(
+      new RenderTemplateCommand(template),
+    );
+    await this.sendEmailUseCase.execute(
+      new SendEmailCommand({
+        to: command.userEmail,
+        subject: `Ihr Konto bei ${org.name} – Passwort festlegen`,
+        html: emailContent.html,
+        text: emailContent.text,
+      }),
+    );
+    this.logger.debug(
+      { email: command.userEmail },
+      'Set-initial-password email sent',
+    );
+  }
+
+  private buildTemplate(
+    command: SendSetInitialPasswordEmailCommand,
+    orgName: string,
+  ): SetInitialPasswordTemplate {
+    const frontendBaseUrl = this.configService.get<string>(
+      'app.frontend.baseUrl',
+    );
+    const accountActivateEndpoint = this.configService.get<string>(
+      'app.frontend.accountActivateEndpoint',
+    );
+    const emailAssetsPath = this.configService.get<string>(
+      'app.frontend.emailAssetsPath',
+    );
+    const assetBase = `${frontendBaseUrl}${emailAssetsPath}`;
+    return new SetInitialPasswordTemplate({
+      resetUrl: `${frontendBaseUrl}${accountActivateEndpoint}?token=${command.resetToken}`,
+      userEmail: command.userEmail,
+      invitingCompanyName: orgName,
+      userName: command.userName,
+      productName: 'Ayunis Core',
+      currentYear: new Date().getFullYear().toString(),
+      logoUrl: `${assetBase}/logo.png`,
+      teamUrl: `${assetBase}/team.png`,
+      bannerUrl: `${assetBase}/banner-welcome.png`,
+    });
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/super-admin-trigger-password-reset/super-admin-trigger-password-reset.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/super-admin-trigger-password-reset/super-admin-trigger-password-reset.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
@@ -69,6 +71,10 @@ describe('SuperAdminTriggerPasswordResetUseCase', () => {
           useValue: mockSendPasswordResetEmailUseCase,
         },
         { provide: ConfigService, useValue: mockConfigService },
+        {
+          provide: getLoggerToken(SuperAdminTriggerPasswordResetUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/super-admin-trigger-password-reset/super-admin-trigger-password-reset.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/super-admin-trigger-password-reset/super-admin-trigger-password-reset.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import type { UUID } from 'crypto';
 import { SuperAdminTriggerPasswordResetCommand } from './super-admin-trigger-password-reset.command';
@@ -17,11 +18,9 @@ import {
 
 @Injectable()
 export class SuperAdminTriggerPasswordResetUseCase {
-  private readonly logger = new Logger(
-    SuperAdminTriggerPasswordResetUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(SuperAdminTriggerPasswordResetUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly usersRepository: UsersRepository,
     private readonly passwordSetTokenService: PasswordSetTokenService,
     private readonly sendPasswordResetEmailUseCase: SendPasswordResetEmailUseCase,
@@ -31,9 +30,12 @@ export class SuperAdminTriggerPasswordResetUseCase {
   async execute(
     command: SuperAdminTriggerPasswordResetCommand,
   ): Promise<SuperAdminTriggerPasswordResetResult> {
-    this.logger.log('Triggering password reset email as super admin', {
-      userId: command.userId,
-    });
+    this.logger.info(
+      {
+        userId: command.userId,
+      },
+      'Triggering password reset email as super admin',
+    );
 
     try {
       const user = await this.usersRepository.findOneById(command.userId);
@@ -48,17 +50,23 @@ export class SuperAdminTriggerPasswordResetUseCase {
 
       const resetUrl = await this.sendResetEmail(user);
 
-      this.logger.log('Email triggered for user', {
-        userId: command.userId,
-        email: user.email,
-      });
+      this.logger.info(
+        {
+          userId: command.userId,
+          email: user.email,
+        },
+        'Email triggered for user',
+      );
 
       return new SuperAdminTriggerPasswordResetResult(resetUrl);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error triggering email as super admin', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Error triggering email as super admin',
+      );
       throw new UserUnexpectedError(
         error instanceof Error ? error : new Error('Unknown error'),
         'super admin trigger password reset email',

--- a/ayunis-core-backend/src/iam/users/application/use-cases/trigger-password-reset/trigger-password-reset.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/trigger-password-reset/trigger-password-reset.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { User } from 'src/iam/users/domain/user.entity';
 import { UserRole } from 'src/iam/users/domain/value-objects/role.object';
@@ -20,6 +22,10 @@ describe('TriggerPasswordResetUseCase', () => {
         { provide: UsersRepository, useValue: usersRepository },
         { provide: PasswordSetTokenService, useValue: tokenService },
         { provide: SendPasswordResetEmailUseCase, useValue: emailUseCase },
+        {
+          provide: getLoggerToken(TriggerPasswordResetUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
     useCase = module.get(TriggerPasswordResetUseCase);

--- a/ayunis-core-backend/src/iam/users/application/use-cases/trigger-password-reset/trigger-password-reset.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/trigger-password-reset/trigger-password-reset.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TriggerPasswordResetCommand } from './trigger-password-reset.command';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedAuthenticationError } from 'src/iam/authentication/application/authentication.errors';
@@ -12,9 +13,9 @@ import type { User } from 'src/iam/users/domain/user.entity';
 
 @Injectable()
 export class TriggerPasswordResetUseCase {
-  private readonly logger = new Logger(TriggerPasswordResetUseCase.name);
-
   constructor(
+    @InjectPinoLogger(TriggerPasswordResetUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly sendPasswordResetEmailUseCase: SendPasswordResetEmailUseCase,
     private readonly passwordSetTokenService: PasswordSetTokenService,
     private readonly usersRepository: UsersRepository,
@@ -22,15 +23,15 @@ export class TriggerPasswordResetUseCase {
 
   async execute(command: TriggerPasswordResetCommand): Promise<void> {
     try {
-      this.logger.log('execute', { email: command.email });
+      this.logger.info({ email: command.email }, 'execute');
 
       const user = await this.usersRepository.findOneByEmail(command.email);
       if (!user) {
-        this.logger.debug('User not found', { email: command.email });
+        this.logger.debug({ email: command.email }, 'User not found');
         return;
       }
       if (user.passwordHash === null) {
-        this.logger.debug('User has no local password', { userId: user.id });
+        this.logger.debug({ userId: user.id }, 'User has no local password');
         return;
       }
 
@@ -42,10 +43,13 @@ export class TriggerPasswordResetUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error triggering password reset', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        email: command.email,
-      });
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          email: command.email,
+        },
+        'Error triggering password reset',
+      );
       throw new UnexpectedAuthenticationError(error);
     }
   }
@@ -60,9 +64,12 @@ export class TriggerPasswordResetUseCase {
       new SendPasswordResetEmailCommand(user.email, resetToken, user.name),
     );
 
-    this.logger.debug('Password reset email sent', {
-      userId: user.id,
-      email: user.email,
-    });
+    this.logger.debug(
+      {
+        userId: user.id,
+        email: user.email,
+      },
+      'Password reset email sent',
+    );
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/trigger-set-initial-password/trigger-set-initial-password.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/trigger-set-initial-password/trigger-set-initial-password.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TriggerSetInitialPasswordCommand } from './trigger-set-initial-password.command';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UnexpectedAuthenticationError } from 'src/iam/authentication/application/authentication.errors';
@@ -11,9 +12,9 @@ import { UsersRepository } from '../../ports/users.repository';
 
 @Injectable()
 export class TriggerSetInitialPasswordUseCase {
-  private readonly logger = new Logger(TriggerSetInitialPasswordUseCase.name);
-
   constructor(
+    @InjectPinoLogger(TriggerSetInitialPasswordUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly sendSetInitialPasswordEmailUseCase: SendSetInitialPasswordEmailUseCase,
     private readonly passwordSetTokenService: PasswordSetTokenService,
     private readonly usersRepository: UsersRepository,
@@ -21,11 +22,11 @@ export class TriggerSetInitialPasswordUseCase {
 
   async execute(command: TriggerSetInitialPasswordCommand): Promise<void> {
     try {
-      this.logger.log('execute', { email: command.email });
+      this.logger.info({ email: command.email }, 'execute');
 
       const user = await this.usersRepository.findOneByEmail(command.email);
       if (!user) {
-        this.logger.debug('User not found', { email: command.email });
+        this.logger.debug({ email: command.email }, 'User not found');
         return;
       }
 
@@ -43,17 +44,23 @@ export class TriggerSetInitialPasswordUseCase {
         ),
       );
 
-      this.logger.debug('Set-initial-password email triggered', {
-        userId: user.id,
-        email: user.email,
-      });
+      this.logger.debug(
+        {
+          userId: user.id,
+          email: user.email,
+        },
+        'Set-initial-password email triggered',
+      );
     } catch (error) {
       if (error instanceof UserNotFoundError) return;
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error triggering set-initial-password', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        email: command.email,
-      });
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          email: command.email,
+        },
+        'Error triggering set-initial-password',
+      );
       throw new UnexpectedAuthenticationError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-password/update-password.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-password/update-password.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -62,6 +64,10 @@ describe('UpdatePasswordUseCase', () => {
           useValue: mockRevokeOtherSessionsForUserUseCase,
         },
         { provide: ContextService, useValue: mockContextService },
+        {
+          provide: getLoggerToken(UpdatePasswordUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-password/update-password.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-password/update-password.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { UsersRepository } from '../../ports/users.repository';
 import { UpdatePasswordCommand } from './update-password.command';
@@ -19,8 +20,9 @@ import { ContextService } from 'src/common/context/services/context.service';
 
 @Injectable()
 export class UpdatePasswordUseCase {
-  private readonly logger = new Logger(UpdatePasswordUseCase.name);
   constructor(
+    @InjectPinoLogger(UpdatePasswordUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly validateUserUseCase: ValidateUserUseCase,
     private readonly usersRepository: UsersRepository,
     private readonly hashTextUseCase: HashTextUseCase,
@@ -30,7 +32,7 @@ export class UpdatePasswordUseCase {
 
   @HandleUnexpectedErrors(UserUnexpectedError)
   async execute(command: UpdatePasswordCommand): Promise<void> {
-    this.logger.log('updatePassword', { userId: command.userId });
+    this.logger.info({ userId: command.userId }, 'updatePassword');
 
     if (command.newPassword !== command.newPasswordConfirmation) {
       throw new UserInvalidInputError('Passwords do not match');

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-user-name/update-user-name.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-user-name/update-user-name.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { UpdateUserNameUseCase } from './update-user-name.use-case';
@@ -28,6 +30,10 @@ describe('UpdateUserNameUseCase', () => {
         UpdateUserNameUseCase,
         { provide: UsersRepository, useValue: mockUsersRepository },
         { provide: EventEmitter2, useValue: mockEventEmitter },
+        {
+          provide: getLoggerToken(UpdateUserNameUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-user-name/update-user-name.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-user-name/update-user-name.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UsersRepository } from '../../ports/users.repository';
 import { UpdateUserNameCommand } from './update-user-name.command';
@@ -9,58 +10,64 @@ import { UserUpdatedEvent } from '../../events/user-updated.event';
 
 @Injectable()
 export class UpdateUserNameUseCase {
-  private readonly logger = new Logger(UpdateUserNameUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateUserNameUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly usersRepository: UsersRepository,
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(command: UpdateUserNameCommand): Promise<User> {
-    this.logger.log('updateUserName', {
-      userId: command.userId,
-      newName: command.newName,
-    });
+    this.logger.info(
+      { userId: command.userId, name: command.newName },
+      'updateUserName',
+    );
 
     try {
-      const user = await this.usersRepository.findOneById(command.userId);
-      if (!user) {
-        throw new UserNotFoundError(command.userId);
-      }
-      this.logger.debug('user found', {
-        userId: user.id,
-        currentName: user.name,
-      });
-      user.name = command.newName;
-      const updatedUser = await this.usersRepository.update(user);
-      this.logger.log('user name updated successfully', {
-        userId: updatedUser.id,
-        newName: updatedUser.name,
-      });
-
-      this.eventEmitter
-        .emitAsync(
-          UserUpdatedEvent.EVENT_NAME,
-          new UserUpdatedEvent(updatedUser.id, updatedUser.orgId, updatedUser),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit UserUpdatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            userId: updatedUser.id,
-          });
-        });
-
-      return updatedUser;
+      return await this.updateName(command);
     } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to update user name', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        userId: command.userId,
-        newName: command.newName,
-      });
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          userId: command.userId,
+          name: command.newName,
+        },
+        'Failed to update user name',
+      );
       throw new UserUnexpectedError(error as Error);
     }
+  }
+
+  private async updateName(command: UpdateUserNameCommand): Promise<User> {
+    const user = await this.usersRepository.findOneById(command.userId);
+    if (!user) throw new UserNotFoundError(command.userId);
+
+    this.logger.debug({ userId: user.id, name: user.name }, 'user found');
+    user.name = command.newName;
+    const updatedUser = await this.usersRepository.update(user);
+    this.logger.info(
+      { userId: updatedUser.id, name: updatedUser.name },
+      'user name updated successfully',
+    );
+    this.emitUserUpdated(updatedUser);
+    return updatedUser;
+  }
+
+  private emitUserUpdated(user: User): void {
+    this.eventEmitter
+      .emitAsync(
+        UserUpdatedEvent.EVENT_NAME,
+        new UserUpdatedEvent(user.id, user.orgId, user),
+      )
+      .catch((err: unknown) => {
+        this.logger.error(
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            userId: user.id,
+          },
+          'Failed to emit UserUpdatedEvent',
+        );
+      });
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { UpdateUserRoleUseCase } from './update-user-role.use-case';
@@ -37,6 +39,10 @@ describe('UpdateUserRoleUseCase', () => {
         { provide: ContextService, useValue: mockContextService },
         { provide: UsersRepository, useValue: mockUsersRepository },
         { provide: EventEmitter2, useValue: mockEventEmitter },
+        {
+          provide: getLoggerToken(UpdateUserRoleUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/update-user-role/update-user-role.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UsersRepository } from '../../ports/users.repository';
 import { UpdateUserRoleCommand } from './update-user-role.command';
@@ -14,19 +15,22 @@ import { UserUpdatedEvent } from '../../events/user-updated.event';
 
 @Injectable()
 export class UpdateUserRoleUseCase {
-  private readonly logger = new Logger(UpdateUserRoleUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateUserRoleUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly contextService: ContextService,
     private readonly usersRepository: UsersRepository,
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(command: UpdateUserRoleCommand): Promise<User> {
-    this.logger.log('updateUserRole', {
-      userId: command.userId,
-      newRole: command.newRole,
-    });
+    this.logger.info(
+      {
+        userId: command.userId,
+        newRole: command.newRole,
+      },
+      'updateUserRole',
+    );
 
     const requesterOrgId = this.contextService.get('orgId');
     if (!requesterOrgId) {
@@ -54,27 +58,37 @@ export class UpdateUserRoleUseCase {
       // Save the updated user
       const updatedUser = await this.usersRepository.update(user);
 
-      this.eventEmitter
-        .emitAsync(
-          UserUpdatedEvent.EVENT_NAME,
-          new UserUpdatedEvent(updatedUser.id, updatedUser.orgId, updatedUser),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit UserUpdatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            userId: updatedUser.id,
-          });
-        });
+      this.emitUserUpdated(updatedUser);
 
       return updatedUser;
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error updating user role', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+        },
+        'Error updating user role',
+      );
       throw new UserUnexpectedError(error as Error);
     }
+  }
+
+  private emitUserUpdated(user: User): void {
+    this.eventEmitter
+      .emitAsync(
+        UserUpdatedEvent.EVENT_NAME,
+        new UserUpdatedEvent(user.id, user.orgId, user),
+      )
+      .catch((err: unknown) => {
+        this.logger.error(
+          {
+            error: err instanceof Error ? err.message : 'Unknown error',
+            userId: user.id,
+          },
+          'Failed to emit UserUpdatedEvent',
+        );
+      });
   }
 }

--- a/ayunis-core-backend/src/iam/users/application/use-cases/validate-password-reset-token/validate-password-reset-token.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/validate-password-reset-token/validate-password-reset-token.use-case.spec.ts
@@ -1,6 +1,7 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { ValidatePasswordResetTokenUseCase } from './validate-password-reset-token.use-case';
 import { ValidatePasswordResetTokenQuery } from './validate-password-reset-token.query';
 import { PasswordSetTokenService } from '../../services/password-set-token.service';
@@ -24,13 +25,14 @@ describe('ValidatePasswordResetTokenUseCase', () => {
       providers: [
         ValidatePasswordResetTokenUseCase,
         { provide: PasswordSetTokenService, useValue: mockTokenService },
+        {
+          provide: getLoggerToken(ValidatePasswordResetTokenUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 
     useCase = module.get(ValidatePasswordResetTokenUseCase);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/iam/users/application/use-cases/validate-password-reset-token/validate-password-reset-token.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/validate-password-reset-token/validate-password-reset-token.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ValidatePasswordResetTokenQuery } from './validate-password-reset-token.query';
 import { PasswordSetTokenService } from '../../services/password-set-token.service';
 import { InvalidTokenError } from 'src/iam/authentication/application/authentication.errors';
@@ -11,16 +12,16 @@ export interface TokenValidationResult {
 
 @Injectable()
 export class ValidatePasswordResetTokenUseCase {
-  private readonly logger = new Logger(ValidatePasswordResetTokenUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ValidatePasswordResetTokenUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly passwordSetTokenService: PasswordSetTokenService,
   ) {}
 
   async execute(
     query: ValidatePasswordResetTokenQuery,
   ): Promise<TokenValidationResult> {
-    this.logger.log('validatePasswordResetToken', { hasToken: !!query.token });
+    this.logger.info({ hasToken: !!query.token }, 'validatePasswordResetToken');
     try {
       // Read-only: never consumes the token, so the frontend can validate it
       // before rendering the form and still redeem it on submit.

--- a/ayunis-core-backend/src/iam/users/application/use-cases/validate-user/validate-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/validate-user/validate-user.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ValidateUserUseCase } from './validate-user.use-case';
@@ -30,6 +32,10 @@ describe('ValidateUserUseCase', () => {
         ValidateUserUseCase,
         { provide: UsersRepository, useValue: mockUsersRepository },
         { provide: CompareHashUseCase, useValue: mockCompareHashUseCase },
+        {
+          provide: getLoggerToken(ValidateUserUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
       ],
     }).compile();
 

--- a/ayunis-core-backend/src/iam/users/application/use-cases/validate-user/validate-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/users/application/use-cases/validate-user/validate-user.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UsersRepository } from '../../ports/users.repository';
 import { ValidateUserQuery } from './validate-user.query';
 import { User } from 'src/iam/users/domain/user.entity';
@@ -13,22 +14,25 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class ValidateUserUseCase {
-  private readonly logger = new Logger(ValidateUserUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ValidateUserUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly usersRepository: UsersRepository,
     private readonly compareHashUseCase: CompareHashUseCase,
   ) {}
 
   async execute(query: ValidateUserQuery): Promise<User> {
-    this.logger.log('validateUser', { email: query.email });
+    this.logger.info({ email: query.email }, 'validateUser');
 
     try {
       const user = await this.usersRepository.findOneByEmail(query.email);
       if (!user) {
-        this.logger.warn('User not found during validation', {
-          email: query.email,
-        });
+        this.logger.warn(
+          {
+            email: query.email,
+          },
+          'User not found during validation',
+        );
         throw new UserNotFoundError('unknown');
       }
       if (user.passwordHash === null) {
@@ -37,41 +41,51 @@ export class ValidateUserUseCase {
         );
       }
 
-      this.logger.debug('Validating password', { userId: user.id });
-
-      try {
-        const isPasswordValid = await this.compareHashUseCase.execute(
-          new CompareHashCommand(query.password, user.passwordHash),
-        );
-
-        if (!isPasswordValid) {
-          this.logger.warn('Invalid password during validation', {
-            email: query.email,
-          });
-          throw new UserAuthenticationFailedError('Invalid password');
-        }
-
-        this.logger.debug('User validated successfully', { userId: user.id });
-        return user;
-      } catch (error) {
-        if (error instanceof ApplicationError) {
-          throw error;
-        }
-        this.logger.error('Password validation failed', {
-          error: error instanceof Error ? error.message : 'Unknown error',
-          email: query.email,
-        });
-        throw new UserAuthenticationFailedError('Password validation failed');
-      }
+      return await this.validatePassword(user, query);
     } catch (error) {
       if (error instanceof UserError) {
         throw error;
       }
-      this.logger.error('User validation failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        email: query.email,
-      });
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          email: query.email,
+        },
+        'User validation failed',
+      );
       throw new UserAuthenticationFailedError('User validation failed');
+    }
+  }
+
+  private async validatePassword(
+    user: User,
+    query: ValidateUserQuery,
+  ): Promise<User> {
+    this.logger.debug({ userId: user.id }, 'Validating password');
+    try {
+      const isPasswordValid = await this.compareHashUseCase.execute(
+        new CompareHashCommand(query.password, user.passwordHash!),
+      );
+      if (!isPasswordValid) {
+        this.logger.warn(
+          { email: query.email },
+          'Invalid password during validation',
+        );
+        throw new UserAuthenticationFailedError('Invalid password');
+      }
+
+      this.logger.debug({ userId: user.id }, 'User validated successfully');
+      return user;
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error(
+        {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          email: query.email,
+        },
+        'Password validation failed',
+      );
+      throw new UserAuthenticationFailedError('Password validation failed');
     }
   }
 }

--- a/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/local-users.repository.ts
+++ b/ayunis-core-backend/src/iam/users/infrastructure/repositories/local/local-users.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   UsersRepository,
   UsersPagination,
@@ -22,13 +23,13 @@ import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-t
 
 @Injectable()
 export class LocalUsersRepository extends UsersRepository {
-  private readonly logger = new Logger(LocalUsersRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalUsersRepository.name)
+    private readonly logger: PinoLogger,
     private readonly txHost: TransactionHost<TransactionalAdapterTypeOrm>,
   ) {
     super();
-    this.logger.log('constructor');
+    this.logger.info('constructor');
   }
 
   // Outside an active transaction txHost.tx resolves to the adapter's fallback
@@ -42,17 +43,17 @@ export class LocalUsersRepository extends UsersRepository {
   }
 
   async findOneById(id: UUID): Promise<User | null> {
-    this.logger.log('findOneById', { id });
+    this.logger.info({ id }, 'findOneById');
     const userEntity = await this.users.findOne({ where: { id } });
     if (!userEntity) {
-      this.logger.warn('User not found by ID', { id });
+      this.logger.warn({ id }, 'User not found by ID');
       return null;
     }
     return UserMapper.toDomain(userEntity);
   }
 
   async findManyByIdsAndOrgId(ids: UUID[], orgId: UUID): Promise<User[]> {
-    this.logger.log('findManyByIdsAndOrgId', { idCount: ids.length, orgId });
+    this.logger.info({ idCount: ids.length, orgId }, 'findManyByIdsAndOrgId');
 
     if (ids.length === 0) {
       return [];
@@ -66,19 +67,19 @@ export class LocalUsersRepository extends UsersRepository {
   }
 
   async findOneByEmail(email: string): Promise<User | null> {
-    this.logger.log('findOneByEmail', { email });
+    this.logger.info({ email }, 'findOneByEmail');
     const userRecord = await this.users.findOne({
       where: { email: ILike(email) },
     });
     if (!userRecord) {
-      this.logger.debug('User not found by email', { email });
+      this.logger.debug({ email }, 'User not found by email');
       return null;
     }
     return UserMapper.toDomain(userRecord);
   }
 
   async findManyByEmails(emails: string[]): Promise<User[]> {
-    this.logger.log('findManyByEmails', { emailCount: emails.length });
+    this.logger.info({ emailCount: emails.length }, 'findManyByEmails');
 
     if (emails.length === 0) {
       return [];
@@ -92,16 +93,19 @@ export class LocalUsersRepository extends UsersRepository {
       .where('LOWER(user.email) IN (:...emails)', { emails: lowerEmails })
       .getMany();
 
-    this.logger.debug('Found users by emails', {
-      requestedCount: emails.length,
-      foundCount: userRecords.length,
-    });
+    this.logger.debug(
+      {
+        requestedCount: emails.length,
+        foundCount: userRecords.length,
+      },
+      'Found users by emails',
+    );
 
     return userRecords.map((record) => UserMapper.toDomain(record));
   }
 
   async findManyBySystemRole(role: SystemRole): Promise<User[]> {
-    this.logger.log('findManyBySystemRole', { role });
+    this.logger.info({ role }, 'findManyBySystemRole');
 
     const userRecords = await this.users.find({
       where: { systemRole: role },
@@ -112,7 +116,7 @@ export class LocalUsersRepository extends UsersRepository {
   }
 
   async findAdminsByOrgId(orgId: UUID): Promise<User[]> {
-    this.logger.log('findAdminsByOrgId', { orgId });
+    this.logger.info({ orgId }, 'findAdminsByOrgId');
     const userRecords = await this.users.find({
       where: { orgId, role: UserRole.ADMIN },
       order: { createdAt: 'DESC' },
@@ -128,12 +132,15 @@ export class LocalUsersRepository extends UsersRepository {
     // The search term is free text over member names and emails, so it is
     // counted rather than logged — it would otherwise persist personal data in
     // centralized logs for their whole retention period.
-    this.logger.log('findManyByOrgId', {
-      orgId,
-      limit: pagination.limit,
-      offset: pagination.offset,
-      hasSearch: filters?.search !== undefined,
-    });
+    this.logger.info(
+      {
+        orgId,
+        limit: pagination.limit,
+        offset: pagination.offset,
+        hasSearch: filters?.search !== undefined,
+      },
+      'findManyByOrgId',
+    );
 
     const queryBuilder = this.users
       .createQueryBuilder('user')
@@ -163,7 +170,7 @@ export class LocalUsersRepository extends UsersRepository {
   }
 
   async findAllIdsByOrgId(orgId: UUID): Promise<UUID[]> {
-    this.logger.log('findAllIdsByOrgId', { orgId });
+    this.logger.info({ orgId }, 'findAllIdsByOrgId');
     const users = await this.users.find({
       where: { orgId },
       select: { id: true },
@@ -175,10 +182,13 @@ export class LocalUsersRepository extends UsersRepository {
     orgId: UUID,
     filters?: UsersFilters,
   ): Promise<UserSummary[]> {
-    this.logger.log('findAllSummariesByOrgId', {
-      orgId,
-      hasSearch: filters?.search !== undefined,
-    });
+    this.logger.info(
+      {
+        orgId,
+        hasSearch: filters?.search !== undefined,
+      },
+      'findAllSummariesByOrgId',
+    );
     const search = filters?.search?.trim();
     return this.users.find({
       where: search
@@ -192,16 +202,19 @@ export class LocalUsersRepository extends UsersRepository {
   }
 
   async create(user: User): Promise<User> {
-    this.logger.log('create', { userId: user.id, email: user.email });
+    this.logger.info({ userId: user.id, email: user.email }, 'create');
     // Check if user already exists by email (case-insensitive)
     const existingUser = await this.users.findOne({
       where: { email: ILike(user.email) },
     });
 
     if (existingUser) {
-      this.logger.warn('Attempted to create user with existing email', {
-        email: user.email,
-      });
+      this.logger.warn(
+        {
+          email: user.email,
+        },
+        'Attempted to create user with existing email',
+      );
       throw new UserAlreadyExistsError(
         `User with email ${user.email} already exists`,
       );
@@ -209,48 +222,60 @@ export class LocalUsersRepository extends UsersRepository {
 
     const userEntity = UserMapper.toEntity(user);
     const savedUserEntity = await this.users.save(userEntity);
-    this.logger.debug('User created successfully', {
-      userId: savedUserEntity.id,
-    });
+    this.logger.debug(
+      {
+        userId: savedUserEntity.id,
+      },
+      'User created successfully',
+    );
     return UserMapper.toDomain(savedUserEntity);
   }
 
   async update(user: User): Promise<User> {
-    this.logger.log('update', { userId: user.id });
+    this.logger.info({ userId: user.id }, 'update');
     // Verify user exists
     const existingUser = await this.users.findOne({
       where: { id: user.id },
     });
 
     if (!existingUser) {
-      this.logger.warn('Attempted to update non-existent user', {
-        userId: user.id,
-      });
+      this.logger.warn(
+        {
+          userId: user.id,
+        },
+        'Attempted to update non-existent user',
+      );
       throw new UserNotFoundError(user.id);
     }
 
     const userEntity = UserMapper.toEntity(user);
     const savedUserEntity = await this.users.save(userEntity);
-    this.logger.debug('User updated successfully', {
-      user: savedUserEntity,
-    });
+    this.logger.debug(
+      {
+        userId: savedUserEntity.id,
+      },
+      'User updated successfully',
+    );
     return UserMapper.toDomain(savedUserEntity);
   }
 
   async delete(id: UUID): Promise<void> {
-    this.logger.log('delete', { id });
+    this.logger.info({ id }, 'delete');
     // Verify user exists
     const existingUser = await this.users.findOne({ where: { id } });
 
     if (!existingUser) {
-      this.logger.warn('Attempted to delete non-existent user', {
-        userId: id,
-      });
+      this.logger.warn(
+        {
+          userId: id,
+        },
+        'Attempted to delete non-existent user',
+      );
       throw new UserNotFoundError(id);
     }
 
     await this.users.delete(id);
-    this.logger.debug('User deleted successfully', { userId: id });
+    this.logger.debug({ userId: id }, 'User deleted successfully');
   }
 
   async isValidPassword(password: string): Promise<boolean> {

--- a/ayunis-core-backend/src/iam/users/infrastructure/tasks/password-set-token-cleanup.task.spec.ts
+++ b/ayunis-core-backend/src/iam/users/infrastructure/tasks/password-set-token-cleanup.task.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { PasswordSetTokenCleanupTask } from './password-set-token-cleanup.task';
 import { createMockPasswordSetTokensRepository } from '../../application/testing/password-set-token.fixtures';
 
@@ -8,11 +8,7 @@ describe('PasswordSetTokenCleanupTask', () => {
 
   beforeEach(() => {
     repository = createMockPasswordSetTokensRepository();
-    task = new PasswordSetTokenCleanupTask(repository);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    task = new PasswordSetTokenCleanupTask(createPinoLoggerMock(), repository);
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/iam/users/infrastructure/tasks/password-set-token-cleanup.task.ts
+++ b/ayunis-core-backend/src/iam/users/infrastructure/tasks/password-set-token-cleanup.task.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { PasswordSetTokensRepository } from '../../application/ports/password-set-tokens.repository';
 
@@ -9,10 +10,11 @@ import { PasswordSetTokensRepository } from '../../application/ports/password-se
  */
 @Injectable()
 export class PasswordSetTokenCleanupTask {
-  private readonly logger = new Logger(PasswordSetTokenCleanupTask.name);
   private isRunning = false;
 
   constructor(
+    @InjectPinoLogger(PasswordSetTokenCleanupTask.name)
+    private readonly logger: PinoLogger,
     private readonly passwordSetTokensRepository: PasswordSetTokensRepository,
   ) {}
 
@@ -26,18 +28,21 @@ export class PasswordSetTokenCleanupTask {
     }
 
     this.isRunning = true;
-    this.logger.log('Starting scheduled password-set-token cleanup');
+    this.logger.info('Starting scheduled password-set-token cleanup');
 
     try {
       const deleted =
         await this.passwordSetTokensRepository.deleteExpiredOrUsed(new Date());
-      this.logger.log('Scheduled password-set-token cleanup completed', {
-        deleted,
-      });
+      this.logger.info(
+        {
+          deleted,
+        },
+        'Scheduled password-set-token cleanup completed',
+      );
     } catch (error) {
       this.logger.error(
+        { err: error as Error },
         'Scheduled password-set-token cleanup failed',
-        error instanceof Error ? error.stack : undefined,
       );
     } finally {
       this.isRunning = false;

--- a/ayunis-core-backend/src/iam/users/presenters/http/admin-user.controller.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/admin-user.controller.ts
@@ -3,11 +3,11 @@ import {
   Controller,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   Patch,
   UnauthorizedException,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiBadRequestResponse,
   ApiBody,
@@ -35,9 +35,9 @@ import { UserResponseDtoMapper } from './mappers/user-response-dto.mapper';
 @ApiTags('Users')
 @Controller('users')
 export class AdminUserController {
-  private readonly logger = new Logger(AdminUserController.name);
-
   constructor(
+    @InjectPinoLogger(AdminUserController.name)
+    private readonly logger: PinoLogger,
     private readonly adminUpdateUserUseCase: AdminUpdateUserUseCase,
     private readonly userResponseDtoMapper: UserResponseDtoMapper,
   ) {}
@@ -83,22 +83,35 @@ export class AdminUserController {
     @Body() dto: AdminUpdateUserDto,
     @CurrentUser(UserProperty.ID) currentUserId: UUID,
   ): Promise<UserResponseDto> {
-    this.logger.log('adminUpdateUser', {
-      userId,
-      hasName: dto.name !== undefined,
-      hasEmail: dto.email !== undefined,
-    });
+    this.logAdminUpdate(userId, dto);
 
+    return this.updateUser(userId, dto, currentUserId);
+  }
+
+  private async updateUser(
+    userId: UUID,
+    dto: AdminUpdateUserDto,
+    currentUserId: UUID,
+  ): Promise<UserResponseDto> {
     if (userId === currentUserId) {
       throw new UnauthorizedException(
         'You cannot edit your own profile through this endpoint',
       );
     }
-
-    const updatedUser = await this.adminUpdateUserUseCase.execute(
+    const user = await this.adminUpdateUserUseCase.execute(
       new AdminUpdateUserCommand(userId, dto.name, dto.email),
     );
+    return this.userResponseDtoMapper.toDto(user);
+  }
 
-    return this.userResponseDtoMapper.toDto(updatedUser);
+  private logAdminUpdate(userId: UUID, dto: AdminUpdateUserDto): void {
+    this.logger.info(
+      {
+        userId,
+        hasName: dto.name !== undefined,
+        hasEmail: dto.email !== undefined,
+      },
+      'adminUpdateUser',
+    );
   }
 }

--- a/ayunis-core-backend/src/iam/users/presenters/http/super-admin-management.controller.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/super-admin-management.controller.ts
@@ -3,13 +3,13 @@ import {
   Get,
   Delete,
   Post,
-  Logger,
   Param,
   Body,
   HttpCode,
   HttpStatus,
   ParseUUIDPipe,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -42,9 +42,9 @@ import {
 @Controller('super-admin/super-admins')
 @SystemRoles(SystemRole.SUPER_ADMIN)
 export class SuperAdminManagementController {
-  private readonly logger = new Logger(SuperAdminManagementController.name);
-
   constructor(
+    @InjectPinoLogger(SuperAdminManagementController.name)
+    private readonly logger: PinoLogger,
     private readonly findSuperAdminsUseCase: FindSuperAdminsUseCase,
     private readonly promoteToSuperAdminUseCase: PromoteToSuperAdminUseCase,
     private readonly demoteFromSuperAdminUseCase: DemoteFromSuperAdminUseCase,
@@ -67,7 +67,7 @@ export class SuperAdminManagementController {
     description: 'User not authenticated or not authorized as super admin',
   })
   async listSuperAdmins(): Promise<SuperAdminUserResponseDto[]> {
-    this.logger.log('listSuperAdmins');
+    this.logger.info('listSuperAdmins');
 
     const superAdmins = await this.findSuperAdminsUseCase.execute();
 
@@ -101,7 +101,7 @@ export class SuperAdminManagementController {
   async promoteToSuperAdmin(
     @Body() dto: PromoteToSuperAdminDto,
   ): Promise<SuperAdminUserResponseDto> {
-    this.logger.log('promoteToSuperAdmin');
+    this.logger.info('promoteToSuperAdmin');
 
     const user = await this.promoteToSuperAdminUseCase.execute(
       new PromoteToSuperAdminCommand({ email: dto.email }),
@@ -146,7 +146,7 @@ export class SuperAdminManagementController {
     @Param('userId', ParseUUIDPipe) userId: UUID,
     @CurrentUser(UserProperty.ID) requestingUserId: UUID,
   ): Promise<void> {
-    this.logger.log(
+    this.logger.info(
       `demoteFromSuperAdmin userId=${userId} requestingUserId=${requestingUserId}`,
     );
 

--- a/ayunis-core-backend/src/iam/users/presenters/http/super-admin-user-exports.controller.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/super-admin-user-exports.controller.ts
@@ -1,11 +1,5 @@
-import {
-  Controller,
-  Get,
-  Header,
-  HttpCode,
-  HttpStatus,
-  Logger,
-} from '@nestjs/common';
+import { Controller, Get, Header, HttpCode, HttpStatus } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiInternalServerErrorResponse,
   ApiOperation,
@@ -21,9 +15,11 @@ import { ExportUsersUseCase } from '../../application/use-cases/export-users/exp
 @Controller('super-admin/users/export')
 @SystemRoles(SystemRole.SUPER_ADMIN)
 export class SuperAdminUserExportsController {
-  private readonly logger = new Logger(SuperAdminUserExportsController.name);
-
-  constructor(private readonly exportUsersUseCase: ExportUsersUseCase) {}
+  constructor(
+    @InjectPinoLogger(SuperAdminUserExportsController.name)
+    private readonly logger: PinoLogger,
+    private readonly exportUsersUseCase: ExportUsersUseCase,
+  ) {}
 
   @Get('users.csv')
   @HttpCode(HttpStatus.OK)
@@ -53,7 +49,7 @@ export class SuperAdminUserExportsController {
     description: 'Internal server error occurred while exporting users',
   })
   async exportUsers(): Promise<string> {
-    this.logger.log('exportUsers');
+    this.logger.info('exportUsers');
 
     return this.exportUsersUseCase.execute();
   }

--- a/ayunis-core-backend/src/iam/users/presenters/http/super-admin-users.controller.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/super-admin-users.controller.ts
@@ -3,13 +3,13 @@ import {
   Get,
   Delete,
   Post,
-  Logger,
   Param,
   Body,
   HttpCode,
   HttpStatus,
   Query,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -51,9 +51,9 @@ import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum'
 @Controller('super-admin/users')
 @SystemRoles(SystemRole.SUPER_ADMIN)
 export class SuperAdminUsersController {
-  private readonly logger = new Logger(SuperAdminUsersController.name);
-
   constructor(
+    @InjectPinoLogger(SuperAdminUsersController.name)
+    private readonly logger: PinoLogger,
     private readonly findUsersByOrgIdUseCase: FindUsersByOrgIdUseCase,
     private readonly findUserByIdUseCase: FindUserByIdUseCase,
     private readonly deleteUserUseCase: DeleteUserUseCase,
@@ -87,7 +87,15 @@ export class SuperAdminUsersController {
     @Param('orgId') orgId: UUID,
     @Query() queryParams: GetUsersQueryParamsDto,
   ): Promise<PaginatedUsersListResponseDto> {
-    this.logger.log('getUsersByOrgId', { orgId, ...queryParams });
+    this.logger.info(
+      {
+        orgId,
+        limit: queryParams.limit,
+        offset: queryParams.offset,
+        hasSearch: queryParams.search !== undefined,
+      },
+      'getUsersByOrgId',
+    );
 
     const users = await this.findUsersByOrgIdUseCase.execute(
       new FindUsersByOrgIdQuery({
@@ -129,7 +137,7 @@ export class SuperAdminUsersController {
     description: 'Internal server error occurred while deleting user',
   })
   async deleteUser(@Param('userId') userId: UUID): Promise<void> {
-    this.logger.log('deleteUser', { userId });
+    this.logger.info({ userId }, 'deleteUser');
 
     // Get the user to retrieve their orgId for the delete command
     const user = await this.findUserByIdUseCase.execute(
@@ -175,7 +183,7 @@ export class SuperAdminUsersController {
   async triggerPasswordReset(
     @Param('userId') userId: UUID,
   ): Promise<TriggerPasswordResetResponseDto> {
-    this.logger.log('triggerPasswordReset', { userId });
+    this.logger.info({ userId }, 'triggerPasswordReset');
 
     const result = await this.superAdminTriggerPasswordResetUseCase.execute(
       new SuperAdminTriggerPasswordResetCommand(userId),
@@ -222,11 +230,15 @@ export class SuperAdminUsersController {
     @Param('orgId') orgId: UUID,
     @Body() createUserDto: CreateUserDto,
   ): Promise<UserResponseDto> {
-    this.logger.log('createUser', { orgId, email: createUserDto.email });
+    return this.createOrganizationUser(orgId, createUserDto);
+  }
 
-    // Generate a secure random password (32 bytes = 256 bits, base64 encoded)
+  private async createOrganizationUser(
+    orgId: UUID,
+    createUserDto: CreateUserDto,
+  ): Promise<UserResponseDto> {
+    this.logger.info({ orgId, email: createUserDto.email }, 'createUser');
     const randomPassword = randomBytes(32).toString('base64');
-
     const user = await this.createUserUseCase.execute(
       new CreateUserCommand({
         email: createUserDto.email,

--- a/ayunis-core-backend/src/iam/users/presenters/http/user-password-reset.controller.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/user-password-reset.controller.ts
@@ -6,9 +6,9 @@ import {
   Body,
   HttpCode,
   HttpStatus,
-  Logger,
   Query,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -39,9 +39,9 @@ import { AdminTriggerPasswordResetCommand } from '../../application/use-cases/ad
 @ApiTags('Users')
 @Controller('users')
 export class UserPasswordResetController {
-  private readonly logger = new Logger(UserPasswordResetController.name);
-
   constructor(
+    @InjectPinoLogger(UserPasswordResetController.name)
+    private readonly logger: PinoLogger,
     private readonly triggerPasswordResetUseCase: TriggerPasswordResetUseCase,
     private readonly resetPasswordUseCase: ResetPasswordUseCase,
     private readonly validatePasswordResetTokenUseCase: ValidatePasswordResetTokenUseCase,
@@ -70,7 +70,7 @@ export class UserPasswordResetController {
     description: "Not authorized to reset this user's password",
   })
   async triggerPasswordResetForUser(@Param('id') userId: UUID): Promise<void> {
-    this.logger.log('triggerPasswordResetForUser', { userId });
+    this.logger.info({ userId }, 'triggerPasswordResetForUser');
 
     await this.adminTriggerPasswordResetUseCase.execute(
       new AdminTriggerPasswordResetCommand(userId),
@@ -101,7 +101,7 @@ export class UserPasswordResetController {
     description: 'Internal server error while processing the request',
   })
   async forgotPassword(@Body() body: ForgotPasswordDto) {
-    this.logger.log('forgotPassword', { email: body.email });
+    this.logger.info({ email: body.email }, 'forgotPassword');
 
     await this.triggerPasswordResetUseCase.execute(
       new TriggerPasswordResetCommand(body.email),
@@ -135,7 +135,7 @@ export class UserPasswordResetController {
     description: 'Internal server error while processing the request',
   })
   async resetPassword(@Body() body: ResetPasswordDto) {
-    this.logger.log('resetPassword', { hasToken: !!body.resetToken });
+    this.logger.info({ hasToken: !!body.resetToken }, 'resetPassword');
 
     await this.resetPasswordUseCase.execute(
       new ResetPasswordCommand(
@@ -171,7 +171,7 @@ export class UserPasswordResetController {
     description: 'Internal server error while processing the request',
   })
   validateResetToken(@Query() query: ValidatePasswordResetTokenDto) {
-    this.logger.log('validateResetToken', { hasToken: !!query.token });
+    this.logger.info({ hasToken: !!query.token }, 'validateResetToken');
 
     return this.validatePasswordResetTokenUseCase.execute(
       new ValidatePasswordResetTokenQuery(query.token),

--- a/ayunis-core-backend/src/iam/users/presenters/http/user.controller.ts
+++ b/ayunis-core-backend/src/iam/users/presenters/http/user.controller.ts
@@ -7,11 +7,11 @@ import {
   Body,
   HttpCode,
   HttpStatus,
-  Logger,
   UnauthorizedException,
   Post,
   Query,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -60,9 +60,9 @@ import { RateLimit } from 'src/common/decorators/rate-limit.decorator';
 @ApiTags('Users')
 @Controller('users')
 export class UserController {
-  private readonly logger = new Logger(UserController.name);
-
   constructor(
+    @InjectPinoLogger(UserController.name)
+    private readonly logger: PinoLogger,
     private readonly findUsersByOrgIdUseCase: FindUsersByOrgIdUseCase,
     private readonly deleteUserUseCase: DeleteUserUseCase,
     private readonly updateUserRoleUseCase: UpdateUserRoleUseCase,
@@ -113,13 +113,28 @@ export class UserController {
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
     @Query() queryParams: GetUsersQueryParamsDto,
   ): Promise<PaginatedUsersListResponseDto> {
-    this.logger.log('getUsersInOrganization', { orgId, ...queryParams });
+    this.logUsersQuery(orgId, queryParams);
 
     const users = await this.findUsersByOrgIdUseCase.execute(
       this.buildFindUsersQuery(orgId, queryParams),
     );
 
     return this.userResponseDtoMapper.toPaginatedDto(users);
+  }
+
+  private logUsersQuery(
+    orgId: UUID,
+    queryParams: GetUsersQueryParamsDto,
+  ): void {
+    this.logger.info(
+      {
+        orgId,
+        limit: queryParams.limit,
+        offset: queryParams.offset,
+        hasSearch: queryParams.search !== undefined,
+      },
+      'getUsersInOrganization',
+    );
   }
 
   private buildFindUsersQuery(
@@ -176,7 +191,7 @@ export class UserController {
     @CurrentUser(UserProperty.ID) currentUserId: UUID,
   ): Promise<UserResponseDto> {
     const newRole = updateUserRoleDto.role;
-    this.logger.log('updateUserRole', { userId, newRole });
+    this.logger.info({ userId, newRole }, 'updateUserRole');
 
     if (userId === currentUserId) {
       throw new UnauthorizedException('You cannot update your own role');
@@ -221,9 +236,12 @@ export class UserController {
     @Body() updateUserNameDto: UpdateUserNameDto,
     @CurrentUser(UserProperty.ID) currentUserId: UUID,
   ): Promise<UserResponseDto> {
-    this.logger.log('updateUserName', {
-      newName: updateUserNameDto.name,
-    });
+    this.logger.info(
+      {
+        name: updateUserNameDto.name,
+      },
+      'updateUserName',
+    );
 
     const updatedUser = await this.updateUserNameUseCase.execute(
       new UpdateUserNameCommand(currentUserId, updateUserNameDto.name),
@@ -260,9 +278,12 @@ export class UserController {
     @Body() updatePasswordDto: UpdatePasswordDto,
     @CurrentUser(UserProperty.ID) currentUserId: UUID,
   ): Promise<void> {
-    this.logger.log('updatePassword', {
-      userId: currentUserId,
-    });
+    this.logger.info(
+      {
+        userId: currentUserId,
+      },
+      'updatePassword',
+    );
 
     await this.updatePasswordUseCase.execute(
       new UpdatePasswordCommand(
@@ -300,7 +321,7 @@ export class UserController {
     description: 'Internal server error occurred while confirming email',
   })
   async confirmEmail(@Body() confirmEmailDto: ConfirmEmailDto): Promise<void> {
-    this.logger.log('confirmEmail', { hasToken: !!confirmEmailDto.token });
+    this.logger.info({ hasToken: !!confirmEmailDto.token }, 'confirmEmail');
 
     await this.confirmEmailUseCase.execute(
       new ConfirmEmailCommand(confirmEmailDto.token),
@@ -338,9 +359,12 @@ export class UserController {
   async resendEmailConfirmation(
     @Body() resendEmailConfirmationDto: ResendEmailConfirmationDto,
   ): Promise<void> {
-    this.logger.log('resendEmailConfirmation', {
-      email: resendEmailConfirmationDto.email,
-    });
+    this.logger.info(
+      {
+        email: resendEmailConfirmationDto.email,
+      },
+      'resendEmailConfirmation',
+    );
 
     await this.resendEmailConfirmationUseCase.execute(
       new ResendEmailConfirmationCommand(resendEmailConfirmationDto.email),
@@ -379,7 +403,7 @@ export class UserController {
     @CurrentUser(UserProperty.ID) currentUserId: UUID,
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
   ): Promise<void> {
-    this.logger.log('deleteUser', { userId });
+    this.logger.info({ userId }, 'deleteUser');
     if (userId === currentUserId) {
       throw new UnauthorizedException('You cannot delete yourself');
     }

--- a/ayunis-core-backend/src/iam/users/users.module.ts
+++ b/ayunis-core-backend/src/iam/users/users.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { getLoggerToken, PinoLogger } from 'nestjs-pino';
 import { UsersRepository } from './application/ports/users.repository';
 import { UsersExportRepository } from './application/ports/users-export.repository';
 import { LocalUsersRepository } from './infrastructure/repositories/local/local-users.repository';
@@ -89,11 +90,14 @@ import { ExportUsersUseCase } from './application/use-cases/export-users/export-
   providers: [
     {
       provide: UsersRepository,
-      useFactory: (txHost: TransactionHost<TransactionalAdapterTypeOrm>) => {
+      useFactory: (
+        logger: PinoLogger,
+        txHost: TransactionHost<TransactionalAdapterTypeOrm>,
+      ) => {
         // FUTURE: Implement cloud users repository when auth.provider === AuthProvider.CLOUD
-        return new LocalUsersRepository(txHost);
+        return new LocalUsersRepository(logger, txHost);
       },
-      inject: [TransactionHost],
+      inject: [getLoggerToken(LocalUsersRepository.name), TransactionHost],
     },
     {
       provide: UsersExportRepository,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches security-sensitive auth, session refresh, password reset, and registration flows across a very large diff; risk is mainly regression from refactors and DI wiring rather than new features.
> 
> **Overview**
> **Migrates logging** in the **authentication**, **users**, and **hashing** IAM areas from `@nestjs/common` `Logger` to **`nestjs-pino`** via `@InjectPinoLogger` and `PinoLogger`. Call sites move to Pino’s **`(bindings, message)`** shape, **`log` → `info`**, and errors logged with **`err`** where appropriate. **`LocalAuthenticationRepository`** now receives a logger from the auth module factory (`getLoggerToken`).
> 
> Unit tests drop `Logger.prototype` spies in favor of **`createPinoLoggerMock()`** and **`getLoggerToken(...)`** providers; **`BcryptHandler`** specs assert structured constructor logging.
> 
> Bundled **refactors** (no intended behavior change): **`RegisterUserUseCase`**, **`CreateUserUseCase`**, **`ConfirmEmailUseCase`**, and several email/password use cases split into private helpers; **`LocalStrategy`** debug logs **`userId`** only (not the full user); **`IsValidPasswordUseCase`** removes an unused logger; list logging uses flags like **`hasSearch`** instead of raw search text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3fc67b0c576a0a59a93a2165d356a97449f478c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->