### PR TITLE
feat(agent-sdk): complete runnable agent SDK (AYC-792)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,9 +16,10 @@ ayunis-core/
 ├── ayunis-core-frontend/      # React SPA (Feature-Sliced Design)
 ├── ayunis-core-code-execution/# Sandboxed code execution microservice
 ├── ayunis-core-anonymize/     # PII anonymization service
-├── packages/inference/        # Provider-agnostic inference contracts
-├── packages/agent-runtime/    # Bare agent loop and hook contracts
-├── packages/agent-extensions/ # Composable capabilities and resource lifetime
+├── packages/inference/        # Provider-neutral inference contracts
+├── packages/agent-runtime/    # Generic model/tool execution loop
+├── packages/agent-extensions/ # Run-scoped capability definitions
+├── packages/agent-harness/    # Runnable agents and private extension engine
 ├── packages/ui/               # Shared React design-system primitives
 ├── ARCHITECTURE.md            # This file
 ├── AGENTS.md                  # AI coding agent guidelines
@@ -27,9 +28,9 @@ ayunis-core/
 
 ---
 
-## Agent package layering
+## Agent SDK
 
-The reusable agent packages form a one-way stack:
+The Agent SDK has one-way package dependencies:
 
 ```text
 @ayunis/inference
@@ -38,21 +39,34 @@ The reusable agent packages form a one-way stack:
         ↑
 @ayunis/agent-extensions
         ↑
-future @ayunis/agent-harness
+@ayunis/agent-harness
 ```
 
-- [`@ayunis/inference`](packages/inference) defines provider-agnostic messages,
-  model requests, and streaming contracts.
-- [`@ayunis/agent-runtime`](packages/agent-runtime/README.md) is the bare agent
-  loop. Hooks are its only extension mechanism; the package has no resource
-  initialization or opinionated agent assembly.
-- [`@ayunis/agent-extensions`](packages/agent-extensions/README.md) resolves
-  named, composable manifests of tools, instructions, and hooks and owns their
-  optional cross-run resource lifetime. Static manifests merge into `RunInput`
-  before the runtime starts, while extension hooks remain ordinary runtime
-  hooks.
-- A future `@ayunis/agent-harness` may provide opinionated assemblies and
-  defaults on top of the lower layers and accept additional runtime extensions.
+- **`@ayunis/inference`** defines provider-neutral messages, schemas, request
+  contracts, and streamed provider output.
+- **`@ayunis/agent-runtime`** executes a resolved model request loop. It knows
+  about messages, models, tools, hooks, run context, and child execution, but
+  not extensions, skills, agents, tenants, or persistence.
+- **`@ayunis/agent-extensions`** defines run-scoped extension contracts and the
+  foundational KnowledgeBases, MCP, and Skills capabilities. Definitions own
+  setup and pure contribution logic, not execution orchestration.
+- **`@ayunis/agent-harness`** exposes immutable runnable agents through
+  `createAgent()`, `.variant()`, and `.run()`. Each run creates the private
+  extension engine that performs ordered setup, typed API registration,
+  transactional activation, contribution reconciliation, collision checks,
+  child-run isolation, and reverse-order cleanup before delegating to the
+  runtime.
+
+Host applications remain responsible for model selection and credentials,
+authorization, tenancy, persistence, knowledge retrieval, MCP connection
+resolution and transports, messages, durable capability state, and consuming
+run events. Those concerns enter through callbacks, tools, `RunContext`, and run
+inputs; the SDK packages do not depend on Ayunis Core infrastructure.
+
+There are no separate public profile, harness registry, extension engine,
+session runner, or agent state-store APIs. Shared routing, policy, resource
+lifecycle, or durable-instance abstractions should be introduced only when a
+concrete host requirement needs them.
 
 Runtime extensions are not **Agent Plugins**. Agent Plugins v1 is a portable
 filesystem package standard centered on `plugin.json`, Agent Skills, and

--- a/packages/agent-extensions/README.md
+++ b/packages/agent-extensions/README.md
@@ -1,8 +1,8 @@
 # @ayunis/agent-extensions
 
 Run-scoped extension definitions and built-in capabilities for Ayunis agents.
-The package depends on `@ayunis/agent-runtime`; the private engine in
-`@ayunis/agent-harness` owns setup, reconciliation, transactions, and cleanup.
+The package depends on `@ayunis/agent-runtime`; the private engine inside
+`@ayunis/agent-harness` executes configured extensions for each `agent.run()`.
 
 ## Define an extension
 
@@ -13,6 +13,7 @@ const Counter = defineExtension({
   name: 'counter',
   setup(ctx, config: { initial: number }) {
     const state = ctx.state(config.initial);
+    ctx.own(() => releaseCounterResources());
     return {
       state,
       api: { increment: () => state.update((value) => value + 1) },
@@ -23,23 +24,23 @@ const Counter = defineExtension({
   },
 });
 
-const configured = Counter.configure({ initial: 0 });
+const configuredCounter = Counter.configure({ initial: 0 });
 ```
 
-Each `agent.run()` sets up a fresh instance. `setup()` keeps mutable state, its
-API, owned resources, and cleanup together. Synchronous `contribute()` derives
-instructions, tools, and structurally stable hooks from the current state.
-State updates are batched and reconciled before the next model request.
+Each run receives a fresh extension instance. `setup()` keeps mutable state, its
+typed API, owned resources, and cleanup together. Synchronous `contribute()`
+derives instructions, tools, and structurally stable hooks from the current
+state. State updates are batched and reconciled before the next model request.
 
-During setup, `ctx.use(Extension)` obtains a required run-local API and
-`ctx.useOptional(Extension)` performs optional lookup. `ctx.own()` registers
-run-owned cleanup. The harness makes state changes and resources acquired during
-skill activation transactional.
+During setup or trusted skill activation, `ctx.use(Extension)` obtains a
+required run-local API and `ctx.useOptional(Extension)` performs optional
+lookup. `ctx.own()` registers run-owned cleanup. The harness makes state changes
+and resources acquired by extension tools transactional.
 
 ## Built-in capabilities
 
 Built-ins use optional subpath imports so root consumers do not load MCP, YAML,
-or filesystem code.
+or filesystem code they do not configure.
 
 ```ts
 import { KnowledgeBases } from '@ayunis/agent-extensions/knowledge-bases';
@@ -51,20 +52,21 @@ import { FilesystemSkillSource } from '@ayunis/agent-extensions/skills/filesyste
 - `KnowledgeBases` resolves authorized IDs and derives its instructions and
   aggregate query/text tools from one sorted active snapshot.
 - `Mcp` resolves authorized connection IDs, owns one client per run connection,
-  discovers tools transactionally, and maps deterministic model names back to
-  original server/tool identities.
+  discovers tools transactionally, and maps deterministic server-namespaced
+  model names back to original MCP identities.
 - `Skills` lists one catalog, contributes one `activate_skill` tool, and manages
   plain definitions created with `Skills.define()`.
 - `FilesystemSkillSource` is optional. It discovers immediate `SKILL.md`
-  children, keeps a canonical path map, validates containment, and lazily
-  reloads only the selected definition.
+  children, keeps a canonical path map, validates containment, and lazily loads
+  only the selected definition.
 
-## Configure an agent
+## Execute extensions through an agent
 
 ```ts
-import { createAgent } from '@ayunis/agent-harness';
 import { KnowledgeBases } from '@ayunis/agent-extensions/knowledge-bases';
+import { Mcp } from '@ayunis/agent-extensions/mcp';
 import { Skills } from '@ayunis/agent-extensions/skills';
+import { createAgent } from '@ayunis/agent-harness';
 
 const legalResearch = Skills.define({
   name: 'legal-research',
@@ -72,26 +74,40 @@ const legalResearch = Skills.define({
   instructions: 'Prefer primary legal sources.',
   async activate(ctx) {
     await ctx.use(KnowledgeBases).add(['municipal-law']);
+    await ctx.use(Mcp).addConnections(['legal-records']);
   },
 });
 
-const agent = createAgent({
+const researcher = createAgent({
   name: 'research-agent',
   instructions: 'Answer with cited evidence.',
-  model: { deployment: 'host-selected' },
+  modelSelector: { deployment: 'host-selected' },
   resolveModel: hostModelResolver,
   extensions: [
     KnowledgeBases.configure({
-      resolveAuthorized: resolveKnowledgeBases,
+      resolveAuthorized: resolveAuthorizedKnowledgeBases,
       query: queryKnowledgeBase,
       getText: getKnowledgeBaseText,
+    }),
+    Mcp.configure({
+      resolveAuthorized: resolveAuthorizedMcpConnections,
     }),
     Skills.configure({ source: hostSkillSource(legalResearch) }),
   ],
 });
+
+const legalResearcher = researcher.variant({
+  name: 'legal-research-agent',
+  instructions: 'State which authority controls the answer.',
+});
+
+for await (const event of legalResearcher.run({ messages, context })) {
+  handleEvent(event);
+}
 ```
 
 Hosts remain responsible for authorization, credentials, persistence,
 transports, model resolution, and infrastructure. These packages contain no
-Ayunis Core database or tenancy dependency and expose no public extension
-registry, session runner, or state store.
+Ayunis Core database or tenancy dependency. Extension setup, reconciliation,
+transactions, and cleanup are execution details of `createAgent()` rather than
+separate public profile, registry, harness, session-runner, or state-store APIs.

--- a/packages/agent-harness/README.md
+++ b/packages/agent-harness/README.md
@@ -3,16 +3,28 @@
 Runnable, immutable agents above `@ayunis/agent-runtime` and
 `@ayunis/agent-extensions`.
 
-## Create and run an agent
+## Configure the foundational extensions
 
 ```ts
+import { KnowledgeBases } from '@ayunis/agent-extensions/knowledge-bases';
+import { Mcp } from '@ayunis/agent-extensions/mcp';
+import { Skills } from '@ayunis/agent-extensions/skills';
 import { createAgent } from '@ayunis/agent-harness';
 import { RunContext } from '@ayunis/agent-runtime';
 
-const agent = createAgent({
+const legalResearch = Skills.define({
+  name: 'legal-research',
+  description: 'Research laws and regulations.',
+  instructions: 'Prefer primary legal sources and cite every conclusion.',
+  async activate(ctx) {
+    await ctx.use(KnowledgeBases).add(['municipal-law']);
+    await ctx.use(Mcp).addConnections(['legal-records']);
+  },
+});
+
+const researcher = createAgent({
   name: 'researcher',
   instructions: 'Answer with cited evidence.',
-  extensions: [KnowledgeBases.configure(knowledgeBaseOptions)],
   modelSelector: { deployment: 'host-selected' },
   resolveModel: async (selector, { context, signal }) =>
     resolveHostModel({
@@ -20,11 +32,41 @@ const agent = createAgent({
       organizationId: context.get('organizationId'),
       signal,
     }),
+  extensions: [
+    KnowledgeBases.configure({
+      resolveAuthorized: resolveAuthorizedKnowledgeBases,
+      query: queryKnowledgeBase,
+      getText: getKnowledgeBaseText,
+      recordUsage: recordKnowledgeUsage,
+    }),
+    Mcp.configure({
+      resolveAuthorized: resolveAuthorizedMcpConnections,
+    }),
+    Skills.configure({
+      source: {
+        list: async () => [
+          {
+            name: legalResearch.name,
+            description: legalResearch.description,
+          },
+        ],
+        load: async (name) => {
+          if (name !== legalResearch.name) throw new Error('Unknown skill.');
+          return legalResearch;
+        },
+      },
+    }),
+  ],
   maxIterations: 12,
 });
 
+const legalResearcher = researcher.variant({
+  name: 'legal-researcher',
+  instructions: 'Explain the controlling jurisdiction.',
+});
+
 const context = RunContext.create({ organizationId: 'org-1' });
-for await (const event of agent.run({
+for await (const event of legalResearcher.run({
   messages,
   tools: hostTools,
   context,
@@ -35,10 +77,9 @@ for await (const event of agent.run({
 ```
 
 The model selector is opaque to the package. `resolveModel()` receives the
-agent's frozen selector and the current run context on every public run, so the
-host remains responsible for model policy, credentials, and concrete provider
-construction. Creating an agent does not resolve a model, initialize an
-extension, or acquire a resource.
+agent's frozen selector and current run context on every root run, so the host
+retains model policy, credentials, and provider construction. Creating an agent
+does not resolve a model, initialize an extension, or acquire a resource.
 
 `agent.run()` forwards runtime events unchanged. Messages, authorization data,
 host tools, abort signals, durable capability state, and persistence remain
@@ -47,18 +88,21 @@ host-owned inputs. When no context is supplied, the agent creates a fresh root
 
 ## Variants
 
-```ts
-const legalResearcher = agent.variant({
-  name: 'legal-researcher',
-  instructions: 'Prefer primary legal sources.',
-  extensions: [Skills.configure(skillsOptions)],
-});
-```
-
-A variant is another frozen runnable agent. It appends instructions and
+A variant is another frozen runnable agent. It may append instructions and
 extensions while inheriting the base agent's model selector, resolver, limits,
-tool choice, and configured extensions. It cannot replace inherited settings
-or repeat an inherited extension.
+tool choice, and configured extensions. It cannot replace inherited settings or
+repeat an inherited extension.
+
+```ts
+const conciseResearcher = researcher.variant({
+  name: 'concise-researcher',
+  instructions: 'Keep the final answer under 300 words.',
+});
+
+for await (const event of conciseResearcher.run({ messages, context })) {
+  handleEvent(event);
+}
+```
 
 ## Run lifecycle and isolation
 
@@ -72,14 +116,13 @@ Every root run performs the following lifecycle:
 
 Cleanup is idempotent and runs after completion, runtime failure, abort, setup
 rollback, or an explicit event-iterator `.return()`. Concurrent runs share only
-the frozen agent configuration; their extension state and run-owned resources
-are independent.
+the frozen agent configuration; their extension state, APIs, and run-owned
+resources are independent.
 
-Tools may use the runtime's `runChild()` seam. The harness intercepts child
-execution to create a new private extension engine around the child input and
-its derived child context. A child receives fresh extension state, hooks, and
-resources, does not inherit the parent's extension instances, and finalizes
-independently. Explicit child host hooks still apply to that child.
+Tools may use the runtime's `runChild()` seam. The harness creates a fresh
+private extension engine around every child input and derived child context. A
+child receives fresh extension state, APIs, hooks, and resources, does not
+inherit its parent's activated capabilities, and finalizes independently.
 
 ## Public boundary
 

--- a/packages/agent-harness/src/integration/foundational-extensions.spec.ts
+++ b/packages/agent-harness/src/integration/foundational-extensions.spec.ts
@@ -1,0 +1,731 @@
+import { defineExtension } from '@ayunis/agent-extensions';
+import {
+  KnowledgeBases,
+  type KnowledgeBaseApi,
+} from '@ayunis/agent-extensions/knowledge-bases';
+import {
+  Mcp,
+  type McpApi,
+  type McpClient,
+  type McpClientFactory,
+  type McpConnectionDefinition,
+} from '@ayunis/agent-extensions/mcp';
+import {
+  Skills,
+  type SkillDefinition,
+  type SkillSource,
+} from '@ayunis/agent-extensions/skills';
+import {
+  MockProvider,
+  RunContext,
+  textTurn,
+  toolCallTurn,
+  type Message,
+  type ProviderRequest,
+  type RunEvent,
+  type Tool,
+} from '@ayunis/agent-runtime';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAgent } from '../index';
+
+const userMessage = (text: string): Message => ({
+  role: 'user',
+  content: [{ type: 'text', text }],
+});
+
+const collect = async (
+  events: AsyncIterable<RunEvent>,
+): Promise<RunEvent[]> => {
+  const collected: RunEvent[] = [];
+  for await (const event of events) collected.push(event);
+  return collected;
+};
+
+const tool = (name: string, execute?: Tool['execute']): Tool => ({
+  name,
+  description: `${name} description`,
+  parameters: { type: 'object', properties: {} },
+  ...(execute ? { execute } : {}),
+});
+
+const skillSource = (definitions: readonly SkillDefinition[]): SkillSource => ({
+  list: async () =>
+    definitions.map(({ name, description }) => ({ name, description })),
+  load: async (name) => {
+    const definition = definitions.find((candidate) => candidate.name === name);
+    if (!definition) throw new Error(`Unknown skill '${name}'.`);
+    return definition;
+  },
+});
+
+const knowledgeBases = () =>
+  KnowledgeBases.configure({
+    resolveAuthorized: async (ids) =>
+      ids.map((id) => ({ id, name: id.toUpperCase() })),
+    query: async () => 'query result',
+    getText: async () => 'text result',
+  });
+
+const connection = (
+  id: string,
+  serverName = id,
+  instructions = `Use the ${id} MCP server.`,
+): McpConnectionDefinition => ({
+  id,
+  serverName,
+  instructions,
+  transport: () => ({}) as never,
+});
+
+const fakeMcpClient = (toolNames: readonly string[], discoveryError?: Error) =>
+  ({
+    connect: vi.fn(async () => undefined),
+    listTools: vi.fn(async () => {
+      if (discoveryError) throw discoveryError;
+      return {
+        tools: toolNames.map((name) => ({
+          name,
+          description: `${name} description`,
+          inputSchema: { type: 'object' as const, properties: {} },
+        })),
+      };
+    }),
+    callTool: vi.fn(async () => ({ content: [], isError: false })),
+    close: vi.fn(async () => undefined),
+  }) satisfies McpClient;
+
+const clientFactory = (clients: readonly McpClient[]): McpClientFactory => {
+  let index = 0;
+  return vi.fn(() => {
+    const client = clients[index++];
+    if (!client) throw new Error('No fake MCP client available.');
+    return client;
+  });
+};
+
+const mcp = (
+  definitions: readonly McpConnectionDefinition[],
+  clients: readonly McpClient[],
+) =>
+  Mcp.configure({
+    resolveAuthorized: async (ids) =>
+      ids.map((id) => {
+        const definition = definitions.find((candidate) => candidate.id === id);
+        if (!definition) throw new Error(`Unknown MCP connection '${id}'.`);
+        return definition;
+      }),
+    createClient: clientFactory(clients),
+  });
+
+const mcpToolName = (serverName: string, toolName: string): string => {
+  const encodedServer = Buffer.from(serverName).toString('base64url');
+  const encodedTool = Buffer.from(toolName).toString('base64url');
+  return `mcp_${encodedServer.length}_${encodedServer}_${encodedTool}`;
+};
+
+const toolNames = (request: ProviderRequest): string[] =>
+  request.tools.map(({ name }) => name);
+
+const expectOnlyActivationTool = (request: ProviderRequest): void => {
+  expect(toolNames(request)).toEqual(['activate_skill']);
+};
+
+const activationResult = (events: readonly RunEvent[], callId: string) =>
+  events.find(
+    (event) => event.type === 'tool_result' && event.toolCallId === callId,
+  );
+
+interface CapturedApis {
+  readonly knowledgeBases: KnowledgeBaseApi;
+  readonly mcp: McpApi;
+}
+
+const captureApis = (
+  captured: CapturedApis[],
+  context: Parameters<NonNullable<SkillDefinition['activate']>>[0],
+): CapturedApis => {
+  const apis = {
+    knowledgeBases: context.use(KnowledgeBases),
+    mcp: context.use(Mcp),
+  };
+  captured.push(apis);
+  return apis;
+};
+
+describe('foundational extension integration', () => {
+  it('exposes knowledge, MCP, and skill capabilities together after activation', async () => {
+    const client = fakeMcpClient(['search']);
+    const records = connection('records', 'records-server');
+    const skill = Skills.define({
+      name: 'legal-research',
+      description: 'Research laws and regulations.',
+      instructions: 'Prefer primary legal sources.',
+      tools: [tool('summarize_record')],
+      async activate(context) {
+        await context.use(KnowledgeBases).add(['legal']);
+        await context.use(Mcp).addConnections(['records']);
+      },
+    });
+    const model = new MockProvider([
+      toolCallTurn({
+        id: 'activate-legal-research',
+        name: 'activate_skill',
+        input: { name: skill.name },
+      }),
+      textTurn('research complete'),
+    ]);
+    const agent = createAgent({
+      name: 'researcher',
+      instructions: 'Research safely.',
+      modelSelector: 'mock',
+      resolveModel: () => model,
+      extensions: [
+        knowledgeBases(),
+        mcp([records], [client]),
+        Skills.configure({ source: skillSource([skill]) }),
+      ],
+    });
+
+    await collect(agent.run({ messages: [userMessage('start')] }));
+
+    expectOnlyActivationTool(model.requests[0]);
+    expect(new Set(toolNames(model.requests[1]))).toEqual(
+      new Set([
+        'knowledge_query',
+        'knowledge_get_text',
+        mcpToolName('records-server', 'search'),
+        'activate_skill',
+        'summarize_record',
+      ]),
+    );
+    expect(model.requests[1].instructions).toContain(
+      '<knowledge_base id="legal" name="LEGAL" />',
+    );
+    expect(model.requests[1].instructions).toContain(records.instructions);
+    expect(model.requests[1].instructions).toContain(skill.instructions);
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it('rolls back knowledge bases staged by a skill that then fails', async () => {
+    const skill = Skills.define({
+      name: 'failing-research',
+      description: 'Prepare research capabilities and then fail.',
+      instructions: 'This failed skill instruction must not be exposed.',
+      async activate(context) {
+        await context.use(KnowledgeBases).add(['legal']);
+        throw new Error('activation failed after knowledge-base staging');
+      },
+    });
+    const model = new MockProvider([
+      toolCallTurn({
+        id: 'activate-failing-research',
+        name: 'activate_skill',
+        input: { name: skill.name },
+      }),
+      textTurn('continued safely'),
+    ]);
+    const agent = createAgent({
+      name: 'researcher',
+      instructions: 'Research safely.',
+      modelSelector: 'mock',
+      resolveModel: () => model,
+      extensions: [
+        knowledgeBases(),
+        Skills.configure({ source: skillSource([skill]) }),
+      ],
+    });
+
+    const events = await collect(
+      agent.run({ messages: [userMessage('start')] }),
+    );
+
+    expect(activationResult(events, 'activate-failing-research')).toMatchObject(
+      {
+        isError: true,
+        result: expect.stringContaining(
+          'activation failed after knowledge-base staging',
+        ),
+      },
+    );
+    expect(model.requests).toHaveLength(2);
+    expectOnlyActivationTool(model.requests[1]);
+    expect(model.requests[1].instructions).not.toContain(skill.instructions);
+    expect(model.requests[1].instructions).not.toContain(
+      '<available_knowledge_bases>',
+    );
+  });
+
+  it('closes every provisional MCP client and rolls back earlier state after discovery failure', async () => {
+    const firstClient = fakeMcpClient(['search']);
+    const secondClient = fakeMcpClient([], new Error('discovery unavailable'));
+    const definitions = [connection('first'), connection('second')];
+    const skill = Skills.define({
+      name: 'broken-connections',
+      description: 'Prepare connections that cannot all be discovered.',
+      instructions: 'Failed connection instructions must not appear.',
+      async activate(context) {
+        await context.use(KnowledgeBases).add(['temporary']);
+        await context.use(Mcp).addConnections(['first', 'second']);
+      },
+    });
+    const model = new MockProvider([
+      toolCallTurn({
+        id: 'activate-broken-connections',
+        name: 'activate_skill',
+        input: { name: skill.name },
+      }),
+      textTurn('continued safely'),
+    ]);
+    const agent = createAgent({
+      name: 'researcher',
+      instructions: 'Research safely.',
+      modelSelector: 'mock',
+      resolveModel: () => model,
+      extensions: [
+        knowledgeBases(),
+        mcp(definitions, [firstClient, secondClient]),
+        Skills.configure({ source: skillSource([skill]) }),
+      ],
+    });
+
+    const events = await collect(
+      agent.run({ messages: [userMessage('start')] }),
+    );
+
+    expect(
+      activationResult(events, 'activate-broken-connections'),
+    ).toMatchObject({
+      isError: true,
+      result: expect.stringContaining('discovery unavailable'),
+    });
+    expect(firstClient.close).toHaveBeenCalledOnce();
+    expect(secondClient.close).toHaveBeenCalledOnce();
+    expectOnlyActivationTool(model.requests[1]);
+    expect(model.requests[1].instructions).not.toContain(skill.instructions);
+    expect(model.requests[1].instructions).not.toContain(
+      '<available_knowledge_bases>',
+    );
+  });
+
+  it('rolls a skill back when one of its tools collides with a host tool', async () => {
+    const skill = Skills.define({
+      name: 'host-collision',
+      description: 'Contributes a tool already owned by the host.',
+      instructions: 'Colliding skill instructions must not appear.',
+      tools: [tool('shared_tool')],
+      activate: (context) => context.use(KnowledgeBases).add(['temporary']),
+    });
+    const model = new MockProvider([
+      toolCallTurn({
+        id: 'activate-host-collision',
+        name: 'activate_skill',
+        input: { name: skill.name },
+      }),
+      textTurn('continued safely'),
+    ]);
+    const agent = createAgent({
+      name: 'researcher',
+      instructions: 'Research safely.',
+      modelSelector: 'mock',
+      resolveModel: () => model,
+      extensions: [
+        knowledgeBases(),
+        Skills.configure({ source: skillSource([skill]) }),
+      ],
+    });
+
+    const events = await collect(
+      agent.run({
+        messages: [userMessage('start')],
+        tools: [tool('shared_tool')],
+      }),
+    );
+
+    expect(activationResult(events, 'activate-host-collision')).toMatchObject({
+      isError: true,
+      result: expect.stringMatching(/shared_tool.*collides.*host/i),
+    });
+    expect(new Set(toolNames(model.requests[1]))).toEqual(
+      new Set(['shared_tool', 'activate_skill']),
+    );
+    expect(model.requests[1].instructions).not.toContain(skill.instructions);
+    expect(model.requests[1].instructions).not.toContain(
+      '<available_knowledge_bases>',
+    );
+  });
+
+  it('rolls later skill state and resources back after a skill-to-skill collision', async () => {
+    const client = fakeMcpClient(['search']);
+    const records = connection('records');
+    const first = Skills.define({
+      name: 'first-skill',
+      description: 'Owns the shared skill tool first.',
+      instructions: 'First skill remains active.',
+      tools: [tool('shared_skill_tool')],
+    });
+    const second = Skills.define({
+      name: 'second-skill',
+      description: 'Attempts to reuse a skill tool name.',
+      instructions: 'Second skill must be rolled back.',
+      tools: [tool('shared_skill_tool')],
+      async activate(context) {
+        await context.use(KnowledgeBases).add(['temporary']);
+        await context.use(Mcp).addConnections(['records']);
+      },
+    });
+    const model = new MockProvider([
+      toolCallTurn({
+        id: 'activate-first',
+        name: 'activate_skill',
+        input: { name: first.name },
+      }),
+      toolCallTurn({
+        id: 'activate-second',
+        name: 'activate_skill',
+        input: { name: second.name },
+      }),
+      textTurn('continued safely'),
+    ]);
+    const agent = createAgent({
+      name: 'researcher',
+      instructions: 'Research safely.',
+      modelSelector: 'mock',
+      resolveModel: () => model,
+      extensions: [
+        knowledgeBases(),
+        mcp([records], [client]),
+        Skills.configure({ source: skillSource([first, second]) }),
+      ],
+    });
+
+    const events = await collect(
+      agent.run({ messages: [userMessage('start')] }),
+    );
+
+    expect(activationResult(events, 'activate-second')).toMatchObject({
+      isError: true,
+      result: expect.stringMatching(/shared_skill_tool.*collides.*skills/i),
+    });
+    expect(new Set(toolNames(model.requests[2]))).toEqual(
+      new Set(['activate_skill', 'shared_skill_tool']),
+    );
+    expect(model.requests[2].instructions).toContain(first.instructions);
+    expect(model.requests[2].instructions).not.toContain(second.instructions);
+    expect(model.requests[2].instructions).not.toContain(
+      '<available_knowledge_bases>',
+    );
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it('rolls state and resources back after a skill-to-MCP tool collision', async () => {
+    const client = fakeMcpClient(['search']);
+    const records = connection('records', 'records-server');
+    const collisionName = mcpToolName(records.serverName, 'search');
+    const skill = Skills.define({
+      name: 'cross-extension-collision',
+      description: 'Attempts to reuse a namespaced MCP tool name.',
+      instructions: 'Cross-extension collision instructions must not appear.',
+      tools: [tool(collisionName)],
+      async activate(context) {
+        await context.use(KnowledgeBases).add(['temporary']);
+        await context.use(Mcp).addConnections(['records']);
+      },
+    });
+    const model = new MockProvider([
+      toolCallTurn({
+        id: 'activate-cross-extension-collision',
+        name: 'activate_skill',
+        input: { name: skill.name },
+      }),
+      textTurn('continued safely'),
+    ]);
+    const agent = createAgent({
+      name: 'researcher',
+      instructions: 'Research safely.',
+      modelSelector: 'mock',
+      resolveModel: () => model,
+      extensions: [
+        knowledgeBases(),
+        mcp([records], [client]),
+        Skills.configure({ source: skillSource([skill]) }),
+      ],
+    });
+
+    const events = await collect(
+      agent.run({ messages: [userMessage('start')] }),
+    );
+
+    expect(
+      activationResult(events, 'activate-cross-extension-collision'),
+    ).toMatchObject({
+      isError: true,
+      result: expect.stringContaining(collisionName),
+    });
+    expectOnlyActivationTool(model.requests[1]);
+    expect(model.requests[1].instructions).not.toContain(skill.instructions);
+    expect(model.requests[1].instructions).not.toContain(
+      '<available_knowledge_bases>',
+    );
+    expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { name: 'knowledge-bases', dependency: KnowledgeBases },
+    { name: 'mcp', dependency: Mcp },
+  ])(
+    'returns a model-actionable, skill-attributed error when $name is missing',
+    async ({ name, dependency }) => {
+      const skill = Skills.define({
+        name: `needs-${name}`,
+        description: `Requires the ${name} extension.`,
+        instructions: 'Missing dependency instructions must not appear.',
+        activate(context) {
+          context.use(dependency);
+        },
+      });
+      const callId = `activate-needs-${name}`;
+      const model = new MockProvider([
+        toolCallTurn({
+          id: callId,
+          name: 'activate_skill',
+          input: { name: skill.name },
+        }),
+        textTurn('continued safely'),
+      ]);
+      const agent = createAgent({
+        name: 'researcher',
+        instructions: 'Research safely.',
+        modelSelector: 'mock',
+        resolveModel: () => model,
+        extensions: [Skills.configure({ source: skillSource([skill]) })],
+      });
+
+      const events = await collect(
+        agent.run({ messages: [userMessage('start')] }),
+      );
+
+      expect(activationResult(events, callId)).toMatchObject({
+        isError: true,
+        result: expect.stringMatching(
+          new RegExp(
+            `Could not activate skill.*skills.*missing extension '${name}'`,
+            'i',
+          ),
+        ),
+      });
+      expectOnlyActivationTool(model.requests[1]);
+      expect(model.requests[1].instructions).not.toContain(skill.instructions);
+    },
+  );
+
+  it('isolates active capabilities, APIs, clients, and cleanup across concurrent runs', async () => {
+    const clients = [fakeMcpClient(['search']), fakeMcpClient(['search'])];
+    const definitions = [connection('alpha'), connection('beta')];
+    const captured: CapturedApis[] = [];
+    let activationIndex = 0;
+    const skill = Skills.define({
+      name: 'isolated-research',
+      description: 'Activates one run-local capability set.',
+      instructions: 'Use only this run capability set.',
+      async activate(context) {
+        const id = definitions[activationIndex++]?.id;
+        if (!id) throw new Error('Unexpected extra activation.');
+        const apis = captureApis(captured, context);
+        await apis.knowledgeBases.add([id]);
+        await apis.mcp.addConnections([id]);
+      },
+    });
+    const models = [
+      new MockProvider([
+        toolCallTurn({
+          id: 'activate-alpha',
+          name: 'activate_skill',
+          input: { name: skill.name },
+        }),
+        textTurn('alpha complete'),
+      ]),
+      new MockProvider([
+        toolCallTurn({
+          id: 'activate-beta',
+          name: 'activate_skill',
+          input: { name: skill.name },
+        }),
+        textTurn('beta complete'),
+      ]),
+    ];
+    const agent = createAgent({
+      name: 'researcher',
+      instructions: 'Research safely.',
+      modelSelector: 'mock',
+      resolveModel: (_selector, { context }) =>
+        models[context.get<number>('slot') ?? 0],
+      extensions: [
+        knowledgeBases(),
+        mcp(definitions, clients),
+        Skills.configure({ source: skillSource([skill]) }),
+      ],
+    });
+
+    await Promise.all(
+      models.map((_model, slot) =>
+        collect(
+          agent.run({
+            messages: [userMessage('start')],
+            context: RunContext.create({ slot }),
+          }),
+        ),
+      ),
+    );
+
+    expect(captured).toHaveLength(2);
+    expect(captured[0].knowledgeBases).not.toBe(captured[1].knowledgeBases);
+    expect(captured[0].mcp).not.toBe(captured[1].mcp);
+    const secondRequests = models.map((model) => model.requests[1]);
+    expect(
+      secondRequests.map((request) => request.instructions).join('\n'),
+    ).toContain('id="alpha"');
+    expect(
+      secondRequests.map((request) => request.instructions).join('\n'),
+    ).toContain('id="beta"');
+    for (const request of secondRequests) {
+      expect(request.instructions.match(/<knowledge_base /g)).toHaveLength(1);
+    }
+    for (const client of clients) expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it('gives a child run fresh foundational state, APIs, clients, and cleanup ownership', async () => {
+    const clients = [fakeMcpClient(['search']), fakeMcpClient(['search'])];
+    const definitions = [connection('parent'), connection('child')];
+    const captured: CapturedApis[] = [];
+    const childEvents: RunEvent[] = [];
+    let activationIndex = 0;
+    const childModel = new MockProvider([
+      toolCallTurn({
+        id: 'activate-child',
+        name: 'activate_skill',
+        input: { name: 'nested-research' },
+      }),
+      textTurn('child complete'),
+    ]);
+    const spawnChild = tool('spawn_child', async (_input, context) => {
+      childEvents.push(
+        ...(await collect(
+          context.runChild({
+            instructions: 'Child instructions.',
+            model: childModel,
+            messages: [userMessage('child start')],
+          }),
+        )),
+      );
+      return 'child completed';
+    });
+    const skill = Skills.define({
+      name: 'nested-research',
+      description: 'Activates isolated parent or child capabilities.',
+      instructions: 'Use only this agent-run capability set.',
+      tools: [spawnChild],
+      async activate(context) {
+        const id = definitions[activationIndex++]?.id;
+        if (!id) throw new Error('Unexpected extra activation.');
+        const apis = captureApis(captured, context);
+        await apis.knowledgeBases.add([id]);
+        await apis.mcp.addConnections([id]);
+      },
+    });
+    const parentModel = new MockProvider([
+      toolCallTurn({
+        id: 'activate-parent',
+        name: 'activate_skill',
+        input: { name: skill.name },
+      }),
+      toolCallTurn({ id: 'spawn-child', name: 'spawn_child', input: {} }),
+      textTurn('parent complete'),
+    ]);
+    const agent = createAgent({
+      name: 'researcher',
+      instructions: 'Parent instructions.',
+      modelSelector: 'mock',
+      resolveModel: () => parentModel,
+      extensions: [
+        knowledgeBases(),
+        mcp(definitions, clients),
+        Skills.configure({ source: skillSource([skill]) }),
+      ],
+    });
+
+    await collect(agent.run({ messages: [userMessage('parent start')] }));
+
+    expectOnlyActivationTool(childModel.requests[0]);
+    expect(childModel.requests[0].instructions).not.toContain('id="parent"');
+    expect(childModel.requests[1].instructions).toContain('id="child"');
+    expect(childModel.requests[1].instructions).not.toContain('id="parent"');
+    expect(parentModel.requests[2].instructions).toContain('id="parent"');
+    expect(parentModel.requests[2].instructions).not.toContain('id="child"');
+    expect(captured[0].knowledgeBases).not.toBe(captured[1].knowledgeBases);
+    expect(captured[0].mcp).not.toBe(captured[1].mcp);
+    expect(childEvents[0]).toMatchObject({ type: 'run_start', depth: 1 });
+    for (const client of clients) expect(client.close).toHaveBeenCalledOnce();
+  });
+
+  it('finalizes the runtime and every acquired extension resource once after abandonment', async () => {
+    const extensionCleanup = vi.fn();
+    const runtimeFinalized = vi.fn();
+    const LifecycleProbe = defineExtension({
+      name: 'lifecycle-probe',
+      setup: (context, config: Record<string, never>) => {
+        context.own(extensionCleanup);
+        return { state: context.state(config), api: {} };
+      },
+      contribute: () => ({
+        hooks: [{ name: 'lifecycle-probe', runEnd: runtimeFinalized }],
+      }),
+    });
+    const client = fakeMcpClient(['search']);
+    const records = connection('records');
+    const skill = Skills.define({
+      name: 'resourceful-research',
+      description: 'Acquires one run-owned MCP client.',
+      instructions: 'Use the acquired resource.',
+      activate: (context) => context.use(Mcp).addConnections(['records']),
+    });
+    const model = new MockProvider([
+      toolCallTurn({
+        id: 'activate-resource',
+        name: 'activate_skill',
+        input: { name: skill.name },
+      }),
+      textTurn('unreachable after abandonment'),
+    ]);
+    const agent = createAgent({
+      name: 'researcher',
+      instructions: 'Research safely.',
+      modelSelector: 'mock',
+      resolveModel: () => model,
+      extensions: [
+        mcp([records], [client]),
+        Skills.configure({ source: skillSource([skill]) }),
+        LifecycleProbe.configure({}),
+      ],
+    });
+    const iterator = agent
+      .run({ messages: [userMessage('start')] })
+      [Symbol.asyncIterator]();
+
+    let next = await iterator.next();
+    while (!next.done && next.value.type !== 'tool_result') {
+      next = await iterator.next();
+    }
+    expect(next).toMatchObject({
+      done: false,
+      value: { type: 'tool_result', toolCallId: 'activate-resource' },
+    });
+    await iterator.return?.();
+    await iterator.return?.();
+
+    expect(runtimeFinalized).toHaveBeenCalledOnce();
+    expect(extensionCleanup).toHaveBeenCalledOnce();
+    expect(client.close).toHaveBeenCalledOnce();
+    expect(model.requests).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are documentation and integration tests only; no production runtime or API surface changes appear in this diff.
> 
> **Overview**
> Documents **`@ayunis/agent-harness`** as the top of the Agent SDK stack (no longer “future”) and rewrites **ARCHITECTURE.md** plus **agent-extensions** and **agent-harness** READMEs around **`createAgent()`**, **`.variant()`**, **`modelSelector`**, and the private per-run extension engine (setup, transactional skill activation, collision checks, child-run isolation, cleanup).
> 
> README examples now wire **KnowledgeBases**, **Mcp**, and **Skills** together and spell out that hosts own auth, models, and persistence—there is no public registry, session runner, or state-store API.
> 
> Adds **`foundational-extensions.spec.ts`**, a broad integration suite that exercises skill activation end-to-end: composed tools/instructions, rollback on activation/MCP discovery failures, host/skill/MCP tool collisions, missing-extension errors, concurrent run isolation, fresh child-run state via **`runChild()`**, and single-shot cleanup when the event iterator is abandoned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 415ddcde706e016e52adc746acf36dba30648f7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->