### PR TITLE
chore(tooling): enforce absolute imports via eslint (AYC-000)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -68,6 +68,12 @@ Watch for complexity creep. When a fix keeps growing — extra parameters, a wat
 
 When work creates or updates a PR, submitting it is an intermediate step. Immediately load `finish-pr` and keep ownership until CI and Cursor Bugbot are clean on the latest submitted revision. Fix actionable findings, amend and resubmit, then repeat the verification loop. Never report PR work as complete while checks are pending or failing, Bugbot has not finished, or actionable findings remain. If verification is prevented by an external condition or the same finding survives three fix attempts, report the work as blocked with evidence instead of calling it done.
 
+### 8. Absolute Imports
+
+New code always uses the path aliases, never relative imports: `src/...` in the backend, `@/...` in the frontend. Both are configured in the respective `tsconfig.json`. Same-directory `./sibling` imports are fine; parent traversal (`../`) is not.
+
+Enforced by `@typescript-eslint/no-restricted-imports` in both `eslint.config.mjs` files. It sits at `warn` so the pre-existing backlog stays visible without failing repo-wide lint, but the pre-commit staged ESLint run uses `--max-warnings=0` — so **any file you touch must have all of its `../` imports converted**, not just the lines you added. Don't go rewriting files you aren't already changing.
+
 ---
 
 ## Forbidden Actions

--- a/ayunis-core-backend/eslint.config.mjs
+++ b/ayunis-core-backend/eslint.config.mjs
@@ -89,6 +89,22 @@ export default tseslint.config(
       ],
       '@typescript-eslint/prefer-optional-chain': 'warn',
       '@typescript-eslint/consistent-type-imports': 'warn',
+      // Absolute imports only. `./sibling` stays fine; parent traversal does not.
+      // `warn` keeps the pre-existing backlog visible without failing repo-wide
+      // lint, while the pre-commit `--max-warnings=0` staged run blocks it on
+      // changed files.
+      '@typescript-eslint/no-restricted-imports': [
+        'warn',
+        {
+          patterns: [
+            {
+              group: ['..', '../*', '../**'],
+              message:
+                "Use the absolute 'src/...' path instead of a relative import.",
+            },
+          ],
+        },
+      ],
       '@typescript-eslint/no-import-type-side-effects': 'warn',
       'no-console': ['warn', { allow: ['warn', 'error'] }],
 

--- a/ayunis-core-frontend/eslint.config.mjs
+++ b/ayunis-core-frontend/eslint.config.mjs
@@ -88,7 +88,7 @@ export default tseslint.config(
       '@typescript-eslint/no-unnecessary-type-assertion': 'error',
       '@typescript-eslint/switch-exhaustiveness-check': 'error',
       '@typescript-eslint/no-duplicate-enum-values': 'error',
-      'eqeqeq': 'error',
+      eqeqeq: 'error',
       'unused-imports/no-unused-imports': 'error',
 
       // New rules (warn)
@@ -102,6 +102,22 @@ export default tseslint.config(
       ],
       '@typescript-eslint/prefer-optional-chain': 'warn',
       '@typescript-eslint/consistent-type-imports': 'warn',
+      // Absolute imports only. `./sibling` stays fine; parent traversal does not.
+      // `warn` keeps the pre-existing backlog visible without failing repo-wide
+      // lint, while the pre-commit `--max-warnings=0` staged run blocks it on
+      // changed files.
+      '@typescript-eslint/no-restricted-imports': [
+        'warn',
+        {
+          patterns: [
+            {
+              group: ['..', '../*', '../**'],
+              message:
+                "Use the absolute '@/...' path instead of a relative import.",
+            },
+          ],
+        },
+      ],
       '@typescript-eslint/no-import-type-side-effects': 'warn',
       'no-console': ['warn', { allow: ['warn', 'error'] }],
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lint and documentation only; no runtime or import-path refactors in this diff, though future edits will be blocked until relative parent imports in touched files are fixed.
> 
> **Overview**
> **Adds a repo-wide policy for alias imports** (`src/...` backend, `@/...` frontend) and wires it into lint plus agent docs.
> 
> Both `eslint.config.mjs` files now warn on parent-relative imports (`../` and variants) via `@typescript-eslint/no-restricted-imports`, with messages pointing at the correct alias style. The rule stays at **warn** for full-repo lint so existing violations remain visible, but **pre-commit staged ESLint already runs with `--max-warnings=0`**, so any touched file must convert all `../` imports in that file—not only new lines.
> 
> **`.claude/CLAUDE.md`** gains **§8 Absolute Imports** describing the convention, enforcement, and scope (don’t bulk-rewrite untouched files). The frontend config also normalizes `eqeqeq` to an unquoted object key (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 685cedcade9224a56c40a359a072f3c7c63acdfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->