### PR TITLE
wip(agent-sdk): add runnable agent (AYC-792)

### DIFF
--- a/packages/agent-harness/README.md
+++ b/packages/agent-harness/README.md
@@ -1,47 +1,90 @@
 # @ayunis/agent-harness
 
-Runnable agent composition above `@ayunis/agent-runtime` and
+Runnable, immutable agents above `@ayunis/agent-runtime` and
 `@ayunis/agent-extensions`.
 
-The package is converging on one public abstraction:
+## Create and run an agent
 
 ```ts
-const agent = createAgent(config);
-const variant = agent.variant({
-  name: 'researcher-with-sources',
-  instructions: 'Prefer primary sources.',
-  extensions: [Sources.configure(options)],
+import { createAgent } from '@ayunis/agent-harness';
+import { RunContext } from '@ayunis/agent-runtime';
+
+const agent = createAgent({
+  name: 'researcher',
+  instructions: 'Answer with cited evidence.',
+  extensions: [KnowledgeBases.configure(knowledgeBaseOptions)],
+  modelSelector: { deployment: 'host-selected' },
+  resolveModel: async (selector, { context, signal }) =>
+    resolveHostModel({
+      selector,
+      organizationId: context.get('organizationId'),
+      signal,
+    }),
+  maxIterations: 12,
 });
 
-for await (const event of variant.run(input)) {
-  // consume runtime events
+const context = RunContext.create({ organizationId: 'org-1' });
+for await (const event of agent.run({
+  messages,
+  tools: hostTools,
+  context,
+  signal: abortController.signal,
+})) {
+  handleEvent(event);
 }
 ```
 
-At this checkpoint the root exports only the agent, configuration, run-input,
-model-resolver, and error contracts. The runnable `createAgent()` implementation
-will follow on the same package surface.
+The model selector is opaque to the package. `resolveModel()` receives the
+agent's frozen selector and the current run context on every public run, so the
+host remains responsible for model policy, credentials, and concrete provider
+construction. Creating an agent does not resolve a model, initialize an
+extension, or acquire a resource.
 
-Agent configuration has a stable name, instructions, configured extensions, an
-opaque host-owned model selector, a resolver callback, and simple run limits.
-Variants append instructions and extensions while inheriting model resolution
-and limits. Configuration is copied and frozen without resolving models,
-running extension setup, or acquiring resources.
+`agent.run()` forwards runtime events unchanged. Messages, authorization data,
+host tools, abort signals, durable capability state, and persistence remain
+host-owned inputs. When no context is supplied, the agent creates a fresh root
+`RunContext`.
 
-Messages, authorization context, capability persistence, and infrastructure
-remain host-owned inputs. The package intentionally has no public profile,
-registry, shared harness, model-policy/capability layer, or state-store
-protocol.
+## Variants
 
-## Private extension execution
+```ts
+const legalResearcher = agent.variant({
+  name: 'legal-researcher',
+  instructions: 'Prefer primary legal sources.',
+  extensions: [Skills.configure(skillsOptions)],
+});
+```
 
-Each future `agent.run()` owns one private extension engine. It sets configured
-extensions up in order, registers run-local APIs, projects owned instructions
-and tools, batches dirty-state reconciliation before model requests, and tears
-resources down in reverse order. State and newly acquired resources participate
-in engine transactions so prospective contributions can be collision-checked
-before an activation commits.
+A variant is another frozen runnable agent. It appends instructions and
+extensions while inheriting the base agent's model selector, resolver, limits,
+tool choice, and configured extensions. It cannot replace inherited settings
+or repeat an inherited extension.
 
-This machinery is deliberately absent from the root exports and package
-subpaths. It is an implementation detail of `createAgent()`, not another public
-runner, registry, or session abstraction.
+## Run lifecycle and isolation
+
+Every root run performs the following lifecycle:
+
+1. resolve the model for the run context;
+2. create a private extension engine and set up configured extensions in order;
+3. collision-check and compose host and extension instructions and tools;
+4. delegate execution to `@ayunis/agent-runtime`;
+5. close the runtime iterator and dispose extension resources in reverse order.
+
+Cleanup is idempotent and runs after completion, runtime failure, abort, setup
+rollback, or an explicit event-iterator `.return()`. Concurrent runs share only
+the frozen agent configuration; their extension state and run-owned resources
+are independent.
+
+Tools may use the runtime's `runChild()` seam. The harness intercepts child
+execution to create a new private extension engine around the child input and
+its derived child context. A child receives fresh extension state, hooks, and
+resources, does not inherit the parent's extension instances, and finalizes
+independently. Explicit child host hooks still apply to that child.
+
+## Public boundary
+
+The root package exports `createAgent()`, its agent/configuration/run types,
+model-resolver contracts, and attributed configuration/model-resolution errors.
+The extension engine remains private. There is no public profile, shared
+harness, registry, session runner, agent-state store, model-policy layer, or
+implicit persistence protocol.

--- a/packages/agent-harness/src/agent/create-agent.spec.ts
+++ b/packages/agent-harness/src/agent/create-agent.spec.ts
@@ -1,0 +1,516 @@
+import { defineExtension } from '@ayunis/agent-extensions';
+import {
+  MockProvider,
+  RunContext,
+  textTurn,
+  toolCallTurn,
+  type Message,
+  type ModelProvider,
+  type RunEvent,
+  type Tool,
+} from '@ayunis/agent-runtime';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  AgentConfigurationError,
+  ModelResolutionError,
+  createAgent,
+} from '../index';
+
+const emptyConfig = {} as Record<string, never>;
+const userMessage = (text: string): Message => ({
+  role: 'user',
+  content: [{ type: 'text', text }],
+});
+const collect = async (
+  events: AsyncIterable<RunEvent>,
+): Promise<RunEvent[]> => {
+  const collected: RunEvent[] = [];
+  for await (const event of events) collected.push(event);
+  return collected;
+};
+const tool = (name: string, execute?: Tool['execute']): Tool => ({
+  name,
+  description: name,
+  parameters: { type: 'object', properties: {} },
+  ...(execute ? { execute } : {}),
+});
+
+const Resource = (setup: () => void, cleanup: () => void) =>
+  defineExtension({
+    name: 'resource',
+    setup: (ctx, config: Record<string, never>) => {
+      setup();
+      ctx.own(cleanup);
+      return { state: ctx.state(config), api: {} };
+    },
+    contribute: () => ({}),
+  });
+
+describe('createAgent', () => {
+  it('validates and snapshots immutable configuration without run work', async () => {
+    const setup = vi.fn();
+    const cleanup = vi.fn();
+    const Lazy = Resource(setup, cleanup);
+    const extensions = [Lazy.configure(emptyConfig)];
+    const selector = { provider: { deployment: 'alpha' } };
+    const resolver = vi.fn(
+      (selector: Readonly<{ provider: { deployment: string } }>) =>
+        new MockProvider([textTurn(selector.provider.deployment)]),
+    );
+
+    const agent = createAgent({
+      name: 'researcher',
+      instructions: 'Research carefully.',
+      extensions,
+      modelSelector: selector,
+      resolveModel: resolver,
+    });
+    selector.provider.deployment = 'changed';
+    extensions.length = 0;
+
+    expect(Object.isFrozen(agent)).toBe(true);
+    expect(agent.name).toBe('researcher');
+    expect(setup).not.toHaveBeenCalled();
+    expect(resolver).not.toHaveBeenCalled();
+
+    await collect(agent.run({ messages: [userMessage('go')] }));
+
+    expect(resolver.mock.calls[0][0]).toEqual({
+      provider: { deployment: 'alpha' },
+    });
+    expect(Object.isFrozen(resolver.mock.calls[0][0])).toBe(true);
+    expect(setup).toHaveBeenCalledOnce();
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it('rejects invalid configuration synchronously', () => {
+    expect(() =>
+      createAgent({
+        name: 'invalid name',
+        instructions: 'Invalid.',
+        modelSelector: 'mock',
+        resolveModel: () => new MockProvider([]),
+      }),
+    ).toThrow(AgentConfigurationError);
+  });
+
+  it('creates frozen variants that append only instructions and extensions', async () => {
+    const Base = defineExtension({
+      name: 'base',
+      setup: (ctx, config: Record<string, never>) => ({
+        state: ctx.state(config),
+        api: {},
+      }),
+      contribute: () => ({
+        instructions: 'Base extension.',
+        tools: [tool('base_tool')],
+      }),
+    });
+    const Extra = defineExtension({
+      name: 'extra',
+      setup: (ctx, config: Record<string, never>) => ({
+        state: ctx.state(config),
+        api: {},
+      }),
+      contribute: () => ({ instructions: 'Extra extension.' }),
+    });
+    const model = new MockProvider([textTurn('done')]);
+    const resolver = vi.fn(() => model);
+    const base = createAgent({
+      name: 'base-agent',
+      instructions: 'Base instructions.',
+      extensions: [Base.configure(emptyConfig)],
+      modelSelector: { deployment: 'alpha' },
+      resolveModel: resolver,
+      maxIterations: 7,
+      toolChoice: 'required',
+    });
+
+    const variant = base.variant({
+      name: 'variant-agent',
+      instructions: 'Variant instructions.',
+      extensions: [Extra.configure(emptyConfig)],
+    });
+    const events = await collect(
+      variant.run({ messages: [userMessage('go')] }),
+    );
+
+    expect(Object.isFrozen(variant)).toBe(true);
+    expect(base.name).toBe('base-agent');
+    expect(variant.name).toBe('variant-agent');
+    expect(events[0]).toMatchObject({ type: 'run_start', maxIterations: 7 });
+    expect(model.requests[0]).toMatchObject({
+      instructions:
+        'Base instructions.\n\nVariant instructions.\n\nBase extension.\n\nExtra extension.',
+      toolChoice: 'required',
+    });
+    expect(model.requests[0].tools.map(({ name }) => name)).toEqual([
+      'base_tool',
+    ]);
+    expect(resolver).toHaveBeenCalledOnce();
+  });
+});
+
+describe('agent.run', () => {
+  it('resolves the opaque model selector for every run with its context and signal', async () => {
+    const models = [
+      new MockProvider([textTurn('first')]),
+      new MockProvider([textTurn('second')]),
+    ];
+    const resolver = vi
+      .fn<() => ModelProvider>()
+      .mockReturnValueOnce(models[0])
+      .mockReturnValueOnce(models[1]);
+    const selector = Object.freeze({ deployment: 'host-owned' });
+    const agent = createAgent({
+      name: 'runner',
+      instructions: 'Run.',
+      modelSelector: selector,
+      resolveModel: resolver,
+    });
+    const firstContext = RunContext.create({ request: 'first' });
+    const secondContext = RunContext.create({ request: 'second' });
+    const controller = new AbortController();
+
+    const firstEvents = await collect(
+      agent.run({
+        messages: [userMessage('one')],
+        context: firstContext,
+        signal: controller.signal,
+      }),
+    );
+    await collect(
+      agent.run({ messages: [userMessage('two')], context: secondContext }),
+    );
+
+    expect(resolver).toHaveBeenNthCalledWith(1, selector, {
+      context: firstContext,
+      signal: controller.signal,
+    });
+    expect(resolver).toHaveBeenNthCalledWith(2, selector, {
+      context: secondContext,
+    });
+    expect(firstEvents.map(({ type }) => type)).toEqual([
+      'run_start',
+      'text_delta',
+      'text_delta',
+      'assistant_message',
+      'run_end',
+    ]);
+    expect(firstEvents.every(({ runId }) => runId === firstContext.runId)).toBe(
+      true,
+    );
+  });
+
+  it('attributes model resolution failures without setting up extensions', async () => {
+    const setup = vi.fn();
+    const Lazy = Resource(setup, vi.fn());
+    const failure = new Error('credentials unavailable');
+    const agent = createAgent({
+      name: 'runner',
+      instructions: 'Run.',
+      extensions: [Lazy.configure(emptyConfig)],
+      modelSelector: 'unavailable',
+      resolveModel: () => {
+        throw failure;
+      },
+    });
+
+    await expect(
+      collect(agent.run({ messages: [userMessage('go')] })),
+    ).rejects.toMatchObject({
+      name: 'ModelResolutionError',
+      agentName: 'runner',
+      cause: failure,
+    });
+    expect(setup).not.toHaveBeenCalled();
+    expect(new ModelResolutionError('runner', failure).message).toMatch(
+      /runner/,
+    );
+  });
+
+  it('rejects initial tool collisions before calling the provider and cleans up', async () => {
+    const cleanup = vi.fn();
+    const Collision = defineExtension({
+      name: 'collision',
+      setup: (ctx, config: Record<string, never>) => {
+        ctx.own(cleanup);
+        return { state: ctx.state(config), api: {} };
+      },
+      contribute: () => ({ tools: [tool('duplicate')] }),
+    });
+    const model = new MockProvider([textTurn('unreachable')]);
+    const agent = createAgent({
+      name: 'runner',
+      instructions: 'Run.',
+      extensions: [Collision.configure(emptyConfig)],
+      modelSelector: 'mock',
+      resolveModel: () => model,
+    });
+
+    await expect(
+      collect(
+        agent.run({
+          messages: [userMessage('go')],
+          tools: [tool('duplicate')],
+        }),
+      ),
+    ).rejects.toThrow(/duplicate/);
+    expect(model.requests).toHaveLength(0);
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it('disposes once after completion, provider failure, and abort', async () => {
+    const completionCleanup = vi.fn();
+    const failureCleanup = vi.fn();
+    const abortCleanup = vi.fn();
+    const failingModel: ModelProvider = {
+      name: 'failing',
+      stream() {
+        throw new Error('provider failed');
+      },
+    };
+    const controller = new AbortController();
+    controller.abort();
+    const cases = [
+      {
+        resource: Resource(vi.fn(), completionCleanup),
+        model: new MockProvider([textTurn('done')]),
+        cleanup: completionCleanup,
+      },
+      {
+        resource: Resource(vi.fn(), failureCleanup),
+        model: failingModel,
+        cleanup: failureCleanup,
+      },
+      {
+        resource: Resource(vi.fn(), abortCleanup),
+        model: new MockProvider([textTurn('unreachable')]),
+        cleanup: abortCleanup,
+        signal: controller.signal,
+      },
+    ];
+
+    for (const [index, entry] of cases.entries()) {
+      const agent = createAgent({
+        name: `runner-${index}`,
+        instructions: 'Run.',
+        extensions: [entry.resource.configure(emptyConfig)],
+        modelSelector: 'mock',
+        resolveModel: () => entry.model,
+      });
+      const events = await collect(
+        agent.run({
+          messages: [userMessage('go')],
+          ...(entry.signal ? { signal: entry.signal } : {}),
+        }),
+      );
+
+      expect(entry.cleanup).toHaveBeenCalledOnce();
+      expect(events.at(-1)?.type).toBe('run_end');
+    }
+  });
+
+  it('rolls failed setup back in reverse order before rejecting', async () => {
+    const lifecycle: string[] = [];
+    const First = defineExtension({
+      name: 'first',
+      setup: (ctx, config: Record<string, never>) => {
+        lifecycle.push('setup:first');
+        ctx.own(() => {
+          lifecycle.push('cleanup:first');
+        });
+        return { state: ctx.state(config), api: {} };
+      },
+      contribute: () => ({}),
+    });
+    const Failing = defineExtension({
+      name: 'failing',
+      setup: (ctx) => {
+        lifecycle.push('setup:failing');
+        ctx.own(() => {
+          lifecycle.push('cleanup:failing');
+        });
+        throw new Error('setup failed');
+      },
+      contribute: () => ({}),
+    });
+    const model = new MockProvider([textTurn('unreachable')]);
+    const agent = createAgent({
+      name: 'runner',
+      instructions: 'Run.',
+      extensions: [First.configure(emptyConfig), Failing.configure()],
+      modelSelector: 'mock',
+      resolveModel: () => model,
+    });
+
+    await expect(
+      collect(agent.run({ messages: [userMessage('go')] })),
+    ).rejects.toThrow('setup failed');
+    expect(lifecycle).toEqual([
+      'setup:first',
+      'setup:failing',
+      'cleanup:failing',
+      'cleanup:first',
+    ]);
+    expect(model.requests).toHaveLength(0);
+  });
+
+  it('closes and disposes an explicitly returned event iterator exactly once', async () => {
+    const cleanup = vi.fn();
+    const Lazy = Resource(vi.fn(), cleanup);
+    const agent = createAgent({
+      name: 'runner',
+      instructions: 'Run.',
+      extensions: [Lazy.configure(emptyConfig)],
+      modelSelector: 'mock',
+      resolveModel: () => new MockProvider([textTurn('unreachable')]),
+    });
+    const iterator = agent
+      .run({ messages: [userMessage('go')] })
+      [Symbol.asyncIterator]();
+
+    expect(await iterator.next()).toMatchObject({
+      done: false,
+      value: { type: 'run_start' },
+    });
+    expect(cleanup).not.toHaveBeenCalled();
+    await iterator.return?.();
+
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it('keeps extension state and resources isolated across concurrent runs', async () => {
+    const setupIds: number[] = [];
+    const cleanupIds: number[] = [];
+    const Counter = defineExtension({
+      name: 'counter',
+      setup: (ctx, config: Record<string, never>) => {
+        const id = setupIds.length;
+        setupIds.push(id);
+        ctx.own(() => {
+          cleanupIds.push(id);
+        });
+        const state = ctx.state(0);
+        return {
+          state,
+          api: {
+            increment: tool('increment', () => {
+              state.update((value) => value + 1);
+              return 'incremented';
+            }),
+            config,
+          },
+        };
+      },
+      contribute: ({ state, api }) => ({
+        instructions: `Count:${state}`,
+        tools: [api.increment],
+      }),
+    });
+    const models = {
+      first: new MockProvider([
+        toolCallTurn({ id: 'increment-1', name: 'increment', input: {} }),
+        textTurn('done'),
+      ]),
+      second: new MockProvider([textTurn('done')]),
+    };
+    const agent = createAgent({
+      name: 'runner',
+      instructions: 'Run.',
+      extensions: [Counter.configure(emptyConfig)],
+      modelSelector: 'mock',
+      resolveModel: (_selector, { context }) =>
+        models[context.get<'first' | 'second'>('run') ?? 'first'],
+    });
+
+    await Promise.all([
+      collect(
+        agent.run({
+          messages: [userMessage('go')],
+          context: RunContext.create({ run: 'first' }),
+        }),
+      ),
+      collect(
+        agent.run({
+          messages: [userMessage('go')],
+          context: RunContext.create({ run: 'second' }),
+        }),
+      ),
+    ]);
+
+    expect(models.first.requests[1].instructions).toBe('Run.\n\nCount:1');
+    expect(models.second.requests[0].instructions).toBe('Run.\n\nCount:0');
+    expect(setupIds).toEqual([0, 1]);
+    expect(cleanupIds.toSorted((left, right) => left - right)).toEqual([0, 1]);
+  });
+
+  it('runs children with fresh extension state, hooks, context, and cleanup', async () => {
+    const setupIds: number[] = [];
+    const cleanupIds: number[] = [];
+    const childEvents: RunEvent[] = [];
+    const childModel = new MockProvider([textTurn('child done')]);
+    const Isolated = defineExtension({
+      name: 'isolated',
+      setup: (ctx, config: Record<string, never>) => {
+        const id = setupIds.length;
+        setupIds.push(id);
+        ctx.own(() => {
+          cleanupIds.push(id);
+        });
+        const state = ctx.state(0);
+        const startHook = {
+          name: `isolated-${id}`,
+          runStart: (hookContext: {
+            emit(event: { name: string; data: unknown }): void;
+          }) => hookContext.emit({ name: 'isolated-start', data: id }),
+        };
+        const spawn = tool('spawn', async (_input, toolContext) => {
+          state.update((value) => value + 1);
+          for await (const event of toolContext.runChild({
+            instructions: 'Child.',
+            model: childModel,
+            messages: [userMessage('child')],
+          })) {
+            childEvents.push(event);
+          }
+          return 'child completed';
+        });
+        return { state, api: { config, spawn, startHook } };
+      },
+      contribute: ({ state, api }) => ({
+        instructions: `Count:${state}`,
+        tools: [api.spawn],
+        hooks: [api.startHook],
+      }),
+    });
+    const parentModel = new MockProvider([
+      toolCallTurn({ id: 'spawn-1', name: 'spawn', input: {} }),
+      textTurn('parent done'),
+    ]);
+    const agent = createAgent({
+      name: 'runner',
+      instructions: 'Parent.',
+      extensions: [Isolated.configure(emptyConfig)],
+      modelSelector: 'mock',
+      resolveModel: () => parentModel,
+    });
+
+    const parentEvents = await collect(
+      agent.run({ messages: [userMessage('go')] }),
+    );
+
+    expect(parentModel.requests[0].instructions).toBe('Parent.\n\nCount:0');
+    expect(parentModel.requests[1].instructions).toBe('Parent.\n\nCount:1');
+    expect(childModel.requests[0].instructions).toBe('Child.\n\nCount:0');
+    expect(setupIds).toEqual([0, 1]);
+    expect(cleanupIds).toEqual([1, 0]);
+    expect(childEvents[0]).toMatchObject({ type: 'run_start', depth: 1 });
+    expect(childEvents.filter(({ type }) => type === 'custom')).toHaveLength(1);
+    expect(parentEvents.filter(({ type }) => type === 'custom')).toHaveLength(
+      1,
+    );
+    expect(childEvents[0].path[0]).toBe(parentEvents[0].runId);
+  });
+});

--- a/packages/agent-harness/src/agent/create-agent.ts
+++ b/packages/agent-harness/src/agent/create-agent.ts
@@ -1,0 +1,27 @@
+import type {
+  Agent,
+  AgentConfig,
+  AgentVariantConfig,
+} from '../contracts/agent';
+import {
+  composeAgentVariant,
+  prepareAgentConfig,
+  type PreparedAgentConfig,
+} from './agent-config';
+import { runAgent } from './run-agent';
+
+export const createAgent = <ModelSelector>(
+  config: AgentConfig<ModelSelector>,
+): Agent<ModelSelector> => createPreparedAgent(prepareAgentConfig(config));
+
+const createPreparedAgent = <ModelSelector>(
+  config: PreparedAgentConfig<ModelSelector>,
+): Agent<ModelSelector> => {
+  const agent: Agent<ModelSelector> = {
+    name: config.name,
+    variant: (variant: AgentVariantConfig) =>
+      createPreparedAgent(composeAgentVariant(config, variant)),
+    run: (input) => runAgent(config, input),
+  };
+  return Object.freeze(agent);
+};

--- a/packages/agent-harness/src/agent/finalize-run.ts
+++ b/packages/agent-harness/src/agent/finalize-run.ts
@@ -1,0 +1,39 @@
+export interface RunFinalizer {
+  finalize(): Promise<void>;
+}
+
+export const createRunFinalizer = (
+  cleanup: () => void | Promise<void>,
+): RunFinalizer => {
+  let finalization: Promise<void> | undefined;
+  return Object.freeze({
+    finalize: () => {
+      finalization ??= Promise.resolve().then(cleanup);
+      return finalization;
+    },
+  });
+};
+
+export async function* finalizeRun<Event>(
+  events: AsyncIterable<Event>,
+  finalizer: RunFinalizer,
+): AsyncGenerator<Event> {
+  const iterator = events[Symbol.asyncIterator]();
+  let completed = false;
+  try {
+    for (;;) {
+      const next = await iterator.next();
+      if (next.done) {
+        completed = true;
+        return;
+      }
+      yield next.value;
+    }
+  } finally {
+    try {
+      if (!completed) await iterator.return?.();
+    } finally {
+      await finalizer.finalize();
+    }
+  }
+}

--- a/packages/agent-harness/src/agent/run-agent.ts
+++ b/packages/agent-harness/src/agent/run-agent.ts
@@ -1,0 +1,106 @@
+import {
+  RunContext,
+  run,
+  type ChildRunHandler,
+  type Hook,
+  type Message,
+  type ModelProvider,
+  type RunEvent,
+  type Tool,
+  type ToolChoice,
+} from '@ayunis/agent-runtime';
+
+import type { AgentRunInput } from '../contracts/agent';
+import { ModelResolutionError } from '../contracts/errors';
+import type { PreparedAgentConfig } from './agent-config';
+import { createRunFinalizer, finalizeRun } from './finalize-run';
+import { ExtensionEngine } from '../extensions/extension-engine';
+
+interface ConfiguredRunInput {
+  readonly instructions: string;
+  readonly model: ModelProvider;
+  readonly messages: readonly Message[];
+  readonly tools?: readonly Tool[];
+  readonly hooks?: readonly Hook[];
+  readonly context: RunContext;
+  readonly signal?: AbortSignal;
+  readonly maxIterations?: number;
+  readonly toolChoice?: ToolChoice;
+}
+
+export async function* runAgent<ModelSelector>(
+  config: PreparedAgentConfig<ModelSelector>,
+  input: AgentRunInput,
+): AsyncGenerator<RunEvent> {
+  const context = input.context ?? RunContext.create();
+  const model = await resolveModel(config, context, input.signal);
+  yield* runConfigured(config, {
+    instructions: config.instructions,
+    model,
+    messages: input.messages,
+    tools: input.tools,
+    context,
+    signal: input.signal,
+    maxIterations: config.maxIterations,
+    toolChoice: config.toolChoice,
+  });
+}
+
+const resolveModel = async <ModelSelector>(
+  config: PreparedAgentConfig<ModelSelector>,
+  context: RunContext,
+  signal?: AbortSignal,
+): Promise<ModelProvider> => {
+  try {
+    const resolutionContext = signal ? { context, signal } : { context };
+    return await config.resolveModel(config.modelSelector, resolutionContext);
+  } catch (error) {
+    throw new ModelResolutionError(config.name, error);
+  }
+};
+
+const runConfigured = async function* <ModelSelector>(
+  config: PreparedAgentConfig<ModelSelector>,
+  input: ConfiguredRunInput,
+): AsyncGenerator<RunEvent> {
+  const engine = await ExtensionEngine.create(config.extensions, input.context);
+  const finalizer = createRunFinalizer(() => engine.dispose());
+  try {
+    const composition = engine.compose({
+      instructions: input.instructions,
+      tools: input.tools ?? [],
+    });
+    const childRunHandler = createChildRunHandler(config);
+    const events = run({
+      instructions: composition.instructions,
+      model: input.model,
+      messages: [...input.messages],
+      tools: [...composition.tools],
+      hooks: [...(input.hooks ?? []), ...composition.hooks],
+      context: input.context,
+      childRunHandler,
+      ...(input.signal ? { signal: input.signal } : {}),
+      ...(input.maxIterations === undefined
+        ? {}
+        : { maxIterations: input.maxIterations }),
+      ...(input.toolChoice === undefined
+        ? {}
+        : { toolChoice: input.toolChoice }),
+    });
+    yield* finalizeRun(events, finalizer);
+  } finally {
+    await finalizer.finalize();
+  }
+};
+
+const createChildRunHandler = <ModelSelector>(
+  config: PreparedAgentConfig<ModelSelector>,
+): ChildRunHandler => {
+  return (input) =>
+    runConfigured(config, {
+      ...input,
+      context: input.context ?? RunContext.create(),
+      maxIterations: input.maxIterations ?? config.maxIterations,
+      toolChoice: input.toolChoice ?? config.toolChoice,
+    });
+};

--- a/packages/agent-harness/src/index.ts
+++ b/packages/agent-harness/src/index.ts
@@ -1,3 +1,4 @@
+export { createAgent } from './agent/create-agent';
 export type {
   Agent,
   AgentConfig,

--- a/packages/agent-harness/src/package-surface.spec.ts
+++ b/packages/agent-harness/src/package-surface.spec.ts
@@ -11,11 +11,12 @@ const expectedExports = [
   'AgentConfigurationError',
   'AgentHarnessError',
   'AgentVariantError',
+  'createAgent',
   'ModelResolutionError',
 ];
 
 describe('package surface', () => {
-  it('exports only agent contracts and errors at this checkpoint', () => {
+  it('exports only the runnable single-agent API and errors', () => {
     expect(sortedKeys(sourceSurface)).toEqual(expectedExports);
     expect(sourceSurface).not.toHaveProperty('defineAgentProfile');
     expect(sourceSurface).not.toHaveProperty('createAgentHarness');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces core agent execution and extension lifecycle orchestration (model resolution, tool collision, cleanup, child runs) that hosts will depend on; behavior is well-tested but mistakes could affect every agent run.
> 
> **Overview**
> Ships the **runnable** `@ayunis/agent-harness` API: **`createAgent()`** now returns a frozen agent with **`run()`** and **`variant()`**, exported from the package root alongside existing contracts and errors.
> 
> Each **`agent.run()`** resolves the host’s opaque **`modelSelector`** per run (with **`RunContext`** and optional abort signal), wraps failures in **`ModelResolutionError`** before extension setup, spins up a private **`ExtensionEngine`**, collision-checks and merges host/extension instructions and tools, then delegates to **`@ayunis/agent-runtime`**. **`finalizeRun`** / a run finalizer ensure extension disposal runs once on success, provider failure, abort, setup rollback, or early async-iterator **`.return()`**. **`runChild`** is wired so child runs get a fresh engine, isolated extension state, and independent cleanup while inheriting agent limits where appropriate.
> 
> The README is rewritten around real usage (create, run, variants, lifecycle, child isolation, public boundary). A large **`create-agent.spec.ts`** suite and updated package-surface tests lock in immutability, variant composition, concurrency isolation, and child-run behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96632977d11cd7c2f849cf6c03169cfef16569dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->