### PR TITLE
feat(artifacts): list artifacts by project (AYC-702)

### DIFF
--- a/ayunis-core-backend/src/domain/artifacts/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/artifacts/SUMMARY.md
@@ -21,6 +21,7 @@ artifacts/
 ├── domain/
 │   ├── artifact.entity.ts
 │   ├── artifact-version.entity.ts
+│   ├── artifacts.constants.ts
 │   └── value-objects/
 │       ├── artifact-type.enum.ts
 │       └── author-type.enum.ts
@@ -41,6 +42,7 @@ artifacts/
 │       ├── create-artifact/
 │       ├── update-artifact/
 │       ├── find-artifacts-by-thread/
+│       ├── find-artifacts-by-workspace/
 │       ├── find-artifact-with-versions/
 │       ├── revert-artifact/
 │       └── export-artifact/
@@ -68,6 +70,7 @@ artifacts/
 ## Dependencies
 
 - **ThreadsModule** — Imported for thread ownership validation when creating artifacts
+- **WorkspacesModule** — Imported for workspace ownership validation when listing artifacts
 - **LetterheadsModule** — Imported for letterhead validation when creating or updating artifacts
 - **StorageModule** — Imported for downloading letterhead PDFs during export
 
@@ -94,4 +97,5 @@ artifacts/
 - Diagram content is stored without document HTML or spreadsheet normalization
 - Content size validation (max ~512K characters) on create and update
 - Thread ownership verification when creating artifacts
+- Workspace artifact listings ignore unsupported legacy discriminator values
 - Retry-on-conflict logic for version number uniqueness (unique constraint + up to 3 retries)

--- a/ayunis-core-backend/src/domain/artifacts/application/ports/artifacts-repository.port.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/ports/artifacts-repository.port.ts
@@ -1,11 +1,25 @@
 import type { UUID } from 'crypto';
-import type { Artifact } from '../../domain/artifact.entity';
-import type { ArtifactVersion } from '../../domain/artifact-version.entity';
+import type { Paginated } from 'src/common/pagination/paginated.entity';
+import type { Artifact } from 'src/domain/artifacts/domain/artifact.entity';
+import type { ArtifactVersion } from 'src/domain/artifacts/domain/artifact-version.entity';
+import type { ArtifactType } from 'src/domain/artifacts/domain/value-objects/artifact-type.enum';
+
+export interface ArtifactsByWorkspaceListOptions {
+  search?: string;
+  type?: ArtifactType;
+  limit: number;
+  offset: number;
+}
 
 export abstract class ArtifactsRepository {
   abstract create(artifact: Artifact): Promise<Artifact>;
   abstract findById(id: UUID, userId: UUID): Promise<Artifact | null>;
   abstract findByThreadId(threadId: UUID, userId: UUID): Promise<Artifact[]>;
+  abstract findByWorkspaceId(
+    workspaceId: UUID,
+    userId: UUID,
+    options: ArtifactsByWorkspaceListOptions,
+  ): Promise<Paginated<Artifact>>;
   abstract findByIdWithVersions(
     id: UUID,
     userId: UUID,

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifacts-by-workspace/find-artifacts-by-workspace.query.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifacts-by-workspace/find-artifacts-by-workspace.query.spec.ts
@@ -1,0 +1,24 @@
+import type { UUID } from 'crypto';
+import { FindArtifactsByWorkspaceQuery } from './find-artifacts-by-workspace.query';
+
+describe('FindArtifactsByWorkspaceQuery', () => {
+  const workspaceId = '223e4567-e89b-12d3-a456-426614174000' as UUID;
+
+  it('trims search terms before they reach the repository', () => {
+    const query = new FindArtifactsByWorkspaceQuery({
+      workspaceId,
+      search: '  project brief  ',
+    });
+
+    expect(query.search).toBe('project brief');
+  });
+
+  it('omits whitespace-only search terms', () => {
+    const query = new FindArtifactsByWorkspaceQuery({
+      workspaceId,
+      search: '   ',
+    });
+
+    expect(query.search).toBeUndefined();
+  });
+});

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifacts-by-workspace/find-artifacts-by-workspace.query.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifacts-by-workspace/find-artifacts-by-workspace.query.ts
@@ -1,0 +1,32 @@
+import type { UUID } from 'crypto';
+import { PaginatedQuery } from 'src/common/pagination/paginated.query';
+import {
+  ARTIFACT_DEFAULT_LIST_LIMIT,
+  ARTIFACT_MAX_LIST_LIMIT,
+} from 'src/domain/artifacts/domain/artifacts.constants';
+import type { ArtifactType } from 'src/domain/artifacts/domain/value-objects/artifact-type.enum';
+
+export class FindArtifactsByWorkspaceQuery extends PaginatedQuery {
+  readonly workspaceId: UUID;
+  readonly search?: string;
+  readonly type?: ArtifactType;
+
+  constructor(params: {
+    workspaceId: UUID;
+    search?: string;
+    type?: ArtifactType;
+    limit?: number;
+    offset?: number;
+  }) {
+    super({
+      limit: Math.min(
+        params.limit ?? ARTIFACT_DEFAULT_LIST_LIMIT,
+        ARTIFACT_MAX_LIST_LIMIT,
+      ),
+      offset: params.offset ?? 0,
+    });
+    this.workspaceId = params.workspaceId;
+    this.search = params.search?.trim() || undefined;
+    this.type = params.type;
+  }
+}

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifacts-by-workspace/find-artifacts-by-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifacts-by-workspace/find-artifacts-by-workspace.use-case.spec.ts
@@ -1,0 +1,124 @@
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import type { UUID } from 'crypto';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { ContextService } from 'src/common/context/services/context.service';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { DocumentArtifact } from 'src/domain/artifacts/domain/artifact.entity';
+import { ArtifactsRepository } from 'src/domain/artifacts/application/ports/artifacts-repository.port';
+import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
+import { FindWorkspaceUseCase } from 'src/domain/workspaces/application/use-cases/find-workspace/find-workspace.use-case';
+import { FindArtifactsByWorkspaceQuery } from './find-artifacts-by-workspace.query';
+import { FindArtifactsByWorkspaceUseCase } from './find-artifacts-by-workspace.use-case';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+
+describe('FindArtifactsByWorkspaceUseCase', () => {
+  let useCase: FindArtifactsByWorkspaceUseCase;
+  let artifactsRepository: jest.Mocked<ArtifactsRepository>;
+  let contextService: jest.Mocked<ContextService>;
+  let findWorkspaceUseCase: jest.Mocked<FindWorkspaceUseCase>;
+
+  const userId = '123e4567-e89b-12d3-a456-426614174000' as UUID;
+  const workspaceId = '223e4567-e89b-12d3-a456-426614174000' as UUID;
+  const threadId = '323e4567-e89b-12d3-a456-426614174000' as UUID;
+
+  beforeEach(async () => {
+    const repository = {
+      findByWorkspaceId: jest.fn(),
+    } as unknown as jest.Mocked<ArtifactsRepository>;
+    const context = {
+      get: jest.fn((key: string) => (key === 'userId' ? userId : undefined)),
+    } as unknown as jest.Mocked<ContextService>;
+    const findWorkspace = {
+      execute: jest.fn().mockResolvedValue({}),
+    } as unknown as jest.Mocked<FindWorkspaceUseCase>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FindArtifactsByWorkspaceUseCase,
+        {
+          provide: getLoggerToken(FindArtifactsByWorkspaceUseCase.name),
+          useValue: createPinoLoggerMock(),
+        },
+        { provide: ArtifactsRepository, useValue: repository },
+        { provide: ContextService, useValue: context },
+        { provide: FindWorkspaceUseCase, useValue: findWorkspace },
+      ],
+    }).compile();
+
+    useCase = module.get(FindArtifactsByWorkspaceUseCase);
+    artifactsRepository = repository;
+    contextService = context;
+    findWorkspaceUseCase = findWorkspace;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns artifacts for the workspace scoped to the authenticated user', async () => {
+    const artifacts = [
+      new DocumentArtifact({
+        threadId,
+        userId,
+        title: 'Project brief',
+      }),
+    ];
+    const paginatedArtifacts = new Paginated({
+      data: artifacts,
+      limit: 20,
+      offset: 0,
+      total: 1,
+    });
+    artifactsRepository.findByWorkspaceId.mockResolvedValue(paginatedArtifacts);
+
+    const result = await useCase.execute(
+      new FindArtifactsByWorkspaceQuery({ workspaceId }),
+    );
+
+    expect(result).toEqual(paginatedArtifacts);
+    expect(artifactsRepository.findByWorkspaceId).toHaveBeenCalledWith(
+      workspaceId,
+      userId,
+      {
+        search: undefined,
+        type: undefined,
+        limit: 20,
+        offset: 0,
+      },
+    );
+  });
+
+  it('returns an empty list when the workspace has no artifacts', async () => {
+    artifactsRepository.findByWorkspaceId.mockResolvedValue(
+      new Paginated({ data: [], limit: 20, offset: 0, total: 0 }),
+    );
+
+    await expect(
+      useCase.execute(new FindArtifactsByWorkspaceQuery({ workspaceId })),
+    ).resolves.toEqual(
+      new Paginated({ data: [], limit: 20, offset: 0, total: 0 }),
+    );
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    contextService.get.mockReturnValue(undefined);
+
+    await expect(
+      useCase.execute(new FindArtifactsByWorkspaceQuery({ workspaceId })),
+    ).rejects.toThrow(UnauthorizedAccessError);
+    expect(artifactsRepository.findByWorkspaceId).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests for workspaces unavailable to the caller', async () => {
+    findWorkspaceUseCase.execute.mockRejectedValue(
+      new WorkspaceNotFoundError(workspaceId),
+    );
+
+    await expect(
+      useCase.execute(new FindArtifactsByWorkspaceQuery({ workspaceId })),
+    ).rejects.toThrow(WorkspaceNotFoundError);
+    expect(artifactsRepository.findByWorkspaceId).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifacts-by-workspace/find-artifacts-by-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/use-cases/find-artifacts-by-workspace/find-artifacts-by-workspace.use-case.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { Paginated } from 'src/common/pagination/paginated.entity';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import type { Artifact } from 'src/domain/artifacts/domain/artifact.entity';
+import { UnexpectedArtifactError } from 'src/domain/artifacts/application/artifacts.errors';
+import { ArtifactsRepository } from 'src/domain/artifacts/application/ports/artifacts-repository.port';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { FindWorkspaceUseCase } from 'src/domain/workspaces/application/use-cases/find-workspace/find-workspace.use-case';
+import { FindWorkspaceQuery } from 'src/domain/workspaces/application/use-cases/find-workspace/find-workspace.query';
+import { FindArtifactsByWorkspaceQuery } from './find-artifacts-by-workspace.query';
+
+@Injectable()
+export class FindArtifactsByWorkspaceUseCase {
+  constructor(
+    @InjectPinoLogger(FindArtifactsByWorkspaceUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly artifactsRepository: ArtifactsRepository,
+    private readonly contextService: ContextService,
+    private readonly findWorkspaceUseCase: FindWorkspaceUseCase,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedArtifactError)
+  async execute(
+    query: FindArtifactsByWorkspaceQuery,
+  ): Promise<Paginated<Artifact>> {
+    const userId = this.contextService.get('userId');
+    if (!userId) {
+      throw new UnauthorizedAccessError();
+    }
+
+    this.logger.info(
+      { workspaceId: query.workspaceId },
+      'Finding artifacts by workspace',
+    );
+    await this.findWorkspaceUseCase.execute(
+      new FindWorkspaceQuery(query.workspaceId),
+    );
+
+    return this.artifactsRepository.findByWorkspaceId(
+      query.workspaceId,
+      userId,
+      {
+        search: query.search,
+        type: query.type,
+        limit: query.limit,
+        offset: query.offset,
+      },
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/artifacts/artifacts.module.ts
+++ b/ayunis-core-backend/src/domain/artifacts/artifacts.module.ts
@@ -13,11 +13,13 @@ import { ThreadsModule } from 'src/domain/threads/threads.module';
 import { LetterheadsModule } from 'src/domain/letterheads/letterheads.module';
 import { StorageModule } from 'src/domain/storage/storage.module';
 import { ThreadPiiMasksModule } from 'src/domain/thread-pii-masks/thread-pii-masks.module';
+import { WorkspacesModule } from 'src/domain/workspaces/workspaces.module';
 
 // Use cases
 import { CreateArtifactUseCase } from './application/use-cases/create-artifact/create-artifact.use-case';
 import { UpdateArtifactUseCase } from './application/use-cases/update-artifact/update-artifact.use-case';
 import { FindArtifactsByThreadUseCase } from './application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.use-case';
+import { FindArtifactsByWorkspaceUseCase } from './application/use-cases/find-artifacts-by-workspace/find-artifacts-by-workspace.use-case';
 import { FindArtifactWithVersionsUseCase } from './application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case';
 import { RevertArtifactUseCase } from './application/use-cases/revert-artifact/revert-artifact.use-case';
 import { ExportArtifactUseCase } from './application/use-cases/export-artifact/export-artifact.use-case';
@@ -30,6 +32,7 @@ import { ApplyEditsToArtifactUseCase } from './application/use-cases/apply-edits
     LetterheadsModule,
     StorageModule,
     ThreadPiiMasksModule,
+    WorkspacesModule,
   ],
   controllers: [ArtifactsController],
   providers: [
@@ -50,6 +53,7 @@ import { ApplyEditsToArtifactUseCase } from './application/use-cases/apply-edits
     UpdateArtifactUseCase,
     ApplyEditsToArtifactUseCase,
     FindArtifactsByThreadUseCase,
+    FindArtifactsByWorkspaceUseCase,
     FindArtifactWithVersionsUseCase,
     RevertArtifactUseCase,
     ExportArtifactUseCase,
@@ -60,6 +64,7 @@ import { ApplyEditsToArtifactUseCase } from './application/use-cases/apply-edits
   ],
   exports: [
     FindArtifactsByThreadUseCase,
+    FindArtifactsByWorkspaceUseCase,
     FindArtifactWithVersionsUseCase,
     CreateArtifactUseCase,
     UpdateArtifactUseCase,

--- a/ayunis-core-backend/src/domain/artifacts/domain/artifacts.constants.ts
+++ b/ayunis-core-backend/src/domain/artifacts/domain/artifacts.constants.ts
@@ -1,0 +1,2 @@
+export const ARTIFACT_DEFAULT_LIST_LIMIT = 20;
+export const ARTIFACT_MAX_LIST_LIMIT = 100;

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/local-artifacts.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/local-artifacts.repository.spec.ts
@@ -1,0 +1,54 @@
+import type { Repository, SelectQueryBuilder } from 'typeorm';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { ArtifactType } from 'src/domain/artifacts/domain/value-objects/artifact-type.enum';
+import { LocalArtifactsRepository } from './local-artifacts.repository';
+import type { ArtifactMapper } from './mappers/artifact.mapper';
+import type { ArtifactVersionMapper } from './mappers/artifact-version.mapper';
+import type { ArtifactRecord } from './schema/artifact.record';
+import type { ArtifactVersionRecord } from './schema/artifact-version.record';
+import type { DocumentArtifactRecord } from './schema/document-artifact.record';
+
+describe('LocalArtifactsRepository', () => {
+  it('lists only supported artifact types for a workspace', async () => {
+    const queryBuilder = {
+      innerJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    } as unknown as jest.Mocked<SelectQueryBuilder<ArtifactRecord>>;
+    const artifactRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+    } as unknown as Repository<ArtifactRecord>;
+    const artifactMapper = {
+      toDomain: jest.fn(),
+    } as unknown as ArtifactMapper;
+    const versionRepository = {} as Repository<ArtifactVersionRecord>;
+    const documentArtifactRepository = {} as Repository<DocumentArtifactRecord>;
+    const versionMapper = {} as ArtifactVersionMapper;
+    const repository = new LocalArtifactsRepository(
+      createPinoLoggerMock(),
+      artifactRepository,
+      documentArtifactRepository,
+      versionRepository,
+      artifactMapper,
+      versionMapper,
+    );
+
+    await repository.findByWorkspaceId(
+      '95da2ba4-7067-4326-9bcb-4c8a83f9fc17',
+      '0e8f87fd-c031-43bc-b149-679eb9d86192',
+      { limit: 20, offset: 0 },
+    );
+
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'artifact.type IN (:...artifactTypes)',
+      { artifactTypes: Object.values(ArtifactType) },
+    );
+    expect(queryBuilder.skip).toHaveBeenCalledWith(0);
+    expect(queryBuilder.take).toHaveBeenCalledWith(20);
+  });
+});

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/local-artifacts.repository.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/persistence/local/local-artifacts.repository.ts
@@ -5,19 +5,26 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UUID } from 'crypto';
 
-import { ArtifactsRepository } from '../../../application/ports/artifacts-repository.port';
-import { ArtifactVersionConflictError } from '../../../application/artifacts.errors';
-import { Artifact } from '../../../domain/artifact.entity';
-import { ArtifactVersion } from '../../../domain/artifact-version.entity';
+import {
+  ArtifactsByWorkspaceListOptions,
+  ArtifactsRepository,
+} from 'src/domain/artifacts/application/ports/artifacts-repository.port';
+import { ArtifactVersionConflictError } from 'src/domain/artifacts/application/artifacts.errors';
+import { Artifact } from 'src/domain/artifacts/domain/artifact.entity';
+import { ArtifactVersion } from 'src/domain/artifacts/domain/artifact-version.entity';
+import { ArtifactType } from 'src/domain/artifacts/domain/value-objects/artifact-type.enum';
 import { ArtifactRecord } from './schema/artifact.record';
 import { DocumentArtifactRecord } from './schema/document-artifact.record';
 import { ArtifactVersionRecord } from './schema/artifact-version.record';
 import { ArtifactMapper } from './mappers/artifact.mapper';
 import { ArtifactVersionMapper } from './mappers/artifact-version.mapper';
 import { isUniqueConstraintViolation } from './unique-constraint.util';
+import { Paginated } from 'src/common/pagination/paginated.entity';
 
 @Injectable()
 export class LocalArtifactsRepository extends ArtifactsRepository {
+  // TypeORM and mapper dependencies are injected individually by NestJS.
+  // eslint-disable-next-line max-params
   constructor(
     @InjectPinoLogger(LocalArtifactsRepository.name)
     private readonly logger: PinoLogger,
@@ -59,6 +66,46 @@ export class LocalArtifactsRepository extends ArtifactsRepository {
       order: { createdAt: 'ASC' },
     });
     return records.map((r) => this.artifactMapper.toDomain(r));
+  }
+
+  async findByWorkspaceId(
+    workspaceId: UUID,
+    userId: UUID,
+    options: ArtifactsByWorkspaceListOptions,
+  ): Promise<Paginated<Artifact>> {
+    const queryBuilder = this.artifactRepo
+      .createQueryBuilder('artifact')
+      .innerJoin('artifact.thread', 'thread')
+      .where('artifact.userId = :userId', { userId })
+      .andWhere('thread.workspaceId = :workspaceId', { workspaceId })
+      .andWhere('artifact.type IN (:...artifactTypes)', {
+        artifactTypes: Object.values(ArtifactType),
+      });
+
+    if (options.search) {
+      queryBuilder.andWhere('artifact.title ILIKE :search', {
+        search: `%${options.search}%`,
+      });
+    }
+    if (options.type) {
+      queryBuilder.andWhere('artifact.type = :artifactType', {
+        artifactType: options.type,
+      });
+    }
+
+    const [records, total] = await queryBuilder
+      .orderBy('artifact.updatedAt', 'DESC')
+      .addOrderBy('artifact.id', 'ASC')
+      .skip(options.offset)
+      .take(options.limit)
+      .getManyAndCount();
+
+    return new Paginated({
+      data: records.map((record) => this.artifactMapper.toDomain(record)),
+      limit: options.limit,
+      offset: options.offset,
+      total,
+    });
   }
 
   async findByIdWithVersions(id: UUID, userId: UUID): Promise<Artifact | null> {

--- a/ayunis-core-backend/src/domain/artifacts/presenters/http/artifacts.controller.ts
+++ b/ayunis-core-backend/src/domain/artifacts/presenters/http/artifacts.controller.ts
@@ -21,40 +21,52 @@ import {
 } from '@nestjs/swagger';
 import { Response } from 'express';
 import { UUID } from 'crypto';
+import { RequireFeature } from 'src/common/guards/feature.guard';
+import { FeatureFlag } from 'src/config/features.config';
+import { ArtifactType } from 'src/domain/artifacts/domain/value-objects/artifact-type.enum';
+import type { Paginated } from 'src/common/pagination/paginated.entity';
+import type { Artifact } from 'src/domain/artifacts/domain/artifact.entity';
 
-import { CreateArtifactUseCase } from '../../application/use-cases/create-artifact/create-artifact.use-case';
-import { UpdateArtifactUseCase } from '../../application/use-cases/update-artifact/update-artifact.use-case';
-import { FindArtifactsByThreadUseCase } from '../../application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.use-case';
-import { FindArtifactWithVersionsUseCase } from '../../application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case';
-import { RevertArtifactUseCase } from '../../application/use-cases/revert-artifact/revert-artifact.use-case';
-import { ExportArtifactUseCase } from '../../application/use-cases/export-artifact/export-artifact.use-case';
+import { CreateArtifactUseCase } from 'src/domain/artifacts/application/use-cases/create-artifact/create-artifact.use-case';
+import { UpdateArtifactUseCase } from 'src/domain/artifacts/application/use-cases/update-artifact/update-artifact.use-case';
+import { FindArtifactsByThreadUseCase } from 'src/domain/artifacts/application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.use-case';
+import { FindArtifactsByWorkspaceUseCase } from 'src/domain/artifacts/application/use-cases/find-artifacts-by-workspace/find-artifacts-by-workspace.use-case';
+import { FindArtifactWithVersionsUseCase } from 'src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.use-case';
+import { RevertArtifactUseCase } from 'src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.use-case';
+import { ExportArtifactUseCase } from 'src/domain/artifacts/application/use-cases/export-artifact/export-artifact.use-case';
 
-import { CreateArtifactCommand } from '../../application/use-cases/create-artifact/create-artifact.command';
-import { UpdateArtifactCommand } from '../../application/use-cases/update-artifact/update-artifact.command';
-import { FindArtifactsByThreadQuery } from '../../application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.query';
-import { FindArtifactWithVersionsQuery } from '../../application/use-cases/find-artifact-with-versions/find-artifact-with-versions.query';
-import { RevertArtifactCommand } from '../../application/use-cases/revert-artifact/revert-artifact.command';
-import { ExportArtifactCommand } from '../../application/use-cases/export-artifact/export-artifact.command';
+import { CreateArtifactCommand } from 'src/domain/artifacts/application/use-cases/create-artifact/create-artifact.command';
+import { UpdateArtifactCommand } from 'src/domain/artifacts/application/use-cases/update-artifact/update-artifact.command';
+import { FindArtifactsByThreadQuery } from 'src/domain/artifacts/application/use-cases/find-artifacts-by-thread/find-artifacts-by-thread.query';
+import { FindArtifactsByWorkspaceQuery } from 'src/domain/artifacts/application/use-cases/find-artifacts-by-workspace/find-artifacts-by-workspace.query';
+import { FindArtifactWithVersionsQuery } from 'src/domain/artifacts/application/use-cases/find-artifact-with-versions/find-artifact-with-versions.query';
+import { RevertArtifactCommand } from 'src/domain/artifacts/application/use-cases/revert-artifact/revert-artifact.command';
+import { ExportArtifactCommand } from 'src/domain/artifacts/application/use-cases/export-artifact/export-artifact.command';
 
 import { CreateArtifactDto } from './dtos/create-artifact.dto';
 import { UpdateArtifactDto } from './dtos/update-artifact.dto';
 import { RevertArtifactDto } from './dtos/revert-artifact.dto';
 import { ExportArtifactQueryDto } from './dtos/export-artifact.dto';
+import { FindArtifactsByWorkspaceQueryParamsDto } from './dtos/find-artifacts-by-workspace-query-params.dto';
 import {
   ArtifactResponseDto,
   ArtifactVersionResponseDto,
 } from './dtos/artifact-response.dto';
+import { ArtifactListResponseDto } from './dtos/artifact-list-response.dto';
 import { ArtifactDtoMapper } from './mappers/artifact-dto.mapper';
 
 @ApiTags('artifacts')
 @Controller('artifacts')
 export class ArtifactsController {
+  // NestJS injects each use case explicitly to keep the HTTP adapter composition visible.
+  // eslint-disable-next-line max-params
   constructor(
     @InjectPinoLogger(ArtifactsController.name)
     private readonly logger: PinoLogger,
     private readonly createArtifactUseCase: CreateArtifactUseCase,
     private readonly updateArtifactUseCase: UpdateArtifactUseCase,
     private readonly findArtifactsByThreadUseCase: FindArtifactsByThreadUseCase,
+    private readonly findArtifactsByWorkspaceUseCase: FindArtifactsByWorkspaceUseCase,
     private readonly findArtifactWithVersionsUseCase: FindArtifactWithVersionsUseCase,
     private readonly revertArtifactUseCase: RevertArtifactUseCase,
     private readonly exportArtifactUseCase: ExportArtifactUseCase,
@@ -166,6 +178,54 @@ export class ArtifactsController {
       new FindArtifactsByThreadQuery({ threadId }),
     );
     return artifacts.map((a) => this.artifactDtoMapper.toDto(a));
+  }
+
+  @Get('workspace/:workspaceId')
+  @RequireFeature(FeatureFlag.Workspaces)
+  @ApiOperation({ summary: 'Get all artifacts in a workspace' })
+  @ApiParam({
+    name: 'workspaceId',
+    description: 'The UUID of the workspace',
+    type: 'string',
+    format: 'uuid',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of artifacts from chats in the workspace',
+    type: ArtifactListResponseDto,
+  })
+  @ApiQuery({ name: 'search', required: false, type: String })
+  @ApiQuery({ name: 'type', required: false, enum: ArtifactType })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  async findByWorkspace(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: UUID,
+    @Query() queryParams: FindArtifactsByWorkspaceQueryParamsDto,
+  ): Promise<ArtifactListResponseDto> {
+    this.logger.info({ workspaceId }, 'findByWorkspace');
+    const pagination = queryParams.toPagination();
+    const page = await this.findArtifactsByWorkspaceUseCase.execute(
+      new FindArtifactsByWorkspaceQuery({
+        workspaceId,
+        search: queryParams.search,
+        type: queryParams.type,
+        ...pagination,
+      }),
+    );
+    return this.toArtifactListDto(page);
+  }
+
+  private toArtifactListDto(
+    page: Paginated<Artifact>,
+  ): ArtifactListResponseDto {
+    return {
+      data: page.data.map((artifact) => this.artifactDtoMapper.toDto(artifact)),
+      pagination: {
+        limit: page.limit,
+        offset: page.offset,
+        total: page.total,
+      },
+    };
   }
 
   @Post(':id/revert')

--- a/ayunis-core-backend/src/domain/artifacts/presenters/http/dtos/artifact-list-response.dto.ts
+++ b/ayunis-core-backend/src/domain/artifacts/presenters/http/dtos/artifact-list-response.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PaginationDto } from 'src/common/pagination/pagination.dto';
+import { ArtifactResponseDto } from './artifact-response.dto';
+
+export class ArtifactListResponseDto {
+  @ApiProperty({ type: [ArtifactResponseDto] })
+  data: ArtifactResponseDto[];
+
+  @ApiProperty({ type: PaginationDto })
+  pagination: PaginationDto;
+}

--- a/ayunis-core-backend/src/domain/artifacts/presenters/http/dtos/find-artifacts-by-workspace-query-params.dto.ts
+++ b/ayunis-core-backend/src/domain/artifacts/presenters/http/dtos/find-artifacts-by-workspace-query-params.dto.ts
@@ -1,0 +1,47 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, Min } from 'class-validator';
+import {
+  ARTIFACT_DEFAULT_LIST_LIMIT,
+  ARTIFACT_MAX_LIST_LIMIT,
+} from 'src/domain/artifacts/domain/artifacts.constants';
+import { ArtifactType } from 'src/domain/artifacts/domain/value-objects/artifact-type.enum';
+
+export class FindArtifactsByWorkspaceQueryParamsDto {
+  @ApiPropertyOptional({ description: 'Search artifacts by title' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({ enum: ArtifactType, description: 'Filter by type' })
+  @IsOptional()
+  @IsEnum(ArtifactType)
+  type?: ArtifactType;
+
+  @ApiPropertyOptional({ description: 'Maximum number of artifacts to return' })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  limit?: number;
+
+  @ApiPropertyOptional({
+    description: 'Number of artifacts to skip',
+    default: 0,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Type(() => Number)
+  offset?: number;
+
+  toPagination(): { limit: number; offset: number } {
+    return {
+      limit: Math.min(
+        this.limit ?? ARTIFACT_DEFAULT_LIST_LIMIT,
+        ARTIFACT_MAX_LIST_LIMIT,
+      ),
+      offset: this.offset ?? 0,
+    };
+  }
+}

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3994,6 +3994,11 @@ export interface UpdateArtifactDto {
   letterheadId?: string | null;
 }
 
+export interface ArtifactListResponseDto {
+  data: ArtifactResponseDto[];
+  pagination: PaginationDto;
+}
+
 export interface RevertArtifactDto {
   /** The version number to revert to */
   versionNumber: number;
@@ -5597,6 +5602,35 @@ export type WorkspaceContextControllerAddDocumentBody = {
 };
 
 export type FavoritesControllerFindAll200Item = WorkspaceFavoriteResponseDto | ThreadFavoriteResponseDto;
+
+export type ArtifactsControllerFindByWorkspaceParams = {
+/**
+ * Search artifacts by title
+ */
+search?: string;
+/**
+ * Filter by type
+ */
+type?: ArtifactsControllerFindByWorkspaceType;
+/**
+ * Maximum number of artifacts to return
+ */
+limit?: number;
+/**
+ * Number of artifacts to skip
+ */
+offset?: number;
+};
+
+export type ArtifactsControllerFindByWorkspaceType = typeof ArtifactsControllerFindByWorkspaceType[keyof typeof ArtifactsControllerFindByWorkspaceType];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const ArtifactsControllerFindByWorkspaceType = {
+  document: 'document',
+  diagram: 'diagram',
+  spreadsheet: 'spreadsheet',
+} as const;
 
 export type ArtifactsControllerExportParams = {
 /**

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -39,9 +39,11 @@ import type {
   AdminUpdateUserDto,
   ApiKeyResponseDto,
   AppAlertResponseDto,
+  ArtifactListResponseDto,
   ArtifactResponseDto,
   ArtifactVersionResponseDto,
   ArtifactsControllerExportParams,
+  ArtifactsControllerFindByWorkspaceParams,
   AssignThreadWorkspaceDto,
   BulkAddTeamMembersDto,
   ChangeSubscriptionRequestDto,
@@ -15858,6 +15860,107 @@ export function useArtifactsControllerFindByThread<TData = Awaited<ReturnType<ty
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
   const queryOptions = getArtifactsControllerFindByThreadQueryOptions(threadId,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Get all artifacts in a workspace
+ */
+export const artifactsControllerFindByWorkspace = (
+    workspaceId: string,
+    params?: ArtifactsControllerFindByWorkspaceParams,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<ArtifactListResponseDto>(
+      {url: `/artifacts/workspace/${workspaceId}`, method: 'GET',
+        params, signal
+    },
+      );
+    }
+  
+
+
+
+export const getArtifactsControllerFindByWorkspaceQueryKey = (workspaceId?: string,
+    params?: ArtifactsControllerFindByWorkspaceParams,) => {
+    return [
+    `/artifacts/workspace/${workspaceId}`, ...(params ? [params]: [])
+    ] as const;
+    }
+
+    
+export const getArtifactsControllerFindByWorkspaceQueryOptions = <TData = Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>, TError = unknown>(workspaceId: string,
+    params?: ArtifactsControllerFindByWorkspaceParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getArtifactsControllerFindByWorkspaceQueryKey(workspaceId,params);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>> = ({ signal }) => artifactsControllerFindByWorkspace(workspaceId,params, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(workspaceId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type ArtifactsControllerFindByWorkspaceQueryResult = NonNullable<Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>>
+export type ArtifactsControllerFindByWorkspaceQueryError = unknown
+
+
+export function useArtifactsControllerFindByWorkspace<TData = Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>, TError = unknown>(
+ workspaceId: string,
+    params: undefined |  ArtifactsControllerFindByWorkspaceParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>,
+          TError,
+          Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useArtifactsControllerFindByWorkspace<TData = Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>, TError = unknown>(
+ workspaceId: string,
+    params?: ArtifactsControllerFindByWorkspaceParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>,
+          TError,
+          Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useArtifactsControllerFindByWorkspace<TData = Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>, TError = unknown>(
+ workspaceId: string,
+    params?: ArtifactsControllerFindByWorkspaceParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get all artifacts in a workspace
+ */
+
+export function useArtifactsControllerFindByWorkspace<TData = Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>, TError = unknown>(
+ workspaceId: string,
+    params?: ArtifactsControllerFindByWorkspaceParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof artifactsControllerFindByWorkspace>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getArtifactsControllerFindByWorkspaceQueryOptions(workspaceId,params,options)
 
   const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -7757,6 +7757,75 @@
         "tags": ["artifacts"]
       }
     },
+    "/artifacts/workspace/{workspaceId}": {
+      "get": {
+        "operationId": "ArtifactsController_findByWorkspace",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "required": true,
+            "in": "path",
+            "description": "The UUID of the workspace",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "required": false,
+            "in": "query",
+            "description": "Search artifacts by title",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "required": false,
+            "in": "query",
+            "description": "Filter by type",
+            "schema": {
+              "enum": ["document", "diagram", "spreadsheet"],
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "Maximum number of artifacts to return",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "description": "Number of artifacts to skip",
+            "schema": {
+              "default": 0,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of artifacts from chats in the workspace",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactListResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get all artifacts in a workspace",
+        "tags": ["artifacts"]
+      }
+    },
     "/artifacts/{id}/revert": {
       "post": {
         "operationId": "ArtifactsController_revert",
@@ -17483,6 +17552,21 @@
             "nullable": true
           }
         }
+      },
+      "ArtifactListResponseDto": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArtifactResponseDto"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationDto"
+          }
+        },
+        "required": ["data", "pagination"]
       },
       "RevertArtifactDto": {
         "type": "object",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New read API with user scoping and workspace feature gating; listing relies on thread join and artifact ownership rather than explicit workspace membership checks in the use case.
> 
> **Overview**
> Adds a **paginated workspace artifact list** so project views can show documents, diagrams, and spreadsheets from all chats in a workspace, not only per-thread.
> 
> **`GET /artifacts/workspace/:workspaceId`** is gated by `@RequireFeature(FeatureFlag.Workspaces)` and accepts optional `search` (title), `type`, `limit` (default 20, max 100), and `offset`. Responses use a new `ArtifactListResponseDto` (`data` + `pagination`).
> 
> The stack wires **`FindArtifactsByWorkspaceUseCase`** through **`ArtifactsRepository.findByWorkspaceId`**. The local repository joins artifacts to threads by `workspaceId`, scopes by authenticated `userId`, orders by `updatedAt` DESC, and **excludes unsupported legacy `artifact.type` values** via `IN (:...artifactTypes)`. OpenAPI and the frontend client gain `useArtifactsControllerFindByWorkspace` and related types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2424e9f54aac858bc36258bdec3cc39e796e255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->