### PR TITLE
wip(workspaces): add sharing access foundation (AYC-703)

### DIFF
--- a/ayunis-core-backend/src/db/migrations/1787222788431-AddWorkspaceSharingFoundation.ts
+++ b/ayunis-core-backend/src/db/migrations/1787222788431-AddWorkspaceSharingFoundation.ts
@@ -1,0 +1,54 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddWorkspaceSharingFoundation1787222788431 implements MigrationInterface {
+    name = 'AddWorkspaceSharingFoundation1787222788431'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TYPE "public"."workspace_team_grants_role_enum" AS ENUM('use', 'edit', 'full')`);
+        await queryRunner.query(`CREATE TABLE "workspace_team_grants" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "workspaceId" character varying NOT NULL, "teamId" character varying NOT NULL, "role" "public"."workspace_team_grants_role_enum" NOT NULL, CONSTRAINT "PK_87fec0a731ae8d9e7083c10260a" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_2ff4d832b168963b4db7504e0f" ON "workspace_team_grants" ("teamId") `);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_b1b4f119fda273430a147a8667" ON "workspace_team_grants" ("workspaceId", "teamId") `);
+        await queryRunner.query(`CREATE TYPE "public"."workspace_team_member_overrides_role_enum" AS ENUM('use', 'edit', 'full')`);
+        await queryRunner.query(`CREATE TABLE "workspace_team_member_overrides" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "teamGrantId" character varying NOT NULL, "userId" character varying NOT NULL, "role" "public"."workspace_team_member_overrides_role_enum", "excluded" boolean NOT NULL, CONSTRAINT "CHK_43d4aad3a4dcb59cb2f75fc756" CHECK (("excluded" = true AND "role" IS NULL) OR ("excluded" = false AND "role" IS NOT NULL)), CONSTRAINT "PK_0fb8f801c3b13f1e567049d8be9" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_fa7ea1c6467cbe47fd63125b33" ON "workspace_team_member_overrides" ("userId") `);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_b88eaa7ce3cdb14bc1ea0df1a0" ON "workspace_team_member_overrides" ("teamGrantId", "userId") `);
+        await queryRunner.query(`CREATE TYPE "public"."workspace_members_role_enum" AS ENUM('use', 'edit', 'full')`);
+        await queryRunner.query(`CREATE TYPE "public"."workspace_members_status_enum" AS ENUM('pending', 'active')`);
+        await queryRunner.query(`CREATE TABLE "workspace_members" ("id" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "workspaceId" character varying NOT NULL, "userId" character varying NOT NULL, "role" "public"."workspace_members_role_enum" NOT NULL, "status" "public"."workspace_members_status_enum" NOT NULL, CONSTRAINT "PK_22ab43ac5865cd62769121d2bc4" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_22176b38813258c2aadaae3244" ON "workspace_members" ("userId") `);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_99bcb5fdac446371d41f048b24" ON "workspace_members" ("workspaceId", "userId") `);
+        await queryRunner.query(`CREATE TYPE "public"."workspaces_visibility_enum" AS ENUM('private', 'organization')`);
+        await queryRunner.query(`ALTER TABLE "workspaces" ADD "visibility" "public"."workspaces_visibility_enum" NOT NULL DEFAULT 'private'`);
+        await queryRunner.query(`ALTER TABLE "workspace_team_grants" ADD CONSTRAINT "FK_2a8f125b1eff74e097929d3dad0" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "workspace_team_grants" ADD CONSTRAINT "FK_2ff4d832b168963b4db7504e0f3" FOREIGN KEY ("teamId") REFERENCES "teams"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "workspace_team_member_overrides" ADD CONSTRAINT "FK_b5ed356f692bf317c7292ddfd3d" FOREIGN KEY ("teamGrantId") REFERENCES "workspace_team_grants"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "workspace_team_member_overrides" ADD CONSTRAINT "FK_fa7ea1c6467cbe47fd63125b332" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "workspace_members" ADD CONSTRAINT "FK_0dd45cb52108d0664df4e7e33e6" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "workspace_members" ADD CONSTRAINT "FK_22176b38813258c2aadaae32448" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "workspace_members" DROP CONSTRAINT "FK_22176b38813258c2aadaae32448"`);
+        await queryRunner.query(`ALTER TABLE "workspace_members" DROP CONSTRAINT "FK_0dd45cb52108d0664df4e7e33e6"`);
+        await queryRunner.query(`ALTER TABLE "workspace_team_member_overrides" DROP CONSTRAINT "FK_fa7ea1c6467cbe47fd63125b332"`);
+        await queryRunner.query(`ALTER TABLE "workspace_team_member_overrides" DROP CONSTRAINT "FK_b5ed356f692bf317c7292ddfd3d"`);
+        await queryRunner.query(`ALTER TABLE "workspace_team_grants" DROP CONSTRAINT "FK_2ff4d832b168963b4db7504e0f3"`);
+        await queryRunner.query(`ALTER TABLE "workspace_team_grants" DROP CONSTRAINT "FK_2a8f125b1eff74e097929d3dad0"`);
+        await queryRunner.query(`ALTER TABLE "workspaces" DROP COLUMN "visibility"`);
+        await queryRunner.query(`DROP TYPE "public"."workspaces_visibility_enum"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_99bcb5fdac446371d41f048b24"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_22176b38813258c2aadaae3244"`);
+        await queryRunner.query(`DROP TABLE "workspace_members"`);
+        await queryRunner.query(`DROP TYPE "public"."workspace_members_status_enum"`);
+        await queryRunner.query(`DROP TYPE "public"."workspace_members_role_enum"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_b88eaa7ce3cdb14bc1ea0df1a0"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_fa7ea1c6467cbe47fd63125b33"`);
+        await queryRunner.query(`DROP TABLE "workspace_team_member_overrides"`);
+        await queryRunner.query(`DROP TYPE "public"."workspace_team_member_overrides_role_enum"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_b1b4f119fda273430a147a8667"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_2ff4d832b168963b4db7504e0f"`);
+        await queryRunner.query(`DROP TABLE "workspace_team_grants"`);
+        await queryRunner.query(`DROP TYPE "public"."workspace_team_grants_role_enum"`);
+    }
+
+}

--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -27,6 +27,10 @@ The whole module sits behind the `workspacesEnabled` feature flag
   catalogue. The backend only guards their shape (`WORKSPACE_ICON_PATTERN`,
   `WORKSPACE_COLOR_PATTERN`); `color` is either a palette key or a `#rrggbb`
   literal produced by the custom-colour picker.
+- **Collaboration foundation** — workspaces persist private/organization
+  visibility. Direct member, team grant, and team-scoped member-override
+  records provide the access-level schema; the sharing API and use-case
+  authorization are added in the following stack layers.
 - **Deletion** — `DeleteWorkspaceUseCase` emits `WorkspaceDeletionRequestedEvent`
   _before_ the row delete and drains the listeners' deferred cleanup only after
   it succeeds, so a failed delete loses nothing. The favorites module listens
@@ -46,11 +50,13 @@ The whole module sits behind the `workspacesEnabled` feature flag
 ```text
 workspaces/
 ├── domain/
-│   ├── workspace.entity.ts          # rename/describe/restyle/instruct
+│   ├── workspace.entity.ts          # identity, appearance and visibility
 │   ├── workspace-run-context.entity.ts
+│   ├── value-objects/               # access level, visibility, membership status
 │   └── workspaces.constants.ts      # limits, defaults, icon/colour patterns
 ├── application/
 │   ├── workspaces.errors.ts
+│   ├── services/workspace-access-policy.service.ts
 │   ├── util/workspace-fields.ts     # field validation (name/description/appearance)
 │   ├── events/
 │   │   └── workspace-deletion-requested.event.ts
@@ -87,6 +93,9 @@ workspaces/
 │   ├── schema/workspace-skill-assignment.record.ts
 │   ├── schema/workspace-knowledge-base-assignment.record.ts
 │   ├── schema/workspace-source-assignment.record.ts
+│   ├── schema/workspace-member.record.ts
+│   ├── schema/workspace-team-grant.record.ts
+│   ├── schema/workspace-team-member-override.record.ts
 │   ├── mappers/workspace.mapper.ts
 │   ├── local-workspaces.repository.ts
 │   └── local-workspaces-repository.module.ts
@@ -100,24 +109,24 @@ workspaces/
 
 ## HTTP API
 
-| Method | Route | Purpose |
-| --- | --- | --- |
-| POST | `/workspaces` | Create a workspace |
-| GET | `/workspaces` | List by most recently updated |
-| GET | `/workspaces/:id` | Read one |
-| PATCH | `/workspaces/:id` | Update name / description / icon / colour |
-| DELETE | `/workspaces/:id` | Delete the workspace and its chats |
-| GET | `/workspaces/:id/context` | Read the full runtime context |
-| GET | `/workspaces/:id/context/skill-candidates` | List accessible skills with attachment state |
-| GET | `/workspaces/:id/context/knowledge-base-candidates` | List accessible knowledge bases with attachment state |
-| GET | `/workspaces/:id/context/skills` | List attached skills |
-| GET | `/workspaces/:id/context/knowledge-bases` | List attached knowledge bases |
-| GET | `/workspaces/:id/context/documents` | List attached documents |
-| POST / DELETE | `/workspaces/:id/context/skills/:skillId` | Attach or detach a skill |
-| POST / DELETE | `/workspaces/:id/context/knowledge-bases/:knowledgeBaseId` | Attach or detach a knowledge base |
-| POST | `/workspaces/:id/context/documents` | Upload and attach a document |
-| DELETE | `/workspaces/:id/context/documents/:documentId` | Remove an attached document |
-| PATCH | `/workspaces/:id/context/instruction` | Update the workspace instruction |
+| Method        | Route                                                      | Purpose                                               |
+| ------------- | ---------------------------------------------------------- | ----------------------------------------------------- |
+| POST          | `/workspaces`                                              | Create a workspace                                    |
+| GET           | `/workspaces`                                              | List by most recently updated                         |
+| GET           | `/workspaces/:id`                                          | Read one                                              |
+| PATCH         | `/workspaces/:id`                                          | Update name / description / icon / colour             |
+| DELETE        | `/workspaces/:id`                                          | Delete the workspace and its chats                    |
+| GET           | `/workspaces/:id/context`                                  | Read the full runtime context                         |
+| GET           | `/workspaces/:id/context/skill-candidates`                 | List accessible skills with attachment state          |
+| GET           | `/workspaces/:id/context/knowledge-base-candidates`        | List accessible knowledge bases with attachment state |
+| GET           | `/workspaces/:id/context/skills`                           | List attached skills                                  |
+| GET           | `/workspaces/:id/context/knowledge-bases`                  | List attached knowledge bases                         |
+| GET           | `/workspaces/:id/context/documents`                        | List attached documents                               |
+| POST / DELETE | `/workspaces/:id/context/skills/:skillId`                  | Attach or detach a skill                              |
+| POST / DELETE | `/workspaces/:id/context/knowledge-bases/:knowledgeBaseId` | Attach or detach a knowledge base                     |
+| POST          | `/workspaces/:id/context/documents`                        | Upload and attach a document                          |
+| DELETE        | `/workspaces/:id/context/documents/:documentId`            | Remove an attached document                           |
+| PATCH         | `/workspaces/:id/context/instruction`                      | Update the workspace instruction                      |
 
 ## Cross-Module Boundaries
 

--- a/ayunis-core-backend/src/domain/workspaces/application/services/workspace-access-policy.service.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/services/workspace-access-policy.service.spec.ts
@@ -1,0 +1,145 @@
+import type { UUID } from 'crypto';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { WorkspaceAccessPolicyService } from './workspace-access-policy.service';
+
+const TEAM_A_ID = '10000000-0000-4000-8000-000000000001' as UUID;
+const TEAM_B_ID = '10000000-0000-4000-8000-000000000002' as UUID;
+
+describe('WorkspaceAccessPolicyService', () => {
+  const policy = new WorkspaceAccessPolicyService();
+  it('gives the owner immutable full access', () => {
+    expect(policy.resolve({ isOwner: true })).toEqual({
+      accessLevel: WorkspaceAccessLevel.FULL,
+      sources: [{ type: 'owner' }],
+    });
+  });
+
+  it('does not grant access for a pending direct invitation', () => {
+    expect(
+      policy.resolve({
+        directMembership: {
+          accessLevel: WorkspaceAccessLevel.EDIT,
+          status: WorkspaceMemberStatus.PENDING,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it('grants an active direct membership', () => {
+    expect(
+      policy.resolve({
+        directMembership: {
+          accessLevel: WorkspaceAccessLevel.EDIT,
+          status: WorkspaceMemberStatus.ACTIVE,
+        },
+      }),
+    ).toEqual({
+      accessLevel: WorkspaceAccessLevel.EDIT,
+      sources: [{ type: 'direct' }],
+    });
+  });
+
+  it('uses a team member access level override', () => {
+    expect(
+      policy.resolve({
+        teamGrants: [
+          {
+            teamId: TEAM_A_ID,
+            accessLevel: WorkspaceAccessLevel.USE,
+            override: {
+              accessLevel: WorkspaceAccessLevel.FULL,
+              excluded: false,
+            },
+          },
+        ],
+      }),
+    ).toEqual({
+      accessLevel: WorkspaceAccessLevel.FULL,
+      sources: [{ type: 'team', teamId: TEAM_A_ID }],
+    });
+  });
+
+  it('excludes only the specified team grant', () => {
+    expect(
+      policy.resolve({
+        teamGrants: [
+          {
+            teamId: TEAM_A_ID,
+            accessLevel: WorkspaceAccessLevel.FULL,
+            override: { accessLevel: null, excluded: true },
+          },
+          { teamId: TEAM_B_ID, accessLevel: WorkspaceAccessLevel.EDIT },
+        ],
+      }),
+    ).toEqual({
+      accessLevel: WorkspaceAccessLevel.EDIT,
+      sources: [{ type: 'team', teamId: TEAM_B_ID }],
+    });
+  });
+
+  it('keeps direct access when a team grant is excluded', () => {
+    expect(
+      policy.resolve({
+        directMembership: {
+          accessLevel: WorkspaceAccessLevel.USE,
+          status: WorkspaceMemberStatus.ACTIVE,
+        },
+        teamGrants: [
+          {
+            teamId: TEAM_A_ID,
+            accessLevel: WorkspaceAccessLevel.FULL,
+            override: { accessLevel: null, excluded: true },
+          },
+        ],
+      }),
+    ).toEqual({
+      accessLevel: WorkspaceAccessLevel.USE,
+      sources: [{ type: 'direct' }],
+    });
+  });
+
+  it('uses the highest access level while retaining every access source', () => {
+    expect(
+      policy.resolve({
+        directMembership: {
+          accessLevel: WorkspaceAccessLevel.USE,
+          status: WorkspaceMemberStatus.ACTIVE,
+        },
+        teamGrants: [
+          { teamId: TEAM_A_ID, accessLevel: WorkspaceAccessLevel.FULL },
+        ],
+        organizationVisible: true,
+      }),
+    ).toEqual({
+      accessLevel: WorkspaceAccessLevel.FULL,
+      sources: [
+        { type: 'direct' },
+        { type: 'team', teamId: TEAM_A_ID },
+        { type: 'organization' },
+      ],
+    });
+  });
+
+  it('compares workspace roles by privilege', () => {
+    expect(
+      policy.hasMinimumAccessLevel(
+        WorkspaceAccessLevel.EDIT,
+        WorkspaceAccessLevel.USE,
+      ),
+    ).toBe(true);
+    expect(
+      policy.hasMinimumAccessLevel(
+        WorkspaceAccessLevel.USE,
+        WorkspaceAccessLevel.EDIT,
+      ),
+    ).toBe(false);
+  });
+
+  it('grants use access through organization visibility', () => {
+    expect(policy.resolve({ organizationVisible: true })).toEqual({
+      accessLevel: WorkspaceAccessLevel.USE,
+      sources: [{ type: 'organization' }],
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/services/workspace-access-policy.service.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/services/workspace-access-policy.service.ts
@@ -1,0 +1,115 @@
+import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+
+const ACCESS_LEVEL_RANK: Record<WorkspaceAccessLevel, number> = {
+  [WorkspaceAccessLevel.USE]: 1,
+  [WorkspaceAccessLevel.EDIT]: 2,
+  [WorkspaceAccessLevel.FULL]: 3,
+};
+
+export interface DirectMembershipCandidate {
+  accessLevel: WorkspaceAccessLevel;
+  status: WorkspaceMemberStatus;
+}
+
+export interface TeamMemberOverrideCandidate {
+  accessLevel: WorkspaceAccessLevel | null;
+  excluded: boolean;
+}
+
+export interface TeamGrantCandidate {
+  teamId: UUID;
+  accessLevel: WorkspaceAccessLevel;
+  override?: TeamMemberOverrideCandidate;
+}
+
+export type WorkspaceAccessSource =
+  | { type: 'owner' }
+  | { type: 'direct' }
+  | { type: 'team'; teamId: UUID }
+  | { type: 'organization' };
+
+export interface WorkspaceAccessResolution {
+  accessLevel: WorkspaceAccessLevel;
+  sources: WorkspaceAccessSource[];
+}
+
+export interface WorkspaceAccessCandidates {
+  isOwner?: boolean;
+  directMembership?: DirectMembershipCandidate;
+  teamGrants?: TeamGrantCandidate[];
+  organizationVisible?: boolean;
+}
+
+interface AccessLevelCandidate {
+  accessLevel: WorkspaceAccessLevel;
+  source: WorkspaceAccessSource;
+}
+
+@Injectable()
+export class WorkspaceAccessPolicyService {
+  resolve(
+    candidates: WorkspaceAccessCandidates,
+  ): WorkspaceAccessResolution | null {
+    if (candidates.isOwner) {
+      return {
+        accessLevel: WorkspaceAccessLevel.FULL,
+        sources: [{ type: 'owner' }],
+      };
+    }
+    const accessLevelCandidates = this.collectAccessLevelCandidates(candidates);
+    if (accessLevelCandidates.length === 0) return null;
+    return {
+      accessLevel: this.highestAccessLevel(accessLevelCandidates),
+      sources: accessLevelCandidates.map(({ source }) => source),
+    };
+  }
+
+  hasMinimumAccessLevel(
+    actual: WorkspaceAccessLevel,
+    required: WorkspaceAccessLevel,
+  ): boolean {
+    return ACCESS_LEVEL_RANK[actual] >= ACCESS_LEVEL_RANK[required];
+  }
+
+  private collectAccessLevelCandidates(
+    candidates: WorkspaceAccessCandidates,
+  ): AccessLevelCandidate[] {
+    const result: AccessLevelCandidate[] = [];
+    const direct = candidates.directMembership;
+    if (direct?.status === WorkspaceMemberStatus.ACTIVE) {
+      result.push({
+        accessLevel: direct.accessLevel,
+        source: { type: 'direct' },
+      });
+    }
+    for (const teamGrant of candidates.teamGrants ?? []) {
+      if (teamGrant.override?.excluded) continue;
+      result.push({
+        accessLevel: teamGrant.override?.accessLevel ?? teamGrant.accessLevel,
+        source: { type: 'team', teamId: teamGrant.teamId },
+      });
+    }
+    if (candidates.organizationVisible) {
+      result.push({
+        accessLevel: WorkspaceAccessLevel.USE,
+        source: { type: 'organization' },
+      });
+    }
+    return result;
+  }
+
+  private highestAccessLevel(
+    candidates: AccessLevelCandidate[],
+  ): WorkspaceAccessLevel {
+    return candidates.reduce(
+      (highest, candidate) =>
+        ACCESS_LEVEL_RANK[candidate.accessLevel] > ACCESS_LEVEL_RANK[highest]
+          ? candidate.accessLevel
+          : highest,
+      candidates[0].accessLevel,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/domain/value-objects/workspace-access-level.enum.ts
+++ b/ayunis-core-backend/src/domain/workspaces/domain/value-objects/workspace-access-level.enum.ts
@@ -1,0 +1,5 @@
+export enum WorkspaceAccessLevel {
+  USE = 'use',
+  EDIT = 'edit',
+  FULL = 'full',
+}

--- a/ayunis-core-backend/src/domain/workspaces/domain/value-objects/workspace-member-status.enum.ts
+++ b/ayunis-core-backend/src/domain/workspaces/domain/value-objects/workspace-member-status.enum.ts
@@ -1,0 +1,4 @@
+export enum WorkspaceMemberStatus {
+  PENDING = 'pending',
+  ACTIVE = 'active',
+}

--- a/ayunis-core-backend/src/domain/workspaces/domain/value-objects/workspace-visibility.enum.ts
+++ b/ayunis-core-backend/src/domain/workspaces/domain/value-objects/workspace-visibility.enum.ts
@@ -1,0 +1,4 @@
+export enum WorkspaceVisibility {
+  PRIVATE = 'private',
+  ORGANIZATION = 'organization',
+}

--- a/ayunis-core-backend/src/domain/workspaces/domain/workspace.entity.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/domain/workspace.entity.spec.ts
@@ -1,0 +1,28 @@
+import type { UUID } from 'crypto';
+import { WorkspaceVisibility } from 'src/domain/workspaces/domain/value-objects/workspace-visibility.enum';
+import { Workspace } from './workspace.entity';
+
+const USER_ID = '10000000-0000-4000-8000-000000000001' as UUID;
+const ORG_ID = '10000000-0000-4000-8000-000000000002' as UUID;
+
+function createWorkspace(): Workspace {
+  return new Workspace({
+    userId: USER_ID,
+    orgId: ORG_ID,
+    name: 'Beschaffungsprojekt',
+  });
+}
+
+describe('Workspace visibility', () => {
+  it('creates a private workspace by default', () => {
+    expect(createWorkspace().visibility).toBe(WorkspaceVisibility.PRIVATE);
+  });
+
+  it('changes workspace visibility', () => {
+    const workspace = createWorkspace();
+
+    workspace.changeVisibility(WorkspaceVisibility.ORGANIZATION);
+
+    expect(workspace.visibility).toBe(WorkspaceVisibility.ORGANIZATION);
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/domain/workspace.entity.ts
+++ b/ayunis-core-backend/src/domain/workspaces/domain/workspace.entity.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_WORKSPACE_COLOR,
   DEFAULT_WORKSPACE_ICON,
 } from './workspaces.constants';
+import { WorkspaceVisibility } from './value-objects/workspace-visibility.enum';
 
 export class Workspace {
   public readonly id: UUID;
@@ -15,6 +16,7 @@ export class Workspace {
   public instruction: string | null;
   public icon: string;
   public color: string;
+  public visibility: WorkspaceVisibility;
   public updatedAt: Date;
 
   constructor(params: {
@@ -26,6 +28,7 @@ export class Workspace {
     instruction?: string | null;
     icon?: string;
     color?: string;
+    visibility?: WorkspaceVisibility;
     createdAt?: Date;
     updatedAt?: Date;
   }) {
@@ -37,6 +40,7 @@ export class Workspace {
     this.instruction = params.instruction ?? null;
     this.icon = params.icon ?? DEFAULT_WORKSPACE_ICON;
     this.color = params.color ?? DEFAULT_WORKSPACE_COLOR;
+    this.visibility = params.visibility ?? WorkspaceVisibility.PRIVATE;
     this.createdAt = params.createdAt ?? new Date();
     this.updatedAt = params.updatedAt ?? new Date();
   }
@@ -59,6 +63,11 @@ export class Workspace {
   restyle(params: { icon?: string; color?: string }): void {
     this.icon = params.icon ?? this.icon;
     this.color = params.color ?? this.color;
+    this.touch();
+  }
+
+  changeVisibility(visibility: WorkspaceVisibility): void {
+    this.visibility = visibility;
     this.touch();
   }
 

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces-repository.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces-repository.module.ts
@@ -6,6 +6,9 @@ import { WorkspaceKnowledgeBaseAssignmentRecord } from './schema/workspace-knowl
 import { WorkspaceSourceAssignmentRecord } from './schema/workspace-source-assignment.record';
 import { LocalWorkspacesRepository } from './local-workspaces.repository';
 import { WorkspaceMapper } from './mappers/workspace.mapper';
+import { WorkspaceMemberRecord } from './schema/workspace-member.record';
+import { WorkspaceTeamGrantRecord } from './schema/workspace-team-grant.record';
+import { WorkspaceTeamMemberOverrideRecord } from './schema/workspace-team-member-override.record';
 
 @Module({
   imports: [
@@ -14,6 +17,9 @@ import { WorkspaceMapper } from './mappers/workspace.mapper';
       WorkspaceSkillAssignmentRecord,
       WorkspaceKnowledgeBaseAssignmentRecord,
       WorkspaceSourceAssignmentRecord,
+      WorkspaceMemberRecord,
+      WorkspaceTeamGrantRecord,
+      WorkspaceTeamMemberOverrideRecord,
     ]),
   ],
   providers: [LocalWorkspacesRepository, WorkspaceMapper],

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace.mapper.spec.ts
@@ -1,6 +1,7 @@
 import { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import { WorkspaceRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace.record';
 import { WorkspaceMapper } from './workspace.mapper';
+import { WorkspaceVisibility } from 'src/domain/workspaces/domain/value-objects/workspace-visibility.enum';
 import {
   aWorkspace,
   TEST_ORG_ID,
@@ -17,6 +18,7 @@ describe('WorkspaceMapper', () => {
       description: 'Einsätze',
       icon: 'flame',
       color: '#6b5bd6',
+      visibility: WorkspaceVisibility.ORGANIZATION,
     });
 
     const roundTripped = mapper.toDomain(mapper.toRecord(workspace));

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace.mapper.ts
@@ -14,6 +14,7 @@ export class WorkspaceMapper {
       instruction: record.instruction,
       icon: record.icon,
       color: record.color,
+      visibility: record.visibility,
       createdAt: record.createdAt,
       updatedAt: record.updatedAt,
     });
@@ -29,6 +30,7 @@ export class WorkspaceMapper {
     record.instruction = domain.instruction;
     record.icon = domain.icon;
     record.color = domain.color;
+    record.visibility = domain.visibility;
     record.createdAt = domain.createdAt;
     record.updatedAt = domain.updatedAt;
     return record;

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace-member.record.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace-member.record.ts
@@ -1,0 +1,32 @@
+import type { UUID } from 'crypto';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseRecord } from 'src/common/db/base-record';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { UserRecord } from 'src/iam/users/infrastructure/repositories/local/schema/user.record';
+import { WorkspaceRecord } from './workspace.record';
+
+@Entity({ name: 'workspace_members' })
+@Index(['workspaceId', 'userId'], { unique: true })
+export class WorkspaceMemberRecord extends BaseRecord {
+  @Column()
+  workspaceId: UUID;
+
+  @ManyToOne(() => WorkspaceRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'workspaceId' })
+  workspace: WorkspaceRecord;
+
+  @Column()
+  @Index()
+  userId: UUID;
+
+  @ManyToOne(() => UserRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: UserRecord;
+
+  @Column({ name: 'role', type: 'enum', enum: WorkspaceAccessLevel })
+  accessLevel: WorkspaceAccessLevel;
+
+  @Column({ type: 'enum', enum: WorkspaceMemberStatus })
+  status: WorkspaceMemberStatus;
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace-team-grant.record.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace-team-grant.record.ts
@@ -1,0 +1,28 @@
+import type { UUID } from 'crypto';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseRecord } from 'src/common/db/base-record';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { TeamRecord } from 'src/iam/teams/infrastructure/repositories/local/schema/team.record';
+import { WorkspaceRecord } from './workspace.record';
+
+@Entity({ name: 'workspace_team_grants' })
+@Index(['workspaceId', 'teamId'], { unique: true })
+export class WorkspaceTeamGrantRecord extends BaseRecord {
+  @Column()
+  workspaceId: UUID;
+
+  @ManyToOne(() => WorkspaceRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'workspaceId' })
+  workspace: WorkspaceRecord;
+
+  @Column()
+  @Index()
+  teamId: UUID;
+
+  @ManyToOne(() => TeamRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'teamId' })
+  team: TeamRecord;
+
+  @Column({ name: 'role', type: 'enum', enum: WorkspaceAccessLevel })
+  accessLevel: WorkspaceAccessLevel;
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace-team-member-override.record.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace-team-member-override.record.ts
@@ -1,0 +1,42 @@
+import type { UUID } from 'crypto';
+import { Check, Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseRecord } from 'src/common/db/base-record';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { UserRecord } from 'src/iam/users/infrastructure/repositories/local/schema/user.record';
+import { WorkspaceTeamGrantRecord } from './workspace-team-grant.record';
+
+@Entity({ name: 'workspace_team_member_overrides' })
+@Index(['teamGrantId', 'userId'], { unique: true })
+@Check(
+  '("excluded" = true AND "role" IS NULL) OR ("excluded" = false AND "role" IS NOT NULL)',
+)
+export class WorkspaceTeamMemberOverrideRecord extends BaseRecord {
+  @Column()
+  teamGrantId: UUID;
+
+  @ManyToOne(() => WorkspaceTeamGrantRecord, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'teamGrantId' })
+  teamGrant: WorkspaceTeamGrantRecord;
+
+  @Column()
+  @Index()
+  userId: UUID;
+
+  @ManyToOne(() => UserRecord, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: UserRecord;
+
+  @Column({
+    name: 'role',
+    type: 'enum',
+    enum: WorkspaceAccessLevel,
+    nullable: true,
+  })
+  accessLevel: WorkspaceAccessLevel | null;
+
+  @Column({ type: 'boolean' })
+  excluded: boolean;
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace.record.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/schema/workspace.record.ts
@@ -3,6 +3,7 @@ import type { UUID } from 'crypto';
 import { BaseRecord } from 'src/common/db/base-record';
 import { OrgRecord } from 'src/iam/orgs/infrastructure/repositories/local/schema/org.record';
 import { UserRecord } from 'src/iam/users/infrastructure/repositories/local/schema/user.record';
+import { WorkspaceVisibility } from 'src/domain/workspaces/domain/value-objects/workspace-visibility.enum';
 
 @Entity({ name: 'workspaces' })
 export class WorkspaceRecord extends BaseRecord {
@@ -20,6 +21,13 @@ export class WorkspaceRecord extends BaseRecord {
 
   @Column({ type: 'varchar', length: 32 })
   color: string;
+
+  @Column({
+    type: 'enum',
+    enum: WorkspaceVisibility,
+    default: WorkspaceVisibility.PRIVATE,
+  })
+  visibility: WorkspaceVisibility;
 
   @Column()
   @Index()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Schema migration and authorization policy design affect future access control, but runtime behavior is unchanged until later layers wire the policy into use cases.
> 
> **Overview**
> Introduces the **data model and domain primitives** for workspace collaboration ahead of sharing APIs and use-case authorization.
> 
> A migration adds `workspaces.visibility` (`private` / `organization`, default private) and tables for **direct members** (role + pending/active status), **team grants**, and **per-user team overrides** (elevated role or exclusion, with a DB check constraint). Matching TypeORM records are registered on the workspaces repository module.
> 
> The `Workspace` entity and mapper now carry **visibility** (`changeVisibility`, default private). New enums cover access levels (`use` / `edit` / `full`), visibility, and membership status.
> 
> **`WorkspaceAccessPolicyService`** resolves effective access from owner, active direct membership, team grants (with overrides), and org-wide visibility—taking the highest role and tracking all contributing sources. Unit tests cover pending invites, exclusions, and role comparison. Module docs (`SUMMARY.md`) describe this as foundation only; no HTTP or existing workspace use cases are changed to enforce it yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5416c2e15af0bd523df07892e5f39e35e83378bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->