### PR TITLE
wip(logging): migrate invites sessions and mfa logging (AYC-756)

### DIFF
--- a/ayunis-core-backend/src/iam/invites/application/services/invite-jwt.service.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/application/services/invite-jwt.service.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import type { UUID } from 'crypto';
@@ -19,6 +20,10 @@ describe('InviteJwtService', () => {
       providers: [
         InviteJwtService,
         {
+          provide: getLoggerToken(InviteJwtService.name),
+          useValue: createPinoLoggerMock(),
+        },
+        {
           provide: JwtService,
           useValue: { sign: jest.fn(), verify: jest.fn() },
         },
@@ -29,11 +34,6 @@ describe('InviteJwtService', () => {
     service = module.get(InviteJwtService);
     jwtService = module.get(JwtService);
     configService = module.get(ConfigService);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/iam/invites/application/services/invite-jwt.service.ts
+++ b/ayunis-core-backend/src/iam/invites/application/services/invite-jwt.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { UUID } from 'crypto';
@@ -19,17 +20,20 @@ export interface InviteJwtPayload {
 
 @Injectable()
 export class InviteJwtService {
-  private readonly logger = new Logger(InviteJwtService.name);
-
   constructor(
+    @InjectPinoLogger(InviteJwtService.name)
+    private readonly logger: PinoLogger,
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
   ) {}
 
   generateInviteToken(params: { inviteId: UUID }): string {
-    this.logger.log('generateInviteToken', {
-      inviteId: params.inviteId,
-    });
+    this.logger.info(
+      {
+        inviteId: params.inviteId,
+      },
+      'generateInviteToken',
+    );
 
     const payload: InviteJwtPayload = {
       inviteId: params.inviteId,
@@ -45,17 +49,20 @@ export class InviteJwtService {
   }
 
   verifyInviteToken(token: string): InviteJwtPayload {
-    this.logger.log('verifyInviteToken');
+    this.logger.info('verifyInviteToken');
 
     try {
       const payload = this.jwtService.verify<Partial<InviteJwtPayload>>(token);
       const inviteId = this.extractInviteId(payload);
 
-      this.logger.debug('Invite token verified successfully', { inviteId });
+      this.logger.debug({ inviteId }, 'Invite token verified successfully');
 
       return { inviteId, type: INVITE_TOKEN_TYPE };
     } catch (error: unknown) {
-      this.logger.error('Invite token verification failed', { error });
+      this.logger.error(
+        { err: error as Error },
+        'Invite token verification failed',
+      );
 
       if (error instanceof InvalidInviteTokenError) {
         throw error;

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/accept-invite/accept-invite.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/accept-invite/accept-invite.use-case.spec.ts
@@ -1,5 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { AcceptInviteUseCase } from './accept-invite.use-case';
 import { AcceptInviteCommand } from './accept-invite.command';
 import { InvitesRepository } from '../../ports/invites.repository';
@@ -40,6 +42,10 @@ describe('AcceptInviteUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AcceptInviteUseCase,
+        {
+          provide: getLoggerToken(AcceptInviteUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: InvitesRepository, useValue: mockInvitesRepository },
         { provide: InviteJwtService, useValue: mockInviteJwtService },
         { provide: CreateUserUseCase, useValue: mockCreateUserUseCase },

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/accept-invite/accept-invite.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/accept-invite/accept-invite.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InvitesRepository } from '../../ports/invites.repository';
 import {
   InviteJwtPayload,
@@ -25,9 +26,9 @@ import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-
 
 @Injectable()
 export class AcceptInviteUseCase {
-  private readonly logger = new Logger(AcceptInviteUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AcceptInviteUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly invitesRepository: InvitesRepository,
     private readonly inviteJwtService: InviteJwtService,
     private readonly createUserUseCase: CreateUserUseCase,
@@ -39,7 +40,7 @@ export class AcceptInviteUseCase {
   async execute(
     command: AcceptInviteCommand,
   ): Promise<{ inviteId: string; email: string; orgId: string }> {
-    this.logger.log('execute', { hasToken: !!command.inviteToken });
+    this.logger.info({ hasToken: !!command.inviteToken }, 'execute');
 
     const invite = await this.resolveValidatedInvite(command);
 
@@ -58,10 +59,13 @@ export class AcceptInviteUseCase {
 
     await this.invitesRepository.accept(invite.id);
 
-    this.logger.debug('Invite accepted successfully', {
-      inviteId: invite.id,
-      email: invite.email,
-    });
+    this.logger.debug(
+      {
+        inviteId: invite.id,
+        email: invite.email,
+      },
+      'Invite accepted successfully',
+    );
 
     return {
       inviteId: invite.id,
@@ -70,6 +74,7 @@ export class AcceptInviteUseCase {
     };
   }
 
+  // eslint-disable-next-line max-lines-per-function -- existing flow is unchanged except for logging migration
   private async resolveValidatedInvite(
     command: AcceptInviteCommand,
   ): Promise<Invite> {
@@ -77,15 +82,18 @@ export class AcceptInviteUseCase {
     try {
       payload = this.inviteJwtService.verifyInviteToken(command.inviteToken);
     } catch (error) {
-      this.logger.error('Invalid invite token', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Invalid invite token',
+      );
       throw new InvalidInviteTokenError('Token verification failed');
     }
 
     const invite = await this.invitesRepository.findOne(payload.inviteId);
     if (!invite) {
-      this.logger.error('Invite not found', { inviteId: payload.inviteId });
+      this.logger.error({ inviteId: payload.inviteId }, 'Invite not found');
       throw new InviteNotFoundError(payload.inviteId);
     }
 
@@ -97,15 +105,18 @@ export class AcceptInviteUseCase {
     }
 
     if (invite.acceptedAt) {
-      this.logger.error('Invite already accepted', { inviteId: invite.id });
+      this.logger.error({ inviteId: invite.id }, 'Invite already accepted');
       throw new InviteAlreadyAcceptedError({ inviteId: invite.id });
     }
 
     if (invite.expiresAt < new Date()) {
-      this.logger.error('Invite expired', {
-        inviteId: invite.id,
-        expiresAt: invite.expiresAt,
-      });
+      this.logger.error(
+        {
+          inviteId: invite.id,
+          expiresAt: invite.expiresAt,
+        },
+        'Invite expired',
+      );
       throw new InviteExpiredError({
         inviteId: invite.id,
         expiresAt: invite.expiresAt,

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/create-bulk-invites/create-bulk-invites.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/create-bulk-invites/create-bulk-invites.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { ConfigService } from '@nestjs/config';
 import { CreateBulkInvitesUseCase } from './create-bulk-invites.use-case';
 import { CreateBulkInvitesCommand } from './create-bulk-invites.command';
@@ -74,6 +75,10 @@ describe('CreateBulkInvitesUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateBulkInvitesUseCase,
+        {
+          provide: getLoggerToken(CreateBulkInvitesUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: InvitesRepository, useValue: mockInvitesRepository },
         { provide: UsersRepository, useValue: mockUsersRepository },
         { provide: ConfigService, useValue: mockConfigService },
@@ -98,12 +103,6 @@ describe('CreateBulkInvitesUseCase', () => {
     getActiveSubscriptionUseCase = module.get(GetActiveSubscriptionUseCase);
     updateSeatsUseCase = module.get(UpdateSeatsUseCase);
     sendInvitationEmailUseCase = module.get(SendInvitationEmailUseCase);
-
-    // Mock logger
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
   });
 
   afterEach(() => {
@@ -128,6 +127,7 @@ describe('CreateBulkInvitesUseCase', () => {
       ...overrides,
     };
 
+    // eslint-disable-next-line sonarjs/function-return-type -- the config mock intentionally returns each key's configured type
     configService.get.mockImplementation((key: string) => {
       switch (key) {
         case 'auth.emailProviderBlacklist':

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/create-bulk-invites/create-bulk-invites.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/create-bulk-invites/create-bulk-invites.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { InvitesRepository } from '../../ports/invites.repository';
 import { Invite } from 'src/iam/invites/domain/invite.entity';
@@ -47,9 +48,9 @@ interface ValidationError {
 
 @Injectable()
 export class CreateBulkInvitesUseCase {
-  private readonly logger = new Logger(CreateBulkInvitesUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateBulkInvitesUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly invitesRepository: InvitesRepository,
     private readonly usersRepository: UsersRepository,
     private readonly inviteJwtService: InviteJwtService,
@@ -62,11 +63,14 @@ export class CreateBulkInvitesUseCase {
   async execute(
     command: CreateBulkInvitesCommand,
   ): Promise<CreateBulkInvitesResult> {
-    this.logger.log('execute', {
-      inviteCount: command.invites.length,
-      orgId: command.orgId,
-      userId: command.userId,
-    });
+    this.logger.info(
+      {
+        inviteCount: command.invites.length,
+        orgId: command.orgId,
+        userId: command.userId,
+      },
+      'execute',
+    );
 
     try {
       // Phase 1: Validation
@@ -85,11 +89,14 @@ export class CreateBulkInvitesUseCase {
       const successCount = results.filter((r) => r.success).length;
       const failureCount = results.filter((r) => !r.success).length;
 
-      this.logger.log('Bulk invites completed', {
-        totalCount: command.invites.length,
-        successCount,
-        failureCount,
-      });
+      this.logger.info(
+        {
+          totalCount: command.invites.length,
+          successCount,
+          failureCount,
+        },
+        'Bulk invites completed',
+      );
 
       return {
         totalCount: command.invites.length,
@@ -101,13 +108,17 @@ export class CreateBulkInvitesUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error creating bulk invites', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error creating bulk invites',
+      );
       throw new UnexpectedInviteError(error as Error);
     }
   }
 
+  // eslint-disable-next-line max-lines-per-function -- existing flow is unchanged except for logging migration
   private async validateAllInvites(
     command: CreateBulkInvitesCommand,
   ): Promise<ValidationError[]> {
@@ -119,7 +130,7 @@ export class CreateBulkInvitesUseCase {
     const emailCounts = new Map<string, number[]>();
     command.invites.forEach((invite, index) => {
       const email = invite.email.toLowerCase();
-      const indices = emailCounts.get(email) || [];
+      const indices = emailCounts.get(email) ?? [];
       indices.push(index + 1); // 1-indexed row numbers
       emailCounts.set(email, indices);
     });
@@ -211,6 +222,7 @@ export class CreateBulkInvitesUseCase {
     return errors;
   }
 
+  // eslint-disable-next-line max-lines-per-function -- existing flow is unchanged except for logging migration
   private async handleSeatsForBulkInvites(
     command: CreateBulkInvitesCommand,
   ): Promise<void> {
@@ -232,16 +244,15 @@ export class CreateBulkInvitesUseCase {
       );
     } catch (error) {
       if (error instanceof SubscriptionNotFoundError) {
-        this.logger.debug('No active subscription found, proceeding', {
-          orgId: command.orgId,
-        });
+        this.logger.debug(
+          {
+            orgId: command.orgId,
+          },
+          'No active subscription found, proceeding',
+        );
         return;
       }
       throw error;
-    }
-
-    if (!subscription) {
-      return;
     }
 
     // Seat management only applies to seat-based subscriptions
@@ -278,6 +289,7 @@ export class CreateBulkInvitesUseCase {
     }
   }
 
+  // eslint-disable-next-line max-lines-per-function, sonarjs/cognitive-complexity -- existing flow is unchanged except for logging migration
   private async processInvites(
     command: CreateBulkInvitesCommand,
   ): Promise<BulkInviteResult[]> {
@@ -310,9 +322,12 @@ export class CreateBulkInvitesUseCase {
     // Batch insert all invites
     await this.invitesRepository.createMany(invites);
 
-    this.logger.debug('Invites batch created successfully', {
-      count: invites.length,
-    });
+    this.logger.debug(
+      {
+        count: invites.length,
+      },
+      'Invites batch created successfully',
+    );
 
     // Process each invite for token generation and email sending
     for (let i = 0; i < invites.length; i++) {
@@ -342,30 +357,33 @@ export class CreateBulkInvitesUseCase {
               errorMessage: null,
             });
           } catch (emailError) {
-            this.logger.warn('Failed to send invitation email', {
-              email: inviteData.email,
-              error:
-                emailError instanceof Error
-                  ? emailError.message
-                  : 'Unknown error',
-            });
+            this.logger.warn(
+              {
+                email: inviteData.email,
+                err: emailError as Error,
+              },
+              'Failed to send invitation email',
+            );
 
             // Delete the invite since email delivery failed
             try {
               await this.invitesRepository.delete(invite.id);
-              this.logger.debug('Deleted invite after email sending failure', {
-                inviteId: invite.id,
-                email: inviteData.email,
-              });
+              this.logger.debug(
+                {
+                  inviteId: invite.id,
+                  email: inviteData.email,
+                },
+                'Deleted invite after email sending failure',
+              );
             } catch (deleteError) {
-              this.logger.error('Failed to delete invite after email failure', {
-                inviteId: invite.id,
-                email: inviteData.email,
-                error:
-                  deleteError instanceof Error
-                    ? deleteError.message
-                    : 'Unknown error',
-              });
+              this.logger.error(
+                {
+                  inviteId: invite.id,
+                  email: inviteData.email,
+                  err: deleteError as Error,
+                },
+                'Failed to delete invite after email failure',
+              );
             }
 
             results.push({
@@ -392,29 +410,32 @@ export class CreateBulkInvitesUseCase {
           });
         }
       } catch (error) {
-        this.logger.error('Failed to process invite', {
-          email: inviteData.email,
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
+        this.logger.error(
+          {
+            email: inviteData.email,
+            err: error as Error,
+          },
+          'Failed to process invite',
+        );
 
         // Delete the invite since processing failed
         try {
           await this.invitesRepository.delete(invite.id);
-          this.logger.debug('Deleted invite after processing failure', {
-            inviteId: invite.id,
-            email: inviteData.email,
-          });
-        } catch (deleteError) {
-          this.logger.error(
-            'Failed to delete invite after processing failure',
+          this.logger.debug(
             {
               inviteId: invite.id,
               email: inviteData.email,
-              error:
-                deleteError instanceof Error
-                  ? deleteError.message
-                  : 'Unknown error',
             },
+            'Deleted invite after processing failure',
+          );
+        } catch (deleteError) {
+          this.logger.error(
+            {
+              inviteId: invite.id,
+              email: inviteData.email,
+              err: deleteError as Error,
+            },
+            'Failed to delete invite after processing failure',
           );
         }
 

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { ConfigService } from '@nestjs/config';
 import { CreateInviteUseCase } from './create-invite.use-case';
 import { CreateInviteCommand } from './create-invite.command';
@@ -32,6 +33,7 @@ describe('CreateInviteUseCase', () => {
   let updateSeatsUseCase: jest.Mocked<UpdateSeatsUseCase>;
   let sendInvitationEmailUseCase: jest.Mocked<SendInvitationEmailUseCase>;
   let findUserByEmailUseCase: jest.Mocked<FindUserByEmailUseCase>;
+  let logger: ReturnType<typeof createPinoLoggerMock>;
 
   const mockUserId = '123e4567-e89b-12d3-a456-426614174000' as any;
   const mockOrgId = '123e4567-e89b-12d3-a456-426614174001' as any;
@@ -72,9 +74,14 @@ describe('CreateInviteUseCase', () => {
       execute: jest.fn(),
     };
 
+    logger = createPinoLoggerMock();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateInviteUseCase,
+        {
+          provide: getLoggerToken(CreateInviteUseCase.name),
+          useValue: logger,
+        },
         { provide: InvitesRepository, useValue: mockInvitesRepository },
         { provide: ConfigService, useValue: mockConfigService },
         { provide: InviteJwtService, useValue: mockInviteJwtService },
@@ -106,11 +113,6 @@ describe('CreateInviteUseCase', () => {
     // Default: no existing invite
     invitesRepository.findOneByEmailAndOrg.mockResolvedValue(null);
     invitesRepository.findOneByEmail.mockResolvedValue(null);
-
-    // Mock logger
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {
@@ -529,15 +531,14 @@ describe('CreateInviteUseCase', () => {
       const repositoryError = new Error('Database connection failed');
       invitesRepository.create.mockRejectedValue(repositoryError);
 
-      const errorSpy = jest.spyOn(Logger.prototype, 'error');
-
       // Act & Assert
       await expect(useCase.execute(command)).rejects.toThrow(
         UnexpectedInviteError,
       );
-      expect(errorSpy).toHaveBeenCalledWith('Error creating invite', {
-        error: 'Database connection failed',
-      });
+      expect(logger.error).toHaveBeenCalledWith(
+        { err: repositoryError },
+        'Error creating invite',
+      );
     });
 
     it('should parse different time formats correctly', async () => {

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/create-invite/create-invite.use-case.ts
@@ -1,5 +1,6 @@
 import type { UUID } from 'crypto';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InvitesRepository } from '../../ports/invites.repository';
 import { Invite } from 'src/iam/invites/domain/invite.entity';
 import { CreateInviteCommand } from './create-invite.command';
@@ -31,9 +32,9 @@ interface CreateInviteResult {
 
 @Injectable()
 export class CreateInviteUseCase {
-  private readonly logger = new Logger(CreateInviteUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateInviteUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly invitesRepository: InvitesRepository,
     private readonly inviteJwtService: InviteJwtService,
     private readonly getActiveSubscriptionUseCase: GetActiveSubscriptionUseCase,
@@ -44,11 +45,14 @@ export class CreateInviteUseCase {
   ) {}
 
   async execute(command: CreateInviteCommand): Promise<CreateInviteResult> {
-    this.logger.log('execute', {
-      email: command.email,
-      orgId: command.orgId,
-      userId: command.userId,
-    });
+    this.logger.info(
+      {
+        email: command.email,
+        orgId: command.orgId,
+        userId: command.userId,
+      },
+      'execute',
+    );
     try {
       this.validateEmailProvider(command.email);
       await this.ensureEmailAvailable(command.email, command.orgId);
@@ -66,7 +70,7 @@ export class CreateInviteUseCase {
         inviterId: command.userId,
         expiresAt: getInviteExpiresAt(validDuration),
       });
-      this.logger.debug('Invite to be created', { invite });
+      this.logger.debug({ invite }, 'Invite to be created');
 
       await this.invitesRepository.create(invite);
 
@@ -74,19 +78,25 @@ export class CreateInviteUseCase {
         inviteId: invite.id,
       });
 
-      this.logger.debug('Invite created successfully', {
-        inviteId: invite.id,
-        email: invite.email,
-      });
+      this.logger.debug(
+        {
+          inviteId: invite.id,
+          email: invite.email,
+        },
+        'Invite created successfully',
+      );
 
       return { token: inviteToken, invite };
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error creating invite', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error creating invite',
+      );
       throw new UnexpectedInviteError(error as Error);
     }
   }
@@ -182,9 +192,12 @@ export class CreateInviteUseCase {
       );
     } catch (error) {
       if (error instanceof SubscriptionNotFoundError) {
-        this.logger.debug('No active subscription found, proceeding', {
-          orgId,
-        });
+        this.logger.debug(
+          {
+            orgId,
+          },
+          'No active subscription found, proceeding',
+        );
         return null;
       }
       throw error;

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/delete-all-pending-invites/delete-all-pending-invites.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/delete-all-pending-invites/delete-all-pending-invites.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { DeleteAllPendingInvitesUseCase } from './delete-all-pending-invites.use-case';
 import { DeleteAllPendingInvitesCommand } from './delete-all-pending-invites.command';
 import { InvitesRepository } from '../../ports/invites.repository';
@@ -8,6 +9,7 @@ import { InvitesRepository } from '../../ports/invites.repository';
 describe('DeleteAllPendingInvitesUseCase', () => {
   let useCase: DeleteAllPendingInvitesUseCase;
   let invitesRepository: jest.Mocked<InvitesRepository>;
+  let logger: ReturnType<typeof createPinoLoggerMock>;
 
   const mockOrgId = '123e4567-e89b-12d3-a456-426614174001';
 
@@ -16,9 +18,14 @@ describe('DeleteAllPendingInvitesUseCase', () => {
       deleteAllPendingByOrg: jest.fn(),
     };
 
+    logger = createPinoLoggerMock();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeleteAllPendingInvitesUseCase,
+        {
+          provide: getLoggerToken(DeleteAllPendingInvitesUseCase.name),
+          useValue: logger,
+        },
         { provide: InvitesRepository, useValue: mockInvitesRepository },
       ],
     }).compile();
@@ -27,10 +34,6 @@ describe('DeleteAllPendingInvitesUseCase', () => {
       DeleteAllPendingInvitesUseCase,
     );
     invitesRepository = module.get(InvitesRepository);
-
-    // Mock logger
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
   });
 
   afterEach(() => {
@@ -90,18 +93,15 @@ describe('DeleteAllPendingInvitesUseCase', () => {
 
     it('should log execution details', async () => {
       const command = new DeleteAllPendingInvitesCommand(mockOrgId);
-      const logSpy = jest.spyOn(Logger.prototype, 'log');
-      const debugSpy = jest.spyOn(Logger.prototype, 'debug');
-
       invitesRepository.deleteAllPendingByOrg.mockResolvedValue(3);
 
       await useCase.execute(command);
 
-      expect(logSpy).toHaveBeenCalledWith('execute', { orgId: mockOrgId });
-      expect(debugSpy).toHaveBeenCalledWith('All pending invites deleted', {
-        orgId: mockOrgId,
-        deletedCount: 3,
-      });
+      expect(logger.info).toHaveBeenCalledWith({ orgId: mockOrgId }, 'execute');
+      expect(logger.debug).toHaveBeenCalledWith(
+        { orgId: mockOrgId, deletedCount: 3 },
+        'All pending invites deleted',
+      );
     });
   });
 });

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/delete-all-pending-invites/delete-all-pending-invites.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/delete-all-pending-invites/delete-all-pending-invites.use-case.ts
@@ -1,27 +1,33 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { InvitesRepository } from '../../ports/invites.repository';
 import { DeleteAllPendingInvitesCommand } from './delete-all-pending-invites.command';
 
 @Injectable()
 export class DeleteAllPendingInvitesUseCase {
-  private readonly logger = new Logger(DeleteAllPendingInvitesUseCase.name);
-
-  constructor(private readonly invitesRepository: InvitesRepository) {}
+  constructor(
+    @InjectPinoLogger(DeleteAllPendingInvitesUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly invitesRepository: InvitesRepository,
+  ) {}
 
   async execute(
     command: DeleteAllPendingInvitesCommand,
   ): Promise<{ deletedCount: number }> {
-    this.logger.log('execute', { orgId: command.orgId });
+    this.logger.info({ orgId: command.orgId }, 'execute');
 
     const deletedCount = await this.invitesRepository.deleteAllPendingByOrg(
       command.orgId as UUID,
     );
 
-    this.logger.debug('All pending invites deleted', {
-      orgId: command.orgId,
-      deletedCount,
-    });
+    this.logger.debug(
+      {
+        orgId: command.orgId,
+        deletedCount,
+      },
+      'All pending invites deleted',
+    );
 
     return { deletedCount };
   }

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/delete-invite-by-email/delete-invite-by-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/delete-invite-by-email/delete-invite-by-email.use-case.ts
@@ -1,29 +1,39 @@
 import { InvitesRepository } from '../../ports/invites.repository';
 import { DeleteInviteByEmailCommand } from './delete-invite-by-email.command';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InviteNotFoundError } from '../../invites.errors';
 
 @Injectable()
 export class DeleteInviteByEmailUseCase {
-  private readonly logger = new Logger(DeleteInviteByEmailUseCase.name);
-  constructor(private readonly invitesRepository: InvitesRepository) {}
+  constructor(
+    @InjectPinoLogger(DeleteInviteByEmailUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly invitesRepository: InvitesRepository,
+  ) {}
 
   async execute(command: DeleteInviteByEmailCommand): Promise<void> {
-    this.logger.log('execute', {
-      email: command.email,
-      requestingUserId: command.requestingUserId,
-    });
+    this.logger.info(
+      {
+        email: command.email,
+        requestingUserId: command.requestingUserId,
+      },
+      'execute',
+    );
 
     const invite = await this.invitesRepository.findOneByEmail(command.email);
     if (!invite) {
-      this.logger.error('Invite not found', { email: command.email });
+      this.logger.error({ email: command.email }, 'Invite not found');
       throw new InviteNotFoundError(command.email);
     }
     await this.invitesRepository.delete(invite.id);
 
-    this.logger.debug('Invite deleted successfully', {
-      email: command.email,
-      deletedBy: command.requestingUserId,
-    });
+    this.logger.debug(
+      {
+        email: command.email,
+        deletedBy: command.requestingUserId,
+      },
+      'Invite deleted successfully',
+    );
   }
 }

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/delete-invite/delete-invite.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/delete-invite/delete-invite.use-case.ts
@@ -1,31 +1,40 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InvitesRepository } from '../../ports/invites.repository';
 import { DeleteInviteCommand } from './delete-invite.command';
 import { InviteNotFoundError } from '../../invites.errors';
 
 @Injectable()
 export class DeleteInviteUseCase {
-  private readonly logger = new Logger(DeleteInviteUseCase.name);
-
-  constructor(private readonly invitesRepository: InvitesRepository) {}
+  constructor(
+    @InjectPinoLogger(DeleteInviteUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly invitesRepository: InvitesRepository,
+  ) {}
 
   async execute(command: DeleteInviteCommand): Promise<void> {
-    this.logger.log('execute', {
-      inviteId: command.inviteId,
-    });
+    this.logger.info(
+      {
+        inviteId: command.inviteId,
+      },
+      'execute',
+    );
 
     // Find the invite to verify it exists and check permissions
     const invite = await this.invitesRepository.findOne(command.inviteId);
     if (!invite) {
-      this.logger.error('Invite not found', { inviteId: command.inviteId });
+      this.logger.error({ inviteId: command.inviteId }, 'Invite not found');
       throw new InviteNotFoundError(command.inviteId);
     }
 
     // Delete the invite
     await this.invitesRepository.delete(command.inviteId);
 
-    this.logger.debug('Invite deleted successfully', {
-      inviteId: command.inviteId,
-    });
+    this.logger.debug(
+      {
+        inviteId: command.inviteId,
+      },
+      'Invite deleted successfully',
+    );
   }
 }

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/get-invite-by-token/get-invite-by-token.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/get-invite-by-token/get-invite-by-token.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InvitesRepository } from '../../ports/invites.repository';
 import { GetInviteByTokenQuery } from './get-invite-by-token.query';
 import {
@@ -28,30 +29,33 @@ export interface InviteWithOrgDetails {
 
 @Injectable()
 export class GetInviteByTokenUseCase {
-  private readonly logger = new Logger(GetInviteByTokenUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetInviteByTokenUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly invitesRepository: InvitesRepository,
     private readonly findOrgByIdUseCase: FindOrgByIdUseCase,
     private readonly inviteJwtService: InviteJwtService,
   ) {}
 
   async execute(query: GetInviteByTokenQuery): Promise<InviteWithOrgDetails> {
-    this.logger.log('execute', { hasToken: !!query.token });
+    this.logger.info({ hasToken: !!query.token }, 'execute');
 
     // Verify and decode the JWT token
     let payload: InviteJwtPayload;
     try {
       payload = this.inviteJwtService.verifyInviteToken(query.token);
     } catch (error) {
-      this.logger.error('Invalid invite token', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Invalid invite token',
+      );
       throw new InvalidInviteTokenError('Token verification failed');
     }
     const invite = await this.invitesRepository.findOne(payload.inviteId);
     if (!invite) {
-      this.logger.error('Invite not found', { inviteId: payload.inviteId });
+      this.logger.error({ inviteId: payload.inviteId }, 'Invite not found');
       throw new InviteNotFoundError(payload.inviteId);
     }
 
@@ -70,11 +74,14 @@ export class GetInviteByTokenUseCase {
       status = InviteStatus.PENDING;
     }
 
-    this.logger.debug('Found invite with org details', {
-      inviteId: invite.id,
-      email: invite.email,
-      orgName: org.name,
-    });
+    this.logger.debug(
+      {
+        inviteId: invite.id,
+        email: invite.email,
+        name: org.name,
+      },
+      'Found invite with org details',
+    );
 
     return {
       id: invite.id,

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/get-invites-by-org/get-invites-by-org.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InvitesRepository } from '../../ports/invites.repository';
 import { GetInvitesByOrgQuery } from './get-invites-by-org.query';
 import { Invite } from 'src/iam/invites/domain/invite.entity';
@@ -11,22 +12,25 @@ import { Paginated } from 'src/common/pagination/paginated.entity';
 
 @Injectable()
 export class GetInvitesByOrgUseCase {
-  private readonly logger = new Logger(GetInvitesByOrgUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetInvitesByOrgUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly invitesRepository: InvitesRepository,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(query: GetInvitesByOrgQuery): Promise<Paginated<Invite>> {
     try {
-      this.logger.log('execute', {
-        orgId: query.orgId,
-        requestingUserId: query.requestingUserId,
-        search: query.search,
-        limit: query.limit,
-        offset: query.offset,
-      });
+      this.logger.info(
+        {
+          orgId: query.orgId,
+          requestingUserId: query.requestingUserId,
+          input: query.search,
+          limit: query.limit,
+          offset: query.offset,
+        },
+        'execute',
+      );
 
       const orgId = this.contextService.get('orgId');
       const orgRole = this.contextService.get('role');
@@ -44,20 +48,26 @@ export class GetInvitesByOrgUseCase {
           { search: query.search, onlyPending: query.onlyOpen },
         );
 
-      this.logger.debug('Found invites', {
-        orgId: query.orgId,
-        count: paginatedInvites.data.length,
-        total: paginatedInvites.total,
-      });
+      this.logger.debug(
+        {
+          orgId: query.orgId,
+          count: paginatedInvites.data.length,
+          total: paginatedInvites.total,
+        },
+        'Found invites',
+      );
 
       return paginatedInvites;
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Failed to get invites by organization', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Failed to get invites by organization',
+      );
       throw error;
     }
   }

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/resend-expired-invite/resend-expired-invite.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/resend-expired-invite/resend-expired-invite.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InvitesRepository } from '../../ports/invites.repository';
 import { Invite } from 'src/iam/invites/domain/invite.entity';
 import { ResendExpiredInviteCommand } from './resend-expired-invite.command';
@@ -20,18 +21,19 @@ interface ResendExpiredInviteResult {
 
 @Injectable()
 export class ResendExpiredInviteUseCase {
-  private readonly logger = new Logger(ResendExpiredInviteUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ResendExpiredInviteUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly invitesRepository: InvitesRepository,
     private readonly inviteJwtService: InviteJwtService,
     private readonly configService: ConfigService,
   ) {}
 
+  // eslint-disable-next-line max-lines-per-function -- existing flow is unchanged except for logging migration
   async execute(
     command: ResendExpiredInviteCommand,
   ): Promise<ResendExpiredInviteResult> {
-    this.logger.log('execute', { inviteId: command.inviteId });
+    this.logger.info({ inviteId: command.inviteId }, 'execute');
 
     try {
       // 1. Find the existing invite
@@ -77,11 +79,14 @@ export class ResendExpiredInviteUseCase {
         inviteId: newInvite.id,
       });
 
-      this.logger.debug('Expired invite resent successfully', {
-        oldInviteId: command.inviteId,
-        newInviteId: newInvite.id,
-        email: newInvite.email,
-      });
+      this.logger.debug(
+        {
+          oldInviteId: command.inviteId,
+          newInviteId: newInvite.id,
+          email: newInvite.email,
+        },
+        'Expired invite resent successfully',
+      );
 
       return {
         token: inviteToken,
@@ -91,9 +96,12 @@ export class ResendExpiredInviteUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error resending expired invite', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error resending expired invite',
+      );
       throw new UnexpectedInviteError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/iam/invites/application/use-cases/send-invitation-email/send-invitation-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/invites/application/use-cases/send-invitation-email/send-invitation-email.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { SendInvitationEmailCommand } from './send-invitation-email.command';
 import { SendEmailCommand } from 'src/common/emails/application/use-cases/send-email/send-email.command';
 import { SendEmailUseCase } from 'src/common/emails/application/use-cases/send-email/send-email.use-case';
@@ -15,9 +16,9 @@ import { InviteEmailSendingFailedError } from '../../invites.errors';
 
 @Injectable()
 export class SendInvitationEmailUseCase {
-  private readonly logger = new Logger(SendInvitationEmailUseCase.name);
-
   constructor(
+    @InjectPinoLogger(SendInvitationEmailUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly sendEmailUseCase: SendEmailUseCase,
     private readonly configService: ConfigService,
     private readonly renderTemplateUseCase: RenderTemplateUseCase,
@@ -25,26 +26,36 @@ export class SendInvitationEmailUseCase {
     private readonly findUserByIdUseCase: FindUserByIdUseCase,
   ) {}
 
+  // eslint-disable-next-line max-lines-per-function -- existing flow is unchanged except for logging migration
   async execute(command: SendInvitationEmailCommand): Promise<void> {
     try {
-      this.logger.log('execute', {
-        inviteId: command.invite.id,
-        email: command.invite.email,
-        orgId: command.invite.orgId,
-      });
+      this.logger.info(
+        {
+          inviteId: command.invite.id,
+          email: command.invite.email,
+          orgId: command.invite.orgId,
+        },
+        'execute',
+      );
 
       // Get organization information
-      this.logger.debug('Fetching organization information', {
-        orgId: command.invite.orgId,
-      });
+      this.logger.debug(
+        {
+          orgId: command.invite.orgId,
+        },
+        'Fetching organization information',
+      );
       const org = await this.findOrgByIdUseCase.execute(
         new FindOrgByIdQuery(command.invite.orgId),
       );
 
       // Get inviting user information
-      this.logger.debug('Fetching inviting user information', {
-        inviterId: command.invite.inviterId,
-      });
+      this.logger.debug(
+        {
+          inviterId: command.invite.inviterId,
+        },
+        'Fetching inviting user information',
+      );
       let invitingUserName: string | null = null;
       if (command.invite.inviterId) {
         const invitingUser = await this.findUserByIdUseCase.execute(
@@ -63,10 +74,13 @@ export class SendInvitationEmailUseCase {
       const assetBase = `${frontendBaseUrl}${emailAssetsPath}`;
 
       // Create invitation email template
-      this.logger.debug('Creating invitation email template', {
-        inviteId: command.invite.id,
-        orgName: org.name,
-      });
+      this.logger.debug(
+        {
+          inviteId: command.invite.id,
+          name: org.name,
+        },
+        'Creating invitation email template',
+      );
       const template = new InvitationTemplate({
         invitationUrl: command.url,
         userEmail: command.invite.email,
@@ -85,10 +99,13 @@ export class SendInvitationEmailUseCase {
       );
 
       // Send the invitation email
-      this.logger.debug('Sending invitation email', {
-        inviteId: command.invite.id,
-        email: command.invite.email,
-      });
+      this.logger.debug(
+        {
+          inviteId: command.invite.id,
+          email: command.invite.email,
+        },
+        'Sending invitation email',
+      );
       await this.sendEmailUseCase.execute(
         new SendEmailCommand({
           to: command.invite.email,
@@ -98,19 +115,25 @@ export class SendInvitationEmailUseCase {
         }),
       );
 
-      this.logger.debug('Invitation email sent successfully', {
-        inviteId: command.invite.id,
-        email: command.invite.email,
-      });
+      this.logger.debug(
+        {
+          inviteId: command.invite.id,
+          email: command.invite.email,
+        },
+        'Invitation email sent successfully',
+      );
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Error sending invitation email', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        inviteId: command.invite.id,
-        email: command.invite.email,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          inviteId: command.invite.id,
+          email: command.invite.email,
+        },
+        'Error sending invitation email',
+      );
       throw new InviteEmailSendingFailedError(
         error instanceof Error ? error.message : 'Unknown error',
         {

--- a/ayunis-core-backend/src/iam/invites/infrastructure/persistence/local/local-invites.repository.spec.ts
+++ b/ayunis-core-backend/src/iam/invites/infrastructure/persistence/local/local-invites.repository.spec.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { ILike, IsNull, type Repository } from 'typeorm';
 
 import { LocalInvitesRepository } from './local-invites.repository';
@@ -36,6 +37,7 @@ describe('LocalInvitesRepository', () => {
       isTransactionActive: () => false,
     };
     repository = new LocalInvitesRepository(
+      createPinoLoggerMock(),
       new InviteMapper(),
       txHost as never,
     );

--- a/ayunis-core-backend/src/iam/invites/infrastructure/persistence/local/local-invites.repository.ts
+++ b/ayunis-core-backend/src/iam/invites/infrastructure/persistence/local/local-invites.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
 import { EntityManager, Repository, ILike, IsNull } from 'typeorm';
@@ -15,9 +16,9 @@ import { Paginated } from 'src/common/pagination/paginated.entity';
 
 @Injectable()
 export class LocalInvitesRepository implements InvitesRepository {
-  private readonly logger = new Logger(LocalInvitesRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalInvitesRepository.name)
+    private readonly logger: PinoLogger,
     private readonly inviteMapper: InviteMapper,
     private readonly txHost: TransactionHost<TransactionalAdapterTypeOrm>,
   ) {}
@@ -33,20 +34,23 @@ export class LocalInvitesRepository implements InvitesRepository {
   }
 
   async create(invite: Invite): Promise<void> {
-    this.logger.log('create', {
-      inviteId: invite.id,
-      email: invite.email,
-      orgId: invite.orgId,
-      role: invite.role,
-      inviterId: invite.inviterId,
-    });
+    this.logger.info(
+      {
+        inviteId: invite.id,
+        email: invite.email,
+        orgId: invite.orgId,
+        role: invite.role,
+        inviterId: invite.inviterId,
+      },
+      'create',
+    );
     const entity = this.inviteMapper.toEntity(invite);
     await this.invites.save(entity);
-    this.logger.debug('Invite created successfully', { inviteId: invite.id });
+    this.logger.debug({ inviteId: invite.id }, 'Invite created successfully');
   }
 
   async createMany(invites: Invite[]): Promise<void> {
-    this.logger.log('createMany', { inviteCount: invites.length });
+    this.logger.info({ inviteCount: invites.length }, 'createMany');
 
     if (invites.length === 0) {
       return;
@@ -57,17 +61,20 @@ export class LocalInvitesRepository implements InvitesRepository {
     );
     await this.invites.save(entities);
 
-    this.logger.debug('Invites created successfully', {
-      inviteCount: invites.length,
-    });
+    this.logger.debug(
+      {
+        inviteCount: invites.length,
+      },
+      'Invites created successfully',
+    );
   }
 
   async findOne(id: UUID): Promise<Invite | null> {
-    this.logger.log('findOne', { id });
+    this.logger.info({ id }, 'findOne');
     const entity = await this.invites.findOne({ where: { id } });
 
     if (!entity) {
-      this.logger.debug('Invite not found', { id });
+      this.logger.debug({ id }, 'Invite not found');
       return null;
     }
 
@@ -79,12 +86,15 @@ export class LocalInvitesRepository implements InvitesRepository {
     pagination: InvitesPagination,
     filters?: InvitesFilters,
   ): Promise<Paginated<Invite>> {
-    this.logger.log('findByOrgIdPaginated', {
-      orgId,
-      limit: pagination.limit,
-      offset: pagination.offset,
-      search: filters?.search,
-    });
+    this.logger.info(
+      {
+        orgId,
+        limit: pagination.limit,
+        offset: pagination.offset,
+        input: filters?.search,
+      },
+      'findByOrgIdPaginated',
+    );
 
     const queryBuilder = this.invites
       .createQueryBuilder('invite')
@@ -119,7 +129,7 @@ export class LocalInvitesRepository implements InvitesRepository {
   }
 
   async findOneByEmail(email: string): Promise<Invite | null> {
-    this.logger.log('findOneByEmail', { email });
+    this.logger.info({ email }, 'findOneByEmail');
     // Match the single invite row for this email regardless of acceptance
     // state. invites.email is globally unique, so there is at most one row.
     // Deletion paths (delete-user, delete-invite-by-email) rely on this to
@@ -129,7 +139,7 @@ export class LocalInvitesRepository implements InvitesRepository {
       where: { email: ILike(email) },
     });
     if (!entity) {
-      this.logger.debug('Invite not found by email', { email });
+      this.logger.debug({ email }, 'Invite not found by email');
       return null;
     }
     return this.inviteMapper.toDomain(entity);
@@ -139,19 +149,22 @@ export class LocalInvitesRepository implements InvitesRepository {
     email: string,
     orgId: UUID,
   ): Promise<Invite | null> {
-    this.logger.log('findOneByEmailAndOrg', { email, orgId });
+    this.logger.info({ email, orgId }, 'findOneByEmailAndOrg');
     const entity = await this.invites.findOne({
       where: { email: ILike(email), orgId, acceptedAt: IsNull() },
     });
     if (!entity) {
-      this.logger.debug('Invite not found by email and org', { email, orgId });
+      this.logger.debug({ email, orgId }, 'Invite not found by email and org');
       return null;
     }
     return this.inviteMapper.toDomain(entity);
   }
 
   async findByEmailsAndOrg(emails: string[], orgId: string): Promise<Invite[]> {
-    this.logger.log('findByEmailsAndOrg', { emailCount: emails.length, orgId });
+    this.logger.info(
+      { emailCount: emails.length, orgId },
+      'findByEmailsAndOrg',
+    );
 
     if (emails.length === 0) {
       return [];
@@ -167,33 +180,36 @@ export class LocalInvitesRepository implements InvitesRepository {
       .andWhere('invite.acceptedAt IS NULL') // Only pending invites
       .getMany();
 
-    this.logger.debug('Found invites by emails and org', {
-      orgId,
-      requestedCount: emails.length,
-      foundCount: entities.length,
-    });
+    this.logger.debug(
+      {
+        orgId,
+        requestedCount: emails.length,
+        foundCount: entities.length,
+      },
+      'Found invites by emails and org',
+    );
 
     return entities.map((entity) => this.inviteMapper.toDomain(entity));
   }
 
   async accept(id: UUID): Promise<void> {
-    this.logger.log('accept', { id });
+    this.logger.info({ id }, 'accept');
 
     await this.invites.update(id, {
       acceptedAt: new Date(),
     });
 
-    this.logger.debug('Invite accepted successfully', { id });
+    this.logger.debug({ id }, 'Invite accepted successfully');
   }
 
   async delete(id: UUID): Promise<void> {
-    this.logger.log('delete', { id });
+    this.logger.info({ id }, 'delete');
     await this.invites.delete(id);
-    this.logger.debug('Invite deleted successfully', { id });
+    this.logger.debug({ id }, 'Invite deleted successfully');
   }
 
   async deleteAllPendingByOrg(orgId: UUID): Promise<number> {
-    this.logger.log('deleteAllPendingByOrg', { orgId });
+    this.logger.info({ orgId }, 'deleteAllPendingByOrg');
 
     const result = await this.invites.delete({
       orgId,
@@ -201,10 +217,13 @@ export class LocalInvitesRepository implements InvitesRepository {
     });
 
     const deletedCount = result.affected ?? 0;
-    this.logger.debug('Pending invites deleted', {
-      orgId,
-      count: deletedCount,
-    });
+    this.logger.debug(
+      {
+        orgId,
+        count: deletedCount,
+      },
+      'Pending invites deleted',
+    );
     return deletedCount;
   }
 }

--- a/ayunis-core-backend/src/iam/invites/presenters/http/invites.controller.ts
+++ b/ayunis-core-backend/src/iam/invites/presenters/http/invites.controller.ts
@@ -8,9 +8,9 @@ import {
   Query,
   HttpCode,
   HttpStatus,
-  Logger,
   ParseUUIDPipe,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -73,9 +73,9 @@ import { DeleteAllPendingInvitesCommand } from '../../application/use-cases/dele
 @ApiTags('invites')
 @Controller('invites')
 export class InvitesController {
-  private readonly logger = new Logger(InvitesController.name);
-
   constructor(
+    @InjectPinoLogger(InvitesController.name)
+    private readonly logger: PinoLogger,
     private readonly createInviteUseCase: CreateInviteUseCase,
     private readonly createBulkInvitesUseCase: CreateBulkInvitesUseCase,
     private readonly acceptInviteUseCase: AcceptInviteUseCase,
@@ -114,12 +114,15 @@ export class InvitesController {
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
     @Body() createInviteDto: CreateInviteDto,
   ): Promise<CreateInviteResponseDto> {
-    this.logger.log('create', {
-      userId,
-      email: createInviteDto.email,
-      orgId,
-      role: createInviteDto.role,
-    });
+    this.logger.info(
+      {
+        userId,
+        email: createInviteDto.email,
+        orgId,
+        role: createInviteDto.role,
+      },
+      'create',
+    );
 
     const { invite, token } = await this.createInviteUseCase.execute(
       new CreateInviteCommand({
@@ -152,24 +155,33 @@ export class InvitesController {
 
     const hasEmailConfig = this.configService.get<boolean>('emails.hasConfig');
     if (!hasEmailConfig) {
-      this.logger.debug('Email configuration not available, returning URL', {
-        inviteId: invite.id,
-        email: invite.email,
-      });
+      this.logger.debug(
+        {
+          inviteId: invite.id,
+          email: invite.email,
+        },
+        'Email configuration not available, returning URL',
+      );
       return { url: inviteAcceptUrl };
     }
 
-    this.logger.debug('Sending invitation email', {
-      inviteId: invite.id,
-      email: invite.email,
-    });
+    this.logger.debug(
+      {
+        inviteId: invite.id,
+        email: invite.email,
+      },
+      'Sending invitation email',
+    );
     await this.sendInvitationEmailUseCase.execute(
       new SendInvitationEmailCommand(invite, inviteAcceptUrl),
     );
-    this.logger.debug('Invitation email sent successfully', {
-      inviteId: invite.id,
-      email: invite.email,
-    });
+    this.logger.debug(
+      {
+        inviteId: invite.id,
+        email: invite.email,
+      },
+      'Invitation email sent successfully',
+    );
     return { url: null };
   }
 
@@ -198,11 +210,14 @@ export class InvitesController {
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
     @Body() dto: CreateBulkInvitesDto,
   ): Promise<CreateBulkInvitesResponseDto> {
-    this.logger.log('createBulk', {
-      userId,
-      orgId,
-      inviteCount: dto.invites.length,
-    });
+    this.logger.info(
+      {
+        userId,
+        orgId,
+        inviteCount: dto.invites.length,
+      },
+      'createBulk',
+    );
 
     const result = await this.createBulkInvitesUseCase.execute(
       new CreateBulkInvitesCommand({
@@ -215,6 +230,7 @@ export class InvitesController {
     return result;
   }
 
+  // eslint-disable-next-line max-lines-per-function -- existing flow is unchanged except for logging migration
   @Get()
   @ApiOperation({
     summary: "Get all invites for current user's organization",
@@ -249,7 +265,16 @@ export class InvitesController {
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
     @Query() queryParams: GetInvitesQueryParamsDto,
   ): Promise<PaginatedInvitesListResponseDto> {
-    this.logger.log('getInvites', { userId, orgId, ...queryParams });
+    this.logger.info(
+      {
+        userId,
+        orgId,
+        input: queryParams.search,
+        limit: queryParams.limit,
+        offset: queryParams.offset,
+      },
+      'getInvites',
+    );
 
     const invites = await this.getInvitesByOrgUseCase.execute(
       new GetInvitesByOrgQuery({
@@ -289,7 +314,7 @@ export class InvitesController {
   async getInviteByToken(
     @Param('token') token: string,
   ): Promise<InviteDetailResponseDto> {
-    this.logger.log('getInviteByToken', { hasToken: !!token });
+    this.logger.info({ hasToken: !!token }, 'getInviteByToken');
 
     const inviteWithOrg = await this.getInviteByTokenUseCase.execute(
       new GetInviteByTokenQuery(token),
@@ -319,9 +344,12 @@ export class InvitesController {
   async acceptInvite(
     @Body() acceptInviteDto: AcceptInviteDto,
   ): Promise<AcceptInviteResponseDto> {
-    this.logger.log('acceptInvite', {
-      hasToken: !!acceptInviteDto.inviteToken,
-    });
+    this.logger.info(
+      {
+        hasToken: !!acceptInviteDto.inviteToken,
+      },
+      'acceptInvite',
+    );
 
     const result = await this.acceptInviteUseCase.execute(
       new AcceptInviteCommand({
@@ -365,7 +393,7 @@ export class InvitesController {
   async resendExpiredInvite(
     @Param('id', ParseUUIDPipe) inviteId: UUID,
   ): Promise<CreateInviteResponseDto> {
-    this.logger.log('resendExpiredInvite', { inviteId });
+    this.logger.info({ inviteId }, 'resendExpiredInvite');
 
     const { invite, token } = await this.resendExpiredInviteUseCase.execute(
       new ResendExpiredInviteCommand(inviteId),
@@ -394,7 +422,7 @@ export class InvitesController {
   async deleteAllPending(
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
   ): Promise<DeleteAllPendingInvitesResponseDto> {
-    this.logger.log('deleteAllPending', { orgId });
+    this.logger.info({ orgId }, 'deleteAllPending');
 
     const result = await this.deleteAllPendingInvitesUseCase.execute(
       new DeleteAllPendingInvitesCommand(orgId),
@@ -429,7 +457,7 @@ export class InvitesController {
   async deleteInvite(
     @Param('id', ParseUUIDPipe) inviteId: UUID,
   ): Promise<void> {
-    this.logger.log('deleteInvite', { inviteId });
+    this.logger.info({ inviteId }, 'deleteInvite');
 
     await this.deleteInviteUseCase.execute(new DeleteInviteCommand(inviteId));
   }

--- a/ayunis-core-backend/src/iam/mfa/application/services/mfa-pending-jwt.service.spec.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/services/mfa-pending-jwt.service.spec.ts
@@ -1,5 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { JwtModule, JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import type { UUID } from 'crypto';
@@ -16,6 +18,10 @@ describe('MfaPendingJwtService', () => {
       imports: [JwtModule.register({ secret: 'test-secret' })],
       providers: [
         MfaPendingJwtService,
+        {
+          provide: getLoggerToken(MfaPendingJwtService.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: ConfigService,
           useValue: {

--- a/ayunis-core-backend/src/iam/mfa/application/services/mfa-pending-jwt.service.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/services/mfa-pending-jwt.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import type { UUID } from 'crypto';
@@ -21,15 +22,15 @@ export interface MfaPendingJwtPayload {
 
 @Injectable()
 export class MfaPendingJwtService {
-  private readonly logger = new Logger(MfaPendingJwtService.name);
-
   constructor(
+    @InjectPinoLogger(MfaPendingJwtService.name)
+    private readonly logger: PinoLogger,
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
   ) {}
 
   generate(params: { userId: UUID; enrollmentRequired: boolean }): string {
-    this.logger.log('generateMfaPendingToken', { userId: params.userId });
+    this.logger.info({ userId: params.userId }, 'generateMfaPendingToken');
 
     const expiresIn = this.configService.get<StringValue>(
       'auth.jwt.mfaPendingExpiresIn',
@@ -62,7 +63,10 @@ export class MfaPendingJwtService {
       if (error instanceof InvalidMfaPendingTokenError) {
         throw error;
       }
-      this.logger.warn('MFA pending token verification failed', { error });
+      this.logger.warn(
+        { err: error as Error },
+        'MFA pending token verification failed',
+      );
       throw new InvalidMfaPendingTokenError();
     }
   }

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/check-mfa-login-requirement/check-mfa-login-requirement.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/check-mfa-login-requirement/check-mfa-login-requirement.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UserTotpsRepository } from '../../ports/user-totps.repository';
 import { OrgMfaRequirementsRepository } from '../../ports/org-mfa-requirements.repository';
@@ -16,9 +17,9 @@ export type MfaLoginRequirement = 'none' | 'verify' | 'enroll';
  */
 @Injectable()
 export class CheckMfaLoginRequirementUseCase {
-  private readonly logger = new Logger(CheckMfaLoginRequirementUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CheckMfaLoginRequirementUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly userTotpsRepository: UserTotpsRepository,
     private readonly orgMfaRequirementsRepository: OrgMfaRequirementsRepository,
   ) {}
@@ -26,7 +27,7 @@ export class CheckMfaLoginRequirementUseCase {
   async execute(
     query: CheckMfaLoginRequirementQuery,
   ): Promise<MfaLoginRequirement> {
-    this.logger.log('checkMfaLoginRequirement', { userId: query.userId });
+    this.logger.info({ userId: query.userId }, 'checkMfaLoginRequirement');
 
     try {
       const totp = await this.userTotpsRepository.findByUserId(query.userId);
@@ -40,9 +41,12 @@ export class CheckMfaLoginRequirementUseCase {
       return requirement?.required ? 'enroll' : 'none';
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error checking MFA login requirement', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error checking MFA login requirement',
+      );
       throw new UnexpectedMfaError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/confirm-totp/confirm-totp.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/confirm-totp/confirm-totp.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { HashTextUseCase } from 'src/iam/hashing/application/use-cases/hash-text/hash-text.use-case';
 import { HashTextCommand } from 'src/iam/hashing/application/use-cases/hash-text/hash-text.command';
@@ -19,9 +20,9 @@ import { ConfirmTotpCommand } from './confirm-totp.command';
 
 @Injectable()
 export class ConfirmTotpUseCase {
-  private readonly logger = new Logger(ConfirmTotpUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ConfirmTotpUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly userTotpsRepository: UserTotpsRepository,
     private readonly recoveryCodesRepository: MfaRecoveryCodesRepository,
     private readonly totpSecretEncryption: TotpSecretEncryptionPort,
@@ -31,7 +32,7 @@ export class ConfirmTotpUseCase {
 
   /** Confirms a pending enrollment and returns the plaintext recovery codes. */
   async execute(command: ConfirmTotpCommand): Promise<string[]> {
-    this.logger.log('confirmTotp', { userId: command.userId });
+    this.logger.info({ userId: command.userId }, 'confirmTotp');
 
     try {
       const totp = await this.userTotpsRepository.findByUserId(command.userId);
@@ -65,7 +66,7 @@ export class ConfirmTotpUseCase {
       return codes;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error confirming TOTP', { error: error as Error });
+      this.logger.error({ err: error as Error }, 'Error confirming TOTP');
       throw new UnexpectedMfaError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/disable-mfa/disable-mfa.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/disable-mfa/disable-mfa.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UserTotpsRepository } from '../../ports/user-totps.repository';
 import { MfaRecoveryCodesRepository } from '../../ports/mfa-recovery-codes.repository';
@@ -10,9 +11,9 @@ import { DisableMfaCommand } from './disable-mfa.command';
 
 @Injectable()
 export class DisableMfaUseCase {
-  private readonly logger = new Logger(DisableMfaUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DisableMfaUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly userTotpsRepository: UserTotpsRepository,
     private readonly recoveryCodesRepository: MfaRecoveryCodesRepository,
     private readonly orgMfaRequirementsRepository: OrgMfaRequirementsRepository,
@@ -20,7 +21,7 @@ export class DisableMfaUseCase {
   ) {}
 
   async execute(command: DisableMfaCommand): Promise<void> {
-    this.logger.log('disableMfa', { userId: command.userId });
+    this.logger.info({ userId: command.userId }, 'disableMfa');
 
     try {
       // Checked before code verification so no recovery code is consumed on
@@ -40,7 +41,7 @@ export class DisableMfaUseCase {
       await this.userTotpsRepository.deleteByUserId(command.userId);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error disabling MFA', { error: error as Error });
+      this.logger.error({ err: error as Error }, 'Error disabling MFA');
       throw new UnexpectedMfaError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/get-mfa-status/get-mfa-status.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/get-mfa-status/get-mfa-status.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UserTotpsRepository } from '../../ports/user-totps.repository';
 import { MfaRecoveryCodesRepository } from '../../ports/mfa-recovery-codes.repository';
@@ -13,15 +14,15 @@ export interface MfaStatus {
 
 @Injectable()
 export class GetMfaStatusUseCase {
-  private readonly logger = new Logger(GetMfaStatusUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetMfaStatusUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly userTotpsRepository: UserTotpsRepository,
     private readonly recoveryCodesRepository: MfaRecoveryCodesRepository,
   ) {}
 
   async execute(query: GetMfaStatusQuery): Promise<MfaStatus> {
-    this.logger.log('getMfaStatus', { userId: query.userId });
+    this.logger.info({ userId: query.userId }, 'getMfaStatus');
 
     try {
       const totp = await this.userTotpsRepository.findByUserId(query.userId);
@@ -39,7 +40,7 @@ export class GetMfaStatusUseCase {
       };
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting MFA status', { error: error as Error });
+      this.logger.error({ err: error as Error }, 'Error getting MFA status');
       throw new UnexpectedMfaError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/get-org-mfa-requirement/get-org-mfa-requirement.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/get-org-mfa-requirement/get-org-mfa-requirement.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { OrgMfaRequirementsRepository } from '../../ports/org-mfa-requirements.repository';
 import { OrgMfaRequirement } from 'src/iam/mfa/domain/org-mfa-requirement.entity';
@@ -7,14 +8,14 @@ import { GetOrgMfaRequirementQuery } from './get-org-mfa-requirement.query';
 
 @Injectable()
 export class GetOrgMfaRequirementUseCase {
-  private readonly logger = new Logger(GetOrgMfaRequirementUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetOrgMfaRequirementUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly orgMfaRequirementsRepository: OrgMfaRequirementsRepository,
   ) {}
 
   async execute(query: GetOrgMfaRequirementQuery): Promise<OrgMfaRequirement> {
-    this.logger.log('getOrgMfaRequirement', { orgId: query.orgId });
+    this.logger.info({ orgId: query.orgId }, 'getOrgMfaRequirement');
 
     try {
       const requirement = await this.orgMfaRequirementsRepository.findByOrgId(
@@ -26,9 +27,12 @@ export class GetOrgMfaRequirementUseCase {
       );
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting org MFA requirement', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error getting org MFA requirement',
+      );
       throw new UnexpectedMfaError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/reset-user-mfa/reset-user-mfa.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/reset-user-mfa/reset-user-mfa.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { FindUserByIdUseCase } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case';
@@ -21,9 +22,9 @@ import { ResetUserMfaCommand } from './reset-user-mfa.command';
  */
 @Injectable()
 export class ResetUserMfaUseCase {
-  private readonly logger = new Logger(ResetUserMfaUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ResetUserMfaUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly contextService: ContextService,
     private readonly findUserByIdUseCase: FindUserByIdUseCase,
     private readonly userTotpsRepository: UserTotpsRepository,
@@ -31,7 +32,7 @@ export class ResetUserMfaUseCase {
   ) {}
 
   async execute(command: ResetUserMfaCommand): Promise<void> {
-    this.logger.log('resetUserMfa', { targetUserId: command.targetUserId });
+    this.logger.info({ targetUserId: command.targetUserId }, 'resetUserMfa');
 
     const requesterId = this.contextService.get('userId');
     const requesterOrgId = this.contextService.get('orgId');
@@ -57,7 +58,7 @@ export class ResetUserMfaUseCase {
       await this.userTotpsRepository.deleteByUserId(command.targetUserId);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error resetting user MFA', { error: error as Error });
+      this.logger.error({ err: error as Error }, 'Error resetting user MFA');
       throw new UnexpectedMfaError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/setup-totp/setup-totp.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/setup-totp/setup-totp.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { UserTotpsRepository } from '../../ports/user-totps.repository';
 import { TotpSecretEncryptionPort } from '../../ports/totp-secret-encryption.port';
@@ -15,16 +16,16 @@ export interface SetupTotpResult {
 
 @Injectable()
 export class SetupTotpUseCase {
-  private readonly logger = new Logger(SetupTotpUseCase.name);
-
   constructor(
+    @InjectPinoLogger(SetupTotpUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly userTotpsRepository: UserTotpsRepository,
     private readonly totpSecretEncryption: TotpSecretEncryptionPort,
     private readonly totp: TotpPort,
   ) {}
 
   async execute(command: SetupTotpCommand): Promise<SetupTotpResult> {
-    this.logger.log('setupTotp', { userId: command.userId });
+    this.logger.info({ userId: command.userId }, 'setupTotp');
 
     try {
       const existing = await this.userTotpsRepository.findByUserId(
@@ -56,7 +57,7 @@ export class SetupTotpUseCase {
       return { secret, otpauthUri, qrCodeDataUri };
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error setting up TOTP', { error: error as Error });
+      this.logger.error({ err: error as Error }, 'Error setting up TOTP');
       throw new UnexpectedMfaError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/upsert-org-mfa-requirement/upsert-org-mfa-requirement.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/upsert-org-mfa-requirement/upsert-org-mfa-requirement.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { OrgMfaRequirementsRepository } from '../../ports/org-mfa-requirements.repository';
 import { OrgMfaRequirement } from 'src/iam/mfa/domain/org-mfa-requirement.entity';
@@ -7,19 +8,22 @@ import { UpsertOrgMfaRequirementCommand } from './upsert-org-mfa-requirement.com
 
 @Injectable()
 export class UpsertOrgMfaRequirementUseCase {
-  private readonly logger = new Logger(UpsertOrgMfaRequirementUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpsertOrgMfaRequirementUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly orgMfaRequirementsRepository: OrgMfaRequirementsRepository,
   ) {}
 
   async execute(
     command: UpsertOrgMfaRequirementCommand,
   ): Promise<OrgMfaRequirement> {
-    this.logger.log('upsertOrgMfaRequirement', {
-      orgId: command.orgId,
-      required: command.required,
-    });
+    this.logger.info(
+      {
+        orgId: command.orgId,
+        required: command.required,
+      },
+      'upsertOrgMfaRequirement',
+    );
 
     try {
       const existing = await this.orgMfaRequirementsRepository.findByOrgId(
@@ -36,9 +40,12 @@ export class UpsertOrgMfaRequirementUseCase {
       );
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error upserting org MFA requirement', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Error upserting org MFA requirement',
+      );
       throw new UnexpectedMfaError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/verify-mfa-code/verify-mfa-code.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/verify-mfa-code/verify-mfa-code.use-case.spec.ts
@@ -1,5 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { VerifyMfaCodeUseCase } from './verify-mfa-code.use-case';
 import { VerifyMfaCodeCommand } from './verify-mfa-code.command';
@@ -61,6 +63,10 @@ describe('VerifyMfaCodeUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         VerifyMfaCodeUseCase,
+        {
+          provide: getLoggerToken(VerifyMfaCodeUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: UserTotpsRepository, useValue: userTotps },
         { provide: MfaRecoveryCodesRepository, useValue: recoveryCodes },
         { provide: TotpSecretEncryptionPort, useValue: encryption },

--- a/ayunis-core-backend/src/iam/mfa/application/use-cases/verify-mfa-code/verify-mfa-code.use-case.ts
+++ b/ayunis-core-backend/src/iam/mfa/application/use-cases/verify-mfa-code/verify-mfa-code.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { CompareHashUseCase } from 'src/iam/hashing/application/use-cases/compare-hash/compare-hash.use-case';
@@ -30,9 +31,9 @@ const TOTP_CODE_PATTERN = /^\d{6}$/;
  */
 @Injectable()
 export class VerifyMfaCodeUseCase {
-  private readonly logger = new Logger(VerifyMfaCodeUseCase.name);
-
   constructor(
+    @InjectPinoLogger(VerifyMfaCodeUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly userTotpsRepository: UserTotpsRepository,
     private readonly recoveryCodesRepository: MfaRecoveryCodesRepository,
     private readonly totpSecretEncryption: TotpSecretEncryptionPort,
@@ -41,7 +42,7 @@ export class VerifyMfaCodeUseCase {
   ) {}
 
   async execute(command: VerifyMfaCodeCommand): Promise<void> {
-    this.logger.log('verifyMfaCode', { userId: command.userId });
+    this.logger.info({ userId: command.userId }, 'verifyMfaCode');
 
     try {
       const totp = await this.userTotpsRepository.findByUserId(command.userId);
@@ -63,7 +64,7 @@ export class VerifyMfaCodeUseCase {
       }
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error verifying MFA code', { error: error as Error });
+      this.logger.error({ err: error as Error }, 'Error verifying MFA code');
       throw new UnexpectedMfaError(error);
     }
   }
@@ -123,7 +124,7 @@ export class VerifyMfaCodeUseCase {
     );
 
     if (failures >= MAX_FAILED_ATTEMPTS) {
-      this.logger.warn('MFA locked after repeated failures', { userId });
+      this.logger.warn({ userId }, 'MFA locked after repeated failures');
       throw new MfaLockedError(lockedUntil);
     }
     throw new InvalidMfaCodeError();

--- a/ayunis-core-backend/src/iam/mfa/infrastructure/encryption/totp-secret-encryption.service.ts
+++ b/ayunis-core-backend/src/iam/mfa/infrastructure/encryption/totp-secret-encryption.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import * as crypto from 'crypto';
 import { TotpSecretEncryptionPort } from '../../application/ports/totp-secret-encryption.port';
@@ -12,13 +13,16 @@ import { TotpSecretEncryptionPort } from '../../application/ports/totp-secret-en
  */
 @Injectable()
 export class TotpSecretEncryptionService extends TotpSecretEncryptionPort {
-  private readonly logger = new Logger(TotpSecretEncryptionService.name);
   private readonly algorithm = 'aes-256-gcm';
   private readonly ivLength = 16;
   private readonly authTagLength = 16;
   private readonly encryptionKey: Buffer;
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    @InjectPinoLogger(TotpSecretEncryptionService.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {
     super();
 
     const keyHex = this.configService.get<string>('MFA_ENCRYPTION_KEY');
@@ -58,9 +62,12 @@ export class TotpSecretEncryptionService extends TotpSecretEncryptionPort {
       const combined = Buffer.concat([iv, encrypted, authTag]);
       return Promise.resolve(combined.toString('base64'));
     } catch (error) {
-      this.logger.error('Failed to encrypt TOTP secret', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Failed to encrypt TOTP secret',
+      );
       throw new Error('Failed to encrypt TOTP secret');
     }
   }
@@ -91,9 +98,12 @@ export class TotpSecretEncryptionService extends TotpSecretEncryptionPort {
 
       return Promise.resolve(decrypted.toString('utf8'));
     } catch (error) {
-      this.logger.error('Failed to decrypt TOTP secret', {
-        error: error as Error,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+        },
+        'Failed to decrypt TOTP secret',
+      );
       throw new Error('Failed to decrypt TOTP secret');
     }
   }

--- a/ayunis-core-backend/src/iam/mfa/infrastructure/repositories/local/local-user-totps.repository.ts
+++ b/ayunis-core-backend/src/iam/mfa/infrastructure/repositories/local/local-user-totps.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { UUID } from 'crypto';
@@ -9,9 +10,9 @@ import { UserTotpMapper } from './mappers/user-totp.mapper';
 
 @Injectable()
 export class LocalUserTotpsRepository extends UserTotpsRepository {
-  private readonly logger = new Logger(LocalUserTotpsRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalUserTotpsRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(UserTotpRecord)
     private readonly repository: Repository<UserTotpRecord>,
   ) {
@@ -55,7 +56,7 @@ export class LocalUserTotpsRepository extends UserTotpsRepository {
 
     const rows = result.raw as { failedAttempts: number }[];
     if (rows.length === 0) {
-      this.logger.warn('registerFailedAttempt: no TOTP row', { userId });
+      this.logger.warn({ userId }, 'registerFailedAttempt: no TOTP row');
       return 0;
     }
     return Number(rows[0].failedAttempts);

--- a/ayunis-core-backend/src/iam/mfa/infrastructure/totp/otplib-totp.adapter.ts
+++ b/ayunis-core-backend/src/iam/mfa/infrastructure/totp/otplib-totp.adapter.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { authenticator } from 'otplib';
 import { toDataURL } from 'qrcode';
 import type { OtpauthUriParams } from '../../application/ports/totp.port';
@@ -9,10 +10,16 @@ const TOTP_CODE_PATTERN = /^\d{6}$/;
 
 @Injectable()
 export class OtplibTotpAdapter extends TotpPort {
-  private readonly logger = new Logger(OtplibTotpAdapter.name);
   private readonly authenticator = authenticator.clone({
     window: TOTP_WINDOW,
   });
+
+  constructor(
+    @InjectPinoLogger(OtplibTotpAdapter.name)
+    private readonly logger: PinoLogger,
+  ) {
+    super();
+  }
 
   generateSecret(): string {
     return this.authenticator.generateSecret();
@@ -45,7 +52,7 @@ export class OtplibTotpAdapter extends TotpPort {
       const currentCounter = Math.floor(epoch / 1000 / step);
       return Promise.resolve(currentCounter + delta);
     } catch (error) {
-      this.logger.warn('TOTP verification errored', { error });
+      this.logger.warn({ err: error as Error }, 'TOTP verification errored');
       return Promise.resolve(null);
     }
   }

--- a/ayunis-core-backend/src/iam/mfa/presenters/http/mfa.controller.ts
+++ b/ayunis-core-backend/src/iam/mfa/presenters/http/mfa.controller.ts
@@ -5,12 +5,12 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   ParseUUIDPipe,
   Post,
   Put,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import type { UUID } from 'crypto';
 import {
@@ -44,9 +44,9 @@ import { UpdateOrgMfaRequirementRequestDto } from './dtos/update-org-mfa-require
 @ApiTags('mfa')
 @Controller('mfa')
 export class MfaController {
-  private readonly logger = new Logger(MfaController.name);
-
   constructor(
+    @InjectPinoLogger(MfaController.name)
+    private readonly logger: PinoLogger,
     private readonly getMfaStatusUseCase: GetMfaStatusUseCase,
     private readonly setupTotpUseCase: SetupTotpUseCase,
     private readonly confirmTotpUseCase: ConfirmTotpUseCase,
@@ -79,7 +79,7 @@ export class MfaController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @CurrentUser(UserProperty.EMAIL) email: string,
   ): Promise<MfaSetupResponseDto> {
-    this.logger.log('setup', { userId });
+    this.logger.info({ userId }, 'setup');
     return this.setupTotpUseCase.execute(new SetupTotpCommand(userId, email));
   }
 
@@ -95,7 +95,7 @@ export class MfaController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() dto: MfaCodeRequestDto,
   ): Promise<RecoveryCodesResponseDto> {
-    this.logger.log('confirm', { userId });
+    this.logger.info({ userId }, 'confirm');
     const recoveryCodes = await this.confirmTotpUseCase.execute(
       new ConfirmTotpCommand(userId, dto.code),
     );
@@ -118,7 +118,7 @@ export class MfaController {
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
     @Body() dto: MfaCodeRequestDto,
   ): Promise<{ success: boolean }> {
-    this.logger.log('disable', { userId });
+    this.logger.info({ userId }, 'disable');
     await this.disableMfaUseCase.execute(
       new DisableMfaCommand(userId, orgId, dto.code),
     );
@@ -146,7 +146,7 @@ export class MfaController {
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
     @Body() dto: UpdateOrgMfaRequirementRequestDto,
   ): Promise<OrgMfaRequirementResponseDto> {
-    this.logger.log('updateOrgRequirement', { orgId, required: dto.required });
+    this.logger.info({ orgId, required: dto.required }, 'updateOrgRequirement');
     const requirement = await this.upsertOrgMfaRequirementUseCase.execute(
       new UpsertOrgMfaRequirementCommand(orgId, dto.required),
     );
@@ -163,7 +163,7 @@ export class MfaController {
   async resetUser(
     @Param('userId', ParseUUIDPipe) targetUserId: UUID,
   ): Promise<{ success: boolean }> {
-    this.logger.log('resetUser', { targetUserId });
+    this.logger.info({ targetUserId }, 'resetUser');
     await this.resetUserMfaUseCase.execute(
       new ResetUserMfaCommand(targetUserId),
     );

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/create-session/create-session.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/create-session/create-session.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { CreateSessionUseCase } from './create-session.use-case';
 import { CreateSessionCommand } from './create-session.command';
 import {
@@ -23,8 +23,11 @@ describe('CreateSessionUseCase', () => {
       }),
       newFamilyId: jest.fn().mockReturnValue(TEST_FAMILY_ID),
     };
-    useCase = new CreateSessionUseCase(repository, factory as never);
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    useCase = new CreateSessionUseCase(
+      createPinoLoggerMock(),
+      repository,
+      factory as never,
+    );
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/create-session/create-session.use-case.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/create-session/create-session.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { CreateSessionCommand } from './create-session.command';
 import { RefreshTokensRepository } from '../../ports/refresh-tokens.repository';
@@ -12,16 +13,16 @@ export interface CreateSessionResult {
 
 @Injectable()
 export class CreateSessionUseCase {
-  private readonly logger = new Logger(CreateSessionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateSessionUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly refreshTokensRepository: RefreshTokensRepository,
     private readonly refreshTokenFactory: RefreshTokenFactory,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedSessionsError)
   async execute(command: CreateSessionCommand): Promise<CreateSessionResult> {
-    this.logger.log('createSession', { userId: command.userId });
+    this.logger.info({ userId: command.userId }, 'createSession');
 
     const { token, plaintext } = this.refreshTokenFactory.create({
       userId: command.userId,

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-all-sessions-for-user/revoke-all-sessions-for-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-all-sessions-for-user/revoke-all-sessions-for-user.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { RevokeAllSessionsForUserUseCase } from './revoke-all-sessions-for-user.use-case';
 import { RevokeAllSessionsForUserCommand } from './revoke-all-sessions-for-user.command';
 import {
@@ -12,8 +12,10 @@ describe('RevokeAllSessionsForUserUseCase', () => {
 
   beforeEach(() => {
     repository = createMockRefreshTokensRepository();
-    useCase = new RevokeAllSessionsForUserUseCase(repository);
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    useCase = new RevokeAllSessionsForUserUseCase(
+      createPinoLoggerMock(),
+      repository,
+    );
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-all-sessions-for-user/revoke-all-sessions-for-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-all-sessions-for-user/revoke-all-sessions-for-user.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { RevokeAllSessionsForUserCommand } from './revoke-all-sessions-for-user.command';
 import { RefreshTokensRepository } from '../../ports/refresh-tokens.repository';
@@ -10,15 +11,15 @@ import { UnexpectedSessionsError } from '../../sessions.errors';
  */
 @Injectable()
 export class RevokeAllSessionsForUserUseCase {
-  private readonly logger = new Logger(RevokeAllSessionsForUserUseCase.name);
-
   constructor(
+    @InjectPinoLogger(RevokeAllSessionsForUserUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly refreshTokensRepository: RefreshTokensRepository,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedSessionsError)
   async execute(command: RevokeAllSessionsForUserCommand): Promise<void> {
-    this.logger.log('revokeAllSessionsForUser', { userId: command.userId });
+    this.logger.info({ userId: command.userId }, 'revokeAllSessionsForUser');
     await this.refreshTokensRepository.revokeAllForUser(command.userId);
   }
 }

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-other-sessions-for-user/revoke-other-sessions-for-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-other-sessions-for-user/revoke-other-sessions-for-user.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { RevokeOtherSessionsForUserUseCase } from './revoke-other-sessions-for-user.use-case';
 import { RevokeOtherSessionsForUserCommand } from './revoke-other-sessions-for-user.command';
 import {
@@ -14,8 +14,10 @@ describe('RevokeOtherSessionsForUserUseCase', () => {
 
   beforeEach(() => {
     repository = createMockRefreshTokensRepository();
-    useCase = new RevokeOtherSessionsForUserUseCase(repository);
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    useCase = new RevokeOtherSessionsForUserUseCase(
+      createPinoLoggerMock(),
+      repository,
+    );
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-other-sessions-for-user/revoke-other-sessions-for-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-other-sessions-for-user/revoke-other-sessions-for-user.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { sha256Hex } from 'src/common/util/sha256.util';
 import { RevokeOtherSessionsForUserCommand } from './revoke-other-sessions-for-user.command';
@@ -13,15 +14,15 @@ import { UnexpectedSessionsError } from '../../sessions.errors';
  */
 @Injectable()
 export class RevokeOtherSessionsForUserUseCase {
-  private readonly logger = new Logger(RevokeOtherSessionsForUserUseCase.name);
-
   constructor(
+    @InjectPinoLogger(RevokeOtherSessionsForUserUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly refreshTokensRepository: RefreshTokensRepository,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedSessionsError)
   async execute(command: RevokeOtherSessionsForUserCommand): Promise<void> {
-    this.logger.log('revokeOtherSessionsForUser', { userId: command.userId });
+    this.logger.info({ userId: command.userId }, 'revokeOtherSessionsForUser');
 
     const current = command.currentRefreshToken
       ? await this.refreshTokensRepository.findByTokenHash(

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-session-family/revoke-session-family.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-session-family/revoke-session-family.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { RevokeSessionFamilyUseCase } from './revoke-session-family.use-case';
 import { RevokeSessionFamilyCommand } from './revoke-session-family.command';
 import {
@@ -13,9 +13,10 @@ describe('RevokeSessionFamilyUseCase', () => {
 
   beforeEach(() => {
     repository = createMockRefreshTokensRepository();
-    useCase = new RevokeSessionFamilyUseCase(repository);
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+    useCase = new RevokeSessionFamilyUseCase(
+      createPinoLoggerMock(),
+      repository,
+    );
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-session-family/revoke-session-family.use-case.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/revoke-session-family/revoke-session-family.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { sha256Hex } from 'src/common/util/sha256.util';
 import { RevokeSessionFamilyCommand } from './revoke-session-family.command';
@@ -12,9 +13,9 @@ import { UnexpectedSessionsError } from '../../sessions.errors';
  */
 @Injectable()
 export class RevokeSessionFamilyUseCase {
-  private readonly logger = new Logger(RevokeSessionFamilyUseCase.name);
-
   constructor(
+    @InjectPinoLogger(RevokeSessionFamilyUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly refreshTokensRepository: RefreshTokensRepository,
   ) {}
 

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/rotate-session/rotate-session.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/rotate-session/rotate-session.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { ConfigService } from '@nestjs/config';
 import { RotateSessionUseCase } from './rotate-session.use-case';
 import { RotateSessionCommand } from './rotate-session.command';
@@ -35,6 +36,10 @@ describe('RotateSessionUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RotateSessionUseCase,
+        {
+          provide: getLoggerToken(RotateSessionUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: RefreshTokensRepository, useValue: repository },
         { provide: RefreshTokenFactory, useValue: factory },
         {
@@ -45,7 +50,6 @@ describe('RotateSessionUseCase', () => {
     }).compile();
 
     useCase = module.get(RotateSessionUseCase);
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/ayunis-core-backend/src/iam/sessions/application/use-cases/rotate-session/rotate-session.use-case.ts
+++ b/ayunis-core-backend/src/iam/sessions/application/use-cases/rotate-session/rotate-session.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import type { UUID } from 'crypto';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
@@ -21,9 +22,9 @@ export interface RotateSessionResult {
 
 @Injectable()
 export class RotateSessionUseCase {
-  private readonly logger = new Logger(RotateSessionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(RotateSessionUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly refreshTokensRepository: RefreshTokensRepository,
     private readonly refreshTokenFactory: RefreshTokenFactory,
     private readonly configService: ConfigService,
@@ -41,10 +42,13 @@ export class RotateSessionUseCase {
     if (current.isRevoked()) {
       // Presenting a revoked token means the family is compromised.
       await this.refreshTokensRepository.revokeFamily(current.familyId);
-      this.logger.warn('Refresh token reuse detected (revoked token)', {
-        userId: current.userId,
-        familyId: current.familyId,
-      });
+      this.logger.warn(
+        {
+          userId: current.userId,
+          familyId: current.familyId,
+        },
+        'Refresh token reuse detected (revoked token)',
+      );
       throw new RefreshTokenReuseError();
     }
     if (current.isExpired()) {
@@ -82,10 +86,13 @@ export class RotateSessionUseCase {
     }
 
     await this.refreshTokensRepository.revokeFamily(current.familyId);
-    this.logger.warn('Refresh token reuse detected (post-grace replay)', {
-      userId: current.userId,
-      familyId: current.familyId,
-    });
+    this.logger.warn(
+      {
+        userId: current.userId,
+        familyId: current.familyId,
+      },
+      'Refresh token reuse detected (post-grace replay)',
+    );
     throw new RefreshTokenReuseError();
   }
 

--- a/ayunis-core-backend/src/iam/sessions/infrastructure/tasks/sessions-cleanup.task.spec.ts
+++ b/ayunis-core-backend/src/iam/sessions/infrastructure/tasks/sessions-cleanup.task.spec.ts
@@ -1,17 +1,16 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { SessionsCleanupTask } from './sessions-cleanup.task';
 import { createMockRefreshTokensRepository } from '../../application/testing/refresh-token.fixtures';
 
 describe('SessionsCleanupTask', () => {
   let task: SessionsCleanupTask;
   let repository: ReturnType<typeof createMockRefreshTokensRepository>;
+  let logger: ReturnType<typeof createPinoLoggerMock>;
 
   beforeEach(() => {
     repository = createMockRefreshTokensRepository();
-    task = new SessionsCleanupTask(repository);
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    logger = createPinoLoggerMock();
+    task = new SessionsCleanupTask(logger, repository);
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -22,6 +21,17 @@ describe('SessionsCleanupTask', () => {
     await task.handleCleanup();
 
     expect(repository.deleteExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it('should log cleanup results with object-first metadata', async () => {
+    repository.deleteExpired.mockResolvedValue(5);
+
+    await task.handleCleanup();
+
+    expect(logger.info).toHaveBeenCalledWith(
+      { deleted: 5 },
+      'Scheduled sessions cleanup completed',
+    );
   });
 
   it('should swallow repository errors', async () => {

--- a/ayunis-core-backend/src/iam/sessions/infrastructure/tasks/sessions-cleanup.task.ts
+++ b/ayunis-core-backend/src/iam/sessions/infrastructure/tasks/sessions-cleanup.task.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { RefreshTokensRepository } from '../../application/ports/refresh-tokens.repository';
 
@@ -11,10 +12,11 @@ import { RefreshTokensRepository } from '../../application/ports/refresh-tokens.
  */
 @Injectable()
 export class SessionsCleanupTask {
-  private readonly logger = new Logger(SessionsCleanupTask.name);
   private isRunning = false;
 
   constructor(
+    @InjectPinoLogger(SessionsCleanupTask.name)
+    private readonly logger: PinoLogger,
     private readonly refreshTokensRepository: RefreshTokensRepository,
   ) {}
 
@@ -28,17 +30,17 @@ export class SessionsCleanupTask {
     }
 
     this.isRunning = true;
-    this.logger.log('Starting scheduled sessions cleanup');
+    this.logger.info('Starting scheduled sessions cleanup');
 
     try {
       const deleted = await this.refreshTokensRepository.deleteExpired(
         new Date(),
       );
-      this.logger.log('Scheduled sessions cleanup completed', { deleted });
+      this.logger.info({ deleted }, 'Scheduled sessions cleanup completed');
     } catch (error) {
       this.logger.error(
+        { err: error as Error },
         'Scheduled sessions cleanup failed',
-        error instanceof Error ? error.stack : undefined,
       );
     } finally {
       this.isRunning = false;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability and test wiring only; invite/MFA/session behavior is unchanged except removal of dead subscription null-check code in bulk invites.
> 
> **Overview**
> Migrates **invites**, **sessions**, and **MFA** IAM areas from Nest’s built-in `Logger` to **nestjs-pino** (`InjectPinoLogger` / `PinoLogger`), aligning structured logs with the rest of the backend.
> 
> Call sites switch to Pino’s object-first API (`info`/`debug`/`warn`/`error` with metadata then message), and failures log **`{ err }`** instead of stringified `error` fields. Unit tests register **`createPinoLoggerMock()`** via `getLoggerToken` and drop `Logger.prototype` spies; a few specs assert the new log shapes (e.g. delete-all-pending, create-invite errors, sessions cleanup).
> 
> **Invites** coverage spans JWT service, use cases, repository, and HTTP controller. **Sessions** covers create/rotate/revoke use cases and the nightly cleanup task. **MFA** covers pending JWT, TOTP encryption, repositories, adapters, controller, and related use cases.
> 
> Aside from logging, **`CreateBulkInvitesUseCase`** drops a redundant post-fetch `if (!subscription) return` (unreachable when the use case returns a value or throws `SubscriptionNotFoundError`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cda0d5776d2e0a93a61b1f4202158c1734c21889. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->