### PR TITLE
test(chat): add PR media smoke marker (AYC-0000)

### DIFF
--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPage.tsx
@@ -22,7 +22,7 @@ import { useIsWorkspacesEnabled } from '@/features/feature-toggles';
 import { WorkspacePicker } from './WorkspacePicker';
 import { useAcademyAccessStatus } from '@/features/academy';
 import { AcademyGateNotice } from '@/widgets/academy-gate-notice';
-import { useTimeBasedGreeting } from '../model/useTimeBasedGreeting';
+import { useTimeBasedGreeting } from '@/pages/new-chat/model/useTimeBasedGreeting';
 import { useFileFromUrl } from '@/shared/hooks/useFileFromUrl';
 import { useChatContext } from '@/shared/contexts/chat/useChatContext';
 import type {
@@ -31,8 +31,8 @@ import type {
 } from '@/shared/contexts/chat/chatContext';
 import { PinnedSkills } from './PinnedSkills';
 import { PersonalizationCard } from './PersonalizationCard';
-import { useUserSystemPromptStatus } from '../api/useUserSystemPromptStatus';
-import { useSkipPersonalization } from '../api/useSkipPersonalization';
+import { useUserSystemPromptStatus } from '@/pages/new-chat/api/useUserSystemPromptStatus';
+import { useSkipPersonalization } from '@/pages/new-chat/api/useSkipPersonalization';
 import { useQueryClient } from '@tanstack/react-query';
 import { getChatSettingsControllerGetSystemPromptQueryKey } from '@/shared/api/generated/ayunisCoreAPI';
 import { useRouter } from '@tanstack/react-router';
@@ -254,6 +254,13 @@ export default function NewChatPage({
           >
             {greeting}
           </h1>
+
+          <p
+            className="text-center text-xs text-muted-foreground"
+            data-testid="pr-media-smoke-marker"
+          >
+            PR media smoke test
+          </p>
 
           <div className="new-chat-input-stack relative w-full">
             <p


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic UI copy for smoke testing plus import path cleanup; no auth, data, or chat logic changes.
> 
> **Overview**
> Adds a muted **“PR media smoke test”** line under the new-chat greeting with `data-testid="pr-media-smoke-marker"` so PR/media pipelines can assert the page rendered.
> 
> Also updates **import paths** for `useTimeBasedGreeting`, `useUserSystemPromptStatus`, and `useSkipPersonalization` from relative (`../...`) to `@/pages/new-chat/...` — no behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fb948bb377289721d6630458938660a3a888073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->