### PR TITLE
ci(e2e): reuse build artifacts for browser tests (AYC-0000)

### DIFF
--- a/.claude/skills/e2e/SKILL.md
+++ b/.claude/skills/e2e/SKILL.md
@@ -131,6 +131,7 @@ tests/<domain>/     Product journeys, one journey per spec file
   seeded scenarios (usage limits, academy states) are Phase 5 (`@seeded-org`).
 - Local runs cap at 4 workers and disable video deliberately (CPU contention
   causes 30s-timeout cascades) — don't raise them to "speed things up".
-- CI (`.github/workflows/e2e-tests.yml`) serves the **built** frontend from
-  the backend (same origin, port 3000) — dev-server-only behaviour won't
-  reproduce there.
+- CI (`.github/workflows/e2e-tests.yml`) builds backend/frontend in upstream
+  jobs, downloads those `dist` artifacts into the e2e job, and serves the
+  **built** frontend from the backend (same origin, port 3000) —
+  dev-server-only behaviour won't reproduce there.

--- a/.claude/skills/pr-media/SKILL.md
+++ b/.claude/skills/pr-media/SKILL.md
@@ -52,7 +52,7 @@ export default [
 
 Guidelines:
 
-- Keep names kebab-case; output is `scene-name--viewport.png` and `scene-name--demo-name--viewport.gif`.
+- Keep scene and demo names kebab-case (`^[a-z0-9]+(?:-[a-z0-9]+)*$`); CI rejects unsafe names before publishing. Output is `scene-name--viewport.png` and `scene-name--demo-name--viewport.gif`.
 - Use `getByTestId` / `getByRole`; avoid text selectors where possible because the UI is localized.
 - Prefer short, deterministic interactions. No `waitForTimeout`; wait on locators or assertions.
 - Include only scenes the reviewer asked for.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -63,7 +63,92 @@ jobs:
             echo "Deleted screenshot comment ${comment_id} on PR #${PR}"
           done <<< "$comment_ids"
 
+  backend-build:
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build backend and runtime packages
+        working-directory: ayunis-core-backend
+        run: |
+          pnpm run build:deps
+          pnpm exec nest build
+
+      - name: Upload backend build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-backend-build
+          path: |
+            ayunis-core-backend/dist
+            packages/agent-runtime/dist
+            packages/inference/dist
+            packages/provider-anthropic/dist
+            packages/provider-gemini/dist
+            packages/provider-mistral/dist
+            packages/provider-ollama/dist
+            packages/provider-openai/dist
+          if-no-files-found: error
+          retention-days: 1
+
+  frontend-build:
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend
+        working-directory: ayunis-core-frontend
+        run: pnpm run build
+
+      - name: Upload frontend build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-frontend-dist
+          path: ayunis-core-frontend/dist
+          if-no-files-found: error
+          retention-days: 1
+
   e2e:
+    needs:
+      - backend-build
+      - frontend-build
     if: github.event_name != 'pull_request' || github.event.action != 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -133,25 +218,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build backend
-        working-directory: ayunis-core-backend
-        # build:deps first: the workspace packages' dist/ is gitignored, and
-        # the compiled backend imports them at module load — without this the
-        # boot dies on module-not-found before the health check.
-        run: |
-          pnpm run build:deps
-          pnpm run build
-
-      - name: Build frontend
-        working-directory: ayunis-core-frontend
-        run: pnpm run build
+      - name: Download backend build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-backend-build
+          path: .
 
       # Same layout as the production image: the backend serves the SPA from
       # dist/frontend (ServeStaticModule), so browser and API share one origin.
-      - name: Bundle frontend into backend
-        run: |
-          rm -rf ayunis-core-backend/dist/frontend
-          cp -r ayunis-core-frontend/dist ayunis-core-backend/dist/frontend
+      - name: Download frontend build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-frontend-dist
+          path: ayunis-core-backend/dist/frontend
 
       - name: Create backend environment file
         working-directory: ayunis-core-backend

--- a/ayunis-core-e2e/README.md
+++ b/ayunis-core-e2e/README.md
@@ -101,11 +101,19 @@ pr-media/         Temporary PR media capture infrastructure; scenes live on pr-m
 ## CI
 
 `.github/workflows/e2e-tests.yml` runs the suite on PRs touching backend,
-frontend, packages, or this package. It mirrors production serving: the
-built backend serves the built SPA from `dist/frontend` (same origin), with
+frontend, packages, or this package. Backend and frontend build jobs run first
+and upload short-lived `dist` artifacts; the e2e job downloads those artifacts
+instead of rebuilding them. It mirrors production serving: the built backend
+serves the built SPA from `dist/frontend` (same origin), with
 Postgres/Redis/MinIO/Mailcatcher as service containers and
-`MOCK_INFERENCE=true`. `E2E_BASE_URL`/`E2E_API_URL` both point at the
-backend (port 3000); Playwright report, traces, and the backend log upload
-as artifacts on failure.
+`MOCK_INFERENCE=true`. `E2E_BASE_URL`/`E2E_API_URL` both point at the backend
+(port 3000); Playwright report, traces, and the backend log upload as artifacts
+on failure.
 
-Temporary screenshots/GIFs are opt-in per PR. Add `.pr-media/scenes.ts` to the disposable `pr-media/pr-<n>` branch with `scripts/pr-media/update-scenes.sh --branch current <scenes.ts>`; CI fetches that scene file, captures exactly those scenes, publishes the media back to `pr-media/pr-<n>`, and deletes the branch/comment when the PR closes. No PR media scenes are committed to product branches.
+Temporary screenshots/GIFs are opt-in per PR. Add `.pr-media/scenes.ts` to the
+disposable `pr-media/pr-<n>` branch with
+`scripts/pr-media/update-scenes.sh --pr <n> <scenes.ts>`; CI fetches that scene
+file, captures exactly those scenes, publishes the media back to
+`pr-media/pr-<n>`, and deletes the branch/comment when the PR closes. No PR
+media scenes are committed to product branches. Scene and demo names must be
+kebab-case so generated filenames are safe and deterministic.

--- a/ayunis-core-e2e/pr-media/capture.shots.ts
+++ b/ayunis-core-e2e/pr-media/capture.shots.ts
@@ -10,6 +10,25 @@ import {
   type PrMediaViewport,
 } from './types';
 
+const mediaNamePattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function assertMediaName(kind: string, name: string): void {
+  if (!mediaNamePattern.test(name)) {
+    throw new Error(
+      `Invalid PR media ${kind} name "${name}". Use kebab-case: ${mediaNamePattern}`,
+    );
+  }
+}
+
+function validateSceneNames(sceneList: PrMediaScene[]): void {
+  for (const scene of sceneList) {
+    assertMediaName('scene', scene.name);
+    for (const demo of scene.demos ?? []) {
+      assertMediaName('demo', demo.name);
+    }
+  }
+}
+
 async function waitForScene(context: PrMediaContext, scene: PrMediaScene) {
   const locator = await scene.waitFor?.(context);
   if (locator) {
@@ -28,6 +47,8 @@ async function prepareScene(
 function viewportsFor(scene: PrMediaScene): PrMediaViewport[] {
   return scene.viewports ?? ['desktop', 'mobile'];
 }
+
+validateSceneNames(scenes);
 
 for (const scene of scenes) {
   for (const viewport of viewportsFor(scene)) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI pipeline restructuring and test-time validation only; no runtime product behavior changes.
> 
> **Overview**
> **Splits E2E CI into parallel backend and frontend build jobs** that upload short-lived `dist` artifacts, then has the main `e2e` job **download those artifacts** instead of compiling backend, workspace packages, and the SPA inside the test job. The frontend artifact is laid out directly under `ayunis-core-backend/dist/frontend` (same production-style serving as before).
> 
> **PR media hardening:** `capture.shots.ts` now **validates scene and demo names** against kebab-case before capture, with matching updates in the e2e README and `pr-media` skill (including documenting `update-scenes.sh --pr`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43b4c34ba491a780146b15a271e1fd08b4797b9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->