### PR TITLE
fix(letterheads): accept permission-encrypted letterhead PDFs (AYC-471)

### DIFF
--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -98,6 +98,7 @@
     "minio": "^8.0.5",
     "mjml": "^4.7.1",
     "multer": "^2.2.0",
+    "mupdf": "^1.28.0",
     "nest-commander": "^3.19.1",
     "nestjs-cls": "^6.0.1",
     "nestjs-pino": "^4.6.1",

--- a/ayunis-core-backend/src/domain/letterheads/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/letterheads/SUMMARY.md
@@ -23,7 +23,8 @@ letterheads/
 │   ├── ports/
 │   │   └── letterheads-repository.port.ts
 │   ├── services/
-│   │   └── letterhead-pdf.service.ts   # Shared PDF validation & storage path builder
+│   │   ├── letterhead-pdf.service.ts   # Shared PDF validation & storage path builder
+│   │   └── pdf-normalizer.service.ts   # MuPDF rewrite for PDFs pdf-lib cannot read
 │   └── use-cases/
 │       ├── create-letterhead/
 │       ├── delete-letterhead/
@@ -62,6 +63,7 @@ letterheads/
 
 - Page margins are validated (non-negative, finite) when a `Letterhead` entity is constructed
 - Uploaded PDFs are validated with `pdf-lib` and must be exactly one page each
+- When `pdf-lib` cannot read an upload (permission-encrypted files, broken cross-reference tables), it is rewritten through MuPDF and the normalized copy is stored — pdf-lib also composites the letterhead at export time, so only bytes it accepts may be stored. PDFs needing a user password are rejected as `LETTERHEAD_PDF_PASSWORD_PROTECTED`, unreadable ones as `LETTERHEAD_INVALID_PDF`, and multi-page ones as `LETTERHEAD_PDF_NOT_SINGLE_PAGE`
 - Create stores the first-page PDF and optional continuation PDF under org-scoped storage paths like `letterheads/<orgId>/<letterheadId>/...`
 - Update can replace either PDF, update metadata/margins, or remove the continuation page and delete its stored object
 - Find-all and find-one are organization-scoped via request context

--- a/ayunis-core-backend/src/domain/letterheads/application/letterheads.errors.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/letterheads.errors.ts
@@ -1,11 +1,13 @@
 import type { ErrorMetadata } from 'src/common/errors/base.error';
 import { ApplicationError } from 'src/common/errors/base.error';
 
-export { InvalidPageMarginsError } from '../domain/letterhead.errors';
+export { InvalidPageMarginsError } from 'src/domain/letterheads/domain/letterhead.errors';
 
 export enum LetterheadErrorCode {
   LETTERHEAD_NOT_FOUND = 'LETTERHEAD_NOT_FOUND',
   LETTERHEAD_INVALID_PDF = 'LETTERHEAD_INVALID_PDF',
+  LETTERHEAD_PDF_NOT_SINGLE_PAGE = 'LETTERHEAD_PDF_NOT_SINGLE_PAGE',
+  LETTERHEAD_PDF_PASSWORD_PROTECTED = 'LETTERHEAD_PDF_PASSWORD_PROTECTED',
   LETTERHEAD_ORG_MISMATCH = 'LETTERHEAD_ORG_MISMATCH',
   UNEXPECTED_LETTERHEAD_ERROR = 'UNEXPECTED_LETTERHEAD_ERROR',
 }
@@ -39,6 +41,28 @@ export class LetterheadInvalidPdfError extends LetterheadError {
       LetterheadErrorCode.LETTERHEAD_INVALID_PDF,
       400,
       metadata,
+    );
+  }
+}
+
+export class LetterheadPdfNotSinglePageError extends LetterheadError {
+  constructor(label: string, pageCount: number, metadata?: ErrorMetadata) {
+    super(
+      `Letterhead PDF must be exactly 1 page, but the ${label} PDF has ${pageCount}`,
+      LetterheadErrorCode.LETTERHEAD_PDF_NOT_SINGLE_PAGE,
+      400,
+      { label, pageCount, ...metadata },
+    );
+  }
+}
+
+export class LetterheadPdfPasswordProtectedError extends LetterheadError {
+  constructor(label: string, metadata?: ErrorMetadata) {
+    super(
+      `The ${label} PDF is protected with a password and cannot be opened`,
+      LetterheadErrorCode.LETTERHEAD_PDF_PASSWORD_PROTECTED,
+      400,
+      { label, ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/letterheads/application/services/letterhead-pdf.service.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/services/letterhead-pdf.service.spec.ts
@@ -1,50 +1,117 @@
 import type { UUID } from 'crypto';
 import { PDFDocument } from 'pdf-lib';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import {
+  LetterheadInvalidPdfError,
+  LetterheadPdfNotSinglePageError,
+  LetterheadPdfPasswordProtectedError,
+} from 'src/domain/letterheads/application/letterheads.errors';
+import {
+  createPdf,
+  encryptPdf,
+} from 'src/domain/letterheads/testing/pdf-fixtures';
 import { LetterheadPdfService } from './letterhead-pdf.service';
-import { LetterheadInvalidPdfError } from '../letterheads.errors';
+import { PdfNormalizerService } from './pdf-normalizer.service';
 
-async function createSinglePagePdf(): Promise<Buffer> {
-  const doc = await PDFDocument.create();
-  doc.addPage();
-  const bytes = await doc.save();
-  return Buffer.from(bytes);
-}
-
-async function createMultiPagePdf(pages: number): Promise<Buffer> {
-  const doc = await PDFDocument.create();
-  for (let i = 0; i < pages; i++) {
-    doc.addPage();
+async function isReadableByPdfLib(buffer: Buffer): Promise<boolean> {
+  try {
+    await PDFDocument.load(buffer);
+    return true;
+  } catch {
+    return false;
   }
-  const bytes = await doc.save();
-  return Buffer.from(bytes);
 }
 
 describe('LetterheadPdfService', () => {
   let service: LetterheadPdfService;
 
   beforeEach(() => {
-    service = new LetterheadPdfService();
+    service = new LetterheadPdfService(
+      createPinoLoggerMock(),
+      new PdfNormalizerService(createPinoLoggerMock()),
+    );
   });
 
-  describe('validateSinglePagePdf', () => {
-    it('should accept a valid single-page PDF', async () => {
-      const pdf = await createSinglePagePdf();
-      await expect(
-        service.validateSinglePagePdf(pdf, 'first page'),
-      ).resolves.toBeUndefined();
+  describe('prepareSinglePagePdf', () => {
+    it('should keep a valid single-page PDF byte-for-byte', async () => {
+      const pdf = await createPdf(1);
+
+      const prepared = await service.prepareSinglePagePdf(pdf, 'first page');
+
+      expect(prepared).toBe(pdf);
     });
 
-    it('should reject a multi-page PDF', async () => {
-      const pdf = await createMultiPagePdf(3);
+    it('should reject a multi-page PDF and report the page count', async () => {
+      const pdf = await createPdf(3);
+
       await expect(
-        service.validateSinglePagePdf(pdf, 'first page'),
-      ).rejects.toThrow(LetterheadInvalidPdfError);
+        service.prepareSinglePagePdf(pdf, 'first page'),
+      ).rejects.toMatchObject({
+        constructor: LetterheadPdfNotSinglePageError,
+        metadata: { pageCount: 3 },
+      });
     });
 
-    it('should reject an invalid buffer', async () => {
+    it('should accept a permission-encrypted PDF that pdf-lib alone rejects', async () => {
+      const encrypted = await encryptPdf(
+        await createPdf(1),
+        'encrypt=aes-256,owner-password=locked',
+      );
+      expect(await isReadableByPdfLib(encrypted)).toBe(false);
+
+      const prepared = await service.prepareSinglePagePdf(
+        encrypted,
+        'first page',
+      );
+
+      expect(await isReadableByPdfLib(prepared)).toBe(true);
+    });
+
+    it('should produce a decrypted PDF that can be composited onto an export', async () => {
+      const encrypted = await encryptPdf(
+        await createPdf(1),
+        'encrypt=rc4-128,owner-password=locked',
+      );
+
+      const prepared = await service.prepareSinglePagePdf(
+        encrypted,
+        'first page',
+      );
+
+      const background = await PDFDocument.load(prepared);
+      const output = await PDFDocument.create();
+      const [embedded] = await output.embedPdf(background, [0]);
+      output.addPage().drawPage(embedded);
+      await expect(output.save()).resolves.toBeDefined();
+    });
+
+    it('should reject an encrypted PDF that has more than one page', async () => {
+      const encrypted = await encryptPdf(
+        await createPdf(2),
+        'encrypt=aes-256,owner-password=locked',
+      );
+
+      await expect(
+        service.prepareSinglePagePdf(encrypted, 'first page'),
+      ).rejects.toThrow(LetterheadPdfNotSinglePageError);
+    });
+
+    it('should reject a PDF that needs a user password', async () => {
+      const encrypted = await encryptPdf(
+        await createPdf(1),
+        'encrypt=aes-256,user-password=secret,owner-password=locked',
+      );
+
+      await expect(
+        service.prepareSinglePagePdf(encrypted, 'first page'),
+      ).rejects.toThrow(LetterheadPdfPasswordProtectedError);
+    });
+
+    it('should reject a buffer that is not a PDF', async () => {
       const buffer = Buffer.from('not a pdf');
+
       await expect(
-        service.validateSinglePagePdf(buffer, 'first page'),
+        service.prepareSinglePagePdf(buffer, 'first page'),
       ).rejects.toThrow(LetterheadInvalidPdfError);
     });
   });

--- a/ayunis-core-backend/src/domain/letterheads/application/services/letterhead-pdf.service.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/services/letterhead-pdf.service.ts
@@ -1,28 +1,85 @@
 import { Injectable } from '@nestjs/common';
 import type { UUID } from 'crypto';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { PDFDocument } from 'pdf-lib';
-import { LetterheadInvalidPdfError } from '../letterheads.errors';
+import {
+  LetterheadInvalidPdfError,
+  LetterheadPdfNotSinglePageError,
+  LetterheadPdfPasswordProtectedError,
+} from 'src/domain/letterheads/application/letterheads.errors';
+import { PdfNormalizerService } from './pdf-normalizer.service';
+
+type PdfLibReadResult =
+  { readable: true; pageCount: number } | { readable: false; reason: string };
 
 @Injectable()
 export class LetterheadPdfService {
-  async validateSinglePagePdf(buffer: Buffer, label: string): Promise<void> {
-    try {
-      const pdfDoc = await PDFDocument.load(buffer);
-      const pageCount = pdfDoc.getPageCount();
-      if (pageCount !== 1) {
-        throw new LetterheadInvalidPdfError(
-          `${label} PDF must be exactly 1 page, got ${pageCount}`,
-        );
-      }
-    } catch (error) {
-      if (error instanceof LetterheadInvalidPdfError) {
-        throw error;
-      }
-      throw new LetterheadInvalidPdfError(`${label} is not a valid PDF file`);
+  constructor(
+    @InjectPinoLogger(LetterheadPdfService.name)
+    private readonly logger: PinoLogger,
+    private readonly pdfNormalizer: PdfNormalizerService,
+  ) {}
+
+  /**
+   * Validates an uploaded letterhead and returns the bytes to store: the upload
+   * itself when pdf-lib can read it, otherwise a normalized copy. Only what
+   * pdf-lib accepts may be stored — it is also the library that composites the
+   * letterhead behind exported documents.
+   */
+  async prepareSinglePagePdf(buffer: Buffer, label: string): Promise<Buffer> {
+    const upload = await this.readWithPdfLib(buffer);
+    if (upload.readable) {
+      this.assertSinglePage(upload.pageCount, label);
+      return buffer;
     }
+
+    this.logger.warn(
+      { label, reason: upload.reason },
+      'pdf-lib cannot read the uploaded letterhead PDF, normalizing it',
+    );
+    const normalized = await this.pdfNormalizer.normalize(buffer);
+    if (normalized.status === 'passwordRequired') {
+      throw new LetterheadPdfPasswordProtectedError(label);
+    }
+    if (normalized.status === 'unreadable') {
+      throw new LetterheadInvalidPdfError(`${label} is not a valid PDF file`, {
+        label,
+        pdfLibError: upload.reason,
+        normalizerError: normalized.reason,
+      });
+    }
+
+    const rewritten = await this.readWithPdfLib(normalized.buffer);
+    if (!rewritten.readable) {
+      throw new LetterheadInvalidPdfError(`${label} is not a valid PDF file`, {
+        label,
+        pdfLibError: upload.reason,
+        normalizedPdfLibError: rewritten.reason,
+      });
+    }
+    this.assertSinglePage(rewritten.pageCount, label);
+    return normalized.buffer;
   }
 
   buildStoragePath(orgId: UUID, letterheadId: UUID, fileName: string): string {
     return `letterheads/${orgId}/${letterheadId}/${fileName}`;
+  }
+
+  private assertSinglePage(pageCount: number, label: string): void {
+    if (pageCount !== 1) {
+      throw new LetterheadPdfNotSinglePageError(label, pageCount);
+    }
+  }
+
+  private async readWithPdfLib(buffer: Buffer): Promise<PdfLibReadResult> {
+    try {
+      const pdfDoc = await PDFDocument.load(buffer);
+      return { readable: true, pageCount: pdfDoc.getPageCount() };
+    } catch (error) {
+      return {
+        readable: false,
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
   }
 }

--- a/ayunis-core-backend/src/domain/letterheads/application/services/pdf-normalizer.service.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/services/pdf-normalizer.service.ts
@@ -29,24 +29,34 @@ export class PdfNormalizerService {
    */
   async normalize(buffer: Buffer): Promise<PdfNormalizationResult> {
     const mupdf = await this.loadMupdf();
+    let document: Mupdf.Document | undefined;
     try {
-      const document = mupdf.PDFDocument.openDocument(
-        buffer,
-        'application/pdf',
-      );
+      document = mupdf.PDFDocument.openDocument(buffer, 'application/pdf');
       if (document.needsPassword()) {
         return { status: 'passwordRequired' };
       }
       if (!(document instanceof mupdf.PDFDocument)) {
         return { status: 'unreadable', reason: 'not a PDF document' };
       }
-      const bytes = document.saveToBuffer('encrypt=none').asUint8Array();
-      return { status: 'normalized', buffer: Buffer.from(bytes) };
+      return { status: 'normalized', buffer: this.saveDecrypted(document) };
     } catch (error) {
       return {
         status: 'unreadable',
         reason: error instanceof Error ? error.message : String(error),
       };
+    } finally {
+      // MuPDF objects live on the WASM heap, which JavaScript garbage
+      // collection does not reclaim.
+      document?.destroy();
+    }
+  }
+
+  private saveDecrypted(document: Mupdf.PDFDocument): Buffer {
+    const saved = document.saveToBuffer('encrypt=none');
+    try {
+      return Buffer.from(saved.asUint8Array());
+    } finally {
+      saved.destroy();
     }
   }
 

--- a/ayunis-core-backend/src/domain/letterheads/application/services/pdf-normalizer.service.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/services/pdf-normalizer.service.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import type * as Mupdf from 'mupdf';
+
+export type PdfNormalizationResult =
+  | { status: 'normalized'; buffer: Buffer }
+  | { status: 'passwordRequired' }
+  | { status: 'unreadable'; reason: string };
+
+type MupdfModule = typeof Mupdf;
+
+@Injectable()
+export class PdfNormalizerService {
+  private mupdf?: Promise<MupdfModule>;
+
+  constructor(
+    @InjectPinoLogger(PdfNormalizerService.name)
+    private readonly logger: PinoLogger,
+  ) {}
+
+  /**
+   * Rewrites a PDF into the plain, unencrypted form pdf-lib can read: it drops
+   * the encryption dictionary that permission-locked files carry (those open
+   * without a password in every viewer, but pdf-lib refuses them) and rebuilds
+   * broken cross-reference tables.
+   *
+   * Files that need a real user password stay closed — decrypting those would
+   * require a password we do not have.
+   */
+  async normalize(buffer: Buffer): Promise<PdfNormalizationResult> {
+    const mupdf = await this.loadMupdf();
+    try {
+      const document = mupdf.PDFDocument.openDocument(
+        buffer,
+        'application/pdf',
+      );
+      if (document.needsPassword()) {
+        return { status: 'passwordRequired' };
+      }
+      if (!(document instanceof mupdf.PDFDocument)) {
+        return { status: 'unreadable', reason: 'not a PDF document' };
+      }
+      const bytes = document.saveToBuffer('encrypt=none').asUint8Array();
+      return { status: 'normalized', buffer: Buffer.from(bytes) };
+    } catch (error) {
+      return {
+        status: 'unreadable',
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  /**
+   * MuPDF is ESM-only with top-level await, so it cannot be `require`d from the
+   * CommonJS build. Importing it lazily also keeps its WASM runtime out of
+   * memory for the common case where pdf-lib reads an upload directly.
+   */
+  private loadMupdf(): Promise<MupdfModule> {
+    this.mupdf ??= import('mupdf').then((mupdf) => {
+      mupdf.setLog((message) =>
+        this.logger.debug({ message }, 'MuPDF diagnostic'),
+      );
+      return mupdf;
+    });
+    return this.mupdf;
+  }
+}

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.use-case.spec.ts
@@ -6,28 +6,34 @@ import type { UUID } from 'crypto';
 import { PDFDocument } from 'pdf-lib';
 import { CreateLetterheadUseCase } from './create-letterhead.use-case';
 import { CreateLetterheadCommand } from './create-letterhead.command';
-import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
-import { LetterheadPdfService } from '../../services/letterhead-pdf.service';
+import { LetterheadsRepository } from 'src/domain/letterheads/application/ports/letterheads-repository.port';
+import { LetterheadPdfService } from 'src/domain/letterheads/application/services/letterhead-pdf.service';
+import { PdfNormalizerService } from 'src/domain/letterheads/application/services/pdf-normalizer.service';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/upload-object/upload-object.use-case';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
-import { LetterheadInvalidPdfError } from '../../letterheads.errors';
+import {
+  LetterheadInvalidPdfError,
+  LetterheadPdfNotSinglePageError,
+} from 'src/domain/letterheads/application/letterheads.errors';
+import {
+  createPdf,
+  encryptPdf,
+} from 'src/domain/letterheads/testing/pdf-fixtures';
 
-async function createSinglePagePdf(): Promise<Buffer> {
-  const doc = await PDFDocument.create();
-  doc.addPage();
-  const bytes = await doc.save();
-  return Buffer.from(bytes);
-}
-
-async function createMultiPagePdf(pages: number): Promise<Buffer> {
-  const doc = await PDFDocument.create();
-  for (let i = 0; i < pages; i++) {
-    doc.addPage();
-  }
-  const bytes = await doc.save();
-  return Buffer.from(bytes);
-}
+/** Providers the letterhead PDF pipeline needs on top of the use case's own. */
+const pdfPipelineProviders = () => [
+  LetterheadPdfService,
+  PdfNormalizerService,
+  {
+    provide: getLoggerToken(LetterheadPdfService.name),
+    useValue: createPinoLoggerMock(),
+  },
+  {
+    provide: getLoggerToken(PdfNormalizerService.name),
+    useValue: createPinoLoggerMock(),
+  },
+];
 
 describe('CreateLetterheadUseCase', () => {
   let useCase: CreateLetterheadUseCase;
@@ -66,7 +72,7 @@ describe('CreateLetterheadUseCase', () => {
           provide: getLoggerToken(CreateLetterheadUseCase.name),
           useValue: createPinoLoggerMock(),
         },
-        LetterheadPdfService,
+        ...pdfPipelineProviders(),
         { provide: LetterheadsRepository, useValue: mockRepository },
         { provide: ContextService, useValue: mockContextService },
         { provide: UploadObjectUseCase, useValue: mockUploadObjectUseCase },
@@ -85,7 +91,7 @@ describe('CreateLetterheadUseCase', () => {
   });
 
   it('should create a letterhead with first-page PDF only', async () => {
-    const pdfBuffer = await createSinglePagePdf();
+    const pdfBuffer = await createPdf(1);
 
     const command = new CreateLetterheadCommand({
       name: 'Stadtverwaltung Musterstadt',
@@ -107,8 +113,8 @@ describe('CreateLetterheadUseCase', () => {
   });
 
   it('should create a letterhead with both first-page and continuation PDFs', async () => {
-    const firstPagePdf = await createSinglePagePdf();
-    const continuationPdf = await createSinglePagePdf();
+    const firstPagePdf = await createPdf(1);
+    const continuationPdf = await createPdf(1);
 
     const command = new CreateLetterheadCommand({
       name: 'Amt für Finanzen',
@@ -125,7 +131,7 @@ describe('CreateLetterheadUseCase', () => {
   });
 
   it('should reject a multi-page first-page PDF', async () => {
-    const multiPagePdf = await createMultiPagePdf(3);
+    const multiPagePdf = await createPdf(3);
 
     const command = new CreateLetterheadCommand({
       name: 'Invalid Letterhead',
@@ -135,14 +141,14 @@ describe('CreateLetterheadUseCase', () => {
     });
 
     await expect(useCase.execute(command)).rejects.toThrow(
-      LetterheadInvalidPdfError,
+      LetterheadPdfNotSinglePageError,
     );
     expect(letterheadsRepository.save).not.toHaveBeenCalled();
   });
 
   it('should reject a multi-page continuation PDF', async () => {
-    const firstPagePdf = await createSinglePagePdf();
-    const multiPageContinuation = await createMultiPagePdf(2);
+    const firstPagePdf = await createPdf(1);
+    const multiPageContinuation = await createPdf(2);
 
     const command = new CreateLetterheadCommand({
       name: 'Invalid Continuation',
@@ -153,9 +159,30 @@ describe('CreateLetterheadUseCase', () => {
     });
 
     await expect(useCase.execute(command)).rejects.toThrow(
-      LetterheadInvalidPdfError,
+      LetterheadPdfNotSinglePageError,
     );
     expect(letterheadsRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('should store a decrypted copy of a permission-encrypted PDF', async () => {
+    const encryptedPdf = await encryptPdf(
+      await createPdf(1),
+      'encrypt=aes-256,owner-password=locked',
+    );
+
+    const command = new CreateLetterheadCommand({
+      name: 'Permission-locked Letterhead',
+      firstPagePdfBuffer: encryptedPdf,
+      firstPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+      continuationPageMargins: { top: 20, bottom: 20, left: 20, right: 20 },
+    });
+
+    await useCase.execute(command);
+
+    const uploaded = uploadObjectUseCase.execute.mock.calls[0][0]
+      .data as Buffer;
+    expect(uploaded).not.toEqual(encryptedPdf);
+    await expect(PDFDocument.load(uploaded)).resolves.toBeDefined();
   });
 
   it('should reject an invalid PDF buffer', async () => {
@@ -185,7 +212,7 @@ describe('CreateLetterheadUseCase', () => {
           provide: getLoggerToken(CreateLetterheadUseCase.name),
           useValue: createPinoLoggerMock(),
         },
-        LetterheadPdfService,
+        ...pdfPipelineProviders(),
         { provide: LetterheadsRepository, useValue: letterheadsRepository },
         { provide: ContextService, useValue: mockContextService },
         { provide: UploadObjectUseCase, useValue: uploadObjectUseCase },
@@ -193,7 +220,7 @@ describe('CreateLetterheadUseCase', () => {
     }).compile();
 
     const useCaseNoOrg = module.get(CreateLetterheadUseCase);
-    const pdfBuffer = await createSinglePagePdf();
+    const pdfBuffer = await createPdf(1);
 
     const command = new CreateLetterheadCommand({
       name: 'No Org',
@@ -208,7 +235,7 @@ describe('CreateLetterheadUseCase', () => {
   });
 
   it('should set description to null when not provided', async () => {
-    const pdfBuffer = await createSinglePagePdf();
+    const pdfBuffer = await createPdf(1);
 
     const command = new CreateLetterheadCommand({
       name: 'Minimal Letterhead',
@@ -223,7 +250,7 @@ describe('CreateLetterheadUseCase', () => {
   });
 
   it('should store files under the correct org-scoped path', async () => {
-    const pdfBuffer = await createSinglePagePdf();
+    const pdfBuffer = await createPdf(1);
 
     const command = new CreateLetterheadCommand({
       name: 'Path Test',
@@ -240,7 +267,7 @@ describe('CreateLetterheadUseCase', () => {
   });
 
   it('should construct the entity only once with valid storage paths', async () => {
-    const pdfBuffer = await createSinglePagePdf();
+    const pdfBuffer = await createPdf(1);
 
     const command = new CreateLetterheadCommand({
       name: 'Single Construction',

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.use-case.ts
@@ -6,10 +6,10 @@ import { ApplicationError } from 'src/common/errors/base.error';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/upload-object/upload-object.use-case';
 import { UploadObjectCommand } from 'src/domain/storage/application/use-cases/upload-object/upload-object.command';
-import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
-import { UnexpectedLetterheadError } from '../../letterheads.errors';
-import { Letterhead } from '../../../domain/letterhead.entity';
-import { LetterheadPdfService } from '../../services/letterhead-pdf.service';
+import { LetterheadsRepository } from 'src/domain/letterheads/application/ports/letterheads-repository.port';
+import { UnexpectedLetterheadError } from 'src/domain/letterheads/application/letterheads.errors';
+import { Letterhead } from 'src/domain/letterheads/domain/letterhead.entity';
+import { LetterheadPdfService } from 'src/domain/letterheads/application/services/letterhead-pdf.service';
 import { CreateLetterheadCommand } from './create-letterhead.command';
 
 @Injectable()
@@ -43,7 +43,7 @@ export class CreateLetterheadUseCase {
     command: CreateLetterheadCommand,
   ): Promise<Letterhead> {
     const orgId = this.resolveOrgId();
-    await this.validatePdfs(command);
+    const pdfs = await this.preparePdfs(command);
     const letterheadId = randomUUID();
     const firstPagePath = this.letterheadPdfService.buildStoragePath(
       orgId,
@@ -51,12 +51,12 @@ export class CreateLetterheadUseCase {
       'first-page.pdf',
     );
     await this.uploadObjectUseCase.execute(
-      new UploadObjectCommand(firstPagePath, command.firstPagePdfBuffer),
+      new UploadObjectCommand(firstPagePath, pdfs.firstPage),
     );
     const continuationPagePath = await this.uploadContinuationPage(
       orgId,
       letterheadId,
-      command.continuationPagePdfBuffer,
+      pdfs.continuationPage,
     );
     return this.letterheadsRepository.save(
       new Letterhead({
@@ -78,17 +78,22 @@ export class CreateLetterheadUseCase {
     return orgId;
   }
 
-  private async validatePdfs(command: CreateLetterheadCommand): Promise<void> {
-    await this.letterheadPdfService.validateSinglePagePdf(
+  private async preparePdfs(
+    command: CreateLetterheadCommand,
+  ): Promise<{ firstPage: Buffer; continuationPage: Buffer | null }> {
+    const firstPage = await this.letterheadPdfService.prepareSinglePagePdf(
       command.firstPagePdfBuffer,
       'first page',
     );
-    if (command.continuationPagePdfBuffer) {
-      await this.letterheadPdfService.validateSinglePagePdf(
+    if (!command.continuationPagePdfBuffer) {
+      return { firstPage, continuationPage: null };
+    }
+    const continuationPage =
+      await this.letterheadPdfService.prepareSinglePagePdf(
         command.continuationPagePdfBuffer,
         'continuation page',
       );
-    }
+    return { firstPage, continuationPage };
   }
 
   private async uploadContinuationPage(

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.use-case.spec.ts
@@ -3,36 +3,21 @@ import { Test } from '@nestjs/testing';
 import { getLoggerToken } from 'nestjs-pino';
 import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { UUID } from 'crypto';
-import { PDFDocument } from 'pdf-lib';
 import { UpdateLetterheadUseCase } from './update-letterhead.use-case';
 import { UpdateLetterheadCommand } from './update-letterhead.command';
-import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
-import { LetterheadPdfService } from '../../services/letterhead-pdf.service';
+import { LetterheadsRepository } from 'src/domain/letterheads/application/ports/letterheads-repository.port';
+import { LetterheadPdfService } from 'src/domain/letterheads/application/services/letterhead-pdf.service';
+import { PdfNormalizerService } from 'src/domain/letterheads/application/services/pdf-normalizer.service';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/upload-object/upload-object.use-case';
 import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import {
   LetterheadNotFoundError,
-  LetterheadInvalidPdfError,
-} from '../../letterheads.errors';
+  LetterheadPdfNotSinglePageError,
+} from 'src/domain/letterheads/application/letterheads.errors';
 import { Letterhead } from 'src/domain/letterheads/domain/letterhead.entity';
-
-async function createSinglePagePdf(): Promise<Buffer> {
-  const doc = await PDFDocument.create();
-  doc.addPage();
-  const bytes = await doc.save();
-  return Buffer.from(bytes);
-}
-
-async function createMultiPagePdf(pages: number): Promise<Buffer> {
-  const doc = await PDFDocument.create();
-  for (let i = 0; i < pages; i++) {
-    doc.addPage();
-  }
-  const bytes = await doc.save();
-  return Buffer.from(bytes);
-}
+import { createPdf } from 'src/domain/letterheads/testing/pdf-fixtures';
 
 describe('UpdateLetterheadUseCase', () => {
   let useCase: UpdateLetterheadUseCase;
@@ -89,6 +74,15 @@ describe('UpdateLetterheadUseCase', () => {
           useValue: createPinoLoggerMock(),
         },
         LetterheadPdfService,
+        PdfNormalizerService,
+        {
+          provide: getLoggerToken(LetterheadPdfService.name),
+          useValue: createPinoLoggerMock(),
+        },
+        {
+          provide: getLoggerToken(PdfNormalizerService.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: LetterheadsRepository, useValue: mockRepository },
         { provide: ContextService, useValue: mockContextService },
         { provide: UploadObjectUseCase, useValue: mockUploadObjectUseCase },
@@ -145,7 +139,7 @@ describe('UpdateLetterheadUseCase', () => {
   });
 
   it('should replace the first-page PDF when a new buffer is provided', async () => {
-    const newPdf = await createSinglePagePdf();
+    const newPdf = await createPdf(1);
 
     const command = new UpdateLetterheadCommand({
       letterheadId: mockLetterheadId,
@@ -159,7 +153,7 @@ describe('UpdateLetterheadUseCase', () => {
   });
 
   it('should add a continuation PDF when provided', async () => {
-    const continuationPdf = await createSinglePagePdf();
+    const continuationPdf = await createPdf(1);
 
     const command = new UpdateLetterheadCommand({
       letterheadId: mockLetterheadId,
@@ -206,7 +200,7 @@ describe('UpdateLetterheadUseCase', () => {
   });
 
   it('should reject a multi-page first-page PDF replacement', async () => {
-    const multiPagePdf = await createMultiPagePdf(2);
+    const multiPagePdf = await createPdf(2);
 
     const command = new UpdateLetterheadCommand({
       letterheadId: mockLetterheadId,
@@ -214,7 +208,7 @@ describe('UpdateLetterheadUseCase', () => {
     });
 
     await expect(useCase.execute(command)).rejects.toThrow(
-      LetterheadInvalidPdfError,
+      LetterheadPdfNotSinglePageError,
     );
   });
 
@@ -244,6 +238,15 @@ describe('UpdateLetterheadUseCase', () => {
           useValue: createPinoLoggerMock(),
         },
         LetterheadPdfService,
+        PdfNormalizerService,
+        {
+          provide: getLoggerToken(LetterheadPdfService.name),
+          useValue: createPinoLoggerMock(),
+        },
+        {
+          provide: getLoggerToken(PdfNormalizerService.name),
+          useValue: createPinoLoggerMock(),
+        },
         { provide: LetterheadsRepository, useValue: letterheadsRepository },
         { provide: ContextService, useValue: mockContextService },
         { provide: UploadObjectUseCase, useValue: uploadObjectUseCase },

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.use-case.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.use-case.ts
@@ -8,13 +8,13 @@ import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/up
 import { UploadObjectCommand } from 'src/domain/storage/application/use-cases/upload-object/upload-object.command';
 import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/delete-object/delete-object.use-case';
 import { DeleteObjectCommand } from 'src/domain/storage/application/use-cases/delete-object/delete-object.command';
-import { LetterheadsRepository } from '../../ports/letterheads-repository.port';
-import { Letterhead } from '../../../domain/letterhead.entity';
+import { LetterheadsRepository } from 'src/domain/letterheads/application/ports/letterheads-repository.port';
+import { Letterhead } from 'src/domain/letterheads/domain/letterhead.entity';
 import {
   LetterheadNotFoundError,
   UnexpectedLetterheadError,
-} from '../../letterheads.errors';
-import { LetterheadPdfService } from '../../services/letterhead-pdf.service';
+} from 'src/domain/letterheads/application/letterheads.errors';
+import { LetterheadPdfService } from 'src/domain/letterheads/application/services/letterhead-pdf.service';
 import { UpdateLetterheadCommand } from './update-letterhead.command';
 
 @Injectable()
@@ -89,8 +89,11 @@ export class UpdateLetterheadUseCase {
     buffer?: Buffer,
   ): Promise<string> {
     if (!buffer) return existing.firstPageStoragePath;
-    await this.letterheadPdfService.validateSinglePagePdf(buffer, 'first page');
-    return this.uploadPdf(orgId, existing.id, 'first-page.pdf', buffer);
+    const firstPage = await this.letterheadPdfService.prepareSinglePagePdf(
+      buffer,
+      'first page',
+    );
+    return this.uploadPdf(orgId, existing.id, 'first-page.pdf', firstPage);
   }
 
   private async resolveContinuationPage(
@@ -99,15 +102,16 @@ export class UpdateLetterheadUseCase {
     command: UpdateLetterheadCommand,
   ): Promise<string | null> {
     if (command.continuationPagePdfBuffer) {
-      await this.letterheadPdfService.validateSinglePagePdf(
-        command.continuationPagePdfBuffer,
-        'continuation page',
-      );
+      const continuationPage =
+        await this.letterheadPdfService.prepareSinglePagePdf(
+          command.continuationPagePdfBuffer,
+          'continuation page',
+        );
       return this.uploadPdf(
         orgId,
         existing.id,
         'continuation.pdf',
-        command.continuationPagePdfBuffer,
+        continuationPage,
       );
     }
     if (!command.removeContinuationPage) {

--- a/ayunis-core-backend/src/domain/letterheads/letterheads.module.ts
+++ b/ayunis-core-backend/src/domain/letterheads/letterheads.module.ts
@@ -2,8 +2,9 @@ import { Module } from '@nestjs/common';
 import { LetterheadsRepository } from './application/ports/letterheads-repository.port';
 import { LocalLetterheadsRepositoryModule } from './infrastructure/persistence/local/local-letterheads-repository.module';
 import { LocalLetterheadsRepository } from './infrastructure/persistence/local/local-letterheads.repository';
-import { StorageModule } from '../storage/storage.module';
+import { StorageModule } from 'src/domain/storage/storage.module';
 import { LetterheadPdfService } from './application/services/letterhead-pdf.service';
+import { PdfNormalizerService } from './application/services/pdf-normalizer.service';
 import { CreateLetterheadUseCase } from './application/use-cases/create-letterhead/create-letterhead.use-case';
 import { FindAllLetterheadsUseCase } from './application/use-cases/find-all-letterheads/find-all-letterheads.use-case';
 import { FindLetterheadUseCase } from './application/use-cases/find-letterhead/find-letterhead.use-case';
@@ -21,6 +22,7 @@ import { LetterheadDtoMapper } from './presenters/http/mappers/letterhead-dto.ma
       useExisting: LocalLetterheadsRepository,
     },
     LetterheadPdfService,
+    PdfNormalizerService,
     CreateLetterheadUseCase,
     FindAllLetterheadsUseCase,
     FindLetterheadUseCase,

--- a/ayunis-core-backend/src/domain/letterheads/testing/pdf-fixtures.ts
+++ b/ayunis-core-backend/src/domain/letterheads/testing/pdf-fixtures.ts
@@ -1,0 +1,26 @@
+import { PDFDocument } from 'pdf-lib';
+
+export async function createPdf(pages: number): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  for (let i = 0; i < pages; i++) {
+    doc.addPage().drawRectangle({ x: 10, y: 10, width: 100, height: 50 });
+  }
+  return Buffer.from(await doc.save());
+}
+
+/**
+ * Applies the encryption real-world letterheads carry — locked against editing,
+ * but openable without a password — via MuPDF write options such as
+ * `encrypt=aes-256,owner-password=locked`.
+ */
+export async function encryptPdf(
+  buffer: Buffer,
+  options: string,
+): Promise<Buffer> {
+  const mupdf = await import('mupdf');
+  const document = mupdf.PDFDocument.openDocument(buffer, 'application/pdf');
+  if (!(document instanceof mupdf.PDFDocument)) {
+    throw new Error('Fixture is not a PDF document');
+  }
+  return Buffer.from(document.saveToBuffer(options).asUint8Array());
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/letterhead-detail/api/useUpdateLetterhead.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/letterhead-detail/api/useUpdateLetterhead.ts
@@ -82,6 +82,12 @@ export function useUpdateLetterhead() {
           case 'LETTERHEAD_INVALID_PDF':
             showError(t('letterheads.editDialog.invalidPdf'));
             break;
+          case 'LETTERHEAD_PDF_NOT_SINGLE_PAGE':
+            showError(t('letterheads.editDialog.pdfNotSinglePage'));
+            break;
+          case 'LETTERHEAD_PDF_PASSWORD_PROTECTED':
+            showError(t('letterheads.editDialog.pdfPasswordProtected'));
+            break;
           case 'LETTERHEAD_INVALID_PAGE_MARGINS':
             showError(t('letterheads.editDialog.invalidPageMargins'));
             break;

--- a/ayunis-core-frontend/src/pages/admin-settings/letterheads-settings/api/useCreateLetterhead.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/letterheads-settings/api/useCreateLetterhead.ts
@@ -5,7 +5,7 @@ import { getLetterheadsControllerFindAllQueryKey } from '@/shared/api/generated/
 import { customAxiosInstance } from '@/shared/api';
 import extractErrorData from '@/shared/api/extract-error-data';
 import type { LetterheadResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
-import type { PageMargins } from '../model/types';
+import type { PageMargins } from '@/pages/admin-settings/letterheads-settings/model/types';
 
 interface CreateLetterheadParams {
   name: string;
@@ -60,6 +60,12 @@ export function useCreateLetterhead(onSuccess?: () => void) {
         switch (code) {
           case 'LETTERHEAD_INVALID_PDF':
             showError(t('letterheads.createDialog.invalidPdf'));
+            break;
+          case 'LETTERHEAD_PDF_NOT_SINGLE_PAGE':
+            showError(t('letterheads.createDialog.pdfNotSinglePage'));
+            break;
+          case 'LETTERHEAD_PDF_PASSWORD_PROTECTED':
+            showError(t('letterheads.createDialog.pdfPasswordProtected'));
             break;
           case 'LETTERHEAD_INVALID_PAGE_MARGINS':
             showError(t('letterheads.createDialog.invalidPageMargins'));

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-letterheads.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-letterheads.json
@@ -33,6 +33,8 @@
       "error": "Fehler beim Erstellen des Briefpapiers.",
       "firstPageRequired": "Eine PDF-Datei für die erste Seite ist erforderlich.",
       "invalidPdf": "Bitte laden Sie eine gültige PDF-Datei hoch.",
+      "pdfNotSinglePage": "Das Briefpapier-PDF darf nur eine Seite enthalten.",
+      "pdfPasswordProtected": "Das PDF ist mit einem Passwort geschützt. Bitte laden Sie es ohne Passwortschutz hoch.",
       "invalidPageMargins": "Bitte geben Sie gültige nicht-negative Seitenränder ein.",
       "pdfPreviewError": "PDF-Vorschau konnte nicht gerendert werden."
     },
@@ -44,6 +46,8 @@
       "success": "Briefpapier erfolgreich aktualisiert.",
       "error": "Fehler beim Aktualisieren des Briefpapiers.",
       "invalidPdf": "Bitte laden Sie eine gültige PDF-Datei hoch.",
+      "pdfNotSinglePage": "Das Briefpapier-PDF darf nur eine Seite enthalten.",
+      "pdfPasswordProtected": "Das PDF ist mit einem Passwort geschützt. Bitte laden Sie es ohne Passwortschutz hoch.",
       "invalidPageMargins": "Bitte geben Sie gültige nicht-negative Seitenränder ein.",
       "removeContinuationPage": "Folgeseiten-Briefpapier entfernen",
       "useDifferentFollowingPages": "Anderes Briefpapier für Folgeseiten verwenden"

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-letterheads.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-letterheads.json
@@ -33,6 +33,8 @@
       "error": "Failed to create letterhead.",
       "firstPageRequired": "A PDF file for the first page is required.",
       "invalidPdf": "Please upload a valid PDF file.",
+      "pdfNotSinglePage": "The letterhead PDF must contain exactly one page.",
+      "pdfPasswordProtected": "This PDF is protected with a password. Please upload it without password protection.",
       "invalidPageMargins": "Please enter valid non-negative page margins.",
       "pdfPreviewError": "Could not render PDF preview."
     },
@@ -44,6 +46,8 @@
       "success": "Letterhead updated successfully.",
       "error": "Failed to update letterhead.",
       "invalidPdf": "Please upload a valid PDF file.",
+      "pdfNotSinglePage": "The letterhead PDF must contain exactly one page.",
+      "pdfPasswordProtected": "This PDF is protected with a password. Please upload it without password protection.",
       "invalidPageMargins": "Please enter valid non-negative page margins.",
       "removeContinuationPage": "Remove following pages letterhead",
       "useDifferentFollowingPages": "Use different letterhead for following pages"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       multer:
         specifier: ^2.2.0
         version: 2.2.0
+      mupdf:
+        specifier: ^1.28.0
+        version: 1.28.0
       nest-commander:
         specifier: ^3.19.1
         version: 3.20.1(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.28)(@types/inquirer@8.2.12)(@types/node@24.12.4)(typescript@6.0.3)
@@ -10383,6 +10386,9 @@ packages:
   multer@2.2.0:
     resolution: {integrity: sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==}
     engines: {node: '>= 10.16.0'}
+
+  mupdf@1.28.0:
+    resolution: {integrity: sha512-ACUnbpECaQ5JLq04pwd89lS+0IGMest5qL5tb08g9TAR7bDtfqflHEkb2Xm3o4rvC/szguLiV+WEbW9kstj8Sg==}
 
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
@@ -24279,6 +24285,8 @@ snapshots:
       busboy: 1.6.0
       concat-stream: 2.0.0
       type-is: 1.6.18
+
+  mupdf@1.28.0: {}
 
   mute-stream@0.0.8: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [AYC-471](https://linear.app/ayunis/issue/AYC-471/briefpapier-pdf-upload-rejects-valid-file) — uploading a letterhead failed with "Bitte laden Sie eine gültige PDF-Datei hoch."

## Cause

`LetterheadPdfService` validated uploads with `PDFDocument.load(buffer)`, which **throws for any PDF carrying an encryption dictionary** — including files that are only locked against editing and open password-free in every viewer (that is why the upload dialog's pdf.js preview rendered the file while the backend refused it). The thrown parse error was swallowed and re-thrown as a single generic `LETTERHEAD_INVALID_PDF`, so neither the user nor the logs could tell an encrypted PDF from a corrupt or multi-page one.

`{ ignoreEncryption: true }` is not a fix: pdf-lib cannot decrypt streams, and the same library composites the letterhead behind exported documents. Verified locally — accepting an encrypted letterhead that way makes the export fail with `Unknown compression method in flate stream`.

## Change

- **Normalize on failure.** When pdf-lib cannot read an upload, it is rewritten through MuPDF (drops encryption, repairs broken cross-reference tables) and the normalized copy is stored. Uploads pdf-lib already accepts are stored byte-for-byte, so the common path is untouched and MuPDF's WASM runtime is only loaded on the fallback path. MuPDF documents and buffers are destroyed after use — their memory lives on the WASM heap, which JS garbage collection does not reclaim.
- **Say why an upload was refused.** New `LETTERHEAD_PDF_NOT_SINGLE_PAGE` and `LETTERHEAD_PDF_PASSWORD_PROTECTED` codes with German and English messages; `LETTERHEAD_INVALID_PDF` now carries the underlying parser error, and the previously swallowed failure is logged.
- PDFs needing a real user password are still rejected — decrypting those would require the password.

New dependency: `mupdf` (WASM, AGPL-3.0, same license as this repo). It is ESM-only with top-level await, so it is loaded via dynamic `import()`; the CommonJS build preserves the call (verified in `dist/`), and the compiled service was smoke-tested under Node 24.

## Verification

- New service specs cover: unchanged bytes for a plain PDF, permission-encrypted PDF (AES-256 and RC4-128) accepted and compositable, encrypted multi-page rejected, user-password PDF rejected, garbage rejected.
- Use-case spec asserts the **decrypted** copy is what gets uploaded to storage.
- Fixtures for the encrypted cases are generated in-test, and each asserts pdf-lib alone cannot read the input.
- Compiled service smoke-tested against PDFs encrypted by a third-party writer (pypdf, RC4-128 and AES-128): stored bytes load and composite in pdf-lib; 200 normalize cycles run without leaking or crashing.
- Full backend suite green (657 suites / 4588 tests) on Node 24; `nest build` clean.

## Not verified

The PDF from the ticket (`Testbrief – Stadt Sternfeld (1).pdf`) is behind Linear's authenticated upload URL, which this agent cannot fetch, so the fix is not confirmed against that exact file. Both plausible causes are covered: if it was permission-encrypted it now uploads, and if it was multi-page the user now gets "Das Briefpapier-PDF darf nur eine Seite enthalten." instead of the generic message. Re-testing with the original file in the demo account is the remaining step.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-471](https://linear.app/ayunis/issue/AYC-471/briefpapier-pdf-upload-rejects-valid-file)

<div><a href="https://cursor.com/agents/bc-83e6d024-f423-4083-86a2-8564f217f7a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83e6d024-f423-4083-86a2-8564f217f7a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

