### PR TITLE
ci: reduce duplicated workflow setup (AYC-0000)

### DIFF
--- a/.claude/skills/pr-media/SKILL.md
+++ b/.claude/skills/pr-media/SKILL.md
@@ -5,7 +5,7 @@ description: Create temporary PR-specific screenshots and short GIF demos withou
 
 # PR Media
 
-PR media scenes are temporary review aids. Never commit scene definitions to the product PR. Store them on the disposable `pr-media/pr-<number>` branch; the e2e workflow deletes that branch when the PR closes.
+PR media scenes are temporary review aids. Never commit scene definitions to the product PR. Store them on the disposable `pr-media/pr-<number>` branch; the App Integration workflow deletes that branch when the PR closes.
 
 For visible frontend changes, PR media is required after the product PR is created or updated unless the user explicitly says not to add PR media. Minimum coverage is a desktop screenshot and a mobile screenshot of the changed UI. Add a short GIF when the change affects an interaction, dialog, menu, transition, or multi-step flow.
 
@@ -22,10 +22,10 @@ For visible frontend changes, PR media is required after the product PR is creat
 3. Upload it to the media branch:
 
    ```bash
-   scripts/pr-media/update-scenes.sh --pr <number> /tmp/pr-media-scenes.ts
+   scripts/update-scenes.sh --pr <number> /tmp/pr-media-scenes.ts
    ```
 
-4. Re-run or wait for the e2e workflow. It will fetch `.pr-media/scenes.ts` from `pr-media/pr-<number>`, capture media with read-only permissions, then publish generated PNG/GIF files back to the same branch and upsert the sticky PR comment.
+4. Re-run or wait for the App Integration workflow. It will fetch `.pr-media/scenes.ts` from `pr-media/pr-<number>`, capture media with read-only permissions, then publish generated PNG/GIF files back to the same branch and upsert the sticky PR comment.
 
 ## Scene file shape
 

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,0 +1,29 @@
+name: Setup Node and pnpm
+description: Install pnpm, configure Node.js, and install workspace dependencies.
+
+inputs:
+  node-version:
+    description: Node.js version to install.
+    required: false
+    default: '24'
+  install-args:
+    description: Arguments passed to pnpm install.
+    required: false
+    default: --frozen-lockfile
+
+runs:
+  using: composite
+  steps:
+    - name: Install pnpm
+      uses: pnpm/action-setup@v6
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: pnpm
+        cache-dependency-path: pnpm-lock.yaml
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install ${{ inputs.install-args }}

--- a/.github/workflows/agent-runtime.yml
+++ b/.github/workflows/agent-runtime.yml
@@ -5,10 +5,18 @@ on:
     paths:
       - 'packages/agent-runtime/**'
       - '.github/workflows/agent-runtime.yml'
+      - '.github/actions/setup-node-pnpm/action.yml'
   push:
     branches: [main]
     paths:
       - 'packages/agent-runtime/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   check:
@@ -22,18 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       # Workspace deps (e.g. @ayunis/inference) resolve via their built `dist`,
       # which `pnpm install` does not produce — build the dep closure first.

--- a/.github/workflows/api-schema-drift.yml
+++ b/.github/workflows/api-schema-drift.yml
@@ -5,6 +5,14 @@ on:
     paths:
       - 'ayunis-core-backend/src/**'
       - '.github/workflows/api-schema-drift.yml'
+      - '.github/actions/setup-node-pnpm/action.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   check:
@@ -29,8 +37,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Start MinIO
         run: |
@@ -42,16 +50,6 @@ jobs:
             quay.io/minio/minio:latest server /data
           # Wait for MinIO to be ready
           timeout 30 bash -c 'until curl -f http://localhost:9000/minio/health/live; do sleep 2; done'
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Create backend environment file
         working-directory: ayunis-core-backend

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -5,11 +5,19 @@ on:
     paths:
       - 'ayunis-core-backend/**'
       - '.github/workflows/backend-tests.yml'
+      - '.github/actions/setup-node-pnpm/action.yml'
       - 'docker-compose.yml'
   push:
     branches: [main]
     paths:
       - 'ayunis-core-backend/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint-and-typecheck:
@@ -22,18 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Build workspace packages
         run: pnpm run build:deps
@@ -75,8 +73,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Start MinIO
         run: |
@@ -88,16 +86,6 @@ jobs:
             quay.io/minio/minio:latest server /data
           # Wait for MinIO to be ready
           timeout 30 bash -c 'until curl -f http://localhost:9000/minio/health/live; do sleep 2; done'
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Build workspace packages
         run: pnpm run build:deps

--- a/.github/workflows/complexity-check.yml
+++ b/.github/workflows/complexity-check.yml
@@ -6,6 +6,14 @@ on:
       - 'ayunis-core-backend/**/*.ts'
       - 'packages/**/*.ts'
       - 'packages/**/*.tsx'
+      - '.github/actions/setup-node-pnpm/action.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   complexity:
@@ -16,18 +24,8 @@ jobs:
         with:
           fetch-depth: 0 # Need full history for the diff
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Get changed TypeScript files
         id: changed-files

--- a/.github/workflows/db-schema-drift.yml
+++ b/.github/workflows/db-schema-drift.yml
@@ -5,6 +5,14 @@ on:
     paths:
       - 'ayunis-core-backend/src/**'
       - '.github/workflows/db-schema-drift.yml'
+      - '.github/actions/setup-node-pnpm/action.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   check:
@@ -29,18 +37,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Create backend environment file
         working-directory: ayunis-core-backend

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -7,196 +7,57 @@ on:
       - '**/*.tsx'
       - '**/knip.json'
       - '.github/workflows/dead-code.yml'
+      - '.github/actions/setup-node-pnpm/action.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  backend:
-    name: Backend
+  check:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ayunis-core-backend
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Backend
+            working-directory: ayunis-core-backend
+            precheck: pnpm run build:deps
+          - name: Agent Runtime
+            working-directory: packages/agent-runtime
+            precheck: ''
+          - name: Inference
+            working-directory: packages/inference
+            precheck: ''
+          - name: Provider Anthropic
+            working-directory: packages/provider-anthropic
+            precheck: ''
+          - name: Provider OpenAI
+            working-directory: packages/provider-openai
+            precheck: ''
+          - name: UI Package
+            working-directory: packages/ui
+            precheck: ''
+          - name: Frontend
+            working-directory: ayunis-core-frontend
+            precheck: ''
 
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build workspace packages
-        run: pnpm run build:deps
+      - name: Prepare workspace dependencies
+        if: matrix.precheck != ''
+        working-directory: ${{ matrix.working-directory }}
+        run: ${{ matrix.precheck }}
 
       - name: Check for dead code
-        run: pnpm exec knip --include files,dependencies,unlisted
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
-
-  agent-runtime:
-    name: Agent Runtime
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/agent-runtime
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Check for dead code
-        run: pnpm exec knip --include files,dependencies,unlisted
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
-
-  inference:
-    name: Inference
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/inference
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Check for dead code
-        run: pnpm exec knip --include files,dependencies,unlisted
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
-
-  provider-anthropic:
-    name: Provider Anthropic
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/provider-anthropic
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Check for dead code
-        run: pnpm exec knip --include files,dependencies,unlisted
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
-
-  provider-openai:
-    name: Provider OpenAI
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/provider-openai
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Check for dead code
-        run: pnpm exec knip --include files,dependencies,unlisted
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
-
-  ui:
-    name: UI Package
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: packages/ui
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Check for dead code
-        run: pnpm exec knip --include files,dependencies,unlisted
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
-
-  frontend:
-    name: Frontend
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ayunis-core-frontend
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Check for dead code
+        working-directory: ${{ matrix.working-directory }}
         run: pnpm exec knip --include files,dependencies,unlisted
         continue-on-error: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -9,6 +9,14 @@ on:
       - 'ayunis-core-frontend/src/**/*.tsx'
       - 'ayunis-core-frontend/.dependency-cruiser.cjs'
       - '.github/workflows/dependency-check.yml'
+      - '.github/actions/setup-node-pnpm/action.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   backend:
@@ -21,18 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Build workspace packages
         run: pnpm run build:deps
@@ -64,18 +62,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Run dependency check
         run: pnpm run deps:check

--- a/.github/workflows/duplication-check.yml
+++ b/.github/workflows/duplication-check.yml
@@ -5,6 +5,14 @@ on:
     paths:
       - '**/*.ts'
       - '**/*.tsx'
+      - '.github/actions/setup-node-pnpm/action.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   backend:
@@ -17,18 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Get changed TypeScript files
         id: changed-files
@@ -56,18 +54,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Get changed TypeScript files
         id: changed-files

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,4 @@
-name: E2E Tests
+name: App Integration
 
 # Browser tests against the real stack: built frontend served by the backend
 # (same-origin, like production), real Postgres/Redis/MinIO/Mailcatcher, and
@@ -26,15 +26,17 @@ on:
       - 'packages/ui/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/e2e-tests.yml'
+      - '.github/actions/setup-node-pnpm/action.yml'
   push:
     branches: [main]
 
 concurrency:
-  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  group: app-integration-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   cleanup-pr-media:
+    name: Cleanup PR media
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     permissions:
@@ -64,6 +66,7 @@ jobs:
           done <<< "$comment_ids"
 
   backend-build:
+    name: Build backend artifact
     if: github.event_name != 'pull_request' || github.event.action != 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -74,18 +77,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Build backend and runtime packages
         working-directory: ayunis-core-backend
@@ -110,6 +103,7 @@ jobs:
           retention-days: 1
 
   frontend-build:
+    name: Build frontend artifact
     if: github.event_name != 'pull_request' || github.event.action != 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -120,18 +114,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Build frontend
         working-directory: ayunis-core-frontend
@@ -146,6 +130,7 @@ jobs:
           retention-days: 1
 
   e2e:
+    name: Browser e2e
     needs:
       - backend-build
       - frontend-build
@@ -195,8 +180,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Start MinIO
         run: |
@@ -207,16 +192,6 @@ jobs:
             -e MINIO_ROOT_PASSWORD=ayunis-ci-minio-secret \
             quay.io/minio/minio:latest server /data
           timeout 30 bash -c 'until curl -f http://localhost:9000/minio/health/live; do sleep 2; done'
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
 
       - name: Download backend build artifact
         uses: actions/download-artifact@v4
@@ -419,6 +394,7 @@ jobs:
           retention-days: 7
 
   publish-pr-media:
+    name: Publish PR media
     needs: e2e
     if: github.event_name == 'pull_request' && needs.e2e.outputs.pr-media-enabled == 'true'
     runs-on: ubuntu-latest
@@ -540,6 +516,7 @@ jobs:
           fi
 
   clear-pr-media-comment:
+    name: Clear PR media comment
     needs: e2e
     if: github.event_name == 'pull_request' && needs.e2e.outputs.clear-pr-media-comment == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -7,12 +7,20 @@ on:
       - 'packages/ui/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/frontend-build.yml'
+      - '.github/actions/setup-node-pnpm/action.yml'
   push:
     branches: [main]
     paths:
       - 'ayunis-core-frontend/**'
       - 'packages/ui/**'
       - 'pnpm-lock.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -25,18 +33,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Run production build
         run: pnpm run build

--- a/.github/workflows/inference.yml
+++ b/.github/workflows/inference.yml
@@ -5,10 +5,18 @@ on:
     paths:
       - 'packages/inference/**'
       - '.github/workflows/inference.yml'
+      - '.github/actions/setup-node-pnpm/action.yml'
   push:
     branches: [main]
     paths:
       - 'packages/inference/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   check:
@@ -22,18 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Run TypeScript type check
         run: pnpm run typecheck

--- a/.github/workflows/provider-anthropic.yml
+++ b/.github/workflows/provider-anthropic.yml
@@ -5,10 +5,18 @@ on:
     paths:
       - 'packages/provider-anthropic/**'
       - '.github/workflows/provider-anthropic.yml'
+      - '.github/actions/setup-node-pnpm/action.yml'
   push:
     branches: [main]
     paths:
       - 'packages/provider-anthropic/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   check:
@@ -22,18 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       # Workspace deps (e.g. @ayunis/inference) resolve via their built `dist`,
       # which `pnpm install` does not produce — build the dep closure first.

--- a/.github/workflows/provider-openai.yml
+++ b/.github/workflows/provider-openai.yml
@@ -5,10 +5,18 @@ on:
     paths:
       - 'packages/provider-openai/**'
       - '.github/workflows/provider-openai.yml'
+      - '.github/actions/setup-node-pnpm/action.yml'
   push:
     branches: [main]
     paths:
       - 'packages/provider-openai/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   check:
@@ -22,18 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       # Workspace deps (e.g. @ayunis/inference) resolve via their built `dist`,
       # which `pnpm install` does not produce — build the dep closure first.

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -11,8 +11,16 @@ on:
       # otherwise slips through because no other workflow watches this file.
       - 'package.json'
       - '.github/workflows/security-audit.yml'
+      - '.github/actions/setup-node-pnpm/action.yml'
   schedule:
     - cron: '0 9 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   audit:
@@ -22,18 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
 
       # Audits the whole workspace from the single root lockfile. Root
       # pnpm.overrides patch known-vulnerable transitive deps (basic-ftp,

--- a/ayunis-core-e2e/README.md
+++ b/ayunis-core-e2e/README.md
@@ -100,9 +100,9 @@ pr-media/         Temporary PR media capture infrastructure; scenes live on pr-m
 
 ## CI
 
-`.github/workflows/e2e-tests.yml` runs the suite on PRs touching backend,
-frontend, packages, or this package. Backend and frontend build jobs run first
-and upload short-lived `dist` artifacts; the e2e job downloads those artifacts
+`.github/workflows/e2e-tests.yml` is named **App Integration** in GitHub and
+runs on PRs touching backend, frontend, packages, or this package. Backend and
+frontend build jobs run first and upload short-lived `dist` artifacts; the e2e job downloads those artifacts
 instead of rebuilding them. It mirrors production serving: the built backend
 serves the built SPA from `dist/frontend` (same origin), with
 Postgres/Redis/MinIO/Mailcatcher as service containers and
@@ -112,7 +112,7 @@ on failure.
 
 Temporary screenshots/GIFs are opt-in per PR. Add `.pr-media/scenes.ts` to the
 disposable `pr-media/pr-<n>` branch with
-`scripts/pr-media/update-scenes.sh --pr <n> <scenes.ts>`; CI fetches that scene
+`scripts/update-scenes.sh --pr <n> <scenes.ts>`; CI fetches that scene
 file, captures exactly those scenes, publishes the media back to
 `pr-media/pr-<n>`, and deletes the branch/comment when the PR closes. No PR
 media scenes are committed to product branches. Scene and demo names must be

--- a/ayunis-core-e2e/pr-media/README.md
+++ b/ayunis-core-e2e/pr-media/README.md
@@ -2,6 +2,6 @@
 
 This directory contains stable infrastructure for temporary PR screenshots and short GIF demos.
 
-Scene definitions do **not** live in product branches. For PR `<n>`, write the scene file to the disposable branch `pr-media/pr-<n>` at `.pr-media/scenes.ts`. The e2e workflow fetches that file, runs these capture helpers with a read-only token, publishes generated media back to the same `pr-media/pr-<n>` branch, and deletes the branch when the PR closes.
+Scene definitions do **not** live in product branches. For PR `<n>`, write the scene file to the disposable branch `pr-media/pr-<n>` at `.pr-media/scenes.ts`. The App Integration workflow fetches that file, runs these capture helpers with a read-only token, publishes generated media back to the same `pr-media/pr-<n>` branch, and deletes the branch when the PR closes.
 
-Use `scripts/pr-media/update-scenes.sh --branch current <scenes.ts>` after a PR exists to create or update the temporary scene branch and re-run the latest E2E Tests workflow for that PR branch when available.
+Use `scripts/update-scenes.sh --pr <n> <scenes.ts>` after a PR exists to create or update the temporary scene branch and re-run the latest App Integration workflow for that PR branch when available.

--- a/scripts/update-scenes.sh
+++ b/scripts/update-scenes.sh
@@ -4,15 +4,15 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/pr-media/update-scenes.sh --pr <number> [--no-rerun] <scenes.ts>
-  scripts/pr-media/update-scenes.sh --branch current [--no-rerun] <scenes.ts>
+  scripts/update-scenes.sh --pr <number> [--no-rerun] <scenes.ts>
+  scripts/update-scenes.sh --branch current [--no-rerun] <scenes.ts>
 
 Creates or updates the disposable pr-media/pr-<number> branch with
 .pr-media/scenes.ts. Existing generated media on that branch is preserved until
 CI replaces it.
 
-Publishing the scene branch uses git only. Re-running the E2E workflow is
-best-effort; if GitHub API access is unavailable, rerun E2E Tests manually.
+Publishing the scene branch uses git only. Re-running the App Integration
+workflow is best-effort; if GitHub API access is unavailable, rerun it manually.
 EOF
 }
 
@@ -147,26 +147,26 @@ echo "Media branch: ${branch}"
 echo "Scene path: .pr-media/scenes.ts"
 
 if [ "$rerun" = false ]; then
-  echo "Skipped E2E rerun because --no-rerun was provided."
-  echo "Manually rerun the E2E Tests workflow for PR #${pr}."
+  echo "Skipped App Integration rerun because --no-rerun was provided."
+  echo "Manually rerun the App Integration workflow for PR #${pr}."
   exit 0
 fi
 
 if ! command -v gh >/dev/null 2>&1; then
-  echo "Media branch updated. Could not rerun E2E automatically because gh is unavailable."
-  echo "Manually rerun the E2E Tests workflow for PR #${pr}."
+  echo "Media branch updated. Could not rerun App Integration automatically because gh is unavailable."
+  echo "Manually rerun the App Integration workflow for PR #${pr}."
   exit 0
 fi
 
 head_branch="$(gh pr view "$pr" --json headRefName --jq .headRefName 2>/dev/null || true)"
 if [ -z "$head_branch" ]; then
   echo "Media branch updated. Could not resolve the PR head branch via GitHub API."
-  echo "Manually rerun the E2E Tests workflow for PR #${pr}."
+  echo "Manually rerun the App Integration workflow for PR #${pr}."
   exit 0
 fi
 
 run_info="$(gh run list \
-  --workflow "E2E Tests" \
+  --workflow "App Integration" \
   --branch "$head_branch" \
   --json databaseId,event,status \
   --jq 'map(select(.event == "pull_request")) | first | [.databaseId, .status] | @tsv' \
@@ -179,14 +179,14 @@ if [ -n "$run_info" ]; then
 fi
 
 if [ -z "$run_id" ]; then
-  echo "Media branch updated. No E2E Tests pull_request run found for ${head_branch}."
-  echo "Push/update the PR or manually rerun E2E Tests for PR #${pr}."
+  echo "Media branch updated. No App Integration pull_request run found for ${head_branch}."
+  echo "Push/update the PR or manually rerun App Integration for PR #${pr}."
 elif [ "$run_status" != "completed" ]; then
-  echo "Media branch updated. E2E Tests workflow run ${run_id} is ${run_status}, so it cannot be rerun automatically."
-  echo "If that run already loaded PR media scenes, manually rerun E2E Tests for PR #${pr}."
+  echo "Media branch updated. App Integration workflow run ${run_id} is ${run_status}, so it cannot be rerun automatically."
+  echo "If that run already loaded PR media scenes, manually rerun App Integration for PR #${pr}."
 elif gh run rerun "$run_id"; then
-  echo "Re-ran E2E Tests workflow run ${run_id} for ${head_branch}"
+  echo "Re-ran App Integration workflow run ${run_id} for ${head_branch}"
 else
-  echo "Media branch updated. Could not rerun E2E Tests workflow run ${run_id}."
-  echo "Manually rerun the E2E Tests workflow for PR #${pr}."
+  echo "Media branch updated. Could not rerun App Integration workflow run ${run_id}."
+  echo "Manually rerun the App Integration workflow for PR #${pr}."
 fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches many CI entry points; a mistake in the composite action or matrix Dead Code job could block PRs repo-wide, though behavior is intended to be equivalent.
> 
> **Overview**
> Introduces a composite action **`.github/actions/setup-node-pnpm`** (pnpm, Node 24, frozen `pnpm install`) and replaces the repeated three-step setup across many workflows with a single **Setup Node.js and pnpm** step. Workflows that use it also gain **`contents: read`** permissions and **concurrency** groups that cancel in-progress runs on PRs; path filters now include the composite action so changes to it retrigger those checks.
> 
> **Dead Code** is collapsed from seven copy-pasted jobs into one **matrix** job (backend, packages, frontend) with optional `build:deps` precheck for backend only.
> 
> The **`e2e-tests.yml`** workflow is renamed in GitHub to **App Integration** (file path unchanged); job display names are clarified and the concurrency group prefix is updated. PR media docs and **`scripts/update-scenes.sh`** (moved from `scripts/pr-media/`) now refer to **App Integration** and the new script path; `gh run list` targets workflow name **App Integration**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4cb57cdcf274405fe0efe6dce86bcc1223e0a24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->