### PR TITLE
wip(extensions): add lifetime-managed mcp runtime extension (AYC-694)

### DIFF
--- a/packages/agent-extensions/README.md
+++ b/packages/agent-extensions/README.md
@@ -48,6 +48,54 @@ reverse order. Applying a manifest rejects collisions with host-provided tools.
 Disposal is idempotent, reverse-ordered, attempts every disposer, and throws an
 `AggregateError` containing all disposal failures.
 
+## MCP extension
+
+MCP support is an optional subpath so core consumers do not load the MCP SDK:
+
+```ts
+import {
+  createStdioTransport,
+  createStreamableHttpTransport,
+  mcpExtension,
+} from '@ayunis/agent-extensions/mcp';
+
+const mcp = configureRuntimeExtension(mcpExtension, {
+  servers: [
+    {
+      name: 'catalog',
+      transport: createStreamableHttpTransport(
+        new URL('https://mcp.example.test'),
+        { requestInit: { headers: { Authorization: `Bearer ${token}` } } },
+      ),
+      requestOptions: { timeout: 30_000 },
+    },
+    {
+      name: 'local-tools',
+      transport: createStdioTransport({
+        command: 'local-mcp-server',
+        args: ['--stdio'],
+      }),
+    },
+  ],
+});
+```
+
+Initialization owns one SDK client per configured server. It connects each
+client and calls the SDK's auto-paginating `listTools()` once, exposing the
+complete static tool manifest before a run starts. Duplicate server or tool
+names fail initialization. Connection or discovery failures close every client
+already created and never return a partial manifest.
+
+Runtime tool calls preserve the MCP `content`, `structuredContent`, and
+`isError` fields in a JSON result string, while also mapping `isError` to the
+runtime's error flag. Per-server request options are forwarded and the current
+run's abort signal is added to each tool call.
+
+The extension owns and closes all clients during disposal, attempts every close,
+and aggregates close failures. Authentication, credentials, tenancy, connection
+pooling, and provider-specific error policy remain host concerns; transport
+factories accept caller-owned SDK options without adding such policy.
+
 ## Layering and terminology
 
 - `@ayunis/agent-runtime` is the bare agent loop and hook contracts.

--- a/packages/agent-extensions/knip.json
+++ b/packages/agent-extensions/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
-  "entry": ["src/index.ts"],
+  "entry": ["src/index.ts", "src/mcp/index.ts"],
   "project": ["src/**/*.ts"],
   "ignore": ["**/*.spec.ts"],
   "ignoreDependencies": ["@ayunis/agent-runtime"]

--- a/packages/agent-extensions/package.json
+++ b/packages/agent-extensions/package.json
@@ -15,6 +15,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./mcp": {
+      "types": "./dist/mcp/index.d.ts",
+      "import": "./dist/mcp/index.js",
+      "require": "./dist/mcp/index.cjs"
     }
   },
   "files": [
@@ -29,6 +34,9 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"src/**/*.ts\"",
     "deps:check": "madge --circular --extensions ts src"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/client": "^2.0.0"
   },
   "peerDependencies": {
     "@ayunis/agent-runtime": "workspace:*"

--- a/packages/agent-extensions/src/mcp/index.ts
+++ b/packages/agent-extensions/src/mcp/index.ts
@@ -1,0 +1,12 @@
+export { mcpExtension } from './mcp-extension';
+export type {
+  McpExtensionConfig,
+  McpRequestOptions,
+  McpServerConfig,
+} from './mcp-extension';
+export {
+  createStdioTransport,
+  createStreamableHttpTransport,
+} from './transports';
+export type { McpTransportFactory } from './transports';
+export type { RuntimeMcpResult } from './result-serializer';

--- a/packages/agent-extensions/src/mcp/mcp-extension.spec.ts
+++ b/packages/agent-extensions/src/mcp/mcp-extension.spec.ts
@@ -1,0 +1,290 @@
+import type {
+  CallToolResult,
+  Implementation,
+  ListToolsResult,
+  Tool as McpTool,
+  Transport,
+} from '@modelcontextprotocol/client';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import {
+  StdioClientTransport,
+  type StdioServerParameters,
+} from '@modelcontextprotocol/client/stdio';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ToolExecutionContext } from '@ayunis/agent-runtime';
+
+import {
+  initializeMcpExtension,
+  type McpClient,
+  type McpClientFactory,
+} from './mcp-extension';
+import {
+  createStdioTransport,
+  createStreamableHttpTransport,
+  type McpTransportFactory,
+} from './transports';
+
+const transport = {} as Transport;
+const transportFactory: McpTransportFactory = () => transport;
+const clientInfo: Implementation = { name: 'test-client', version: '1.0.0' };
+
+const discoveredTool = (
+  name: string,
+  inputSchema: McpTool['inputSchema'] = {
+    type: 'object',
+    properties: {},
+  },
+): McpTool => ({ name, description: `${name} description`, inputSchema });
+
+const fakeClient = (
+  tools: readonly McpTool[] = [],
+  overrides: Partial<McpClient> = {},
+): McpClient => ({
+  connect: vi.fn().mockResolvedValue(undefined),
+  listTools: vi
+    .fn()
+    .mockResolvedValue({ tools: [...tools] } satisfies ListToolsResult),
+  callTool: vi.fn().mockResolvedValue({ content: [] } satisfies CallToolResult),
+  close: vi.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+const clientFactory = (...clients: McpClient[]): McpClientFactory => {
+  const queue = [...clients];
+  return vi.fn(() => {
+    const client = queue.shift();
+    if (client === undefined) {
+      throw new Error('No fake client configured');
+    }
+    return client;
+  });
+};
+
+const executionContext = (signal?: AbortSignal): ToolExecutionContext => ({
+  context: {} as ToolExecutionContext['context'],
+  toolCallId: 'call-1',
+  signal,
+  emit: vi.fn(),
+  runChild: vi.fn(),
+});
+
+describe('MCP extension initialization', () => {
+  it('connects every client and discovers each complete SDK-aggregated tool list once', async () => {
+    const first = fakeClient([discoveredTool('first')]);
+    const second = fakeClient([
+      discoveredTool('page-one'),
+      discoveredTool('page-two'),
+    ]);
+    const createClient = clientFactory(first, second);
+
+    const extension = await initializeMcpExtension(
+      {
+        clientInfo,
+        servers: [
+          { name: 'alpha', transport: transportFactory },
+          { name: 'beta', transport: transportFactory },
+        ],
+      },
+      createClient,
+    );
+
+    expect(createClient).toHaveBeenCalledTimes(2);
+    expect(first.connect).toHaveBeenCalledOnce();
+    expect(second.connect).toHaveBeenCalledOnce();
+    expect(first.listTools).toHaveBeenCalledOnce();
+    expect(second.listTools).toHaveBeenCalledOnce();
+    expect(first.listTools).toHaveBeenCalledWith(undefined, undefined);
+    expect(second.listTools).toHaveBeenCalledWith(undefined, undefined);
+    expect(extension.tools?.map(({ name }) => name)).toEqual([
+      'first',
+      'page-one',
+      'page-two',
+    ]);
+  });
+
+  it('maps discovered input schemas to runtime parameters without loss', async () => {
+    const inputSchema = {
+      type: 'object' as const,
+      properties: {
+        city: { type: 'string', enum: ['Berlin', 'Munich'] },
+      },
+      required: ['city'],
+      additionalProperties: false,
+    };
+    const client = fakeClient([discoveredTool('weather', inputSchema)]);
+
+    const extension = await initializeMcpExtension(
+      {
+        clientInfo,
+        servers: [{ name: 'weather', transport: transportFactory }],
+      },
+      clientFactory(client),
+    );
+
+    expect(extension.tools?.[0].parameters).toBe(inputSchema);
+  });
+
+  it('rejects duplicate server names before opening a client', async () => {
+    const createClient = clientFactory();
+
+    await expect(
+      initializeMcpExtension(
+        {
+          clientInfo,
+          servers: [
+            { name: 'duplicate', transport: transportFactory },
+            { name: 'duplicate', transport: transportFactory },
+          ],
+        },
+        createClient,
+      ),
+    ).rejects.toThrow('Duplicate MCP server name: duplicate');
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate discovered tool names and closes every opened client', async () => {
+    const first = fakeClient([discoveredTool('duplicate')]);
+    const second = fakeClient([discoveredTool('duplicate')]);
+
+    await expect(
+      initializeMcpExtension(
+        {
+          clientInfo,
+          servers: [
+            { name: 'first', transport: transportFactory },
+            { name: 'second', transport: transportFactory },
+          ],
+        },
+        clientFactory(first, second),
+      ),
+    ).rejects.toThrow('Duplicate MCP tool name: duplicate');
+    expect(first.close).toHaveBeenCalledOnce();
+    expect(second.close).toHaveBeenCalledOnce();
+  });
+
+  it.each(['connect', 'listTools'] as const)(
+    'closes every opened client when %s fails',
+    async (operation) => {
+      const first = fakeClient([discoveredTool('first')]);
+      const failing = fakeClient([], {
+        [operation]: vi
+          .fn()
+          .mockRejectedValue(new Error(`${operation} failed`)),
+      });
+
+      await expect(
+        initializeMcpExtension(
+          {
+            clientInfo,
+            servers: [
+              { name: 'first', transport: transportFactory },
+              { name: 'failing', transport: transportFactory },
+            ],
+          },
+          clientFactory(first, failing),
+        ),
+      ).rejects.toThrow(`${operation} failed`);
+      expect(first.close).toHaveBeenCalledOnce();
+      expect(failing.close).toHaveBeenCalledOnce();
+    },
+  );
+});
+
+describe('MCP runtime tools', () => {
+  it('delegates the original call with request options and preserves the MCP result', async () => {
+    const result: CallToolResult = {
+      content: [{ type: 'text', text: 'forecast' }],
+      structuredContent: { temperature: 21 },
+      isError: true,
+    };
+    const client = fakeClient([discoveredTool('weather')], {
+      callTool: vi.fn().mockResolvedValue(result),
+    });
+    const extension = await initializeMcpExtension(
+      {
+        clientInfo,
+        servers: [
+          {
+            name: 'weather-server',
+            transport: transportFactory,
+            requestOptions: { timeout: 12_345 },
+          },
+        ],
+      },
+      clientFactory(client),
+    );
+    const abortController = new AbortController();
+
+    const output = await extension.tools?.[0].execute?.(
+      { city: 'Berlin' },
+      executionContext(abortController.signal),
+    );
+
+    expect(client.callTool).toHaveBeenCalledWith(
+      { name: 'weather', arguments: { city: 'Berlin' } },
+      { timeout: 12_345, signal: abortController.signal },
+    );
+    expect(output).toEqual({
+      result:
+        '{"content":[{"type":"text","text":"forecast"}],"structuredContent":{"temperature":21},"isError":true}',
+      isError: true,
+    });
+  });
+});
+
+describe('MCP client lifetime', () => {
+  it('closes every client once even when another close fails', async () => {
+    const first = fakeClient([], {
+      close: vi.fn().mockRejectedValue(new Error('first close failed')),
+    });
+    const second = fakeClient([], {
+      close: vi.fn().mockRejectedValue(new Error('second close failed')),
+    });
+    const extension = await initializeMcpExtension(
+      {
+        clientInfo,
+        servers: [
+          { name: 'first', transport: transportFactory },
+          { name: 'second', transport: transportFactory },
+        ],
+      },
+      clientFactory(first, second),
+    );
+
+    const error = await extension
+      .dispose?.()
+      .catch((reason: unknown) => reason);
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toHaveLength(2);
+    expect(first.close).toHaveBeenCalledOnce();
+    expect(second.close).toHaveBeenCalledOnce();
+    await expect(extension.dispose?.()).resolves.toBeUndefined();
+    expect(first.close).toHaveBeenCalledOnce();
+    expect(second.close).toHaveBeenCalledOnce();
+  });
+});
+
+describe('MCP transport factories', () => {
+  it('creates the declared Streamable HTTP transport with caller-owned options', async () => {
+    const requestInit = { headers: { Authorization: 'Bearer host-owned' } };
+    const factory = createStreamableHttpTransport(
+      new URL('https://mcp.example.test'),
+      { requestInit },
+    );
+
+    expect(await factory()).toBeInstanceOf(StreamableHTTPClientTransport);
+  });
+
+  it('creates the declared stdio transport with caller-owned process parameters', async () => {
+    const parameters: StdioServerParameters = {
+      command: 'mcp-server',
+      args: ['--stdio'],
+      env: { HOST_OWNED: 'true' },
+    };
+    const factory = createStdioTransport(parameters);
+
+    expect(await factory()).toBeInstanceOf(StdioClientTransport);
+  });
+});

--- a/packages/agent-extensions/src/mcp/mcp-extension.ts
+++ b/packages/agent-extensions/src/mcp/mcp-extension.ts
@@ -1,0 +1,210 @@
+import {
+  Client,
+  type CallToolRequestOptions,
+  type CallToolResult,
+  type Implementation,
+  type ListToolsResult,
+  type RequestOptions,
+  type Tool as McpTool,
+  type Transport,
+} from '@modelcontextprotocol/client';
+import type { Tool, ToolExecutionContext } from '@ayunis/agent-runtime';
+
+import type {
+  RuntimeExtension,
+  RuntimeExtensionInstance,
+} from '../extensions/runtime-extension';
+import { serializeMcpResult, toRuntimeMcpResult } from './result-serializer';
+import type { McpTransportFactory } from './transports';
+
+const DEFAULT_CLIENT_INFO: Implementation = {
+  name: '@ayunis/agent-extensions',
+  version: '0.1.0',
+};
+
+export type McpRequestOptions = Omit<RequestOptions, 'signal'>;
+
+export interface McpServerConfig {
+  readonly name: string;
+  readonly transport: McpTransportFactory;
+  readonly requestOptions?: McpRequestOptions;
+}
+
+export interface McpExtensionConfig {
+  readonly servers: readonly McpServerConfig[];
+  readonly clientInfo?: Implementation;
+}
+
+export interface McpClient {
+  connect(transport: Transport, options?: RequestOptions): Promise<void>;
+  listTools(
+    params?: undefined,
+    options?: RequestOptions,
+  ): Promise<ListToolsResult>;
+  callTool(
+    params: { name: string; arguments?: Record<string, unknown> },
+    options?: CallToolRequestOptions,
+  ): Promise<CallToolResult>;
+  close(): Promise<void>;
+}
+
+export type McpClientFactory = (clientInfo: Implementation) => McpClient;
+
+interface InitializedMcpExtension extends RuntimeExtensionInstance {
+  readonly tools: readonly Tool[];
+  dispose(): Promise<void>;
+}
+
+export const mcpExtension: RuntimeExtension<McpExtensionConfig> = (config) =>
+  initializeMcpExtension(config);
+
+export const initializeMcpExtension = async (
+  config: McpExtensionConfig,
+  createClient: McpClientFactory = createSdkClient,
+): Promise<InitializedMcpExtension> => {
+  validateServerNames(config.servers);
+  const clients: McpClient[] = [];
+  const tools: Tool[] = [];
+  const toolNames = new Set<string>();
+
+  try {
+    for (const server of config.servers) {
+      const client = createClient(config.clientInfo ?? DEFAULT_CLIENT_INFO);
+      clients.push(client);
+      await connectClient(client, server);
+      const discovered = await client.listTools(
+        undefined,
+        server.requestOptions,
+      );
+      appendTools(tools, toolNames, discovered.tools, client, server);
+    }
+  } catch (error) {
+    return rollbackClients(clients, error);
+  }
+
+  return {
+    name: 'mcp',
+    tools,
+    dispose: createDisposer(clients),
+  };
+};
+
+const createSdkClient: McpClientFactory = (clientInfo) =>
+  new Client(clientInfo);
+
+const connectClient = async (
+  client: McpClient,
+  server: McpServerConfig,
+): Promise<void> => {
+  const transport = await server.transport();
+  await client.connect(transport, server.requestOptions);
+};
+
+const appendTools = (
+  target: Tool[],
+  names: Set<string>,
+  discovered: readonly McpTool[],
+  client: McpClient,
+  server: McpServerConfig,
+): void => {
+  for (const mcpTool of discovered) {
+    if (names.has(mcpTool.name)) {
+      throw new Error(`Duplicate MCP tool name: ${mcpTool.name}`);
+    }
+    names.add(mcpTool.name);
+    target.push(toRuntimeTool(mcpTool, client, server.requestOptions));
+  }
+};
+
+const toRuntimeTool = (
+  mcpTool: McpTool,
+  client: McpClient,
+  requestOptions?: McpRequestOptions,
+): Tool => ({
+  name: mcpTool.name,
+  description: mcpTool.description ?? mcpTool.title ?? '',
+  parameters: mcpTool.inputSchema,
+  execute: async (input, context) =>
+    executeMcpTool(client, mcpTool.name, input, context, requestOptions),
+});
+
+const executeMcpTool = async (
+  client: McpClient,
+  name: string,
+  input: Record<string, unknown>,
+  context: ToolExecutionContext,
+  requestOptions?: McpRequestOptions,
+) => {
+  const result = await client.callTool(
+    { name, arguments: input },
+    withAbortSignal(requestOptions, context.signal),
+  );
+  const runtimeResult = toRuntimeMcpResult(result);
+  return {
+    result: serializeMcpResult(runtimeResult),
+    isError: runtimeResult.isError,
+  };
+};
+
+const withAbortSignal = (
+  options: McpRequestOptions | undefined,
+  signal: AbortSignal | undefined,
+): CallToolRequestOptions | undefined => {
+  if (signal === undefined) {
+    return options;
+  }
+  return { ...options, signal };
+};
+
+const validateServerNames = (servers: readonly McpServerConfig[]): void => {
+  const names = new Set<string>();
+  for (const server of servers) {
+    if (names.has(server.name)) {
+      throw new Error(`Duplicate MCP server name: ${server.name}`);
+    }
+    names.add(server.name);
+  }
+};
+
+const createDisposer = (
+  clients: readonly McpClient[],
+): (() => Promise<void>) => {
+  let disposed = false;
+  return async () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    await closeClients(clients);
+  };
+};
+
+const closeClients = async (clients: readonly McpClient[]): Promise<void> => {
+  const errors: unknown[] = [];
+  for (const client of clients.toReversed()) {
+    try {
+      await client.close();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, 'Failed to close MCP clients');
+  }
+};
+
+const rollbackClients = async (
+  clients: readonly McpClient[],
+  initializationError: unknown,
+): Promise<never> => {
+  try {
+    await closeClients(clients);
+  } catch (closeError) {
+    throw new AggregateError(
+      [initializationError, closeError],
+      'MCP initialization and rollback failed',
+      { cause: initializationError },
+    );
+  }
+  throw initializationError;
+};

--- a/packages/agent-extensions/src/mcp/result-serializer.ts
+++ b/packages/agent-extensions/src/mcp/result-serializer.ts
@@ -1,0 +1,20 @@
+import type { CallToolResult } from '@modelcontextprotocol/client';
+
+export interface RuntimeMcpResult {
+  readonly content: CallToolResult['content'];
+  readonly structuredContent?: unknown;
+  readonly isError: boolean;
+}
+
+export const toRuntimeMcpResult = (
+  result: CallToolResult,
+): RuntimeMcpResult => ({
+  content: result.content,
+  ...(result.structuredContent === undefined
+    ? {}
+    : { structuredContent: result.structuredContent }),
+  isError: result.isError ?? false,
+});
+
+export const serializeMcpResult = (result: RuntimeMcpResult): string =>
+  JSON.stringify(result);

--- a/packages/agent-extensions/src/mcp/transports.ts
+++ b/packages/agent-extensions/src/mcp/transports.ts
@@ -1,0 +1,24 @@
+import {
+  StreamableHTTPClientTransport,
+  type StreamableHTTPClientTransportOptions,
+  type Transport,
+} from '@modelcontextprotocol/client';
+import {
+  StdioClientTransport,
+  type StdioServerParameters,
+} from '@modelcontextprotocol/client/stdio';
+
+export type McpTransportFactory = () => Transport | Promise<Transport>;
+
+export const createStreamableHttpTransport = (
+  url: URL,
+  options?: StreamableHTTPClientTransportOptions,
+): McpTransportFactory => {
+  return () => new StreamableHTTPClientTransport(url, options);
+};
+
+export const createStdioTransport = (
+  parameters: StdioServerParameters,
+): McpTransportFactory => {
+  return () => new StdioClientTransport(parameters);
+};

--- a/packages/agent-extensions/src/package-surface.spec.ts
+++ b/packages/agent-extensions/src/package-surface.spec.ts
@@ -11,17 +11,30 @@ interface PackageManifest {
 }
 
 describe('package surface', () => {
-  it('publishes one core entry point with ESM, CJS, and declarations', async () => {
+  it('publishes separate core and optional MCP entry points', async () => {
     const manifest = JSON.parse(
       await readFile(new URL('../package.json', import.meta.url), 'utf8'),
     ) as PackageManifest;
 
-    expect(Object.keys(manifest.exports)).toEqual(['.']);
+    expect(Object.keys(manifest.exports)).toEqual(['.', './mcp']);
     expect(manifest.exports['.']).toEqual({
       types: './dist/index.d.ts',
       import: './dist/index.js',
       require: './dist/index.cjs',
     });
+    expect(manifest.exports['./mcp']).toEqual({
+      types: './dist/mcp/index.d.ts',
+      import: './dist/mcp/index.js',
+      require: './dist/mcp/index.cjs',
+    });
     expect(manifest.files).toEqual(['dist']);
+  });
+
+  it('keeps MCP implementation exports out of the core entry point', async () => {
+    const core = await import('./index');
+
+    expect(
+      Object.keys(core).sort((left, right) => left.localeCompare(right)),
+    ).toEqual(['configureRuntimeExtension', 'initializeExtensionSet']);
   });
 });

--- a/packages/agent-extensions/tsup.config.ts
+++ b/packages/agent-extensions/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/mcp/index.ts'],
   format: ['esm', 'cjs'],
   dts: {
     compilerOptions: { ignoreDeprecations: '6.0' },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -681,6 +681,10 @@ importers:
         version: 4.2.4
 
   packages/agent-extensions:
+    dependencies:
+      '@modelcontextprotocol/client':
+        specifier: ^2.0.0
+        version: 2.0.0
     devDependencies:
       '@ayunis/agent-runtime':
         specifier: workspace:*


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New network and subprocess MCP connectivity during extension init and tool execution; failures are bounded by rollback/disposal, but hosts must configure transports and credentials correctly.
> 
> **Overview**
> Adds **optional MCP integration** via `@ayunis/agent-extensions/mcp` so core consumers are not forced to load `@modelcontextprotocol/client`. The package gains a second build/export entry, a direct dependency on the MCP SDK, and README guidance for wiring servers.
> 
> The new **`mcpExtension`** follows the existing runtime-extension lifecycle: at init it opens one SDK client per configured server (stdio or streamable HTTP transport factories), runs `listTools()` once to build a static tool manifest, and rejects duplicate server or tool names. Connect/discovery failures roll back and close opened clients; **disposal** is idempotent, closes all clients in reverse order, and surfaces close failures as an **`AggregateError`**.
> 
> At run time, discovered MCP tools become agent-runtime **`Tool`** entries (schemas passed through). **`callTool`** forwards per-server request options plus the run **abort signal**, returns MCP **`content` / `structuredContent` / `isError`** as a JSON string, and maps **`isError`** to the runtime error flag. Auth and other policy stay with the host via caller-owned transport options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 945c4bfc22aa164fe9aa0a83bc9aa5ca430d2989. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->