### PR TITLE
wip(extensions): add runtime extension foundation (AYC-694)

### DIFF
--- a/.github/workflows/agent-extensions.yml
+++ b/.github/workflows/agent-extensions.yml
@@ -1,0 +1,63 @@
+name: Agent Extensions
+
+on:
+  pull_request:
+    paths:
+      - 'packages/agent-extensions/**'
+      - '.github/workflows/agent-extensions.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/agent-extensions/**'
+
+jobs:
+  check:
+    name: Lint, typecheck, test, build
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: packages/agent-extensions
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace dependencies
+        run: pnpm --filter "@ayunis/agent-extensions^..." build
+
+      - name: Run TypeScript type check
+        run: pnpm run typecheck
+
+      - name: Run linter
+        run: pnpm run lint
+
+      - name: Run tests
+        run: pnpm run test
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Check ESM, CJS, and declaration outputs
+        run: |
+          node --input-type=module -e "await import('./dist/index.js')"
+          node -e "require('./dist/index.cjs')"
+          test -f dist/index.d.ts
+
+      - name: Check circular dependencies
+        run: pnpm run deps:check
+
+      - name: Check package contents
+        run: pnpm pack --dry-run --json

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -30,6 +30,9 @@ jobs:
           - name: Agent Runtime
             working-directory: packages/agent-runtime
             precheck: ''
+          - name: Agent Extensions
+            working-directory: packages/agent-extensions
+            precheck: ''
           - name: Inference
             working-directory: packages/inference
             precheck: ''

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,11 +16,48 @@ ayunis-core/
 ├── ayunis-core-frontend/      # React SPA (Feature-Sliced Design)
 ├── ayunis-core-code-execution/# Sandboxed code execution microservice
 ├── ayunis-core-anonymize/     # PII anonymization service
-├── packages/ui/              # Shared React design-system primitives
+├── packages/inference/        # Provider-agnostic inference contracts
+├── packages/agent-runtime/    # Bare agent loop and hook contracts
+├── packages/agent-extensions/ # Composable capabilities and resource lifetime
+├── packages/ui/               # Shared React design-system primitives
 ├── ARCHITECTURE.md            # This file
 ├── AGENTS.md                  # AI coding agent guidelines
 └── docker-compose.yml         # Local dev infrastructure
 ```
+
+---
+
+## Agent package layering
+
+The reusable agent packages form a one-way stack:
+
+```text
+@ayunis/inference
+        ↑
+@ayunis/agent-runtime
+        ↑
+@ayunis/agent-extensions
+        ↑
+future @ayunis/agent-harness
+```
+
+- [`@ayunis/inference`](packages/inference) defines provider-agnostic messages,
+  model requests, and streaming contracts.
+- [`@ayunis/agent-runtime`](packages/agent-runtime/README.md) is the bare agent
+  loop. Hooks are its only extension mechanism; the package has no resource
+  initialization or opinionated agent assembly.
+- [`@ayunis/agent-extensions`](packages/agent-extensions/README.md) resolves
+  named, composable manifests of tools, instructions, and hooks and owns their
+  optional cross-run resource lifetime. Static manifests merge into `RunInput`
+  before the runtime starts, while extension hooks remain ordinary runtime
+  hooks.
+- A future `@ayunis/agent-harness` may provide opinionated assemblies and
+  defaults on top of the lower layers and accept additional runtime extensions.
+
+Runtime extensions are not **Agent Plugins**. Agent Plugins v1 is a portable
+filesystem package standard centered on `plugin.json`, Agent Skills, and
+`mcp.json`. A future loader may adapt that format into runtime extensions, but
+none of these packages implements the Agent Plugins standard.
 
 ---
 

--- a/packages/agent-extensions/.gitignore
+++ b/packages/agent-extensions/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+coverage/

--- a/packages/agent-extensions/.madgerc
+++ b/packages/agent-extensions/.madgerc
@@ -1,0 +1,7 @@
+{
+  "detectiveOptions": {
+    "ts": {
+      "skipTypeImports": true
+    }
+  }
+}

--- a/packages/agent-extensions/.prettierrc
+++ b/packages/agent-extensions/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/packages/agent-extensions/README.md
+++ b/packages/agent-extensions/README.md
@@ -1,0 +1,77 @@
+# @ayunis/agent-extensions
+
+Composable, in-process extensions for `@ayunis/agent-runtime`.
+
+A runtime extension resolves a static manifest of tools, instructions, and
+hooks during initialization. An extension may also own resources across runs
+and release them during disposal. The extension set applies every static part
+directly to a `RunInput`; the runtime itself remains unchanged and hooks remain
+its only extension mechanism.
+
+```ts
+import {
+  configureRuntimeExtension,
+  initializeExtensionSet,
+  type RuntimeExtension,
+} from '@ayunis/agent-extensions';
+import { run } from '@ayunis/agent-runtime';
+
+interface AuditConfig {
+  destination: string;
+}
+
+const auditExtension: RuntimeExtension<AuditConfig> = async (config) => ({
+  name: 'audit',
+  instructions: `Audit destination: ${config.destination}`,
+  hooks: [auditHook],
+  async dispose() {
+    await flushAuditEvents();
+  },
+});
+
+const extensions = await initializeExtensionSet([
+  configureRuntimeExtension(auditExtension, { destination: 'ledger' }),
+]);
+
+try {
+  for await (const event of run(extensions.apply(input))) {
+    handleEvent(event);
+  }
+} finally {
+  await extensions.dispose();
+}
+```
+
+Factories initialize sequentially in registration order. Initialization fails
+on duplicate extension or tool names and rolls back completed instances in
+reverse order. Applying a manifest rejects collisions with host-provided tools.
+Disposal is idempotent, reverse-ordered, attempts every disposer, and throws an
+`AggregateError` containing all disposal failures.
+
+## Layering and terminology
+
+- `@ayunis/agent-runtime` is the bare agent loop and hook contracts.
+- `@ayunis/agent-extensions` packages composable capabilities and their
+  cross-run resource lifetime around those hooks.
+- A future `@ayunis/agent-harness` may provide opinionated agent assemblies and
+  defaults while accepting additional runtime extensions.
+
+A runtime extension is not an **Agent Plugin**. Agent Plugins v1 is a portable
+filesystem package standard built around `plugin.json`, Agent Skills, and
+`mcp.json`. Loading that standard is outside this package; a future adapter may
+translate a plugin into runtime extensions.
+
+The package is workspace-private. Publishing requires coordinated versioning
+and publication of `@ayunis/inference`, `@ayunis/agent-runtime`, and this
+package.
+
+## Development
+
+```bash
+pnpm --filter '@ayunis/agent-extensions^...' run build
+pnpm --filter @ayunis/agent-extensions run typecheck
+pnpm --filter @ayunis/agent-extensions run lint
+pnpm --filter @ayunis/agent-extensions run test
+pnpm --filter @ayunis/agent-extensions run build
+pnpm --filter @ayunis/agent-extensions run deps:check
+```

--- a/packages/agent-extensions/eslint.config.mjs
+++ b/packages/agent-extensions/eslint.config.mjs
@@ -1,0 +1,88 @@
+// @ts-check
+import eslint from '@eslint/js';
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
+import sonarjs from 'eslint-plugin-sonarjs';
+import unusedImports from 'eslint-plugin-unused-imports';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: [
+      'eslint.config.mjs',
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/coverage/**',
+    ],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  sonarjs.configs.recommended,
+  eslintPluginPrettierRecommended,
+  {
+    languageOptions: {
+      globals: { ...globals.node },
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    plugins: { 'unused-imports': unusedImports },
+  },
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/require-await': 'error',
+      '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+      '@typescript-eslint/switch-exhaustiveness-check': [
+        'error',
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+      '@typescript-eslint/no-duplicate-enum-values': 'error',
+      eqeqeq: 'error',
+      'unused-imports/no-unused-imports': 'error',
+      complexity: ['warn', 10],
+      'max-lines-per-function': [
+        'warn',
+        { max: 50, skipBlankLines: true, skipComments: true },
+      ],
+      'max-params': ['warn', 5],
+      '@typescript-eslint/no-unnecessary-condition': 'warn',
+      '@typescript-eslint/prefer-nullish-coalescing': [
+        'warn',
+        { ignorePrimitives: true },
+      ],
+      '@typescript-eslint/prefer-optional-chain': 'warn',
+      '@typescript-eslint/consistent-type-imports': 'warn',
+      '@typescript-eslint/no-import-type-side-effects': 'warn',
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
+    },
+  },
+  {
+    files: ['**/*.spec.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-floating-promises': 'off',
+      '@typescript-eslint/unbound-method': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/require-await': 'off',
+      '@typescript-eslint/no-unnecessary-condition': 'off',
+      'no-console': 'off',
+      complexity: 'off',
+      'max-lines-per-function': 'off',
+      'max-params': 'off',
+    },
+  },
+);

--- a/packages/agent-extensions/knip.json
+++ b/packages/agent-extensions/knip.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://unpkg.com/knip@latest/schema.json",
+  "entry": ["src/index.ts"],
+  "project": ["src/**/*.ts"],
+  "ignore": ["**/*.spec.ts"],
+  "ignoreDependencies": ["@ayunis/agent-runtime"]
+}

--- a/packages/agent-extensions/package.json
+++ b/packages/agent-extensions/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@ayunis/agent-extensions",
+  "version": "0.1.0",
+  "description": "Composable runtime extensions and lifetime management for the Ayunis agent runtime",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "deps:check": "madge --circular --extensions ts src"
+  },
+  "peerDependencies": {
+    "@ayunis/agent-runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "@ayunis/agent-runtime": "workspace:*",
+    "@eslint/js": "^9.18.0",
+    "@types/node": "^24.12.2",
+    "eslint": "^10.6.0",
+    "eslint-config-prettier": "^10.0.1",
+    "eslint-plugin-prettier": "^5.5.5",
+    "eslint-plugin-sonarjs": "^4.0.2",
+    "eslint-plugin-unused-imports": "^4.1.4",
+    "globals": "^16.0.0",
+    "knip": "^6.24.0",
+    "madge": "^8.0.0",
+    "prettier": "^3.9.4",
+    "tsup": "^8.3.5",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.64.0",
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/agent-extensions/src/extensions/extension-set.spec.ts
+++ b/packages/agent-extensions/src/extensions/extension-set.spec.ts
@@ -1,0 +1,247 @@
+import {
+  MockProvider,
+  run,
+  textTurn,
+  type Hook,
+  type RunInput,
+  type Tool,
+} from '@ayunis/agent-runtime';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  configureRuntimeExtension,
+  initializeExtensionSet,
+  type RuntimeExtensionInitializer,
+  type RuntimeExtensionInstance,
+} from '../index';
+
+const tool = (name: string): Tool => ({
+  name,
+  description: `${name} tool`,
+  parameters: { type: 'object', properties: {} },
+  execute: () => name,
+});
+
+const input = (overrides: Partial<RunInput> = {}): RunInput => ({
+  instructions: 'Host instructions.',
+  model: new MockProvider([textTurn('done')]),
+  messages: [{ role: 'user', content: [{ type: 'text', text: 'go' }] }],
+  ...overrides,
+});
+
+const consume = async (runInput: RunInput): Promise<void> => {
+  for await (const event of run(runInput)) {
+    if (event.type === 'run_end') {
+      return;
+    }
+  }
+};
+
+const initializer =
+  (instance: RuntimeExtensionInstance): RuntimeExtensionInitializer =>
+  () =>
+    instance;
+
+describe('extension initialization and static manifests', () => {
+  it('initializes factories in registration order and exposes their manifests', async () => {
+    const order: string[] = [];
+    const first = tool('first-tool');
+    const second = tool('second-tool');
+    const set = await initializeExtensionSet([
+      async () => {
+        order.push('first:start');
+        await Promise.resolve();
+        order.push('first:end');
+        return { name: 'first', tools: [first] };
+      },
+      () => {
+        order.push('second');
+        return { name: 'second', tools: [second] };
+      },
+    ]);
+
+    expect(order).toEqual(['first:start', 'first:end', 'second']);
+    expect(set.instances.map(({ name }) => name)).toEqual(['first', 'second']);
+    expect(set.instances[0].tools).toEqual([first]);
+    expect(set.instances[1].tools).toEqual([second]);
+  });
+
+  it('passes factory configuration through a configured initializer', async () => {
+    const extension = vi.fn((config: { name: string }) => ({
+      name: config.name,
+    }));
+
+    const set = await initializeExtensionSet([
+      configureRuntimeExtension(extension, { name: 'configured' }),
+    ]);
+
+    expect(extension).toHaveBeenCalledWith({ name: 'configured' });
+    expect(set.instances[0].name).toBe('configured');
+  });
+
+  it('merges static parts before runStart and preserves hook order and references', async () => {
+    const seen: string[] = [];
+    const snapshots: Array<{
+      instructions: string;
+      tools: readonly string[];
+    }> = [];
+    const observe = (name: string): Hook => ({
+      name,
+      runStart: ({ instructions, tools }) => {
+        seen.push(name);
+        snapshots.push({
+          instructions,
+          tools: tools.map((entry) => entry.name),
+        });
+      },
+    });
+    const hostHook = observe('host');
+    const firstHook = observe('first');
+    const secondHook = observe('second');
+    const hostTool = tool('host-tool');
+    const set = await initializeExtensionSet([
+      initializer({
+        name: 'first',
+        tools: [tool('first-tool')],
+        instructions: 'First instructions.',
+        hooks: [firstHook],
+      }),
+      initializer({
+        name: 'second',
+        tools: [tool('second-tool')],
+        instructions: 'Second instructions.',
+        hooks: [secondHook],
+      }),
+    ]);
+
+    const applied = set.apply(input({ tools: [hostTool], hooks: [hostHook] }));
+    expect(applied.hooks).toEqual([hostHook, firstHook, secondHook]);
+    expect(applied.hooks?.[1]).toBe(firstHook);
+    expect(applied.hooks?.[2]).toBe(secondHook);
+    await consume(applied);
+
+    expect(seen).toEqual(['host', 'first', 'second']);
+    expect(snapshots).toEqual(
+      Array.from({ length: 3 }, () => ({
+        instructions:
+          'Host instructions.\n\nFirst instructions.\n\nSecond instructions.',
+        tools: ['host-tool', 'first-tool', 'second-tool'],
+      })),
+    );
+  });
+
+  it('adds a hook-only extension as the original hook array entries', async () => {
+    const first: Hook = { name: 'first' };
+    const second: Hook = { name: 'second' };
+    const set = await initializeExtensionSet([
+      initializer({ name: 'hooks', hooks: [first, second] }),
+    ]);
+
+    const applied = set.apply(input());
+
+    expect(applied.hooks).toEqual([first, second]);
+    expect(applied.hooks?.[0]).toBe(first);
+    expect(applied.hooks?.[1]).toBe(second);
+  });
+
+  it('returns the original run input for an empty extension set', async () => {
+    const set = await initializeExtensionSet([]);
+    const runInput = input();
+
+    expect(set.apply(runInput)).toBe(runInput);
+  });
+});
+
+describe('manifest collision validation', () => {
+  it('rejects duplicate extension names during initialization', async () => {
+    await expect(
+      initializeExtensionSet([
+        initializer({ name: 'duplicate' }),
+        initializer({ name: 'duplicate' }),
+      ]),
+    ).rejects.toThrow('Duplicate runtime extension name: duplicate');
+  });
+
+  it('rejects duplicate extension tools during initialization', async () => {
+    await expect(
+      initializeExtensionSet([
+        initializer({ name: 'first', tools: [tool('duplicate')] }),
+        initializer({ name: 'second', tools: [tool('duplicate')] }),
+      ]),
+    ).rejects.toThrow('Duplicate runtime extension tool name: duplicate');
+  });
+
+  it('rejects host and extension tool collisions when applying the manifest', async () => {
+    const set = await initializeExtensionSet([
+      initializer({ name: 'extension', tools: [tool('duplicate')] }),
+    ]);
+
+    expect(() => set.apply(input({ tools: [tool('duplicate')] }))).toThrow(
+      'Runtime extension tool conflicts with host tool: duplicate',
+    );
+  });
+});
+
+describe('extension lifetime', () => {
+  it('rolls back completed instances in reverse order after initialization fails', async () => {
+    const events: string[] = [];
+
+    await expect(
+      initializeExtensionSet([
+        async () => ({
+          name: 'first',
+          dispose: async () => {
+            events.push('dispose:first');
+          },
+        }),
+        async () => ({
+          name: 'second',
+          dispose: async () => {
+            events.push('dispose:second');
+          },
+        }),
+        async () => {
+          throw new Error('initialization failed');
+        },
+      ]),
+    ).rejects.toThrow('initialization failed');
+    expect(events).toEqual(['dispose:second', 'dispose:first']);
+  });
+
+  it('disposes once in reverse order and attempts every disposer', async () => {
+    const events: string[] = [];
+    const set = await initializeExtensionSet([
+      initializer({
+        name: 'first',
+        dispose: async () => {
+          events.push('first');
+          throw new Error('first failed');
+        },
+      }),
+      initializer({
+        name: 'second',
+        dispose: async () => {
+          events.push('second');
+          throw new Error('second failed');
+        },
+      }),
+      initializer({
+        name: 'third',
+        dispose: async () => {
+          events.push('third');
+        },
+      }),
+    ]);
+
+    const error = await set.dispose().catch((reason: unknown) => reason);
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual([
+      expect.objectContaining({ message: 'second failed' }),
+      expect.objectContaining({ message: 'first failed' }),
+    ]);
+    expect(events).toEqual(['third', 'second', 'first']);
+
+    await expect(set.dispose()).resolves.toBeUndefined();
+    expect(events).toEqual(['third', 'second', 'first']);
+  });
+});

--- a/packages/agent-extensions/src/extensions/extension-set.ts
+++ b/packages/agent-extensions/src/extensions/extension-set.ts
@@ -1,0 +1,162 @@
+import type { Hook, RunInput, Tool } from '@ayunis/agent-runtime';
+
+import type {
+  RuntimeExtensionInitializer,
+  RuntimeExtensionInstance,
+  RuntimeExtensionSet,
+} from './runtime-extension';
+
+interface StaticManifest {
+  readonly tools: readonly Tool[];
+  readonly instructions: readonly string[];
+  readonly hooks: readonly Hook[];
+}
+
+class InitializedExtensionSet implements RuntimeExtensionSet {
+  readonly instances: readonly RuntimeExtensionInstance[];
+  private readonly manifest: StaticManifest;
+  private disposed = false;
+
+  constructor(instances: readonly RuntimeExtensionInstance[]) {
+    this.instances = [...instances];
+    this.manifest = collectManifest(instances);
+  }
+
+  apply(input: RunInput): RunInput {
+    if (!hasStaticParts(this.manifest)) {
+      return input;
+    }
+    validateHostTools(input.tools ?? [], this.manifest.tools);
+
+    return {
+      ...input,
+      instructions: appendInstructions(
+        input.instructions,
+        this.manifest.instructions,
+      ),
+      ...(this.manifest.tools.length > 0
+        ? { tools: [...(input.tools ?? []), ...this.manifest.tools] }
+        : {}),
+      ...(this.manifest.hooks.length > 0
+        ? { hooks: [...(input.hooks ?? []), ...this.manifest.hooks] }
+        : {}),
+    };
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    await disposeInstances(this.instances);
+  }
+}
+
+export const initializeExtensionSet = async (
+  initializers: readonly RuntimeExtensionInitializer[],
+): Promise<RuntimeExtensionSet> => {
+  const instances: RuntimeExtensionInstance[] = [];
+  const extensionNames = new Set<string>();
+  const toolNames = new Set<string>();
+
+  try {
+    for (const initialize of initializers) {
+      const instance = await initialize();
+      instances.push(instance);
+      validateInstance(instance, extensionNames, toolNames);
+    }
+    return new InitializedExtensionSet(instances);
+  } catch (error) {
+    return rollbackInitialization(instances, error);
+  }
+};
+
+const validateInstance = (
+  instance: RuntimeExtensionInstance,
+  extensionNames: Set<string>,
+  toolNames: Set<string>,
+): void => {
+  if (extensionNames.has(instance.name)) {
+    throw new Error(`Duplicate runtime extension name: ${instance.name}`);
+  }
+  extensionNames.add(instance.name);
+
+  for (const extensionTool of instance.tools ?? []) {
+    if (toolNames.has(extensionTool.name)) {
+      throw new Error(
+        `Duplicate runtime extension tool name: ${extensionTool.name}`,
+      );
+    }
+    toolNames.add(extensionTool.name);
+  }
+};
+
+const collectManifest = (
+  instances: readonly RuntimeExtensionInstance[],
+): StaticManifest => ({
+  tools: instances.flatMap(({ tools }) => tools ?? []),
+  instructions: instances.flatMap(({ instructions }) =>
+    instructions === undefined ? [] : [instructions],
+  ),
+  hooks: instances.flatMap(({ hooks }) => hooks ?? []),
+});
+
+const hasStaticParts = (manifest: StaticManifest): boolean =>
+  manifest.tools.length > 0 ||
+  manifest.instructions.length > 0 ||
+  manifest.hooks.length > 0;
+
+const appendInstructions = (
+  hostInstructions: string,
+  extensionInstructions: readonly string[],
+): string => {
+  return [hostInstructions, ...extensionInstructions]
+    .filter((instructions) => instructions.length > 0)
+    .join('\n\n');
+};
+
+const validateHostTools = (
+  hostTools: readonly Tool[],
+  extensionTools: readonly Tool[],
+): void => {
+  const hostNames = new Set(hostTools.map(({ name }) => name));
+  for (const extensionTool of extensionTools) {
+    if (hostNames.has(extensionTool.name)) {
+      throw new Error(
+        `Runtime extension tool conflicts with host tool: ${extensionTool.name}`,
+      );
+    }
+  }
+};
+
+const disposeInstances = async (
+  instances: readonly RuntimeExtensionInstance[],
+): Promise<void> => {
+  const errors: unknown[] = [];
+  for (const instance of instances.toReversed()) {
+    try {
+      await instance.dispose?.();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, 'Failed to dispose runtime extensions');
+  }
+};
+
+const rollbackInitialization = async (
+  instances: readonly RuntimeExtensionInstance[],
+  initializationError: unknown,
+): Promise<never> => {
+  try {
+    await disposeInstances(instances);
+  } catch (rollbackError) {
+    throw new AggregateError(
+      [initializationError, rollbackError],
+      'Runtime extension initialization and rollback failed',
+      { cause: initializationError },
+    );
+  }
+  throw initializationError;
+};

--- a/packages/agent-extensions/src/extensions/runtime-extension.ts
+++ b/packages/agent-extensions/src/extensions/runtime-extension.ts
@@ -1,0 +1,29 @@
+import type { Hook, RunInput, Tool } from '@ayunis/agent-runtime';
+
+export interface RuntimeExtensionInstance {
+  readonly name: string;
+  readonly tools?: readonly Tool[];
+  readonly instructions?: string;
+  readonly hooks?: readonly Hook[];
+  dispose?(): Promise<void>;
+}
+
+export type RuntimeExtension<Config> = (
+  config: Config,
+) => RuntimeExtensionInstance | Promise<RuntimeExtensionInstance>;
+
+export type RuntimeExtensionInitializer = () =>
+  RuntimeExtensionInstance | Promise<RuntimeExtensionInstance>;
+
+export interface RuntimeExtensionSet {
+  readonly instances: readonly RuntimeExtensionInstance[];
+  apply(input: RunInput): RunInput;
+  dispose(): Promise<void>;
+}
+
+export const configureRuntimeExtension = <Config>(
+  extension: RuntimeExtension<Config>,
+  config: Config,
+): RuntimeExtensionInitializer => {
+  return () => extension(config);
+};

--- a/packages/agent-extensions/src/index.ts
+++ b/packages/agent-extensions/src/index.ts
@@ -1,0 +1,8 @@
+export { initializeExtensionSet } from './extensions/extension-set';
+export { configureRuntimeExtension } from './extensions/runtime-extension';
+export type {
+  RuntimeExtension,
+  RuntimeExtensionInitializer,
+  RuntimeExtensionInstance,
+  RuntimeExtensionSet,
+} from './extensions/runtime-extension';

--- a/packages/agent-extensions/src/package-surface.spec.ts
+++ b/packages/agent-extensions/src/package-surface.spec.ts
@@ -1,0 +1,27 @@
+import { readFile } from 'node:fs/promises';
+
+import { describe, expect, it } from 'vitest';
+
+interface PackageManifest {
+  exports: Record<
+    string,
+    { types?: string; import?: string; require?: string }
+  >;
+  files: string[];
+}
+
+describe('package surface', () => {
+  it('publishes one core entry point with ESM, CJS, and declarations', async () => {
+    const manifest = JSON.parse(
+      await readFile(new URL('../package.json', import.meta.url), 'utf8'),
+    ) as PackageManifest;
+
+    expect(Object.keys(manifest.exports)).toEqual(['.']);
+    expect(manifest.exports['.']).toEqual({
+      types: './dist/index.d.ts',
+      import: './dist/index.js',
+      require: './dist/index.cjs',
+    });
+    expect(manifest.files).toEqual(['dist']);
+  });
+});

--- a/packages/agent-extensions/tsconfig.json
+++ b/packages/agent-extensions/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src", "vitest.config.ts", "tsup.config.ts"]
+}

--- a/packages/agent-extensions/tsup.config.ts
+++ b/packages/agent-extensions/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: {
+    compilerOptions: { ignoreDeprecations: '6.0' },
+  },
+  sourcemap: true,
+  clean: true,
+  target: 'es2023',
+});

--- a/packages/agent-extensions/vitest.config.ts
+++ b/packages/agent-extensions/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    passWithNoTests: false,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -680,6 +680,57 @@ importers:
         specifier: ^4.2.4
         version: 4.2.4
 
+  packages/agent-extensions:
+    devDependencies:
+      '@ayunis/agent-runtime':
+        specifier: workspace:*
+        version: link:../agent-runtime
+      '@eslint/js':
+        specifier: ^9.18.0
+        version: 9.39.4
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.13.3
+      eslint:
+        specifier: ^10.6.0
+        version: 10.6.0(jiti@2.7.0)
+      eslint-config-prettier:
+        specifier: ^10.0.1
+        version: 10.1.8(eslint@10.6.0(jiti@2.7.0))
+      eslint-plugin-prettier:
+        specifier: ^5.5.5
+        version: 5.5.6(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.6.0(jiti@2.7.0)))(eslint@10.6.0(jiti@2.7.0))(prettier@3.9.4)
+      eslint-plugin-sonarjs:
+        specifier: ^4.0.2
+        version: 4.0.3(eslint@10.6.0(jiti@2.7.0))
+      eslint-plugin-unused-imports:
+        specifier: ^4.1.4
+        version: 4.4.1(@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))
+      globals:
+        specifier: ^16.0.0
+        version: 16.5.0
+      knip:
+        specifier: ^6.24.0
+        version: 6.25.0
+      madge:
+        specifier: ^8.0.0
+        version: 8.0.0(typescript@6.0.3)
+      prettier:
+        specifier: ^3.9.4
+        version: 3.9.4
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(@swc/core@1.15.43)(jiti@2.7.0)(postcss@8.5.26)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      typescript-eslint:
+        specifier: ^8.64.0
+        version: 8.64.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@29.1.1)(vite@7.3.5(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/agent-runtime:
     dependencies:
       '@ayunis/inference':
@@ -4821,11 +4872,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm-eabi@4.61.1':
-    resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.62.4':
     resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
     cpu: [arm]
@@ -4833,11 +4879,6 @@ packages:
 
   '@rollup/rollup-android-arm64@4.60.4':
     resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.61.1':
-    resolution: {integrity: sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==}
     cpu: [arm64]
     os: [android]
 
@@ -4851,11 +4892,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-arm64@4.61.1':
-    resolution: {integrity: sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.62.4':
     resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
     cpu: [arm64]
@@ -4863,11 +4899,6 @@ packages:
 
   '@rollup/rollup-darwin-x64@4.60.4':
     resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.61.1':
-    resolution: {integrity: sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==}
     cpu: [x64]
     os: [darwin]
 
@@ -4881,11 +4912,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-arm64@4.61.1':
-    resolution: {integrity: sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.62.4':
     resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
     cpu: [arm64]
@@ -4896,11 +4922,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.61.1':
-    resolution: {integrity: sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==}
-    cpu: [x64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-x64@4.62.4':
     resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
     cpu: [x64]
@@ -4908,12 +4929,6 @@ packages:
 
   '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
-    resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -4930,12 +4945,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
-    resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
     cpu: [arm]
@@ -4944,12 +4953,6 @@ packages:
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-gnu@4.61.1':
-    resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -4966,12 +4969,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-musl@4.61.1':
-    resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-arm64-musl@4.62.4':
     resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
     cpu: [arm64]
@@ -4980,12 +4977,6 @@ packages:
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-gnu@4.61.1':
-    resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
@@ -5002,12 +4993,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-musl@4.61.1':
-    resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-loong64-musl@4.62.4':
     resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
     cpu: [loong64]
@@ -5016,12 +5001,6 @@ packages:
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
-    resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -5038,12 +5017,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-musl@4.61.1':
-    resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-ppc64-musl@4.62.4':
     resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
     cpu: [ppc64]
@@ -5052,12 +5025,6 @@ packages:
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
-    resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -5074,12 +5041,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-musl@4.61.1':
-    resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-riscv64-musl@4.62.4':
     resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
     cpu: [riscv64]
@@ -5088,12 +5049,6 @@ packages:
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-s390x-gnu@4.61.1':
-    resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -5110,12 +5065,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.61.1':
-    resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-x64-gnu@4.62.4':
     resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
     cpu: [x64]
@@ -5124,12 +5073,6 @@ packages:
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-x64-musl@4.61.1':
-    resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -5145,11 +5088,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openbsd-x64@4.61.1':
-    resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
-    cpu: [x64]
-    os: [openbsd]
-
   '@rollup/rollup-openbsd-x64@4.62.4':
     resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
     cpu: [x64]
@@ -5157,11 +5095,6 @@ packages:
 
   '@rollup/rollup-openharmony-arm64@4.60.4':
     resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rollup/rollup-openharmony-arm64@4.61.1':
-    resolution: {integrity: sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==}
     cpu: [arm64]
     os: [openharmony]
 
@@ -5175,11 +5108,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-arm64-msvc@4.61.1':
-    resolution: {integrity: sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.62.4':
     resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
     cpu: [arm64]
@@ -5187,11 +5115,6 @@ packages:
 
   '@rollup/rollup-win32-ia32-msvc@4.60.4':
     resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.61.1':
-    resolution: {integrity: sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==}
     cpu: [ia32]
     os: [win32]
 
@@ -5205,11 +5128,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.61.1':
-    resolution: {integrity: sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==}
-    cpu: [x64]
-    os: [win32]
-
   '@rollup/rollup-win32-x64-gnu@4.62.4':
     resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
     cpu: [x64]
@@ -5217,11 +5135,6 @@ packages:
 
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.61.1':
-    resolution: {integrity: sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==}
     cpu: [x64]
     os: [win32]
 
@@ -12101,11 +12014,6 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rollup@4.61.1:
-    resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@4.62.4:
     resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -17822,16 +17730,10 @@ snapshots:
   '@rollup/rollup-android-arm-eabi@4.60.4':
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.61.1':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.62.4':
     optional: true
 
   '@rollup/rollup-android-arm64@4.60.4':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.61.1':
     optional: true
 
   '@rollup/rollup-android-arm64@4.62.4':
@@ -17840,16 +17742,10 @@ snapshots:
   '@rollup/rollup-darwin-arm64@4.60.4':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.61.1':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.62.4':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.60.4':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.61.1':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.62.4':
@@ -17858,16 +17754,10 @@ snapshots:
   '@rollup/rollup-freebsd-arm64@4.60.4':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.61.1':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.62.4':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.60.4':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.61.1':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.62.4':
@@ -17876,16 +17766,10 @@ snapshots:
   '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.4':
@@ -17894,16 +17778,10 @@ snapshots:
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.61.1':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.61.1':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.62.4':
@@ -17912,16 +17790,10 @@ snapshots:
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.61.1':
-    optional: true
-
   '@rollup/rollup-linux-loong64-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.61.1':
     optional: true
 
   '@rollup/rollup-linux-loong64-musl@4.62.4':
@@ -17930,16 +17802,10 @@ snapshots:
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
-    optional: true
-
   '@rollup/rollup-linux-ppc64-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.61.1':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.62.4':
@@ -17948,16 +17814,10 @@ snapshots:
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.61.1':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.62.4':
@@ -17966,16 +17826,10 @@ snapshots:
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.61.1':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.61.1':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.62.4':
@@ -17984,16 +17838,10 @@ snapshots:
   '@rollup/rollup-linux-x64-musl@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.61.1':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.62.4':
     optional: true
 
   '@rollup/rollup-openbsd-x64@4.60.4':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.61.1':
     optional: true
 
   '@rollup/rollup-openbsd-x64@4.62.4':
@@ -18002,16 +17850,10 @@ snapshots:
   '@rollup/rollup-openharmony-arm64@4.60.4':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.61.1':
-    optional: true
-
   '@rollup/rollup-openharmony-arm64@4.62.4':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.60.4':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.61.1':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.62.4':
@@ -18020,25 +17862,16 @@ snapshots:
   '@rollup/rollup-win32-ia32-msvc@4.60.4':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.61.1':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.62.4':
     optional: true
 
   '@rollup/rollup-win32-x64-gnu@4.60.4':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.61.1':
-    optional: true
-
   '@rollup/rollup-win32-x64-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.60.4':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.61.1':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.62.4':
@@ -19919,6 +19752,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.9(vite@7.3.5(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.5(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -22037,7 +21878,7 @@ snapshots:
       lodash.merge: 4.6.2
       minimatch: 10.2.5
       scslre: 0.3.0
-      semver: 7.8.1
+      semver: 7.8.5
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
 
@@ -22459,7 +22300,7 @@ snapshots:
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.2
-      rollup: 4.61.1
+      rollup: 4.62.4
 
   flat-cache@4.0.1:
     dependencies:
@@ -26855,37 +26696,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
-  rollup@4.61.1:
-    dependencies:
-      '@types/estree': 1.0.9
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.61.1
-      '@rollup/rollup-android-arm64': 4.61.1
-      '@rollup/rollup-darwin-arm64': 4.61.1
-      '@rollup/rollup-darwin-x64': 4.61.1
-      '@rollup/rollup-freebsd-arm64': 4.61.1
-      '@rollup/rollup-freebsd-x64': 4.61.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.61.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.61.1
-      '@rollup/rollup-linux-arm64-gnu': 4.61.1
-      '@rollup/rollup-linux-arm64-musl': 4.61.1
-      '@rollup/rollup-linux-loong64-gnu': 4.61.1
-      '@rollup/rollup-linux-loong64-musl': 4.61.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.61.1
-      '@rollup/rollup-linux-ppc64-musl': 4.61.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.61.1
-      '@rollup/rollup-linux-riscv64-musl': 4.61.1
-      '@rollup/rollup-linux-s390x-gnu': 4.61.1
-      '@rollup/rollup-linux-x64-gnu': 4.61.1
-      '@rollup/rollup-linux-x64-musl': 4.61.1
-      '@rollup/rollup-openbsd-x64': 4.61.1
-      '@rollup/rollup-openharmony-arm64': 4.61.1
-      '@rollup/rollup-win32-arm64-msvc': 4.61.1
-      '@rollup/rollup-win32-ia32-msvc': 4.61.1
-      '@rollup/rollup-win32-x64-gnu': 4.61.1
-      '@rollup/rollup-win32-x64-msvc': 4.61.1
-      fsevents: 2.3.3
-
   rollup@4.62.4:
     dependencies:
       '@types/estree': 1.0.9
@@ -27887,7 +27697,7 @@ snapshots:
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.22.4)(yaml@2.9.0)
       resolve-from: 5.0.0
-      rollup: 4.61.1
+      rollup: 4.62.4
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
@@ -28353,6 +28163,23 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
+  vite@7.3.5(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      terser: 5.48.0
+      tsx: 4.22.4
+      yaml: 2.9.0
+
   vite@7.3.5(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
@@ -28424,6 +28251,35 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.13.2
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@29.1.1)(vite@7.3.5(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@7.3.5(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.2.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.5(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.13.3
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Greenfield library and CI/docs only; no production backend or frontend wiring yet, so runtime behavior of the main app is unchanged.
> 
> **Overview**
> Introduces **`@ayunis/agent-extensions`**, a new workspace package that sits above `@ayunis/agent-runtime` and composes named extensions into a single **`RunInput`** before `run()` starts.
> 
> The core API is **`initializeExtensionSet`**, **`configureRuntimeExtension`**, and **`apply` / `dispose`**: factories run in registration order; merged manifests append **instructions**, **tools**, and **hooks** after host values; duplicate extension/tool names and host tool collisions fail fast; failed init rolls back disposers in reverse order; **`dispose`** is idempotent and surfaces multiple failures via **`AggregateError`**.
> 
> **CI and docs** add a dedicated **`agent-extensions`** workflow (lint, typecheck, test, build, ESM/CJS/d.ts checks, madge, pack dry-run), include the package in **dead-code (knip)** matrix, document the **inference → runtime → extensions → harness** stack in **`ARCHITECTURE.md`**, and update **`pnpm-lock.yaml`** for the new package’s dev graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c249cff110d856722a41e00abd0ae3e8d962394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->