### PR TITLE
fix(observability): allow frontend appsignal telemetry (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/common/middleware/security-headers.middleware.spec.ts
+++ b/ayunis-core-backend/src/common/middleware/security-headers.middleware.spec.ts
@@ -1,0 +1,39 @@
+import { createServer } from 'node:http';
+import type { Request, Response } from 'express';
+import { createPinoLoggerMock } from '../testing/pino-logger.mock';
+import { SecurityHeadersMiddleware } from './security-headers.middleware';
+
+describe('SecurityHeadersMiddleware', () => {
+  it('allows browser telemetry to reach the AppSignal collector', async () => {
+    const middleware = new SecurityHeadersMiddleware(createPinoLoggerMock());
+    const server = createServer((request, response) => {
+      middleware.use(
+        request as unknown as Request,
+        response as unknown as Response,
+        () => response.end(),
+      );
+    });
+
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve),
+    );
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Test server did not bind to a TCP port');
+      }
+
+      const response = await fetch(`http://127.0.0.1:${address.port}`);
+      const policy = response.headers.get('content-security-policy');
+
+      expect(policy).toContain(
+        "connect-src 'self' https://appsignal-endpoint.net",
+      );
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+});

--- a/ayunis-core-backend/src/common/middleware/security-headers.middleware.ts
+++ b/ayunis-core-backend/src/common/middleware/security-headers.middleware.ts
@@ -17,6 +17,7 @@ export class SecurityHeadersMiddleware implements NestMiddleware {
         ...helmet.contentSecurityPolicy.getDefaultDirectives(),
         'script-src': ["'self'", "'unsafe-inline'"],
         'style-src': ["'self'", "'unsafe-inline'"],
+        'connect-src': ["'self'", 'https://appsignal-endpoint.net'],
       },
     },
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small CSP allowlist change for a single HTTPS telemetry host, with regression coverage and no auth or data-path changes.
> 
> **Overview**
> Unblocks browser AppSignal reporting by extending the Helmet **Content-Security-Policy** `connect-src` directive to allow `https://appsignal-endpoint.net` alongside `'self'`.
> 
> Adds an integration test on `SecurityHeadersMiddleware` that serves a real HTTP response and asserts the emitted CSP includes that `connect-src` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f2be99876568342c86e499549370bd7de8cdb7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->