### PR TITLE
feat(logging): enforce pino-only backend (AYC-760)

### DIFF
--- a/ayunis-core-backend/eslint.config.mjs
+++ b/ayunis-core-backend/eslint.config.mjs
@@ -115,6 +115,34 @@ export default tseslint.config(
       'sonarjs/no-hardcoded-passwords': 'warn',
     },
   },
+  {
+    files: ['src/**/*.ts'],
+    // Bootstrap's static Nest Logger delegates to Pino after app.useLogger;
+    // application code must inject PinoLogger directly instead.
+    ignores: ['src/main.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@nestjs/common',
+              importNames: ['Logger'],
+              message: 'Inject PinoLogger from nestjs-pino instead.',
+            },
+          ],
+        },
+      ],
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "NewExpression[callee.name='Logger'], NewExpression[callee.type='MemberExpression'][callee.property.name='Logger']",
+          message: 'Inject PinoLogger instead of constructing Logger.',
+        },
+      ],
+    },
+  },
   // Relaxed rules for test files
   {
     files: ['**/*.spec.ts', '**/*.test.ts', '**/*.e2e-spec.ts', 'test/**/*.ts'],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lint-only guardrails with a narrow bootstrap exception; no runtime or auth/data behavior changes.
> 
> **Overview**
> Adds an ESLint override for **`src/**/*.ts`** (excluding **`src/main.ts`**) so backend application code cannot use Nest’s **`Logger`**.
> 
> **`no-restricted-imports`** errors on importing **`Logger`** from **`@nestjs/common`**, with a message to inject **`PinoLogger`** from **`nestjs-pino`**. **`no-restricted-syntax`** errors on **`new Logger(...)`** (including member-expression callees), for the same reason. Bootstrap in **`main.ts`** stays exempt because the static Nest logger is wired to Pino after **`app.useLogger`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48f4b62c698188a1a162aeb04ec98557c6013b03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->