### PR TITLE
test(chat): add e2e marker to new chat page (AYC-0000)

### DIFF
--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -22,7 +22,7 @@ import { useIsWorkspacesEnabled } from '@/features/feature-toggles';
 import { WorkspacePicker } from './WorkspacePicker';
 import { useAcademyAccessStatus } from '@/features/academy';
 import { AcademyGateNotice } from '@/widgets/academy-gate-notice';
-import { useTimeBasedGreeting } from '../model/useTimeBasedGreeting';
+import { useTimeBasedGreeting } from '@/pages/new-chat/model/useTimeBasedGreeting';
 import { useFileFromUrl } from '@/shared/hooks/useFileFromUrl';
 import { useChatContext } from '@/shared/contexts/chat/useChatContext';
 import type {
@@ -31,8 +31,8 @@ import type {
 } from '@/shared/contexts/chat/chatContext';
 import { PinnedSkills } from './PinnedSkills';
 import { PersonalizationCard } from './PersonalizationCard';
-import { useUserSystemPromptStatus } from '../api/useUserSystemPromptStatus';
-import { useSkipPersonalization } from '../api/useSkipPersonalization';
+import { useUserSystemPromptStatus } from '@/pages/new-chat/api/useUserSystemPromptStatus';
+import { useSkipPersonalization } from '@/pages/new-chat/api/useSkipPersonalization';
 import { useQueryClient } from '@tanstack/react-query';
 import { getChatSettingsControllerGetSystemPromptQueryKey } from '@/shared/api/generated/ayunisCoreAPI';
 import { useRouter } from '@tanstack/react-router';
@@ -254,6 +254,13 @@ export default function NewChatPage({
           >
             {greeting}
           </h1>
+
+          <p
+            className="text-center text-sm text-muted-foreground"
+            data-testid="new-chat-e2e-test-marker"
+          >
+            E2E test Paul L.
+          </p>
 
           <div className="new-chat-input-stack relative w-full">
             <p


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only test marker and import path cleanup; no auth, API, or chat logic changes.
> 
> **Overview**
> Adds a **visible E2E hook** on the new chat compose area: a muted paragraph under the greeting with `data-testid="new-chat-e2e-test-marker"` and the label “E2E test Paul L.” so tests can assert the page loaded.
> 
> Also **normalizes imports** in `NewChatPage.tsx` from relative `../model` and `../api` paths to `@/pages/new-chat/...` aliases (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da73e34b073330018a0273595e44c4403b0d0516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->