### PR TITLE
chore(packages): align agent-runtime, inference and provider engines to node 24 (AYC-000)

### DIFF
--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/inference/package.json
+++ b/packages/inference/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/provider-anthropic/package.json
+++ b/packages/provider-anthropic/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/provider-gemini/package.json
+++ b/packages/provider-gemini/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/provider-mistral/package.json
+++ b/packages/provider-mistral/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/provider-ollama/package.json
+++ b/packages/provider-ollama/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/provider-openai/package.json
+++ b/packages/provider-openai/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Package.json engine declarations only; no application logic changes, though consumers on Node 20–23 may see install warnings or enforcement depending on tooling.
> 
> **Overview**
> Raises the declared **Node.js** minimum from `>=20` to `>=24` in seven workspace packages: `@ayunis/agent-runtime`, `@ayunis/inference`, and the Anthropic, Gemini, Mistral, Ollama, and OpenAI provider packages.
> 
> This is a **metadata-only** change to each package’s `engines.node` field; no runtime or source code is modified in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 159ab71535391cd563c1f9f4ccd4fd586859dba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->