### PR TITLE
feat(extensions): add runtime skills extensions (AYC-694)

### DIFF
--- a/packages/agent-extensions/README.md
+++ b/packages/agent-extensions/README.md
@@ -96,6 +96,84 @@ and aggregates close failures. Authentication, credentials, tenancy, connection
 pooling, and provider-specific error policy remain host concerns; transport
 factories accept caller-owned SDK options without adding such policy.
 
+## Skills extension
+
+Skills use a source port and an optional subpath, independent of storage:
+
+```ts
+import {
+  skillsExtension,
+  type SkillSource,
+} from '@ayunis/agent-extensions/skills';
+
+const source: SkillSource = {
+  async list() {
+    return [{ name: 'access_review', description: 'Review user access' }];
+  },
+  async load(name) {
+    return {
+      name,
+      description: 'Review user access',
+      instructions: 'Follow the access review checklist.',
+      tools: [listAccessTool],
+    };
+  },
+};
+
+const skills = configureRuntimeExtension(skillsExtension, { source });
+```
+
+The source is listed once during initialization, making available-skill
+instructions and the `activate_skill` schema static and introspectable. Calling
+the activation tool loads the selected definition. Only a successful tool call
+causes its instructions and tools to be injected by `afterToolCall` for the next
+model iteration. Per-run pending and activated state lives in `RunContext`, and
+tool-name collisions return model-actionable activation errors. The current
+run's abort signal is forwarded to `SkillSource.load` so sources can cancel
+remote or blocking work.
+
+### Filesystem skill source
+
+The optional filesystem source reads immediate child directories using the
+Agent Skills `SKILL.md` convention:
+
+```text
+skills/
+└── access-review/
+    └── SKILL.md
+```
+
+```md
+---
+name: access-review
+description: Review user access
+allowed-tools: list_access notify_owner
+---
+
+Follow the access review checklist.
+```
+
+```ts
+import { FilesystemSkillSource } from '@ayunis/agent-extensions/skills/filesystem';
+
+const source = new FilesystemSkillSource({
+  root: './skills',
+  toolCatalog: {
+    list_access: listAccessTool,
+    notify_owner: notifyOwnerTool,
+  },
+});
+```
+
+Discovery metadata is cached, while the selected `SKILL.md` is safely re-read
+on activation. Allowed tools resolve only through the host catalog. Canonical
+path containment prevents model input or symlinks from escaping the configured
+root. There is no watcher or hot reload.
+
+This source implements the directory-based Agent Skills convention only. It is
+not an Agent Plugins loader and does not claim conformance with the broader
+Agent Plugins package standard (`plugin.json`, `mcp.json`, and packaging rules).
+
 ## Layering and terminology
 
 - `@ayunis/agent-runtime` is the bare agent loop and hook contracts.

--- a/packages/agent-extensions/knip.json
+++ b/packages/agent-extensions/knip.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
-  "entry": ["src/index.ts", "src/mcp/index.ts"],
+  "entry": [
+    "src/index.ts",
+    "src/mcp/index.ts",
+    "src/skills/index.ts",
+    "src/skills/filesystem/index.ts"
+  ],
   "project": ["src/**/*.ts"],
   "ignore": ["**/*.spec.ts"],
   "ignoreDependencies": ["@ayunis/agent-runtime"]

--- a/packages/agent-extensions/package.json
+++ b/packages/agent-extensions/package.json
@@ -20,6 +20,16 @@
       "types": "./dist/mcp/index.d.ts",
       "import": "./dist/mcp/index.js",
       "require": "./dist/mcp/index.cjs"
+    },
+    "./skills": {
+      "types": "./dist/skills/index.d.ts",
+      "import": "./dist/skills/index.js",
+      "require": "./dist/skills/index.cjs"
+    },
+    "./skills/filesystem": {
+      "types": "./dist/skills/filesystem/index.d.ts",
+      "import": "./dist/skills/filesystem/index.js",
+      "require": "./dist/skills/filesystem/index.cjs"
     }
   },
   "files": [
@@ -36,7 +46,8 @@
     "deps:check": "madge --circular --extensions ts src"
   },
   "dependencies": {
-    "@modelcontextprotocol/client": "^2.0.0"
+    "@modelcontextprotocol/client": "^2.0.0",
+    "yaml": "^2.9.0"
   },
   "peerDependencies": {
     "@ayunis/agent-runtime": "workspace:*"

--- a/packages/agent-extensions/src/mcp/mcp-extension.spec.ts
+++ b/packages/agent-extensions/src/mcp/mcp-extension.spec.ts
@@ -64,6 +64,7 @@ const clientFactory = (...clients: McpClient[]): McpClientFactory => {
 const executionContext = (signal?: AbortSignal): ToolExecutionContext => ({
   context: {} as ToolExecutionContext['context'],
   toolCallId: 'call-1',
+  toolNames: [],
   signal,
   emit: vi.fn(),
   runChild: vi.fn(),

--- a/packages/agent-extensions/src/package-surface.spec.ts
+++ b/packages/agent-extensions/src/package-surface.spec.ts
@@ -11,12 +11,17 @@ interface PackageManifest {
 }
 
 describe('package surface', () => {
-  it('publishes separate core and optional MCP entry points', async () => {
+  it('publishes separate core, MCP, skills, and filesystem entry points', async () => {
     const manifest = JSON.parse(
       await readFile(new URL('../package.json', import.meta.url), 'utf8'),
     ) as PackageManifest;
 
-    expect(Object.keys(manifest.exports)).toEqual(['.', './mcp']);
+    expect(Object.keys(manifest.exports)).toEqual([
+      '.',
+      './mcp',
+      './skills',
+      './skills/filesystem',
+    ]);
     expect(manifest.exports['.']).toEqual({
       types: './dist/index.d.ts',
       import: './dist/index.js',
@@ -26,6 +31,16 @@ describe('package surface', () => {
       types: './dist/mcp/index.d.ts',
       import: './dist/mcp/index.js',
       require: './dist/mcp/index.cjs',
+    });
+    expect(manifest.exports['./skills']).toEqual({
+      types: './dist/skills/index.d.ts',
+      import: './dist/skills/index.js',
+      require: './dist/skills/index.cjs',
+    });
+    expect(manifest.exports['./skills/filesystem']).toEqual({
+      types: './dist/skills/filesystem/index.d.ts',
+      import: './dist/skills/filesystem/index.js',
+      require: './dist/skills/filesystem/index.cjs',
     });
     expect(manifest.files).toEqual(['dist']);
   });

--- a/packages/agent-extensions/src/skills/available-skills.ts
+++ b/packages/agent-extensions/src/skills/available-skills.ts
@@ -1,0 +1,81 @@
+import type { JsonSchema } from '@ayunis/agent-runtime';
+
+import type { SkillSummary } from './skill-source';
+
+export interface AvailableSkills {
+  readonly names: readonly string[];
+  readonly instructions: string;
+  readonly activationSchema: JsonSchema;
+}
+
+export const buildAvailableSkills = (
+  summaries: readonly SkillSummary[],
+): AvailableSkills => {
+  const sorted = [...summaries].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+  validateSummaries(sorted);
+  const names = sorted.map(({ name }) => name);
+
+  return {
+    names,
+    instructions: formatInstructions(sorted),
+    activationSchema: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          enum: names,
+          description: 'The name of the skill to activate.',
+        },
+      },
+      required: ['name'],
+      additionalProperties: false,
+    },
+  };
+};
+
+const validateSummaries = (summaries: readonly SkillSummary[]): void => {
+  const names = new Set<string>();
+  for (const summary of summaries) {
+    if (!summary.name || !summary.description) {
+      throw new Error('Skill summaries require a name and description');
+    }
+    if (names.has(summary.name)) {
+      throw new Error(`Duplicate skill summary name: ${summary.name}`);
+    }
+    names.add(summary.name);
+  }
+};
+
+const formatInstructions = (summaries: readonly SkillSummary[]): string => {
+  const entries = summaries
+    .map(
+      ({ name, description }) =>
+        `  <skill>\n    <name>${escapeXml(name)}</name>\n` +
+        `    <description>${escapeXml(description)}</description>\n  </skill>`,
+    )
+    .join('\n');
+
+  return [
+    'Additional skills are available through progressive disclosure.',
+    'Call activate_skill with one of the exact names below before using it.',
+    '<available_skills>',
+    entries,
+    '</available_skills>',
+  ].join('\n');
+};
+
+const XML_ENTITIES: Readonly<Record<string, string>> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&apos;',
+};
+
+const escapeXml = (value: string): string =>
+  value.replaceAll(
+    /[&<>"']/g,
+    (character) => XML_ENTITIES[character] ?? character,
+  );

--- a/packages/agent-extensions/src/skills/filesystem/filesystem-skill-source.spec.ts
+++ b/packages/agent-extensions/src/skills/filesystem/filesystem-skill-source.spec.ts
@@ -1,0 +1,258 @@
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { Tool } from '@ayunis/agent-runtime';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { FilesystemSkillSource } from './filesystem-skill-source';
+
+const roots: string[] = [];
+
+async function temporaryDirectory(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'agent-skills-'));
+  roots.push(root);
+  return root;
+}
+
+async function writeSkill(
+  root: string,
+  directory: string,
+  options: {
+    name?: string;
+    description?: string;
+    instructions?: string;
+    allowedTools?: string | readonly string[];
+    newline?: '\n' | '\r\n';
+  } = {},
+): Promise<string> {
+  const newline = options.newline ?? '\n';
+  const skillDirectory = join(root, directory);
+  await mkdir(skillDirectory, { recursive: true });
+  const allowedTools =
+    options.allowedTools === undefined
+      ? ''
+      : `${newline}allowed-tools: ${formatYamlValue(options.allowedTools)}`;
+  const defaultDescription = `Use the ${directory} workflow`;
+  const description = options.description ?? defaultDescription;
+  const markdown = [
+    '---',
+    `name: ${options.name ?? directory}`,
+    `description: ${description}${allowedTools}`,
+    '---',
+    options.instructions ?? `Follow the ${directory} instructions.`,
+    '',
+  ].join(newline);
+  const path = join(skillDirectory, 'SKILL.md');
+  await writeFile(path, markdown);
+  return path;
+}
+
+function formatYamlValue(value: string | readonly string[]): string {
+  return typeof value === 'string' ? value : JSON.stringify(value);
+}
+
+function tool(name: string): Tool {
+  return {
+    name,
+    description: `${name} description`,
+    parameters: { type: 'object', properties: {} },
+    execute: () => `${name} result`,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true })),
+  );
+});
+
+describe('FilesystemSkillSource', () => {
+  it('returns an empty list when the configured directory is missing', async () => {
+    const root = join(await temporaryDirectory(), 'missing');
+    const source = new FilesystemSkillSource({ root });
+
+    await expect(source.list()).resolves.toEqual([]);
+  });
+
+  it('discovers only immediate child directories containing SKILL.md', async () => {
+    const root = await temporaryDirectory();
+    await writeSkill(root, 'access-review');
+    await mkdir(join(root, 'empty-directory'));
+    await writeSkill(join(root, 'container'), 'nested-skill');
+    await writeFile(join(root, 'SKILL.md'), 'not a child skill');
+    const source = new FilesystemSkillSource({ root });
+
+    await expect(source.list()).resolves.toEqual([
+      {
+        name: 'access-review',
+        description: 'Use the access-review workflow',
+      },
+    ]);
+  });
+
+  it.each(['\n', '\r\n'] as const)(
+    'parses standard frontmatter and Markdown instructions with %j input',
+    async (newline) => {
+      const root = await temporaryDirectory();
+      await writeSkill(root, 'incident-response', {
+        description: 'Coordinate incident response',
+        instructions: '# Response\n\nPage the incident lead.',
+        newline,
+      });
+      const source = new FilesystemSkillSource({ root });
+
+      await source.list();
+      await expect(source.load('incident-response')).resolves.toMatchObject({
+        name: 'incident-response',
+        description: 'Coordinate incident response',
+        instructions: '# Response\n\nPage the incident lead.',
+      });
+    },
+  );
+
+  it.each([
+    ['Uppercase', 'must match the Agent Skills name format'],
+    ['double--hyphen', 'must match the Agent Skills name format'],
+    ['different-name', 'must match its parent directory'],
+  ])('rejects invalid or mismatched skill name %s', async (name, message) => {
+    const root = await temporaryDirectory();
+    const path = await writeSkill(root, 'access-review', { name });
+    const source = new FilesystemSkillSource({ root });
+
+    await expect(source.list()).rejects.toThrow(
+      `Invalid skill at ${await realpath(path)}: Skill name ${message}`,
+    );
+  });
+
+  it('resolves allowed tool names only through the supplied catalog', async () => {
+    const root = await temporaryDirectory();
+    await writeSkill(root, 'access-review', {
+      allowedTools: 'list_access notify_owner',
+    });
+    const listAccess = tool('list_access');
+    const notifyOwner = tool('notify_owner');
+    const source = new FilesystemSkillSource({
+      root,
+      toolCatalog: { list_access: listAccess, notify_owner: notifyOwner },
+    });
+
+    await source.list();
+    const definition = await source.load('access-review');
+
+    expect(definition.tools).toEqual([listAccess, notifyOwner]);
+  });
+
+  it.each([
+    ['unknown tool names', 'list_access missing_tool', 'Unknown allowed tool'],
+    [
+      'duplicate tool names',
+      ['list_access', 'list_access'],
+      'Duplicate allowed tool',
+    ],
+  ])('rejects %s', async (_, allowedTools, message) => {
+    const root = await temporaryDirectory();
+    await writeSkill(root, 'access-review', { allowedTools });
+    const source = new FilesystemSkillSource({
+      root,
+      toolCatalog: { list_access: tool('list_access') },
+    });
+
+    await expect(source.list()).rejects.toThrow(message);
+  });
+
+  it('never interpolates a requested skill name into a filesystem path', async () => {
+    const parent = await temporaryDirectory();
+    const root = join(parent, 'skills');
+    await mkdir(root);
+    const outsidePath = await writeSkill(parent, 'outside');
+    const source = new FilesystemSkillSource({ root });
+    await source.list();
+
+    await expect(source.load('../outside')).rejects.toThrow(
+      'Unknown scanned skill: ../outside',
+    );
+    await expect(readFile(outsidePath, 'utf8')).resolves.toContain(
+      'Follow the outside instructions.',
+    );
+  });
+
+  it('rejects skill symlinks that escape the configured root', async () => {
+    const parent = await temporaryDirectory();
+    const root = join(parent, 'skills');
+    const outside = join(parent, 'outside');
+    await mkdir(root);
+    await writeSkill(outside, 'escaped');
+    await symlink(join(outside, 'escaped'), join(root, 'escaped'));
+    const source = new FilesystemSkillSource({ root });
+
+    await expect(source.list()).rejects.toThrow(
+      'resolves outside the configured root',
+    );
+  });
+
+  it('attributes malformed YAML errors to the skill path', async () => {
+    const root = await temporaryDirectory();
+    const path = await writeSkill(root, 'access-review');
+    await writeFile(
+      path,
+      '---\nname: access-review\ndescription: [invalid\n---\nInstructions',
+    );
+    const source = new FilesystemSkillSource({ root });
+
+    await expect(source.list()).rejects.toThrow(
+      `Invalid skill at ${await realpath(path)}:`,
+    );
+  });
+
+  it('rejects a definition whose canonical name changes after discovery', async () => {
+    const root = await temporaryDirectory();
+    const path = await writeSkill(root, 'access-review');
+    const source = new FilesystemSkillSource({ root });
+    await source.list();
+    await writeFile(
+      path,
+      '---\nname: incident-response\ndescription: Changed\n---\nChanged.',
+    );
+
+    await expect(source.load('access-review')).rejects.toThrow(
+      'canonical name changed after discovery',
+    );
+  });
+
+  it('caches discovery while re-reading the selected definition on activation', async () => {
+    const root = await temporaryDirectory();
+    const path = await writeSkill(root, 'access-review', {
+      instructions: 'Original instructions.',
+    });
+    const source = new FilesystemSkillSource({ root });
+    const firstList = await source.list();
+    await writeSkill(root, 'new-skill');
+    await writeFile(
+      path,
+      '---\nname: access-review\ndescription: Updated\n---\nUpdated instructions.',
+    );
+
+    const secondList = await source.list();
+    const loaded = await source.load('access-review');
+
+    expect(secondList).toBe(firstList);
+    expect(secondList).toHaveLength(1);
+    await expect(source.load('new-skill')).rejects.toThrow(
+      'Unknown scanned skill: new-skill',
+    );
+    expect(loaded).toMatchObject({
+      name: 'access-review',
+      description: 'Updated',
+      instructions: 'Updated instructions.',
+    });
+  });
+});

--- a/packages/agent-extensions/src/skills/filesystem/filesystem-skill-source.ts
+++ b/packages/agent-extensions/src/skills/filesystem/filesystem-skill-source.ts
@@ -1,0 +1,182 @@
+import { readFile, readdir, realpath } from 'node:fs/promises';
+import { isAbsolute, join, relative, sep } from 'node:path';
+
+import type { Tool } from '@ayunis/agent-runtime';
+
+import type {
+  SkillDefinition,
+  SkillLoadOptions,
+  SkillSource,
+  SkillSummary,
+} from '../skill-source';
+import { parseSkillMarkdown } from './skill-markdown';
+
+export interface FilesystemSkillSourceConfig {
+  readonly root: string;
+  readonly toolCatalog?: Readonly<Record<string, Tool>>;
+}
+
+interface Discovery {
+  readonly canonicalRoot?: string;
+  readonly summaries: readonly SkillSummary[];
+  readonly paths: ReadonlyMap<string, string>;
+}
+
+export class FilesystemSkillSource implements SkillSource {
+  private readonly root: string;
+  private readonly toolCatalog: ReadonlyMap<string, Tool>;
+  private discovery?: Promise<Discovery>;
+
+  constructor(config: FilesystemSkillSourceConfig) {
+    this.root = config.root;
+    this.toolCatalog = new Map(Object.entries(config.toolCatalog ?? {}));
+  }
+
+  async list(): Promise<readonly SkillSummary[]> {
+    return (await this.getDiscovery()).summaries;
+  }
+
+  async load(
+    name: string,
+    options?: SkillLoadOptions,
+  ): Promise<SkillDefinition> {
+    options?.signal?.throwIfAborted();
+    const discovery = await this.getDiscovery();
+    const path = discovery.paths.get(name);
+    if (!path || !discovery.canonicalRoot) {
+      throw new Error(`Unknown scanned skill: ${name}`);
+    }
+    const currentPath = await realpath(path);
+    assertContained(discovery.canonicalRoot, currentPath);
+    return this.readDefinition(currentPath, name, true, options?.signal);
+  }
+
+  private getDiscovery(): Promise<Discovery> {
+    this.discovery ??= this.scan();
+    return this.discovery;
+  }
+
+  private async scan(): Promise<Discovery> {
+    const canonicalRoot = await resolveRoot(this.root);
+    if (!canonicalRoot) {
+      return { summaries: [], paths: new Map() };
+    }
+    const entries = (await readdir(canonicalRoot, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
+      .sort((left, right) => left.name.localeCompare(right.name));
+    const summaries: SkillSummary[] = [];
+    const paths = new Map<string, string>();
+    const canonicalPaths = new Set<string>();
+
+    for (const entry of entries) {
+      const path = await resolveSkillPath(canonicalRoot, entry.name);
+      if (!path) {
+        continue;
+      }
+      assertContained(canonicalRoot, path);
+      if (canonicalPaths.has(path)) {
+        throw new Error(`Duplicate canonical skill path: ${path}`);
+      }
+      const definition = await this.readDefinition(path, entry.name, false);
+      if (paths.has(definition.name)) {
+        throw new Error(`Duplicate canonical skill name: ${definition.name}`);
+      }
+      canonicalPaths.add(path);
+      paths.set(definition.name, path);
+      summaries.push({
+        name: definition.name,
+        description: definition.description,
+      });
+    }
+    return { canonicalRoot, summaries, paths };
+  }
+
+  private async readDefinition(
+    path: string,
+    expectedName: string,
+    isReload: boolean,
+    signal?: AbortSignal,
+  ): Promise<SkillDefinition> {
+    try {
+      const parsed = parseSkillMarkdown(
+        await readFile(path, { encoding: 'utf8', signal }),
+        expectedName,
+      );
+      const tools = this.resolveTools(parsed.allowedToolNames);
+      return {
+        name: parsed.name,
+        description: parsed.description,
+        instructions: parsed.instructions,
+        ...(tools.length > 0 ? { tools } : {}),
+      };
+    } catch (error) {
+      const message = reloadErrorMessage(error, isReload);
+      throw new Error(`Invalid skill at ${path}: ${message}`, { cause: error });
+    }
+  }
+
+  private resolveTools(names: readonly string[]): Tool[] {
+    return names.map((name) => {
+      const resolved = this.toolCatalog.get(name);
+      if (!resolved) {
+        throw new Error(`Unknown allowed tool: ${name}`);
+      }
+      if (resolved.name !== name) {
+        throw new Error(
+          `Tool catalog entry ${name} resolves to ${resolved.name}`,
+        );
+      }
+      return resolved;
+    });
+  }
+}
+
+const resolveRoot = async (root: string): Promise<string | undefined> => {
+  try {
+    return await realpath(root);
+  } catch (error) {
+    if (hasErrorCode(error, 'ENOENT')) {
+      return undefined;
+    }
+    throw error;
+  }
+};
+
+const resolveSkillPath = async (
+  root: string,
+  directoryName: string,
+): Promise<string | undefined> => {
+  try {
+    return await realpath(join(root, directoryName, 'SKILL.md'));
+  } catch (error) {
+    if (hasErrorCode(error, 'ENOENT') || hasErrorCode(error, 'ENOTDIR')) {
+      return undefined;
+    }
+    throw error;
+  }
+};
+
+const assertContained = (root: string, path: string): void => {
+  const pathFromRoot = relative(root, path);
+  if (
+    isAbsolute(pathFromRoot) ||
+    pathFromRoot === '..' ||
+    pathFromRoot.startsWith(`..${sep}`)
+  ) {
+    throw new Error(`Skill path ${path} resolves outside the configured root`);
+  }
+};
+
+const reloadErrorMessage = (error: unknown, isReload: boolean): string => {
+  const message = error instanceof Error ? error.message : String(error);
+  if (isReload && message === 'Skill name must match its parent directory') {
+    return 'Skill canonical name changed after discovery';
+  }
+  return message;
+};
+
+const hasErrorCode = (error: unknown, code: string): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  error.code === code;

--- a/packages/agent-extensions/src/skills/filesystem/index.ts
+++ b/packages/agent-extensions/src/skills/filesystem/index.ts
@@ -1,0 +1,4 @@
+export {
+  FilesystemSkillSource,
+  type FilesystemSkillSourceConfig,
+} from './filesystem-skill-source';

--- a/packages/agent-extensions/src/skills/filesystem/skill-markdown.ts
+++ b/packages/agent-extensions/src/skills/filesystem/skill-markdown.ts
@@ -1,0 +1,99 @@
+import { parseDocument } from 'yaml';
+
+export interface ParsedSkillMarkdown {
+  readonly name: string;
+  readonly description: string;
+  readonly instructions: string;
+  readonly allowedToolNames: readonly string[];
+}
+
+export const parseSkillMarkdown = (
+  markdown: string,
+  expectedName: string,
+): ParsedSkillMarkdown => {
+  const { frontmatter, instructions } = splitMarkdown(markdown);
+  const metadata = parseFrontmatter(frontmatter);
+  const name = requiredString(metadata, 'name');
+  const description = requiredString(metadata, 'description');
+  validateName(name, expectedName);
+  if (description.length > 1024) {
+    throw new Error('Skill description must be at most 1024 characters');
+  }
+  const normalizedInstructions = instructions.trim();
+  if (!normalizedInstructions) {
+    throw new Error('Skill instructions must not be empty');
+  }
+
+  return {
+    name,
+    description,
+    instructions: normalizedInstructions,
+    allowedToolNames: parseAllowedTools(metadata['allowed-tools']),
+  };
+};
+
+const splitMarkdown = (
+  markdown: string,
+): { frontmatter: string; instructions: string } => {
+  const normalized = markdown.replaceAll('\r\n', '\n');
+  const match = /^---\n([\s\S]*?)\n---(?:\n|$)([\s\S]*)$/.exec(normalized);
+  if (!match) {
+    throw new Error('SKILL.md requires YAML frontmatter');
+  }
+  return { frontmatter: match[1], instructions: match[2] };
+};
+
+const parseFrontmatter = (frontmatter: string): Record<string, unknown> => {
+  const document = parseDocument(frontmatter, { uniqueKeys: true });
+  if (document.errors.length > 0) {
+    throw document.errors[0];
+  }
+  const value: unknown = document.toJS();
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('Skill frontmatter must be a YAML mapping');
+  }
+  return value as Record<string, unknown>;
+};
+
+const requiredString = (
+  metadata: Readonly<Record<string, unknown>>,
+  field: string,
+): string => {
+  const value = metadata[field];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Skill ${field} must be a non-empty string`);
+  }
+  return value;
+};
+
+const validateName = (name: string, expectedName: string): void => {
+  const validName = /^(?!-)(?!.*--)[a-z0-9-]{1,64}(?<!-)$/.test(name);
+  if (!validName) {
+    throw new Error('Skill name must match the Agent Skills name format');
+  }
+  if (name !== expectedName) {
+    throw new Error('Skill name must match its parent directory');
+  }
+};
+
+const parseAllowedTools = (value: unknown): string[] => {
+  if (value === undefined) {
+    return [];
+  }
+  const names =
+    typeof value === 'string'
+      ? value.split(/\s+/).filter(Boolean)
+      : parseAllowedToolArray(value);
+  const uniqueNames = new Set(names);
+  if (uniqueNames.size !== names.length) {
+    throw new Error('Duplicate allowed tool name');
+  }
+  return names;
+};
+
+const parseAllowedToolArray = (value: unknown): string[] => {
+  if (!Array.isArray(value) || value.some((name) => typeof name !== 'string')) {
+    throw new Error('allowed-tools must be a string or an array of strings');
+  }
+  return value as string[];
+};

--- a/packages/agent-extensions/src/skills/index.ts
+++ b/packages/agent-extensions/src/skills/index.ts
@@ -1,0 +1,8 @@
+export type {
+  SkillDefinition,
+  SkillLoadOptions,
+  SkillSource,
+  SkillSummary,
+} from './skill-source';
+export { skillsExtension } from './skills-extension';
+export type { SkillsExtensionConfig } from './skills-extension';

--- a/packages/agent-extensions/src/skills/skill-source.ts
+++ b/packages/agent-extensions/src/skills/skill-source.ts
@@ -1,0 +1,20 @@
+import type { Tool } from '@ayunis/agent-runtime';
+
+export interface SkillSummary {
+  readonly name: string;
+  readonly description: string;
+}
+
+export interface SkillDefinition extends SkillSummary {
+  readonly instructions: string;
+  readonly tools?: readonly Tool[];
+}
+
+export interface SkillLoadOptions {
+  readonly signal?: AbortSignal;
+}
+
+export interface SkillSource {
+  list(): Promise<readonly SkillSummary[]>;
+  load(name: string, options?: SkillLoadOptions): Promise<SkillDefinition>;
+}

--- a/packages/agent-extensions/src/skills/skills-extension.spec.ts
+++ b/packages/agent-extensions/src/skills/skills-extension.spec.ts
@@ -1,0 +1,501 @@
+import {
+  MockProvider,
+  run,
+  RunContext,
+  textTurn,
+  toolCallTurn,
+  type Hook,
+  type Tool,
+} from '@ayunis/agent-runtime';
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  SkillDefinition,
+  SkillSource,
+  SkillSummary,
+} from './skill-source';
+import { skillsExtension } from './skills-extension';
+
+const summaries: SkillSummary[] = [
+  { name: 'incident_response', description: 'Triage <urgent> incidents' },
+  { name: 'access_review', description: 'Review access & permissions' },
+];
+
+const definitions: Record<string, SkillDefinition> = {
+  access_review: {
+    name: 'access_review',
+    description: 'Review access & permissions',
+    instructions: 'Follow the access review checklist.',
+    tools: [tool('list_access')],
+  },
+  incident_response: {
+    name: 'incident_response',
+    description: 'Triage <urgent> incidents',
+    instructions: 'Follow the incident response playbook.',
+    tools: [tool('page_responder')],
+  },
+};
+
+function tool(name: string): Tool {
+  return {
+    name,
+    description: `${name} description`,
+    parameters: { type: 'object', properties: {} },
+    execute: () => `${name} result`,
+  };
+}
+
+function source(overrides: Partial<SkillSource> = {}): SkillSource {
+  return {
+    list: vi.fn(async () => summaries),
+    load: vi.fn(async (name) => {
+      const definition = definitions[name];
+      if (!definition) {
+        throw new Error(`Skill not found: ${name}`);
+      }
+      return definition;
+    }),
+    ...overrides,
+  };
+}
+
+type ExecutableTool = Tool & Required<Pick<Tool, 'execute'>>;
+
+function isExecutableTool(tool: Tool | undefined): tool is ExecutableTool {
+  return typeof tool?.execute === 'function';
+}
+
+async function initialize(skillSource: SkillSource = source()) {
+  const instance = await skillsExtension({ source: skillSource });
+  const activationTool = instance.tools?.[0];
+  const hook = instance.hooks?.[0];
+  if (!isExecutableTool(activationTool) || !hook) {
+    throw new Error('Skills extension did not expose its activation lifecycle');
+  }
+  return { instance, activationTool, hook };
+}
+
+function startRun(
+  hook: Hook,
+  context: RunContext,
+  tools: readonly Tool[] = [],
+) {
+  return hook.runStart?.({
+    context,
+    messages: [],
+    instructions: '',
+    tools: [...tools],
+    transformMessages: vi.fn(),
+    addTools: vi.fn(),
+    removeTools: vi.fn(),
+    setTools: vi.fn(),
+    addInstructions: vi.fn(),
+    setInstructions: vi.fn(),
+    abort: vi.fn(),
+    emit: vi.fn(),
+  });
+}
+
+async function executeActivation(
+  activationTool: ExecutableTool,
+  context: RunContext,
+  name: unknown,
+  toolCallId = `activate-${String(name)}`,
+  toolNames: readonly string[] = [activationTool.name],
+  signal?: AbortSignal,
+) {
+  return activationTool.execute(
+    { name },
+    {
+      context,
+      toolCallId,
+      toolNames,
+      signal,
+      emit: vi.fn(),
+      runChild: vi.fn(),
+    },
+  );
+}
+
+async function completeActivation(
+  hook: Hook,
+  context: RunContext,
+  toolCallId: string,
+  isError = false,
+) {
+  const addTools = vi.fn();
+  const addInstructions = vi.fn();
+  await hook.afterToolCall?.({
+    context,
+    iteration: 1,
+    toolCall: { id: toolCallId, name: 'activate_skill', input: {} },
+    result: isError ? 'activation failed' : 'activation succeeded',
+    isError,
+    outcome: isError ? 'error' : 'success',
+    isLastToolCall: true,
+    transformMessages: vi.fn(),
+    addTools,
+    removeTools: vi.fn(),
+    setTools: vi.fn(),
+    addInstructions,
+    setInstructions: vi.fn(),
+    abort: vi.fn(),
+    emit: vi.fn(),
+  });
+  return { addTools, addInstructions };
+}
+
+describe('skillsExtension', () => {
+  it('contributes no activation manifest when the source has no skills', async () => {
+    const skillSource = source({ list: vi.fn(async () => []) });
+
+    const instance = await skillsExtension({ source: skillSource });
+
+    expect(skillSource.list).toHaveBeenCalledOnce();
+    expect(instance).toEqual({ name: 'skills' });
+  });
+
+  it('lists once and exposes deterministic escaped summaries with an exact activation enum', async () => {
+    const skillSource = source();
+    const { instance, activationTool } = await initialize(skillSource);
+
+    expect(skillSource.list).toHaveBeenCalledTimes(1);
+    expect(instance.instructions).toContain(
+      '<name>access_review</name>\n    <description>Review access &amp; permissions</description>',
+    );
+    expect(instance.instructions).toContain(
+      '<name>incident_response</name>\n    <description>Triage &lt;urgent&gt; incidents</description>',
+    );
+    expect(instance.instructions?.indexOf('access_review')).toBeLessThan(
+      instance.instructions?.indexOf('incident_response') ?? 0,
+    );
+    expect(activationTool.parameters).toEqual({
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          enum: ['access_review', 'incident_response'],
+          description: 'The name of the skill to activate.',
+        },
+      },
+      required: ['name'],
+      additionalProperties: false,
+    });
+  });
+
+  it.each([{}, { name: 42 }, { name: 'unknown_skill' }])(
+    'validates activation input before execution: %j',
+    async (input) => {
+      const skillSource = source();
+      const { activationTool } = await initialize(skillSource);
+
+      expect(() => activationTool.validateInput?.(input)).toThrow(
+        /valid skill name|Unknown skill/,
+      );
+      expect(skillSource.load).not.toHaveBeenCalled();
+    },
+  );
+
+  it('returns source load failures as model-actionable tool errors', async () => {
+    const skillSource = source({
+      load: vi.fn(async () => {
+        throw new Error('definition disappeared');
+      }),
+    });
+    const { activationTool, hook } = await initialize(skillSource);
+    const context = RunContext.create();
+    await startRun(hook, context, [activationTool]);
+
+    await expect(
+      executeActivation(activationTool, context, 'access_review'),
+    ).resolves.toEqual({
+      result:
+        'Could not activate skill "access_review": definition disappeared',
+      isError: true,
+    });
+  });
+
+  it('returns invalid loaded definitions as model-actionable tool errors', async () => {
+    const skillSource = source({
+      load: vi.fn(async () => ({
+        ...definitions.access_review,
+        name: 'different_skill',
+      })),
+    });
+    const { activationTool, hook } = await initialize(skillSource);
+    const context = RunContext.create();
+    await startRun(hook, context, [activationTool]);
+
+    const result = await executeActivation(
+      activationTool,
+      context,
+      'access_review',
+    );
+
+    expect(result).toMatchObject({ isError: true });
+    expect((result as { result: string }).result).toContain(
+      'loaded definition name does not match',
+    );
+  });
+
+  it('injects a successfully loaded skill after its tool call for the next iteration', async () => {
+    const { activationTool, hook } = await initialize();
+    const context = RunContext.create();
+    await startRun(hook, context, [activationTool]);
+    const toolCallId = 'activate-access';
+
+    await expect(
+      executeActivation(activationTool, context, 'access_review', toolCallId),
+    ).resolves.toEqual({
+      result: 'Activated skill "access_review".',
+      isError: false,
+    });
+    const injection = await completeActivation(hook, context, toolCallId);
+
+    expect(injection.addInstructions).toHaveBeenCalledWith(
+      'Follow the access review checklist.',
+    );
+    expect(injection.addTools).toHaveBeenCalledWith(
+      definitions.access_review.tools?.[0],
+    );
+  });
+
+  it('never injects capabilities after a failed activation tool call', async () => {
+    const { activationTool, hook } = await initialize();
+    const context = RunContext.create();
+    await startRun(hook, context, [activationTool]);
+    const toolCallId = 'activate-access';
+    await executeActivation(
+      activationTool,
+      context,
+      'access_review',
+      toolCallId,
+    );
+
+    const injection = await completeActivation(hook, context, toolCallId, true);
+
+    expect(injection.addInstructions).not.toHaveBeenCalled();
+    expect(injection.addTools).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['a host tool', [tool('list_access')], 'list_access'],
+    ['the activation tool', [], 'activate_skill'],
+  ])('rejects activated tools that replace %s', async (_, hostTools, name) => {
+    const skillSource = source({
+      load: vi.fn(async () => ({
+        ...definitions.access_review,
+        tools: [tool(name)],
+      })),
+    });
+    const { activationTool, hook } = await initialize(skillSource);
+    const context = RunContext.create();
+    await startRun(hook, context, [activationTool, ...hostTools]);
+
+    const result = await executeActivation(
+      activationTool,
+      context,
+      'access_review',
+      'activate-access',
+      [activationTool.name, ...hostTools.map(({ name }) => name)],
+    );
+
+    expect(result).toMatchObject({ isError: true });
+    expect((result as { result: string }).result).toContain(
+      `tool name conflicts: ${name}`,
+    );
+  });
+
+  it('allows skill tools after a host removes the conflicting tool', async () => {
+    const hostTool = tool('list_access');
+    const { activationTool, hook } = await initialize();
+    const context = RunContext.create();
+    await startRun(hook, context, [activationTool, hostTool]);
+
+    const result = await executeActivation(
+      activationTool,
+      context,
+      'access_review',
+      'activate-access',
+      [activationTool.name],
+    );
+
+    expect(result).toEqual({
+      result: 'Activated skill "access_review".',
+      isError: false,
+    });
+  });
+
+  it('rejects skill tools that replace tools added by host runStart hooks', async () => {
+    const hostTool = tool('shared_tool');
+    const skillSource = source({
+      load: vi.fn(async () => ({
+        ...definitions.access_review,
+        tools: [tool('shared_tool')],
+      })),
+    });
+    const instance = await skillsExtension({ source: skillSource });
+    const model = new MockProvider([
+      toolCallTurn({
+        id: 'activate-access',
+        name: 'activate_skill',
+        input: { name: 'access_review' },
+      }),
+      textTurn('Activation handled.'),
+    ]);
+    const dynamicHostHook: Hook = {
+      name: 'dynamic-host-tools',
+      runStart: ({ addTools }) => addTools(hostTool),
+    };
+    const results: Array<{ result: string; isError: boolean }> = [];
+
+    for await (const event of run({
+      instructions: 'Use the available skills.',
+      model,
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'go' }] }],
+      tools: [...(instance.tools ?? [])],
+      hooks: [dynamicHostHook, ...(instance.hooks ?? [])],
+    })) {
+      if (event.type === 'tool_result') {
+        results.push({ result: event.result, isError: event.isError });
+      }
+    }
+
+    expect(results[0]).toEqual({
+      result:
+        'Could not activate skill "access_review": tool name conflicts: shared_tool',
+      isError: true,
+    });
+  });
+
+  it('passes the run abort signal to the skill source', async () => {
+    let receivedSignal: AbortSignal | undefined;
+    const skillSource = source({
+      load: vi.fn(
+        async (_name: string, options?: { readonly signal?: AbortSignal }) => {
+          receivedSignal = options?.signal;
+          return definitions.access_review;
+        },
+      ),
+    });
+    const { activationTool, hook } = await initialize(skillSource);
+    const context = RunContext.create();
+    const controller = new AbortController();
+    await startRun(hook, context, [activationTool]);
+
+    await executeActivation(
+      activationTool,
+      context,
+      'access_review',
+      'activate-access',
+      [activationTool.name],
+      controller.signal,
+    );
+
+    expect(receivedSignal).toBe(controller.signal);
+  });
+
+  it('does not load a skill when the run is already aborted', async () => {
+    const skillSource = source();
+    const { activationTool, hook } = await initialize(skillSource);
+    const context = RunContext.create();
+    const controller = new AbortController();
+    controller.abort();
+    await startRun(hook, context, [activationTool]);
+
+    const result = await executeActivation(
+      activationTool,
+      context,
+      'access_review',
+      'activate-access',
+      [activationTool.name],
+      controller.signal,
+    );
+
+    expect(result).toMatchObject({ isError: true });
+    expect(skillSource.load).not.toHaveBeenCalled();
+  });
+
+  it('rejects tools from a later skill that replace an activated tool', async () => {
+    const skillSource = source({
+      load: vi.fn(async (name) => ({
+        ...definitions[name],
+        tools: [tool('shared_tool')],
+      })),
+    });
+    const { activationTool, hook } = await initialize(skillSource);
+    const context = RunContext.create();
+    await startRun(hook, context, [activationTool]);
+    await executeActivation(activationTool, context, 'access_review', 'first');
+    await completeActivation(hook, context, 'first');
+
+    const result = await executeActivation(
+      activationTool,
+      context,
+      'incident_response',
+      'second',
+    );
+
+    expect(result).toMatchObject({ isError: true });
+    expect((result as { result: string }).result).toContain(
+      'tool name conflicts: shared_tool',
+    );
+  });
+
+  it('makes duplicate activation idempotent', async () => {
+    const skillSource = source();
+    const { activationTool, hook } = await initialize(skillSource);
+    const context = RunContext.create();
+    await startRun(hook, context, [activationTool]);
+    await executeActivation(activationTool, context, 'access_review', 'first');
+    await completeActivation(hook, context, 'first');
+
+    await expect(
+      executeActivation(activationTool, context, 'access_review', 'second'),
+    ).resolves.toEqual({
+      result: 'Skill "access_review" is already active.',
+      isError: false,
+    });
+    const injection = await completeActivation(hook, context, 'second');
+
+    expect(skillSource.load).toHaveBeenCalledTimes(1);
+    expect(injection.addInstructions).not.toHaveBeenCalled();
+    expect(injection.addTools).not.toHaveBeenCalled();
+  });
+
+  it('isolates pending and activated state across concurrent root and child runs', async () => {
+    const { activationTool, hook } = await initialize();
+    const root = RunContext.create();
+    const child = root.deriveChild();
+    await Promise.all([
+      startRun(hook, root, [activationTool]),
+      startRun(hook, child, [activationTool]),
+    ]);
+
+    await executeActivation(
+      activationTool,
+      root,
+      'access_review',
+      'root-activation',
+    );
+    const childBeforeActivation = await completeActivation(
+      hook,
+      child,
+      'root-activation',
+    );
+    await executeActivation(
+      activationTool,
+      child,
+      'access_review',
+      'child-activation',
+    );
+    const childActivation = await completeActivation(
+      hook,
+      child,
+      'child-activation',
+    );
+
+    expect(childBeforeActivation.addTools).not.toHaveBeenCalled();
+    expect(childActivation.addTools).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/agent-extensions/src/skills/skills-extension.ts
+++ b/packages/agent-extensions/src/skills/skills-extension.ts
@@ -1,0 +1,250 @@
+import type {
+  AfterToolCallContext,
+  Hook,
+  RunContext,
+  Tool,
+  ToolExecutionResult,
+} from '@ayunis/agent-runtime';
+
+import type { RuntimeExtension } from '../extensions/runtime-extension';
+import { buildAvailableSkills } from './available-skills';
+import type { SkillDefinition, SkillSource } from './skill-source';
+
+const ACTIVATE_SKILL = 'activate_skill';
+const RUN_STATE = Symbol('skills-extension-run-state');
+
+export interface SkillsExtensionConfig {
+  readonly source: SkillSource;
+}
+
+interface PendingActivation {
+  readonly name: string;
+  readonly definition: SkillDefinition;
+  readonly toolNames: readonly string[];
+}
+
+interface SkillsRunState {
+  readonly activatedNames: Set<string>;
+  readonly pendingToolNames: Set<string>;
+  readonly pendingByCall: Map<string, PendingActivation>;
+  readonly pendingNames: Set<string>;
+}
+
+export const skillsExtension: RuntimeExtension<SkillsExtensionConfig> = async ({
+  source,
+}) => {
+  const available = buildAvailableSkills(await source.list());
+  if (available.names.length === 0) {
+    return { name: 'skills' };
+  }
+  const knownNames = new Set(available.names);
+  const activationTool = createActivationTool(source, knownNames);
+
+  return {
+    name: 'skills',
+    tools: [activationTool],
+    instructions: available.instructions,
+    hooks: [createSkillsHook()],
+  };
+};
+
+const createActivationTool = (
+  source: SkillSource,
+  knownNames: ReadonlySet<string>,
+): Tool => ({
+  name: ACTIVATE_SKILL,
+  description:
+    'Load one available skill and make its instructions and tools available.',
+  parameters: buildActivationSchema(knownNames),
+  validateInput: (input) => {
+    parseSkillName(input, knownNames);
+  },
+  execute: async (input, { context, signal, toolCallId, toolNames }) => {
+    const name = parseSkillName(input, knownNames);
+    const state = getRunState(context);
+    if (!state) {
+      return activationError(name, 'skill run state is unavailable');
+    }
+    if (state.activatedNames.has(name) || state.pendingNames.has(name)) {
+      return activationSuccess(`Skill "${name}" is already active.`);
+    }
+    return loadActivation({
+      source,
+      state,
+      name,
+      toolCallId,
+      currentToolNames: toolNames,
+      signal,
+    });
+  },
+});
+
+const buildActivationSchema = (knownNames: ReadonlySet<string>) => ({
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+      enum: [...knownNames],
+      description: 'The name of the skill to activate.',
+    },
+  },
+  required: ['name'],
+  additionalProperties: false,
+});
+
+const parseSkillName = (
+  input: Record<string, unknown>,
+  knownNames: ReadonlySet<string>,
+): string => {
+  if (
+    typeof input.name !== 'string' ||
+    input.name.length === 0 ||
+    Object.keys(input).some((key) => key !== 'name')
+  ) {
+    throw new Error('activate_skill requires exactly one valid skill name');
+  }
+  if (!knownNames.has(input.name)) {
+    throw new Error(`Unknown skill: ${input.name}`);
+  }
+  return input.name;
+};
+
+interface LoadActivationParams {
+  readonly source: SkillSource;
+  readonly state: SkillsRunState;
+  readonly name: string;
+  readonly toolCallId: string;
+  readonly currentToolNames: readonly string[];
+  readonly signal?: AbortSignal;
+}
+
+const loadActivation = async ({
+  source,
+  state,
+  name,
+  toolCallId,
+  currentToolNames,
+  signal,
+}: LoadActivationParams): Promise<ToolExecutionResult> => {
+  try {
+    signal?.throwIfAborted();
+    const definition = await source.load(name, { signal });
+    signal?.throwIfAborted();
+    validateDefinition(definition, name);
+    const toolNames = claimToolNames(
+      state,
+      definition.tools ?? [],
+      currentToolNames,
+    );
+    state.pendingNames.add(name);
+    state.pendingByCall.set(toolCallId, { name, definition, toolNames });
+    return activationSuccess(`Activated skill "${name}".`);
+  } catch (error) {
+    return activationError(name, errorMessage(error));
+  }
+};
+
+const validateDefinition = (
+  definition: SkillDefinition,
+  requestedName: string,
+): void => {
+  if (definition.name !== requestedName) {
+    throw new Error(
+      'loaded definition name does not match the requested skill',
+    );
+  }
+  if (!definition.description || !definition.instructions) {
+    throw new Error(
+      'loaded definition requires a description and instructions',
+    );
+  }
+  if (definition.tools !== undefined && !Array.isArray(definition.tools)) {
+    throw new TypeError('loaded definition tools must be an array');
+  }
+};
+
+const claimToolNames = (
+  state: SkillsRunState,
+  tools: readonly Tool[],
+  currentToolNames: readonly string[],
+): string[] => {
+  const claimed = new Set([...currentToolNames, ...state.pendingToolNames]);
+  const toolNames: string[] = [];
+  for (const skillTool of tools) {
+    if (!skillTool.name || claimed.has(skillTool.name)) {
+      throw new Error(`tool name conflicts: ${skillTool.name}`);
+    }
+    claimed.add(skillTool.name);
+    toolNames.push(skillTool.name);
+  }
+  for (const name of toolNames) {
+    state.pendingToolNames.add(name);
+  }
+  return toolNames;
+};
+
+const createSkillsHook = (): Hook => ({
+  name: 'skills-activation',
+  runStart: ({ context }) => {
+    context.set<SkillsRunState>(RUN_STATE, {
+      activatedNames: new Set(),
+      pendingToolNames: new Set(),
+      pendingByCall: new Map(),
+      pendingNames: new Set(),
+    });
+  },
+  beforeModelCall: ({ context }) => {
+    getRunState(context)?.pendingToolNames.clear();
+  },
+  afterToolCall: (context) => {
+    applyPendingActivation(context);
+  },
+});
+
+const applyPendingActivation = (context: AfterToolCallContext): void => {
+  if (context.toolCall.name !== ACTIVATE_SKILL) {
+    return;
+  }
+  const state = getRunState(context.context);
+  const pending = state?.pendingByCall.get(context.toolCall.id);
+  if (!state || !pending) {
+    return;
+  }
+  state.pendingByCall.delete(context.toolCall.id);
+  state.pendingNames.delete(pending.name);
+  if (context.isError) {
+    releaseToolNames(state, pending.toolNames);
+    return;
+  }
+  state.activatedNames.add(pending.name);
+  context.addInstructions(pending.definition.instructions);
+  context.addTools(...(pending.definition.tools ?? []));
+};
+
+const releaseToolNames = (
+  state: SkillsRunState,
+  toolNames: readonly string[],
+): void => {
+  for (const name of toolNames) {
+    state.pendingToolNames.delete(name);
+  }
+};
+
+const getRunState = (context: RunContext): SkillsRunState | undefined =>
+  context.get<SkillsRunState>(RUN_STATE);
+
+const activationSuccess = (result: string): ToolExecutionResult => ({
+  result,
+  isError: false,
+});
+
+const activationError = (
+  name: string,
+  reason: string,
+): ToolExecutionResult => ({
+  result: `Could not activate skill "${name}": ${reason}`,
+  isError: true,
+});
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);

--- a/packages/agent-extensions/tsup.config.ts
+++ b/packages/agent-extensions/tsup.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/mcp/index.ts'],
+  entry: [
+    'src/index.ts',
+    'src/mcp/index.ts',
+    'src/skills/index.ts',
+    'src/skills/filesystem/index.ts',
+  ],
   format: ['esm', 'cjs'],
   dts: {
     compilerOptions: { ignoreDeprecations: '6.0' },

--- a/packages/agent-runtime/src/contracts/tool.ts
+++ b/packages/agent-runtime/src/contracts/tool.ts
@@ -13,6 +13,8 @@ export interface ToolExecutionContext {
   /** The run's context bag (host data: tenancy, identity, per-run state). */
   readonly context: RunContext;
   readonly toolCallId: string;
+  /** Names in the effective tool set at the start of this execution. */
+  readonly toolNames: readonly string[];
   readonly signal?: AbortSignal;
   /** Emits a `custom` RunEvent into the run's event stream. */
   emit(event: CustomEventInput): void;

--- a/packages/agent-runtime/src/engine/tool-executor.ts
+++ b/packages/agent-runtime/src/engine/tool-executor.ts
@@ -222,6 +222,7 @@ const buildToolContext = (
   return {
     context: state.context,
     toolCallId,
+    toolNames: state.tools.map(({ name }) => name),
     signal: state.signal,
     emit: (event) => state.emits.push(event),
     runChild: state.runChild,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -685,6 +685,9 @@ importers:
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
         version: 2.0.0
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@ayunis/agent-runtime':
         specifier: workspace:*


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the runtime tool execution contract (`toolNames`) and dynamically adds tools/instructions mid-run; filesystem loading adds path-safety surface area though it is explicitly guarded and tested.
> 
> **Overview**
> Adds **progressive-disclosure skills** to `@ayunis/agent-extensions` via new subpaths `@ayunis/agent-extensions/skills` and `@ayunis/agent-extensions/skills/filesystem`. Hosts plug in a `SkillSource`; init lists skills once and exposes static instructions plus an `activate_skill` tool. Successful activation loads the definition (with abort forwarded to `load`) and injects instructions and tools on `afterToolCall` for the next iteration, with per-run state in `RunContext`, idempotent re-activation, and model-actionable errors on load failures or tool-name conflicts.
> 
> The optional **`FilesystemSkillSource`** discovers immediate child folders with `SKILL.md` (YAML frontmatter, `allowed-tools` resolved through a host catalog), caches discovery, re-reads the selected file on activation, and enforces root containment against traversal/symlinks.
> 
> **`@ayunis/agent-runtime`** extends `ToolExecutionContext` with `toolNames` (effective tool set at execution start) so the skills extension can detect collisions with host or hook-added tools. Package build/knip exports, `yaml` dependency, README, and broad tests accompany the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0616309f3c922748b660e319e742565c0e92b5d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->