### PR TITLE
wip(agent-sdk): add foundational extensions (AYC-792)

### DIFF
--- a/packages/agent-extensions/README.md
+++ b/packages/agent-extensions/README.md
@@ -1,10 +1,10 @@
 # @ayunis/agent-extensions
 
-Public contracts and built-in capabilities for run-scoped agent extensions.
-The package depends on `@ayunis/agent-runtime`, while execution and lifecycle
-coordination belong to the private machinery in `@ayunis/agent-harness`.
+Run-scoped extension definitions and built-in capabilities for Ayunis agents.
+The package depends on `@ayunis/agent-runtime`; the private engine in
+`@ayunis/agent-harness` owns setup, reconciliation, transactions, and cleanup.
 
-## Definitions and configuration
+## Define an extension
 
 ```ts
 import { defineExtension } from '@ayunis/agent-extensions';
@@ -26,17 +26,72 @@ const Counter = defineExtension({
 const configured = Counter.configure({ initial: 0 });
 ```
 
-A definition has stable identity. `.configure()` copies and freezes configuration
-without running setup, allocating state, or acquiring resources. Each agent run
-later calls `setup()` once, then synchronously projects its current state through
-`contribute()`.
+Each `agent.run()` sets up a fresh instance. `setup()` keeps mutable state, its
+API, owned resources, and cleanup together. Synchronous `contribute()` derives
+instructions, tools, and structurally stable hooks from the current state.
+State updates are batched and reconciled before the next model request.
 
 During setup, `ctx.use(Extension)` obtains a required run-local API and
-`ctx.useOptional(Extension)` performs optional lookup. `ctx.state()` creates
-state owned by the current extension, and `ctx.own()` registers cleanup. The
-private harness engine makes both state updates and resource ownership
-transaction-aware.
+`ctx.useOptional(Extension)` performs optional lookup. `ctx.own()` registers
+run-owned cleanup. The harness makes state changes and resources acquired during
+skill activation transactional.
 
-This package intentionally exposes no extension session, registry, or runner.
-Hosts provide authorization, credentials, persistence, and infrastructure;
-`@ayunis/agent-harness` owns execution and cleanup.
+## Built-in capabilities
+
+Built-ins use optional subpath imports so root consumers do not load MCP, YAML,
+or filesystem code.
+
+```ts
+import { KnowledgeBases } from '@ayunis/agent-extensions/knowledge-bases';
+import { Mcp } from '@ayunis/agent-extensions/mcp';
+import { Skills } from '@ayunis/agent-extensions/skills';
+import { FilesystemSkillSource } from '@ayunis/agent-extensions/skills/filesystem';
+```
+
+- `KnowledgeBases` resolves authorized IDs and derives its instructions and
+  aggregate query/text tools from one sorted active snapshot.
+- `Mcp` resolves authorized connection IDs, owns one client per run connection,
+  discovers tools transactionally, and maps deterministic model names back to
+  original server/tool identities.
+- `Skills` lists one catalog, contributes one `activate_skill` tool, and manages
+  plain definitions created with `Skills.define()`.
+- `FilesystemSkillSource` is optional. It discovers immediate `SKILL.md`
+  children, keeps a canonical path map, validates containment, and lazily
+  reloads only the selected definition.
+
+## Configure an agent
+
+```ts
+import { createAgent } from '@ayunis/agent-harness';
+import { KnowledgeBases } from '@ayunis/agent-extensions/knowledge-bases';
+import { Skills } from '@ayunis/agent-extensions/skills';
+
+const legalResearch = Skills.define({
+  name: 'legal-research',
+  description: 'Research laws and regulations.',
+  instructions: 'Prefer primary legal sources.',
+  async activate(ctx) {
+    await ctx.use(KnowledgeBases).add(['municipal-law']);
+  },
+});
+
+const agent = createAgent({
+  name: 'research-agent',
+  instructions: 'Answer with cited evidence.',
+  model: { deployment: 'host-selected' },
+  resolveModel: hostModelResolver,
+  extensions: [
+    KnowledgeBases.configure({
+      resolveAuthorized: resolveKnowledgeBases,
+      query: queryKnowledgeBase,
+      getText: getKnowledgeBaseText,
+    }),
+    Skills.configure({ source: hostSkillSource(legalResearch) }),
+  ],
+});
+```
+
+Hosts remain responsible for authorization, credentials, persistence,
+transports, model resolution, and infrastructure. These packages contain no
+Ayunis Core database or tenancy dependency and expose no public extension
+registry, session runner, or state store.

--- a/packages/agent-extensions/knip.json
+++ b/packages/agent-extensions/knip.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
-  "entry": ["src/index.ts"],
+  "entry": [
+    "src/index.ts",
+    "src/knowledge-bases/index.ts",
+    "src/mcp/index.ts",
+    "src/skills/index.ts",
+    "src/skills/filesystem/index.ts"
+  ],
   "project": ["src/**/*.ts"],
   "ignore": ["**/*.spec.ts"]
 }

--- a/packages/agent-extensions/package.json
+++ b/packages/agent-extensions/package.json
@@ -15,6 +15,26 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./knowledge-bases": {
+      "types": "./dist/knowledge-bases/index.d.ts",
+      "import": "./dist/knowledge-bases/index.js",
+      "require": "./dist/knowledge-bases/index.cjs"
+    },
+    "./mcp": {
+      "types": "./dist/mcp/index.d.ts",
+      "import": "./dist/mcp/index.js",
+      "require": "./dist/mcp/index.cjs"
+    },
+    "./skills": {
+      "types": "./dist/skills/index.d.ts",
+      "import": "./dist/skills/index.js",
+      "require": "./dist/skills/index.cjs"
+    },
+    "./skills/filesystem": {
+      "types": "./dist/skills/filesystem/index.d.ts",
+      "import": "./dist/skills/filesystem/index.js",
+      "require": "./dist/skills/filesystem/index.cjs"
     }
   },
   "files": [
@@ -31,7 +51,9 @@
     "deps:check": "madge --circular --extensions ts src"
   },
   "dependencies": {
-    "@ayunis/agent-runtime": "workspace:*"
+    "@ayunis/agent-runtime": "workspace:*",
+    "@modelcontextprotocol/client": "^2.0.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",

--- a/packages/agent-extensions/src/knowledge-bases/index.ts
+++ b/packages/agent-extensions/src/knowledge-bases/index.ts
@@ -1,0 +1,14 @@
+export { KnowledgeBases } from './knowledge-bases';
+export type {
+  KnowledgeBaseApi,
+  KnowledgeBaseConfig,
+  KnowledgeBaseState,
+  KnowledgeBaseSummary,
+  KnowledgeBaseUsageEvent,
+} from './knowledge-bases';
+export type {
+  KnowledgeGetTextInput,
+  KnowledgeGetTextPort,
+  KnowledgeQueryInput,
+  KnowledgeQueryPort,
+} from './knowledge-tools';

--- a/packages/agent-extensions/src/knowledge-bases/knowledge-bases.spec.ts
+++ b/packages/agent-extensions/src/knowledge-bases/knowledge-bases.spec.ts
@@ -1,0 +1,294 @@
+import type {
+  AfterToolCallContext,
+  RunContext,
+  RunEvent,
+  ToolExecutionContext,
+} from '@ayunis/agent-runtime';
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  ExtensionApi,
+  ExtensionContext,
+  ExtensionDefinitionIdentity,
+  ExtensionState,
+} from '../extensions/context';
+import {
+  KnowledgeBases,
+  type KnowledgeBaseConfig,
+  type KnowledgeBaseSummary,
+} from './knowledge-bases';
+
+const alpha: KnowledgeBaseSummary = { id: 'alpha', name: 'Alpha & more' };
+const beta: KnowledgeBaseSummary = { id: 'beta', name: 'Beta' };
+
+const createConfig = (
+  overrides: Partial<KnowledgeBaseConfig> = {},
+): KnowledgeBaseConfig => ({
+  resolveAuthorized: vi.fn(async (ids: readonly string[]) =>
+    ids.map((id) => ({ id, name: id.toUpperCase() })),
+  ),
+  query: vi.fn(async () => 'query result'),
+  getText: vi.fn(async () => 'text result'),
+  ...overrides,
+});
+
+describe('KnowledgeBases', () => {
+  it('contributes nothing while no knowledge base is active', async () => {
+    const run = await setupKnowledgeBases(createConfig());
+
+    expect(run.contribution()).toEqual({ hooks: [run.hook] });
+  });
+
+  it.each([
+    {
+      name: 'missing',
+      resolved: [alpha],
+      expected: /missing.*beta/i,
+    },
+    {
+      name: 'duplicate',
+      resolved: [alpha, alpha],
+      expected: /duplicate.*alpha/i,
+    },
+    {
+      name: 'unrequested',
+      resolved: [alpha, { id: 'gamma', name: 'Gamma' }],
+      expected: /unrequested.*gamma/i,
+    },
+  ])(
+    'commits nothing for $name resolver results',
+    async ({ resolved, expected }) => {
+      const run = await setupKnowledgeBases(
+        createConfig({ resolveAuthorized: vi.fn(async () => resolved) }),
+      );
+
+      await expect(run.api.add(['alpha', 'beta'])).rejects.toThrow(expected);
+      expect(run.active()).toEqual([]);
+      expect(run.contribution().tools).toBeUndefined();
+    },
+  );
+
+  it('rejects duplicate requested IDs before resolving', async () => {
+    const resolveAuthorized = vi.fn(async () => [alpha]);
+    const run = await setupKnowledgeBases(createConfig({ resolveAuthorized }));
+
+    await expect(run.api.add(['alpha', 'alpha'])).rejects.toThrow(
+      /duplicate requested.*alpha/i,
+    );
+    expect(resolveAuthorized).not.toHaveBeenCalled();
+  });
+
+  it('adds and removes deterministically and idempotently', async () => {
+    const resolveAuthorized = vi.fn(async () => [beta, alpha]);
+    const run = await setupKnowledgeBases(createConfig({ resolveAuthorized }));
+
+    await run.api.add(['beta', 'alpha']);
+    await run.api.add(['alpha', 'beta']);
+    run.api.remove(['missing', 'alpha', 'alpha']);
+    run.api.remove(['alpha']);
+
+    expect(resolveAuthorized).toHaveBeenCalledOnce();
+    expect(run.active()).toEqual([beta]);
+  });
+
+  it('derives escaped instructions and both schemas from one sorted snapshot', async () => {
+    const run = await setupKnowledgeBases(
+      createConfig({ resolveAuthorized: vi.fn(async () => [beta, alpha]) }),
+    );
+    await run.api.add(['beta', 'alpha']);
+
+    const contribution = run.contribution();
+    expect(contribution.instructions).toContain(
+      '<knowledge_base id="alpha" name="Alpha &amp; more" />',
+    );
+    expect(contribution.instructions?.indexOf('alpha')).toBeLessThan(
+      contribution.instructions?.indexOf('beta') ?? 0,
+    );
+    expect(contribution.tools?.map(({ name }) => name)).toEqual([
+      'knowledge_query',
+      'knowledge_get_text',
+    ]);
+    for (const tool of contribution.tools ?? []) {
+      expect(
+        (
+          tool.parameters.properties as Record<
+            string,
+            { enum?: readonly string[] }
+          >
+        ).knowledgeBaseId.enum,
+      ).toEqual(['alpha', 'beta']);
+    }
+  });
+
+  it('delegates validated typed input and runtime context to host ports', async () => {
+    const query = vi.fn(async () => 'query result');
+    const getText = vi.fn(async () => 'text result');
+    const run = await setupKnowledgeBases(createConfig({ query, getText }));
+    await run.api.add(['alpha']);
+    const [queryTool, textTool] = run.contribution().tools ?? [];
+    const context = toolContext();
+
+    await expect(
+      queryTool.execute?.(
+        { knowledgeBaseId: 'alpha', query: 'permits' },
+        context,
+      ),
+    ).resolves.toBe('query result');
+    await expect(
+      textTool.execute?.(
+        {
+          knowledgeBaseId: 'alpha',
+          documentId: 'doc-1',
+          startLine: 2,
+          numLines: 4,
+        },
+        context,
+      ),
+    ).resolves.toBe('text result');
+    expect(query).toHaveBeenCalledWith(
+      { knowledgeBaseId: 'alpha', query: 'permits' },
+      context,
+    );
+    expect(getText).toHaveBeenCalledWith(
+      {
+        knowledgeBaseId: 'alpha',
+        documentId: 'doc-1',
+        startLine: 2,
+        numLines: 4,
+      },
+      context,
+    );
+  });
+
+  it('applies advertised text defaults before delegating to the host', async () => {
+    const getText = vi.fn(async () => 'text result');
+    const run = await setupKnowledgeBases(createConfig({ getText }));
+    await run.api.add(['alpha']);
+    const textTool = run
+      .contribution()
+      .tools?.find(({ name }) => name === 'knowledge_get_text');
+    const context = toolContext();
+
+    await textTool?.execute?.(
+      { knowledgeBaseId: 'alpha', documentId: 'doc-1' },
+      context,
+    );
+
+    expect(getText).toHaveBeenCalledWith(
+      {
+        knowledgeBaseId: 'alpha',
+        documentId: 'doc-1',
+        startLine: 1,
+        numLines: 100,
+      },
+      context,
+    );
+  });
+
+  it('keeps one usage hook that observes current active knowledge bases', async () => {
+    const recordUsage = vi.fn();
+    const run = await setupKnowledgeBases(createConfig({ recordUsage }));
+    const hook = run.hook;
+    await run.api.add(['alpha']);
+
+    await hook.afterToolCall?.(
+      afterToolCallContext('knowledge_query') as AfterToolCallContext,
+    );
+    run.api.remove(['alpha']);
+    await hook.afterToolCall?.(
+      afterToolCallContext('knowledge_get_text') as AfterToolCallContext,
+    );
+
+    expect(
+      recordUsage.mock.calls.map(([event]) => event.activeKnowledgeBases),
+    ).toEqual([[{ id: 'alpha', name: 'ALPHA' }], []]);
+    expect(run.contribution().hooks?.[0]).toBe(hook);
+  });
+
+  it('does not share active knowledge bases between controlled runs', async () => {
+    const configured = KnowledgeBases.configure(createConfig());
+    const first = await setupConfigured(
+      configured.definition,
+      configured.config,
+    );
+    const second = await setupConfigured(
+      configured.definition,
+      configured.config,
+    );
+
+    await first.api.add(['alpha']);
+
+    expect(first.active()).toHaveLength(1);
+    expect(second.active()).toEqual([]);
+  });
+});
+
+const setupKnowledgeBases = (config: KnowledgeBaseConfig) =>
+  setupConfigured(KnowledgeBases, config);
+
+const setupConfigured = async (
+  definition: typeof KnowledgeBases,
+  config: Readonly<KnowledgeBaseConfig>,
+) => {
+  const controlled = controlledContext();
+  const setup = await definition.setup(controlled.context, config);
+  const contribution = () =>
+    definition.contribute(
+      { state: setup.state.current, api: setup.api },
+      config,
+    );
+  const hook = contribution().hooks?.[0];
+  if (!hook) throw new Error('Expected the stable usage hook.');
+  return {
+    api: setup.api,
+    hook,
+    contribution,
+    active: () => [...setup.state.current.knowledgeBases.values()],
+  };
+};
+
+const controlledContext = (): { context: ExtensionContext } => ({
+  context: {
+    extensionName: 'knowledge-bases',
+    state: <State>(initial: State): ExtensionState<State> => {
+      let value = initial;
+      return {
+        get current() {
+          return value;
+        },
+        update(updater) {
+          value = updater(value);
+        },
+      };
+    },
+    use: <Definition extends ExtensionDefinitionIdentity>(
+      definition: Definition,
+    ): ExtensionApi<Definition> => {
+      throw new Error(`Missing controlled API: ${definition.name}`);
+    },
+    useOptional: () => undefined,
+    own: () => undefined,
+  },
+});
+
+const toolContext = (): ToolExecutionContext =>
+  ({
+    context: {} as RunContext,
+    toolCallId: 'call-1',
+    toolNames: ['knowledge_query', 'knowledge_get_text'],
+    signal: new AbortController().signal,
+    emit: vi.fn(),
+    runChild: () => emptyChildRun(),
+  }) satisfies ToolExecutionContext;
+
+async function* emptyChildRun(): AsyncGenerator<RunEvent> {
+  yield* [];
+}
+
+const afterToolCallContext = (name: string) => ({
+  toolCall: { id: 'call-1', name, input: {} },
+  result: 'ok',
+  isError: false,
+  outcome: 'success' as const,
+  isLastToolCall: true,
+});

--- a/packages/agent-extensions/src/knowledge-bases/knowledge-bases.ts
+++ b/packages/agent-extensions/src/knowledge-bases/knowledge-bases.ts
@@ -1,0 +1,201 @@
+import type { AfterToolCallContext, Hook } from '@ayunis/agent-runtime';
+
+import type { ExtensionState } from '../extensions/context';
+import { defineExtension } from '../extensions/extension';
+import { buildKnowledgeInstructions } from './knowledge-instructions';
+import {
+  createKnowledgeTools,
+  type KnowledgeGetTextPort,
+  type KnowledgeQueryPort,
+} from './knowledge-tools';
+
+export interface KnowledgeBaseSummary {
+  readonly id: string;
+  readonly name: string;
+}
+
+export interface KnowledgeBaseState {
+  readonly knowledgeBases: ReadonlyMap<string, KnowledgeBaseSummary>;
+}
+
+export interface KnowledgeBaseUsageEvent {
+  readonly event: AfterToolCallContext;
+  readonly activeKnowledgeBases: readonly KnowledgeBaseSummary[];
+}
+
+export interface KnowledgeBaseConfig {
+  resolveAuthorized(
+    ids: readonly string[],
+  ): Promise<readonly KnowledgeBaseSummary[]>;
+  query: KnowledgeQueryPort;
+  getText: KnowledgeGetTextPort;
+  recordUsage?(event: KnowledgeBaseUsageEvent): void | Promise<void>;
+}
+
+export interface KnowledgeBaseApi {
+  add(ids: readonly string[]): Promise<void>;
+  remove(ids: readonly string[]): void;
+}
+
+const usageHook = Symbol('knowledge-base-usage-hook');
+interface RuntimeKnowledgeBaseApi extends KnowledgeBaseApi {
+  readonly [usageHook]: Hook;
+}
+
+export const KnowledgeBases = defineExtension<
+  'knowledge-bases',
+  KnowledgeBaseState,
+  KnowledgeBaseApi,
+  KnowledgeBaseConfig
+>({
+  name: 'knowledge-bases',
+  setup(context, config) {
+    const state = context.state<KnowledgeBaseState>({
+      knowledgeBases: new Map(),
+    });
+    const api = createApi(state, config);
+    return { state, api };
+  },
+  contribute({ state, api }, config) {
+    const active = sortedSummaries(state.knowledgeBases.values());
+    const hook = (api as RuntimeKnowledgeBaseApi)[usageHook];
+    if (active.length === 0) {
+      return { hooks: [hook] };
+    }
+    const ids = active.map(({ id }) => id);
+    return {
+      instructions: buildKnowledgeInstructions(active),
+      tools: createKnowledgeTools({
+        knowledgeBaseIds: ids,
+        query: config.query,
+        getText: config.getText,
+      }),
+      hooks: [hook],
+    };
+  },
+});
+
+const createApi = (
+  state: ExtensionState<KnowledgeBaseState>,
+  config: Readonly<KnowledgeBaseConfig>,
+): RuntimeKnowledgeBaseApi => {
+  const api: RuntimeKnowledgeBaseApi = {
+    add: (ids) => addKnowledgeBases(state, config, ids),
+    remove: (ids) => removeKnowledgeBases(state, ids),
+    [usageHook]: createUsageHook(state, config),
+  };
+  return api;
+};
+
+const addKnowledgeBases = async (
+  state: ExtensionState<KnowledgeBaseState>,
+  config: Readonly<KnowledgeBaseConfig>,
+  requestedIds: readonly string[],
+): Promise<void> => {
+  assertUniqueRequestedIds(requestedIds);
+  const missingIds = requestedIds.filter(
+    (id) => !state.current.knowledgeBases.has(id),
+  );
+  if (missingIds.length === 0) {
+    return;
+  }
+  const resolved = await config.resolveAuthorized([...missingIds]);
+  validateResolved(missingIds, resolved);
+  state.update((current) => ({
+    knowledgeBases: mergeKnowledgeBases(current.knowledgeBases, resolved),
+  }));
+};
+
+const removeKnowledgeBases = (
+  state: ExtensionState<KnowledgeBaseState>,
+  ids: readonly string[],
+): void => {
+  const removed = new Set(ids);
+  const remaining = [...state.current.knowledgeBases.values()].filter(
+    ({ id }) => !removed.has(id),
+  );
+  if (remaining.length === state.current.knowledgeBases.size) {
+    return;
+  }
+  state.update(() => ({ knowledgeBases: toSortedMap(remaining) }));
+};
+
+const validateResolved = (
+  requestedIds: readonly string[],
+  resolved: readonly KnowledgeBaseSummary[],
+): void => {
+  const requested = new Set(requestedIds);
+  const resolvedIds = new Set<string>();
+  for (const summary of resolved) {
+    validateSummary(summary);
+    if (resolvedIds.has(summary.id)) {
+      throw new Error(`Duplicate resolved knowledge base '${summary.id}'.`);
+    }
+    if (!requested.has(summary.id)) {
+      throw new Error(
+        `Unrequested knowledge base '${summary.id}' was resolved.`,
+      );
+    }
+    resolvedIds.add(summary.id);
+  }
+  const missing = requestedIds.find((id) => !resolvedIds.has(id));
+  if (missing) {
+    throw new Error(`Missing authorized knowledge base '${missing}'.`);
+  }
+};
+
+const validateSummary = (summary: KnowledgeBaseSummary): void => {
+  if (!summary.id || !summary.name) {
+    throw new Error('Resolved knowledge bases require non-empty id and name.');
+  }
+};
+
+const assertUniqueRequestedIds = (ids: readonly string[]): void => {
+  const seen = new Set<string>();
+  for (const id of ids) {
+    if (!id) {
+      throw new Error('Knowledge base IDs must not be empty.');
+    }
+    if (seen.has(id)) {
+      throw new Error(`Duplicate requested knowledge base '${id}'.`);
+    }
+    seen.add(id);
+  }
+};
+
+const mergeKnowledgeBases = (
+  current: ReadonlyMap<string, KnowledgeBaseSummary>,
+  additions: readonly KnowledgeBaseSummary[],
+): ReadonlyMap<string, KnowledgeBaseSummary> =>
+  toSortedMap([...current.values(), ...additions]);
+
+const toSortedMap = (
+  summaries: readonly KnowledgeBaseSummary[],
+): ReadonlyMap<string, KnowledgeBaseSummary> =>
+  new Map(sortedSummaries(summaries).map((summary) => [summary.id, summary]));
+
+const sortedSummaries = (
+  summaries: Iterable<KnowledgeBaseSummary>,
+): KnowledgeBaseSummary[] =>
+  [...summaries].sort((left, right) => left.id.localeCompare(right.id));
+
+const createUsageHook = (
+  state: ExtensionState<KnowledgeBaseState>,
+  config: Readonly<KnowledgeBaseConfig>,
+): Hook => ({
+  name: 'knowledge-base-usage',
+  afterToolCall: (event) => {
+    if (!isKnowledgeTool(event.toolCall.name) || !config.recordUsage) {
+      return;
+    }
+    return config.recordUsage({
+      event,
+      activeKnowledgeBases: sortedSummaries(
+        state.current.knowledgeBases.values(),
+      ),
+    });
+  },
+});
+
+const isKnowledgeTool = (name: string): boolean =>
+  name === 'knowledge_query' || name === 'knowledge_get_text';

--- a/packages/agent-extensions/src/knowledge-bases/knowledge-instructions.ts
+++ b/packages/agent-extensions/src/knowledge-bases/knowledge-instructions.ts
@@ -1,0 +1,38 @@
+interface KnowledgeBaseInstructionSummary {
+  readonly id: string;
+  readonly name: string;
+}
+
+export const buildKnowledgeInstructions = (
+  knowledgeBases: readonly KnowledgeBaseInstructionSummary[],
+): string => {
+  if (knowledgeBases.length === 0) {
+    return '';
+  }
+  const entries = knowledgeBases
+    .map(
+      ({ id, name }) =>
+        `<knowledge_base id="${escapeXml(id)}" name="${escapeXml(name)}" />`,
+    )
+    .join('\n');
+  return [
+    '<available_knowledge_bases>',
+    'Use knowledge_query to search these knowledge bases and knowledge_get_text to read exact document sections.',
+    entries,
+    '</available_knowledge_bases>',
+  ].join('\n');
+};
+
+const XML_ENTITIES: Readonly<Record<string, string>> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&apos;',
+};
+
+const escapeXml = (value: string): string =>
+  value.replaceAll(
+    /[&<>"']/g,
+    (character) => XML_ENTITIES[character] ?? character,
+  );

--- a/packages/agent-extensions/src/knowledge-bases/knowledge-tools.ts
+++ b/packages/agent-extensions/src/knowledge-bases/knowledge-tools.ts
@@ -1,0 +1,161 @@
+import type {
+  Tool,
+  ToolExecutionContext,
+  ToolExecutionOutput,
+} from '@ayunis/agent-runtime';
+
+export interface KnowledgeQueryInput {
+  readonly knowledgeBaseId: string;
+  readonly query: string;
+}
+
+export interface KnowledgeGetTextInput {
+  readonly knowledgeBaseId: string;
+  readonly documentId: string;
+  readonly startLine: number;
+  readonly numLines: number;
+}
+
+export type KnowledgeQueryPort = (
+  input: KnowledgeQueryInput,
+  context: ToolExecutionContext,
+) => ToolExecutionOutput | Promise<ToolExecutionOutput>;
+
+export type KnowledgeGetTextPort = (
+  input: KnowledgeGetTextInput,
+  context: ToolExecutionContext,
+) => ToolExecutionOutput | Promise<ToolExecutionOutput>;
+
+interface KnowledgeToolOptions {
+  readonly knowledgeBaseIds: readonly string[];
+  readonly query: KnowledgeQueryPort;
+  readonly getText: KnowledgeGetTextPort;
+}
+
+export const createKnowledgeTools = (
+  options: KnowledgeToolOptions,
+): readonly Tool[] => [createQueryTool(options), createTextTool(options)];
+
+const createQueryTool = (options: KnowledgeToolOptions): Tool => ({
+  name: 'knowledge_query',
+  description: 'Search one active knowledge base using semantic search.',
+  parameters: {
+    type: 'object',
+    properties: {
+      knowledgeBaseId: knowledgeBaseIdSchema(options.knowledgeBaseIds),
+      query: {
+        type: 'string',
+        description: 'The semantic search query.',
+      },
+    },
+    required: ['knowledgeBaseId', 'query'],
+    additionalProperties: false,
+  },
+  validateInput: (input) => parseQueryInput(input, options.knowledgeBaseIds),
+  execute: (input, context) =>
+    options.query(parseQueryInput(input, options.knowledgeBaseIds), context),
+});
+
+const createTextTool = (options: KnowledgeToolOptions): Tool => ({
+  name: 'knowledge_get_text',
+  description: 'Read exact lines from a document in an active knowledge base.',
+  parameters: {
+    type: 'object',
+    properties: {
+      knowledgeBaseId: knowledgeBaseIdSchema(options.knowledgeBaseIds),
+      documentId: { type: 'string', description: 'The document ID.' },
+      startLine: { type: 'integer', minimum: 1, default: 1 },
+      numLines: { type: 'integer', minimum: 1, maximum: 100, default: 100 },
+    },
+    required: ['knowledgeBaseId', 'documentId'],
+    additionalProperties: false,
+  },
+  validateInput: (input) => parseTextInput(input, options.knowledgeBaseIds),
+  execute: (input, context) =>
+    options.getText(parseTextInput(input, options.knowledgeBaseIds), context),
+});
+
+const knowledgeBaseIdSchema = (ids: readonly string[]) => ({
+  type: 'string',
+  description: 'The ID of an active knowledge base.',
+  enum: [...ids],
+});
+
+const parseQueryInput = (
+  input: Record<string, unknown>,
+  activeIds: readonly string[],
+): KnowledgeQueryInput => {
+  assertExactKeys(input, ['knowledgeBaseId', 'query']);
+  const knowledgeBaseId = activeKnowledgeBaseId(
+    input.knowledgeBaseId,
+    activeIds,
+  );
+  if (typeof input.query !== 'string' || input.query.length === 0) {
+    throw new Error('knowledge_query requires a non-empty query.');
+  }
+  return { knowledgeBaseId, query: input.query };
+};
+
+const parseTextInput = (
+  input: Record<string, unknown>,
+  activeIds: readonly string[],
+): KnowledgeGetTextInput => {
+  assertExactKeys(input, [
+    'knowledgeBaseId',
+    'documentId',
+    'startLine',
+    'numLines',
+  ]);
+  const knowledgeBaseId = activeKnowledgeBaseId(
+    input.knowledgeBaseId,
+    activeIds,
+  );
+  if (typeof input.documentId !== 'string' || input.documentId.length === 0) {
+    throw new Error('knowledge_get_text requires a non-empty documentId.');
+  }
+  assertOptionalInteger(input.startLine, 'startLine', 1);
+  assertOptionalInteger(input.numLines, 'numLines', 1, 100);
+  return {
+    knowledgeBaseId,
+    documentId: input.documentId,
+    startLine: (input.startLine as number | undefined) ?? 1,
+    numLines: (input.numLines as number | undefined) ?? 100,
+  };
+};
+
+const activeKnowledgeBaseId = (
+  value: unknown,
+  activeIds: readonly string[],
+): string => {
+  if (typeof value !== 'string' || !activeIds.includes(value)) {
+    throw new Error('A currently active knowledgeBaseId is required.');
+  }
+  return value;
+};
+
+const assertExactKeys = (
+  input: Record<string, unknown>,
+  allowed: readonly string[],
+): void => {
+  if (Object.keys(input).some((key) => !allowed.includes(key))) {
+    throw new Error('Knowledge tool input contains an unsupported field.');
+  }
+};
+
+const assertOptionalInteger = (
+  value: unknown,
+  name: string,
+  minimum: number,
+  maximum = Number.MAX_SAFE_INTEGER,
+): void => {
+  if (
+    value !== undefined &&
+    (!Number.isInteger(value) ||
+      (value as number) < minimum ||
+      (value as number) > maximum)
+  ) {
+    throw new Error(
+      `${name} must be an integer from ${minimum} to ${maximum}.`,
+    );
+  }
+};

--- a/packages/agent-extensions/src/mcp/index.ts
+++ b/packages/agent-extensions/src/mcp/index.ts
@@ -1,0 +1,18 @@
+export { Mcp } from './mcp';
+export type {
+  ActiveMcpConnection,
+  McpApi,
+  McpConfig,
+  McpConnectionDefinition,
+  McpState,
+} from './mcp';
+export type {
+  McpClient,
+  McpClientFactory,
+  McpRequestOptions,
+} from './mcp-client';
+export type { McpTransportFactory } from './transports';
+export {
+  createStdioTransport,
+  createStreamableHttpTransport,
+} from './transports';

--- a/packages/agent-extensions/src/mcp/mcp-client.ts
+++ b/packages/agent-extensions/src/mcp/mcp-client.ts
@@ -1,0 +1,34 @@
+import {
+  Client,
+  type CallToolRequestOptions,
+  type CallToolResult,
+  type Implementation,
+  type ListToolsResult,
+  type RequestOptions,
+  type Transport,
+} from '@modelcontextprotocol/client';
+
+export type McpRequestOptions = Omit<RequestOptions, 'signal'>;
+
+export interface McpClient {
+  connect(transport: Transport, options?: RequestOptions): Promise<void>;
+  listTools(
+    params?: undefined,
+    options?: RequestOptions,
+  ): Promise<ListToolsResult>;
+  callTool(
+    params: { name: string; arguments?: Record<string, unknown> },
+    options?: CallToolRequestOptions,
+  ): Promise<CallToolResult>;
+  close(): Promise<void>;
+}
+
+export type McpClientFactory = (clientInfo: Implementation) => McpClient;
+
+export const DEFAULT_MCP_CLIENT_INFO: Implementation = {
+  name: '@ayunis/agent-extensions',
+  version: '0.1.0',
+};
+
+export const createMcpClient: McpClientFactory = (clientInfo) =>
+  new Client(clientInfo);

--- a/packages/agent-extensions/src/mcp/mcp-instructions.ts
+++ b/packages/agent-extensions/src/mcp/mcp-instructions.ts
@@ -1,0 +1,36 @@
+interface McpInstructionConnection {
+  readonly id: string;
+  readonly serverName: string;
+  readonly instructions?: string;
+}
+
+export const buildMcpInstructions = (
+  connections: readonly McpInstructionConnection[],
+): string => {
+  const instructed = connections.filter(({ instructions }) => instructions);
+  if (instructed.length === 0) {
+    return '';
+  }
+  return [
+    '<active_mcp_connections>',
+    ...instructed.map(
+      ({ id, serverName, instructions }) =>
+        `  <connection id="${escapeXml(id)}" server="${escapeXml(serverName)}">${escapeXml(instructions ?? '')}</connection>`,
+    ),
+    '</active_mcp_connections>',
+  ].join('\n');
+};
+
+const escapeXml = (value: string): string =>
+  value.replaceAll(
+    /[&<>"']/g,
+    (character) => XML_ENTITIES[character] ?? character,
+  );
+
+const XML_ENTITIES: Readonly<Record<string, string>> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&apos;',
+};

--- a/packages/agent-extensions/src/mcp/mcp-tools.ts
+++ b/packages/agent-extensions/src/mcp/mcp-tools.ts
@@ -1,0 +1,71 @@
+import type { Tool as SdkTool } from '@modelcontextprotocol/client';
+import type { Tool, ToolExecutionContext } from '@ayunis/agent-runtime';
+
+import type { McpClient, McpRequestOptions } from './mcp-client';
+import { serializeMcpResult, toRuntimeMcpResult } from './result-serializer';
+
+export interface McpToolConnection {
+  readonly id: string;
+  readonly serverName: string;
+  readonly client: McpClient;
+  readonly discoveredTools: readonly SdkTool[];
+  readonly requestOptions?: McpRequestOptions;
+}
+
+export const createMcpTools = (
+  connections: readonly McpToolConnection[],
+): readonly Tool[] =>
+  connections
+    .flatMap((connection) =>
+      connection.discoveredTools.map((tool) => toRuntimeTool(connection, tool)),
+    )
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+export const namespaceMcpToolName = (
+  serverName: string,
+  toolName: string,
+): string => {
+  const encodedServerName = encodeIdentity(serverName);
+  return `mcp_${encodedServerName.length}_${encodedServerName}_${encodeIdentity(toolName)}`;
+};
+
+const toRuntimeTool = (
+  connection: McpToolConnection,
+  discovered: SdkTool,
+): Tool => ({
+  name: namespaceMcpToolName(connection.serverName, discovered.name),
+  description: discovered.description ?? discovered.title ?? '',
+  parameters: discovered.inputSchema,
+  execute: (input, context) =>
+    executeMcpTool(connection, discovered.name, input, context),
+});
+
+const executeMcpTool = async (
+  connection: McpToolConnection,
+  originalName: string,
+  input: Record<string, unknown>,
+  context: ToolExecutionContext,
+) => {
+  const result = await connection.client.callTool(
+    { name: originalName, arguments: input },
+    withAbortSignal(connection.requestOptions, context.signal),
+  );
+  const runtimeResult = toRuntimeMcpResult(result);
+  return {
+    result: serializeMcpResult(runtimeResult),
+    isError: runtimeResult.isError,
+  };
+};
+
+const withAbortSignal = (
+  options: McpRequestOptions | undefined,
+  signal: AbortSignal | undefined,
+) => {
+  if (signal === undefined) {
+    return options;
+  }
+  return { ...options, signal };
+};
+
+const encodeIdentity = (value: string): string =>
+  Buffer.from(value, 'utf8').toString('base64url');

--- a/packages/agent-extensions/src/mcp/mcp.spec.ts
+++ b/packages/agent-extensions/src/mcp/mcp.spec.ts
@@ -1,0 +1,394 @@
+import type {
+  CallToolResult,
+  ListToolsResult,
+  Transport,
+} from '@modelcontextprotocol/client';
+import type {
+  RunContext,
+  RunEvent,
+  ToolExecutionContext,
+} from '@ayunis/agent-runtime';
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  ExtensionApi,
+  ExtensionContext,
+  ExtensionDefinitionIdentity,
+  ExtensionState,
+} from '../extensions/context';
+import type { McpClient, McpClientFactory } from './mcp-client';
+import { Mcp, type McpConfig, type McpConnectionDefinition } from './mcp';
+import { namespaceMcpToolName } from './mcp-tools';
+
+const firstConnection: McpConnectionDefinition = {
+  id: 'first',
+  serverName: 'server one',
+  instructions: 'Use the first server.',
+  transport: () => ({}) as Transport,
+  requestOptions: { timeout: 250 },
+};
+
+const secondConnection: McpConnectionDefinition = {
+  id: 'second',
+  serverName: 'server two',
+  transport: () => ({}) as Transport,
+};
+
+const legacyCollisionIdentities = [
+  { serverName: 'é?é', toolName: 'é' },
+  { serverName: 'é', toolName: 'é?é' },
+] as const;
+
+const collisionModelNames = ['mcp_7_w6k_w6k_w6k', 'mcp_3_w6k_w6k_w6k'];
+
+describe('Mcp', () => {
+  it('rejects duplicate requested IDs before resolution or opening clients', async () => {
+    const resolveAuthorized = vi.fn(async () => [firstConnection]);
+    const createClient = vi.fn<McpClientFactory>();
+    const run = await setupMcp(
+      createConfig({ resolveAuthorized, createClient }),
+    );
+
+    await expect(run.api.addConnections(['first', 'first'])).rejects.toThrow(
+      /duplicate requested.*first/i,
+    );
+    expect(resolveAuthorized).not.toHaveBeenCalled();
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate server namespaces before opening clients', async () => {
+    const duplicate = { ...secondConnection, serverName: 'server one' };
+    const createClient = vi.fn<McpClientFactory>();
+    const run = await setupMcp(
+      createConfig({
+        resolveAuthorized: vi.fn(async () => [firstConnection, duplicate]),
+        createClient,
+      }),
+    );
+
+    await expect(run.api.addConnections(['first', 'second'])).rejects.toThrow(
+      /duplicate MCP server namespace.*server one/i,
+    );
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('rolls back every provisional client when discovery fails', async () => {
+    const firstClient = fakeClient([mcpTool('search')]);
+    const secondClient = fakeClient([], new Error('discovery failed'));
+    const createClient = clientFactory([firstClient, secondClient]);
+    const run = await setupMcp(
+      createConfig({
+        resolveAuthorized: vi.fn(async () => [
+          firstConnection,
+          secondConnection,
+        ]),
+        createClient,
+      }),
+    );
+
+    await expect(run.api.addConnections(['first', 'second'])).rejects.toThrow(
+      'discovery failed',
+    );
+
+    expect(firstClient.close).toHaveBeenCalledOnce();
+    expect(secondClient.close).toHaveBeenCalledOnce();
+    expect(run.active()).toEqual([]);
+    expect(run.contribution()).toEqual({});
+  });
+
+  it('commits a complete addition once and keeps repeated IDs idempotent', async () => {
+    const firstClient = fakeClient([mcpTool('search')]);
+    const createClient = clientFactory([firstClient]);
+    const resolveAuthorized = vi.fn(async () => [firstConnection]);
+    const run = await setupMcp(
+      createConfig({ resolveAuthorized, createClient }),
+    );
+
+    await run.api.addConnections(['first']);
+    await run.api.addConnections(['first']);
+
+    expect(resolveAuthorized).toHaveBeenCalledOnce();
+    expect(createClient).toHaveBeenCalledOnce();
+    expect(firstClient.connect).toHaveBeenCalledOnce();
+    expect(firstClient.listTools).toHaveBeenCalledOnce();
+    expect(run.active().map(({ id }) => id)).toEqual(['first']);
+    expect(run.contribution().instructions).toContain('Use the first server.');
+  });
+
+  it('namespaces the same original tool name injectively by server', async () => {
+    const firstClient = fakeClient([mcpTool('search')]);
+    const secondClient = fakeClient([mcpTool('search')]);
+    const run = await setupMcp(
+      createConfig({
+        resolveAuthorized: vi.fn(async () => [
+          secondConnection,
+          firstConnection,
+        ]),
+        createClient: clientFactory([secondClient, firstClient]),
+      }),
+    );
+    await run.api.addConnections(['second', 'first']);
+
+    const names = run.contribution().tools?.map(({ name }) => name) ?? [];
+    expect(names).toHaveLength(2);
+    expect(new Set(names).size).toBe(2);
+    expect(names).toEqual(
+      [...names].sort((left, right) => left.localeCompare(right)),
+    );
+  });
+
+  it('namespaces a legacy collision injectively and deterministically', () => {
+    expect(legacyMcpToolName(legacyCollisionIdentities[0])).toBe(
+      legacyMcpToolName(legacyCollisionIdentities[1]),
+    );
+
+    const names = legacyCollisionIdentities.map(({ serverName, toolName }) =>
+      namespaceMcpToolName(serverName, toolName),
+    );
+    expect(names).toEqual(collisionModelNames);
+    expect(new Set(names).size).toBe(legacyCollisionIdentities.length);
+    expect(
+      legacyCollisionIdentities.map(({ serverName, toolName }) =>
+        namespaceMcpToolName(serverName, toolName),
+      ),
+    ).toEqual(names);
+    expect(names.every((name) => /^[A-Za-z0-9_-]{1,64}$/.test(name))).toBe(
+      true,
+    );
+  });
+
+  it('executes legacy-colliding names with their original identities', async () => {
+    const definitions = legacyCollisionIdentities.map(
+      ({ serverName }, index) => ({
+        ...firstConnection,
+        id: `collision-${index}`,
+        serverName,
+      }),
+    );
+    const clients = legacyCollisionIdentities.map(({ toolName }) =>
+      fakeClient([mcpTool(toolName)]),
+    );
+    const run = await setupMcp(
+      createConfig({
+        resolveAuthorized: vi.fn(async () => definitions),
+        createClient: clientFactory(clients),
+      }),
+    );
+    await run.api.addConnections(definitions.map(({ id }) => id));
+
+    const toolsByName = new Map(
+      run.contribution().tools?.map((tool) => [tool.name, tool]),
+    );
+    for (const name of collisionModelNames) {
+      const execute = toolsByName.get(name)?.execute;
+      if (!execute) throw new Error(`Missing namespaced MCP tool '${name}'.`);
+      await execute({}, toolContext());
+    }
+    legacyCollisionIdentities.forEach(({ toolName }, index) => {
+      expect(clients[index]?.callTool).toHaveBeenCalledWith(
+        { name: toolName, arguments: {} },
+        { timeout: 250, signal: expect.any(AbortSignal) },
+      );
+    });
+  });
+
+  it('maps execution to the original identity and preserves result fields', async () => {
+    const result: CallToolResult = {
+      content: [{ type: 'text', text: 'found' }],
+      structuredContent: { total: 1 },
+      isError: true,
+    };
+    const client = fakeClient([mcpTool('search')], undefined, result);
+    const run = await setupMcp(
+      createConfig({
+        resolveAuthorized: vi.fn(async () => [firstConnection]),
+        createClient: clientFactory([client]),
+      }),
+    );
+    await run.api.addConnections(['first']);
+    const [tool] = run.contribution().tools ?? [];
+    const context = toolContext();
+
+    await expect(
+      tool.execute?.({ phrase: 'permit' }, context),
+    ).resolves.toEqual({
+      result: JSON.stringify({
+        content: result.content,
+        structuredContent: { total: 1 },
+        isError: true,
+      }),
+      isError: true,
+    });
+    expect(client.callTool).toHaveBeenCalledWith(
+      { name: 'search', arguments: { phrase: 'permit' } },
+      { timeout: 250, signal: context.signal },
+    );
+  });
+
+  it('registers each committed client for one aggregate-safe disposal', async () => {
+    const firstClient = fakeClient([mcpTool('first')]);
+    const secondClient = fakeClient([mcpTool('second')]);
+    firstClient.close.mockRejectedValueOnce(new Error('first close failed'));
+    secondClient.close.mockRejectedValueOnce(new Error('second close failed'));
+    const run = await setupMcp(
+      createConfig({
+        resolveAuthorized: vi.fn(async () => [
+          firstConnection,
+          secondConnection,
+        ]),
+        createClient: clientFactory([firstClient, secondClient]),
+      }),
+    );
+    await run.api.addConnections(['first', 'second']);
+
+    await expect(run.dispose()).rejects.toThrow(AggregateError);
+    expect(firstClient.close).toHaveBeenCalledOnce();
+    expect(secondClient.close).toHaveBeenCalledOnce();
+  });
+
+  it('creates independent clients and active maps for concurrent contexts', async () => {
+    const clients = [fakeClient([]), fakeClient([])];
+    const config = createConfig({
+      resolveAuthorized: vi.fn(async () => [firstConnection]),
+      createClient: clientFactory(clients),
+    });
+    const configured = Mcp.configure(config);
+    const [first, second] = await Promise.all([
+      setupConfigured(configured.definition, configured.config),
+      setupConfigured(configured.definition, configured.config),
+    ]);
+
+    await Promise.all([
+      first.api.addConnections(['first']),
+      second.api.addConnections(['first']),
+    ]);
+
+    expect(first.active()).toHaveLength(1);
+    expect(second.active()).toHaveLength(1);
+    expect(clients[0].connect).toHaveBeenCalledOnce();
+    expect(clients[1].connect).toHaveBeenCalledOnce();
+  });
+});
+
+const createConfig = (overrides: Partial<McpConfig> = {}): McpConfig => ({
+  resolveAuthorized: vi.fn(async () => []),
+  createClient: vi.fn(() => fakeClient([])),
+  ...overrides,
+});
+
+const setupMcp = (config: McpConfig) => setupConfigured(Mcp, config);
+
+const setupConfigured = async (
+  definition: typeof Mcp,
+  config: Readonly<McpConfig>,
+) => {
+  const controlled = controlledContext();
+  const setup = await definition.setup(controlled.context, config);
+  return {
+    api: setup.api,
+    active: () => [...setup.state.current.connections.values()],
+    contribution: () =>
+      definition.contribute(
+        { state: setup.state.current, api: setup.api },
+        config,
+      ),
+    dispose: controlled.dispose,
+  };
+};
+
+const controlledContext = (): {
+  context: ExtensionContext;
+  dispose(): Promise<void>;
+} => {
+  const cleanups: Array<() => void | Promise<void>> = [];
+  return {
+    context: {
+      extensionName: 'mcp',
+      state: <State>(initial: State): ExtensionState<State> => {
+        let value = initial;
+        return {
+          get current() {
+            return value;
+          },
+          update(updater) {
+            value = updater(value);
+          },
+        };
+      },
+      use: <Definition extends ExtensionDefinitionIdentity>(
+        definition: Definition,
+      ): ExtensionApi<Definition> => {
+        throw new Error(`Missing controlled API: ${definition.name}`);
+      },
+      useOptional: () => undefined,
+      own: (cleanup) => cleanups.push(cleanup),
+    },
+    dispose: async () => {
+      const failures: unknown[] = [];
+      for (const cleanup of cleanups.toReversed()) {
+        try {
+          await cleanup();
+        } catch (error) {
+          failures.push(error);
+        }
+      }
+      if (failures.length > 0) {
+        throw new AggregateError(failures, 'Cleanup failed.');
+      }
+    },
+  };
+};
+
+const legacyMcpToolName = ({
+  serverName,
+  toolName,
+}: {
+  serverName: string;
+  toolName: string;
+}): string =>
+  `mcp_${Buffer.from(serverName).toString('base64url')}_${Buffer.from(toolName).toString('base64url')}`;
+
+const mcpTool = (name: string) => ({
+  name,
+  description: `${name} description`,
+  inputSchema: { type: 'object', properties: {} },
+});
+
+const fakeClient = (
+  tools: ReturnType<typeof mcpTool>[],
+  discoveryError?: Error,
+  result: CallToolResult = { content: [], isError: false },
+) =>
+  ({
+    connect: vi.fn(async () => undefined),
+    listTools: vi.fn(async (): Promise<ListToolsResult> => {
+      if (discoveryError) throw discoveryError;
+      return { tools } as ListToolsResult;
+    }),
+    callTool: vi.fn(async () => result),
+    close: vi.fn(async () => undefined),
+  }) satisfies McpClient;
+
+const clientFactory = (
+  clients: McpClient[],
+): ReturnType<typeof vi.fn<McpClientFactory>> => {
+  let index = 0;
+  return vi.fn(() => {
+    const client = clients[index++];
+    if (!client) throw new Error('No fake MCP client available.');
+    return client;
+  });
+};
+
+const toolContext = (): ToolExecutionContext => ({
+  context: {} as RunContext,
+  toolCallId: 'call-1',
+  toolNames: [],
+  signal: new AbortController().signal,
+  emit: vi.fn(),
+  runChild: () => emptyChildRun(),
+});
+
+async function* emptyChildRun(): AsyncGenerator<RunEvent> {
+  yield* [];
+}

--- a/packages/agent-extensions/src/mcp/mcp.ts
+++ b/packages/agent-extensions/src/mcp/mcp.ts
@@ -1,0 +1,287 @@
+import type {
+  Implementation,
+  Tool as SdkTool,
+} from '@modelcontextprotocol/client';
+
+import type { ExtensionContext, ExtensionState } from '../extensions/context';
+import { defineExtension } from '../extensions/extension';
+import {
+  createMcpClient,
+  DEFAULT_MCP_CLIENT_INFO,
+  type McpClient,
+  type McpClientFactory,
+  type McpRequestOptions,
+} from './mcp-client';
+import { buildMcpInstructions } from './mcp-instructions';
+import { createMcpTools, namespaceMcpToolName } from './mcp-tools';
+import type { McpTransportFactory } from './transports';
+
+export interface McpConnectionDefinition {
+  readonly id: string;
+  readonly serverName: string;
+  readonly instructions?: string;
+  readonly transport: McpTransportFactory;
+  readonly requestOptions?: McpRequestOptions;
+}
+
+export interface ActiveMcpConnection extends McpConnectionDefinition {
+  readonly client: McpClient;
+  readonly discoveredTools: readonly SdkTool[];
+}
+
+export interface McpState {
+  readonly connections: ReadonlyMap<string, ActiveMcpConnection>;
+}
+
+export interface McpConfig {
+  resolveAuthorized(
+    ids: readonly string[],
+  ): Promise<readonly McpConnectionDefinition[]>;
+  readonly clientInfo?: Implementation;
+  readonly createClient?: McpClientFactory;
+}
+
+export interface McpApi {
+  addConnections(ids: readonly string[]): Promise<void>;
+}
+
+export const Mcp = defineExtension<'mcp', McpState, McpApi, McpConfig>({
+  name: 'mcp',
+  setup(context, config) {
+    const state = context.state<McpState>({ connections: new Map() });
+    return {
+      state,
+      api: {
+        addConnections: (ids) => addConnections(context, state, config, ids),
+      },
+    };
+  },
+  contribute({ state }) {
+    const connections = sortedConnections(state.connections.values());
+    if (connections.length === 0) {
+      return {};
+    }
+    const instructions = buildMcpInstructions(connections);
+    return {
+      ...(instructions ? { instructions } : {}),
+      tools: createMcpTools(connections),
+    };
+  },
+});
+
+const addConnections = async (
+  context: ExtensionContext,
+  state: ExtensionState<McpState>,
+  config: Readonly<McpConfig>,
+  requestedIds: readonly string[],
+): Promise<void> => {
+  assertUniqueRequestedIds(requestedIds);
+  const missingIds = requestedIds.filter(
+    (id) => !state.current.connections.has(id),
+  );
+  if (missingIds.length === 0) {
+    return;
+  }
+  const resolved = await config.resolveAuthorized([...missingIds]);
+  validateResolved(missingIds, resolved, state.current.connections);
+  const provisional = await prepareConnections(resolved, config);
+  for (const connection of provisional) {
+    context.own(closeOnce(connection.client));
+  }
+  state.update((current) => ({
+    connections: mergeConnections(current.connections, provisional),
+  }));
+};
+
+const prepareConnections = async (
+  definitions: readonly McpConnectionDefinition[],
+  config: Readonly<McpConfig>,
+): Promise<ActiveMcpConnection[]> => {
+  const prepared: ActiveMcpConnection[] = [];
+  const createClient = config.createClient ?? createMcpClient;
+  try {
+    for (const definition of sortedDefinitions(definitions)) {
+      const client = createClient(config.clientInfo ?? DEFAULT_MCP_CLIENT_INFO);
+      prepared.push(await connectAndDiscover(definition, client));
+    }
+    validateModelToolNames(prepared);
+    return prepared;
+  } catch (error) {
+    return closeProvisional(prepared, error);
+  }
+};
+
+const connectAndDiscover = async (
+  definition: McpConnectionDefinition,
+  client: McpClient,
+): Promise<ActiveMcpConnection> => {
+  const active = { ...definition, client, discoveredTools: [] };
+  try {
+    const transport = await definition.transport();
+    await client.connect(transport, definition.requestOptions);
+    const { tools } = await client.listTools(
+      undefined,
+      definition.requestOptions,
+    );
+    validateDiscoveredTools(definition.serverName, tools);
+    return { ...definition, client, discoveredTools: [...tools] };
+  } catch (error) {
+    return closeFailedConnection(active, error);
+  }
+};
+
+const validateResolved = (
+  requestedIds: readonly string[],
+  resolved: readonly McpConnectionDefinition[],
+  active: ReadonlyMap<string, ActiveMcpConnection>,
+): void => {
+  const requested = new Set(requestedIds);
+  const resolvedIds = new Set<string>();
+  for (const definition of resolved) {
+    validateDefinition(definition);
+    if (resolvedIds.has(definition.id)) {
+      throw new Error(`Duplicate resolved MCP connection '${definition.id}'.`);
+    }
+    if (!requested.has(definition.id)) {
+      throw new Error(
+        `Unrequested MCP connection '${definition.id}' was resolved.`,
+      );
+    }
+    resolvedIds.add(definition.id);
+  }
+  const missing = requestedIds.find((id) => !resolvedIds.has(id));
+  if (missing)
+    throw new Error(`Missing authorized MCP connection '${missing}'.`);
+  assertUniqueServerNames(resolved, active);
+};
+
+const validateDefinition = (definition: McpConnectionDefinition): void => {
+  if (!definition.id || !definition.serverName) {
+    throw new Error('MCP connections require non-empty id and serverName.');
+  }
+  if (typeof definition.transport !== 'function') {
+    throw new Error(`MCP connection '${definition.id}' requires a transport.`);
+  }
+};
+
+const assertUniqueServerNames = (
+  definitions: readonly McpConnectionDefinition[],
+  active: ReadonlyMap<string, ActiveMcpConnection>,
+): void => {
+  const names = new Set(
+    [...active.values()].map(({ serverName }) => serverName),
+  );
+  for (const definition of definitions) {
+    if (names.has(definition.serverName)) {
+      throw new Error(
+        `Duplicate MCP server namespace '${definition.serverName}'.`,
+      );
+    }
+    names.add(definition.serverName);
+  }
+};
+
+const assertUniqueRequestedIds = (ids: readonly string[]): void => {
+  const seen = new Set<string>();
+  for (const id of ids) {
+    if (!id) throw new Error('MCP connection IDs must not be empty.');
+    if (seen.has(id)) {
+      throw new Error(`Duplicate requested MCP connection '${id}'.`);
+    }
+    seen.add(id);
+  }
+};
+
+const validateDiscoveredTools = (
+  serverName: string,
+  tools: readonly SdkTool[],
+): void => {
+  const names = new Set<string>();
+  for (const tool of tools) {
+    if (!tool.name)
+      throw new Error(`MCP server '${serverName}' returned an unnamed tool.`);
+    if (names.has(tool.name)) {
+      throw new Error(
+        `MCP server '${serverName}' returned duplicate tool '${tool.name}'.`,
+      );
+    }
+    names.add(tool.name);
+  }
+};
+
+const validateModelToolNames = (
+  connections: readonly ActiveMcpConnection[],
+): void => {
+  const names = new Set<string>();
+  for (const connection of connections) {
+    for (const tool of connection.discoveredTools) {
+      const name = namespaceMcpToolName(connection.serverName, tool.name);
+      if (names.has(name))
+        throw new Error(`Duplicate namespaced MCP tool '${name}'.`);
+      names.add(name);
+    }
+  }
+};
+
+const mergeConnections = (
+  current: ReadonlyMap<string, ActiveMcpConnection>,
+  additions: readonly ActiveMcpConnection[],
+): ReadonlyMap<string, ActiveMcpConnection> =>
+  new Map(
+    sortedConnections([...current.values(), ...additions]).map((connection) => [
+      connection.id,
+      connection,
+    ]),
+  );
+
+const sortedConnections = (
+  connections: Iterable<ActiveMcpConnection>,
+): ActiveMcpConnection[] =>
+  [...connections].sort((left, right) => left.id.localeCompare(right.id));
+
+const sortedDefinitions = (
+  definitions: readonly McpConnectionDefinition[],
+): McpConnectionDefinition[] =>
+  [...definitions].sort((left, right) => left.id.localeCompare(right.id));
+
+const closeOnce = (client: McpClient): (() => Promise<void>) => {
+  let closed = false;
+  return async () => {
+    if (closed) return;
+    closed = true;
+    await client.close();
+  };
+};
+
+const closeFailedConnection = async (
+  connection: ActiveMcpConnection,
+  operationError: unknown,
+): Promise<never> => {
+  try {
+    await connection.client.close();
+  } catch (closeError) {
+    throw new AggregateError(
+      [operationError, closeError],
+      'MCP connection and cleanup failed.',
+    );
+  }
+  throw operationError;
+};
+
+const closeProvisional = async (
+  connections: readonly ActiveMcpConnection[],
+  operationError: unknown,
+): Promise<never> => {
+  const failures: unknown[] = [operationError];
+  for (const connection of connections.toReversed()) {
+    try {
+      await connection.client.close();
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  if (failures.length > 1) {
+    throw new AggregateError(failures, 'MCP addition and rollback failed.');
+  }
+  throw operationError;
+};

--- a/packages/agent-extensions/src/mcp/result-serializer.ts
+++ b/packages/agent-extensions/src/mcp/result-serializer.ts
@@ -1,0 +1,20 @@
+import type { CallToolResult } from '@modelcontextprotocol/client';
+
+export interface RuntimeMcpResult {
+  readonly content: CallToolResult['content'];
+  readonly structuredContent?: unknown;
+  readonly isError: boolean;
+}
+
+export const toRuntimeMcpResult = (
+  result: CallToolResult,
+): RuntimeMcpResult => ({
+  content: result.content,
+  ...(result.structuredContent === undefined
+    ? {}
+    : { structuredContent: result.structuredContent }),
+  isError: result.isError ?? false,
+});
+
+export const serializeMcpResult = (result: RuntimeMcpResult): string =>
+  JSON.stringify(result);

--- a/packages/agent-extensions/src/mcp/transports.ts
+++ b/packages/agent-extensions/src/mcp/transports.ts
@@ -1,0 +1,24 @@
+import {
+  StreamableHTTPClientTransport,
+  type StreamableHTTPClientTransportOptions,
+  type Transport,
+} from '@modelcontextprotocol/client';
+import {
+  StdioClientTransport,
+  type StdioServerParameters,
+} from '@modelcontextprotocol/client/stdio';
+
+export type McpTransportFactory = () => Transport | Promise<Transport>;
+
+export const createStreamableHttpTransport =
+  (
+    url: URL,
+    options?: StreamableHTTPClientTransportOptions,
+  ): McpTransportFactory =>
+  () =>
+    new StreamableHTTPClientTransport(url, options);
+
+export const createStdioTransport =
+  (parameters: StdioServerParameters): McpTransportFactory =>
+  () =>
+    new StdioClientTransport(parameters);

--- a/packages/agent-extensions/src/package-surface.spec.ts
+++ b/packages/agent-extensions/src/package-surface.spec.ts
@@ -1,46 +1,99 @@
+import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { access, readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import * as sourceSurface from './index';
+import * as knowledgeBasesSource from './knowledge-bases';
+import * as rootSource from './index';
+import * as mcpSource from './mcp';
+import * as filesystemSource from './skills/filesystem';
+import * as skillsSource from './skills';
 
 const packageRoot = fileURLToPath(new URL('..', import.meta.url));
-const expectedExports = [
+const rootExports = [
   'defineExtension',
   'DuplicateExtensionError',
   'ExtensionError',
   'InvalidExtensionNameError',
   'MissingExtensionError',
 ];
+const subpaths = {
+  'knowledge-bases': ['KnowledgeBases'],
+  mcp: ['createStdioTransport', 'createStreamableHttpTransport', 'Mcp'],
+  skills: ['Skills'],
+  'skills/filesystem': ['FilesystemSkillSource'],
+} as const;
 
 describe('package surface', () => {
-  it('exports only application-facing extension definitions and errors', () => {
-    expect(sortedKeys(sourceSurface)).toEqual(expectedExports);
-    expect(sourceSurface).not.toHaveProperty('configureRuntimeExtension');
-    expect(sourceSurface).not.toHaveProperty('initializeExtensionSet');
-    expect(sourceSurface).not.toHaveProperty('createExtensionSession');
+  it('keeps the root limited to extension definitions and errors', () => {
+    expect(sortedKeys(rootSource)).toEqual(rootExports);
+    expect(rootSource).not.toHaveProperty('configureRuntimeExtension');
+    expect(rootSource).not.toHaveProperty('initializeExtensionSet');
+    expect(rootSource).not.toHaveProperty('createExtensionSession');
   });
 
-  it('loads the built output as ESM and CJS', async () => {
-    const esm = await import(new URL('../dist/index.js', import.meta.url).href);
+  it('exposes exact built-in source subpaths', () => {
+    expect(sortedKeys(knowledgeBasesSource)).toEqual(
+      sortedKeysFrom(subpaths['knowledge-bases']),
+    );
+    expect(sortedKeys(mcpSource)).toEqual(sortedKeysFrom(subpaths.mcp));
+    expect(sortedKeys(skillsSource)).toEqual(sortedKeysFrom(subpaths.skills));
+    expect(sortedKeys(filesystemSource)).toEqual(
+      sortedKeysFrom(subpaths['skills/filesystem']),
+    );
+  });
+
+  it('loads every entry as ESM and CJS and emits declarations', async () => {
     const require = createRequire(import.meta.url);
-    const cjs = require('../dist/index.cjs') as Record<string, unknown>;
-
-    expect(sortedKeys(esm)).toEqual(expectedExports);
-    expect(sortedKeys(cjs)).toEqual(expectedExports);
+    await assertBuiltEntry('', rootExports, require);
+    for (const [subpath, expected] of Object.entries(subpaths)) {
+      await assertBuiltEntry(subpath, expected, require);
+    }
   });
 
-  it('emits declarations and exposes only the root subpath', async () => {
-    await access(new URL('../dist/index.d.ts', import.meta.url));
+  it('publishes only the intended root and optional subpaths', async () => {
     const packageJson = JSON.parse(
       await readFile(`${packageRoot}/package.json`, 'utf8'),
-    ) as { exports: Record<string, unknown> };
+    ) as { exports: Record<string, unknown>; files: string[] };
 
-    expect(Object.keys(packageJson.exports)).toEqual(['.']);
+    expect(Object.keys(packageJson.exports)).toEqual([
+      '.',
+      './knowledge-bases',
+      './mcp',
+      './skills',
+      './skills/filesystem',
+    ]);
+    expect(packageJson.files).toEqual(['dist']);
+  });
+
+  it('does not pull MCP, YAML, or filesystem adapters into root consumers', async () => {
+    const rootBundle = await readFile(`${packageRoot}/dist/index.js`, 'utf8');
+
+    expect(rootBundle).not.toContain('@modelcontextprotocol');
+    expect(rootBundle).not.toContain('yaml');
+    expect(rootBundle).not.toContain('node:fs');
+    expect(rootBundle).not.toContain('FilesystemSkillSource');
   });
 });
 
+const assertBuiltEntry = async (
+  subpath: string,
+  expected: readonly string[],
+  require: NodeJS.Require,
+): Promise<void> => {
+  const prefix = subpath ? `${subpath}/` : '';
+  const esm = await import(
+    new URL(`../dist/${prefix}index.js`, import.meta.url).href
+  );
+  const cjs = require(`../dist/${prefix}index.cjs`) as Record<string, unknown>;
+  await readFile(`${packageRoot}/dist/${prefix}index.d.ts`, 'utf8');
+  expect(sortedKeys(esm)).toEqual(sortedKeysFrom(expected));
+  expect(sortedKeys(cjs)).toEqual(sortedKeysFrom(expected));
+};
+
 const sortedKeys = (value: object): string[] =>
   Object.keys(value).sort((left, right) => left.localeCompare(right));
+
+const sortedKeysFrom = (values: readonly string[]): string[] =>
+  [...values].sort((left, right) => left.localeCompare(right));

--- a/packages/agent-extensions/src/skills/available-skills.ts
+++ b/packages/agent-extensions/src/skills/available-skills.ts
@@ -1,0 +1,86 @@
+import type { JsonSchema } from '@ayunis/agent-runtime';
+
+import type { SkillSummary } from './skill-definition';
+
+export interface AvailableSkills {
+  readonly summaries: ReadonlyMap<string, SkillSummary>;
+  readonly names: readonly string[];
+  readonly instructions: string;
+  readonly activationSchema: JsonSchema;
+}
+
+export const buildAvailableSkills = (
+  summaries: readonly SkillSummary[],
+): AvailableSkills => {
+  const sorted = [...summaries].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+  validateSummaries(sorted);
+  const names = sorted.map(({ name }) => name);
+  return {
+    summaries: new Map(sorted.map((summary) => [summary.name, summary])),
+    names,
+    instructions: formatInstructions(sorted),
+    activationSchema: activationSchema(names),
+  };
+};
+
+const validateSummaries = (summaries: readonly SkillSummary[]): void => {
+  const names = new Set<string>();
+  for (const summary of summaries) {
+    if (!summary.name || !summary.description) {
+      throw new Error('Skill summaries require a name and description.');
+    }
+    if (names.has(summary.name)) {
+      throw new Error(`Duplicate skill summary name '${summary.name}'.`);
+    }
+    names.add(summary.name);
+  }
+};
+
+const formatInstructions = (summaries: readonly SkillSummary[]): string => {
+  if (summaries.length === 0) {
+    return '';
+  }
+  const entries = summaries
+    .map(
+      ({ name, description }) =>
+        `  <skill>\n    <name>${escapeXml(name)}</name>\n` +
+        `    <description>${escapeXml(description)}</description>\n  </skill>`,
+    )
+    .join('\n');
+  return [
+    'Additional skills are available through progressive disclosure.',
+    'Call activate_skill with one exact name before using that skill.',
+    '<available_skills>',
+    entries,
+    '</available_skills>',
+  ].join('\n');
+};
+
+const activationSchema = (names: readonly string[]): JsonSchema => ({
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+      enum: [...names],
+      description: 'The exact name of the skill to activate.',
+    },
+  },
+  required: ['name'],
+  additionalProperties: false,
+});
+
+const escapeXml = (value: string): string =>
+  value.replaceAll(
+    /[&<>"']/g,
+    (character) => XML_ENTITIES[character] ?? character,
+  );
+
+const XML_ENTITIES: Readonly<Record<string, string>> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&apos;',
+};

--- a/packages/agent-extensions/src/skills/filesystem/filesystem-skill-source.spec.ts
+++ b/packages/agent-extensions/src/skills/filesystem/filesystem-skill-source.spec.ts
@@ -1,0 +1,289 @@
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { Tool } from '@ayunis/agent-runtime';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { FilesystemSkillSource } from './filesystem-skill-source';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true })),
+  );
+});
+
+describe('FilesystemSkillSource', () => {
+  it('returns an empty catalog for a missing root', async () => {
+    const source = new FilesystemSkillSource({
+      root: join(await temporaryDirectory(), 'missing'),
+    });
+
+    await expect(source.list()).resolves.toEqual([]);
+  });
+
+  it('discovers only immediate child directories with valid SKILL.md files', async () => {
+    const root = await temporaryDirectory();
+    await writeSkill(root, 'access-review');
+    await mkdir(join(root, 'empty'));
+    await writeSkill(join(root, 'container'), 'nested');
+    await writeFile(join(root, 'SKILL.md'), 'not a child');
+    const source = new FilesystemSkillSource({ root });
+
+    await expect(source.list()).resolves.toEqual([
+      {
+        name: 'access-review',
+        description: 'Use the access-review workflow',
+      },
+    ]);
+  });
+
+  it('never interpolates model input into a path', async () => {
+    const parent = await temporaryDirectory();
+    const root = join(parent, 'skills');
+    await mkdir(root);
+    const outside = await writeSkill(parent, 'outside');
+    const source = new FilesystemSkillSource({ root });
+    await source.list();
+
+    await expect(source.load('../outside')).rejects.toThrow(
+      'Unknown scanned skill: ../outside',
+    );
+    await expect(readFile(outside, 'utf8')).resolves.toContain(
+      'Follow the outside instructions.',
+    );
+  });
+
+  it('rejects symlinks escaping the root and duplicate canonical paths', async () => {
+    const parent = await temporaryDirectory();
+    const root = join(parent, 'skills');
+    const outside = join(parent, 'outside');
+    await mkdir(root);
+    await writeSkill(outside, 'escaped');
+    await symlink(join(outside, 'escaped'), join(root, 'escaped'));
+
+    await expect(new FilesystemSkillSource({ root }).list()).rejects.toThrow(
+      /outside the configured root/i,
+    );
+
+    await rm(join(root, 'escaped'));
+    await writeSkill(root, 'canonical');
+    await symlink(join(root, 'canonical'), join(root, 'alias'));
+    await expect(new FilesystemSkillSource({ root }).list()).rejects.toThrow(
+      /duplicate canonical skill path/i,
+    );
+  });
+
+  it.each([
+    ['Uppercase', /must match the Agent Skills name format/i],
+    ['double--hyphen', /must match the Agent Skills name format/i],
+    ['different-name', /must match its parent directory/i],
+  ] as const)(
+    'rejects invalid or mismatched skill name %s',
+    async (name, expected) => {
+      const root = await temporaryDirectory();
+      const path = await writeSkill(root, 'access-review', { name });
+      const source = new FilesystemSkillSource({ root });
+
+      await expect(source.list()).rejects.toThrow(
+        new RegExp(
+          `Invalid skill at ${await realpath(path)}:.*${expected.source}`,
+        ),
+      );
+    },
+  );
+
+  it('rejects a canonical-name change after discovery', async () => {
+    const root = await temporaryDirectory();
+    const path = await writeSkill(root, 'access-review');
+    const source = new FilesystemSkillSource({ root });
+    await source.list();
+    await writeFile(
+      path,
+      '---\nname: changed-name\ndescription: Changed\n---\nChanged.',
+    );
+
+    await expect(source.load('access-review')).rejects.toThrow(
+      /canonical name changed after discovery/i,
+    );
+  });
+
+  it('retries discovery after a failed scan instead of caching rejection', async () => {
+    const root = await temporaryDirectory();
+    const path = await writeSkill(root, 'access-review', { name: 'Invalid' });
+    const source = new FilesystemSkillSource({ root });
+
+    await expect(source.list()).rejects.toThrow(/name format/i);
+    await writeFile(
+      path,
+      '---\nname: access-review\ndescription: Valid\n---\nRecovered.',
+    );
+
+    await expect(source.list()).resolves.toEqual([
+      { name: 'access-review', description: 'Valid' },
+    ]);
+  });
+
+  it('caches discovery metadata and rereads only the selected definition', async () => {
+    const root = await temporaryDirectory();
+    const path = await writeSkill(root, 'access-review', {
+      instructions: 'Original instructions.',
+    });
+    const source = new FilesystemSkillSource({ root });
+    const firstList = await source.list();
+    await writeSkill(root, 'new-skill');
+    await writeFile(
+      path,
+      '---\nname: access-review\ndescription: Updated\n---\nUpdated instructions.',
+    );
+
+    const secondList = await source.list();
+    const loaded = await source.load('access-review');
+
+    expect(secondList).toBe(firstList);
+    expect(secondList).toHaveLength(1);
+    await expect(source.load('new-skill')).rejects.toThrow(
+      'Unknown scanned skill: new-skill',
+    );
+    expect(loaded).toMatchObject({
+      name: 'access-review',
+      description: 'Updated',
+      instructions: 'Updated instructions.',
+    });
+    expect(Object.isFrozen(loaded)).toBe(true);
+    expect(loaded).not.toHaveProperty('setup');
+  });
+
+  it('attributes malformed YAML errors to the canonical skill path', async () => {
+    const root = await temporaryDirectory();
+    const path = await writeSkill(root, 'access-review');
+    await writeFile(
+      path,
+      '---\nname: access-review\ndescription: [invalid\n---\nInstructions',
+    );
+    const source = new FilesystemSkillSource({ root });
+
+    await expect(source.list()).rejects.toThrow(
+      `Invalid skill at ${await realpath(path)}:`,
+    );
+  });
+
+  it('honors an already-aborted load signal', async () => {
+    const root = await temporaryDirectory();
+    await writeSkill(root, 'access-review');
+    const source = new FilesystemSkillSource({ root });
+    await source.list();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      source.load('access-review', { signal: controller.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('preserves an abort raised while reading a selected skill', async () => {
+    const root = await temporaryDirectory();
+    await writeSkill(root, 'access-review');
+    const source = new FilesystemSkillSource({ root });
+    await source.list();
+    const controller = new AbortController();
+
+    const loading = source.load('access-review', {
+      signal: controller.signal,
+    });
+    controller.abort();
+
+    await expect(loading).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('resolves allowed tools only through the supplied host catalog', async () => {
+    const root = await temporaryDirectory();
+    await writeSkill(root, 'access-review', {
+      allowedTools: 'list_access notify_owner',
+    });
+    const listAccess = tool('list_access');
+    const notifyOwner = tool('notify_owner');
+    const source = new FilesystemSkillSource({
+      root,
+      toolCatalog: { list_access: listAccess, notify_owner: notifyOwner },
+    });
+
+    await source.list();
+    await expect(source.load('access-review')).resolves.toMatchObject({
+      tools: [listAccess, notifyOwner],
+    });
+  });
+
+  it.each([
+    ['unknown', 'list_access missing', /unknown allowed tool.*missing/i],
+    ['duplicate', ['list_access', 'list_access'], /duplicate allowed tool/i],
+  ])('rejects %s allowed tools', async (_name, allowedTools, expected) => {
+    const root = await temporaryDirectory();
+    await writeSkill(root, 'access-review', { allowedTools });
+    const source = new FilesystemSkillSource({
+      root,
+      toolCatalog: { list_access: tool('list_access') },
+    });
+
+    await expect(source.list()).rejects.toThrow(expected);
+  });
+});
+
+const temporaryDirectory = async (): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), 'agent-skills-'));
+  roots.push(root);
+  return root;
+};
+
+const writeSkill = async (
+  root: string,
+  directory: string,
+  options: {
+    name?: string;
+    description?: string;
+    instructions?: string;
+    allowedTools?: string | readonly string[];
+    newline?: '\n' | '\r\n';
+  } = {},
+): Promise<string> => {
+  const newline = options.newline ?? '\n';
+  const skillDirectory = join(root, directory);
+  await mkdir(skillDirectory, { recursive: true });
+  const allowedTools =
+    options.allowedTools === undefined
+      ? ''
+      : `${newline}allowed-tools: ${formatYaml(options.allowedTools)}`;
+  const defaultDescription = `Use the ${directory} workflow`;
+  const description = options.description ?? defaultDescription;
+  const markdown = [
+    '---',
+    `name: ${options.name ?? directory}`,
+    `description: ${description}${allowedTools}`,
+    '---',
+    options.instructions ?? `Follow the ${directory} instructions.`,
+    '',
+  ].join(newline);
+  const path = join(skillDirectory, 'SKILL.md');
+  await writeFile(path, markdown);
+  return path;
+};
+
+const formatYaml = (value: string | readonly string[]): string =>
+  typeof value === 'string' ? value : JSON.stringify(value);
+
+const tool = (name: string): Tool => ({
+  name,
+  description: `${name} description`,
+  parameters: { type: 'object', properties: {} },
+  execute: () => `${name} result`,
+});

--- a/packages/agent-extensions/src/skills/filesystem/filesystem-skill-source.ts
+++ b/packages/agent-extensions/src/skills/filesystem/filesystem-skill-source.ts
@@ -1,0 +1,214 @@
+import { readFile, readdir, realpath } from 'node:fs/promises';
+import { isAbsolute, join, relative, sep } from 'node:path';
+
+import type { Tool } from '@ayunis/agent-runtime';
+
+import {
+  defineSkill,
+  type SkillDefinition,
+  type SkillSummary,
+} from '../skill-definition';
+import type { SkillLoadOptions, SkillSource } from '../skill-source';
+import { parseSkillMarkdown } from './skill-markdown';
+
+export interface FilesystemSkillSourceConfig {
+  readonly root: string;
+  readonly toolCatalog?: Readonly<Record<string, Tool>>;
+}
+
+interface Discovery {
+  readonly canonicalRoot?: string;
+  readonly summaries: readonly SkillSummary[];
+  readonly paths: ReadonlyMap<string, string>;
+}
+
+export class FilesystemSkillSource implements SkillSource {
+  private readonly root: string;
+  private readonly toolCatalog: ReadonlyMap<string, Tool>;
+  private discovery?: Promise<Discovery>;
+
+  constructor(config: FilesystemSkillSourceConfig) {
+    this.root = config.root;
+    this.toolCatalog = new Map(Object.entries(config.toolCatalog ?? {}));
+  }
+
+  async list(): Promise<readonly SkillSummary[]> {
+    return (await this.getDiscovery()).summaries;
+  }
+
+  async load(
+    name: string,
+    options?: SkillLoadOptions,
+  ): Promise<SkillDefinition> {
+    options?.signal?.throwIfAborted();
+    const discovery = await this.getDiscovery();
+    const path = discovery.paths.get(name);
+    if (!path || !discovery.canonicalRoot) {
+      throw new Error(`Unknown scanned skill: ${name}`);
+    }
+    const currentPath = await realpath(path);
+    assertContained(discovery.canonicalRoot, currentPath);
+    options?.signal?.throwIfAborted();
+    return this.readDefinition(currentPath, name, true, options?.signal);
+  }
+
+  private async getDiscovery(): Promise<Discovery> {
+    this.discovery ??= this.scan();
+    try {
+      return await this.discovery;
+    } catch (error) {
+      this.discovery = undefined;
+      throw error;
+    }
+  }
+
+  private async scan(): Promise<Discovery> {
+    const canonicalRoot = await resolveRoot(this.root);
+    if (!canonicalRoot) return { summaries: [], paths: new Map() };
+    const entries = (await readdir(canonicalRoot, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
+      .sort((left, right) => left.name.localeCompare(right.name));
+    return this.scanEntries(
+      canonicalRoot,
+      entries.map(({ name }) => name),
+    );
+  }
+
+  private async scanEntries(
+    canonicalRoot: string,
+    directoryNames: readonly string[],
+  ): Promise<Discovery> {
+    const candidates = await resolveCandidates(canonicalRoot, directoryNames);
+    const summaries: SkillSummary[] = [];
+    const paths = new Map<string, string>();
+    for (const { directoryName, path } of candidates) {
+      const definition = await this.readDefinition(path, directoryName, false);
+      if (paths.has(definition.name)) {
+        throw new Error(`Duplicate canonical skill name: ${definition.name}`);
+      }
+      paths.set(definition.name, path);
+      summaries.push({
+        name: definition.name,
+        description: definition.description,
+      });
+    }
+    return { canonicalRoot, summaries, paths };
+  }
+
+  private async readDefinition(
+    path: string,
+    expectedName: string,
+    isReload: boolean,
+    signal?: AbortSignal,
+  ): Promise<SkillDefinition> {
+    try {
+      const parsed = parseSkillMarkdown(
+        await readFile(path, { encoding: 'utf8', signal }),
+        expectedName,
+      );
+      const tools = this.resolveTools(parsed.allowedToolNames);
+      return defineSkill({
+        name: parsed.name,
+        description: parsed.description,
+        instructions: parsed.instructions,
+        ...(tools.length > 0 ? { tools } : {}),
+      });
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw error;
+      }
+      throw new Error(
+        `Invalid skill at ${path}: ${reloadErrorMessage(error, isReload)}`,
+        { cause: error },
+      );
+    }
+  }
+
+  private resolveTools(names: readonly string[]): Tool[] {
+    return names.map((name) => {
+      const resolved = this.toolCatalog.get(name);
+      if (!resolved) throw new Error(`Unknown allowed tool: ${name}`);
+      if (resolved.name !== name) {
+        throw new Error(
+          `Tool catalog entry '${name}' resolves to '${resolved.name}'.`,
+        );
+      }
+      return resolved;
+    });
+  }
+}
+
+interface SkillCandidate {
+  readonly directoryName: string;
+  readonly path: string;
+}
+
+const resolveCandidates = async (
+  root: string,
+  directoryNames: readonly string[],
+): Promise<SkillCandidate[]> => {
+  const candidates: SkillCandidate[] = [];
+  const canonicalPaths = new Set<string>();
+  for (const directoryName of directoryNames) {
+    const path = await resolveSkillPath(root, directoryName);
+    if (!path) continue;
+    assertContained(root, path);
+    if (canonicalPaths.has(path)) {
+      throw new Error(`Duplicate canonical skill path: ${path}`);
+    }
+    canonicalPaths.add(path);
+    candidates.push({ directoryName, path });
+  }
+  return candidates;
+};
+
+const resolveRoot = async (root: string): Promise<string | undefined> => {
+  try {
+    return await realpath(root);
+  } catch (error) {
+    if (hasErrorCode(error, 'ENOENT')) return undefined;
+    throw error;
+  }
+};
+
+const resolveSkillPath = async (
+  root: string,
+  directoryName: string,
+): Promise<string | undefined> => {
+  try {
+    return await realpath(join(root, directoryName, 'SKILL.md'));
+  } catch (error) {
+    if (hasErrorCode(error, 'ENOENT') || hasErrorCode(error, 'ENOTDIR')) {
+      return undefined;
+    }
+    throw error;
+  }
+};
+
+const assertContained = (root: string, path: string): void => {
+  const pathFromRoot = relative(root, path);
+  if (
+    isAbsolute(pathFromRoot) ||
+    pathFromRoot === '..' ||
+    pathFromRoot.startsWith(`..${sep}`)
+  ) {
+    throw new Error(`Skill path ${path} resolves outside the configured root.`);
+  }
+};
+
+const reloadErrorMessage = (error: unknown, isReload: boolean): string => {
+  const message = error instanceof Error ? error.message : String(error);
+  if (isReload && message === 'Skill name must match its parent directory.') {
+    return 'Skill canonical name changed after discovery.';
+  }
+  return message;
+};
+
+const hasErrorCode = (error: unknown, code: string): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  error.code === code;
+
+const isAbortError = (error: unknown): boolean =>
+  error instanceof Error && error.name === 'AbortError';

--- a/packages/agent-extensions/src/skills/filesystem/index.ts
+++ b/packages/agent-extensions/src/skills/filesystem/index.ts
@@ -1,0 +1,4 @@
+export {
+  FilesystemSkillSource,
+  type FilesystemSkillSourceConfig,
+} from './filesystem-skill-source';

--- a/packages/agent-extensions/src/skills/filesystem/skill-markdown.spec.ts
+++ b/packages/agent-extensions/src/skills/filesystem/skill-markdown.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseSkillMarkdown } from './skill-markdown';
+
+describe('parseSkillMarkdown', () => {
+  it.each(['\n', '\r\n'] as const)(
+    'parses Agent Skills frontmatter and instructions with %j lines',
+    (newline) => {
+      const markdown = [
+        '---',
+        'name: incident-response',
+        'description: Coordinate incident response',
+        'allowed-tools: [page_lead, inspect_logs]',
+        '---',
+        '# Response',
+        '',
+        'Page the incident lead.',
+      ].join(newline);
+
+      expect(parseSkillMarkdown(markdown, 'incident-response')).toEqual({
+        name: 'incident-response',
+        description: 'Coordinate incident response',
+        instructions: '# Response\n\nPage the incident lead.',
+        allowedToolNames: ['page_lead', 'inspect_logs'],
+      });
+    },
+  );
+
+  it.each([
+    ['missing frontmatter', 'Instructions only', /requires YAML frontmatter/i],
+    [
+      'invalid name',
+      '---\nname: Invalid\ndescription: Valid\n---\nInstructions',
+      /name format/i,
+    ],
+    [
+      'long description',
+      `---\nname: valid\ndescription: ${'x'.repeat(1025)}\n---\nInstructions`,
+      /at most 1024/i,
+    ],
+    [
+      'empty instructions',
+      '---\nname: valid\ndescription: Valid\n---\n',
+      /instructions must not be empty/i,
+    ],
+  ])('rejects %s', (_name, markdown, expected) => {
+    expect(() => parseSkillMarkdown(markdown, 'valid')).toThrow(expected);
+  });
+});

--- a/packages/agent-extensions/src/skills/filesystem/skill-markdown.ts
+++ b/packages/agent-extensions/src/skills/filesystem/skill-markdown.ts
@@ -1,0 +1,90 @@
+import { parseDocument } from 'yaml';
+
+export interface ParsedSkillMarkdown {
+  readonly name: string;
+  readonly description: string;
+  readonly instructions: string;
+  readonly allowedToolNames: readonly string[];
+}
+
+export const parseSkillMarkdown = (
+  markdown: string,
+  expectedName: string,
+): ParsedSkillMarkdown => {
+  const { frontmatter, instructions } = splitMarkdown(markdown);
+  const metadata = parseFrontmatter(frontmatter);
+  const name = requiredString(metadata, 'name');
+  const description = requiredString(metadata, 'description');
+  validateName(name, expectedName);
+  if (description.length > 1024) {
+    throw new Error('Skill description must be at most 1024 characters.');
+  }
+  const normalizedInstructions = instructions.trim();
+  if (!normalizedInstructions) {
+    throw new Error('Skill instructions must not be empty.');
+  }
+  return {
+    name,
+    description,
+    instructions: normalizedInstructions,
+    allowedToolNames: parseAllowedTools(metadata['allowed-tools']),
+  };
+};
+
+const splitMarkdown = (
+  markdown: string,
+): { frontmatter: string; instructions: string } => {
+  const normalized = markdown.replaceAll('\r\n', '\n');
+  const match = /^---\n([\s\S]*?)\n---(?:\n|$)([\s\S]*)$/.exec(normalized);
+  if (!match) throw new Error('SKILL.md requires YAML frontmatter.');
+  return { frontmatter: match[1], instructions: match[2] };
+};
+
+const parseFrontmatter = (frontmatter: string): Record<string, unknown> => {
+  const document = parseDocument(frontmatter, { uniqueKeys: true });
+  if (document.errors.length > 0) throw document.errors[0];
+  const value: unknown = document.toJS();
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('Skill frontmatter must be a YAML mapping.');
+  }
+  return value as Record<string, unknown>;
+};
+
+const requiredString = (
+  metadata: Readonly<Record<string, unknown>>,
+  field: string,
+): string => {
+  const value = metadata[field];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Skill ${field} must be a non-empty string.`);
+  }
+  return value;
+};
+
+const validateName = (name: string, expectedName: string): void => {
+  if (!/^(?!-)(?!.*--)[a-z0-9-]{1,64}(?<!-)$/.test(name)) {
+    throw new Error('Skill name must match the Agent Skills name format.');
+  }
+  if (name !== expectedName) {
+    throw new Error('Skill name must match its parent directory.');
+  }
+};
+
+const parseAllowedTools = (value: unknown): string[] => {
+  if (value === undefined) return [];
+  const names =
+    typeof value === 'string'
+      ? value.split(/\s+/).filter(Boolean)
+      : parseAllowedToolArray(value);
+  if (new Set(names).size !== names.length) {
+    throw new Error('Duplicate allowed tool name.');
+  }
+  return names;
+};
+
+const parseAllowedToolArray = (value: unknown): string[] => {
+  if (!Array.isArray(value) || value.some((name) => typeof name !== 'string')) {
+    throw new Error('allowed-tools must be a string or an array of strings.');
+  }
+  return value as string[];
+};

--- a/packages/agent-extensions/src/skills/index.ts
+++ b/packages/agent-extensions/src/skills/index.ts
@@ -1,0 +1,14 @@
+export { Skills } from './skills';
+export type {
+  PendingSkillActivation,
+  SkillsApi,
+  SkillsConfig,
+  SkillsDefinition,
+  SkillsState,
+} from './skills';
+export type {
+  SkillDefinition,
+  SkillDefinitionSpec,
+  SkillSummary,
+} from './skill-definition';
+export type { SkillLoadOptions, SkillSource } from './skill-source';

--- a/packages/agent-extensions/src/skills/skill-definition.ts
+++ b/packages/agent-extensions/src/skills/skill-definition.ts
@@ -1,0 +1,56 @@
+import type { Tool } from '@ayunis/agent-runtime';
+
+import type { ExtensionContext } from '../extensions/context';
+
+export interface SkillSummary {
+  readonly name: string;
+  readonly description: string;
+}
+
+export interface SkillDefinitionSpec extends SkillSummary {
+  readonly instructions: string;
+  readonly tools?: readonly Tool[];
+  activate?(context: ExtensionContext): void | Promise<void>;
+}
+
+export type SkillDefinition = SkillDefinitionSpec;
+
+export const defineSkill = (spec: SkillDefinitionSpec): SkillDefinition => {
+  validateSkill(spec);
+  const definition = Object.freeze({
+    name: spec.name,
+    description: spec.description,
+    instructions: spec.instructions,
+    ...(spec.tools ? { tools: Object.freeze([...spec.tools]) } : {}),
+    ...(spec.activate
+      ? { activate: (context: ExtensionContext) => spec.activate?.(context) }
+      : {}),
+  });
+  return definition;
+};
+
+const validateSkill = (spec: SkillDefinitionSpec): void => {
+  if (!/^(?!-)(?!.*--)[a-z0-9-]{1,64}(?<!-)$/.test(spec.name)) {
+    throw new Error('Skill name must match the Agent Skills name format.');
+  }
+  if (!spec.description || spec.description.length > 1024) {
+    throw new Error(
+      'Skill description must contain between 1 and 1024 characters.',
+    );
+  }
+  if (!spec.instructions.trim()) {
+    throw new Error('Skill instructions must not be empty.');
+  }
+  validateTools(spec.tools ?? []);
+};
+
+const validateTools = (tools: readonly Tool[]): void => {
+  const names = new Set<string>();
+  for (const tool of tools) {
+    if (!tool.name) throw new Error('Skill tools require a non-empty name.');
+    if (names.has(tool.name)) {
+      throw new Error(`Duplicate skill tool name '${tool.name}'.`);
+    }
+    names.add(tool.name);
+  }
+};

--- a/packages/agent-extensions/src/skills/skill-source.ts
+++ b/packages/agent-extensions/src/skills/skill-source.ts
@@ -1,0 +1,12 @@
+import type { SkillDefinition, SkillSummary } from './skill-definition';
+
+export type { SkillDefinition, SkillSummary } from './skill-definition';
+
+export interface SkillLoadOptions {
+  readonly signal?: AbortSignal;
+}
+
+export interface SkillSource {
+  list(): Promise<readonly SkillSummary[]>;
+  load(name: string, options?: SkillLoadOptions): Promise<SkillDefinition>;
+}

--- a/packages/agent-extensions/src/skills/skills.spec.ts
+++ b/packages/agent-extensions/src/skills/skills.spec.ts
@@ -1,0 +1,456 @@
+import type {
+  AfterToolCallContext,
+  RunContext,
+  RunEvent,
+  Tool,
+  ToolExecutionContext,
+} from '@ayunis/agent-runtime';
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  ExtensionContext,
+  ExtensionDefinitionIdentity,
+  ExtensionState,
+} from '../extensions/context';
+import { MissingExtensionError } from '../extensions/errors';
+import { defineExtension, type ExtensionSetup } from '../extensions/extension';
+import { KnowledgeBases } from '../knowledge-bases/knowledge-bases';
+import { Skills } from './skills';
+import type { SkillsConfig } from './skills';
+import type {
+  SkillDefinition,
+  SkillSource,
+  SkillSummary,
+} from './skill-source';
+
+const summary: SkillSummary = {
+  name: 'legal-research',
+  description: 'Research <laws> & regulations.',
+};
+
+const definition = () =>
+  Skills.define({
+    ...summary,
+    instructions: 'Use primary legal sources.',
+    tools: [tool('find_statute')],
+  });
+
+describe('Skills.define', () => {
+  it('returns a validated frozen plain definition without extension lifecycle', () => {
+    const skill = definition();
+
+    expect(skill).toMatchObject({
+      ...summary,
+      instructions: 'Use primary legal sources.',
+    });
+    expect(Object.isFrozen(skill)).toBe(true);
+    expect(Object.isFrozen(skill.tools)).toBe(true);
+    expect(skill).not.toHaveProperty('setup');
+    expect(skill).not.toHaveProperty('configure');
+  });
+
+  it.each([
+    [{ ...summary, name: 'Invalid Name', instructions: 'valid' }, /name/i],
+    [{ ...summary, description: '', instructions: 'valid' }, /description/i],
+    [{ ...summary, instructions: '' }, /instructions/i],
+    [
+      {
+        ...summary,
+        instructions: 'valid',
+        tools: [tool('same'), tool('same')],
+      },
+      /duplicate.*same/i,
+    ],
+  ])('rejects invalid definitions', (input, expected) => {
+    expect(() => Skills.define(input)).toThrow(expected);
+  });
+});
+
+describe('Skills extension', () => {
+  it('contributes no catalog, activation tool, or hook for an empty source', async () => {
+    const engine = controlledEngine();
+    const config = { source: sourceWith([]) };
+    const setup = await engine.setup(Skills, config);
+
+    expect(
+      Skills.contribute({ state: setup.state.current, api: setup.api }, config),
+    ).toEqual({});
+  });
+
+  it('lists once and contributes a deterministic escaped catalog and exact choices', async () => {
+    const source = sourceWith([
+      { name: 'zebra', description: 'Last' },
+      summary,
+    ]);
+    const run = await setupSkills({ source });
+
+    expect(source.list).toHaveBeenCalledOnce();
+    expect(source.load).not.toHaveBeenCalled();
+    expect(run.contribution().instructions).toContain(
+      '<name>legal-research</name>',
+    );
+    expect(run.contribution().instructions).toContain(
+      'Research &lt;laws&gt; &amp; regulations.',
+    );
+    expect(activationNameSchema(run.activationTool).enum).toEqual([
+      'legal-research',
+      'zebra',
+    ]);
+    expect(run.contribution().tools?.map(({ name }) => name)).toEqual([
+      'activate_skill',
+    ]);
+  });
+
+  it('loads only the selected definition and validates loaded metadata', async () => {
+    const source = sourceWith([summary], async () => ({
+      ...definition(),
+      description: 'Changed description',
+    }));
+    const run = await setupSkills({ source });
+
+    await expect(run.activate('legal-research')).rejects.toThrow(
+      /legal-research.*metadata/i,
+    );
+    expect(source.load).toHaveBeenCalledWith('legal-research', {
+      signal: expect.any(AbortSignal),
+    });
+    expect(run.state().pendingByCall.size).toBe(0);
+    expect(run.state().activated.size).toBe(0);
+  });
+
+  it('forwards cancellation to skill loading and preserves abort failures', async () => {
+    const abortError = new DOMException(
+      'The operation was aborted',
+      'AbortError',
+    );
+    const source = {
+      list: vi.fn(async () => [summary]),
+      load: vi.fn(async () => {
+        throw abortError;
+      }),
+    } satisfies SkillSource;
+    const run = await setupSkills({ source });
+
+    await expect(run.activate('legal-research')).rejects.toBe(abortError);
+    expect(source.load).toHaveBeenCalledWith('legal-research', {
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it('returns attributed model-actionable source and activation failures', async () => {
+    const failingSource = sourceWith([summary], async () => {
+      throw new Error('source unavailable');
+    });
+    const sourceRun = await setupSkills({ source: failingSource });
+
+    await expect(sourceRun.activate('legal-research')).rejects.toThrow(
+      'Could not activate skill "legal-research": source unavailable',
+    );
+
+    const missingDependency = Skills.define({
+      ...summary,
+      instructions: 'Needs knowledge.',
+      activate: (context) => context.use(KnowledgeBases).add(['legal']),
+    });
+    const dependencyRun = await setupSkills({
+      source: sourceWith([summary], async () => missingDependency),
+    });
+
+    await expect(
+      dependencyRun.activate('legal-research'),
+    ).rejects.toMatchObject({
+      message: expect.stringMatching(/legal-research.*knowledge-bases/i),
+      cause: expect.objectContaining({
+        consumerName: 'skills',
+        missingExtensionName: 'knowledge-bases',
+      }),
+    });
+  });
+
+  it('prepares capabilities transactionally and rolls back state and resources on failure', async () => {
+    const cleanup = vi.fn();
+    let dependencyState: ExtensionState<boolean>;
+    const Dependency = defineExtension({
+      name: 'dependency',
+      setup: (context, config: Record<string, never>) => {
+        dependencyState = context.state(false);
+        return {
+          state: dependencyState,
+          api: {
+            activate: () => {
+              dependencyState.update(() => true);
+              context.own(cleanup);
+            },
+            config,
+          },
+        };
+      },
+      contribute: () => ({}),
+    });
+    const engine = controlledEngine();
+    const dependency = await engine.setup(Dependency, {});
+    const skill = Skills.define({
+      ...summary,
+      instructions: 'Failure should not leak.',
+      activate: (context) => {
+        context.use(Dependency).activate();
+        throw new Error('trusted activation failed');
+      },
+    });
+    const run = await setupSkills(
+      { source: sourceWith([summary], async () => skill) },
+      engine,
+    );
+
+    await expect(
+      engine.transaction(() => run.activate('legal-research')),
+    ).rejects.toThrow(/legal-research.*trusted activation failed/i);
+
+    expect(dependency.state.current).toBe(false);
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(run.state().pendingByCall.size).toBe(0);
+    expect(run.contribution().tools?.map(({ name }) => name)).toEqual([
+      'activate_skill',
+    ]);
+  });
+
+  it('keeps prepared instructions and tools staged until successful completion', async () => {
+    const activate = vi.fn();
+    const skill = Skills.define({
+      ...summary,
+      instructions: 'Activated instructions.',
+      tools: [tool('activated_tool')],
+      activate,
+    });
+    const run = await setupSkills({
+      source: sourceWith([summary], async () => skill),
+    });
+
+    const output = await run.activate('legal-research', 'call-1');
+    expect(output).toMatchObject({ isError: false });
+    expect(run.state().activated.size).toBe(0);
+    expect(run.state().pendingByCall.size).toBe(1);
+    expect(run.contribution().instructions).toContain(
+      'Activated instructions.',
+    );
+    expect(run.contribution().tools?.map(({ name }) => name)).toEqual([
+      'activate_skill',
+      'activated_tool',
+    ]);
+
+    await run.complete('call-1', 'success');
+
+    expect(run.state().pendingByCall.size).toBe(0);
+    expect([...run.state().activated.keys()]).toEqual(['legal-research']);
+    expect(run.state().activated.get('legal-research')).toMatchObject({
+      name: skill.name,
+      description: skill.description,
+      instructions: skill.instructions,
+    });
+    expect(activate).toHaveBeenCalledOnce();
+  });
+
+  it.each(['error', 'aborted'] as const)(
+    'discards prepared activation after an %s outcome',
+    async (outcome) => {
+      const run = await setupSkills({
+        source: sourceWith([summary], async () => definition()),
+      });
+      await run.activate('legal-research', 'call-1');
+
+      await run.complete('call-1', outcome);
+
+      expect(run.state().pendingByCall.size).toBe(0);
+      expect(run.state().activated.size).toBe(0);
+      expect(run.contribution().tools?.map(({ name }) => name)).toEqual([
+        'activate_skill',
+      ]);
+    },
+  );
+
+  it('makes repeated activation idempotent and completes it only once', async () => {
+    const activate = vi.fn();
+    const skill = Skills.define({ ...definition(), activate });
+    const source = sourceWith([summary], async () => skill);
+    const run = await setupSkills({ source });
+
+    await run.activate('legal-research', 'first-call');
+    await run.complete('first-call', 'success');
+    await run.activate('legal-research', 'second-call');
+    await run.complete('first-call', 'success');
+    await run.complete('second-call', 'success');
+
+    expect(source.load).toHaveBeenCalledOnce();
+    expect(activate).toHaveBeenCalledOnce();
+    expect(run.state().activated.size).toBe(1);
+    expect(run.contribution().hooks?.[0]).toBe(run.hook);
+  });
+});
+
+const setupSkills = async (
+  config: SkillsConfig,
+  engine = controlledEngine(),
+) => {
+  const setup = await engine.setup(Skills, config);
+  const contribution = () =>
+    Skills.contribute({ state: setup.state.current, api: setup.api }, config);
+  const activationTool = contribution().tools?.find(
+    ({ name }) => name === 'activate_skill',
+  );
+  const hook = contribution().hooks?.[0];
+  if (!activationTool || !hook) {
+    throw new Error('Expected Skills activation tool and hook.');
+  }
+  return {
+    activationTool,
+    hook,
+    contribution,
+    state: () => setup.state.current,
+    activate: (name: string, toolCallId = 'call-1') =>
+      activationTool.execute?.({ name }, toolContext(toolCallId)),
+    complete: (toolCallId: string, outcome: 'success' | 'error' | 'aborted') =>
+      hook.afterToolCall?.(
+        afterToolCallContext(
+          toolCallId,
+          outcome,
+        ) as unknown as AfterToolCallContext,
+      ),
+  };
+};
+
+const sourceWith = (
+  summaries: readonly SkillSummary[],
+  load: (name: string) => Promise<SkillDefinition> = async () => definition(),
+): SkillSource & {
+  list: ReturnType<typeof vi.fn>;
+  load: ReturnType<typeof vi.fn>;
+} => ({
+  list: vi.fn(async () => summaries),
+  load: vi.fn(load),
+});
+
+const controlledEngine = () => {
+  const registry = new Map<ExtensionDefinitionIdentity, unknown>();
+  const cleanups: Array<() => void | Promise<void>> = [];
+  let consumerName = 'skills';
+  let transaction: Transaction | undefined;
+  const context: ExtensionContext = {
+    get extensionName() {
+      return consumerName;
+    },
+    state: <State>(initial: State): ExtensionState<State> => {
+      return controlledCell(initial, () => transaction);
+    },
+    use: <Definition extends ExtensionDefinitionIdentity>(
+      definition: Definition,
+    ) => {
+      if (!registry.has(definition)) {
+        throw new MissingExtensionError(consumerName, definition.name);
+      }
+      return registry.get(definition);
+    },
+    useOptional: <Definition extends ExtensionDefinitionIdentity>(
+      definition: Definition,
+    ) => registry.get(definition),
+    own: (cleanup) =>
+      transaction ? transaction.cleanups.push(cleanup) : cleanups.push(cleanup),
+  };
+  return {
+    setup: async <Config, State, Api>(
+      definition: ExtensionDefinitionIdentity & {
+        setup(
+          context: ExtensionContext,
+          config: Readonly<Config>,
+        ): ExtensionSetup<State, Api> | Promise<ExtensionSetup<State, Api>>;
+      },
+      config: Readonly<Config>,
+    ) => {
+      consumerName = definition.name;
+      const setup = await definition.setup(context, config);
+      registry.set(definition, setup.api);
+      return setup;
+    },
+    transaction: async <Result>(operation: () => Result | Promise<Result>) => {
+      const active: Transaction = { staged: new Map(), cleanups: [] };
+      transaction = active;
+      try {
+        const result = await operation();
+        for (const [cell, value] of active.staged) cell.commit(value);
+        cleanups.push(...active.cleanups);
+        return result;
+      } catch (error) {
+        for (const cleanup of active.cleanups.toReversed()) await cleanup();
+        throw error;
+      } finally {
+        transaction = undefined;
+      }
+    },
+  };
+};
+
+interface Transaction {
+  readonly staged: Map<ControlledCell<unknown>, unknown>;
+  readonly cleanups: Array<() => void | Promise<void>>;
+}
+
+interface ControlledCell<State> extends ExtensionState<State> {
+  commit(value: unknown): void;
+}
+
+const controlledCell = <State>(
+  initial: State,
+  activeTransaction: () => Transaction | undefined,
+): ControlledCell<State> => {
+  let committed = initial;
+  const cell: ControlledCell<State> = {
+    get current() {
+      const staged = activeTransaction()?.staged.get(cell);
+      return (staged === undefined ? committed : staged) as State;
+    },
+    update(updater) {
+      const next = updater(cell.current);
+      const active = activeTransaction();
+      if (active) active.staged.set(cell, next);
+      else committed = next;
+    },
+    commit(value) {
+      committed = value as State;
+    },
+  };
+  return cell;
+};
+
+const tool = (name: string): Tool => ({
+  name,
+  description: `${name} description`,
+  parameters: { type: 'object', properties: {} },
+  execute: () => 'ok',
+});
+
+const activationNameSchema = (activationTool: Tool): { enum?: string[] } =>
+  (activationTool.parameters.properties as Record<string, { enum?: string[] }>)
+    .name;
+
+const toolContext = (toolCallId: string): ToolExecutionContext => ({
+  context: {} as RunContext,
+  toolCallId,
+  toolNames: ['activate_skill'],
+  signal: new AbortController().signal,
+  emit: vi.fn(),
+  runChild: () => emptyChildRun(),
+});
+
+async function* emptyChildRun(): AsyncGenerator<RunEvent> {
+  yield* [];
+}
+
+const afterToolCallContext = (
+  id: string,
+  outcome: 'success' | 'error' | 'aborted',
+) => ({
+  toolCall: { id, name: 'activate_skill', input: { name: summary.name } },
+  result: outcome,
+  isError: outcome !== 'success',
+  outcome,
+  isLastToolCall: true,
+});

--- a/packages/agent-extensions/src/skills/skills.ts
+++ b/packages/agent-extensions/src/skills/skills.ts
@@ -1,0 +1,303 @@
+import type { Hook, Tool, ToolExecutionResult } from '@ayunis/agent-runtime';
+
+import type { ExtensionContext, ExtensionState } from '../extensions/context';
+import {
+  defineExtension,
+  type ConfiguredExtension,
+  type ExtensionDefinition,
+} from '../extensions/extension';
+import { buildAvailableSkills, type AvailableSkills } from './available-skills';
+import {
+  defineSkill,
+  type SkillDefinition,
+  type SkillDefinitionSpec,
+  type SkillSummary,
+} from './skill-definition';
+import type { SkillSource } from './skill-source';
+
+const ACTIVATE_SKILL = 'activate_skill';
+const activationTool = Symbol('skills-activation-tool');
+const catalogInstructions = Symbol('skills-catalog-instructions');
+const completionHook = Symbol('skills-completion-hook');
+
+export interface PendingSkillActivation {
+  readonly name: string;
+  readonly definition: SkillDefinition;
+}
+
+export interface SkillsState {
+  readonly pendingByCall: ReadonlyMap<string, PendingSkillActivation>;
+  readonly activated: ReadonlyMap<string, SkillDefinition>;
+}
+
+export interface SkillsConfig {
+  readonly source: SkillSource;
+}
+
+export type SkillsApi = object;
+
+interface RuntimeSkillsApi {
+  readonly [activationTool]: Tool;
+  readonly [catalogInstructions]: string;
+  readonly [completionHook]: Hook;
+}
+
+type BaseSkillsDefinition = ExtensionDefinition<
+  'skills',
+  SkillsConfig,
+  SkillsState,
+  SkillsApi
+>;
+
+export type SkillsDefinition = Omit<BaseSkillsDefinition, 'configure'> & {
+  define(spec: SkillDefinitionSpec): SkillDefinition;
+  configure(
+    config: SkillsConfig,
+  ): ConfiguredExtension<SkillsDefinition, SkillsConfig>;
+};
+
+const BaseSkills = defineExtension<
+  'skills',
+  SkillsState,
+  SkillsApi,
+  SkillsConfig
+>({
+  name: 'skills',
+  async setup(context, config) {
+    const available = buildAvailableSkills(await config.source.list());
+    const state = context.state<SkillsState>({
+      pendingByCall: new Map(),
+      activated: new Map(),
+    });
+    const api = createRuntimeApi(context, state, config.source, available);
+    return { state, api };
+  },
+  contribute({ state, api }) {
+    const runtimeApi = api as RuntimeSkillsApi;
+    if (!runtimeApi[catalogInstructions]) {
+      return {};
+    }
+    const definitions = capabilityDefinitions(state);
+    return {
+      instructions: buildInstructions(
+        runtimeApi[catalogInstructions],
+        definitions,
+      ),
+      tools: [
+        runtimeApi[activationTool],
+        ...definitions.flatMap(({ tools }) => [...(tools ?? [])]),
+      ],
+      hooks: [runtimeApi[completionHook]],
+    };
+  },
+});
+
+export const Skills: SkillsDefinition = Object.freeze({
+  ...BaseSkills,
+  define: defineSkill,
+  configure(config: SkillsConfig) {
+    const configured = BaseSkills.configure(config);
+    return Object.freeze({ definition: Skills, config: configured.config });
+  },
+});
+
+const createRuntimeApi = (
+  context: ExtensionContext,
+  state: ExtensionState<SkillsState>,
+  source: SkillSource,
+  available: AvailableSkills,
+): RuntimeSkillsApi => ({
+  [activationTool]: createActivationTool(context, state, source, available),
+  [catalogInstructions]: available.instructions,
+  [completionHook]: createCompletionHook(state),
+});
+
+const createActivationTool = (
+  context: ExtensionContext,
+  state: ExtensionState<SkillsState>,
+  source: SkillSource,
+  available: AvailableSkills,
+): Tool => ({
+  name: ACTIVATE_SKILL,
+  description: 'Activate one available skill for the current agent run.',
+  parameters: available.activationSchema,
+  validateInput: (input) => parseSkillName(input, available.names),
+  execute: async (input, toolContext) => {
+    const name = parseSkillName(input, available.names);
+    if (isAlreadyPrepared(state.current, name)) {
+      return activationSuccess(`Skill "${name}" is already active.`);
+    }
+    return prepareActivation({
+      context,
+      state,
+      source,
+      expected: available.summaries.get(name),
+      name,
+      toolCallId: toolContext.toolCallId,
+      signal: toolContext.signal,
+    });
+  },
+});
+
+interface ActivationPreparation {
+  readonly context: ExtensionContext;
+  readonly state: ExtensionState<SkillsState>;
+  readonly source: SkillSource;
+  readonly expected?: SkillSummary;
+  readonly name: string;
+  readonly toolCallId: string;
+  readonly signal?: AbortSignal;
+}
+
+const prepareActivation = async (
+  preparation: ActivationPreparation,
+): Promise<ToolExecutionResult> => {
+  try {
+    const loaded = await preparation.source.load(
+      preparation.name,
+      preparation.signal ? { signal: preparation.signal } : undefined,
+    );
+    validateLoadedMetadata(loaded, preparation.expected, preparation.name);
+    const definition = defineSkill(loaded);
+    await definition.activate?.(preparation.context);
+    stagePending(preparation.state, preparation.toolCallId, definition);
+    return activationSuccess(
+      `Prepared skill "${preparation.name}" for activation.`,
+    );
+  } catch (error) {
+    preparation.signal?.throwIfAborted();
+    if (isAbortError(error)) {
+      throw error;
+    }
+    throw new SkillActivationError(preparation.name, error);
+  }
+};
+
+const stagePending = (
+  state: ExtensionState<SkillsState>,
+  toolCallId: string,
+  definition: SkillDefinition,
+): void => {
+  state.update((current) => {
+    if (current.pendingByCall.has(toolCallId)) {
+      throw new Error(`Tool call '${toolCallId}' already prepared a skill.`);
+    }
+    const pendingByCall = new Map(current.pendingByCall);
+    pendingByCall.set(toolCallId, { name: definition.name, definition });
+    return { ...current, pendingByCall };
+  });
+};
+
+const createCompletionHook = (state: ExtensionState<SkillsState>): Hook => ({
+  name: 'skills-activation-completion',
+  afterToolCall: (event) => {
+    if (event.toolCall.name !== ACTIVATE_SKILL) {
+      return;
+    }
+    const pending = state.current.pendingByCall.get(event.toolCall.id);
+    if (!pending) {
+      return;
+    }
+    state.update((current) =>
+      completePending(current, event.toolCall.id, event.outcome),
+    );
+  },
+});
+
+const completePending = (
+  current: Readonly<SkillsState>,
+  toolCallId: string,
+  outcome: 'success' | 'error' | 'aborted',
+): SkillsState => {
+  const pending = current.pendingByCall.get(toolCallId);
+  const pendingByCall = new Map(current.pendingByCall);
+  pendingByCall.delete(toolCallId);
+  if (!pending || outcome !== 'success') {
+    return { ...current, pendingByCall };
+  }
+  const activated = new Map(current.activated);
+  activated.set(pending.name, pending.definition);
+  return { pendingByCall, activated };
+};
+
+const capabilityDefinitions = (
+  state: Readonly<SkillsState>,
+): SkillDefinition[] => {
+  const definitions = new Map(state.activated);
+  for (const pending of state.pendingByCall.values()) {
+    definitions.set(pending.name, pending.definition);
+  }
+  return [...definitions.values()].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+};
+
+const buildInstructions = (
+  catalog: string,
+  definitions: readonly SkillDefinition[],
+): string =>
+  [catalog, ...definitions.map(({ instructions }) => instructions)]
+    .filter(Boolean)
+    .join('\n\n');
+
+const validateLoadedMetadata = (
+  definition: SkillDefinition,
+  expected: SkillSummary | undefined,
+  requestedName: string,
+): void => {
+  if (
+    !expected ||
+    definition.name !== requestedName ||
+    definition.description !== expected.description
+  ) {
+    throw new Error(
+      'Loaded skill identity or metadata does not match its catalog entry.',
+    );
+  }
+};
+
+const parseSkillName = (
+  input: Record<string, unknown>,
+  availableNames: readonly string[],
+): string => {
+  if (
+    Object.keys(input).length !== 1 ||
+    typeof input.name !== 'string' ||
+    !availableNames.includes(input.name)
+  ) {
+    throw new Error(
+      'activate_skill requires exactly one available skill name.',
+    );
+  }
+  return input.name;
+};
+
+const isAlreadyPrepared = (
+  state: Readonly<SkillsState>,
+  name: string,
+): boolean =>
+  state.activated.has(name) ||
+  [...state.pendingByCall.values()].some((pending) => pending.name === name);
+
+const activationSuccess = (result: string): ToolExecutionResult => ({
+  result,
+  isError: false,
+});
+
+class SkillActivationError extends Error {
+  constructor(
+    readonly skillName: string,
+    cause: unknown,
+  ) {
+    super(`Could not activate skill "${skillName}": ${errorMessage(cause)}`, {
+      cause,
+    });
+    this.name = 'SkillActivationError';
+  }
+}
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const isAbortError = (error: unknown): boolean =>
+  error instanceof Error && error.name === 'AbortError';

--- a/packages/agent-extensions/tsup.config.ts
+++ b/packages/agent-extensions/tsup.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: [
+    'src/index.ts',
+    'src/knowledge-bases/index.ts',
+    'src/mcp/index.ts',
+    'src/skills/index.ts',
+    'src/skills/filesystem/index.ts',
+  ],
   format: ['esm', 'cjs'],
   dts: {
     compilerOptions: { ignoreDeprecations: '6.0' },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -685,6 +685,12 @@ importers:
       '@ayunis/agent-runtime':
         specifier: workspace:*
         version: link:../agent-runtime
+      '@modelcontextprotocol/client':
+        specifier: ^2.0.0
+        version: 2.0.0
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.18.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New MCP and filesystem skill loading paths touch authorization, external processes, and path traversal boundaries; mistakes could widen tool exposure or leak resources if hosts misconfigure resolvers.
> 
> **Overview**
> Adds **first-party built-in extensions** to `@ayunis/agent-extensions` as optional package subpaths (`knowledge-bases`, `mcp`, `skills`, `skills/filesystem`) so the root export still only exposes `defineExtension` and extension errors—heavy deps stay out of the main bundle.
> 
> **KnowledgeBases** activates host-authorized knowledge bases at runtime, emits XML instructions and `knowledge_query` / `knowledge_get_text` tools scoped to active IDs, and optionally records usage via an `afterToolCall` hook.
> 
> **Mcp** resolves authorized connections, connects and discovers tools per run (with rollback on failure), namespaces model tool names deterministically, forwards execution to MCP servers, and registers client cleanup via `ctx.own()`.
> 
> **Skills** builds a catalog from a `SkillSource`, exposes `activate_skill`, stages instructions/tools until the tool call succeeds, and supports `Skills.define()` plus optional **FilesystemSkillSource** for `SKILL.md` discovery with path containment and YAML frontmatter parsing.
> 
> Packaging/build updates add `@modelcontextprotocol/client` and `yaml`, multi-entry `tsup`/`knip` config, expanded README with agent configuration examples, and tests that lock the public surface and subpath isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfa7f139e2e0581bea75cec428b4d23859be731a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->