### PR TITLE
wip(logging): migrate organization iam logging (AYC-758)

### DIFF
--- a/ayunis-core-backend/src/iam/onboarding/application/use-cases/get-onboarding/get-onboarding.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/onboarding/application/use-cases/get-onboarding/get-onboarding.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
 import { GetOnboardingUseCase } from './get-onboarding.use-case';
@@ -18,6 +20,10 @@ describe('GetOnboardingUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetOnboardingUseCase,
+        {
+          provide: getLoggerToken(GetOnboardingUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: OnboardingRepository, useValue: mockOnboardingRepository },
       ],
     }).compile();

--- a/ayunis-core-backend/src/iam/onboarding/application/use-cases/get-onboarding/get-onboarding.use-case.ts
+++ b/ayunis-core-backend/src/iam/onboarding/application/use-cases/get-onboarding/get-onboarding.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OnboardingRepository } from '../../ports/onboarding.repository';
 import { GetOnboardingQuery } from './get-onboarding.query';
 import { Onboarding } from 'src/iam/onboarding/domain/onboarding.entity';
@@ -7,12 +8,14 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetOnboardingUseCase {
-  private readonly logger = new Logger(GetOnboardingUseCase.name);
-
-  constructor(private readonly onboardingRepository: OnboardingRepository) {}
+  constructor(
+    @InjectPinoLogger(GetOnboardingUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly onboardingRepository: OnboardingRepository,
+  ) {}
 
   async execute(query: GetOnboardingQuery): Promise<Onboarding> {
-    this.logger.log('getOnboarding', { userId: query.userId });
+    this.logger.info({ userId: query.userId }, 'getOnboarding');
 
     try {
       const onboarding = await this.onboardingRepository.findByUserId(
@@ -25,10 +28,13 @@ export class GetOnboardingUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Failed to get onboarding', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        userId: query.userId,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          userId: query.userId,
+        },
+        'Failed to get onboarding',
+      );
       throw new OnboardingUnexpectedError(error as Error);
     }
   }

--- a/ayunis-core-backend/src/iam/onboarding/application/use-cases/mark-welcome-video-seen/mark-welcome-video-seen.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/onboarding/application/use-cases/mark-welcome-video-seen/mark-welcome-video-seen.use-case.spec.ts
@@ -1,4 +1,6 @@
 import { Test } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { randomUUID } from 'crypto';
 import { OnboardingRepository } from '../../ports/onboarding.repository';
@@ -20,6 +22,10 @@ describe('MarkWelcomeVideoSeenUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MarkWelcomeVideoSeenUseCase,
+        {
+          provide: getLoggerToken(MarkWelcomeVideoSeenUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: OnboardingRepository, useValue: onboardingRepository },
       ],
     }).compile();

--- a/ayunis-core-backend/src/iam/onboarding/application/use-cases/mark-welcome-video-seen/mark-welcome-video-seen.use-case.ts
+++ b/ayunis-core-backend/src/iam/onboarding/application/use-cases/mark-welcome-video-seen/mark-welcome-video-seen.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { Onboarding } from 'src/iam/onboarding/domain/onboarding.entity';
 import { OnboardingUnexpectedError } from '../../onboarding.errors';
@@ -7,13 +8,15 @@ import { MarkWelcomeVideoSeenCommand } from './mark-welcome-video-seen.command';
 
 @Injectable()
 export class MarkWelcomeVideoSeenUseCase {
-  private readonly logger = new Logger(MarkWelcomeVideoSeenUseCase.name);
-
-  constructor(private readonly onboardingRepository: OnboardingRepository) {}
+  constructor(
+    @InjectPinoLogger(MarkWelcomeVideoSeenUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly onboardingRepository: OnboardingRepository,
+  ) {}
 
   @HandleUnexpectedErrors(OnboardingUnexpectedError)
   async execute(command: MarkWelcomeVideoSeenCommand): Promise<Onboarding> {
-    this.logger.log('markWelcomeVideoSeen', { userId: command.userId });
+    this.logger.info({ userId: command.userId }, 'markWelcomeVideoSeen');
 
     return this.onboardingRepository.markWelcomeVideoSeen(
       command.userId,

--- a/ayunis-core-backend/src/iam/onboarding/application/use-cases/update-onboarding/update-onboarding.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/onboarding/application/use-cases/update-onboarding/update-onboarding.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
 import { UpdateOnboardingUseCase } from './update-onboarding.use-case';
@@ -18,6 +20,10 @@ describe('UpdateOnboardingUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UpdateOnboardingUseCase,
+        {
+          provide: getLoggerToken(UpdateOnboardingUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: OnboardingRepository, useValue: mockOnboardingRepository },
       ],
     }).compile();

--- a/ayunis-core-backend/src/iam/onboarding/application/use-cases/update-onboarding/update-onboarding.use-case.ts
+++ b/ayunis-core-backend/src/iam/onboarding/application/use-cases/update-onboarding/update-onboarding.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OnboardingRepository } from '../../ports/onboarding.repository';
 import { UpdateOnboardingCommand } from './update-onboarding.command';
 import { Onboarding } from 'src/iam/onboarding/domain/onboarding.entity';
@@ -7,17 +8,22 @@ import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-
 
 @Injectable()
 export class UpdateOnboardingUseCase {
-  private readonly logger = new Logger(UpdateOnboardingUseCase.name);
-
-  constructor(private readonly onboardingRepository: OnboardingRepository) {}
+  constructor(
+    @InjectPinoLogger(UpdateOnboardingUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly onboardingRepository: OnboardingRepository,
+  ) {}
 
   @HandleUnexpectedErrors(OnboardingUnexpectedError)
   async execute(command: UpdateOnboardingCommand): Promise<Onboarding> {
-    this.logger.log('updateOnboarding', {
-      userId: command.userId,
-      completedStepIdsCount: command.completedStepIds.length,
-      hidden: command.hidden,
-    });
+    this.logger.info(
+      {
+        userId: command.userId,
+        completedStepIdsCount: command.completedStepIds.length,
+        hidden: command.hidden,
+      },
+      'updateOnboarding',
+    );
 
     const onboarding = new Onboarding({
       userId: command.userId,

--- a/ayunis-core-backend/src/iam/onboarding/presenters/http/onboarding.controller.ts
+++ b/ayunis-core-backend/src/iam/onboarding/presenters/http/onboarding.controller.ts
@@ -6,8 +6,8 @@ import {
   Body,
   HttpCode,
   HttpStatus,
-  Logger,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -35,9 +35,9 @@ import { MarkWelcomeVideoSeenCommand } from '../../application/use-cases/mark-we
 @ApiTags('Onboarding')
 @Controller('onboarding')
 export class OnboardingController {
-  private readonly logger = new Logger(OnboardingController.name);
-
   constructor(
+    @InjectPinoLogger(OnboardingController.name)
+    private readonly logger: PinoLogger,
     private readonly getOnboardingUseCase: GetOnboardingUseCase,
     private readonly updateOnboardingUseCase: UpdateOnboardingUseCase,
     private readonly markWelcomeVideoSeenUseCase: MarkWelcomeVideoSeenUseCase,
@@ -63,7 +63,7 @@ export class OnboardingController {
   async getOnboarding(
     @CurrentUser(UserProperty.ID) currentUserId: UUID,
   ): Promise<OnboardingResponseDto> {
-    this.logger.log('getOnboarding');
+    this.logger.info('getOnboarding');
 
     const onboarding = await this.getOnboardingUseCase.execute(
       new GetOnboardingQuery(currentUserId),
@@ -91,7 +91,7 @@ export class OnboardingController {
   async markWelcomeVideoSeen(
     @CurrentUser(UserProperty.ID) currentUserId: UUID,
   ): Promise<OnboardingResponseDto> {
-    this.logger.log('markWelcomeVideoSeen');
+    this.logger.info('markWelcomeVideoSeen');
 
     const onboarding = await this.markWelcomeVideoSeenUseCase.execute(
       new MarkWelcomeVideoSeenCommand(currentUserId),
@@ -125,10 +125,13 @@ export class OnboardingController {
     @Body() updateOnboardingDto: UpdateOnboardingDto,
     @CurrentUser(UserProperty.ID) currentUserId: UUID,
   ): Promise<OnboardingResponseDto> {
-    this.logger.log('updateOnboarding', {
-      completedStepIdsCount: updateOnboardingDto.completedStepIds.length,
-      hidden: updateOnboardingDto.hidden,
-    });
+    this.logger.info(
+      {
+        completedStepIdsCount: updateOnboardingDto.completedStepIds.length,
+        hidden: updateOnboardingDto.hidden,
+      },
+      'updateOnboarding',
+    );
 
     const onboarding = await this.updateOnboardingUseCase.execute(
       new UpdateOnboardingCommand(

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/create-org/create-org.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/create-org/create-org.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CreateOrgUseCase } from './create-org.use-case';
@@ -26,6 +28,10 @@ describe('CreateOrgUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateOrgUseCase,
+        {
+          provide: getLoggerToken(CreateOrgUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: OrgsRepository, useValue: mockOrgsRepository },
         {
           provide: EventEmitter2,

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/create-org/create-org.use-case.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/create-org/create-org.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { OrgsRepository } from '../../ports/orgs.repository';
 import { CreateOrgCommand } from './create-org.command';
@@ -11,16 +12,16 @@ import { SeedDefaultRolePermissionsCommand } from 'src/iam/permissions/applicati
 
 @Injectable()
 export class CreateOrgUseCase {
-  private readonly logger = new Logger(CreateOrgUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateOrgUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly orgsRepository: OrgsRepository,
     private readonly eventEmitter: EventEmitter2,
     private readonly seedDefaultRolePermissionsUseCase: SeedDefaultRolePermissionsUseCase,
   ) {}
   @HandleUnexpectedErrors(UnexpectedOrgError)
   async execute(command: CreateOrgCommand): Promise<Org> {
-    this.logger.log('create', { name: command.name });
+    this.logger.info({ name: command.name }, 'create');
 
     if (!command.name || command.name.trim() === '') {
       this.logger.warn('Attempted to create organization with empty name');
@@ -29,10 +30,13 @@ export class CreateOrgUseCase {
 
     const org = new Org({ name: command.name });
     const createdOrg = await this.orgsRepository.create(org);
-    this.logger.debug('Organization created successfully', {
-      id: createdOrg.id,
-      name: createdOrg.name,
-    });
+    this.logger.debug(
+      {
+        id: createdOrg.id,
+        name: createdOrg.name,
+      },
+      'Organization created successfully',
+    );
 
     await this.seedDefaultRolePermissionsUseCase.execute(
       new SeedDefaultRolePermissionsCommand(createdOrg.id),
@@ -44,10 +48,13 @@ export class CreateOrgUseCase {
         new OrgCreatedEvent(createdOrg.id, createdOrg),
       )
       .catch((err: unknown) => {
-        this.logger.error('Failed to emit OrgCreatedEvent', {
-          error: err instanceof Error ? err.message : 'Unknown error',
-          orgId: createdOrg.id,
-        });
+        this.logger.error(
+          {
+            err: err as Error,
+            orgId: createdOrg.id,
+          },
+          'Failed to emit OrgCreatedEvent',
+        );
       });
 
     return createdOrg;

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/delete-org/delete-org.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/delete-org/delete-org.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { DeleteOrgUseCase } from './delete-org.use-case';
@@ -26,6 +28,10 @@ describe('DeleteOrgUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DeleteOrgUseCase,
+        {
+          provide: getLoggerToken(DeleteOrgUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: OrgsRepository, useValue: mockOrgsRepository },
         { provide: EventEmitter2, useValue: eventEmitter },
       ],

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/delete-org/delete-org.use-case.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/delete-org/delete-org.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { OrgsRepository } from '../../ports/orgs.repository';
 import { DeleteOrgCommand } from './delete-org.command';
@@ -8,15 +9,15 @@ import { runDeferredCleanup } from 'src/common/events/run-deferred-cleanup';
 
 @Injectable()
 export class DeleteOrgUseCase {
-  private readonly logger = new Logger(DeleteOrgUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteOrgUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly orgsRepository: OrgsRepository,
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(command: DeleteOrgCommand): Promise<void> {
-    this.logger.log('delete', { id: command.id });
+    this.logger.info({ id: command.id }, 'delete');
 
     try {
       // Listeners resolve org-scoped data the database cascade cannot reach
@@ -29,11 +30,14 @@ export class DeleteOrgUseCase {
         event,
       );
 
-      this.logger.debug('Deleting organization', { id: command.id });
+      this.logger.debug({ id: command.id }, 'Deleting organization');
       await this.orgsRepository.delete(command.id);
-      this.logger.debug('Organization deleted successfully', {
-        id: command.id,
-      });
+      this.logger.debug(
+        {
+          id: command.id,
+        },
+        'Organization deleted successfully',
+      );
 
       await runDeferredCleanup(event.takeCleanupTasks(), this.logger);
     } catch (error) {
@@ -41,10 +45,13 @@ export class DeleteOrgUseCase {
         // Error already logged and properly formatted, just rethrow
         throw error;
       }
-      this.logger.error('Failed to delete organization', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        id: command.id,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          id: command.id,
+        },
+        'Failed to delete organization',
+      );
       throw new OrgDeletionFailedError(
         command.id,
         'Failed to delete organization',

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/find-org-by-id/find-org-by-id.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/find-org-by-id/find-org-by-id.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
 import { FindOrgByIdUseCase } from './find-org-by-id.use-case';
 import { FindOrgByIdQuery } from './find-org-by-id.query';
@@ -19,6 +21,10 @@ describe('FindOrgByIdUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FindOrgByIdUseCase,
+        {
+          provide: getLoggerToken(FindOrgByIdUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: OrgsRepository, useValue: mockOrgsRepository },
       ],
     }).compile();

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/find-org-by-id/find-org-by-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/find-org-by-id/find-org-by-id.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OrgsRepository } from '../../ports/orgs.repository';
 import { FindOrgByIdQuery } from './find-org-by-id.query';
 import { Org } from 'src/iam/orgs/domain/org.entity';
@@ -6,25 +7,30 @@ import { OrgError, OrgNotFoundError } from '../../orgs.errors';
 
 @Injectable()
 export class FindOrgByIdUseCase {
-  private readonly logger = new Logger(FindOrgByIdUseCase.name);
-
-  constructor(private readonly orgsRepository: OrgsRepository) {}
+  constructor(
+    @InjectPinoLogger(FindOrgByIdUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly orgsRepository: OrgsRepository,
+  ) {}
 
   async execute(query: FindOrgByIdQuery): Promise<Org> {
-    this.logger.log('findById', { id: query.id });
+    this.logger.info({ id: query.id }, 'findById');
     try {
       const org = await this.orgsRepository.findById(query.id);
-      this.logger.debug('Organization found', { id: query.id });
+      this.logger.debug({ id: query.id }, 'Organization found');
       return org;
     } catch (error) {
       if (error instanceof OrgError) {
         // Error already logged and properly formatted, just rethrow
         throw error;
       }
-      this.logger.error('Failed to find organization by ID', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        id: query.id,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          id: query.id,
+        },
+        'Failed to find organization by ID',
+      );
       throw new OrgNotFoundError(query.id);
     }
   }

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
 import { SuperAdminGetAllOrgsUseCase } from './super-admin-get-all-orgs.use-case';
 import { OrgsRepository } from '../../ports/orgs.repository';
@@ -19,6 +21,10 @@ describe('SuperAdminGetAllOrgsUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SuperAdminGetAllOrgsUseCase,
+        {
+          provide: getLoggerToken(SuperAdminGetAllOrgsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: OrgsRepository,
           useValue: {

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.use-case.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/super-admin-get-all-orgs/super-admin-get-all-orgs.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Org } from 'src/iam/orgs/domain/org.entity';
 import { OrgsRepository } from '../../ports/orgs.repository';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -9,25 +10,31 @@ import { Paginated } from 'src/common/pagination/paginated.entity';
 
 @Injectable()
 export class SuperAdminGetAllOrgsUseCase {
-  private readonly logger = new Logger(SuperAdminGetAllOrgsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(SuperAdminGetAllOrgsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly orgsRepository: OrgsRepository,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(query: SuperAdminGetAllOrgsQuery): Promise<Paginated<Org>> {
-    this.logger.log('superAdminGetAllOrgs', {
-      limit: query.limit,
-      offset: query.offset,
-      search: query.search,
-    });
+    this.logger.info(
+      {
+        limit: query.limit,
+        offset: query.offset,
+        text: query.search,
+      },
+      'superAdminGetAllOrgs',
+    );
 
     const systemRole = this.contextService.get('systemRole');
     if (systemRole !== SystemRole.SUPER_ADMIN) {
-      this.logger.warn('Non-super admin attempted to list all orgs', {
-        systemRole,
-      });
+      this.logger.warn(
+        {
+          systemRole,
+        },
+        'Non-super admin attempted to list all orgs',
+      );
       throw new OrgUnauthorizedError('Super admin privileges required');
     }
 

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/update-org/update-org.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/update-org/update-org.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
 import { UpdateOrgUseCase } from './update-org.use-case';
 import { UpdateOrgCommand } from './update-org.command';
@@ -19,6 +21,10 @@ describe('UpdateOrgUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UpdateOrgUseCase,
+        {
+          provide: getLoggerToken(UpdateOrgUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: OrgsRepository, useValue: mockOrgsRepository },
       ],
     }).compile();

--- a/ayunis-core-backend/src/iam/orgs/application/use-cases/update-org/update-org.use-case.ts
+++ b/ayunis-core-backend/src/iam/orgs/application/use-cases/update-org/update-org.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OrgsRepository } from '../../ports/orgs.repository';
 import { UpdateOrgCommand } from './update-org.command';
 import { Org } from 'src/iam/orgs/domain/org.entity';
@@ -6,30 +7,38 @@ import { OrgError, OrgUpdateFailedError } from '../../orgs.errors';
 
 @Injectable()
 export class UpdateOrgUseCase {
-  private readonly logger = new Logger(UpdateOrgUseCase.name);
-
-  constructor(private readonly orgsRepository: OrgsRepository) {}
+  constructor(
+    @InjectPinoLogger(UpdateOrgUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly orgsRepository: OrgsRepository,
+  ) {}
 
   async execute(command: UpdateOrgCommand): Promise<Org> {
-    this.logger.log('update', { id: command.org.id, name: command.org.name });
+    this.logger.info({ id: command.org.id, name: command.org.name }, 'update');
 
     try {
-      this.logger.debug('Updating organization', { id: command.org.id });
+      this.logger.debug({ id: command.org.id }, 'Updating organization');
       const updatedOrg = await this.orgsRepository.update(command.org);
-      this.logger.debug('Organization updated successfully', {
-        id: updatedOrg.id,
-        name: updatedOrg.name,
-      });
+      this.logger.debug(
+        {
+          id: updatedOrg.id,
+          name: updatedOrg.name,
+        },
+        'Organization updated successfully',
+      );
       return updatedOrg;
     } catch (error) {
       if (error instanceof OrgError) {
         // Error already logged and properly formatted, just rethrow
         throw error;
       }
-      this.logger.error('Failed to update organization', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        id: command.org.id,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          id: command.org.id,
+        },
+        'Failed to update organization',
+      );
       throw new OrgUpdateFailedError(
         command.org.id,
         'Failed to update organization',

--- a/ayunis-core-backend/src/iam/orgs/infrastructure/repositories/local/local-orgs.repository.ts
+++ b/ayunis-core-backend/src/iam/orgs/infrastructure/repositories/local/local-orgs.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   OrgsRepository,
   OrgsPagination,
@@ -21,29 +22,29 @@ import { Paginated } from 'src/common/pagination/paginated.entity';
 
 @Injectable()
 export class LocalOrgsRepository extends OrgsRepository {
-  private readonly logger = new Logger(LocalOrgsRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalOrgsRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(OrgRecord)
     private readonly orgRepository: Repository<OrgRecord>,
   ) {
     super();
-    this.logger.log('constructor');
+    this.logger.info('constructor');
   }
 
   async findById(id: UUID): Promise<Org> {
-    this.logger.log('findById', { id });
+    this.logger.info({ id }, 'findById');
 
     try {
       const orgEntity = await this.orgRepository.findOne({
         where: { id },
       });
       if (!orgEntity) {
-        this.logger.warn('Organization not found', { id });
+        this.logger.warn({ id }, 'Organization not found');
         throw new OrgNotFoundError(id);
       }
 
-      this.logger.debug('Organization found', { id, name: orgEntity.name });
+      this.logger.debug({ id, name: orgEntity.name }, 'Organization found');
       return OrgMapper.toDomain(orgEntity);
     } catch (error) {
       if (error instanceof OrgNotFoundError) {
@@ -52,20 +53,20 @@ export class LocalOrgsRepository extends OrgsRepository {
       }
 
       const err = error instanceof Error ? error : new Error('Unknown error');
-      this.logger.error('Error finding organization', { error: err, id });
+      this.logger.error({ err, id }, 'Error finding organization');
       throw new OrgNotFoundError(id);
     }
   }
 
   async findByUserId(userId: UUID): Promise<Org> {
-    this.logger.log('findByUserId', { userId });
+    this.logger.info({ userId }, 'findByUserId');
 
     const orgEntity = await this.orgRepository.findOne({
       where: { users: { id: userId } },
     });
 
     if (!orgEntity) {
-      this.logger.warn('Organization not found', { userId });
+      this.logger.warn({ userId }, 'Organization not found');
       throw new OrgNotFoundError(userId);
     }
 
@@ -83,11 +84,14 @@ export class LocalOrgsRepository extends OrgsRepository {
     pagination: OrgsPagination,
     filters?: OrgsFilters,
   ): Promise<Paginated<Org>> {
-    this.logger.log('findAllForSuperAdmin', {
-      limit: pagination.limit,
-      offset: pagination.offset,
-      search: filters?.search,
-    });
+    this.logger.info(
+      {
+        limit: pagination.limit,
+        offset: pagination.offset,
+        text: filters?.search,
+      },
+      'findAllForSuperAdmin',
+    );
 
     try {
       const queryBuilder = this.orgRepository
@@ -119,33 +123,42 @@ export class LocalOrgsRepository extends OrgsRepository {
       });
     } catch (error) {
       const err = error instanceof Error ? error : new Error('Unknown error');
-      this.logger.error('Failed to retrieve organizations for super admin', {
-        error: err,
-      });
+      this.logger.error(
+        {
+          err,
+        },
+        'Failed to retrieve organizations for super admin',
+      );
       throw new OrgRetrievalFailedError(err.message);
     }
   }
 
   async create(org: Org): Promise<Org> {
-    this.logger.log('create', { id: org.id, name: org.name });
+    this.logger.info({ id: org.id, name: org.name }, 'create');
 
     try {
       const orgEntity = OrgMapper.toEntity(org);
       const savedOrgEntity = await this.orgRepository.save(orgEntity);
 
-      this.logger.debug('Organization created successfully', {
-        id: savedOrgEntity.id,
-        name: savedOrgEntity.name,
-      });
+      this.logger.debug(
+        {
+          id: savedOrgEntity.id,
+          name: savedOrgEntity.name,
+        },
+        'Organization created successfully',
+      );
 
       return OrgMapper.toDomain(savedOrgEntity);
     } catch (error) {
       const err = error instanceof Error ? error : new Error('Unknown error');
-      this.logger.error('Error creating organization', {
-        error: err,
-        id: org.id,
-        name: org.name,
-      });
+      this.logger.error(
+        {
+          err,
+          id: org.id,
+          name: org.name,
+        },
+        'Error creating organization',
+      );
 
       throw new OrgCreationFailedError(
         `Failed to create organization: ${err.message}`,
@@ -154,7 +167,7 @@ export class LocalOrgsRepository extends OrgsRepository {
   }
 
   async update(org: Org): Promise<Org> {
-    this.logger.log('update', { id: org.id, name: org.name });
+    this.logger.info({ id: org.id, name: org.name }, 'update');
 
     try {
       // Verify org exists
@@ -163,19 +176,25 @@ export class LocalOrgsRepository extends OrgsRepository {
       });
 
       if (!existingOrg) {
-        this.logger.warn('Attempted to update non-existent organization', {
-          id: org.id,
-        });
+        this.logger.warn(
+          {
+            id: org.id,
+          },
+          'Attempted to update non-existent organization',
+        );
         throw new OrgNotFoundError(org.id);
       }
 
       const orgEntity = OrgMapper.toEntity(org);
       const savedOrgEntity = await this.orgRepository.save(orgEntity);
 
-      this.logger.debug('Organization updated successfully', {
-        id: savedOrgEntity.id,
-        name: savedOrgEntity.name,
-      });
+      this.logger.debug(
+        {
+          id: savedOrgEntity.id,
+          name: savedOrgEntity.name,
+        },
+        'Organization updated successfully',
+      );
 
       return OrgMapper.toDomain(savedOrgEntity);
     } catch (error) {
@@ -185,18 +204,21 @@ export class LocalOrgsRepository extends OrgsRepository {
       }
 
       const err = error instanceof Error ? error : new Error('Unknown error');
-      this.logger.error('Error updating organization', {
-        error: err,
-        id: org.id,
-        name: org.name,
-      });
+      this.logger.error(
+        {
+          err,
+          id: org.id,
+          name: org.name,
+        },
+        'Error updating organization',
+      );
 
       throw new OrgUpdateFailedError(org.id, err.message);
     }
   }
 
   async delete(id: UUID): Promise<void> {
-    this.logger.log('delete', { id });
+    this.logger.info({ id }, 'delete');
 
     try {
       // Verify org exists
@@ -205,14 +227,17 @@ export class LocalOrgsRepository extends OrgsRepository {
       });
 
       if (!existingOrg) {
-        this.logger.warn('Attempted to delete non-existent organization', {
-          id,
-        });
+        this.logger.warn(
+          {
+            id,
+          },
+          'Attempted to delete non-existent organization',
+        );
         throw new OrgNotFoundError(id);
       }
 
       await this.orgRepository.delete(id);
-      this.logger.debug('Organization deleted successfully', { id });
+      this.logger.debug({ id }, 'Organization deleted successfully');
     } catch (error) {
       if (error instanceof OrgNotFoundError) {
         // Already logged and correctly typed, just rethrow
@@ -220,7 +245,7 @@ export class LocalOrgsRepository extends OrgsRepository {
       }
 
       const err = error instanceof Error ? error : new Error('Unknown error');
-      this.logger.error('Error deleting organization', { error: err, id });
+      this.logger.error({ err, id }, 'Error deleting organization');
       throw new OrgDeletionFailedError(id, err.message);
     }
   }

--- a/ayunis-core-backend/src/iam/orgs/orgs.module.ts
+++ b/ayunis-core-backend/src/iam/orgs/orgs.module.ts
@@ -5,6 +5,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { OrgRecord } from './infrastructure/repositories/local/schema/org.record';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { getLoggerToken, PinoLogger } from 'nestjs-pino';
 
 // Import use cases
 import { FindOrgByIdUseCase } from './application/use-cases/find-org-by-id/find-org-by-id.use-case';
@@ -23,10 +24,16 @@ import { PermissionsModule } from 'src/iam/permissions/permissions.module';
   providers: [
     {
       provide: OrgsRepository,
-      useFactory: (orgRepository: Repository<OrgRecord>) => {
-        return new LocalOrgsRepository(orgRepository);
+      useFactory: (
+        logger: PinoLogger,
+        orgRepository: Repository<OrgRecord>,
+      ) => {
+        return new LocalOrgsRepository(logger, orgRepository);
       },
-      inject: [getRepositoryToken(OrgRecord)],
+      inject: [
+        getLoggerToken(LocalOrgsRepository.name),
+        getRepositoryToken(OrgRecord),
+      ],
     },
     // Use cases
     FindOrgByIdUseCase,

--- a/ayunis-core-backend/src/iam/orgs/presenters/http/super-admin-orgs.controller.ts
+++ b/ayunis-core-backend/src/iam/orgs/presenters/http/super-admin-orgs.controller.ts
@@ -4,11 +4,11 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   Post,
   Query,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiBadRequestResponse,
   ApiBody,
@@ -41,9 +41,9 @@ import { SuperAdminGetAllOrgsQuery } from '../../application/use-cases/super-adm
 @Controller('super-admin/orgs')
 @SystemRoles(SystemRole.SUPER_ADMIN)
 export class SuperAdminOrgsController {
-  private readonly logger = new Logger(SuperAdminOrgsController.name);
-
   constructor(
+    @InjectPinoLogger(SuperAdminOrgsController.name)
+    private readonly logger: PinoLogger,
     private readonly superAdminGetAllOrgsUseCase: SuperAdminGetAllOrgsUseCase,
     private readonly superAdminOrgResponseDtoMapper: SuperAdminOrgResponseDtoMapper,
     private readonly findOrgByIdUseCase: FindOrgByIdUseCase,
@@ -74,7 +74,7 @@ export class SuperAdminOrgsController {
   async createOrg(
     @Body() createOrgDto: CreateOrgRequestDto,
   ): Promise<SuperAdminOrgResponseDto> {
-    this.logger.log('Creating organization', { name: createOrgDto.name });
+    this.logger.info({ name: createOrgDto.name }, 'Creating organization');
 
     const command = new CreateOrgCommand(createOrgDto.name);
     const org = await this.createOrgUseCase.execute(command);

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-fair-use-limits/get-fair-use-limits.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-fair-use-limits/get-fair-use-limits.use-case.spec.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@nestjs/common';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { GetFairUseLimitsUseCase } from './get-fair-use-limits.use-case';
 import type { PlatformConfigRepositoryPort } from '../../ports/platform-config.repository';
 import { PlatformConfig } from 'src/iam/platform-config/domain/platform-config.entity';
@@ -7,7 +7,7 @@ import { PlatformConfigKey } from 'src/iam/platform-config/domain/platform-confi
 describe('GetFairUseLimitsUseCase', () => {
   let useCase: GetFairUseLimitsUseCase;
   let repository: jest.Mocked<PlatformConfigRepositoryPort>;
-  let warnSpy: jest.SpyInstance;
+  const logger = createPinoLoggerMock();
 
   const THREE_HOURS_MS = 3 * 60 * 60 * 1000;
   const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
@@ -19,12 +19,8 @@ describe('GetFairUseLimitsUseCase', () => {
       setMany: jest.fn(),
     };
 
-    useCase = new GetFairUseLimitsUseCase(repository);
-    warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    warnSpy.mockRestore();
+    useCase = new GetFairUseLimitsUseCase(logger, repository);
+    logger.warn.mockClear();
   });
 
   const stubConfig = (values: Partial<Record<PlatformConfigKey, string>>) => {
@@ -57,7 +53,7 @@ describe('GetFairUseLimitsUseCase', () => {
       high: { limit: 75, windowMs: 10800000 },
       images: { limit: 25, windowMs: 86400000 },
     });
-    expect(warnSpy).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('should fall back to baked-in defaults and warn once per key when every key is missing', async () => {
@@ -72,13 +68,13 @@ describe('GetFairUseLimitsUseCase', () => {
       high: { limit: 50, windowMs: THREE_HOURS_MS },
       images: { limit: 10, windowMs: TWENTY_FOUR_HOURS_MS },
     });
-    expect(warnSpy).toHaveBeenCalledTimes(10);
+    expect(logger.warn).toHaveBeenCalledTimes(10);
 
     // Calling again with the same (still-missing) state must not re-warn —
     // otherwise the quota resolver would flood logs on every chat message.
-    warnSpy.mockClear();
+    logger.warn.mockClear();
     await useCase.execute();
-    expect(warnSpy).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('should substitute defaults for individual missing keys while keeping configured ones', async () => {
@@ -93,7 +89,7 @@ describe('GetFairUseLimitsUseCase', () => {
     expect(result.low).toEqual({ limit: 1000, windowMs: THREE_HOURS_MS });
     expect(result.medium).toEqual({ limit: 250, windowMs: THREE_HOURS_MS });
     expect(result.high).toEqual({ limit: 50, windowMs: 21600000 });
-    expect(warnSpy).toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
   });
 
   it('should fall back to default and warn when a stored value is not numeric', async () => {
@@ -111,12 +107,12 @@ describe('GetFairUseLimitsUseCase', () => {
     const result = await useCase.execute();
 
     expect(result.low.limit).toBe(1000);
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining(PlatformConfigKey.FAIR_USE_LOW_LIMIT),
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         key: PlatformConfigKey.FAIR_USE_LOW_LIMIT,
         storedValue: 'not-a-number',
       }),
+      'Platform config key has an invalid value; falling back to default',
     );
   });
 
@@ -124,13 +120,13 @@ describe('GetFairUseLimitsUseCase', () => {
     // First run: every key is missing, so each produces one warn.
     repository.get.mockResolvedValue(null);
     await useCase.execute();
-    expect(warnSpy).toHaveBeenCalledTimes(10);
+    expect(logger.warn).toHaveBeenCalledTimes(10);
 
     // Second run: every key is now valid. No new warns, AND crucially the
     // success branch must `warnedKeys.delete(key)` so a future regression
     // can warn again. This assertion alone still passes if `delete` is
     // dropped — the *third* run is what locks the contract in.
-    warnSpy.mockClear();
+    logger.warn.mockClear();
     stubConfig({
       [PlatformConfigKey.FAIR_USE_ZERO_LIMIT]: '999999',
       [PlatformConfigKey.FAIR_USE_ZERO_WINDOW_MS]: '3600000',
@@ -144,16 +140,16 @@ describe('GetFairUseLimitsUseCase', () => {
       [PlatformConfigKey.FAIR_USE_IMAGES_WINDOW_MS]: '86400000',
     });
     await useCase.execute();
-    expect(warnSpy).toHaveBeenCalledTimes(0);
+    expect(logger.warn).toHaveBeenCalledTimes(0);
 
     // Third run: config has been wiped again. Because the previous run
     // cleared `warnedKeys`, each key must re-warn so operators aren't left
     // guessing when config silently regresses. If the `delete` line is
     // dropped from the use case, this assertion fails (0 vs 10).
-    warnSpy.mockClear();
+    logger.warn.mockClear();
     repository.get.mockResolvedValue(null);
     await useCase.execute();
-    expect(warnSpy).toHaveBeenCalledTimes(10);
+    expect(logger.warn).toHaveBeenCalledTimes(10);
   });
 
   it('should expose the configured images limit when set and fall back independently of message tiers', async () => {
@@ -176,11 +172,11 @@ describe('GetFairUseLimitsUseCase', () => {
       windowMs: TWENTY_FOUR_HOURS_MS,
     });
     expect(result.low).toEqual({ limit: 1500, windowMs: 3600000 });
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining(PlatformConfigKey.FAIR_USE_IMAGES_LIMIT),
+    expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
         key: PlatformConfigKey.FAIR_USE_IMAGES_LIMIT,
       }),
+      'Platform config key is not set; falling back to default',
     );
   });
 
@@ -200,6 +196,6 @@ describe('GetFairUseLimitsUseCase', () => {
 
     expect(result.medium.limit).toBe(200);
     expect(result.high.windowMs).toBe(THREE_HOURS_MS);
-    expect(warnSpy).toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
   });
 });

--- a/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-fair-use-limits/get-fair-use-limits.use-case.ts
+++ b/ayunis-core-backend/src/iam/platform-config/application/use-cases/get-fair-use-limits/get-fair-use-limits.use-case.ts
@@ -1,7 +1,11 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { PlatformConfigRepositoryPort } from '../../ports/platform-config.repository';
 import { PlatformConfigKey } from '../../../domain/platform-config-keys.enum';
-import { FairUseLimitsByTier } from '../../../domain/fair-use-limits';
+import {
+  FairUseLimit,
+  FairUseLimitsByTier,
+} from '../../../domain/fair-use-limits';
 
 const THREE_HOURS_MS = 3 * 60 * 60 * 1000;
 const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
@@ -33,75 +37,55 @@ const DEFAULT_FAIR_USE_LIMITS: FairUseLimitsByTier = {
 
 @Injectable()
 export class GetFairUseLimitsUseCase {
-  private readonly logger = new Logger(GetFairUseLimitsUseCase.name);
   private readonly warnedKeys = new Set<PlatformConfigKey>();
 
   constructor(
+    @InjectPinoLogger(GetFairUseLimitsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly configRepository: PlatformConfigRepositoryPort,
   ) {}
 
   async execute(): Promise<FairUseLimitsByTier> {
-    const [
-      zeroLimit,
-      zeroWindow,
-      lowLimit,
-      lowWindow,
-      mediumLimit,
-      mediumWindow,
-      highLimit,
-      highWindow,
-      imagesLimit,
-      imagesWindow,
-    ] = await Promise.all([
-      this.readPositiveNumber(
+    const [zero, low, medium, high, images] = await Promise.all([
+      this.readLimits(
         PlatformConfigKey.FAIR_USE_ZERO_LIMIT,
-        DEFAULT_FAIR_USE_LIMITS.zero.limit,
-      ),
-      this.readPositiveNumber(
         PlatformConfigKey.FAIR_USE_ZERO_WINDOW_MS,
-        DEFAULT_FAIR_USE_LIMITS.zero.windowMs,
+        DEFAULT_FAIR_USE_LIMITS.zero,
       ),
-      this.readPositiveNumber(
+      this.readLimits(
         PlatformConfigKey.FAIR_USE_LOW_LIMIT,
-        DEFAULT_FAIR_USE_LIMITS.low.limit,
-      ),
-      this.readPositiveNumber(
         PlatformConfigKey.FAIR_USE_LOW_WINDOW_MS,
-        DEFAULT_FAIR_USE_LIMITS.low.windowMs,
+        DEFAULT_FAIR_USE_LIMITS.low,
       ),
-      this.readPositiveNumber(
+      this.readLimits(
         PlatformConfigKey.FAIR_USE_MEDIUM_LIMIT,
-        DEFAULT_FAIR_USE_LIMITS.medium.limit,
-      ),
-      this.readPositiveNumber(
         PlatformConfigKey.FAIR_USE_MEDIUM_WINDOW_MS,
-        DEFAULT_FAIR_USE_LIMITS.medium.windowMs,
+        DEFAULT_FAIR_USE_LIMITS.medium,
       ),
-      this.readPositiveNumber(
+      this.readLimits(
         PlatformConfigKey.FAIR_USE_HIGH_LIMIT,
-        DEFAULT_FAIR_USE_LIMITS.high.limit,
-      ),
-      this.readPositiveNumber(
         PlatformConfigKey.FAIR_USE_HIGH_WINDOW_MS,
-        DEFAULT_FAIR_USE_LIMITS.high.windowMs,
+        DEFAULT_FAIR_USE_LIMITS.high,
       ),
-      this.readPositiveNumber(
+      this.readLimits(
         PlatformConfigKey.FAIR_USE_IMAGES_LIMIT,
-        DEFAULT_FAIR_USE_LIMITS.images.limit,
-      ),
-      this.readPositiveNumber(
         PlatformConfigKey.FAIR_USE_IMAGES_WINDOW_MS,
-        DEFAULT_FAIR_USE_LIMITS.images.windowMs,
+        DEFAULT_FAIR_USE_LIMITS.images,
       ),
     ]);
+    return { zero, low, medium, high, images };
+  }
 
-    return {
-      zero: { limit: zeroLimit, windowMs: zeroWindow },
-      low: { limit: lowLimit, windowMs: lowWindow },
-      medium: { limit: mediumLimit, windowMs: mediumWindow },
-      high: { limit: highLimit, windowMs: highWindow },
-      images: { limit: imagesLimit, windowMs: imagesWindow },
-    };
+  private async readLimits(
+    limitKey: PlatformConfigKey,
+    windowKey: PlatformConfigKey,
+    defaults: FairUseLimit,
+  ): Promise<FairUseLimit> {
+    const [limit, windowMs] = await Promise.all([
+      this.readPositiveNumber(limitKey, defaults.limit),
+      this.readPositiveNumber(windowKey, defaults.windowMs),
+    ]);
+    return { limit, windowMs };
   }
 
   private async readPositiveNumber(
@@ -113,8 +97,8 @@ export class GetFairUseLimitsUseCase {
     if (!config) {
       this.warnOnce(key, () =>
         this.logger.warn(
-          `Platform config key '${key}' is not set; falling back to default`,
           { key, defaultValue },
+          'Platform config key is not set; falling back to default',
         ),
       );
       return defaultValue;
@@ -124,8 +108,8 @@ export class GetFairUseLimitsUseCase {
     if (!Number.isFinite(parsed) || parsed <= 0) {
       this.warnOnce(key, () =>
         this.logger.warn(
-          `Platform config key '${key}' has an invalid value; falling back to default`,
           { key, storedValue: config.value, defaultValue },
+          'Platform config key has an invalid value; falling back to default',
         ),
       );
       return defaultValue;

--- a/ayunis-core-backend/src/iam/platform-config/presenters/http/app-alert.controller.ts
+++ b/ayunis-core-backend/src/iam/platform-config/presenters/http/app-alert.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, Logger, HttpCode, HttpStatus } from '@nestjs/common';
+import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -18,9 +19,11 @@ import { AppAlertResponseDto } from './dto/app-alert-response.dto';
 @ApiTags('App Alert')
 @Controller('app-alert')
 export class AppAlertController {
-  private readonly logger = new Logger(AppAlertController.name);
-
-  constructor(private readonly getAppAlertUseCase: GetAppAlertUseCase) {}
+  constructor(
+    @InjectPinoLogger(AppAlertController.name)
+    private readonly logger: PinoLogger,
+    private readonly getAppAlertUseCase: GetAppAlertUseCase,
+  ) {}
 
   @Get()
   @HttpCode(HttpStatus.OK)
@@ -37,7 +40,7 @@ export class AppAlertController {
   @ApiUnauthorizedResponse({ description: 'User not authenticated' })
   @ApiInternalServerErrorResponse({ description: 'Internal server error' })
   async getAppAlert(): Promise<AppAlertResponseDto> {
-    this.logger.log('Getting app alert configuration');
+    this.logger.info('Getting app alert configuration');
     return this.getAppAlertUseCase.execute();
   }
 }

--- a/ayunis-core-backend/src/iam/platform-config/presenters/http/super-admin-platform-config.controller.ts
+++ b/ayunis-core-backend/src/iam/platform-config/presenters/http/super-admin-platform-config.controller.ts
@@ -3,10 +3,10 @@ import {
   Get,
   Put,
   Body,
-  Logger,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -37,9 +37,9 @@ import { SetAppAlertRequestDto } from './dto/set-app-alert-request.dto';
 @Controller('super-admin/platform-config')
 @SystemRoles(SystemRole.SUPER_ADMIN)
 export class SuperAdminPlatformConfigController {
-  private readonly logger = new Logger(SuperAdminPlatformConfigController.name);
-
   constructor(
+    @InjectPinoLogger(SuperAdminPlatformConfigController.name)
+    private readonly logger: PinoLogger,
     private readonly getCreditsPerEuroUseCase: GetCreditsPerEuroUseCase,
     private readonly setCreditsPerEuroUseCase: SetCreditsPerEuroUseCase,
     private readonly getFairUseLimitsUseCase: GetFairUseLimitsUseCase,
@@ -71,7 +71,7 @@ export class SuperAdminPlatformConfigController {
     description: 'Internal server error',
   })
   async getCreditsPerEuro(): Promise<CreditsPerEuroResponseDto> {
-    this.logger.log('Getting credits-per-euro configuration');
+    this.logger.info('Getting credits-per-euro configuration');
     const creditsPerEuro = await this.getCreditsPerEuroUseCase.execute();
     return { creditsPerEuro };
   }
@@ -100,12 +100,15 @@ export class SuperAdminPlatformConfigController {
   async setCreditsPerEuro(
     @Body() dto: SetCreditsPerEuroRequestDto,
   ): Promise<void> {
-    this.logger.log(`Setting credits-per-euro to ${dto.creditsPerEuro}`);
+    this.logger.info(
+      { creditsPerEuro: dto.creditsPerEuro },
+      'Setting credits-per-euro',
+    );
     const command = new SetCreditsPerEuroCommand({
       creditsPerEuro: dto.creditsPerEuro,
     });
     await this.setCreditsPerEuroUseCase.execute(command);
-    this.logger.log('Successfully updated credits-per-euro configuration');
+    this.logger.info('Successfully updated credits-per-euro configuration');
   }
 
   @Get('fair-use-limits')
@@ -127,7 +130,7 @@ export class SuperAdminPlatformConfigController {
     description: 'Internal server error',
   })
   async getFairUseLimits(): Promise<FairUseLimitsResponseDto> {
-    this.logger.log('Getting fair-use limits configuration');
+    this.logger.info('Getting fair-use limits configuration');
     const limits = await this.getFairUseLimitsUseCase.execute();
     return limits;
   }
@@ -154,8 +157,9 @@ export class SuperAdminPlatformConfigController {
     description: 'Internal server error',
   })
   async setFairUseLimit(@Body() dto: SetFairUseLimitRequestDto): Promise<void> {
-    this.logger.log(
-      `Setting fair-use limit for tier '${dto.tier}' to ${dto.limit}/${dto.windowMs}ms`,
+    this.logger.info(
+      { tier: dto.tier, limit: dto.limit, windowMs: dto.windowMs },
+      'Setting fair-use limit',
     );
     const command = new SetFairUseLimitCommand({
       tier: dto.tier,
@@ -163,7 +167,7 @@ export class SuperAdminPlatformConfigController {
       windowMs: dto.windowMs,
     });
     await this.setFairUseLimitUseCase.execute(command);
-    this.logger.log('Successfully updated fair-use limit');
+    this.logger.info('Successfully updated fair-use limit');
   }
 
   @Put('image-fair-use-limit')
@@ -190,15 +194,16 @@ export class SuperAdminPlatformConfigController {
   async setImageFairUseLimit(
     @Body() dto: SetImageFairUseLimitRequestDto,
   ): Promise<void> {
-    this.logger.log(
-      `Setting image fair-use limit to ${dto.limit}/${dto.windowMs}ms`,
+    this.logger.info(
+      { limit: dto.limit, windowMs: dto.windowMs },
+      'Setting image fair-use limit',
     );
     const command = new SetImageFairUseLimitCommand({
       limit: dto.limit,
       windowMs: dto.windowMs,
     });
     await this.setImageFairUseLimitUseCase.execute(command);
-    this.logger.log('Successfully updated image fair-use limit');
+    this.logger.info('Successfully updated image fair-use limit');
   }
 
   @Put('app-alert')
@@ -224,12 +229,12 @@ export class SuperAdminPlatformConfigController {
     description: 'Internal server error',
   })
   async setAppAlert(@Body() dto: SetAppAlertRequestDto): Promise<void> {
-    this.logger.log(`Setting app alert: enabled=${dto.enabled}`);
+    this.logger.info({ enabled: dto.enabled }, 'Setting app alert');
     const command = new SetAppAlertCommand({
       enabled: dto.enabled,
       message: dto.message,
     });
     await this.setAppAlertUseCase.execute(command);
-    this.logger.log('Successfully updated app alert banner');
+    this.logger.info('Successfully updated app alert banner');
   }
 }

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/configure-org-sso-connection/configure-org-sso-connection.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/configure-org-sso-connection/configure-org-sso-connection.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { FindOrgByIdUseCase } from 'src/iam/orgs/application/use-cases/find-org-by-id/find-org-by-id.use-case';
 import { SsoConnectionUniqueConstraintError } from 'src/iam/sso/application/ports/org-sso-connections.repository';
 import { FindOrgByIdQuery } from 'src/iam/orgs/application/use-cases/find-org-by-id/find-org-by-id.query';
@@ -32,6 +33,7 @@ describe(ConfigureOrgSsoConnectionUseCase.name, () => {
     repository = createMockOrgSsoConnectionsRepository();
     findOrgById = { execute: jest.fn().mockResolvedValue(anOrg()) };
     useCase = new ConfigureOrgSsoConnectionUseCase(
+      createPinoLoggerMock(),
       repository,
       findOrgById as unknown as FindOrgByIdUseCase,
     );

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/configure-org-sso-connection/configure-org-sso-connection.use-case.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/configure-org-sso-connection/configure-org-sso-connection.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { FindOrgByIdQuery } from 'src/iam/orgs/application/use-cases/find-org-by-id/find-org-by-id.query';
 import { FindOrgByIdUseCase } from 'src/iam/orgs/application/use-cases/find-org-by-id/find-org-by-id.use-case';
@@ -24,9 +25,9 @@ import { ConfigureOrgSsoConnectionCommand } from 'src/iam/sso/application/use-ca
 
 @Injectable()
 export class ConfigureOrgSsoConnectionUseCase {
-  private readonly logger = new Logger(ConfigureOrgSsoConnectionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ConfigureOrgSsoConnectionUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly repository: OrgSsoConnectionsRepository,
     private readonly findOrgById: FindOrgByIdUseCase,
   ) {}
@@ -36,10 +37,13 @@ export class ConfigureOrgSsoConnectionUseCase {
     command: ConfigureOrgSsoConnectionCommand,
   ): Promise<OrgSsoConnection> {
     const { emailDomain, zitadelOrgId } = this.normalizeConfiguration(command);
-    this.logger.log('Configuring organization SSO connection', {
-      orgId: command.orgId,
-      emailDomain,
-    });
+    this.logger.info(
+      {
+        orgId: command.orgId,
+        domain: emailDomain,
+      },
+      'Configuring organization SSO connection',
+    );
 
     await this.findOrgById.execute(new FindOrgByIdQuery(command.orgId));
     const [existing, domainOwner, zitadelOrgOwner] = await Promise.all([

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/get-org-sso-connection/get-org-sso-connection.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/get-org-sso-connection/get-org-sso-connection.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import {
   TEST_ORG_ID,
   anOrgSsoConnection,
@@ -11,7 +12,10 @@ describe(GetOrgSsoConnectionUseCase.name, () => {
     const repository = createMockOrgSsoConnectionsRepository();
     const connection = anOrgSsoConnection();
     repository.findByOrgId.mockResolvedValue(connection);
-    const useCase = new GetOrgSsoConnectionUseCase(repository);
+    const useCase = new GetOrgSsoConnectionUseCase(
+      createPinoLoggerMock(),
+      repository,
+    );
 
     await expect(
       useCase.execute(new GetOrgSsoConnectionQuery(TEST_ORG_ID)),
@@ -20,7 +24,10 @@ describe(GetOrgSsoConnectionUseCase.name, () => {
 
   it('returns null when the organization has no SSO connection', async () => {
     const repository = createMockOrgSsoConnectionsRepository();
-    const useCase = new GetOrgSsoConnectionUseCase(repository);
+    const useCase = new GetOrgSsoConnectionUseCase(
+      createPinoLoggerMock(),
+      repository,
+    );
 
     await expect(
       useCase.execute(new GetOrgSsoConnectionQuery(TEST_ORG_ID)),

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/get-org-sso-connection/get-org-sso-connection.use-case.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/get-org-sso-connection/get-org-sso-connection.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { OrgSsoConnectionsRepository } from 'src/iam/sso/application/ports/org-sso-connections.repository';
 import { UnexpectedSsoError } from 'src/iam/sso/application/sso.errors';
@@ -7,17 +8,22 @@ import type { OrgSsoConnection } from 'src/iam/sso/domain/org-sso-connection.ent
 
 @Injectable()
 export class GetOrgSsoConnectionUseCase {
-  private readonly logger = new Logger(GetOrgSsoConnectionUseCase.name);
-
-  constructor(private readonly repository: OrgSsoConnectionsRepository) {}
+  constructor(
+    @InjectPinoLogger(GetOrgSsoConnectionUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: OrgSsoConnectionsRepository,
+  ) {}
 
   @HandleUnexpectedErrors(UnexpectedSsoError)
   async execute(
     query: GetOrgSsoConnectionQuery,
   ): Promise<OrgSsoConnection | null> {
-    this.logger.log('Getting organization SSO connection', {
-      orgId: query.orgId,
-    });
+    this.logger.info(
+      {
+        orgId: query.orgId,
+      },
+      'Getting organization SSO connection',
+    );
     return this.repository.findByOrgId(query.orgId);
   }
 }

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/set-org-sso-enabled/set-org-sso-enabled.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/set-org-sso-enabled/set-org-sso-enabled.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import {
   TEST_ORG_ID,
   anOrgSsoConnection,
@@ -17,7 +18,7 @@ describe(SetOrgSsoEnabledUseCase.name, () => {
 
   beforeEach(() => {
     repository = createMockOrgSsoConnectionsRepository();
-    useCase = new SetOrgSsoEnabledUseCase(repository);
+    useCase = new SetOrgSsoEnabledUseCase(createPinoLoggerMock(), repository);
   });
 
   it('rejects an organization without an SSO connection', async () => {

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/set-org-sso-enabled/set-org-sso-enabled.use-case.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/set-org-sso-enabled/set-org-sso-enabled.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { OrgSsoConnectionsRepository } from 'src/iam/sso/application/ports/org-sso-connections.repository';
 import {
@@ -16,16 +17,21 @@ import { SetOrgSsoEnabledCommand } from 'src/iam/sso/application/use-cases/set-o
 
 @Injectable()
 export class SetOrgSsoEnabledUseCase {
-  private readonly logger = new Logger(SetOrgSsoEnabledUseCase.name);
-
-  constructor(private readonly repository: OrgSsoConnectionsRepository) {}
+  constructor(
+    @InjectPinoLogger(SetOrgSsoEnabledUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: OrgSsoConnectionsRepository,
+  ) {}
 
   @HandleUnexpectedErrors(UnexpectedSsoError)
   async execute(command: SetOrgSsoEnabledCommand): Promise<OrgSsoConnection> {
-    this.logger.log('Setting organization SSO state', {
-      orgId: command.orgId,
-      enabled: command.enabled,
-    });
+    this.logger.info(
+      {
+        orgId: command.orgId,
+        enabled: command.enabled,
+      },
+      'Setting organization SSO state',
+    );
     const existing = await this.repository.findByOrgId(command.orgId);
     if (!existing) {
       throw new SsoConnectionNotFoundError(command.orgId);

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/set-org-sso-jit-provisioning/set-org-sso-jit-provisioning.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/set-org-sso-jit-provisioning/set-org-sso-jit-provisioning.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import {
   TEST_ORG_ID,
   anOrgSsoConnection,
@@ -16,7 +17,10 @@ describe(SetOrgSsoJitProvisioningUseCase.name, () => {
 
   beforeEach(() => {
     repository = createMockOrgSsoConnectionsRepository();
-    useCase = new SetOrgSsoJitProvisioningUseCase(repository);
+    useCase = new SetOrgSsoJitProvisioningUseCase(
+      createPinoLoggerMock(),
+      repository,
+    );
   });
 
   it('rejects an organization without an SSO connection', async () => {

--- a/ayunis-core-backend/src/iam/sso/application/use-cases/set-org-sso-jit-provisioning/set-org-sso-jit-provisioning.use-case.ts
+++ b/ayunis-core-backend/src/iam/sso/application/use-cases/set-org-sso-jit-provisioning/set-org-sso-jit-provisioning.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { OrgSsoConnectionsRepository } from 'src/iam/sso/application/ports/org-sso-connections.repository';
 import {
@@ -11,18 +12,23 @@ import { SetOrgSsoJitProvisioningCommand } from 'src/iam/sso/application/use-cas
 
 @Injectable()
 export class SetOrgSsoJitProvisioningUseCase {
-  private readonly logger = new Logger(SetOrgSsoJitProvisioningUseCase.name);
-
-  constructor(private readonly repository: OrgSsoConnectionsRepository) {}
+  constructor(
+    @InjectPinoLogger(SetOrgSsoJitProvisioningUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: OrgSsoConnectionsRepository,
+  ) {}
 
   @HandleUnexpectedErrors(UnexpectedSsoError)
   async execute(
     command: SetOrgSsoJitProvisioningCommand,
   ): Promise<OrgSsoConnection> {
-    this.logger.log('Setting organization SSO JIT provisioning', {
-      orgId: command.orgId,
-      enabled: command.enabled,
-    });
+    this.logger.info(
+      {
+        orgId: command.orgId,
+        enabled: command.enabled,
+      },
+      'Setting organization SSO JIT provisioning',
+    );
     const existing = await this.repository.findByOrgId(command.orgId);
     if (!existing) {
       throw new SsoConnectionNotFoundError(command.orgId);

--- a/ayunis-core-backend/src/iam/sso/presenters/http/super-admin-sso-connections.controller.spec.ts
+++ b/ayunis-core-backend/src/iam/sso/presenters/http/super-admin-sso-connections.controller.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { SYSTEM_ROLES_KEY } from 'src/iam/authorization/application/decorators/system-roles.decorator';
 import { ConfigureOrgSsoConnectionCommand } from 'src/iam/sso/application/use-cases/configure-org-sso-connection/configure-org-sso-connection.command';
 import { GetOrgSsoConnectionQuery } from 'src/iam/sso/application/use-cases/get-org-sso-connection/get-org-sso-connection.query';
@@ -14,18 +15,21 @@ import { SystemRole } from 'src/iam/users/domain/value-objects/system-role.enum'
 const SUPER_ADMIN_ID = '33333333-3333-3333-3333-333333333333';
 
 function createController() {
+  const logger = createPinoLoggerMock();
   const getConnection = { execute: jest.fn() };
   const configureConnection = { execute: jest.fn() };
   const setEnabled = { execute: jest.fn() };
   const setJit = { execute: jest.fn() };
   return {
     controller: new SuperAdminSsoConnectionsController(
+      logger,
       getConnection as never,
       configureConnection as never,
       setEnabled as never,
       setJit as never,
       new OrgSsoConnectionResponseDtoMapper(),
     ),
+    logger,
     getConnection,
     configureConnection,
     setEnabled,
@@ -53,7 +57,7 @@ describe(SuperAdminSsoConnectionsController.name, () => {
   });
 
   it('configures a verified connection through the application use case', async () => {
-    const { controller, configureConnection } = createController();
+    const { controller, configureConnection, logger } = createController();
     const connection = anOrgSsoConnection({ jitProvisioningEnabled: true });
     configureConnection.execute.mockResolvedValue(connection);
 
@@ -75,10 +79,26 @@ describe(SuperAdminSsoConnectionsController.name, () => {
       ),
     );
     expect(result.connection).toMatchObject({ orgId: TEST_ORG_ID });
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connection: expect.objectContaining({
+          domain: 'stadt.example',
+          zitadelOrgId: 'zitadel-org-1',
+        }),
+        confirmation: { domainVerified: true },
+      }),
+      'Superadmin changed SSO connection',
+    );
+    expect(logger.info.mock.calls[0]?.[0]).not.toHaveProperty(
+      'connection.emailDomain',
+    );
+    expect(logger.info.mock.calls[0]?.[0]).not.toHaveProperty(
+      'confirmation.domain',
+    );
   });
 
   it('updates runtime enablement independently', async () => {
-    const { controller, setEnabled } = createController();
+    const { controller, setEnabled, logger } = createController();
     setEnabled.execute.mockResolvedValue(anOrgSsoConnection({ enabled: true }));
 
     const result = await controller.setEnabled(
@@ -99,6 +119,19 @@ describe(SuperAdminSsoConnectionsController.name, () => {
       }),
     );
     expect(result.connection).toMatchObject({ enabled: true });
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        confirmation: {
+          confirmed: true,
+          domain: 'stadt.example',
+          reviewedZitadelOrgId: 'zitadel-org-1',
+        },
+      }),
+      'Superadmin changed SSO connection',
+    );
+    expect(logger.info.mock.calls[0]?.[0]).not.toHaveProperty(
+      'confirmation.reviewedEmailDomain',
+    );
   });
 
   it('updates JIT provisioning independently', async () => {

--- a/ayunis-core-backend/src/iam/sso/presenters/http/super-admin-sso-connections.controller.ts
+++ b/ayunis-core-backend/src/iam/sso/presenters/http/super-admin-sso-connections.controller.ts
@@ -3,12 +3,12 @@ import {
   Body,
   Controller,
   Get,
-  Logger,
   Param,
   ParseUUIDPipe,
   Patch,
   Put,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiForbiddenResponse,
   ApiOkResponse,
@@ -55,9 +55,9 @@ interface SsoAuditEvent {
 @ApiForbiddenResponse({ description: 'The requester is not a super admin' })
 @ApiParam({ name: 'orgId', format: 'uuid' })
 export class SuperAdminSsoConnectionsController {
-  private readonly logger = new Logger(SuperAdminSsoConnectionsController.name);
-
   constructor(
+    @InjectPinoLogger(SuperAdminSsoConnectionsController.name)
+    private readonly logger: PinoLogger,
     private readonly getConnectionUseCase: GetOrgSsoConnectionUseCase,
     private readonly configureConnectionUseCase: ConfigureOrgSsoConnectionUseCase,
     private readonly setEnabledUseCase: SetOrgSsoEnabledUseCase,
@@ -120,7 +120,7 @@ export class SuperAdminSsoConnectionsController {
       confirmation: reviewedMapping
         ? {
             confirmed: true,
-            reviewedEmailDomain: reviewedMapping.emailDomain,
+            emailDomain: reviewedMapping.emailDomain,
             reviewedZitadelOrgId: reviewedMapping.zitadelOrgId,
           }
         : undefined,
@@ -174,12 +174,26 @@ export class SuperAdminSsoConnectionsController {
   }
 
   private audit(event: SsoAuditEvent): void {
-    this.logger.log('Superadmin changed SSO connection', {
-      operation: event.operation,
-      actorId: event.actorId,
-      orgId: event.orgId,
-      connection: this.responseMapper.toDto(event.connection),
-      confirmation: event.confirmation,
-    });
+    const { emailDomain: domain, ...connection } = this.responseMapper.toDto(
+      event.connection,
+    );
+    const { emailDomain: confirmedDomain, ...confirmation } =
+      event.confirmation ?? {};
+
+    this.logger.info(
+      {
+        operation: event.operation,
+        actorId: event.actorId,
+        orgId: event.orgId,
+        connection: { ...connection, domain },
+        confirmation: event.confirmation
+          ? {
+              ...confirmation,
+              ...(confirmedDomain ? { domain: confirmedDomain } : {}),
+            }
+          : undefined,
+      },
+      'Superadmin changed SSO connection',
+    );
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/add-team-member/add-team-member.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/add-team-member/add-team-member.use-case.ts
@@ -1,4 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { TeamMembersRepository } from '../../ports/team-members.repository';
 import { FindUserByIdUseCase } from 'src/iam/users/application/use-cases/find-user-by-id/find-user-by-id.use-case';
@@ -16,9 +18,9 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 @Injectable()
 export class AddTeamMemberUseCase {
-  private readonly logger = new Logger(AddTeamMemberUseCase.name);
-
   constructor(
+    @InjectPinoLogger(AddTeamMemberUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly teamsRepository: TeamsRepository,
     private readonly teamMembersRepository: TeamMembersRepository,
     private readonly findUserByIdUseCase: FindUserByIdUseCase,
@@ -27,90 +29,85 @@ export class AddTeamMemberUseCase {
 
   async execute(command: AddTeamMemberCommand): Promise<TeamMember> {
     const orgId = this.contextService.get('orgId');
+    if (!orgId) throw new UnauthorizedAccessError();
 
-    if (!orgId) {
-      throw new UnauthorizedAccessError();
-    }
-
-    this.logger.log('execute', {
-      teamId: command.teamId,
-      userId: command.userId,
-      orgId,
-    });
+    this.logger.info(
+      { teamId: command.teamId, userId: command.userId, orgId },
+      'execute',
+    );
 
     try {
-      // Verify team exists and belongs to organization
-      const team = await this.teamsRepository.findById(command.teamId);
-
-      if (!team) {
-        this.logger.error('Team not found', { teamId: command.teamId });
-        throw new TeamNotFoundError(command.teamId);
-      }
-
-      if (team.orgId !== orgId) {
-        this.logger.error('Team does not belong to organization', {
-          teamId: command.teamId,
-          teamOrgId: team.orgId,
-          requestOrgId: orgId,
-        });
-        throw new TeamNotFoundError(command.teamId);
-      }
-
-      // Verify user exists (throws UserNotFoundError if not found)
-      const user = await this.findUserByIdUseCase.execute(
-        new FindUserByIdQuery(command.userId),
+      return await this.addMember(command, orgId);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error(
+        { err: error as Error, teamId: command.teamId, userId: command.userId },
+        'Failed to add team member',
       );
+      throw error;
+    }
+  }
 
-      // Verify user belongs to same organization
-      if (user.orgId !== orgId) {
-        this.logger.error('User does not belong to organization', {
-          userId: command.userId,
-          userOrgId: user.orgId,
-          requestOrgId: orgId,
-        });
-        throw new UserNotInSameOrgError(command.userId);
-      }
+  private async addMember(
+    command: AddTeamMemberCommand,
+    orgId: UUID,
+  ): Promise<TeamMember> {
+    await this.assertTeamBelongsToOrg(command.teamId, orgId);
+    await this.assertUserBelongsToOrg(command.userId, orgId);
+    await this.assertNotMember(command.teamId, command.userId);
 
-      // Check if user is already a member
-      const existingMember =
-        await this.teamMembersRepository.findByTeamIdAndUserId(
-          command.teamId,
-          command.userId,
-        );
-
-      if (existingMember) {
-        this.logger.error('User is already a team member', {
-          teamId: command.teamId,
-          userId: command.userId,
-        });
-        throw new UserAlreadyTeamMemberError(command.teamId, command.userId);
-      }
-
-      // Create team member
-      const teamMember = new TeamMember({
-        teamId: command.teamId,
-        userId: command.userId,
-      });
-
-      const createdMember = await this.teamMembersRepository.create(teamMember);
-
-      this.logger.debug('Team member added successfully', {
+    const createdMember = await this.teamMembersRepository.create(
+      new TeamMember({ teamId: command.teamId, userId: command.userId }),
+    );
+    this.logger.debug(
+      {
         teamId: command.teamId,
         userId: command.userId,
         memberId: createdMember.id,
-      });
+      },
+      'Team member added successfully',
+    );
+    return createdMember;
+  }
 
-      return createdMember;
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to add team member', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        teamId: command.teamId,
-        userId: command.userId,
-      });
-      throw error;
+  private async assertTeamBelongsToOrg(
+    teamId: UUID,
+    orgId: UUID,
+  ): Promise<void> {
+    const team = await this.teamsRepository.findById(teamId);
+    if (!team) {
+      this.logger.error({ teamId }, 'Team not found');
+      throw new TeamNotFoundError(teamId);
     }
+    if (team.orgId !== orgId) {
+      this.logger.error(
+        { teamId, teamOrgId: team.orgId, requestOrgId: orgId },
+        'Team does not belong to organization',
+      );
+      throw new TeamNotFoundError(teamId);
+    }
+  }
+
+  private async assertUserBelongsToOrg(
+    userId: UUID,
+    orgId: UUID,
+  ): Promise<void> {
+    const user = await this.findUserByIdUseCase.execute(
+      new FindUserByIdQuery(userId),
+    );
+    if (user.orgId === orgId) return;
+    this.logger.error(
+      { userId, userOrgId: user.orgId, requestOrgId: orgId },
+      'User does not belong to organization',
+    );
+    throw new UserNotInSameOrgError(userId);
+  }
+
+  private async assertNotMember(teamId: UUID, userId: UUID): Promise<void> {
+    const existingMember =
+      await this.teamMembersRepository.findByTeamIdAndUserId(teamId, userId);
+    if (!existingMember) return;
+    this.logger.error({ teamId, userId }, 'User is already a team member');
+    throw new UserAlreadyTeamMemberError(teamId, userId);
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/bulk-add-team-members/bulk-add-team-members.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/bulk-add-team-members/bulk-add-team-members.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
 import { BulkAddTeamMembersUseCase } from './bulk-add-team-members.use-case';
 import { BulkAddTeamMembersCommand } from './bulk-add-team-members.command';
@@ -25,6 +27,10 @@ describe('BulkAddTeamMembersUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         BulkAddTeamMembersUseCase,
+        {
+          provide: getLoggerToken(BulkAddTeamMembersUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: AddTeamMemberUseCase, useValue: mockAddTeamMemberUseCase },
       ],
     }).compile();

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/bulk-add-team-members/bulk-add-team-members.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/bulk-add-team-members/bulk-add-team-members.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { AddTeamMemberUseCase } from '../add-team-member/add-team-member.use-case';
 import { AddTeamMemberCommand } from '../add-team-member/add-team-member.command';
 import { BulkAddTeamMembersCommand } from './bulk-add-team-members.command';
@@ -12,60 +13,71 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class BulkAddTeamMembersUseCase {
-  private readonly logger = new Logger(BulkAddTeamMembersUseCase.name);
-
-  constructor(private readonly addTeamMemberUseCase: AddTeamMemberUseCase) {}
+  constructor(
+    @InjectPinoLogger(BulkAddTeamMembersUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly addTeamMemberUseCase: AddTeamMemberUseCase,
+  ) {}
 
   async execute(command: BulkAddTeamMembersCommand): Promise<TeamMember[]> {
     const uniqueUserIds = [...new Set(command.userIds)];
-
-    this.logger.log('execute', {
-      teamId: command.teamId,
-      count: uniqueUserIds.length,
-    });
+    this.logger.info(
+      { teamId: command.teamId, count: uniqueUserIds.length },
+      'execute',
+    );
 
     try {
-      const added: TeamMember[] = [];
-      for (const userId of uniqueUserIds) {
-        try {
-          added.push(
-            await this.addTeamMemberUseCase.execute(
-              new AddTeamMemberCommand({ teamId: command.teamId, userId }),
-            ),
-          );
-        } catch (error) {
-          if (
-            error instanceof UserAlreadyTeamMemberError ||
-            error instanceof UserNotInSameOrgError ||
-            error instanceof UserNotFoundError
-          ) {
-            this.logger.warn('Skipped user during bulk add', {
-              teamId: command.teamId,
-              userId,
-              reason: error.code,
-            });
-            continue;
-          }
-          throw error;
-        }
-      }
-
-      this.logger.debug('Bulk add finished', {
-        teamId: command.teamId,
-        requested: uniqueUserIds.length,
-        added: added.length,
-      });
-
+      const added = await this.addMembers(command, uniqueUserIds);
+      this.logger.debug(
+        {
+          teamId: command.teamId,
+          requested: uniqueUserIds.length,
+          added: added.length,
+        },
+        'Bulk add finished',
+      );
       return added;
     } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Error bulk adding team members', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        teamId: command.teamId,
-      });
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error(
+        { err: error as Error, teamId: command.teamId },
+        'Error bulk adding team members',
+      );
       throw error;
     }
+  }
+
+  private async addMembers(
+    command: BulkAddTeamMembersCommand,
+    userIds: BulkAddTeamMembersCommand['userIds'],
+  ): Promise<TeamMember[]> {
+    const added: TeamMember[] = [];
+    for (const userId of userIds) {
+      try {
+        added.push(
+          await this.addTeamMemberUseCase.execute(
+            new AddTeamMemberCommand({ teamId: command.teamId, userId }),
+          ),
+        );
+      } catch (error) {
+        if (!this.isSkippable(error)) throw error;
+        this.logger.warn(
+          { teamId: command.teamId, userId, reason: error.code },
+          'Skipped user during bulk add',
+        );
+      }
+    }
+    return added;
+  }
+
+  private isSkippable(
+    error: unknown,
+  ): error is
+    UserAlreadyTeamMemberError | UserNotInSameOrgError | UserNotFoundError {
+    return (
+      error instanceof UserAlreadyTeamMemberError ||
+      error instanceof UserNotInSameOrgError ||
+      error instanceof UserNotFoundError
+    );
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/check-user-team-membership/check-user-team-membership.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/check-user-team-membership/check-user-team-membership.use-case.ts
@@ -1,12 +1,15 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TeamMembersRepository } from '../../ports/team-members.repository';
 import { CheckUserTeamMembershipQuery } from './check-user-team-membership.query';
 
 @Injectable()
 export class CheckUserTeamMembershipUseCase {
-  private readonly logger = new Logger(CheckUserTeamMembershipUseCase.name);
-
-  constructor(private readonly teamMembersRepository: TeamMembersRepository) {}
+  constructor(
+    @InjectPinoLogger(CheckUserTeamMembershipUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly teamMembersRepository: TeamMembersRepository,
+  ) {}
 
   /**
    * Check if a user is a member of a specific team
@@ -14,10 +17,13 @@ export class CheckUserTeamMembershipUseCase {
    * @returns true if the user is a member of the team, false otherwise
    */
   async execute(query: CheckUserTeamMembershipQuery): Promise<boolean> {
-    this.logger.log('checkUserTeamMembership', {
-      userId: query.userId,
-      teamId: query.teamId,
-    });
+    this.logger.info(
+      {
+        userId: query.userId,
+        teamId: query.teamId,
+      },
+      'checkUserTeamMembership',
+    );
 
     const membership = await this.teamMembersRepository.findByTeamIdAndUserId(
       query.teamId,

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/create-team/create-team.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/create-team/create-team.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
 import { CreateTeamUseCase } from './create-team.use-case';
 import { CreateTeamCommand } from './create-team.command';
@@ -33,6 +35,10 @@ describe('CreateTeamUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateTeamUseCase,
+        {
+          provide: getLoggerToken(CreateTeamUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: TeamsRepository, useValue: mockTeamsRepository },
         { provide: ContextService, useValue: mockContextService },
       ],

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/create-team/create-team.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/create-team/create-team.use-case.ts
@@ -1,4 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { CreateTeamCommand } from './create-team.command';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { Team } from 'src/iam/teams/domain/team.entity';
@@ -13,9 +15,9 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 @Injectable()
 export class CreateTeamUseCase {
-  private readonly logger = new Logger(CreateTeamUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateTeamUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly teamsRepository: TeamsRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -29,7 +31,7 @@ export class CreateTeamUseCase {
 
     const trimmedName = command.name.trim() || '';
 
-    this.logger.log('createTeam', { name: trimmedName, orgId });
+    this.logger.info({ name: trimmedName, orgId }, 'createTeam');
 
     if (!trimmedName) {
       this.logger.warn('Attempted to create team with empty name');
@@ -37,38 +39,35 @@ export class CreateTeamUseCase {
     }
 
     try {
-      const existingTeam = await this.teamsRepository.findByNameAndOrgId(
-        trimmedName,
-        orgId,
-      );
-
-      if (existingTeam) {
-        this.logger.warn('Team with this name already exists', {
-          name: trimmedName,
-          orgId,
-        });
-        throw new TeamNameAlreadyExistsError(trimmedName);
-      }
-
-      this.logger.debug('Creating new team', { name: trimmedName, orgId });
-      const team = new Team({ name: trimmedName, orgId });
-      const createdTeam = await this.teamsRepository.create(team);
-      this.logger.debug('Team created successfully', {
-        id: createdTeam.id,
-        name: createdTeam.name,
-      });
-
-      return createdTeam;
+      return await this.createTeam(trimmedName, orgId);
     } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to create team', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        name: command.name,
-        orgId,
-      });
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error(
+        { err: error as Error, name: command.name, orgId },
+        'Failed to create team',
+      );
       throw new UnexpectedTeamError(error);
     }
+  }
+
+  private async createTeam(name: string, orgId: UUID): Promise<Team> {
+    const existingTeam = await this.teamsRepository.findByNameAndOrgId(
+      name,
+      orgId,
+    );
+    if (existingTeam) {
+      this.logger.warn({ name, orgId }, 'Team with this name already exists');
+      throw new TeamNameAlreadyExistsError(name);
+    }
+
+    this.logger.debug({ name, orgId }, 'Creating new team');
+    const createdTeam = await this.teamsRepository.create(
+      new Team({ name, orgId }),
+    );
+    this.logger.debug(
+      { id: createdTeam.id, name: createdTeam.name },
+      'Team created successfully',
+    );
+    return createdTeam;
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/delete-team/delete-team.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/delete-team/delete-team.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { DeleteTeamCommand } from './delete-team.command';
 import { TeamNotFoundError } from '../../teams.errors';
@@ -8,9 +9,9 @@ import { Transactional } from '@nestjs-cls/transactional';
 
 @Injectable()
 export class DeleteTeamUseCase {
-  private readonly logger = new Logger(DeleteTeamUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeleteTeamUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly teamsRepository: TeamsRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -23,20 +24,23 @@ export class DeleteTeamUseCase {
       throw new UnauthorizedAccessError();
     }
 
-    this.logger.log('execute', { teamId: command.teamId, orgId });
+    this.logger.info({ teamId: command.teamId, orgId }, 'execute');
 
     const team = await this.teamsRepository.findById(command.teamId);
     if (!team) {
-      this.logger.error('Team not found', { teamId: command.teamId });
+      this.logger.error({ teamId: command.teamId }, 'Team not found');
       throw new TeamNotFoundError(command.teamId);
     }
 
     if (team.orgId !== orgId) {
-      this.logger.error('Team does not belong to organization', {
-        teamId: command.teamId,
-        teamOrgId: team.orgId,
-        requestOrgId: orgId,
-      });
+      this.logger.error(
+        {
+          teamId: command.teamId,
+          teamOrgId: team.orgId,
+          requestOrgId: orgId,
+        },
+        'Team does not belong to organization',
+      );
       throw new TeamNotFoundError(command.teamId);
     }
 
@@ -46,6 +50,6 @@ export class DeleteTeamUseCase {
 
     await this.teamsRepository.delete(command.teamId);
 
-    this.logger.debug('Team deleted successfully', { teamId: command.teamId });
+    this.logger.debug({ teamId: command.teamId }, 'Team deleted successfully');
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
 import { FindAllUserIdsByTeamIdUseCase } from './find-all-user-ids-by-team-id.use-case';
 import { TeamMembersRepository } from '../../ports/team-members.repository';
@@ -17,6 +19,10 @@ describe('FindAllUserIdsByTeamIdUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FindAllUserIdsByTeamIdUseCase,
+        {
+          provide: getLoggerToken(FindAllUserIdsByTeamIdUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: TeamMembersRepository,
           useValue: teamMembersRepository,

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UUID } from 'crypto';
 import { TeamMembersRepository } from '../../ports/team-members.repository';
 import { FindAllUserIdsByTeamIdQuery } from './find-all-user-ids-by-team-id.query';
@@ -9,12 +10,14 @@ import { FindAllUserIdsByTeamIdQuery } from './find-all-user-ids-by-team-id.quer
  */
 @Injectable()
 export class FindAllUserIdsByTeamIdUseCase {
-  private readonly logger = new Logger(FindAllUserIdsByTeamIdUseCase.name);
-
-  constructor(private readonly teamMembersRepository: TeamMembersRepository) {}
+  constructor(
+    @InjectPinoLogger(FindAllUserIdsByTeamIdUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly teamMembersRepository: TeamMembersRepository,
+  ) {}
 
   async execute(query: FindAllUserIdsByTeamIdQuery): Promise<UUID[]> {
-    this.logger.log('execute', { teamId: query.teamId });
+    this.logger.info({ teamId: query.teamId }, 'execute');
 
     return this.teamMembersRepository.findAllUserIdsByTeamId(query.teamId);
   }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/find-teams-by-user-id/find-teams-by-user-id.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/find-teams-by-user-id/find-teams-by-user-id.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { Team } from 'src/iam/teams/domain/team.entity';
 import { FindTeamsByUserIdQuery } from './find-teams-by-user-id.query';
@@ -7,12 +8,14 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class FindTeamsByUserIdUseCase {
-  private readonly logger = new Logger(FindTeamsByUserIdUseCase.name);
-
-  constructor(private readonly teamsRepository: TeamsRepository) {}
+  constructor(
+    @InjectPinoLogger(FindTeamsByUserIdUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly teamsRepository: TeamsRepository,
+  ) {}
 
   async execute(query: FindTeamsByUserIdQuery): Promise<Team[]> {
-    this.logger.log('execute', { userId: query.userId });
+    this.logger.info({ userId: query.userId }, 'execute');
 
     try {
       return await this.teamsRepository.findByUserId(query.userId);
@@ -20,10 +23,13 @@ export class FindTeamsByUserIdUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Failed to find teams by user ID', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        userId: query.userId,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          userId: query.userId,
+        },
+        'Failed to find teams by user ID',
+      );
       throw new UnexpectedTeamError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/get-team/get-team.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/get-team/get-team.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { GetTeamQuery } from './get-team.query';
 import { Team } from '../../../domain/team.entity';
@@ -9,9 +10,9 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 @Injectable()
 export class GetTeamUseCase {
-  private readonly logger = new Logger(GetTeamUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetTeamUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly teamsRepository: TeamsRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -23,38 +24,47 @@ export class GetTeamUseCase {
       throw new UnauthorizedAccessError();
     }
 
-    this.logger.log('execute', { teamId: query.teamId, orgId });
+    this.logger.info({ teamId: query.teamId, orgId }, 'execute');
 
     try {
       const team = await this.teamsRepository.findById(query.teamId);
 
       if (!team) {
-        this.logger.error('Team not found', { teamId: query.teamId });
+        this.logger.error({ teamId: query.teamId }, 'Team not found');
         throw new TeamNotFoundError(query.teamId);
       }
 
       if (team.orgId !== orgId) {
-        this.logger.error('Team does not belong to organization', {
-          teamId: query.teamId,
-          teamOrgId: team.orgId,
-          requestOrgId: orgId,
-        });
+        this.logger.error(
+          {
+            teamId: query.teamId,
+            teamOrgId: team.orgId,
+            requestOrgId: orgId,
+          },
+          'Team does not belong to organization',
+        );
         throw new TeamNotFoundError(query.teamId);
       }
 
-      this.logger.debug('Team retrieved successfully', {
-        teamId: query.teamId,
-      });
+      this.logger.debug(
+        {
+          teamId: query.teamId,
+        },
+        'Team retrieved successfully',
+      );
 
       return team;
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Failed to retrieve team', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        teamId: query.teamId,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          teamId: query.teamId,
+        },
+        'Failed to retrieve team',
+      );
       throw new UnexpectedTeamError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/list-my-teams/list-my-teams.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/list-my-teams/list-my-teams.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { Team } from 'src/iam/teams/domain/team.entity';
 import { UnexpectedTeamError } from '../../teams.errors';
@@ -8,9 +9,9 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 @Injectable()
 export class ListMyTeamsUseCase {
-  private readonly logger = new Logger(ListMyTeamsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ListMyTeamsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly teamsRepository: TeamsRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -22,24 +23,30 @@ export class ListMyTeamsUseCase {
       throw new UnauthorizedAccessError();
     }
 
-    this.logger.log('listMyTeams', { userId });
+    this.logger.info({ userId }, 'listMyTeams');
 
     try {
       const teams = await this.teamsRepository.findByUserId(userId);
-      this.logger.debug('User teams retrieved successfully', {
-        userId,
-        count: teams.length,
-      });
+      this.logger.debug(
+        {
+          userId,
+          count: teams.length,
+        },
+        'User teams retrieved successfully',
+      );
 
       return teams;
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Failed to retrieve user teams', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        userId,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          userId,
+        },
+        'Failed to retrieve user teams',
+      );
       throw new UnexpectedTeamError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/list-team-members/list-team-members.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/list-team-members/list-team-members.use-case.ts
@@ -1,70 +1,54 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { TeamsRepository } from '../../ports/teams.repository';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TeamMembersRepository } from '../../ports/team-members.repository';
 import { ListTeamMembersQuery } from './list-team-members.query';
 import { TeamMember } from '../../../domain/team-member.entity';
-import { TeamNotFoundError, UnexpectedTeamError } from '../../teams.errors';
+import { UnexpectedTeamError } from '../../teams.errors';
 import { ApplicationError } from 'src/common/errors/base.error';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { GetTeamUseCase } from '../get-team/get-team.use-case';
+import { GetTeamQuery } from '../get-team/get-team.query';
 import { Paginated } from 'src/common/pagination';
 
 @Injectable()
 export class ListTeamMembersUseCase {
-  private readonly logger = new Logger(ListTeamMembersUseCase.name);
-
   constructor(
-    private readonly teamsRepository: TeamsRepository,
+    @InjectPinoLogger(ListTeamMembersUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly teamMembersRepository: TeamMembersRepository,
-    private readonly contextService: ContextService,
+    private readonly getTeamUseCase: GetTeamUseCase,
   ) {}
 
   async execute(query: ListTeamMembersQuery): Promise<Paginated<TeamMember>> {
-    const orgId = this.contextService.get('orgId');
-
-    if (!orgId) {
-      throw new UnauthorizedAccessError();
-    }
-
-    this.logger.log('execute', { teamId: query.teamId, orgId });
+    this.logger.info({ teamId: query.teamId }, 'execute');
 
     try {
-      const team = await this.teamsRepository.findById(query.teamId);
-
-      if (!team) {
-        this.logger.error('Team not found', { teamId: query.teamId });
-        throw new TeamNotFoundError(query.teamId);
-      }
-
-      if (team.orgId !== orgId) {
-        this.logger.error('Team does not belong to organization', {
-          teamId: query.teamId,
-          teamOrgId: team.orgId,
-          requestOrgId: orgId,
-        });
-        throw new TeamNotFoundError(query.teamId);
-      }
-
+      await this.getTeamUseCase.execute(new GetTeamQuery(query.teamId));
       const members = await this.teamMembersRepository.findByTeamId(
         query.teamId,
         { limit: query.limit, offset: query.offset },
       );
 
-      this.logger.debug('Team members retrieved successfully', {
-        teamId: query.teamId,
-        count: members.data.length,
-        total: members.total,
-      });
+      this.logger.debug(
+        {
+          teamId: query.teamId,
+          count: members.data.length,
+          total: members.total,
+        },
+        'Team members retrieved successfully',
+      );
 
       return members;
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Failed to retrieve team members', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        teamId: query.teamId,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          teamId: query.teamId,
+        },
+        'Failed to retrieve team members',
+      );
       throw new UnexpectedTeamError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/list-teams/list-teams.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/list-teams/list-teams.use-case.spec.ts
@@ -1,4 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { Test } from '@nestjs/testing';
 import { ListTeamsUseCase } from './list-teams.use-case';
 import { TeamsRepository } from '../../ports/teams.repository';
@@ -33,6 +35,10 @@ describe('ListTeamsUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ListTeamsUseCase,
+        {
+          provide: getLoggerToken(ListTeamsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: TeamsRepository, useValue: mockTeamsRepository },
         {
           provide: TeamMembersRepository,

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/list-teams/list-teams.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/list-teams/list-teams.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { TeamMembersRepository } from '../../ports/team-members.repository';
 import { UnexpectedTeamError } from '../../teams.errors';
@@ -9,9 +10,9 @@ import { TeamWithMemberCount } from './team-with-member-count.view';
 
 @Injectable()
 export class ListTeamsUseCase {
-  private readonly logger = new Logger(ListTeamsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ListTeamsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly teamsRepository: TeamsRepository,
     private readonly teamMembersRepository: TeamMembersRepository,
     private readonly contextService: ContextService,
@@ -24,7 +25,7 @@ export class ListTeamsUseCase {
       throw new UnauthorizedAccessError();
     }
 
-    this.logger.log('listTeams', { orgId });
+    this.logger.info({ orgId }, 'listTeams');
 
     try {
       const teams = await this.teamsRepository.findByOrgId(orgId);
@@ -32,10 +33,13 @@ export class ListTeamsUseCase {
         teams.map((team) => team.id),
       );
 
-      this.logger.debug('Teams retrieved successfully', {
-        orgId,
-        count: teams.length,
-      });
+      this.logger.debug(
+        {
+          orgId,
+          count: teams.length,
+        },
+        'Teams retrieved successfully',
+      );
 
       return teams.map((team) => ({
         team,
@@ -45,10 +49,13 @@ export class ListTeamsUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Failed to retrieve teams', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          orgId,
+        },
+        'Failed to retrieve teams',
+      );
       throw new UnexpectedTeamError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/remove-team-member/remove-team-member.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/remove-team-member/remove-team-member.use-case.ts
@@ -1,4 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { TeamMembersRepository } from '../../ports/team-members.repository';
 import { RemoveTeamMemberCommand } from './remove-team-member.command';
@@ -11,9 +13,9 @@ import { Transactional } from '@nestjs-cls/transactional';
 
 @Injectable()
 export class RemoveTeamMemberUseCase {
-  private readonly logger = new Logger(RemoveTeamMemberUseCase.name);
-
   constructor(
+    @InjectPinoLogger(RemoveTeamMemberUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly teamsRepository: TeamsRepository,
     private readonly teamMembersRepository: TeamMembersRepository,
     private readonly contextService: ContextService,
@@ -27,69 +29,69 @@ export class RemoveTeamMemberUseCase {
       throw new UnauthorizedAccessError();
     }
 
-    this.logger.log('execute', {
-      teamId: command.teamId,
-      userId: command.userId,
-      orgId,
-    });
+    this.logger.info(
+      {
+        teamId: command.teamId,
+        userId: command.userId,
+        orgId,
+      },
+      'execute',
+    );
 
     try {
-      // Verify team exists and belongs to organization
-      const team = await this.teamsRepository.findById(command.teamId);
-
-      if (!team) {
-        this.logger.error('Team not found', { teamId: command.teamId });
-        throw new TeamNotFoundError(command.teamId);
-      }
-
-      if (team.orgId !== orgId) {
-        this.logger.error('Team does not belong to organization', {
-          teamId: command.teamId,
-          teamOrgId: team.orgId,
-          requestOrgId: orgId,
-        });
-        throw new TeamNotFoundError(command.teamId);
-      }
-
-      // Verify user is a member of the team
-      const existingMember =
-        await this.teamMembersRepository.findByTeamIdAndUserId(
-          command.teamId,
-          command.userId,
-        );
-
-      if (!existingMember) {
-        this.logger.error('User is not a team member', {
-          teamId: command.teamId,
-          userId: command.userId,
-        });
-        throw new TeamMemberNotFoundError(command.teamId, command.userId);
-      }
-
-      // Note: Threads that used shared agents from this team will show a
-      // "conversation no longer accessible" disclaimer when the removed user
-      // tries to continue the chat. The history is preserved.
-
-      // Remove team member
-      await this.teamMembersRepository.deleteByTeamIdAndUserId(
-        command.teamId,
-        command.userId,
-      );
-
-      this.logger.debug('Team member removed successfully', {
-        teamId: command.teamId,
-        userId: command.userId,
-      });
+      await this.removeMember(command, orgId);
     } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to remove team member', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        teamId: command.teamId,
-        userId: command.userId,
-      });
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error(
+        { err: error as Error, teamId: command.teamId, userId: command.userId },
+        'Failed to remove team member',
+      );
       throw error;
     }
+  }
+
+  private async removeMember(
+    command: RemoveTeamMemberCommand,
+    orgId: UUID,
+  ): Promise<void> {
+    await this.assertTeamBelongsToOrg(command.teamId, orgId);
+    await this.assertMemberExists(command.teamId, command.userId);
+    // Shared-agent thread history is retained; access is denied after removal.
+    await this.teamMembersRepository.deleteByTeamIdAndUserId(
+      command.teamId,
+      command.userId,
+    );
+    this.logger.debug(
+      { teamId: command.teamId, userId: command.userId },
+      'Team member removed successfully',
+    );
+  }
+
+  private async assertTeamBelongsToOrg(
+    teamId: UUID,
+    orgId: UUID,
+  ): Promise<void> {
+    const team = await this.teamsRepository.findById(teamId);
+    if (!team) {
+      this.logger.error({ teamId }, 'Team not found');
+      throw new TeamNotFoundError(teamId);
+    }
+    if (team.orgId !== orgId) {
+      this.logger.error(
+        { teamId, teamOrgId: team.orgId, requestOrgId: orgId },
+        'Team does not belong to organization',
+      );
+      throw new TeamNotFoundError(teamId);
+    }
+  }
+
+  private async assertMemberExists(teamId: UUID, userId: UUID): Promise<void> {
+    const member = await this.teamMembersRepository.findByTeamIdAndUserId(
+      teamId,
+      userId,
+    );
+    if (member) return;
+    this.logger.error({ teamId, userId }, 'User is not a team member');
+    throw new TeamMemberNotFoundError(teamId, userId);
   }
 }

--- a/ayunis-core-backend/src/iam/teams/application/use-cases/update-team/update-team.use-case.ts
+++ b/ayunis-core-backend/src/iam/teams/application/use-cases/update-team/update-team.use-case.ts
@@ -1,4 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UpdateTeamCommand } from './update-team.command';
 import { TeamsRepository } from '../../ports/teams.repository';
 import { Team } from '../../../domain/team.entity';
@@ -14,9 +16,9 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 @Injectable()
 export class UpdateTeamUseCase {
-  private readonly logger = new Logger(UpdateTeamUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateTeamUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly teamsRepository: TeamsRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -30,10 +32,13 @@ export class UpdateTeamUseCase {
 
     const trimmedName = command.name.trim() || '';
 
-    this.logger.log('updateTeam', {
-      teamId: command.teamId,
-      name: trimmedName,
-    });
+    this.logger.info(
+      {
+        teamId: command.teamId,
+        name: trimmedName,
+      },
+      'updateTeam',
+    );
 
     if (!trimmedName) {
       this.logger.warn('Attempted to update team with empty name');
@@ -41,63 +46,70 @@ export class UpdateTeamUseCase {
     }
 
     try {
-      const team = await this.teamsRepository.findById(command.teamId);
-
-      if (team?.orgId !== orgId) {
-        this.logger.warn('Team not found or belongs to different org', {
-          teamId: command.teamId,
-          orgId,
-        });
-        throw new TeamNotFoundError(command.teamId);
-      }
-
-      // Only check for duplicates if the name is being changed
-      if (team.name !== trimmedName) {
-        const existingTeam = await this.teamsRepository.findByNameAndOrgId(
-          trimmedName,
-          orgId,
-        );
-
-        if (existingTeam && existingTeam.id !== command.teamId) {
-          this.logger.warn('Team with this name already exists', {
-            name: trimmedName,
-            orgId,
-          });
-          throw new TeamNameAlreadyExistsError(trimmedName);
-        }
-      }
-
-      this.logger.debug('Updating team', {
-        id: team.id,
-        oldName: team.name,
-        newName: trimmedName,
-      });
-
-      team.name = trimmedName;
-      if (command.modelOverrideEnabled !== undefined) {
-        team.modelOverrideEnabled = command.modelOverrideEnabled;
-      }
-      team.updatedAt = new Date();
-
-      const updatedTeam = await this.teamsRepository.update(team);
-
-      this.logger.debug('Team updated successfully', {
-        id: updatedTeam.id,
-        name: updatedTeam.name,
-      });
-
-      return updatedTeam;
+      return await this.updateTeam(command, trimmedName, orgId);
     } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Failed to update team', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        teamId: command.teamId,
-        name: command.name,
-        orgId,
-      });
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error(
+        {
+          err: error as Error,
+          teamId: command.teamId,
+          name: command.name,
+          orgId,
+        },
+        'Failed to update team',
+      );
       throw new UnexpectedTeamError(error);
     }
+  }
+
+  private async updateTeam(
+    command: UpdateTeamCommand,
+    name: string,
+    orgId: UUID,
+  ): Promise<Team> {
+    const team = await this.getTeam(command.teamId, orgId);
+    await this.assertNameAvailable(team, name, orgId);
+    this.logger.debug(
+      { id: team.id, name: { old: team.name, new: name } },
+      'Updating team',
+    );
+
+    team.name = name;
+    if (command.modelOverrideEnabled !== undefined) {
+      team.modelOverrideEnabled = command.modelOverrideEnabled;
+    }
+    team.updatedAt = new Date();
+
+    const updatedTeam = await this.teamsRepository.update(team);
+    this.logger.debug(
+      { id: updatedTeam.id, name: updatedTeam.name },
+      'Team updated successfully',
+    );
+    return updatedTeam;
+  }
+
+  private async getTeam(teamId: UUID, orgId: UUID): Promise<Team> {
+    const team = await this.teamsRepository.findById(teamId);
+    if (team?.orgId === orgId) return team;
+    this.logger.warn(
+      { teamId, orgId },
+      'Team not found or belongs to different org',
+    );
+    throw new TeamNotFoundError(teamId);
+  }
+
+  private async assertNameAvailable(
+    team: Team,
+    name: string,
+    orgId: UUID,
+  ): Promise<void> {
+    if (team.name === name) return;
+    const existingTeam = await this.teamsRepository.findByNameAndOrgId(
+      name,
+      orgId,
+    );
+    if (!existingTeam || existingTeam.id === team.id) return;
+    this.logger.warn({ name, orgId }, 'Team with this name already exists');
+    throw new TeamNameAlreadyExistsError(name);
   }
 }

--- a/ayunis-core-backend/src/iam/teams/infrastructure/repositories/local/local-team-members.repository.ts
+++ b/ayunis-core-backend/src/iam/teams/infrastructure/repositories/local/local-team-members.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TeamMembersRepository } from 'src/iam/teams/application/ports/team-members.repository';
 import { TeamMember } from 'src/iam/teams/domain/team-member.entity';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -10,21 +11,21 @@ import { Paginated, PaginatedQueryParams } from 'src/common/pagination';
 
 @Injectable()
 export class LocalTeamMembersRepository extends TeamMembersRepository {
-  private readonly logger = new Logger(LocalTeamMembersRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalTeamMembersRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(TeamMemberRecord)
     private readonly teamMemberRepository: Repository<TeamMemberRecord>,
   ) {
     super();
-    this.logger.log('constructor');
+    this.logger.info('constructor');
   }
 
   async findByTeamId(
     teamId: UUID,
     pagination: PaginatedQueryParams,
   ): Promise<Paginated<TeamMember>> {
-    this.logger.log('findByTeamId', { teamId, pagination });
+    this.logger.info({ teamId, pagination }, 'findByTeamId');
 
     const [records, total] = await this.teamMemberRepository.findAndCount({
       where: { teamId },
@@ -34,10 +35,13 @@ export class LocalTeamMembersRepository extends TeamMembersRepository {
       take: pagination.limit,
     });
 
-    this.logger.debug('Team members found', {
-      teamId,
-      count: records.length,
-    });
+    this.logger.debug(
+      {
+        teamId,
+        count: records.length,
+      },
+      'Team members found',
+    );
 
     return new Paginated({
       data: records.map((record) => TeamMemberMapper.toDomain(record)),
@@ -51,7 +55,7 @@ export class LocalTeamMembersRepository extends TeamMembersRepository {
     teamId: UUID,
     userId: UUID,
   ): Promise<TeamMember | null> {
-    this.logger.log('findByTeamIdAndUserId', { teamId, userId });
+    this.logger.info({ teamId, userId }, 'findByTeamIdAndUserId');
 
     const record = await this.teamMemberRepository.findOne({
       where: { teamId, userId },
@@ -59,20 +63,23 @@ export class LocalTeamMembersRepository extends TeamMembersRepository {
     });
 
     if (!record) {
-      this.logger.debug('Team member not found', { teamId, userId });
+      this.logger.debug({ teamId, userId }, 'Team member not found');
       return null;
     }
 
-    this.logger.debug('Team member found', { teamId, userId });
+    this.logger.debug({ teamId, userId }, 'Team member found');
     return TeamMemberMapper.toDomain(record);
   }
 
   async create(teamMember: TeamMember): Promise<TeamMember> {
-    this.logger.log('create', {
-      id: teamMember.id,
-      teamId: teamMember.teamId,
-      userId: teamMember.userId,
-    });
+    this.logger.info(
+      {
+        id: teamMember.id,
+        teamId: teamMember.teamId,
+        userId: teamMember.userId,
+      },
+      'create',
+    );
 
     const record = TeamMemberMapper.toRecord(teamMember);
     const savedRecord = await this.teamMemberRepository.save(record);
@@ -83,45 +90,51 @@ export class LocalTeamMembersRepository extends TeamMembersRepository {
       relations: ['user'],
     });
 
-    this.logger.debug('Team member created successfully', {
-      id: savedRecord.id,
-    });
+    this.logger.debug(
+      {
+        id: savedRecord.id,
+      },
+      'Team member created successfully',
+    );
 
     return TeamMemberMapper.toDomain(reloadedRecord!);
   }
 
   async delete(id: UUID): Promise<void> {
-    this.logger.log('delete', { id });
+    this.logger.info({ id }, 'delete');
 
     await this.teamMemberRepository.delete(id);
-    this.logger.debug('Team member deleted successfully', { id });
+    this.logger.debug({ id }, 'Team member deleted successfully');
   }
 
   async deleteByTeamIdAndUserId(teamId: UUID, userId: UUID): Promise<void> {
-    this.logger.log('deleteByTeamIdAndUserId', { teamId, userId });
+    this.logger.info({ teamId, userId }, 'deleteByTeamIdAndUserId');
 
     await this.teamMemberRepository.delete({ teamId, userId });
-    this.logger.debug('Team member deleted successfully', { teamId, userId });
+    this.logger.debug({ teamId, userId }, 'Team member deleted successfully');
   }
 
   async findAllUserIdsByTeamId(teamId: UUID): Promise<UUID[]> {
-    this.logger.log('findAllUserIdsByTeamId', { teamId });
+    this.logger.info({ teamId }, 'findAllUserIdsByTeamId');
 
     const records = await this.teamMemberRepository.find({
       where: { teamId },
       select: ['userId'],
     });
 
-    this.logger.debug('All team member user IDs found', {
-      teamId,
-      count: records.length,
-    });
+    this.logger.debug(
+      {
+        teamId,
+        count: records.length,
+      },
+      'All team member user IDs found',
+    );
 
     return records.map((record) => record.userId);
   }
 
   async countByTeamIds(teamIds: UUID[]): Promise<Map<UUID, number>> {
-    this.logger.log('countByTeamIds', { count: teamIds.length });
+    this.logger.info({ count: teamIds.length }, 'countByTeamIds');
 
     const counts = new Map<UUID, number>(teamIds.map((id) => [id, 0]));
     if (teamIds.length === 0) {

--- a/ayunis-core-backend/src/iam/teams/infrastructure/repositories/local/local-teams.repository.ts
+++ b/ayunis-core-backend/src/iam/teams/infrastructure/repositories/local/local-teams.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TeamsRepository } from 'src/iam/teams/application/ports/teams.repository';
 import { Team } from 'src/iam/teams/domain/team.entity';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -10,53 +11,53 @@ import { UUID } from 'crypto';
 
 @Injectable()
 export class LocalTeamsRepository extends TeamsRepository {
-  private readonly logger = new Logger(LocalTeamsRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalTeamsRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(TeamRecord)
     private readonly teamRepository: Repository<TeamRecord>,
   ) {
     super();
-    this.logger.log('constructor');
+    this.logger.info('constructor');
   }
 
   async findById(id: UUID): Promise<Team | null> {
-    this.logger.log('findById', { id });
+    this.logger.info({ id }, 'findById');
 
     const teamRecord = await this.teamRepository.findOne({
       where: { id },
     });
 
     if (!teamRecord) {
-      this.logger.debug('Team not found', { id });
+      this.logger.debug({ id }, 'Team not found');
       return null;
     }
 
-    this.logger.debug('Team found', { id, name: teamRecord.name });
+    this.logger.debug({ id, name: teamRecord.name }, 'Team found');
     return TeamMapper.toDomain(teamRecord);
   }
 
   async findByOrgId(orgId: UUID): Promise<Team[]> {
-    this.logger.log('findByOrgId', { orgId });
+    this.logger.info({ orgId }, 'findByOrgId');
 
     const teamRecords = await this.teamRepository.find({
       where: { orgId },
       order: { createdAt: 'DESC' },
     });
 
-    this.logger.debug('Teams found', { orgId, count: teamRecords.length });
+    this.logger.debug({ orgId, count: teamRecords.length }, 'Teams found');
     return teamRecords.map((record) => TeamMapper.toDomain(record));
   }
 
   async findByNameAndOrgId(name: string, orgId: UUID): Promise<Team | null> {
-    this.logger.log('findByNameAndOrgId', { name, orgId });
+    this.logger.info({ name, orgId }, 'findByNameAndOrgId');
 
     const teamRecord = await this.teamRepository.findOne({
       where: { name, orgId },
     });
 
     if (!teamRecord) {
-      this.logger.debug('Team not found', { name, orgId });
+      this.logger.debug({ name, orgId }, 'Team not found');
       return null;
     }
 
@@ -64,7 +65,7 @@ export class LocalTeamsRepository extends TeamsRepository {
   }
 
   async findByUserId(userId: UUID): Promise<Team[]> {
-    this.logger.log('findByUserId', { userId });
+    this.logger.info({ userId }, 'findByUserId');
 
     const teamRecords = await this.teamRepository
       .createQueryBuilder('team')
@@ -73,52 +74,67 @@ export class LocalTeamsRepository extends TeamsRepository {
       .orderBy('team.name', 'ASC')
       .getMany();
 
-    this.logger.debug('Teams found for user', {
-      userId,
-      count: teamRecords.length,
-    });
+    this.logger.debug(
+      {
+        userId,
+        count: teamRecords.length,
+      },
+      'Teams found for user',
+    );
     return teamRecords.map((record) => TeamMapper.toDomain(record));
   }
 
   async create(team: Team): Promise<Team> {
-    this.logger.log('create', {
-      id: team.id,
-      name: team.name,
-      orgId: team.orgId,
-    });
+    this.logger.info(
+      {
+        id: team.id,
+        name: team.name,
+        orgId: team.orgId,
+      },
+      'create',
+    );
 
     const teamRecord = TeamMapper.toRecord(team);
     const savedRecord = await this.teamRepository.save(teamRecord);
 
-    this.logger.debug('Team created successfully', {
-      id: savedRecord.id,
-      name: savedRecord.name,
-    });
+    this.logger.debug(
+      {
+        id: savedRecord.id,
+        name: savedRecord.name,
+      },
+      'Team created successfully',
+    );
 
     return TeamMapper.toDomain(savedRecord);
   }
 
   async update(team: Team): Promise<Team> {
-    this.logger.log('update', {
-      id: team.id,
-      name: team.name,
-    });
+    this.logger.info(
+      {
+        id: team.id,
+        name: team.name,
+      },
+      'update',
+    );
 
     const teamRecord = TeamMapper.toRecord(team);
     const savedRecord = await this.teamRepository.save(teamRecord);
 
-    this.logger.debug('Team updated successfully', {
-      id: savedRecord.id,
-      name: savedRecord.name,
-    });
+    this.logger.debug(
+      {
+        id: savedRecord.id,
+        name: savedRecord.name,
+      },
+      'Team updated successfully',
+    );
 
     return TeamMapper.toDomain(savedRecord);
   }
 
   async delete(id: UUID): Promise<void> {
-    this.logger.log('delete', { id });
+    this.logger.info({ id }, 'delete');
 
     await this.teamRepository.delete(id);
-    this.logger.debug('Team deleted successfully', { id });
+    this.logger.debug({ id }, 'Team deleted successfully');
   }
 }

--- a/ayunis-core-backend/src/iam/teams/presenters/http/teams.controller.ts
+++ b/ayunis-core-backend/src/iam/teams/presenters/http/teams.controller.ts
@@ -10,8 +10,8 @@ import {
   ParseUUIDPipe,
   HttpCode,
   HttpStatus,
-  Logger,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -65,9 +65,9 @@ import { Permission } from 'src/iam/permissions/domain/value-objects/permission.
   ListTeamMembersQueryDto,
 )
 export class TeamsController {
-  private readonly logger = new Logger(TeamsController.name);
-
   constructor(
+    @InjectPinoLogger(TeamsController.name)
+    private readonly logger: PinoLogger,
     private readonly createTeamUseCase: CreateTeamUseCase,
     private readonly updateTeamUseCase: UpdateTeamUseCase,
     private readonly deleteTeamUseCase: DeleteTeamUseCase,
@@ -107,11 +107,14 @@ export class TeamsController {
     description: 'Internal server error',
   })
   async listTeams(): Promise<TeamResponseDto[]> {
-    this.logger.log('Listing teams for organization');
+    this.logger.info('Listing teams for organization');
 
     const teams = await this.listTeamsUseCase.execute();
 
-    this.logger.log(`Successfully retrieved ${teams.length} teams`);
+    this.logger.info(
+      { teamCount: teams.length },
+      'Successfully retrieved teams',
+    );
     return this.teamDtoMapper.toDtoListWithMemberCount(teams);
   }
 
@@ -133,11 +136,14 @@ export class TeamsController {
     description: 'Internal server error',
   })
   async listMyTeams(): Promise<TeamResponseDto[]> {
-    this.logger.log('Listing teams for current user');
+    this.logger.info('Listing teams for current user');
 
     const teams = await this.listMyTeamsUseCase.execute();
 
-    this.logger.log(`Successfully retrieved ${teams.length} teams for user`);
+    this.logger.info(
+      { teamCount: teams.length },
+      'Successfully retrieved teams for user',
+    );
     return this.teamDtoMapper.toDtoList(teams);
   }
 
@@ -172,12 +178,12 @@ export class TeamsController {
   async getTeam(
     @Param('id', ParseUUIDPipe) id: UUID,
   ): Promise<TeamResponseDto> {
-    this.logger.log(`Getting team with id: ${id}`);
+    this.logger.info({ teamId: id }, 'Getting team');
 
     const query = new GetTeamQuery(id);
     const response = await this.getTeamUseCase.execute(query);
 
-    this.logger.log(`Successfully retrieved team with id: ${id}`);
+    this.logger.info({ teamId: id }, 'Successfully retrieved team');
     return this.teamDtoMapper.toDto(response);
   }
 
@@ -216,12 +222,12 @@ export class TeamsController {
   async createTeam(
     @Body() createTeamDto: CreateTeamDto,
   ): Promise<TeamResponseDto> {
-    this.logger.log(`Creating team with name: ${createTeamDto.name}`);
+    this.logger.info({ name: createTeamDto.name }, 'Creating team');
 
     const command = new CreateTeamCommand(createTeamDto.name);
     const team = await this.createTeamUseCase.execute(command);
 
-    this.logger.log(`Successfully created team with id: ${team.id}`);
+    this.logger.info({ teamId: team.id }, 'Successfully created team');
     return this.teamDtoMapper.toDto(team);
   }
 
@@ -261,9 +267,7 @@ export class TeamsController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() updateTeamDto: UpdateTeamDto,
   ): Promise<TeamResponseDto> {
-    this.logger.log(
-      `Updating team ${id} with name: ${updateTeamDto.name}, modelOverrideEnabled: ${updateTeamDto.modelOverrideEnabled}`,
-    );
+    this.logger.info({ teamId: id, ...updateTeamDto }, 'Updating team');
 
     const command = new UpdateTeamCommand(
       id,
@@ -272,7 +276,7 @@ export class TeamsController {
     );
     const team = await this.updateTeamUseCase.execute(command);
 
-    this.logger.log(`Successfully updated team with id: ${team.id}`);
+    this.logger.info({ teamId: team.id }, 'Successfully updated team');
     return this.teamDtoMapper.toDto(team);
   }
 
@@ -303,12 +307,12 @@ export class TeamsController {
     description: 'Internal server error',
   })
   async deleteTeam(@Param('id', ParseUUIDPipe) id: UUID): Promise<void> {
-    this.logger.log(`Deleting team with id: ${id}`);
+    this.logger.info({ teamId: id }, 'Deleting team');
 
     const command = new DeleteTeamCommand(id);
     await this.deleteTeamUseCase.execute(command);
 
-    this.logger.log(`Successfully deleted team with id: ${id}`);
+    this.logger.info({ teamId: id }, 'Successfully deleted team');
   }
 
   @RequirePermission(Permission.MANAGE_TEAMS, Permission.ASSIGN_USERS_TO_TEAMS)
@@ -339,7 +343,7 @@ export class TeamsController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Query() queryDto: ListTeamMembersQueryDto,
   ): Promise<PaginatedTeamMembersResponseDto> {
-    this.logger.log(`Listing members for team: ${id}`);
+    this.logger.info({ teamId: id }, 'Listing members for team');
 
     const query = new ListTeamMembersQuery({
       teamId: id,
@@ -348,8 +352,9 @@ export class TeamsController {
     });
     const result = await this.listTeamMembersUseCase.execute(query);
 
-    this.logger.log(
-      `Successfully retrieved ${result.data.length} members for team: ${id}`,
+    this.logger.info(
+      { teamId: id, memberCount: result.data.length },
+      'Successfully retrieved members for team',
     );
     return {
       data: this.teamMemberDtoMapper.toDtoList(result.data),
@@ -397,17 +402,13 @@ export class TeamsController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() addTeamMemberDto: AddTeamMemberDto,
   ): Promise<TeamMemberResponseDto> {
-    this.logger.log(`Adding user ${addTeamMemberDto.userId} to team: ${id}`);
+    const { userId } = addTeamMemberDto;
+    this.logger.info({ teamId: id, userId }, 'Adding user to team');
 
-    const command = new AddTeamMemberCommand({
-      teamId: id,
-      userId: addTeamMemberDto.userId,
-    });
+    const command = new AddTeamMemberCommand({ teamId: id, userId });
     const teamMember = await this.addTeamMemberUseCase.execute(command);
 
-    this.logger.log(
-      `Successfully added user ${addTeamMemberDto.userId} to team: ${id}`,
-    );
+    this.logger.info({ teamId: id, userId }, 'Successfully added user to team');
     return this.teamMemberDtoMapper.toDto(teamMember);
   }
 
@@ -431,8 +432,9 @@ export class TeamsController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Body() bulkAddTeamMembersDto: BulkAddTeamMembersDto,
   ): Promise<TeamMemberResponseDto[]> {
-    this.logger.log(
-      `Adding ${bulkAddTeamMembersDto.userIds.length} users to team: ${id}`,
+    this.logger.info(
+      { teamId: id, userCount: bulkAddTeamMembersDto.userIds.length },
+      'Adding users to team',
     );
 
     const command = new BulkAddTeamMembersCommand({
@@ -441,8 +443,9 @@ export class TeamsController {
     });
     const teamMembers = await this.bulkAddTeamMembersUseCase.execute(command);
 
-    this.logger.log(
-      `Successfully added ${teamMembers.length} users to team: ${id}`,
+    this.logger.info(
+      { teamId: id, userCount: teamMembers.length },
+      'Successfully added users to team',
     );
     return this.teamMemberDtoMapper.toDtoList(teamMembers);
   }
@@ -477,7 +480,7 @@ export class TeamsController {
     @Param('id', ParseUUIDPipe) id: UUID,
     @Param('userId', ParseUUIDPipe) userId: UUID,
   ): Promise<void> {
-    this.logger.log(`Removing user ${userId} from team: ${id}`);
+    this.logger.info({ teamId: id, userId }, 'Removing user from team');
 
     const command = new RemoveTeamMemberCommand({
       teamId: id,
@@ -485,6 +488,9 @@ export class TeamsController {
     });
     await this.removeTeamMemberUseCase.execute(command);
 
-    this.logger.log(`Successfully removed user ${userId} from team: ${id}`);
+    this.logger.info(
+      { teamId: id, userId },
+      'Successfully removed user from team',
+    );
   }
 }

--- a/ayunis-core-backend/src/iam/teams/teams.module.ts
+++ b/ayunis-core-backend/src/iam/teams/teams.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { getLoggerToken, PinoLogger } from 'nestjs-pino';
 
 import { TeamsRepository } from './application/ports/teams.repository';
 import { TeamMembersRepository } from './application/ports/team-members.repository';
@@ -38,10 +39,16 @@ import { UsersModule } from '../users/users.module';
   providers: [
     {
       provide: TeamsRepository,
-      useFactory: (teamRepository: Repository<TeamRecord>) => {
-        return new LocalTeamsRepository(teamRepository);
+      useFactory: (
+        logger: PinoLogger,
+        teamRepository: Repository<TeamRecord>,
+      ) => {
+        return new LocalTeamsRepository(logger, teamRepository);
       },
-      inject: [getRepositoryToken(TeamRecord)],
+      inject: [
+        getLoggerToken(LocalTeamsRepository.name),
+        getRepositoryToken(TeamRecord),
+      ],
     },
     {
       provide: TeamMembersRepository,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are mostly observability and test wiring; limited functional edits (team member listing auth path) are refactors that should preserve behavior.
> 
> **Overview**
> Migrates **onboarding**, **orgs**, **platform-config**, **SSO**, and **teams** IAM areas from Nest’s built-in `Logger` to **nestjs-pino** (`InjectPinoLogger` / `PinoLogger`), with structured logs using the `(metadata, message)` shape and `err` on errors instead of stringified `error` fields.
> 
> **Tests and DI** register `createPinoLoggerMock()` via `getLoggerToken`; `LocalOrgsRepository` and `LocalTeamsRepository` factories now inject the Pino logger. Controllers and use-case specs were updated accordingly.
> 
> **Logging-only tweaks** include fair-use list/search fields logged as `text`, platform-config warn messages as static strings with `key` in metadata, and SSO super-admin audit logs mapping `emailDomain` → `domain` (with spec assertions on the new shape).
> 
> **Small behavior-preserving refactors** bundled with the migration: `GetFairUseLimitsUseCase` groups limit/window reads via `readLimits`; several team use cases extract private helpers (`addMember`, `assertTeamBelongsToOrg`, etc.); `ListTeamMembersUseCase` delegates org/team checks to `GetTeamUseCase` instead of duplicating repository lookups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6dff20136cb915829ce503ac49f255d5ced9823. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->