### PR TITLE
wip(logging): migrate billing and limit logging (AYC-759)

### DIFF
--- a/ayunis-core-backend/src/iam/addons/application/use-cases/activate-addon/activate-addon.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/activate-addon/activate-addon.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import type { EventEmitter2 } from '@nestjs/event-emitter';
 import { ActivateAddonUseCase } from './activate-addon.use-case';
@@ -28,7 +29,11 @@ describe('ActivateAddonUseCase', () => {
   it('creates the addon row and emits addon.activated when the addon is inactive', async () => {
     const repo = makeRepo(null);
     const eventEmitter = makeEventEmitter();
-    const useCase = new ActivateAddonUseCase(repo, eventEmitter);
+    const useCase = new ActivateAddonUseCase(
+      createPinoLoggerMock(),
+      repo,
+      eventEmitter,
+    );
 
     await useCase.execute(
       new ActivateAddonCommand(
@@ -59,7 +64,11 @@ describe('ActivateAddonUseCase', () => {
     });
     const repo = makeRepo(existing);
     const eventEmitter = makeEventEmitter();
-    const useCase = new ActivateAddonUseCase(repo, eventEmitter);
+    const useCase = new ActivateAddonUseCase(
+      createPinoLoggerMock(),
+      repo,
+      eventEmitter,
+    );
 
     await useCase.execute(
       new ActivateAddonCommand(
@@ -78,7 +87,11 @@ describe('ActivateAddonUseCase', () => {
     (repo.create as jest.Mock).mockRejectedValue(
       new Error('unique constraint violation'),
     );
-    const useCase = new ActivateAddonUseCase(repo, makeEventEmitter());
+    const useCase = new ActivateAddonUseCase(
+      createPinoLoggerMock(),
+      repo,
+      makeEventEmitter(),
+    );
 
     await expect(
       useCase.execute(

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/activate-addon/activate-addon.use-case.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/activate-addon/activate-addon.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { OrgAddon } from 'src/iam/addons/domain/org-addon.entity';
@@ -9,18 +10,21 @@ import { ActivateAddonCommand } from './activate-addon.command';
 
 @Injectable()
 export class ActivateAddonUseCase {
-  private readonly logger = new Logger(ActivateAddonUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ActivateAddonUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly orgAddonRepository: OrgAddonRepository,
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(command: ActivateAddonCommand): Promise<void> {
-    this.logger.log('Activating addon', {
-      orgId: command.orgId,
-      type: command.type,
-    });
+    this.logger.info(
+      {
+        orgId: command.orgId,
+        type: command.type,
+      },
+      'Activating addon',
+    );
 
     try {
       const existing = await this.orgAddonRepository.findByOrgAndType(
@@ -48,15 +52,14 @@ export class ActivateAddonUseCase {
           ),
         )
         .catch((err: unknown) => {
-          this.logger.error('Failed to emit AddonActivatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            orgId: command.orgId,
-            type: command.type,
-          });
+          this.logger.error(
+            { err: err as Error, orgId: command.orgId, type: command.type },
+            'Failed to emit AddonActivatedEvent',
+          );
         });
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error activating addon', { error: error as Error });
+      this.logger.error({ err: error as Error }, 'Error activating addon');
       throw new UnexpectedAddonError('activate', { error: error as Error });
     }
   }

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/deactivate-addon/deactivate-addon.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/deactivate-addon/deactivate-addon.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import type { EventEmitter2 } from '@nestjs/event-emitter';
 import { DeactivateAddonUseCase } from './deactivate-addon.use-case';
@@ -32,7 +33,11 @@ describe('DeactivateAddonUseCase', () => {
     });
     const repo = makeRepo(existing);
     const eventEmitter = makeEventEmitter();
-    const useCase = new DeactivateAddonUseCase(repo, eventEmitter);
+    const useCase = new DeactivateAddonUseCase(
+      createPinoLoggerMock(),
+      repo,
+      eventEmitter,
+    );
 
     await useCase.execute(
       new DeactivateAddonCommand(
@@ -56,7 +61,11 @@ describe('DeactivateAddonUseCase', () => {
   it('is a no-op without an event when the addon is already inactive', async () => {
     const repo = makeRepo(null);
     const eventEmitter = makeEventEmitter();
-    const useCase = new DeactivateAddonUseCase(repo, eventEmitter);
+    const useCase = new DeactivateAddonUseCase(
+      createPinoLoggerMock(),
+      repo,
+      eventEmitter,
+    );
 
     await useCase.execute(
       new DeactivateAddonCommand(
@@ -77,7 +86,11 @@ describe('DeactivateAddonUseCase', () => {
     });
     const repo = makeRepo(existing);
     (repo.delete as jest.Mock).mockRejectedValue(new Error('deadlock'));
-    const useCase = new DeactivateAddonUseCase(repo, makeEventEmitter());
+    const useCase = new DeactivateAddonUseCase(
+      createPinoLoggerMock(),
+      repo,
+      makeEventEmitter(),
+    );
 
     await expect(
       useCase.execute(

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/deactivate-addon/deactivate-addon.use-case.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/deactivate-addon/deactivate-addon.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { OrgAddonRepository } from '../../ports/org-addon.repository';
@@ -8,18 +9,21 @@ import { DeactivateAddonCommand } from './deactivate-addon.command';
 
 @Injectable()
 export class DeactivateAddonUseCase {
-  private readonly logger = new Logger(DeactivateAddonUseCase.name);
-
   constructor(
+    @InjectPinoLogger(DeactivateAddonUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly orgAddonRepository: OrgAddonRepository,
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async execute(command: DeactivateAddonCommand): Promise<void> {
-    this.logger.log('Deactivating addon', {
-      orgId: command.orgId,
-      type: command.type,
-    });
+    this.logger.info(
+      {
+        orgId: command.orgId,
+        type: command.type,
+      },
+      'Deactivating addon',
+    );
 
     try {
       const existing = await this.orgAddonRepository.findByOrgAndType(
@@ -43,15 +47,14 @@ export class DeactivateAddonUseCase {
           ),
         )
         .catch((err: unknown) => {
-          this.logger.error('Failed to emit AddonDeactivatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            orgId: command.orgId,
-            type: command.type,
-          });
+          this.logger.error(
+            { err: err as Error, orgId: command.orgId, type: command.type },
+            'Failed to emit AddonDeactivatedEvent',
+          );
         });
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error deactivating addon', { error: error as Error });
+      this.logger.error({ err: error as Error }, 'Error deactivating addon');
       throw new UnexpectedAddonError('deactivate', { error: error as Error });
     }
   }

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/is-addon-active/is-addon-active.use-case.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/is-addon-active/is-addon-active.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { OrgAddonRepository } from '../../ports/org-addon.repository';
 import { UnexpectedAddonError } from '../../addons.errors';
@@ -6,15 +7,20 @@ import { IsAddonActiveQuery } from './is-addon-active.query';
 
 @Injectable()
 export class IsAddonActiveUseCase {
-  private readonly logger = new Logger(IsAddonActiveUseCase.name);
-
-  constructor(private readonly orgAddonRepository: OrgAddonRepository) {}
+  constructor(
+    @InjectPinoLogger(IsAddonActiveUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly orgAddonRepository: OrgAddonRepository,
+  ) {}
 
   async execute(query: IsAddonActiveQuery): Promise<boolean> {
-    this.logger.log('Checking if addon is active', {
-      orgId: query.orgId,
-      type: query.type,
-    });
+    this.logger.info(
+      {
+        orgId: query.orgId,
+        type: query.type,
+      },
+      'Checking if addon is active',
+    );
 
     try {
       const addon = await this.orgAddonRepository.findByOrgAndType(
@@ -24,9 +30,10 @@ export class IsAddonActiveUseCase {
       return addon !== null;
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error checking if addon is active', {
-        error: error as Error,
-      });
+      this.logger.error(
+        { err: error as Error },
+        'Error checking if addon is active',
+      );
       throw new UnexpectedAddonError('check', { error: error as Error });
     }
   }

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/list-org-addons/list-org-addons.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/list-org-addons/list-org-addons.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { ListOrgAddonsUseCase } from './list-org-addons.use-case';
 import { ListOrgAddonsQuery } from './list-org-addons.query';
@@ -19,7 +20,10 @@ function makeRepo(active: OrgAddon[]): OrgAddonRepository {
 
 describe('ListOrgAddonsUseCase', () => {
   it('returns the full addon catalog with active=false when the org has no addons', async () => {
-    const useCase = new ListOrgAddonsUseCase(makeRepo([]));
+    const useCase = new ListOrgAddonsUseCase(
+      createPinoLoggerMock(),
+      makeRepo([]),
+    );
 
     const result = await useCase.execute(new ListOrgAddonsQuery(ORG_ID));
 
@@ -33,7 +37,10 @@ describe('ListOrgAddonsUseCase', () => {
       orgId: ORG_ID,
       type: AddonType.AYUNIS_CORE_ACADEMY,
     });
-    const useCase = new ListOrgAddonsUseCase(makeRepo([academy]));
+    const useCase = new ListOrgAddonsUseCase(
+      createPinoLoggerMock(),
+      makeRepo([academy]),
+    );
 
     const result = await useCase.execute(new ListOrgAddonsQuery(ORG_ID));
 
@@ -48,7 +55,7 @@ describe('ListOrgAddonsUseCase', () => {
     (repo.findAllByOrgId as jest.Mock).mockRejectedValue(
       new Error('connection refused'),
     );
-    const useCase = new ListOrgAddonsUseCase(repo);
+    const useCase = new ListOrgAddonsUseCase(createPinoLoggerMock(), repo);
 
     await expect(
       useCase.execute(new ListOrgAddonsQuery(ORG_ID)),

--- a/ayunis-core-backend/src/iam/addons/application/use-cases/list-org-addons/list-org-addons.use-case.ts
+++ b/ayunis-core-backend/src/iam/addons/application/use-cases/list-org-addons/list-org-addons.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { AddonStatus } from 'src/iam/addons/domain/addon-status';
 import { AddonType } from 'src/iam/addons/domain/value-objects/addon-type.enum';
@@ -8,12 +9,14 @@ import { ListOrgAddonsQuery } from './list-org-addons.query';
 
 @Injectable()
 export class ListOrgAddonsUseCase {
-  private readonly logger = new Logger(ListOrgAddonsUseCase.name);
-
-  constructor(private readonly orgAddonRepository: OrgAddonRepository) {}
+  constructor(
+    @InjectPinoLogger(ListOrgAddonsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly orgAddonRepository: OrgAddonRepository,
+  ) {}
 
   async execute(query: ListOrgAddonsQuery): Promise<AddonStatus[]> {
-    this.logger.log('Listing org addons', { orgId: query.orgId });
+    this.logger.info({ orgId: query.orgId }, 'Listing org addons');
 
     try {
       const activeAddons = await this.orgAddonRepository.findAllByOrgId(
@@ -28,9 +31,7 @@ export class ListOrgAddonsUseCase {
       }));
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error listing org addons', {
-        error: error as Error,
-      });
+      this.logger.error({ err: error as Error }, 'Error listing org addons');
       throw new UnexpectedAddonError('list', { error: error as Error });
     }
   }

--- a/ayunis-core-backend/src/iam/addons/infrastructure/persistence/postgres/org-addon.repository.ts
+++ b/ayunis-core-backend/src/iam/addons/infrastructure/persistence/postgres/org-addon.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { UUID } from 'crypto';
@@ -10,9 +11,9 @@ import { OrgAddonMapper } from './mappers/org-addon.mapper';
 
 @Injectable()
 export class PostgresOrgAddonRepository extends OrgAddonRepository {
-  private readonly logger = new Logger(PostgresOrgAddonRepository.name);
-
   constructor(
+    @InjectPinoLogger(PostgresOrgAddonRepository.name)
+    private readonly logger: PinoLogger,
     @InjectRepository(OrgAddonRecord)
     private readonly repository: Repository<OrgAddonRecord>,
   ) {
@@ -36,7 +37,7 @@ export class PostgresOrgAddonRepository extends OrgAddonRepository {
   }
 
   async create(addon: OrgAddon): Promise<OrgAddon> {
-    this.logger.debug('create', { orgId: addon.orgId, type: addon.type });
+    this.logger.debug({ orgId: addon.orgId, type: addon.type }, 'create');
 
     const record = OrgAddonMapper.toRecord(addon);
     await this.repository.save(record);

--- a/ayunis-core-backend/src/iam/addons/presenters/http/addons.controller.ts
+++ b/ayunis-core-backend/src/iam/addons/presenters/http/addons.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, HttpStatus, Logger } from '@nestjs/common';
+import { Controller, Get, HttpStatus } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -18,9 +19,11 @@ import { AddonStatusResponseDto } from './dto/addon-status-response.dto';
 @ApiTags('Addons')
 @Controller('addons')
 export class AddonsController {
-  private readonly logger = new Logger(AddonsController.name);
-
-  constructor(private readonly listOrgAddonsUseCase: ListOrgAddonsUseCase) {}
+  constructor(
+    @InjectPinoLogger(AddonsController.name)
+    private readonly logger: PinoLogger,
+    private readonly listOrgAddonsUseCase: ListOrgAddonsUseCase,
+  ) {}
 
   @Get()
   @ApiOperation({
@@ -32,7 +35,7 @@ export class AddonsController {
   async list(
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
   ): Promise<AddonStatusResponseDto[]> {
-    this.logger.log('list', { orgId });
+    this.logger.info({ orgId }, 'list');
 
     const statuses = await this.listOrgAddonsUseCase.execute(
       new ListOrgAddonsQuery(orgId),

--- a/ayunis-core-backend/src/iam/addons/presenters/http/super-admin-addons.controller.ts
+++ b/ayunis-core-backend/src/iam/addons/presenters/http/super-admin-addons.controller.ts
@@ -4,11 +4,11 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   ParseEnumPipe,
   Post,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -36,9 +36,9 @@ import { AddonStatusResponseDto } from './dto/addon-status-response.dto';
 @Controller('super-admin/addons')
 @SystemRoles(SystemRole.SUPER_ADMIN)
 export class SuperAdminAddonsController {
-  private readonly logger = new Logger(SuperAdminAddonsController.name);
-
   constructor(
+    @InjectPinoLogger(SuperAdminAddonsController.name)
+    private readonly logger: PinoLogger,
     private readonly listOrgAddonsUseCase: ListOrgAddonsUseCase,
     private readonly activateAddonUseCase: ActivateAddonUseCase,
     private readonly deactivateAddonUseCase: DeactivateAddonUseCase,
@@ -52,7 +52,7 @@ export class SuperAdminAddonsController {
   @ApiResponse({ status: HttpStatus.OK, type: [AddonStatusResponseDto] })
   @ApiUnauthorizedResponse({ description: 'Not authorized as super admin' })
   async list(@Param('orgId') orgId: UUID): Promise<AddonStatusResponseDto[]> {
-    this.logger.log('list', { orgId });
+    this.logger.info({ orgId }, 'list');
 
     const statuses = await this.listOrgAddonsUseCase.execute(
       new ListOrgAddonsQuery(orgId),
@@ -72,7 +72,7 @@ export class SuperAdminAddonsController {
     @Param('type', new ParseEnumPipe(AddonType)) type: AddonType,
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<void> {
-    this.logger.log('activate', { orgId, type });
+    this.logger.info({ orgId, type }, 'activate');
 
     await this.activateAddonUseCase.execute(
       new ActivateAddonCommand(orgId, type, userId),
@@ -94,7 +94,7 @@ export class SuperAdminAddonsController {
     @Param('type', new ParseEnumPipe(AddonType)) type: AddonType,
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<void> {
-    this.logger.log('deactivate', { orgId, type });
+    this.logger.info({ orgId, type }, 'deactivate');
 
     await this.deactivateAddonUseCase.execute(
       new DeactivateAddonCommand(orgId, type, userId),

--- a/ayunis-core-backend/src/iam/budget-alerts/application/listeners/budget-alerts.listener.spec.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/listeners/budget-alerts.listener.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -41,9 +43,17 @@ describe('BudgetAlertsListener', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         BudgetAlertsListener,
+        {
+          provide: getLoggerToken(BudgetAlertsListener.name),
+          useValue: createPinoLoggerMock(),
+        },
         // Real evaluator on purpose: the listener's debounce guarantees only
         // hold together with the evaluator's per-org serialization.
         BudgetAlertEvaluator,
+        {
+          provide: getLoggerToken(BudgetAlertEvaluator.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: OrgContextRunner, useValue: orgContextRunner },
         { provide: EvaluateBudgetAlertsForOrgUseCase, useValue: evaluateOrg },
       ],

--- a/ayunis-core-backend/src/iam/budget-alerts/application/listeners/budget-alerts.listener.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/listeners/budget-alerts.listener.ts
@@ -1,5 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import type { OnModuleDestroy } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OnEvent } from '@nestjs/event-emitter';
 import type { UUID } from 'crypto';
 
@@ -38,10 +39,13 @@ interface CooldownState {
  */
 @Injectable()
 export class BudgetAlertsListener implements OnModuleDestroy {
-  private readonly logger = new Logger(BudgetAlertsListener.name);
   private readonly cooldowns = new Map<UUID, CooldownState>();
 
-  constructor(private readonly budgetAlertEvaluator: BudgetAlertEvaluator) {}
+  constructor(
+    @InjectPinoLogger(BudgetAlertsListener.name)
+    private readonly logger: PinoLogger,
+    private readonly budgetAlertEvaluator: BudgetAlertEvaluator,
+  ) {}
 
   onModuleDestroy(): void {
     for (const state of this.cooldowns.values()) {
@@ -65,9 +69,12 @@ export class BudgetAlertsListener implements OnModuleDestroy {
     }
 
     this.startCooldown(orgId);
-    this.logger.debug('Evaluating budget alerts after token consumption', {
-      orgId,
-    });
+    this.logger.debug(
+      {
+        orgId,
+      },
+      'Evaluating budget alerts after token consumption',
+    );
     await this.budgetAlertEvaluator.evaluate(orgId);
   }
 

--- a/ayunis-core-backend/src/iam/budget-alerts/application/services/budget-alert-evaluator.service.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/services/budget-alert-evaluator.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 
 import { OrgContextRunner } from 'src/common/context/services/org-context-runner.service';
@@ -15,10 +16,11 @@ import { EvaluateBudgetAlertsForOrgUseCase } from '../use-cases/evaluate-budget-
  */
 @Injectable()
 export class BudgetAlertEvaluator {
-  private readonly logger = new Logger(BudgetAlertEvaluator.name);
   private readonly inFlight = new Map<UUID, Promise<void>>();
 
   constructor(
+    @InjectPinoLogger(BudgetAlertEvaluator.name)
+    private readonly logger: PinoLogger,
     private readonly orgContextRunner: OrgContextRunner,
     private readonly evaluateBudgetAlertsForOrgUseCase: EvaluateBudgetAlertsForOrgUseCase,
   ) {}
@@ -38,7 +40,7 @@ export class BudgetAlertEvaluator {
 
   private async evaluateOrg(orgId: UUID): Promise<void> {
     try {
-      this.logger.debug('Evaluating budget alerts', { orgId });
+      this.logger.debug({ orgId }, 'Evaluating budget alerts');
 
       await this.orgContextRunner.runForOrg(orgId, () =>
         this.evaluateBudgetAlertsForOrgUseCase.execute(
@@ -46,10 +48,10 @@ export class BudgetAlertEvaluator {
         ),
       );
     } catch (error) {
-      this.logger.error('Failed to evaluate budget alerts', {
-        orgId,
-        stack: error instanceof Error ? error.stack : String(error),
-      });
+      this.logger.error(
+        { err: error as Error, orgId },
+        'Failed to evaluate budget alerts',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/iam/budget-alerts/application/tasks/budget-alert-cleanup.task.spec.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/tasks/budget-alert-cleanup.task.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { CleanupBudgetAlertNotificationsUseCase } from '../use-cases/cleanup-budget-alert-notifications/cleanup-budget-alert-notifications.use-case';
@@ -13,6 +15,10 @@ describe('BudgetAlertCleanupTask', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         BudgetAlertCleanupTask,
+        {
+          provide: getLoggerToken(BudgetAlertCleanupTask.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: CleanupBudgetAlertNotificationsUseCase,
           useValue: cleanup,

--- a/ayunis-core-backend/src/iam/budget-alerts/application/tasks/budget-alert-cleanup.task.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/tasks/budget-alert-cleanup.task.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { CleanupBudgetAlertNotificationsUseCase } from '../use-cases/cleanup-budget-alert-notifications/cleanup-budget-alert-notifications.use-case';
 
@@ -9,21 +10,22 @@ import { CleanupBudgetAlertNotificationsUseCase } from '../use-cases/cleanup-bud
  */
 @Injectable()
 export class BudgetAlertCleanupTask {
-  private readonly logger = new Logger(BudgetAlertCleanupTask.name);
-
   constructor(
+    @InjectPinoLogger(BudgetAlertCleanupTask.name)
+    private readonly logger: PinoLogger,
     private readonly cleanupBudgetAlertNotificationsUseCase: CleanupBudgetAlertNotificationsUseCase,
   ) {}
 
   @Cron(CronExpression.EVERY_DAY_AT_4AM)
   async handleCleanup(): Promise<void> {
-    this.logger.log('Purging expired budget alert notifications');
+    this.logger.info('Purging expired budget alert notifications');
     try {
       await this.cleanupBudgetAlertNotificationsUseCase.execute();
     } catch (error) {
-      this.logger.error('Budget alert notification cleanup failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        { err: error as Error },
+        'Budget alert notification cleanup failed',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/iam/budget-alerts/application/tasks/budget-alert-evaluation.task.spec.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/tasks/budget-alert-evaluation.task.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -20,6 +22,10 @@ describe('BudgetAlertEvaluationTask', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         BudgetAlertEvaluationTask,
+        {
+          provide: getLoggerToken(BudgetAlertEvaluationTask.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: ListUsageBasedSubscriptionOrgIdsUseCase,
           useValue: listOrgIds,

--- a/ayunis-core-backend/src/iam/budget-alerts/application/tasks/budget-alert-evaluation.task.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/tasks/budget-alert-evaluation.task.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Cron, CronExpression } from '@nestjs/schedule';
 
 import { ListUsageBasedSubscriptionOrgIdsUseCase } from 'src/iam/subscriptions/application/use-cases/list-usage-based-subscription-org-ids/list-usage-based-subscription-org-ids.use-case';
@@ -16,16 +17,16 @@ import { BudgetAlertEvaluator } from '../services/budget-alert-evaluator.service
  */
 @Injectable()
 export class BudgetAlertEvaluationTask {
-  private readonly logger = new Logger(BudgetAlertEvaluationTask.name);
-
   constructor(
+    @InjectPinoLogger(BudgetAlertEvaluationTask.name)
+    private readonly logger: PinoLogger,
     private readonly listUsageBasedSubscriptionOrgIdsUseCase: ListUsageBasedSubscriptionOrgIdsUseCase,
     private readonly budgetAlertEvaluator: BudgetAlertEvaluator,
   ) {}
 
   @Cron(CronExpression.EVERY_DAY_AT_7AM)
   async handleDailyEvaluation(): Promise<void> {
-    this.logger.log('Running daily budget alert evaluation sweep');
+    this.logger.info('Running daily budget alert evaluation sweep');
     try {
       const orgIds =
         await this.listUsageBasedSubscriptionOrgIdsUseCase.execute();
@@ -36,9 +37,10 @@ export class BudgetAlertEvaluationTask {
       }
     } catch (error) {
       // Only the org listing can throw — the evaluator never rejects.
-      this.logger.error('Daily budget alert evaluation sweep failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        { err: error as Error },
+        'Daily budget alert evaluation sweep failed',
+      );
     }
   }
 }

--- a/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/cleanup-budget-alert-notifications/cleanup-budget-alert-notifications.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/cleanup-budget-alert-notifications/cleanup-budget-alert-notifications.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { BudgetAlertNotificationRepository } from '../../ports/budget-alert-notification.repository';
@@ -14,6 +16,10 @@ describe('CleanupBudgetAlertNotificationsUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CleanupBudgetAlertNotificationsUseCase,
+        {
+          provide: getLoggerToken(CleanupBudgetAlertNotificationsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: BudgetAlertNotificationRepository, useValue: repository },
       ],
     }).compile();

--- a/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/cleanup-budget-alert-notifications/cleanup-budget-alert-notifications.use-case.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/cleanup-budget-alert-notifications/cleanup-budget-alert-notifications.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { BudgetAlertNotificationRepository } from '../../ports/budget-alert-notification.repository';
 import { UnexpectedBudgetAlertError } from '../../budget-alerts.errors';
@@ -11,26 +12,27 @@ const RETENTION_MONTHS = 12;
 
 @Injectable()
 export class CleanupBudgetAlertNotificationsUseCase {
-  private readonly logger = new Logger(
-    CleanupBudgetAlertNotificationsUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(CleanupBudgetAlertNotificationsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly notificationRepository: BudgetAlertNotificationRepository,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedBudgetAlertError)
   async execute(): Promise<number> {
-    this.logger.log('execute');
+    this.logger.info('execute');
     const now = new Date();
     const cutoff = new Date(
       Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - RETENTION_MONTHS, 1),
     );
     const deleted = await this.notificationRepository.deleteBefore(cutoff);
     if (deleted > 0) {
-      this.logger.log('Purged expired budget alert notifications', {
-        deleted,
-      });
+      this.logger.info(
+        {
+          deleted,
+        },
+        'Purged expired budget alert notifications',
+      );
     }
     return deleted;
   }

--- a/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/evaluate-budget-alerts-for-org/evaluate-budget-alerts-for-org.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/evaluate-budget-alerts-for-org/evaluate-budget-alerts-for-org.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -25,6 +27,10 @@ describe('EvaluateBudgetAlertsForOrgUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EvaluateBudgetAlertsForOrgUseCase,
+        {
+          provide: getLoggerToken(EvaluateBudgetAlertsForOrgUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: GetBudgetAlertTargetsForOrgUseCase,
           useValue: getTargets,

--- a/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/evaluate-budget-alerts-for-org/evaluate-budget-alerts-for-org.use-case.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/evaluate-budget-alerts-for-org/evaluate-budget-alerts-for-org.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { UnexpectedBudgetAlertError } from '../../budget-alerts.errors';
 import { GetBudgetAlertTargetsForOrgUseCase } from '../get-budget-alert-targets-for-org/get-budget-alert-targets-for-org.use-case';
@@ -15,16 +16,16 @@ import { EvaluateBudgetAlertsForOrgQuery } from './evaluate-budget-alerts-for-or
  */
 @Injectable()
 export class EvaluateBudgetAlertsForOrgUseCase {
-  private readonly logger = new Logger(EvaluateBudgetAlertsForOrgUseCase.name);
-
   constructor(
+    @InjectPinoLogger(EvaluateBudgetAlertsForOrgUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly getBudgetAlertTargetsForOrgUseCase: GetBudgetAlertTargetsForOrgUseCase,
     private readonly processBudgetAlertCrossingsUseCase: ProcessBudgetAlertCrossingsUseCase,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedBudgetAlertError)
   async execute(query: EvaluateBudgetAlertsForOrgQuery): Promise<void> {
-    this.logger.log('execute', { orgId: query.orgId });
+    this.logger.info({ orgId: query.orgId }, 'execute');
 
     const result = await this.getBudgetAlertTargetsForOrgUseCase.execute(
       new GetBudgetAlertTargetsForOrgQuery(query.orgId),
@@ -32,9 +33,12 @@ export class EvaluateBudgetAlertsForOrgUseCase {
     // Null means the org has no usage-based subscription — no budgets exist
     // that could cross a threshold, so there is nothing to evaluate.
     if (!result) {
-      this.logger.debug('Org has no usage-based subscription, skipping', {
-        orgId: query.orgId,
-      });
+      this.logger.debug(
+        {
+          orgId: query.orgId,
+        },
+        'Org has no usage-based subscription, skipping',
+      );
       return;
     }
 

--- a/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/get-budget-alert-targets-for-org/get-budget-alert-targets-for-org.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/get-budget-alert-targets-for-org/get-budget-alert-targets-for-org.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -50,6 +52,10 @@ describe('GetBudgetAlertTargetsForOrgUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetBudgetAlertTargetsForOrgUseCase,
+        {
+          provide: getLoggerToken(GetBudgetAlertTargetsForOrgUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: GetMonthlyCreditLimitUseCase, useValue: creditLimit },
         { provide: GetMonthlyCreditUsageUseCase, useValue: orgUsage },
         {

--- a/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/get-budget-alert-targets-for-org/get-budget-alert-targets-for-org.use-case.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/get-budget-alert-targets-for-org/get-budget-alert-targets-for-org.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import type { UserCreditLimitOverviewItem } from 'src/iam/credit-limits/application/use-cases/get-user-credit-limits-overview/user-credit-limit.view';
@@ -29,9 +30,9 @@ export interface BudgetAlertTargets {
 
 @Injectable()
 export class GetBudgetAlertTargetsForOrgUseCase {
-  private readonly logger = new Logger(GetBudgetAlertTargetsForOrgUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetBudgetAlertTargetsForOrgUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly getMonthlyCreditLimitUseCase: GetMonthlyCreditLimitUseCase,
     private readonly getMonthlyCreditUsageUseCase: GetMonthlyCreditUsageUseCase,
     private readonly getUserCreditLimitsOverviewUseCase: GetUserCreditLimitsOverviewUseCase,
@@ -42,7 +43,7 @@ export class GetBudgetAlertTargetsForOrgUseCase {
   async execute(
     query: GetBudgetAlertTargetsForOrgQuery,
   ): Promise<BudgetAlertTargets | null> {
-    this.logger.log('execute', { orgId: query.orgId });
+    this.logger.info({ orgId: query.orgId }, 'execute');
 
     const { monthlyCredits, startsAt } =
       await this.getMonthlyCreditLimitUseCase.execute(

--- a/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/process-budget-alert-crossings/process-budget-alert-crossings.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/process-budget-alert-crossings/process-budget-alert-crossings.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -48,6 +50,10 @@ describe('ProcessBudgetAlertCrossingsUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ProcessBudgetAlertCrossingsUseCase,
+        {
+          provide: getLoggerToken(ProcessBudgetAlertCrossingsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: GetOrgAdminsUseCase, useValue: admins },
         { provide: SendBudgetWarningEmailUseCase, useValue: sendEmail },
         { provide: BudgetAlertNotificationRepository, useValue: repository },

--- a/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/process-budget-alert-crossings/process-budget-alert-crossings.use-case.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/process-budget-alert-crossings/process-budget-alert-crossings.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import type { User } from 'src/iam/users/domain/user.entity';
 import { GetOrgAdminsUseCase } from 'src/iam/users/application/use-cases/get-org-admins/get-org-admins.use-case';
@@ -31,9 +32,9 @@ const SCOPE_TO_WARNING: Record<BudgetAlertScope, BudgetWarningScope> = {
 
 @Injectable()
 export class ProcessBudgetAlertCrossingsUseCase {
-  private readonly logger = new Logger(ProcessBudgetAlertCrossingsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ProcessBudgetAlertCrossingsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly notificationRepository: BudgetAlertNotificationRepository,
     private readonly getOrgAdminsUseCase: GetOrgAdminsUseCase,
     private readonly sendBudgetWarningEmailUseCase: SendBudgetWarningEmailUseCase,
@@ -41,7 +42,7 @@ export class ProcessBudgetAlertCrossingsUseCase {
 
   @HandleUnexpectedErrors(UnexpectedBudgetAlertError)
   async execute(query: ProcessBudgetAlertCrossingsQuery): Promise<void> {
-    this.logger.log('execute', { orgId: query.orgId });
+    this.logger.info({ orgId: query.orgId }, 'execute');
 
     const sentKeys = await this.loadSentKeys(query.orgId, query.periodStart);
     const crossings = collectCrossings(query.targets, sentKeys);
@@ -53,10 +54,13 @@ export class ProcessBudgetAlertCrossingsUseCase {
       new GetOrgAdminsQuery(query.orgId),
     );
     if (admins.length === 0) {
-      this.logger.warn('Budget crossing with no admins to notify', {
-        orgId: query.orgId,
-        crossings: crossings.length,
-      });
+      this.logger.warn(
+        {
+          orgId: query.orgId,
+          crossings: crossings.length,
+        },
+        'Budget crossing with no admins to notify',
+      );
       return;
     }
 
@@ -99,12 +103,15 @@ export class ProcessBudgetAlertCrossingsUseCase {
         );
         delivered += 1;
       } catch (error) {
-        this.logger.error('Failed to send budget warning to admin', {
-          scope: crossing.target.scope,
-          targetId: crossing.target.targetId,
-          recipientId: admin.id,
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
+        this.logger.error(
+          {
+            scope: crossing.target.scope,
+            targetId: crossing.target.targetId,
+            recipientId: admin.id,
+            err: error as Error,
+          },
+          'Failed to send budget warning to admin',
+        );
       }
     }
     return delivered;
@@ -124,12 +131,15 @@ export class ProcessBudgetAlertCrossingsUseCase {
     } catch (error) {
       // A failed insert must not block the org's remaining crossings; the
       // already-delivered email may repeat next run (at-least-once delivery).
-      this.logger.error('Failed to record budget alert crossing', {
-        orgId,
-        scope: crossing.target.scope,
-        targetId: crossing.target.targetId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+      this.logger.error(
+        {
+          orgId,
+          scope: crossing.target.scope,
+          targetId: crossing.target.targetId,
+          err: error as Error,
+        },
+        'Failed to record budget alert crossing',
+      );
     }
   }
 

--- a/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/send-budget-warning-email/send-budget-warning-email.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/send-budget-warning-email/send-budget-warning-email.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
@@ -37,6 +39,10 @@ describe('SendBudgetWarningEmailUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SendBudgetWarningEmailUseCase,
+        {
+          provide: getLoggerToken(SendBudgetWarningEmailUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SendEmailUseCase, useValue: sendEmail },
         { provide: RenderTemplateUseCase, useValue: renderTemplate },
         { provide: ConfigService, useValue: config },

--- a/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/send-budget-warning-email/send-budget-warning-email.use-case.ts
+++ b/ayunis-core-backend/src/iam/budget-alerts/application/use-cases/send-budget-warning-email/send-budget-warning-email.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { BudgetWarningTemplate } from 'src/common/email-templates/domain/email-template.entity';
@@ -27,9 +28,9 @@ const SETTINGS_PATH_BY_SCOPE: Record<
 
 @Injectable()
 export class SendBudgetWarningEmailUseCase {
-  private readonly logger = new Logger(SendBudgetWarningEmailUseCase.name);
-
   constructor(
+    @InjectPinoLogger(SendBudgetWarningEmailUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly sendEmailUseCase: SendEmailUseCase,
     private readonly renderTemplateUseCase: RenderTemplateUseCase,
     private readonly configService: ConfigService,
@@ -37,7 +38,7 @@ export class SendBudgetWarningEmailUseCase {
 
   @HandleUnexpectedErrors(BudgetWarningEmailSendingFailedError)
   async execute(command: SendBudgetWarningEmailCommand): Promise<void> {
-    this.logger.log('execute', { scope: command.scope });
+    this.logger.info({ scope: command.scope }, 'execute');
 
     const template = this.buildTemplate(command);
     const content = this.renderTemplateUseCase.execute(

--- a/ayunis-core-backend/src/iam/credit-limits/application/listeners/subscription-cancelled.listener.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/listeners/subscription-cancelled.listener.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { SubscriptionType } from 'src/iam/subscriptions/domain/value-objects/subscription-type.enum';
 import type { SubscriptionCancelledEvent } from 'src/iam/subscriptions/application/events/subscription-cancelled.event';
 import type { RemoveOrgCreditLimitsUseCase } from '../use-cases/remove-org-credit-limits/remove-org-credit-limits.use-case';
@@ -15,6 +16,7 @@ describe('SubscriptionCancelledListener', () => {
   beforeEach(() => {
     removeOrgCreditLimits = { execute: jest.fn() };
     listener = new SubscriptionCancelledListener(
+      createPinoLoggerMock(),
       removeOrgCreditLimits as unknown as RemoveOrgCreditLimitsUseCase,
     );
   });

--- a/ayunis-core-backend/src/iam/credit-limits/application/listeners/subscription-cancelled.listener.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/listeners/subscription-cancelled.listener.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { OnEvent } from '@nestjs/event-emitter';
 import { SubscriptionCancelledEvent } from 'src/iam/subscriptions/application/events/subscription-cancelled.event';
 import { SubscriptionType } from 'src/iam/subscriptions/domain/value-objects/subscription-type.enum';
@@ -13,9 +14,9 @@ import { RemoveOrgCreditLimitsCommand } from '../use-cases/remove-org-credit-lim
  */
 @Injectable()
 export class SubscriptionCancelledListener {
-  private readonly logger = new Logger(SubscriptionCancelledListener.name);
-
   constructor(
+    @InjectPinoLogger(SubscriptionCancelledListener.name)
+    private readonly logger: PinoLogger,
     private readonly removeOrgCreditLimitsUseCase: RemoveOrgCreditLimitsUseCase,
   ) {}
 
@@ -27,9 +28,12 @@ export class SubscriptionCancelledListener {
       return;
     }
 
-    this.logger.log('Clearing credit limits after usage-based cancellation', {
-      orgId: event.orgId,
-    });
+    this.logger.info(
+      {
+        orgId: event.orgId,
+      },
+      'Clearing credit limits after usage-based cancellation',
+    );
 
     await this.removeOrgCreditLimitsUseCase.execute(
       new RemoveOrgCreditLimitsCommand(event.orgId),

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/get-team-credit-limits-overview/get-team-credit-limits-overview.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/get-team-credit-limits-overview/get-team-credit-limits-overview.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -45,6 +47,10 @@ describe('GetTeamCreditLimitsOverviewUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetTeamCreditLimitsOverviewUseCase,
+        {
+          provide: getLoggerToken(GetTeamCreditLimitsOverviewUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: CreditLimitRepository, useValue: repository },
         { provide: ContextService, useValue: context },
         { provide: ListTeamsUseCase, useValue: listTeams },

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/get-team-credit-limits-overview/get-team-credit-limits-overview.use-case.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/get-team-credit-limits-overview/get-team-credit-limits-overview.use-case.ts
@@ -1,6 +1,7 @@
 import type { UUID } from 'crypto';
 import type { TeamCreditLimitOverviewItem } from './team-credit-limit.view';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -15,9 +16,9 @@ import { GetTeamCreditLimitsOverviewQuery } from './get-team-credit-limits-overv
 
 @Injectable()
 export class GetTeamCreditLimitsOverviewUseCase {
-  private readonly logger = new Logger(GetTeamCreditLimitsOverviewUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetTeamCreditLimitsOverviewUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly creditLimitRepository: CreditLimitRepository,
     private readonly contextService: ContextService,
     private readonly listTeamsUseCase: ListTeamsUseCase,
@@ -33,7 +34,7 @@ export class GetTeamCreditLimitsOverviewUseCase {
       throw new UnauthorizedAccessError();
     }
 
-    this.logger.log('Listing team credit limits', { orgId });
+    this.logger.info({ orgId }, 'Listing team credit limits');
 
     const limits = await this.creditLimitRepository.findTeamLimits(orgId);
     return this.enrich(orgId, limits, query.since);

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/get-user-credit-limits-overview/get-user-credit-limits-overview.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/get-user-credit-limits-overview/get-user-credit-limits-overview.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -48,6 +50,10 @@ describe('GetUserCreditLimitsOverviewUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetUserCreditLimitsOverviewUseCase,
+        {
+          provide: getLoggerToken(GetUserCreditLimitsOverviewUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: CreditLimitRepository, useValue: repository },
         { provide: ContextService, useValue: context },
         { provide: FindUsersByIdsUseCase, useValue: findUsersByIds },

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/get-user-credit-limits-overview/get-user-credit-limits-overview.use-case.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/get-user-credit-limits-overview/get-user-credit-limits-overview.use-case.ts
@@ -1,7 +1,8 @@
 import type { UUID } from 'crypto';
 import type { User } from 'src/iam/users/domain/user.entity';
 import type { UserCreditLimitOverviewItem } from './user-credit-limit.view';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -17,9 +18,9 @@ import { GetUserCreditLimitsOverviewQuery } from './get-user-credit-limits-overv
 
 @Injectable()
 export class GetUserCreditLimitsOverviewUseCase {
-  private readonly logger = new Logger(GetUserCreditLimitsOverviewUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetUserCreditLimitsOverviewUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly creditLimitRepository: CreditLimitRepository,
     private readonly contextService: ContextService,
     private readonly findUsersByIdsUseCase: FindUsersByIdsUseCase,
@@ -35,7 +36,7 @@ export class GetUserCreditLimitsOverviewUseCase {
       throw new UnauthorizedAccessError();
     }
 
-    this.logger.log('Listing user credit limits', { orgId });
+    this.logger.info({ orgId }, 'Listing user credit limits');
 
     const limits = await this.creditLimitRepository.findUserLimits(orgId);
     return this.enrich(orgId, limits, query.since);

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-org-credit-limits/remove-org-credit-limits.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-org-credit-limits/remove-org-credit-limits.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { CreditLimitRepository } from '../../ports/credit-limit.repository';
@@ -20,6 +22,10 @@ describe('RemoveOrgCreditLimitsUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RemoveOrgCreditLimitsUseCase,
+        {
+          provide: getLoggerToken(RemoveOrgCreditLimitsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: CreditLimitRepository, useValue: repository },
       ],
     }).compile();

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-org-credit-limits/remove-org-credit-limits.use-case.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-org-credit-limits/remove-org-credit-limits.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { CreditLimitRepository } from '../../ports/credit-limit.repository';
 import { UnexpectedCreditLimitError } from '../../credit-limits.errors';
@@ -11,22 +12,28 @@ import { RemoveOrgCreditLimitsCommand } from './remove-org-credit-limits.command
  */
 @Injectable()
 export class RemoveOrgCreditLimitsUseCase {
-  private readonly logger = new Logger(RemoveOrgCreditLimitsUseCase.name);
-
-  constructor(private readonly creditLimitRepository: CreditLimitRepository) {}
+  constructor(
+    @InjectPinoLogger(RemoveOrgCreditLimitsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly creditLimitRepository: CreditLimitRepository,
+  ) {}
 
   async execute(command: RemoveOrgCreditLimitsCommand): Promise<void> {
-    this.logger.log('Removing all credit limits for org', {
-      orgId: command.orgId,
-    });
+    this.logger.info(
+      {
+        orgId: command.orgId,
+      },
+      'Removing all credit limits for org',
+    );
 
     try {
       await this.creditLimitRepository.deleteByOrg(command.orgId);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to remove org credit limits', {
-        error: error as Error,
-      });
+      this.logger.error(
+        { err: error as Error },
+        'Failed to remove org credit limits',
+      );
       throw new UnexpectedCreditLimitError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-team-credit-limit/remove-team-credit-limit.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-team-credit-limit/remove-team-credit-limit.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -23,6 +25,10 @@ describe('RemoveTeamCreditLimitUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RemoveTeamCreditLimitUseCase,
+        {
+          provide: getLoggerToken(RemoveTeamCreditLimitUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: CreditLimitRepository, useValue: repository },
         { provide: ContextService, useValue: { get: () => orgId } },
       ],

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-team-credit-limit/remove-team-credit-limit.use-case.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-team-credit-limit/remove-team-credit-limit.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -8,9 +9,9 @@ import { RemoveTeamCreditLimitCommand } from './remove-team-credit-limit.command
 
 @Injectable()
 export class RemoveTeamCreditLimitUseCase {
-  private readonly logger = new Logger(RemoveTeamCreditLimitUseCase.name);
-
   constructor(
+    @InjectPinoLogger(RemoveTeamCreditLimitUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly creditLimitRepository: CreditLimitRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -21,18 +22,22 @@ export class RemoveTeamCreditLimitUseCase {
       throw new UnauthorizedAccessError();
     }
 
-    this.logger.log('Removing team credit limit', {
-      orgId,
-      teamId: command.teamId,
-    });
+    this.logger.info(
+      {
+        orgId,
+        teamId: command.teamId,
+      },
+      'Removing team credit limit',
+    );
 
     try {
       await this.creditLimitRepository.deleteByTeamId(orgId, command.teamId);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to remove team credit limit', {
-        error: error as Error,
-      });
+      this.logger.error(
+        { err: error as Error },
+        'Failed to remove team credit limit',
+      );
       throw new UnexpectedCreditLimitError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-user-credit-limit/remove-user-credit-limit.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-user-credit-limit/remove-user-credit-limit.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -23,6 +25,10 @@ describe('RemoveUserCreditLimitUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RemoveUserCreditLimitUseCase,
+        {
+          provide: getLoggerToken(RemoveUserCreditLimitUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: CreditLimitRepository, useValue: repository },
         { provide: ContextService, useValue: { get: () => orgId } },
       ],

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-user-credit-limit/remove-user-credit-limit.use-case.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/remove-user-credit-limit/remove-user-credit-limit.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -8,9 +9,9 @@ import { RemoveUserCreditLimitCommand } from './remove-user-credit-limit.command
 
 @Injectable()
 export class RemoveUserCreditLimitUseCase {
-  private readonly logger = new Logger(RemoveUserCreditLimitUseCase.name);
-
   constructor(
+    @InjectPinoLogger(RemoveUserCreditLimitUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly creditLimitRepository: CreditLimitRepository,
     private readonly contextService: ContextService,
   ) {}
@@ -21,18 +22,22 @@ export class RemoveUserCreditLimitUseCase {
       throw new UnauthorizedAccessError();
     }
 
-    this.logger.log('Removing user credit limit', {
-      orgId,
-      userId: command.userId,
-    });
+    this.logger.info(
+      {
+        orgId,
+        userId: command.userId,
+      },
+      'Removing user credit limit',
+    );
 
     try {
       await this.creditLimitRepository.deleteByUserId(orgId, command.userId);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to remove user credit limit', {
-        error: error as Error,
-      });
+      this.logger.error(
+        { err: error as Error },
+        'Failed to remove user credit limit',
+      );
       throw new UnexpectedCreditLimitError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/resolve-credit-limits-for-user/resolve-credit-limits-for-user.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/resolve-credit-limits-for-user/resolve-credit-limits-for-user.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -35,6 +37,10 @@ describe('ResolveCreditLimitsForUserUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ResolveCreditLimitsForUserUseCase,
+        {
+          provide: getLoggerToken(ResolveCreditLimitsForUserUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: CreditLimitRepository, useValue: repository },
         { provide: FindTeamsByUserIdUseCase, useValue: findTeams },
       ],

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/resolve-credit-limits-for-user/resolve-credit-limits-for-user.use-case.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/resolve-credit-limits-for-user/resolve-credit-limits-for-user.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { FindTeamsByUserIdUseCase } from 'src/iam/teams/application/use-cases/find-teams-by-user-id/find-teams-by-user-id.use-case';
 import { FindTeamsByUserIdQuery } from 'src/iam/teams/application/use-cases/find-teams-by-user-id/find-teams-by-user-id.query';
@@ -10,9 +11,9 @@ import type { CreditLimitsForUser } from './resolve-credit-limits-for-user.resul
 
 @Injectable()
 export class ResolveCreditLimitsForUserUseCase {
-  private readonly logger = new Logger(ResolveCreditLimitsForUserUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ResolveCreditLimitsForUserUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly creditLimitRepository: CreditLimitRepository,
     private readonly findTeamsByUserIdUseCase: FindTeamsByUserIdUseCase,
   ) {}
@@ -20,10 +21,13 @@ export class ResolveCreditLimitsForUserUseCase {
   async execute(
     query: ResolveCreditLimitsForUserQuery,
   ): Promise<CreditLimitsForUser> {
-    this.logger.log('Resolving credit limits for user', {
-      orgId: query.orgId,
-      userId: query.userId,
-    });
+    this.logger.info(
+      {
+        orgId: query.orgId,
+        userId: query.userId,
+      },
+      'Resolving credit limits for user',
+    );
 
     try {
       const userLimitEntity = await this.creditLimitRepository.findByUserId(
@@ -45,9 +49,10 @@ export class ResolveCreditLimitsForUserUseCase {
       };
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to resolve credit limits for user', {
-        error: error as Error,
-      });
+      this.logger.error(
+        { err: error as Error },
+        'Failed to resolve credit limits for user',
+      );
       throw new UnexpectedCreditLimitError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/set-team-credit-limit/set-team-credit-limit.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/set-team-credit-limit/set-team-credit-limit.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -34,6 +36,10 @@ describe('SetTeamCreditLimitUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SetTeamCreditLimitUseCase,
+        {
+          provide: getLoggerToken(SetTeamCreditLimitUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: CreditLimitRepository, useValue: repository },
         { provide: ContextService, useValue: context },
         { provide: GetTeamUseCase, useValue: getTeam },

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/set-team-credit-limit/set-team-credit-limit.use-case.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/set-team-credit-limit/set-team-credit-limit.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -15,9 +16,9 @@ import { SetTeamCreditLimitCommand } from './set-team-credit-limit.command';
 
 @Injectable()
 export class SetTeamCreditLimitUseCase {
-  private readonly logger = new Logger(SetTeamCreditLimitUseCase.name);
-
   constructor(
+    @InjectPinoLogger(SetTeamCreditLimitUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly creditLimitRepository: CreditLimitRepository,
     private readonly contextService: ContextService,
     private readonly getTeamUseCase: GetTeamUseCase,
@@ -35,11 +36,14 @@ export class SetTeamCreditLimitUseCase {
       );
     }
 
-    this.logger.log('Setting team credit limit', {
-      orgId,
-      teamId: command.teamId,
-      monthlyCredits: command.monthlyCredits,
-    });
+    this.logger.info(
+      {
+        orgId,
+        teamId: command.teamId,
+        monthlyCredits: command.monthlyCredits,
+      },
+      'Setting team credit limit',
+    );
 
     try {
       await this.getTeamUseCase.execute(new GetTeamQuery(command.teamId));
@@ -60,9 +64,10 @@ export class SetTeamCreditLimitUseCase {
       return await this.creditLimitRepository.save(limit);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to set team credit limit', {
-        error: error as Error,
-      });
+      this.logger.error(
+        { err: error as Error },
+        'Failed to set team credit limit',
+      );
       throw new UnexpectedCreditLimitError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/set-user-credit-limit/set-user-credit-limit.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/set-user-credit-limit/set-user-credit-limit.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ContextService } from 'src/common/context/services/context.service';
@@ -38,6 +40,10 @@ describe('SetUserCreditLimitUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SetUserCreditLimitUseCase,
+        {
+          provide: getLoggerToken(SetUserCreditLimitUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: CreditLimitRepository, useValue: repository },
         { provide: ContextService, useValue: context },
         { provide: FindUsersByIdsUseCase, useValue: findUsersByIds },

--- a/ayunis-core-backend/src/iam/credit-limits/application/use-cases/set-user-credit-limit/set-user-credit-limit.use-case.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/application/use-cases/set-user-credit-limit/set-user-credit-limit.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
@@ -16,9 +17,9 @@ import { SetUserCreditLimitCommand } from './set-user-credit-limit.command';
 
 @Injectable()
 export class SetUserCreditLimitUseCase {
-  private readonly logger = new Logger(SetUserCreditLimitUseCase.name);
-
   constructor(
+    @InjectPinoLogger(SetUserCreditLimitUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly creditLimitRepository: CreditLimitRepository,
     private readonly contextService: ContextService,
     private readonly findUsersByIdsUseCase: FindUsersByIdsUseCase,
@@ -36,11 +37,14 @@ export class SetUserCreditLimitUseCase {
       );
     }
 
-    this.logger.log('Setting user credit limit', {
-      orgId,
-      userId: command.userId,
-      monthlyCredits: command.monthlyCredits,
-    });
+    this.logger.info(
+      {
+        orgId,
+        userId: command.userId,
+        monthlyCredits: command.monthlyCredits,
+      },
+      'Setting user credit limit',
+    );
 
     try {
       const members = await this.findUsersByIdsUseCase.execute(
@@ -68,9 +72,10 @@ export class SetUserCreditLimitUseCase {
       return await this.creditLimitRepository.save(limit);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to set user credit limit', {
-        error: error as Error,
-      });
+      this.logger.error(
+        { err: error as Error },
+        'Failed to set user credit limit',
+      );
       throw new UnexpectedCreditLimitError(error);
     }
   }

--- a/ayunis-core-backend/src/iam/credit-limits/presenters/http/credit-limits.controller.ts
+++ b/ayunis-core-backend/src/iam/credit-limits/presenters/http/credit-limits.controller.ts
@@ -8,8 +8,8 @@ import {
   ParseUUIDPipe,
   HttpCode,
   HttpStatus,
-  Logger,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { UUID } from 'crypto';
 import { Roles } from 'src/iam/authorization/application/decorators/roles.decorator';
@@ -40,9 +40,9 @@ import { CreditLimitDtoMapper } from './mappers/credit-limit-dto.mapper';
 @Controller('credit-limits')
 @RequireUsageBasedSubscription()
 export class CreditLimitsController {
-  private readonly logger = new Logger(CreditLimitsController.name);
-
   constructor(
+    @InjectPinoLogger(CreditLimitsController.name)
+    private readonly logger: PinoLogger,
     private readonly getUserCreditLimitsOverviewUseCase: GetUserCreditLimitsOverviewUseCase,
     private readonly getTeamCreditLimitsOverviewUseCase: GetTeamCreditLimitsOverviewUseCase,
     private readonly setUserCreditLimitUseCase: SetUserCreditLimitUseCase,
@@ -59,7 +59,7 @@ export class CreditLimitsController {
   })
   @ApiResponse({ status: 200, type: [UserCreditLimitItemDto] })
   async getUserLimits(): Promise<UserCreditLimitItemDto[]> {
-    this.logger.log('Getting user credit limits');
+    this.logger.info('Getting user credit limits');
     const items = await this.getUserCreditLimitsOverviewUseCase.execute();
     return this.mapper.toUserItems(items);
   }
@@ -71,7 +71,7 @@ export class CreditLimitsController {
   })
   @ApiResponse({ status: 200, type: [TeamCreditLimitItemDto] })
   async getTeamLimits(): Promise<TeamCreditLimitItemDto[]> {
-    this.logger.log('Getting team credit limits');
+    this.logger.info('Getting team credit limits');
     const items = await this.getTeamCreditLimitsOverviewUseCase.execute();
     return this.mapper.toTeamItems(items);
   }
@@ -84,7 +84,7 @@ export class CreditLimitsController {
     @Param('userId', ParseUUIDPipe) userId: UUID,
     @Body() dto: SetCreditLimitDto,
   ): Promise<UserCreditLimitResponseDto> {
-    this.logger.log(`Setting credit limit for user ${userId}`);
+    this.logger.info({ userId }, 'Setting credit limit for user');
     const limit = await this.setUserCreditLimitUseCase.execute(
       new SetUserCreditLimitCommand(userId, dto.monthlyCredits),
     );
@@ -99,7 +99,7 @@ export class CreditLimitsController {
     @Param('teamId', ParseUUIDPipe) teamId: UUID,
     @Body() dto: SetCreditLimitDto,
   ): Promise<TeamCreditLimitResponseDto> {
-    this.logger.log(`Setting credit limit for team ${teamId}`);
+    this.logger.info({ teamId }, 'Setting credit limit for team');
     const limit = await this.setTeamCreditLimitUseCase.execute(
       new SetTeamCreditLimitCommand(teamId, dto.monthlyCredits),
     );
@@ -114,7 +114,7 @@ export class CreditLimitsController {
   async removeUserLimit(
     @Param('userId', ParseUUIDPipe) userId: UUID,
   ): Promise<void> {
-    this.logger.log(`Removing credit limit for user ${userId}`);
+    this.logger.info({ userId }, 'Removing credit limit for user');
     await this.removeUserCreditLimitUseCase.execute(
       new RemoveUserCreditLimitCommand(userId),
     );
@@ -128,7 +128,7 @@ export class CreditLimitsController {
   async removeTeamLimit(
     @Param('teamId', ParseUUIDPipe) teamId: UUID,
   ): Promise<void> {
-    this.logger.log(`Removing credit limit for team ${teamId}`);
+    this.logger.info({ teamId }, 'Removing credit limit for team');
     await this.removeTeamCreditLimitUseCase.execute(
       new RemoveTeamCreditLimitCommand(teamId),
     );

--- a/ayunis-core-backend/src/iam/legal-acceptances/application/use-cases/create-legal-acceptance/create-legal-acceptance.use-case.ts
+++ b/ayunis-core-backend/src/iam/legal-acceptances/application/use-cases/create-legal-acceptance/create-legal-acceptance.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   CreateLegalAcceptanceCommand,
   CreatePrivacyPolicyAcceptanceCommand,
@@ -12,16 +13,16 @@ import { PrivacyPolicyAcceptance } from 'src/iam/legal-acceptances/domain/legal-
 
 @Injectable()
 export class CreateLegalAcceptanceUseCase {
-  private readonly logger = new Logger(CreateLegalAcceptanceUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateLegalAcceptanceUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly legalAcceptanceRepository: LegalAcceptancesRepository,
     private readonly configService: ConfigService,
   ) {}
 
   async execute(command: CreateLegalAcceptanceCommand): Promise<void> {
     const { userId, orgId, type } = command;
-    this.logger.log(
+    this.logger.info(
       `Creating legal acceptance for user ${userId} in org ${orgId} with type ${type}`,
     );
     const isSelfHosted = this.configService.get<boolean>('app.isSelfHosted');

--- a/ayunis-core-backend/src/iam/quotas/application/use-cases/check-quota/check-quota.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/quotas/application/use-cases/check-quota/check-quota.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -37,6 +39,10 @@ describe('CheckQuotaUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CheckQuotaUseCase,
+        {
+          provide: getLoggerToken(CheckQuotaUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: UsageQuotaRepositoryPort, useValue: usageQuotaRepository },
         { provide: QuotaLimitResolverService, useValue: limitResolver },
         {

--- a/ayunis-core-backend/src/iam/quotas/application/use-cases/check-quota/check-quota.use-case.ts
+++ b/ayunis-core-backend/src/iam/quotas/application/use-cases/check-quota/check-quota.use-case.ts
@@ -1,49 +1,46 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { UsageQuotaRepositoryPort } from '../../ports/usage-quota.repository.port';
 import { QuotaLimitResolverService } from '../../services/quota-limit-resolver.service';
 import { CheckQuotaQuery } from './check-quota.query';
 import { QuotaExceededError } from '../../quotas.errors';
 import { IsUsageBasedSubscriptionUseCase } from 'src/iam/subscriptions/application/use-cases/is-usage-based-subscription/is-usage-based-subscription.use-case';
 import { IsUsageBasedSubscriptionQuery } from 'src/iam/subscriptions/application/use-cases/is-usage-based-subscription/is-usage-based-subscription.query';
+import type { UsageQuota } from '../../../domain/usage-quota.entity';
 
 @Injectable()
 export class CheckQuotaUseCase {
-  private readonly logger = new Logger(CheckQuotaUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CheckQuotaUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly usageQuotaRepository: UsageQuotaRepositoryPort,
     private readonly limitResolver: QuotaLimitResolverService,
     private readonly isUsageBasedSubscriptionUseCase: IsUsageBasedSubscriptionUseCase,
   ) {}
 
   async execute(query: CheckQuotaQuery): Promise<void> {
-    // Fair-use is the protection of last resort for flat-fee plans.
-    // Usage-based orgs already self-limit via their purchased credit budget
-    // (enforced by CreditBudgetGuardService), so applying fair-use on top
-    // would double-cap them.
     const isUsageBased = await this.isUsageBasedSubscriptionUseCase.execute(
       new IsUsageBasedSubscriptionQuery(query.orgId),
     );
     if (isUsageBased) {
-      this.logger.debug('Skipping fair-use quota for usage-based org', {
-        orgId: query.orgId,
-        quotaType: query.quotaType,
-      });
+      this.logger.debug(
+        { orgId: query.orgId, quotaType: query.quotaType },
+        'Skipping fair-use quota for usage-based org',
+      );
       return;
     }
 
+    await this.checkAndIncrement(query);
+  }
+
+  private async checkAndIncrement(query: CheckQuotaQuery): Promise<void> {
     const { limit, windowMs } = await this.limitResolver.resolve(
       query.quotaType,
     );
-
-    this.logger.debug('Checking quota', {
-      userId: query.userId,
-      quotaType: query.quotaType,
-      limit,
-    });
-
-    // Use checkAndIncrement which atomically checks limit BEFORE incrementing
-    // This prevents counter inflation on rejected requests
+    this.logger.debug(
+      { userId: query.userId, quotaType: query.quotaType, limit },
+      'Checking quota',
+    );
     const { quota, exceeded } =
       await this.usageQuotaRepository.checkAndIncrement(
         query.userId,
@@ -53,31 +50,43 @@ export class CheckQuotaUseCase {
       );
 
     if (exceeded) {
-      const retryAfterSeconds = Math.ceil(quota.getRemainingTime() / 1000);
+      this.throwQuotaExceeded(query, quota, limit, windowMs);
+    }
+    this.logger.debug(
+      {
+        userId: query.userId,
+        quotaType: query.quotaType,
+        count: quota.count,
+        limit,
+        remaining: limit - quota.count,
+      },
+      'Quota check passed',
+    );
+  }
 
-      this.logger.warn('Quota exceeded', {
+  private throwQuotaExceeded(
+    query: CheckQuotaQuery,
+    quota: UsageQuota,
+    limit: number,
+    windowMs: number,
+  ): never {
+    const retryAfterSeconds = Math.ceil(quota.getRemainingTime() / 1000);
+    this.logger.warn(
+      {
         userId: query.userId,
         quotaType: query.quotaType,
         count: quota.count,
         limit,
         retryAfterSeconds,
-      });
-
-      throw new QuotaExceededError(
-        query.quotaType,
-        limit,
-        windowMs,
-        retryAfterSeconds,
-        { currentCount: quota.count },
-      );
-    }
-
-    this.logger.debug('Quota check passed', {
-      userId: query.userId,
-      quotaType: query.quotaType,
-      count: quota.count,
+      },
+      'Quota exceeded',
+    );
+    throw new QuotaExceededError(
+      query.quotaType,
       limit,
-      remaining: limit - quota.count,
-    });
+      windowMs,
+      retryAfterSeconds,
+      { currentCount: quota.count },
+    );
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/services/subscription-factory.service.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/services/subscription-factory.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import type { UUID } from 'crypto';
 import { Subscription } from 'src/iam/subscriptions/domain/subscription.entity';
@@ -50,9 +51,9 @@ export interface BuildSubscriptionParams {
  */
 @Injectable()
 export class SubscriptionFactory {
-  private readonly logger = new Logger(SubscriptionFactory.name);
-
   constructor(
+    @InjectPinoLogger(SubscriptionFactory.name)
+    private readonly logger: PinoLogger,
     private readonly configService: ConfigService,
     private readonly getInvitesByOrgUseCase: GetInvitesByOrgUseCase,
     private readonly findUsersByOrgIdUseCase: FindUsersByOrgIdUseCase,
@@ -73,10 +74,13 @@ export class SubscriptionFactory {
       );
     }
 
-    this.logger.log('Building usage-based subscription', {
-      orgId: params.orgId,
-      monthlyCredits: params.monthlyCredits,
-    });
+    this.logger.info(
+      {
+        orgId: params.orgId,
+        monthlyCredits: params.monthlyCredits,
+      },
+      'Building usage-based subscription',
+    );
 
     return new UsageBasedSubscription({
       orgId: params.orgId,
@@ -91,10 +95,13 @@ export class SubscriptionFactory {
   ): Promise<SeatBasedSubscription> {
     const noOfSeats = params.noOfSeats ?? 1;
 
-    this.logger.log('Building seat-based subscription', {
-      orgId: params.orgId,
-      noOfSeats,
-    });
+    this.logger.info(
+      {
+        orgId: params.orgId,
+        noOfSeats,
+      },
+      'Building seat-based subscription',
+    );
 
     if (noOfSeats <= 0) {
       throw new InvalidSubscriptionDataError(
@@ -152,10 +159,13 @@ export class SubscriptionFactory {
       openInvitesCount + (usersResult.total ?? usersResult.data.length) >
       noOfSeats
     ) {
-      this.logger.warn('Too many used seats', {
-        orgId,
-        openInvites: openInvitesCount,
-      });
+      this.logger.warn(
+        {
+          orgId,
+          openInvites: openInvitesCount,
+        },
+        'Too many used seats',
+      );
       throw new TooManyUsedSeatsError({
         orgId,
         openInvites: openInvitesCount,

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/cancel-subscription/cancel-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/cancel-subscription/cancel-subscription.use-case.ts
@@ -1,9 +1,9 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CancelSubscriptionCommand } from './cancel-subscription.command';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
 import {
-  SubscriptionNotFoundError,
   SubscriptionAlreadyCancelledError,
   UnexpectedSubscriptionError,
 } from '../../subscription.errors';
@@ -14,12 +14,13 @@ import { SubscriptionCancelledEvent } from '../../events/subscription-cancelled.
 import { toSubscriptionEventData } from '../../mappers/to-subscription-event-data.mapper';
 import { ContextService } from 'src/common/context/services/context.service';
 import { validateSubscriptionAccess } from '../../util/validate-subscription-access';
+import type { Subscription } from '../../../domain/subscription.entity';
 
 @Injectable()
 export class CancelSubscriptionUseCase {
-  private readonly logger = new Logger(CancelSubscriptionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CancelSubscriptionUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly subscriptionRepository: SubscriptionRepository,
     private readonly getActiveSubscriptionUseCase: GetActiveSubscriptionUseCase,
     private readonly eventEmitter: EventEmitter2,
@@ -27,76 +28,87 @@ export class CancelSubscriptionUseCase {
   ) {}
 
   async execute(command: CancelSubscriptionCommand): Promise<void> {
-    this.logger.log('Cancelling subscription', {
-      orgId: command.orgId,
-      requestingUserId: command.requestingUserId,
-    });
-
+    this.logger.info(
+      { orgId: command.orgId, requestingUserId: command.requestingUserId },
+      'Cancelling subscription',
+    );
     try {
       validateSubscriptionAccess(
         this.contextService,
         command.requestingUserId,
         command.orgId,
       );
-
-      this.logger.debug('Finding subscription');
-      const result = await this.getActiveSubscriptionUseCase.execute(
-        new GetActiveSubscriptionQuery({
+      const subscription = await this.findSubscription(command);
+      await this.cancelSubscription(command, subscription);
+    } catch (error) {
+      if (error instanceof ApplicationError) throw error;
+      this.logger.error(
+        {
+          err: error as Error,
           orgId: command.orgId,
           requestingUserId: command.requestingUserId,
-        }),
+        },
+        'Subscription cancellation failed',
       );
-      if (!result) {
-        this.logger.warn('Subscription not found', {
-          orgId: command.orgId,
-        });
-        throw new SubscriptionNotFoundError(command.orgId);
-      }
-      const subscription = result.subscription;
+      throw new UnexpectedSubscriptionError('Unexpected error');
+    }
+  }
 
-      this.logger.debug('Checking if subscription is already cancelled');
-      if (subscription.cancelledAt) {
-        this.logger.warn('Subscription already cancelled', {
-          orgId: command.orgId,
-          cancelledAt: subscription.cancelledAt,
-        });
-        throw new SubscriptionAlreadyCancelledError(command.orgId);
-      }
+  private async findSubscription(
+    command: CancelSubscriptionCommand,
+  ): Promise<Subscription> {
+    this.logger.debug('Finding subscription');
+    const result = await this.getActiveSubscriptionUseCase.execute(
+      new GetActiveSubscriptionQuery({
+        orgId: command.orgId,
+        requestingUserId: command.requestingUserId,
+      }),
+    );
+    return result.subscription;
+  }
 
-      this.logger.debug('Updating subscription to cancelled');
-      subscription.cancelledAt = new Date();
-      await this.subscriptionRepository.update(subscription);
-
-      this.logger.debug('Subscription cancelled successfully', {
+  private async cancelSubscription(
+    command: CancelSubscriptionCommand,
+    subscription: Subscription,
+  ): Promise<void> {
+    this.logger.debug('Checking if subscription is already cancelled');
+    if (subscription.cancelledAt) {
+      this.logger.warn(
+        { orgId: command.orgId, cancelledAt: subscription.cancelledAt },
+        'Subscription already cancelled',
+      );
+      throw new SubscriptionAlreadyCancelledError(command.orgId);
+    }
+    subscription.cancelledAt = new Date();
+    await this.subscriptionRepository.update(subscription);
+    this.logger.debug(
+      {
         subscriptionId: subscription.id,
         orgId: command.orgId,
         cancelledAt: subscription.cancelledAt,
-      });
+      },
+      'Subscription cancelled successfully',
+    );
+    this.emitCancelledEvent(command.orgId, subscription);
+  }
 
-      this.eventEmitter
-        .emitAsync(
-          SubscriptionCancelledEvent.EVENT_NAME,
-          new SubscriptionCancelledEvent(
-            command.orgId,
-            toSubscriptionEventData(subscription),
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit SubscriptionCancelledEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            orgId: command.orgId,
-          });
-        });
-    } catch (error) {
-      if (error instanceof ApplicationError) {
-        throw error;
-      }
-      this.logger.error('Subscription cancellation failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-        requestingUserId: command.requestingUserId,
+  private emitCancelledEvent(
+    orgId: CancelSubscriptionCommand['orgId'],
+    subscription: Subscription,
+  ): void {
+    this.eventEmitter
+      .emitAsync(
+        SubscriptionCancelledEvent.EVENT_NAME,
+        new SubscriptionCancelledEvent(
+          orgId,
+          toSubscriptionEventData(subscription),
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error(
+          { err: err as Error, orgId },
+          'Failed to emit SubscriptionCancelledEvent',
+        );
       });
-      throw new UnexpectedSubscriptionError('Unexpected error');
-    }
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/change-subscription/change-subscription.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/change-subscription/change-subscription.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { ConfigService } from '@nestjs/config';
 import { randomUUID } from 'crypto';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -70,7 +71,15 @@ describe('ChangeSubscriptionUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ChangeSubscriptionUseCase,
+        {
+          provide: getLoggerToken(ChangeSubscriptionUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         SubscriptionFactory,
+        {
+          provide: getLoggerToken(SubscriptionFactory.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: SubscriptionRepository,
           useValue: {
@@ -98,11 +107,6 @@ describe('ChangeSubscriptionUseCase', () => {
     configService = module.get(ConfigService);
     contextService = module.get(ContextService);
     eventEmitter = module.get(EventEmitter2);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/change-subscription/change-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/change-subscription/change-subscription.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ChangeSubscriptionCommand } from './change-subscription.command';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
@@ -18,9 +19,9 @@ import { SubscriptionFactory } from '../../services/subscription-factory.service
 
 @Injectable()
 export class ChangeSubscriptionUseCase {
-  private readonly logger = new Logger(ChangeSubscriptionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(ChangeSubscriptionUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly subscriptionRepository: SubscriptionRepository,
     private readonly subscriptionFactory: SubscriptionFactory,
     private readonly eventEmitter: EventEmitter2,
@@ -28,11 +29,14 @@ export class ChangeSubscriptionUseCase {
   ) {}
 
   async execute(command: ChangeSubscriptionCommand): Promise<Subscription> {
-    this.logger.log('Changing subscription', {
-      orgId: command.orgId,
-      type: command.type,
-      disposition: command.disposition,
-    });
+    this.logger.info(
+      {
+        orgId: command.orgId,
+        type: command.type,
+        disposition: command.disposition,
+      },
+      'Changing subscription',
+    );
 
     try {
       validateSubscriptionAccess(
@@ -71,11 +75,14 @@ export class ChangeSubscriptionUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Subscription change failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-        requestingUserId: command.requestingUserId,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          orgId: command.orgId,
+          requestingUserId: command.requestingUserId,
+        },
+        'Subscription change failed',
+      );
       throw new UnexpectedSubscriptionError(
         'Unexpected error during subscription change',
         { error: error as Error },
@@ -92,7 +99,7 @@ export class ChangeSubscriptionUseCase {
     const subscription =
       await this.subscriptionRepository.findLatestByOrgId(orgId);
     if (!subscription) {
-      this.logger.warn('No subscription to change', { orgId });
+      this.logger.warn({ orgId }, 'No subscription to change');
       throw new SubscriptionNotFoundError(orgId);
     }
     return subscription;
@@ -123,9 +130,10 @@ export class ChangeSubscriptionUseCase {
 
   private safeEmit(eventName: string, event: object): void {
     this.eventEmitter.emitAsync(eventName, event).catch((err: unknown) => {
-      this.logger.error(`Failed to emit ${eventName}`, {
-        error: err instanceof Error ? err.message : 'Unknown error',
-      });
+      this.logger.error(
+        { err: err as Error, eventName },
+        'Failed to emit subscription event',
+      );
     });
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { ConfigService } from '@nestjs/config';
 import { randomUUID } from 'crypto';
 import { CreateSubscriptionUseCase } from './create-subscription.use-case';
@@ -50,7 +51,15 @@ describe('CreateSubscriptionUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateSubscriptionUseCase,
+        {
+          provide: getLoggerToken(CreateSubscriptionUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         SubscriptionFactory,
+        {
+          provide: getLoggerToken(SubscriptionFactory.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: SubscriptionRepository,
           useValue: {
@@ -88,11 +97,6 @@ describe('CreateSubscriptionUseCase', () => {
     configService = module.get(ConfigService);
     contextService = module.get(ContextService);
     eventEmitter = module.get(EventEmitter2);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/create-subscription/create-subscription.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CreateSubscriptionCommand } from './create-subscription.command';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
@@ -17,9 +18,9 @@ import { SubscriptionFactory } from '../../services/subscription-factory.service
 
 @Injectable()
 export class CreateSubscriptionUseCase {
-  private readonly logger = new Logger(CreateSubscriptionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(CreateSubscriptionUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly subscriptionRepository: SubscriptionRepository,
     private readonly subscriptionFactory: SubscriptionFactory,
     private readonly eventEmitter: EventEmitter2,
@@ -41,42 +42,54 @@ export class CreateSubscriptionUseCase {
       const createdSubscription =
         await this.subscriptionRepository.create(subscription);
 
-      this.logger.debug('Subscription created successfully', {
-        subscriptionId: createdSubscription.id,
-        orgId: command.orgId,
-        type: command.type,
-      });
+      this.logger.debug(
+        {
+          subscriptionId: createdSubscription.id,
+          orgId: command.orgId,
+          type: command.type,
+        },
+        'Subscription created successfully',
+      );
 
-      this.eventEmitter
-        .emitAsync(
-          SubscriptionCreatedEvent.EVENT_NAME,
-          new SubscriptionCreatedEvent(
-            command.orgId,
-            toSubscriptionEventData(createdSubscription),
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit SubscriptionCreatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            orgId: command.orgId,
-          });
-        });
-
+      this.emitCreatedEvent(command, createdSubscription);
       return createdSubscription;
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Subscription creation failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-        requestingUserId: command.requestingUserId,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          orgId: command.orgId,
+          requestingUserId: command.requestingUserId,
+        },
+        'Subscription creation failed',
+      );
       throw new UnexpectedSubscriptionError(
         'Unexpected error during subscription creation',
         { error: error as Error },
       );
     }
+  }
+
+  private emitCreatedEvent(
+    command: CreateSubscriptionCommand,
+    subscription: Subscription,
+  ): void {
+    this.eventEmitter
+      .emitAsync(
+        SubscriptionCreatedEvent.EVENT_NAME,
+        new SubscriptionCreatedEvent(
+          command.orgId,
+          toSubscriptionEventData(subscription),
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error(
+          { err: err as Error, orgId: command.orgId },
+          'Failed to emit SubscriptionCreatedEvent',
+        );
+      });
   }
 
   private async ensureNoExistingSubscription(
@@ -85,9 +98,12 @@ export class CreateSubscriptionUseCase {
     const subscriptions = await this.subscriptionRepository.findByOrgId(orgId);
     const hasNonCancelled = subscriptions.some((s) => !s.cancelledAt);
     if (hasNonCancelled) {
-      this.logger.warn('Subscription already exists for organization', {
-        orgId,
-      });
+      this.logger.warn(
+        {
+          orgId,
+        },
+        'Subscription already exists for organization',
+      );
       throw new SubscriptionAlreadyExistsError(orgId);
     }
   }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-active-subscription/get-active-subscription.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-active-subscription/get-active-subscription.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { randomUUID } from 'crypto';
 import { GetActiveSubscriptionUseCase } from './get-active-subscription.use-case';
@@ -79,6 +80,10 @@ describe('GetActiveSubscriptionUseCase', () => {
       providers: [
         GetActiveSubscriptionUseCase,
         {
+          provide: getLoggerToken(GetActiveSubscriptionUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
+        {
           provide: SubscriptionRepository,
           useValue: { findByOrgId: jest.fn() },
         },
@@ -102,11 +107,6 @@ describe('GetActiveSubscriptionUseCase', () => {
     getInvitesByOrgUseCase = module.get(GetInvitesByOrgUseCase);
     findUsersByOrgIdUseCase = module.get(FindUsersByOrgIdUseCase);
     contextService = module.get(ContextService);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   afterEach(() => {

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-active-subscription/get-active-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-active-subscription/get-active-subscription.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetActiveSubscriptionQuery } from './get-active-subscription.query';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
 import { Subscription } from 'src/iam/subscriptions/domain/subscription.entity';
@@ -17,9 +18,9 @@ import { getNextRenewalDate } from '../../util/get-next-renewal-date';
 
 @Injectable()
 export class GetActiveSubscriptionUseCase {
-  private readonly logger = new Logger(GetActiveSubscriptionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetActiveSubscriptionUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly subscriptionRepository: SubscriptionRepository,
     private readonly getInvitesByOrgUseCase: GetInvitesByOrgUseCase,
     private readonly findUsersByOrgIdUseCase: FindUsersByOrgIdUseCase,
@@ -31,10 +32,13 @@ export class GetActiveSubscriptionUseCase {
     availableSeats: number | null;
     nextRenewalDate: Date;
   }> {
-    this.logger.log('Getting subscription', {
-      orgId: query.orgId,
-      requestingUserId: query.requestingUserId,
-    });
+    this.logger.info(
+      {
+        orgId: query.orgId,
+        requestingUserId: query.requestingUserId,
+      },
+      'Getting subscription',
+    );
 
     try {
       this.logger.debug('Checking if user is from organization');
@@ -44,23 +48,7 @@ export class GetActiveSubscriptionUseCase {
         query.orgId,
       );
 
-      const subscriptions = (
-        await this.subscriptionRepository.findByOrgId(query.orgId)
-      ).filter(isActive);
-      if (subscriptions.length === 0) {
-        this.logger.warn('Subscription not found', {
-          orgId: query.orgId,
-        });
-        throw new SubscriptionNotFoundError(query.orgId);
-      }
-      if (subscriptions.length > 1) {
-        this.logger.warn('Multiple active subscriptions found', {
-          orgId: query.orgId,
-        });
-        throw new MultipleActiveSubscriptionsError(query.orgId);
-      }
-
-      const subscription = subscriptions[0];
+      const subscription = await this.findActiveSubscription(query.orgId);
 
       const availableSeats = await computeAvailableSeats(
         subscription,
@@ -76,12 +64,32 @@ export class GetActiveSubscriptionUseCase {
         // Already logged and properly typed error, just rethrow
         throw error;
       }
-      this.logger.error('Getting subscription failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: query.orgId,
-        requestingUserId: query.requestingUserId,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          orgId: query.orgId,
+          requestingUserId: query.requestingUserId,
+        },
+        'Getting subscription failed',
+      );
       throw error;
     }
+  }
+
+  private async findActiveSubscription(
+    orgId: GetActiveSubscriptionQuery['orgId'],
+  ): Promise<Subscription> {
+    const subscriptions = (
+      await this.subscriptionRepository.findByOrgId(orgId)
+    ).filter(isActive);
+    if (subscriptions.length === 0) {
+      this.logger.warn({ orgId }, 'Subscription not found');
+      throw new SubscriptionNotFoundError(orgId);
+    }
+    if (subscriptions.length > 1) {
+      this.logger.warn({ orgId }, 'Multiple active subscriptions found');
+      throw new MultipleActiveSubscriptionsError(orgId);
+    }
+    return subscriptions[0];
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-current-price/get-current-price.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-current-price/get-current-price.use-case.ts
@@ -1,11 +1,15 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ConfigService } from '@nestjs/config';
 import { PriceNotFoundError } from '../../subscription.errors';
 
 @Injectable()
 export class GetCurrentPriceUseCase {
-  private readonly logger = new Logger(GetCurrentPriceUseCase.name);
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    @InjectPinoLogger(GetCurrentPriceUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly configService: ConfigService,
+  ) {}
 
   execute(): number {
     const pricePerSeatMonthly = this.configService.get<number>(

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-latest-subscription/get-latest-subscription.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-latest-subscription/get-latest-subscription.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
 import { randomUUID } from 'crypto';
 import { GetLatestSubscriptionUseCase } from './get-latest-subscription.use-case';
@@ -83,6 +84,10 @@ describe('GetLatestSubscriptionUseCase', () => {
       providers: [
         GetLatestSubscriptionUseCase,
         {
+          provide: getLoggerToken(GetLatestSubscriptionUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
+        {
           provide: SubscriptionRepository,
           useValue: { findLatestByOrgId: jest.fn() },
         },
@@ -106,11 +111,6 @@ describe('GetLatestSubscriptionUseCase', () => {
     getInvitesByOrgUseCase = module.get(GetInvitesByOrgUseCase);
     findUsersByOrgIdUseCase = module.get(FindUsersByOrgIdUseCase);
     contextService = module.get(ContextService);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   beforeEach(() => {

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-latest-subscription/get-latest-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-latest-subscription/get-latest-subscription.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetLatestSubscriptionQuery } from './get-latest-subscription.query';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
 import { Subscription } from 'src/iam/subscriptions/domain/subscription.entity';
@@ -16,9 +17,9 @@ import { getNextRenewalDate } from '../../util/get-next-renewal-date';
 
 @Injectable()
 export class GetLatestSubscriptionUseCase {
-  private readonly logger = new Logger(GetLatestSubscriptionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetLatestSubscriptionUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly subscriptionRepository: SubscriptionRepository,
     private readonly getInvitesByOrgUseCase: GetInvitesByOrgUseCase,
     private readonly findUsersByOrgIdUseCase: FindUsersByOrgIdUseCase,
@@ -30,10 +31,13 @@ export class GetLatestSubscriptionUseCase {
     availableSeats: number | null;
     nextRenewalDate: Date;
   }> {
-    this.logger.log('Getting latest subscription', {
-      orgId: query.orgId,
-      requestingUserId: query.requestingUserId,
-    });
+    this.logger.info(
+      {
+        orgId: query.orgId,
+        requestingUserId: query.requestingUserId,
+      },
+      'Getting latest subscription',
+    );
 
     try {
       validateSubscriptionAccess(
@@ -62,9 +66,10 @@ export class GetLatestSubscriptionUseCase {
       return { subscription, availableSeats, nextRenewalDate };
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Error getting latest subscription', {
-        error: error as Error,
-      });
+      this.logger.error(
+        { err: error as Error },
+        'Error getting latest subscription',
+      );
       throw new UnexpectedSubscriptionError(
         'Failed to get latest subscription',
       );

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-monthly-credit-limit/get-monthly-credit-limit.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-monthly-credit-limit/get-monthly-credit-limit.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { GetMonthlyCreditLimitUseCase } from './get-monthly-credit-limit.use-case';
@@ -34,6 +36,10 @@ describe('GetMonthlyCreditLimitUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         GetMonthlyCreditLimitUseCase,
+        {
+          provide: getLoggerToken(GetMonthlyCreditLimitUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: SubscriptionRepository,
           useValue: mockSubscriptionRepository,

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-monthly-credit-limit/get-monthly-credit-limit.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/get-monthly-credit-limit/get-monthly-credit-limit.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { GetMonthlyCreditLimitQuery } from './get-monthly-credit-limit.query';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
 import { isActive } from '../../util/is-active';
@@ -12,9 +13,9 @@ import { UnexpectedSubscriptionError } from '../../subscription.errors';
  */
 @Injectable()
 export class GetMonthlyCreditLimitUseCase {
-  private readonly logger = new Logger(GetMonthlyCreditLimitUseCase.name);
-
   constructor(
+    @InjectPinoLogger(GetMonthlyCreditLimitUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly subscriptionRepository: SubscriptionRepository,
   ) {}
 
@@ -30,9 +31,12 @@ export class GetMonthlyCreditLimitUseCase {
         .find(isUsageBased);
 
       if (!usageSubscription) {
-        this.logger.debug('No active usage-based subscription found', {
-          orgId: query.orgId,
-        });
+        this.logger.debug(
+          {
+            orgId: query.orgId,
+          },
+          'No active usage-based subscription found',
+        );
         return { monthlyCredits: null, startsAt: null };
       }
 
@@ -42,7 +46,10 @@ export class GetMonthlyCreditLimitUseCase {
       };
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to get monthly credit limit', error);
+      this.logger.error(
+        { err: error as Error },
+        'Failed to get monthly credit limit',
+      );
       throw new UnexpectedSubscriptionError((error as Error).message, {
         orgId: query.orgId,
       });

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/has-active-subscription/has-active-subscription.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/has-active-subscription/has-active-subscription.use-case.spec.ts
@@ -1,6 +1,8 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import type { PinoLogger } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { ConfigService } from '@nestjs/config';
 import { HasActiveSubscriptionUseCase } from './has-active-subscription.use-case';
 import { HasActiveSubscriptionQuery } from './has-active-subscription.query';
@@ -17,6 +19,7 @@ describe('HasActiveSubscriptionUseCase', () => {
   let subscriptionRepository: jest.Mocked<SubscriptionRepository>;
   let configService: jest.Mocked<ConfigService>;
   let mockIsActive: jest.MockedFunction<typeof isActive>;
+  let logger: jest.Mocked<PinoLogger>;
 
   const mockOrgId = '123e4567-e89b-12d3-a456-426614174000' as any;
 
@@ -36,6 +39,10 @@ describe('HasActiveSubscriptionUseCase', () => {
       providers: [
         HasActiveSubscriptionUseCase,
         {
+          provide: getLoggerToken(HasActiveSubscriptionUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
+        {
           provide: SubscriptionRepository,
           useValue: mockSubscriptionRepository,
         },
@@ -49,11 +56,7 @@ describe('HasActiveSubscriptionUseCase', () => {
     subscriptionRepository = module.get(SubscriptionRepository);
     configService = module.get(ConfigService);
     mockIsActive = isActive as jest.MockedFunction<typeof isActive>;
-
-    // Mock logger
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    logger = module.get(getLoggerToken(HasActiveSubscriptionUseCase.name));
   });
 
   afterEach(() => {
@@ -161,15 +164,14 @@ describe('HasActiveSubscriptionUseCase', () => {
       configService.get.mockReturnValue(false);
       subscriptionRepository.findByOrgId.mockResolvedValue([]);
 
-      const logSpy = jest.spyOn(Logger.prototype, 'log');
-
       // Act
       await useCase.execute(query);
 
       // Assert
-      expect(logSpy).toHaveBeenCalledWith('Checking active subscription', {
-        orgId: query.orgId,
-      });
+      expect(logger.info).toHaveBeenCalledWith(
+        { orgId: query.orgId },
+        'Checking active subscription',
+      );
     });
 
     it('should log debug information when no subscriptions found', async () => {
@@ -178,18 +180,14 @@ describe('HasActiveSubscriptionUseCase', () => {
       configService.get.mockReturnValue(false);
       subscriptionRepository.findByOrgId.mockResolvedValue([]);
 
-      const debugSpy = jest.spyOn(Logger.prototype, 'debug');
-
       // Act
       await useCase.execute(query);
 
       // Assert
-      expect(debugSpy).toHaveBeenCalledWith('Finding subscription');
-      expect(debugSpy).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledWith('Finding subscription');
+      expect(logger.debug).toHaveBeenCalledWith(
+        { orgId: mockOrgId },
         'No subscription found for organization',
-        {
-          orgId: mockOrgId,
-        },
       );
     });
 
@@ -219,19 +217,17 @@ describe('HasActiveSubscriptionUseCase', () => {
       const genericError = new Error('Database connection failed');
       subscriptionRepository.findByOrgId.mockRejectedValue(genericError);
 
-      const errorSpy = jest.spyOn(Logger.prototype, 'error');
-
       // Act & Assert
       await expect(useCase.execute(query)).rejects.toThrow(
         'Database connection failed',
       );
 
-      expect(errorSpy).toHaveBeenCalledWith(
-        'Checking active subscription failed',
+      expect(logger.error).toHaveBeenCalledWith(
         {
-          error: 'Database connection failed',
+          err: genericError,
           orgId: mockOrgId,
         },
+        'Checking active subscription failed',
       );
     });
 
@@ -295,17 +291,15 @@ describe('HasActiveSubscriptionUseCase', () => {
 
       subscriptionRepository.findByOrgId.mockRejectedValue('string error');
 
-      const errorSpy = jest.spyOn(Logger.prototype, 'error');
-
       // Act & Assert
       await expect(useCase.execute(query)).rejects.toBeDefined();
 
-      expect(errorSpy).toHaveBeenCalledWith(
-        'Checking active subscription failed',
+      expect(logger.error).toHaveBeenCalledWith(
         {
-          error: 'Unknown error',
+          err: 'string error',
           orgId: mockOrgId,
         },
+        'Checking active subscription failed',
       );
     });
   });

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/has-active-subscription/has-active-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/has-active-subscription/has-active-subscription.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HasActiveSubscriptionQuery } from './has-active-subscription.query';
 import { HasActiveSubscriptionResult } from './has-active-subscription.result';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
@@ -8,9 +9,9 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class HasActiveSubscriptionUseCase {
-  private readonly logger = new Logger(HasActiveSubscriptionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(HasActiveSubscriptionUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly subscriptionRepository: SubscriptionRepository,
     private readonly configService: ConfigService,
   ) {}
@@ -26,9 +27,12 @@ export class HasActiveSubscriptionUseCase {
       return { hasActiveSubscription: true, subscriptionType: null };
     }
 
-    this.logger.log('Checking active subscription', {
-      orgId: query.orgId,
-    });
+    this.logger.info(
+      {
+        orgId: query.orgId,
+      },
+      'Checking active subscription',
+    );
 
     try {
       this.logger.debug('Finding subscription');
@@ -36,9 +40,12 @@ export class HasActiveSubscriptionUseCase {
         query.orgId,
       );
       if (subscriptions.length === 0) {
-        this.logger.debug('No subscription found for organization', {
-          orgId: query.orgId,
-        });
+        this.logger.debug(
+          {
+            orgId: query.orgId,
+          },
+          'No subscription found for organization',
+        );
         return { hasActiveSubscription: false, subscriptionType: null };
       }
 
@@ -56,10 +63,10 @@ export class HasActiveSubscriptionUseCase {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Checking active subscription failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: query.orgId,
-      });
+      this.logger.error(
+        { err: error as Error, orgId: query.orgId },
+        'Checking active subscription failed',
+      );
       throw error;
     }
   }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/is-usage-based-subscription/is-usage-based-subscription.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/is-usage-based-subscription/is-usage-based-subscription.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { IsUsageBasedSubscriptionUseCase } from './is-usage-based-subscription.use-case';
@@ -34,6 +36,10 @@ describe('IsUsageBasedSubscriptionUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         IsUsageBasedSubscriptionUseCase,
+        {
+          provide: getLoggerToken(IsUsageBasedSubscriptionUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         {
           provide: SubscriptionRepository,
           useValue: mockSubscriptionRepository,

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/is-usage-based-subscription/is-usage-based-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/is-usage-based-subscription/is-usage-based-subscription.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { IsUsageBasedSubscriptionQuery } from './is-usage-based-subscription.query';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
 import { isActive } from '../../util/is-active';
@@ -13,9 +14,9 @@ import { UnexpectedSubscriptionError } from '../../subscription.errors';
  */
 @Injectable()
 export class IsUsageBasedSubscriptionUseCase {
-  private readonly logger = new Logger(IsUsageBasedSubscriptionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(IsUsageBasedSubscriptionUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly subscriptionRepository: SubscriptionRepository,
   ) {}
 
@@ -27,7 +28,10 @@ export class IsUsageBasedSubscriptionUseCase {
       return subscriptions.filter(isActive).some(isUsageBased);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error('Failed to determine subscription type', error);
+      this.logger.error(
+        { err: error as Error },
+        'Failed to determine subscription type',
+      );
       throw new UnexpectedSubscriptionError((error as Error).message, {
         orgId: query.orgId,
       });

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/list-usage-based-subscription-org-ids/list-usage-based-subscription-org-ids.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/list-usage-based-subscription-org-ids/list-usage-based-subscription-org-ids.use-case.spec.ts
@@ -1,3 +1,5 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import type { UUID } from 'crypto';
@@ -20,6 +22,10 @@ describe('ListUsageBasedSubscriptionOrgIdsUseCase', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ListUsageBasedSubscriptionOrgIdsUseCase,
+        {
+          provide: getLoggerToken(ListUsageBasedSubscriptionOrgIdsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: SubscriptionRepository, useValue: repository },
       ],
     }).compile();

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/list-usage-based-subscription-org-ids/list-usage-based-subscription-org-ids.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/list-usage-based-subscription-org-ids/list-usage-based-subscription-org-ids.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
 import { ApplicationError } from 'src/common/errors/base.error';
@@ -10,16 +11,14 @@ import { UnexpectedSubscriptionError } from '../../subscription.errors';
  */
 @Injectable()
 export class ListUsageBasedSubscriptionOrgIdsUseCase {
-  private readonly logger = new Logger(
-    ListUsageBasedSubscriptionOrgIdsUseCase.name,
-  );
-
   constructor(
+    @InjectPinoLogger(ListUsageBasedSubscriptionOrgIdsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly subscriptionRepository: SubscriptionRepository,
   ) {}
 
   async execute(): Promise<UUID[]> {
-    this.logger.log('execute');
+    this.logger.info('execute');
     try {
       return await this.subscriptionRepository.findActiveUsageBasedOrgIds(
         new Date(),
@@ -27,8 +26,8 @@ export class ListUsageBasedSubscriptionOrgIdsUseCase {
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
       this.logger.error(
+        { err: error as Error },
         'Failed to list orgs with usage-based subscriptions',
-        error,
       );
       throw new UnexpectedSubscriptionError((error as Error).message);
     }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/uncancel-subscription/uncancel-subscription.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/uncancel-subscription/uncancel-subscription.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { UncancelSubscriptionUseCase } from './uncancel-subscription.use-case';
 import { UncancelSubscriptionCommand } from './uncancel-subscription.command';
@@ -77,6 +78,10 @@ describe('UncancelSubscriptionUseCase', () => {
       providers: [
         UncancelSubscriptionUseCase,
         {
+          provide: getLoggerToken(UncancelSubscriptionUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
+        {
           provide: SubscriptionRepository,
           useValue: {
             findLatestByOrgId: jest.fn(),
@@ -98,11 +103,6 @@ describe('UncancelSubscriptionUseCase', () => {
     subscriptionRepository = module.get(SubscriptionRepository);
     contextService = module.get(ContextService);
     eventEmitter = module.get(EventEmitter2);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   beforeEach(() => {

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/uncancel-subscription/uncancel-subscription.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/uncancel-subscription/uncancel-subscription.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UncancelSubscriptionCommand } from './uncancel-subscription.command';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
@@ -19,19 +20,22 @@ import type { Subscription } from 'src/iam/subscriptions/domain/subscription.ent
 
 @Injectable()
 export class UncancelSubscriptionUseCase {
-  private readonly logger = new Logger(UncancelSubscriptionUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UncancelSubscriptionUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly subscriptionRepository: SubscriptionRepository,
     private readonly eventEmitter: EventEmitter2,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(command: UncancelSubscriptionCommand): Promise<void> {
-    this.logger.log('Uncancelling subscription', {
-      orgId: command.orgId,
-      requestingUserId: command.requestingUserId,
-    });
+    this.logger.info(
+      {
+        orgId: command.orgId,
+        requestingUserId: command.requestingUserId,
+      },
+      'Uncancelling subscription',
+    );
 
     try {
       validateSubscriptionAccess(
@@ -40,68 +44,79 @@ export class UncancelSubscriptionUseCase {
         command.orgId,
       );
 
-      this.logger.debug('Finding subscription');
-      const subscription = await this.subscriptionRepository.findLatestByOrgId(
-        command.orgId,
-      );
-      if (!subscription) {
-        this.logger.warn('Subscription not found', {
-          orgId: command.orgId,
-        });
-        throw new SubscriptionNotFoundError(command.orgId);
-      }
-
-      this.logger.debug('Checking if subscription is cancelled');
-      if (!subscription.cancelledAt) {
-        this.logger.warn('Subscription is not cancelled', {
-          orgId: command.orgId,
-        });
-        throw new SubscriptionNotCancelledError(command.orgId);
-      }
-
-      this.logger.debug('Checking if subscription can still be uncancelled');
-      if (!this.canUncancel(subscription)) {
-        this.logger.warn('Subscription has expired and cannot be uncancelled', {
-          orgId: command.orgId,
-        });
-        throw new SubscriptionExpiredError(command.orgId);
-      }
-
+      const subscription = await this.findSubscription(command.orgId);
+      this.ensureCanUncancel(command.orgId, subscription);
       subscription.cancelledAt = null;
-
-      this.logger.debug('Updating subscription to uncancelled');
       await this.subscriptionRepository.update(subscription);
-
-      this.logger.debug('Subscription uncancelled successfully', {
-        subscriptionId: subscription.id,
-        orgId: command.orgId,
-      });
-
-      this.eventEmitter
-        .emitAsync(
-          SubscriptionUncancelledEvent.EVENT_NAME,
-          new SubscriptionUncancelledEvent(
-            command.orgId,
-            toSubscriptionEventData(subscription),
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit SubscriptionUncancelledEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            orgId: command.orgId,
-          });
-        });
+      this.logger.debug(
+        { subscriptionId: subscription.id, orgId: command.orgId },
+        'Subscription uncancelled successfully',
+      );
+      this.emitUncancelledEvent(command.orgId, subscription);
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
-      this.logger.error('Subscription uncancellation failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-        requestingUserId: command.requestingUserId,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          orgId: command.orgId,
+          requestingUserId: command.requestingUserId,
+        },
+        'Subscription uncancellation failed',
+      );
       throw new UnexpectedSubscriptionError('Unexpected error');
     }
+  }
+
+  private async findSubscription(
+    orgId: UncancelSubscriptionCommand['orgId'],
+  ): Promise<Subscription> {
+    this.logger.debug('Finding subscription');
+    const subscription =
+      await this.subscriptionRepository.findLatestByOrgId(orgId);
+    if (!subscription) {
+      this.logger.warn({ orgId }, 'Subscription not found');
+      throw new SubscriptionNotFoundError(orgId);
+    }
+    return subscription;
+  }
+
+  private ensureCanUncancel(
+    orgId: UncancelSubscriptionCommand['orgId'],
+    subscription: Subscription,
+  ): void {
+    if (!subscription.cancelledAt) {
+      this.logger.warn({ orgId }, 'Subscription is not cancelled');
+      throw new SubscriptionNotCancelledError(orgId);
+    }
+    if (!this.canUncancel(subscription)) {
+      this.logger.warn(
+        { orgId },
+        'Subscription has expired and cannot be uncancelled',
+      );
+      throw new SubscriptionExpiredError(orgId);
+    }
+  }
+
+  private emitUncancelledEvent(
+    orgId: UncancelSubscriptionCommand['orgId'],
+    subscription: Subscription,
+  ): void {
+    this.eventEmitter
+      .emitAsync(
+        SubscriptionUncancelledEvent.EVENT_NAME,
+        new SubscriptionUncancelledEvent(
+          orgId,
+          toSubscriptionEventData(subscription),
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error(
+          { err: err as Error, orgId },
+          'Failed to emit SubscriptionUncancelledEvent',
+        );
+      });
   }
 
   /**

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-billing-info/update-billing-info.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-billing-info/update-billing-info.use-case.ts
@@ -8,7 +8,8 @@ import { GetActiveSubscriptionQuery } from '../get-active-subscription/get-activ
 import { GetActiveSubscriptionUseCase } from '../get-active-subscription/get-active-subscription.use-case';
 import { UpdateBillingInfoCommand } from './update-billing-info.command';
 import { ApplicationError } from 'src/common/errors/base.error';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { SubscriptionBillingInfoUpdatedEvent } from '../../events/subscription-billing-info-updated.event';
 import type { BillingInfoEventData } from '../../events/subscription-event-data.types';
@@ -17,9 +18,9 @@ import { validateSubscriptionAccess } from '../../util/validate-subscription-acc
 
 @Injectable()
 export class UpdateBillingInfoUseCase {
-  private readonly logger = new Logger(UpdateBillingInfoUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateBillingInfoUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly subscriptionRepository: SubscriptionRepository,
     private readonly getActiveSubscriptionUseCase: GetActiveSubscriptionUseCase,
     private readonly eventEmitter: EventEmitter2,
@@ -40,6 +41,8 @@ export class UpdateBillingInfoUseCase {
         }),
       );
 
+      // Cross-module runtime boundaries are guarded even when their types are non-null.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (!subscription) {
         throw new SubscriptionNotFoundError(command.orgId);
       }
@@ -56,42 +59,47 @@ export class UpdateBillingInfoUseCase {
 
       subscription.subscription.billingInfo = billingInfo;
 
-      const billingInfoEventData: BillingInfoEventData = {
-        companyName: billingInfo.companyName,
-        street: billingInfo.street,
-        houseNumber: billingInfo.houseNumber,
-        postalCode: billingInfo.postalCode,
-        city: billingInfo.city,
-        country: billingInfo.country,
-        vatNumber: billingInfo.vatNumber,
-        subText: billingInfo.subText,
-        orgId: command.orgId,
-        subscriptionId: subscription.subscription.id,
-      };
-
-      this.eventEmitter
-        .emitAsync(
-          SubscriptionBillingInfoUpdatedEvent.EVENT_NAME,
-          new SubscriptionBillingInfoUpdatedEvent(
-            command.orgId,
-            billingInfoEventData,
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error(
-            'Failed to emit SubscriptionBillingInfoUpdatedEvent',
-            {
-              error: err instanceof Error ? err.message : 'Unknown error',
-              orgId: command.orgId,
-            },
-          );
-        });
+      this.emitBillingInfoUpdated(
+        command,
+        subscription.subscription.id,
+        billingInfo,
+      );
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
-      this.logger.error(error);
+      this.logger.error({ err: error as Error });
       throw new UnexpectedSubscriptionError((error as Error).message, {
         error: error as Error,
       });
     }
+  }
+
+  private emitBillingInfoUpdated(
+    command: UpdateBillingInfoCommand,
+    subscriptionId: BillingInfoEventData['subscriptionId'],
+    billingInfo: SubscriptionBillingInfo,
+  ): void {
+    const eventData: BillingInfoEventData = {
+      companyName: billingInfo.companyName,
+      street: billingInfo.street,
+      houseNumber: billingInfo.houseNumber,
+      postalCode: billingInfo.postalCode,
+      city: billingInfo.city,
+      country: billingInfo.country,
+      vatNumber: billingInfo.vatNumber,
+      subText: billingInfo.subText,
+      orgId: command.orgId,
+      subscriptionId,
+    };
+    this.eventEmitter
+      .emitAsync(
+        SubscriptionBillingInfoUpdatedEvent.EVENT_NAME,
+        new SubscriptionBillingInfoUpdatedEvent(command.orgId, eventData),
+      )
+      .catch((err: unknown) => {
+        this.logger.error(
+          { err: err as Error, orgId: command.orgId },
+          'Failed to emit SubscriptionBillingInfoUpdatedEvent',
+        );
+      });
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-monthly-credits/update-monthly-credits.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-monthly-credits/update-monthly-credits.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { randomUUID } from 'crypto';
 import { UpdateMonthlyCreditsUseCase } from './update-monthly-credits.use-case';
@@ -76,6 +77,10 @@ describe('UpdateMonthlyCreditsUseCase', () => {
       providers: [
         UpdateMonthlyCreditsUseCase,
         {
+          provide: getLoggerToken(UpdateMonthlyCreditsUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
+        {
           provide: SubscriptionRepository,
           useValue: { update: jest.fn() },
         },
@@ -98,11 +103,6 @@ describe('UpdateMonthlyCreditsUseCase', () => {
     subscriptionRepository = module.get(SubscriptionRepository);
     getActiveSubscriptionUseCase = module.get(GetActiveSubscriptionUseCase);
     contextService = module.get(ContextService);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   beforeEach(() => {

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-monthly-credits/update-monthly-credits.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-monthly-credits/update-monthly-credits.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UpdateMonthlyCreditsCommand } from './update-monthly-credits.command';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
@@ -15,12 +16,13 @@ import { SubscriptionMonthlyCreditsUpdatedEvent } from '../../events/subscriptio
 import { toSubscriptionEventData } from '../../mappers/to-subscription-event-data.mapper';
 import { ContextService } from 'src/common/context/services/context.service';
 import { validateSubscriptionAccess } from '../../util/validate-subscription-access';
+import type { UsageBasedSubscription } from '../../../domain/usage-based-subscription.entity';
 
 @Injectable()
 export class UpdateMonthlyCreditsUseCase {
-  private readonly logger = new Logger(UpdateMonthlyCreditsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateMonthlyCreditsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly subscriptionRepository: SubscriptionRepository,
     private readonly getActiveSubscriptionUseCase: GetActiveSubscriptionUseCase,
     private readonly eventEmitter: EventEmitter2,
@@ -28,11 +30,14 @@ export class UpdateMonthlyCreditsUseCase {
   ) {}
 
   async execute(command: UpdateMonthlyCreditsCommand): Promise<void> {
-    this.logger.log('Updating monthly credits of subscription', {
-      orgId: command.orgId,
-      requestingUserId: command.requestingUserId,
-      monthlyCredits: command.monthlyCredits,
-    });
+    this.logger.info(
+      {
+        orgId: command.orgId,
+        requestingUserId: command.requestingUserId,
+        monthlyCredits: command.monthlyCredits,
+      },
+      'Updating monthly credits of subscription',
+    );
 
     try {
       validateSubscriptionAccess(
@@ -41,72 +46,84 @@ export class UpdateMonthlyCreditsUseCase {
         command.orgId,
       );
 
-      this.logger.debug('Validating monthly credits');
-      if (command.monthlyCredits < 0) {
-        this.logger.warn('Invalid monthly credits provided', {
-          monthlyCredits: command.monthlyCredits,
-        });
-        throw new InvalidSubscriptionDataError(
-          'Monthly credits must be 0 or greater',
-        );
-      }
-
-      this.logger.debug('Finding subscription');
-      const { subscription } = await this.getActiveSubscriptionUseCase.execute(
-        new GetActiveSubscriptionQuery({
-          orgId: command.orgId,
-          requestingUserId: command.requestingUserId,
-        }),
-      );
-
-      if (!isUsageBased(subscription)) {
-        throw new InvalidSubscriptionTypeError(
-          'Credit updates are only allowed for usage-based subscriptions',
-        );
-      }
-
+      this.validateMonthlyCredits(command.monthlyCredits);
+      const subscription = await this.findSubscription(command);
       const previousCredits = subscription.monthlyCredits;
       subscription.monthlyCredits = command.monthlyCredits;
       await this.subscriptionRepository.update(subscription);
-
-      this.logger.debug('Monthly credits updated successfully', {
-        subscriptionId: subscription.id,
-        orgId: command.orgId,
-        previousCredits,
-        newCredits: subscription.monthlyCredits,
-      });
-
-      this.eventEmitter
-        .emitAsync(
-          SubscriptionMonthlyCreditsUpdatedEvent.EVENT_NAME,
-          new SubscriptionMonthlyCreditsUpdatedEvent(
-            command.orgId,
-            toSubscriptionEventData(subscription),
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error(
-            'Failed to emit SubscriptionMonthlyCreditsUpdatedEvent',
-            {
-              error: err instanceof Error ? err.message : 'Unknown error',
-              orgId: command.orgId,
-            },
-          );
-        });
+      this.logger.debug(
+        {
+          subscriptionId: subscription.id,
+          orgId: command.orgId,
+          previousCredits,
+          newCredits: subscription.monthlyCredits,
+        },
+        'Monthly credits updated successfully',
+      );
+      this.emitUpdatedEvent(command.orgId, subscription);
     } catch (error) {
       if (error instanceof ApplicationError) {
         // Already logged and properly typed error, just rethrow
         throw error;
       }
-      this.logger.error('Updating monthly credits failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-        requestingUserId: command.requestingUserId,
-        monthlyCredits: command.monthlyCredits,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          orgId: command.orgId,
+          requestingUserId: command.requestingUserId,
+          monthlyCredits: command.monthlyCredits,
+        },
+        'Updating monthly credits failed',
+      );
       throw new UnexpectedSubscriptionError(
         'Unexpected error during monthly credits update',
       );
     }
+  }
+
+  private validateMonthlyCredits(monthlyCredits: number): void {
+    if (monthlyCredits < 0) {
+      this.logger.warn({ monthlyCredits }, 'Invalid monthly credits provided');
+      throw new InvalidSubscriptionDataError(
+        'Monthly credits must be 0 or greater',
+      );
+    }
+  }
+
+  private async findSubscription(
+    command: UpdateMonthlyCreditsCommand,
+  ): Promise<UsageBasedSubscription> {
+    const { subscription } = await this.getActiveSubscriptionUseCase.execute(
+      new GetActiveSubscriptionQuery({
+        orgId: command.orgId,
+        requestingUserId: command.requestingUserId,
+      }),
+    );
+    if (!isUsageBased(subscription)) {
+      throw new InvalidSubscriptionTypeError(
+        'Credit updates are only allowed for usage-based subscriptions',
+      );
+    }
+    return subscription;
+  }
+
+  private emitUpdatedEvent(
+    orgId: UpdateMonthlyCreditsCommand['orgId'],
+    subscription: UsageBasedSubscription,
+  ): void {
+    this.eventEmitter
+      .emitAsync(
+        SubscriptionMonthlyCreditsUpdatedEvent.EVENT_NAME,
+        new SubscriptionMonthlyCreditsUpdatedEvent(
+          orgId,
+          toSubscriptionEventData(subscription),
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error(
+          { err: err as Error, orgId },
+          'Failed to emit SubscriptionMonthlyCreditsUpdatedEvent',
+        );
+      });
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-seats/update-seats.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-seats/update-seats.use-case.ts
@@ -1,9 +1,9 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { UpdateSeatsCommand } from './update-seats.command';
 import { SubscriptionRepository } from '../../ports/subscription.repository';
 import {
-  SubscriptionNotFoundError,
   InvalidSubscriptionDataError,
   TooManyUsedSeatsError,
   UnexpectedSubscriptionError,
@@ -21,12 +21,13 @@ import { SubscriptionSeatsUpdatedEvent } from '../../events/subscription-seats-u
 import { toSubscriptionEventData } from '../../mappers/to-subscription-event-data.mapper';
 import { ContextService } from 'src/common/context/services/context.service';
 import { validateSubscriptionAccess } from '../../util/validate-subscription-access';
+import type { SeatBasedSubscription } from '../../../domain/seat-based-subscription.entity';
 
 @Injectable()
 export class UpdateSeatsUseCase {
-  private readonly logger = new Logger(UpdateSeatsUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateSeatsUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly subscriptionRepository: SubscriptionRepository,
     private readonly findUsersByOrgIdUseCase: FindUsersByOrgIdUseCase,
     private readonly getInvitesByOrgUseCase: GetInvitesByOrgUseCase,
@@ -36,11 +37,14 @@ export class UpdateSeatsUseCase {
   ) {}
 
   async execute(command: UpdateSeatsCommand): Promise<void> {
-    this.logger.log('Adding seats to subscription', {
-      orgId: command.orgId,
-      requestingUserId: command.requestingUserId,
-      noOfSeats: command.noOfSeats,
-    });
+    this.logger.info(
+      {
+        orgId: command.orgId,
+        requestingUserId: command.requestingUserId,
+        noOfSeats: command.noOfSeats,
+      },
+      'Adding seats to subscription',
+    );
 
     try {
       validateSubscriptionAccess(
@@ -48,110 +52,117 @@ export class UpdateSeatsUseCase {
         command.requestingUserId,
         command.orgId,
       );
-      this.logger.debug('Validating seat count');
-      if (command.noOfSeats <= 0) {
-        this.logger.warn('Invalid number of seats provided', {
-          noOfSeats: command.noOfSeats,
-        });
-        throw new InvalidSubscriptionDataError(
-          'Number of seats must be greater than 0',
-        );
-      }
-
-      this.logger.debug('Finding subscription');
-      const result = await this.getActiveSubscriptionUseCase.execute(
-        new GetActiveSubscriptionQuery({
-          orgId: command.orgId,
-          requestingUserId: command.requestingUserId,
-        }),
-      );
-      if (!result) {
-        this.logger.warn('Subscription not found', {
-          orgId: command.orgId,
-        });
-        throw new SubscriptionNotFoundError(command.orgId);
-      }
-      const subscription = result.subscription;
-
-      if (!isSeatBased(subscription)) {
-        throw new InvalidSubscriptionTypeError(
-          'Seat updates are only allowed for seat-based subscriptions',
-        );
-      }
-
-      const usersResult = await this.findUsersByOrgIdUseCase.execute(
-        new FindUsersByOrgIdQuery({
-          orgId: command.orgId,
-          pagination: { limit: 1000, offset: 0 },
-        }),
-      );
-      const openInvitesResult = await this.getInvitesByOrgUseCase.execute(
-        new GetInvitesByOrgQuery({
-          orgId: command.orgId,
-          requestingUserId: command.requestingUserId,
-          onlyOpen: true,
-        }),
-      );
-      const openInvitesCount =
-        openInvitesResult.total ?? openInvitesResult.data.length;
-      if (
-        command.noOfSeats <
-        (usersResult.total ?? usersResult.data.length) + openInvitesCount
-      ) {
-        this.logger.warn('Too many used seats', {
-          orgId: command.orgId,
-          openInvites: openInvitesCount,
-        });
-        throw new TooManyUsedSeatsError({
-          orgId: command.orgId,
-          openInvites: openInvitesCount,
-        });
-      }
-
-      this.logger.debug('Updating seats of subscription', {
-        currentSeats: subscription.noOfSeats,
-        newSeats: command.noOfSeats,
-      });
-
-      const previousSeats = subscription.noOfSeats;
-      subscription.noOfSeats = command.noOfSeats;
-      await this.subscriptionRepository.update(subscription);
-
-      this.logger.debug('Seats updated successfully', {
-        subscriptionId: subscription.id,
-        orgId: command.orgId,
-        previousSeats,
-        newSeats: subscription.noOfSeats,
-      });
-
-      this.eventEmitter
-        .emitAsync(
-          SubscriptionSeatsUpdatedEvent.EVENT_NAME,
-          new SubscriptionSeatsUpdatedEvent(
-            command.orgId,
-            toSubscriptionEventData(subscription),
-          ),
-        )
-        .catch((err: unknown) => {
-          this.logger.error('Failed to emit SubscriptionSeatsUpdatedEvent', {
-            error: err instanceof Error ? err.message : 'Unknown error',
-            orgId: command.orgId,
-          });
-        });
+      this.validateSeatCount(command.noOfSeats);
+      const subscription = await this.findSubscription(command);
+      await this.ensureEnoughSeats(command);
+      await this.updateSubscription(command, subscription);
     } catch (error) {
       if (error instanceof ApplicationError) {
         // Already logged and properly typed error, just rethrow
         throw error;
       }
-      this.logger.error('Adding seats failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-        requestingUserId: command.requestingUserId,
-        noOfSeats: command.noOfSeats,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          orgId: command.orgId,
+          requestingUserId: command.requestingUserId,
+          noOfSeats: command.noOfSeats,
+        },
+        'Adding seats failed',
+      );
       throw new UnexpectedSubscriptionError(
         'Unexpected error during seat addition',
       );
     }
+  }
+
+  private validateSeatCount(noOfSeats: number): void {
+    if (noOfSeats <= 0) {
+      this.logger.warn({ noOfSeats }, 'Invalid number of seats provided');
+      throw new InvalidSubscriptionDataError(
+        'Number of seats must be greater than 0',
+      );
+    }
+  }
+
+  private async findSubscription(
+    command: UpdateSeatsCommand,
+  ): Promise<SeatBasedSubscription> {
+    const { subscription } = await this.getActiveSubscriptionUseCase.execute(
+      new GetActiveSubscriptionQuery({
+        orgId: command.orgId,
+        requestingUserId: command.requestingUserId,
+      }),
+    );
+    if (!isSeatBased(subscription)) {
+      throw new InvalidSubscriptionTypeError(
+        'Seat updates are only allowed for seat-based subscriptions',
+      );
+    }
+    return subscription;
+  }
+
+  private async ensureEnoughSeats(command: UpdateSeatsCommand): Promise<void> {
+    const users = await this.findUsersByOrgIdUseCase.execute(
+      new FindUsersByOrgIdQuery({
+        orgId: command.orgId,
+        pagination: { limit: 1000, offset: 0 },
+      }),
+    );
+    const invites = await this.getInvitesByOrgUseCase.execute(
+      new GetInvitesByOrgQuery({
+        orgId: command.orgId,
+        requestingUserId: command.requestingUserId,
+        onlyOpen: true,
+      }),
+    );
+    const openInvites = invites.total ?? invites.data.length;
+    const occupiedSeats = (users.total ?? users.data.length) + openInvites;
+    if (command.noOfSeats < occupiedSeats) {
+      this.logger.warn(
+        { orgId: command.orgId, openInvites },
+        'Too many used seats',
+      );
+      throw new TooManyUsedSeatsError({ orgId: command.orgId, openInvites });
+    }
+  }
+
+  private async updateSubscription(
+    command: UpdateSeatsCommand,
+    subscription: SeatBasedSubscription,
+  ): Promise<void> {
+    const previousSeats = subscription.noOfSeats;
+    subscription.noOfSeats = command.noOfSeats;
+    await this.subscriptionRepository.update(subscription);
+    this.logger.debug(
+      {
+        subscriptionId: subscription.id,
+        orgId: command.orgId,
+        previousSeats,
+        newSeats: subscription.noOfSeats,
+      },
+      'Seats updated successfully',
+    );
+    this.emitUpdatedEvent(command.orgId, subscription);
+  }
+
+  private emitUpdatedEvent(
+    orgId: UpdateSeatsCommand['orgId'],
+    subscription: SeatBasedSubscription,
+  ): void {
+    this.eventEmitter
+      .emitAsync(
+        SubscriptionSeatsUpdatedEvent.EVENT_NAME,
+        new SubscriptionSeatsUpdatedEvent(
+          orgId,
+          toSubscriptionEventData(subscription),
+        ),
+      )
+      .catch((err: unknown) => {
+        this.logger.error(
+          { err: err as Error, orgId },
+          'Failed to emit SubscriptionSeatsUpdatedEvent',
+        );
+      });
   }
 }

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-start-date/update-start-date.use-case.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-start-date/update-start-date.use-case.spec.ts
@@ -1,6 +1,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { getLoggerToken } from 'nestjs-pino';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import { randomUUID } from 'crypto';
 import { UpdateStartDateUseCase } from './update-start-date.use-case';
 import { UpdateStartDateCommand } from './update-start-date.command';
@@ -74,6 +75,10 @@ describe('UpdateStartDateUseCase', () => {
       providers: [
         UpdateStartDateUseCase,
         {
+          provide: getLoggerToken(UpdateStartDateUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
+        {
           provide: SubscriptionRepository,
           useValue: {
             findLatestByOrgId: jest.fn(),
@@ -90,11 +95,6 @@ describe('UpdateStartDateUseCase', () => {
     useCase = module.get(UpdateStartDateUseCase);
     subscriptionRepository = module.get(SubscriptionRepository);
     contextService = module.get(ContextService);
-
-    jest.spyOn(Logger.prototype, 'log').mockImplementation();
-    jest.spyOn(Logger.prototype, 'debug').mockImplementation();
-    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
-    jest.spyOn(Logger.prototype, 'error').mockImplementation();
   });
 
   beforeEach(() => {

--- a/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-start-date/update-start-date.use-case.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/application/use-cases/update-start-date/update-start-date.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { ApplicationError } from 'src/common/errors/base.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { isSeatBased } from 'src/iam/subscriptions/domain/subscription-type-guards';
@@ -14,19 +15,22 @@ import { UpdateStartDateCommand } from './update-start-date.command';
 
 @Injectable()
 export class UpdateStartDateUseCase {
-  private readonly logger = new Logger(UpdateStartDateUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateStartDateUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly subscriptionRepository: SubscriptionRepository,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(command: UpdateStartDateCommand): Promise<Subscription> {
-    this.logger.log('Updating subscription start date', {
-      orgId: command.orgId,
-      requestingUserId: command.requestingUserId,
-      startsAt: command.startsAt.toISOString(),
-    });
+    this.logger.info(
+      {
+        orgId: command.orgId,
+        requestingUserId: command.requestingUserId,
+        startsAt: command.startsAt.toISOString(),
+      },
+      'Updating subscription start date',
+    );
 
     try {
       validateSubscriptionAccess(
@@ -58,10 +62,10 @@ export class UpdateStartDateUseCase {
         throw error;
       }
 
-      this.logger.error('Error updating subscription start date', {
-        error: error as Error,
-        orgId: command.orgId,
-      });
+      this.logger.error(
+        { err: error as Error, orgId: command.orgId },
+        'Error updating subscription start date',
+      );
       throw new UnexpectedSubscriptionError(
         'Unexpected error during subscription start date update',
         { error },

--- a/ayunis-core-backend/src/iam/subscriptions/infrastructure/persistence/local/local-subscriptions.repository.spec.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/infrastructure/persistence/local/local-subscriptions.repository.spec.ts
@@ -1,3 +1,4 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { DataSource, EntityManager } from 'typeorm';
 import { LocalSubscriptionsRepository } from './local-subscriptions.repository';
 import { SubscriptionMapper } from './mappers/subscription.mapper';
@@ -48,6 +49,7 @@ describe('LocalSubscriptionsRepository ambient transaction', () => {
       );
 
     const repository = new LocalSubscriptionsRepository(
+      createPinoLoggerMock(),
       new SubscriptionMapper(new SubscriptionBillingInfoMapper()),
       new SubscriptionBillingInfoMapper(),
       { transaction: dataSourceTransaction } as unknown as DataSource,

--- a/ayunis-core-backend/src/iam/subscriptions/infrastructure/persistence/local/local-subscriptions.repository.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/infrastructure/persistence/local/local-subscriptions.repository.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { TransactionHost } from '@nestjs-cls/transactional';
 import { TransactionalAdapterTypeOrm } from '@nestjs-cls/transactional-adapter-typeorm';
 import { DataSource, EntityManager, IsNull, Repository } from 'typeorm';
@@ -21,9 +22,9 @@ import { SubscriptionBillingInfoMapper } from './mappers/subscription-billing-in
 
 @Injectable()
 export class LocalSubscriptionsRepository extends SubscriptionRepository {
-  private readonly logger = new Logger(LocalSubscriptionsRepository.name);
-
   constructor(
+    @InjectPinoLogger(LocalSubscriptionsRepository.name)
+    private readonly logger: PinoLogger,
     private readonly subscriptionMapper: SubscriptionMapper,
     private readonly subscriptionBillingInfoMapper: SubscriptionBillingInfoMapper,
     private readonly dataSource: DataSource,
@@ -73,7 +74,10 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
 
       return records.map((record) => this.subscriptionMapper.toDomain(record));
     } catch (error) {
-      this.logger.error(`Failed to find subscription by orgId ${orgId}`, error);
+      this.logger.error(
+        { err: error as Error, orgId },
+        'Failed to find subscription by organization ID',
+      );
       throw error;
     }
   }
@@ -89,8 +93,8 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
       return record ? this.subscriptionMapper.toDomain(record) : null;
     } catch (error) {
       this.logger.error(
-        `Failed to find latest subscription by orgId ${orgId}`,
-        error,
+        { err: error as Error, orgId },
+        'Failed to find latest subscription by organization ID',
       );
       throw error;
     }
@@ -101,7 +105,10 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
       const records = await this.subscriptions.find();
       return records.map((record) => this.subscriptionMapper.toDomain(record));
     } catch (error) {
-      this.logger.error(`Failed to find all subscriptions`, error);
+      this.logger.error(
+        { err: error as Error },
+        'Failed to find all subscriptions',
+      );
       throw error;
     }
   }
@@ -121,8 +128,8 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
       return rows.map((row) => row.orgId);
     } catch (error) {
       this.logger.error(
+        { err: error as Error },
         'Failed to find orgs with active usage-based subscriptions',
-        error,
       );
       throw error;
     }
@@ -138,12 +145,15 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
         this.insertSubscriptionWithBilling(manager, record),
       );
 
-      this.logger.log(`Created subscription with id ${subscription.id}`);
+      this.logger.info(
+        { subscriptionId: subscription.id },
+        'Created subscription',
+      );
       return this.subscriptionMapper.toDomain(record);
     } catch (error) {
       this.logger.error(
-        `Failed to create subscription with id ${subscription.id}`,
-        error,
+        { err: error as Error, subscriptionId: subscription.id },
+        'Failed to create subscription',
       );
       throw error;
     }
@@ -172,14 +182,19 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
         await this.insertSubscriptionWithBilling(manager, record);
       });
 
-      this.logger.log(
-        `Replaced subscription ${oldSubscriptionId} (${disposition}) with ${newSubscription.id}`,
+      this.logger.info(
+        {
+          oldSubscriptionId,
+          disposition,
+          newSubscriptionId: newSubscription.id,
+        },
+        'Replaced subscription',
       );
       return this.subscriptionMapper.toDomain(record);
     } catch (error) {
       this.logger.error(
-        `Failed to replace subscription ${oldSubscriptionId}`,
-        error,
+        { err: error as Error, oldSubscriptionId },
+        'Failed to replace subscription',
       );
       throw error;
     }
@@ -202,12 +217,15 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
     try {
       const record = this.subscriptionMapper.toRecord(subscription);
       await this.subscriptions.save(record);
-      this.logger.log(`Updated subscription with id ${subscription.id}`);
+      this.logger.info(
+        { subscriptionId: subscription.id },
+        'Updated subscription',
+      );
       return this.subscriptionMapper.toDomain(record);
     } catch (error) {
       this.logger.error(
-        `Failed to update subscription with id ${subscription.id}`,
-        error,
+        { err: error as Error, subscriptionId: subscription.id },
+        'Failed to update subscription',
       );
       throw error;
     }
@@ -239,14 +257,15 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
       }
 
       const updatedRecord = await this.subscriptions.save(record);
-      this.logger.log(
-        `Updated start date for subscription with id ${params.subscriptionId}`,
+      this.logger.info(
+        { subscriptionId: params.subscriptionId },
+        'Updated subscription start date',
       );
       return this.subscriptionMapper.toDomain(updatedRecord);
     } catch (error) {
       this.logger.error(
-        `Failed to update start date for subscription with id ${params.subscriptionId}`,
-        error,
+        { err: error as Error, subscriptionId: params.subscriptionId },
+        'Failed to update subscription start date',
       );
       throw error;
     }
@@ -262,14 +281,12 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
         subscriptionId,
       );
       await this.billingInfo.save(record);
-      this.logger.log(
-        `Updated billing info for subscription with id ${subscriptionId}`,
-      );
+      this.logger.info({ subscriptionId }, 'Updated subscription billing info');
       return this.subscriptionBillingInfoMapper.toDomain(record);
     } catch (error) {
       this.logger.error(
-        `Failed to update billing info for subscription with id ${subscriptionId}`,
-        error,
+        { err: error as Error, subscriptionId },
+        'Failed to update subscription billing info',
       );
       throw error;
     }
@@ -279,12 +296,18 @@ export class LocalSubscriptionsRepository extends SubscriptionRepository {
     try {
       const result = await this.subscriptions.delete(id);
       if (result.affected === 0) {
-        this.logger.warn(`No subscription found with id ${id} to delete`);
+        this.logger.warn(
+          { subscriptionId: id },
+          'No subscription found to delete',
+        );
       } else {
-        this.logger.log(`Deleted subscription with id ${id}`);
+        this.logger.info({ subscriptionId: id }, 'Deleted subscription');
       }
     } catch (error) {
-      this.logger.error(`Failed to delete subscription with id ${id}`, error);
+      this.logger.error(
+        { err: error as Error, subscriptionId: id },
+        'Failed to delete subscription',
+      );
       throw error;
     }
   }

--- a/ayunis-core-backend/src/iam/subscriptions/presenters/http/subscriptions.controller.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/presenters/http/subscriptions.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, Logger } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -21,9 +22,9 @@ import { UUID } from 'crypto';
 @Controller('subscriptions')
 @ApiExtraModels(ActiveSubscriptionResponseDto, PriceResponseDto)
 export class SubscriptionsController {
-  private readonly logger = new Logger(SubscriptionsController.name);
-
   constructor(
+    @InjectPinoLogger(SubscriptionsController.name)
+    private readonly logger: PinoLogger,
     private readonly hasActiveSubscriptionUseCase: HasActiveSubscriptionUseCase,
     private readonly getCurrentPriceUseCase: GetCurrentPriceUseCase,
   ) {}
@@ -46,13 +47,14 @@ export class SubscriptionsController {
   async hasActiveSubscription(
     @CurrentUser(UserProperty.ORG_ID) orgId: UUID,
   ): Promise<ActiveSubscriptionResponseDto> {
-    this.logger.log(`Checking active subscription for org ${orgId}`);
+    this.logger.info({ orgId }, 'Checking active subscription');
 
     const query = new HasActiveSubscriptionQuery(orgId);
     const result = await this.hasActiveSubscriptionUseCase.execute(query);
 
-    this.logger.log(
-      `Active subscription check result for org ${orgId}: ${result.hasActiveSubscription}`,
+    this.logger.info(
+      { orgId, hasActiveSubscription: result.hasActiveSubscription },
+      'Active subscription check completed',
     );
 
     return {
@@ -81,12 +83,13 @@ export class SubscriptionsController {
     description: 'Internal server error',
   })
   getCurrentPrice(): PriceResponseDto {
-    this.logger.log('Getting current price per seat monthly');
+    this.logger.info('Getting current price per seat monthly');
 
     const pricePerSeatMonthly = this.getCurrentPriceUseCase.execute();
 
-    this.logger.log(
-      `Successfully retrieved current price: ${pricePerSeatMonthly}`,
+    this.logger.info(
+      { pricePerSeatMonthly },
+      'Successfully retrieved current price',
     );
 
     return { pricePerSeatMonthly };

--- a/ayunis-core-backend/src/iam/subscriptions/presenters/http/super-admin-subscriptions.controller.ts
+++ b/ayunis-core-backend/src/iam/subscriptions/presenters/http/super-admin-subscriptions.controller.ts
@@ -4,12 +4,12 @@ import {
   Post,
   Delete,
   Body,
-  Logger,
   Put,
   Param,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiTags,
   ApiOperation,
@@ -81,9 +81,9 @@ const INTERNAL_ERROR_DESCRIPTION = 'Internal server error';
   UpdateMonthlyCreditsDto,
 )
 export class SuperAdminSubscriptionsController {
-  private readonly logger = new Logger(SuperAdminSubscriptionsController.name);
-
   constructor(
+    @InjectPinoLogger(SuperAdminSubscriptionsController.name)
+    private readonly logger: PinoLogger,
     private readonly getLatestSubscriptionUseCase: GetLatestSubscriptionUseCase,
     private readonly createSubscriptionUseCase: CreateSubscriptionUseCase,
     private readonly changeSubscriptionUseCase: ChangeSubscriptionUseCase,
@@ -117,9 +117,7 @@ export class SuperAdminSubscriptionsController {
     @Param('orgId') orgId: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<SubscriptionResponseDtoNullable> {
-    this.logger.log(
-      `Getting subscription for org ${orgId} by super admin ${userId}`,
-    );
+    this.logger.info({ orgId, userId }, 'Getting subscription as super admin');
 
     try {
       const query = new GetLatestSubscriptionQuery({
@@ -130,12 +128,12 @@ export class SuperAdminSubscriptionsController {
       const result = await this.getLatestSubscriptionUseCase.execute(query);
 
       const responseDto = this.subscriptionResponseMapper.toDto(result);
-      this.logger.log(`Successfully retrieved subscription for org ${orgId}`);
+      this.logger.info({ orgId }, 'Successfully retrieved subscription');
 
       return { subscription: responseDto };
     } catch (error) {
       if (error instanceof SubscriptionNotFoundError) {
-        this.logger.warn(`No subscription found for org ${orgId}`);
+        this.logger.warn({ orgId }, 'No subscription found');
         return { subscription: undefined };
       }
       throw error;
@@ -172,13 +170,11 @@ export class SuperAdminSubscriptionsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() createSubscriptionDto: CreateSubscriptionRequestDto,
   ): Promise<void> {
-    this.logger.log(
-      `Creating subscription for org ${orgId} by super admin ${userId}`,
-    );
+    this.logger.info({ orgId, userId }, 'Creating subscription as super admin');
     await this.createSubscriptionUseCase.execute(
       toCreateCommand(orgId, userId, createSubscriptionDto),
     );
-    this.logger.log(`Successfully created subscription for org ${orgId}`);
+    this.logger.info({ orgId }, 'Successfully created subscription');
   }
 
   @Post(':orgId/change')
@@ -208,13 +204,11 @@ export class SuperAdminSubscriptionsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() changeSubscriptionDto: ChangeSubscriptionRequestDto,
   ): Promise<void> {
-    this.logger.log(
-      `Changing subscription for org ${orgId} by super admin ${userId}`,
-    );
+    this.logger.info({ orgId, userId }, 'Changing subscription as super admin');
     await this.changeSubscriptionUseCase.execute(
       toChangeCommand(orgId, userId, changeSubscriptionDto),
     );
-    this.logger.log(`Successfully changed subscription for org ${orgId}`);
+    this.logger.info({ orgId }, 'Successfully changed subscription');
   }
 
   @Put(':orgId/seats')
@@ -244,14 +238,17 @@ export class SuperAdminSubscriptionsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() updateSeatsDto: UpdateSeatsDto,
   ): Promise<void> {
-    this.logger.log(`Updating seats for org ${orgId} by super admin ${userId}`);
+    this.logger.info(
+      { orgId, userId },
+      'Updating subscription seats as super admin',
+    );
     const command = new UpdateSeatsCommand({
       orgId,
       requestingUserId: userId,
       noOfSeats: updateSeatsDto.noOfSeats,
     });
     await this.updateSeatsUseCase.execute(command);
-    this.logger.log(`Successfully updated seats for org ${orgId}`);
+    this.logger.info({ orgId }, 'Successfully updated subscription seats');
   }
 
   @Put(':orgId/monthly-credits')
@@ -279,8 +276,9 @@ export class SuperAdminSubscriptionsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() updateMonthlyCreditsDto: UpdateMonthlyCreditsDto,
   ): Promise<void> {
-    this.logger.log(
-      `Updating monthly credits for org ${orgId} by super admin ${userId}`,
+    this.logger.info(
+      { orgId, userId },
+      'Updating monthly credits as super admin',
     );
     const command = new UpdateMonthlyCreditsCommand({
       orgId,
@@ -288,7 +286,7 @@ export class SuperAdminSubscriptionsController {
       monthlyCredits: updateMonthlyCreditsDto.monthlyCredits,
     });
     await this.updateMonthlyCreditsUseCase.execute(command);
-    this.logger.log(`Successfully updated monthly credits for org ${orgId}`);
+    this.logger.info({ orgId }, 'Successfully updated monthly credits');
   }
 
   @Put(':orgId/billing-info')
@@ -318,8 +316,9 @@ export class SuperAdminSubscriptionsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() updateBillingInfoDto: UpdateBillingInfoDto,
   ): Promise<void> {
-    this.logger.log(
-      `Updating billing info for org ${orgId} by super admin ${userId}`,
+    this.logger.info(
+      { orgId, userId },
+      'Updating subscription billing info as super admin',
     );
     const command = new UpdateBillingInfoCommand({
       orgId,
@@ -327,7 +326,10 @@ export class SuperAdminSubscriptionsController {
       billingInfo: toBillingInfoParams(updateBillingInfoDto),
     });
     await this.updateBillingInfoUseCase.execute(command);
-    this.logger.log(`Successfully updated billing info for org ${orgId}`);
+    this.logger.info(
+      { orgId },
+      'Successfully updated subscription billing info',
+    );
   }
 
   @Put(':orgId/start-date')
@@ -357,8 +359,9 @@ export class SuperAdminSubscriptionsController {
     @CurrentUser(UserProperty.ID) userId: UUID,
     @Body() updateStartDateDto: UpdateStartDateDto,
   ): Promise<void> {
-    this.logger.log(
-      `Updating subscription start date for org ${orgId} by super admin ${userId}`,
+    this.logger.info(
+      { orgId, userId },
+      'Updating subscription start date as super admin',
     );
 
     const command = new UpdateStartDateCommand({
@@ -368,9 +371,7 @@ export class SuperAdminSubscriptionsController {
     });
 
     await this.updateStartDateUseCase.execute(command);
-    this.logger.log(
-      `Successfully updated subscription start date for org ${orgId}`,
-    );
+    this.logger.info({ orgId }, 'Successfully updated subscription start date');
   }
 
   @Delete(':orgId')
@@ -399,8 +400,9 @@ export class SuperAdminSubscriptionsController {
     @Param('orgId') orgId: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<void> {
-    this.logger.log(
-      `Cancelling subscription for org ${orgId} by super admin ${userId}`,
+    this.logger.info(
+      { orgId, userId },
+      'Cancelling subscription as super admin',
     );
 
     const command = new CancelSubscriptionCommand({
@@ -408,7 +410,7 @@ export class SuperAdminSubscriptionsController {
       requestingUserId: userId,
     });
     await this.cancelSubscriptionUseCase.execute(command);
-    this.logger.log(`Successfully cancelled subscription for org ${orgId}`);
+    this.logger.info({ orgId }, 'Successfully cancelled subscription');
   }
 
   @Post(':orgId/uncancel')
@@ -437,8 +439,9 @@ export class SuperAdminSubscriptionsController {
     @Param('orgId') orgId: UUID,
     @CurrentUser(UserProperty.ID) userId: UUID,
   ): Promise<void> {
-    this.logger.log(
-      `Uncancelling subscription for org ${orgId} by super admin ${userId}`,
+    this.logger.info(
+      { orgId, userId },
+      'Uncancelling subscription as super admin',
     );
 
     const command = new UncancelSubscriptionCommand({
@@ -447,6 +450,6 @@ export class SuperAdminSubscriptionsController {
     });
 
     await this.uncancelSubscriptionUseCase.execute(command);
-    this.logger.log(`Successfully uncancelled subscription for org ${orgId}`);
+    this.logger.info({ orgId }, 'Successfully uncancelled subscription');
   }
 }

--- a/ayunis-core-backend/src/iam/trials/application/use-cases/create-trial/create-trial.use-case.ts
+++ b/ayunis-core-backend/src/iam/trials/application/use-cases/create-trial/create-trial.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Trial } from 'src/iam/trials/domain/trial.entity';
 import { TrialRepository } from '../../ports/trial.repository';
 import { CreateTrialCommand } from './create-trial.command';
@@ -11,70 +12,35 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class CreateTrialUseCase {
-  private readonly logger = new Logger(CreateTrialUseCase.name);
-
-  constructor(private readonly trialRepository: TrialRepository) {}
+  constructor(
+    @InjectPinoLogger(CreateTrialUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly trialRepository: TrialRepository,
+  ) {}
 
   async execute(command: CreateTrialCommand): Promise<Trial> {
-    this.logger.log('Creating trial for organization', {
-      orgId: command.orgId,
-      maxMessages: command.maxMessages,
-    });
-
-    try {
-      this.logger.debug('Checking if trial already exists');
-      const existingTrial = await this.trialRepository.findByOrgId(
-        command.orgId,
-      );
-
-      if (existingTrial) {
-        this.logger.warn('Trial already exists for organization', {
-          orgId: command.orgId,
-          existingTrialId: existingTrial.id,
-        });
-
-        throw new TrialAlreadyExistsError(command.orgId, {
-          existingTrialId: existingTrial.id,
-        });
-      }
-
-      this.logger.debug('Creating trial entity');
-      const trial = new Trial({
+    this.logger.info(
+      {
         orgId: command.orgId,
         maxMessages: command.maxMessages,
-        messagesSent: 0,
-      });
+      },
+      'Creating trial for organization',
+    );
 
-      this.logger.debug('Saving trial to repository');
-      const createdTrial = await this.trialRepository.create(trial);
-
-      if (!createdTrial) {
-        this.logger.error('Failed to create trial in repository', {
-          orgId: command.orgId,
-        });
-
-        throw new TrialCreationFailedError(
-          command.orgId,
-          'Repository operation failed',
-        );
-      }
-
-      this.logger.log('Trial created successfully', {
-        trialId: createdTrial.id,
-        orgId: createdTrial.orgId,
-        maxMessages: createdTrial.maxMessages,
-        messagesSent: createdTrial.messagesSent,
-      });
-
-      return createdTrial;
+    try {
+      await this.ensureTrialDoesNotExist(command.orgId);
+      return await this.createTrial(command);
     } catch (error) {
       if (error instanceof ApplicationError) throw error;
 
-      this.logger.error('Trial creation failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-        maxMessages: command.maxMessages,
-      });
+      this.logger.error(
+        {
+          err: error as Error,
+          orgId: command.orgId,
+          maxMessages: command.maxMessages,
+        },
+        'Trial creation failed',
+      );
 
       throw new UnexpectedTrialError(
         command.orgId,
@@ -82,5 +48,51 @@ export class CreateTrialUseCase {
         { ...(error instanceof Error && { originalError: error.message }) },
       );
     }
+  }
+
+  private async ensureTrialDoesNotExist(
+    orgId: CreateTrialCommand['orgId'],
+  ): Promise<void> {
+    const existingTrial = await this.trialRepository.findByOrgId(orgId);
+    if (existingTrial) {
+      this.logger.warn(
+        { orgId, existingTrialId: existingTrial.id },
+        'Trial already exists for organization',
+      );
+      throw new TrialAlreadyExistsError(orgId, {
+        existingTrialId: existingTrial.id,
+      });
+    }
+  }
+
+  private async createTrial(command: CreateTrialCommand): Promise<Trial> {
+    const trial = new Trial({
+      orgId: command.orgId,
+      maxMessages: command.maxMessages,
+      messagesSent: 0,
+    });
+    const createdTrial = await this.trialRepository.create(trial);
+    // Persistence implementations are guarded even when their port types are non-null.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!createdTrial) {
+      this.logger.error(
+        { orgId: command.orgId },
+        'Failed to create trial in repository',
+      );
+      throw new TrialCreationFailedError(
+        command.orgId,
+        'Repository operation failed',
+      );
+    }
+    this.logger.info(
+      {
+        trialId: createdTrial.id,
+        orgId: createdTrial.orgId,
+        maxMessages: createdTrial.maxMessages,
+        messagesSent: createdTrial.messagesSent,
+      },
+      'Trial created successfully',
+    );
+    return createdTrial;
   }
 }

--- a/ayunis-core-backend/src/iam/trials/application/use-cases/get-trial/get-trial.use-case.ts
+++ b/ayunis-core-backend/src/iam/trials/application/use-cases/get-trial/get-trial.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Trial } from 'src/iam/trials/domain/trial.entity';
 import { TrialRepository } from '../../ports/trial.repository';
 import { GetTrialQuery } from './get-trial.query';
@@ -7,14 +8,19 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class GetTrialUseCase {
-  private readonly logger = new Logger(GetTrialUseCase.name);
-
-  constructor(private readonly trialRepository: TrialRepository) {}
+  constructor(
+    @InjectPinoLogger(GetTrialUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly trialRepository: TrialRepository,
+  ) {}
 
   async execute(query: GetTrialQuery): Promise<Trial> {
-    this.logger.debug('Getting trial for organization', {
-      orgId: query.orgId,
-    });
+    this.logger.debug(
+      {
+        orgId: query.orgId,
+      },
+      'Getting trial for organization',
+    );
 
     try {
       this.logger.debug('Finding trial in repository');
@@ -30,10 +36,10 @@ export class GetTrialUseCase {
         // Already logged and properly typed error, just rethrow
         throw error;
       }
-      this.logger.error('Failed to get trial', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: query.orgId,
-      });
+      this.logger.error(
+        { err: error as Error, orgId: query.orgId },
+        'Failed to get trial',
+      );
       throw new UnexpectedTrialError(
         query.orgId,
         'Unexpected error during trial retrieval',

--- a/ayunis-core-backend/src/iam/trials/application/use-cases/increment-trial-messages/increment-trial-messages.use-case.ts
+++ b/ayunis-core-backend/src/iam/trials/application/use-cases/increment-trial-messages/increment-trial-messages.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Trial } from 'src/iam/trials/domain/trial.entity';
 import { TrialRepository } from '../../ports/trial.repository';
 import { IncrementTrialMessagesCommand } from './increment-trial-messages.command';
@@ -12,80 +13,33 @@ import { ApplicationError } from 'src/common/errors/base.error';
 
 @Injectable()
 export class IncrementTrialMessagesUseCase {
-  private readonly logger = new Logger(IncrementTrialMessagesUseCase.name);
-
-  constructor(private readonly trialRepository: TrialRepository) {}
+  constructor(
+    @InjectPinoLogger(IncrementTrialMessagesUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly trialRepository: TrialRepository,
+  ) {}
 
   async execute(command: IncrementTrialMessagesCommand): Promise<Trial> {
-    this.logger.debug('Incrementing trial messages', {
-      orgId: command.orgId,
-    });
+    this.logger.debug(
+      {
+        orgId: command.orgId,
+      },
+      'Incrementing trial messages',
+    );
 
     try {
-      this.logger.debug('Finding trial for organization');
-      const currentTrial = await this.trialRepository.findByOrgId(
-        command.orgId,
-      );
-
-      if (!currentTrial) {
-        this.logger.warn('Trial not found for organization', {
-          orgId: command.orgId,
-        });
-
-        throw new TrialNotFoundError(command.orgId);
-      }
-
-      this.logger.debug('Checking trial capacity');
-      if (currentTrial.messagesSent >= currentTrial.maxMessages) {
-        this.logger.warn('Trial capacity exceeded, cannot increment', {
-          orgId: command.orgId,
-          messagesSent: currentTrial.messagesSent,
-          maxMessages: currentTrial.maxMessages,
-          remainingMessages:
-            currentTrial.maxMessages - currentTrial.messagesSent,
-        });
-
-        throw new TrialCapacityExceededError(
-          command.orgId,
-          currentTrial.messagesSent,
-          currentTrial.maxMessages,
-        );
-      }
-
-      this.logger.debug('Incrementing trial message count');
-      const updatedTrial = await this.trialRepository.incrementMessagesSent(
-        command.orgId,
-      );
-
-      if (!updatedTrial) {
-        this.logger.error('Failed to increment trial messages in repository', {
-          orgId: command.orgId,
-        });
-
-        throw new TrialUpdateFailedError(
-          command.orgId,
-          'Repository operation failed',
-          { operation: 'incrementMessagesSent' },
-        );
-      }
-
-      this.logger.log('Trial messages incremented successfully', {
-        orgId: command.orgId,
-        messagesSent: updatedTrial.messagesSent,
-        maxMessages: updatedTrial.maxMessages,
-        remainingMessages: updatedTrial.maxMessages - updatedTrial.messagesSent,
-      });
-
-      return updatedTrial;
+      const trial = await this.findTrial(command.orgId);
+      this.ensureCapacity(command.orgId, trial);
+      return await this.incrementMessages(command.orgId);
     } catch (error) {
       if (error instanceof ApplicationError) {
         throw error;
       }
 
-      this.logger.error('Failed to increment trial messages', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-      });
+      this.logger.error(
+        { err: error as Error, orgId: command.orgId },
+        'Failed to increment trial messages',
+      );
 
       throw new UnexpectedTrialError(
         command.orgId,
@@ -93,5 +47,62 @@ export class IncrementTrialMessagesUseCase {
         { ...(error instanceof Error && { originalError: error.message }) },
       );
     }
+  }
+
+  private async findTrial(
+    orgId: IncrementTrialMessagesCommand['orgId'],
+  ): Promise<Trial> {
+    const trial = await this.trialRepository.findByOrgId(orgId);
+    if (!trial) {
+      this.logger.warn({ orgId }, 'Trial not found for organization');
+      throw new TrialNotFoundError(orgId);
+    }
+    return trial;
+  }
+
+  private ensureCapacity(
+    orgId: IncrementTrialMessagesCommand['orgId'],
+    trial: Trial,
+  ): void {
+    if (trial.messagesSent < trial.maxMessages) return;
+    this.logger.warn(
+      {
+        orgId,
+        messagesSent: trial.messagesSent,
+        maxMessages: trial.maxMessages,
+        remainingMessages: trial.maxMessages - trial.messagesSent,
+      },
+      'Trial capacity exceeded, cannot increment',
+    );
+    throw new TrialCapacityExceededError(
+      orgId,
+      trial.messagesSent,
+      trial.maxMessages,
+    );
+  }
+
+  private async incrementMessages(
+    orgId: IncrementTrialMessagesCommand['orgId'],
+  ): Promise<Trial> {
+    const trial = await this.trialRepository.incrementMessagesSent(orgId);
+    if (!trial) {
+      this.logger.error(
+        { orgId },
+        'Failed to increment trial messages in repository',
+      );
+      throw new TrialUpdateFailedError(orgId, 'Repository operation failed', {
+        operation: 'incrementMessagesSent',
+      });
+    }
+    this.logger.info(
+      {
+        orgId,
+        messagesSent: trial.messagesSent,
+        maxMessages: trial.maxMessages,
+        remainingMessages: trial.maxMessages - trial.messagesSent,
+      },
+      'Trial messages incremented successfully',
+    );
+    return trial;
   }
 }

--- a/ayunis-core-backend/src/iam/trials/application/use-cases/update-trial/update-trial.use-case.ts
+++ b/ayunis-core-backend/src/iam/trials/application/use-cases/update-trial/update-trial.use-case.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { Trial } from 'src/iam/trials/domain/trial.entity';
 import { TrialRepository } from '../../ports/trial.repository';
 import { UpdateTrialCommand } from './update-trial.command';
@@ -14,88 +15,28 @@ import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.e
 
 @Injectable()
 export class UpdateTrialUseCase {
-  private readonly logger = new Logger(UpdateTrialUseCase.name);
-
   constructor(
+    @InjectPinoLogger(UpdateTrialUseCase.name)
+    private readonly logger: PinoLogger,
     private readonly trialRepository: TrialRepository,
     private readonly contextService: ContextService,
   ) {}
 
   async execute(command: UpdateTrialCommand): Promise<Trial> {
     try {
-      this.logger.debug('Finding existing trial');
-      const systemRole = this.contextService.get<SystemRole>('systemRole');
-      if (systemRole !== SystemRole.SUPER_ADMIN) {
-        throw new UnauthorizedAccessError({
-          orgId: command.orgId,
-          systemRole: systemRole,
-        });
-      }
-      this.logger.log('Updating trial for organization', {
-        orgId: command.orgId,
-        maxMessages: command.maxMessages,
-        messagesSent: command.messagesSent,
-      });
-      const existingTrial = await this.trialRepository.findByOrgId(
-        command.orgId,
-      );
-
-      if (!existingTrial) {
-        this.logger.warn('Trial not found for organization', {
-          orgId: command.orgId,
-        });
-
-        throw new TrialNotFoundError(command.orgId);
-      }
-
-      this.logger.debug('Updating trial entity');
-      const updatedTrial = new Trial({
-        id: existingTrial.id,
-        createdAt: existingTrial.createdAt,
-        updatedAt: new Date(),
-        orgId: existingTrial.orgId,
-        messagesSent:
-          command.messagesSent !== undefined
-            ? command.messagesSent
-            : existingTrial.messagesSent,
-        maxMessages:
-          command.maxMessages !== undefined
-            ? command.maxMessages
-            : existingTrial.maxMessages,
-      });
-
-      this.logger.debug('Saving updated trial to repository');
-      const savedTrial = await this.trialRepository.update(updatedTrial);
-
-      if (!savedTrial) {
-        this.logger.error('Failed to update trial in repository', {
-          orgId: command.orgId,
-        });
-
-        throw new TrialUpdateFailedError(
-          command.orgId,
-          'Repository operation failed',
-        );
-      }
-
-      this.logger.log('Trial updated successfully', {
-        trialId: savedTrial.id,
-        orgId: savedTrial.orgId,
-        maxMessages: savedTrial.maxMessages,
-        messagesSent: savedTrial.messagesSent,
-      });
-
-      return savedTrial;
+      this.ensureSuperAdmin(command.orgId);
+      const existingTrial = await this.findTrial(command.orgId);
+      return await this.updateTrial(command, existingTrial);
     } catch (error) {
       if (error instanceof ApplicationError) {
         // Already logged and properly typed error, just rethrow
         throw error;
       }
 
-      this.logger.error('Trial update failed', {
-        error: error instanceof Error ? error.message : 'Unknown error',
-        orgId: command.orgId,
-      });
+      this.logger.error(
+        { err: error as Error, orgId: command.orgId },
+        'Trial update failed',
+      );
 
       throw new UnexpectedTrialError(
         command.orgId,
@@ -103,5 +44,66 @@ export class UpdateTrialUseCase {
         { ...(error instanceof Error && { originalError: error.message }) },
       );
     }
+  }
+
+  private ensureSuperAdmin(orgId: UpdateTrialCommand['orgId']): void {
+    const systemRole = this.contextService.get<SystemRole>('systemRole');
+    if (systemRole !== SystemRole.SUPER_ADMIN) {
+      throw new UnauthorizedAccessError({ orgId, systemRole });
+    }
+  }
+
+  private async findTrial(orgId: UpdateTrialCommand['orgId']): Promise<Trial> {
+    const trial = await this.trialRepository.findByOrgId(orgId);
+    if (!trial) {
+      this.logger.warn({ orgId }, 'Trial not found for organization');
+      throw new TrialNotFoundError(orgId);
+    }
+    return trial;
+  }
+
+  private async updateTrial(
+    command: UpdateTrialCommand,
+    existingTrial: Trial,
+  ): Promise<Trial> {
+    this.logger.info(
+      {
+        orgId: command.orgId,
+        maxMessages: command.maxMessages,
+        messagesSent: command.messagesSent,
+      },
+      'Updating trial for organization',
+    );
+    const updatedTrial = new Trial({
+      id: existingTrial.id,
+      createdAt: existingTrial.createdAt,
+      updatedAt: new Date(),
+      orgId: existingTrial.orgId,
+      messagesSent: command.messagesSent ?? existingTrial.messagesSent,
+      maxMessages: command.maxMessages ?? existingTrial.maxMessages,
+    });
+    const savedTrial = await this.trialRepository.update(updatedTrial);
+    // Persistence implementations are guarded even when their port types are non-null.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!savedTrial) {
+      this.logger.error(
+        { orgId: command.orgId },
+        'Failed to update trial in repository',
+      );
+      throw new TrialUpdateFailedError(
+        command.orgId,
+        'Repository operation failed',
+      );
+    }
+    this.logger.info(
+      {
+        trialId: savedTrial.id,
+        orgId: savedTrial.orgId,
+        maxMessages: savedTrial.maxMessages,
+        messagesSent: savedTrial.messagesSent,
+      },
+      'Trial updated successfully',
+    );
+    return savedTrial;
   }
 }

--- a/ayunis-core-backend/src/iam/trials/presenters/http/super-admin-trials.controller.ts
+++ b/ayunis-core-backend/src/iam/trials/presenters/http/super-admin-trials.controller.ts
@@ -4,11 +4,11 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Logger,
   Param,
   Post,
   Put,
 } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import {
   ApiBadRequestResponse,
   ApiBody,
@@ -48,9 +48,9 @@ import { TrialNotFoundError } from '../../application/trial.errors';
   UpdateTrialRequestDto,
 )
 export class SuperAdminTrialsController {
-  private readonly logger = new Logger(SuperAdminTrialsController.name);
-
   constructor(
+    @InjectPinoLogger(SuperAdminTrialsController.name)
+    private readonly logger: PinoLogger,
     private readonly createTrialUseCase: CreateTrialUseCase,
     private readonly getTrialUseCase: GetTrialUseCase,
     private readonly updateTrialUseCase: UpdateTrialUseCase,
@@ -81,10 +81,13 @@ export class SuperAdminTrialsController {
   async createTrial(
     @Body() createTrialDto: CreateTrialRequestDto,
   ): Promise<SuperAdminTrialResponseDto> {
-    this.logger.log('Creating trial', {
-      orgId: createTrialDto.orgId,
-      maxMessages: createTrialDto.maxMessages,
-    });
+    this.logger.info(
+      {
+        orgId: createTrialDto.orgId,
+        maxMessages: createTrialDto.maxMessages,
+      },
+      'Creating trial',
+    );
 
     const command = new CreateTrialCommand(
       createTrialDto.orgId,
@@ -165,11 +168,14 @@ export class SuperAdminTrialsController {
     @Param('orgId') orgId: UUID,
     @Body() updateTrialDto: UpdateTrialRequestDto,
   ): Promise<SuperAdminTrialResponseDto> {
-    this.logger.log('Updating trial', {
-      orgId,
-      maxMessages: updateTrialDto.maxMessages,
-      messagesSent: updateTrialDto.messagesSent,
-    });
+    this.logger.info(
+      {
+        orgId,
+        maxMessages: updateTrialDto.maxMessages,
+        messagesSent: updateTrialDto.messagesSent,
+      },
+      'Updating trial',
+    );
 
     const command = new UpdateTrialCommand(
       orgId,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly observability and test wiring; a few subscription/quota refactors are structural only, but the large diff warrants normal regression on subscription and quota paths.
> 
> **Overview**
> Migrates **billing and limits** IAM surfaces from Nest’s built-in `Logger` to **nestjs-pino** (`@InjectPinoLogger`, `PinoLogger`). Info/debug/warn/error calls now follow Pino’s **bindings-first** shape (e.g. `{ err, orgId }`, message), including structured `err` on failures and event-emission catch blocks.
> 
> **Scope:** addons use cases/controllers/repository, budget-alert listeners/tasks/use cases, credit-limits use cases/controller and subscription-cancelled listener, legal acceptances, `CheckQuotaUseCase` (small refactor into private helpers), and the subscriptions stack (factory, many use cases, presenters). Unit tests drop `Logger.prototype` spies in favor of **`createPinoLoggerMock()`** and **`getLoggerToken(ClassName)`** in Nest testing modules.
> 
> Several subscription use cases (**cancel**, **change**, **create**, **uncancel**, **update monthly credits/billing**) also **extract private methods** for find/emit/validate steps; behavior is intended to stay the same aside from log format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be4a3ebf3cb5480103f64fcd5d1b0033d42cf535. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->