### PR TITLE
feat(chat): increase context budget to 200k tokens (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/context-budget.constants.ts
+++ b/ayunis-core-backend/src/domain/runs/application/context-budget.constants.ts
@@ -1,0 +1,1 @@
+export const MAX_CONTEXT_TOKENS = 200_000;

--- a/ayunis-core-backend/src/domain/runs/application/services/inference-orchestrator.service.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/inference-orchestrator.service.ts
@@ -15,8 +15,7 @@ import { enrichContentWithIntegration } from '../helpers/resolve-integration.hel
 import { ApplicationError } from 'src/common/errors/base.error';
 import { RunExecutionFailedError } from '../runs.errors';
 import type { RunParams } from '../use-cases/execute-run/run-params.interface';
-
-const MAX_CONTEXT_TOKENS = 80000;
+import { MAX_CONTEXT_TOKENS } from '../context-budget.constants';
 
 @Injectable()
 export class InferenceOrchestratorService {

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.spec.ts
@@ -1117,8 +1117,16 @@ describe('ExecuteRunViaRuntimeUseCase', () => {
     expect(countTokens).toHaveBeenCalledTimes(4);
   });
 
+  it('accepts a latest turn at the 200k context budget', async () => {
+    const { useCase, provider } = buildHarness({ tokensPerMessage: 200_000 });
+
+    await drain(await useCase.execute(userCommand()));
+
+    expect(provider.requests).toHaveLength(1);
+  });
+
   it('does not call the provider when the latest turn exceeds the budget', async () => {
-    const { useCase, provider } = buildHarness({ tokensPerMessage: 80_001 });
+    const { useCase, provider } = buildHarness({ tokensPerMessage: 200_001 });
 
     await expect(
       drain(await useCase.execute(userCommand())),

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run-via-runtime/execute-run-via-runtime.use-case.ts
@@ -64,9 +64,9 @@ import type {
   PreparedRuntimeRun,
   PreparedRuntimeTools,
 } from './execute-run-via-runtime.types';
+import { MAX_CONTEXT_TOKENS } from '../../context-budget.constants';
 
 const RUNTIME_MAX_ITERATIONS = 50;
-const MAX_CONTEXT_TOKENS = 80000;
 
 interface SeededInput {
   message: Message;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Larger prompts increase inference cost and latency and may stress provider limits, but behavior is unchanged aside from the higher cap and shared constant.
> 
> **Overview**
> Raises the shared **run context token budget** from **80k to 200k** by introducing `MAX_CONTEXT_TOKENS` in `context-budget.constants.ts` and wiring it into the legacy inference path (`InferenceOrchestratorService` message trimming) and the agent-runtime path (`ExecuteRunViaRuntimeUseCase` history materialization and context-budget hooks).
> 
> Runtime tests now assert that a turn exactly at **200k** is accepted and that **200,001** tokens still triggers `RunContextBudgetExceededError` without calling the provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbaa33acd36f8c8d8ae7812ce87eb53191fec48e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->