### PR TITLE
wip(workspaces): resolve effective member access (AYC-703)

### DIFF
--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -60,32 +60,21 @@ workspaces/
 │   ├── util/workspace-fields.ts     # field validation (name/description/appearance)
 │   ├── events/
 │   │   └── workspace-deletion-requested.event.ts
+│   ├── services/workspace-access.service.ts
 │   ├── ports/workspaces-repository.port.ts
+│   ├── ports/workspace-access-repository.port.ts
 │   ├── testing/workspace.fixtures.ts
 │   └── use-cases/
 │       ├── create-workspace/
-│       ├── attach-skill-to-workspace/
-│       ├── detach-skill-from-workspace/
-│       ├── attach-knowledge-base-to-workspace/
-│       ├── detach-knowledge-base-from-workspace/
-│       ├── add-document-to-workspace/
-│       ├── remove-document-from-workspace/
-│       ├── update-workspace-instruction/
-│       ├── build-workspace-run-context/
-│       ├── list-workspace-skill-candidates/
-│       ├── list-workspace-knowledge-base-candidates/
-│       ├── list-workspace-skills/
-│       ├── list-workspace-knowledge-bases/
-│       ├── list-workspace-documents/
-│       ├── find-all-workspaces/
-│       ├── find-workspaces-by-ids/
-│       ├── find-workspace/
-│       ├── update-workspace/
-│       ├── update-workspace-instruction/
+│       ├── get-workspace-access/
+│       ├── find-all-workspaces/ / find-workspaces-by-ids/ / find-workspace/
+│       ├── update-workspace/ / update-workspace-instruction/
 │       ├── attach-skill-to-workspace/ / detach-skill-from-workspace/
 │       ├── attach-knowledge-base-to-workspace/ / detach-knowledge-base-from-workspace/
 │       ├── add-document-to-workspace/ / remove-document-from-workspace/
-│       ├── list-workspace-*-candidates/
+│       ├── list-workspace-skill-candidates/ / list-workspace-skills/
+│       ├── list-workspace-knowledge-base-candidates/ / list-workspace-knowledge-bases/
+│       ├── list-workspace-documents/
 │       ├── build-workspace-run-context/
 │       └── delete-workspace/
 ├── infrastructure/persistence/local/
@@ -98,6 +87,7 @@ workspaces/
 │   ├── schema/workspace-team-member-override.record.ts
 │   ├── mappers/workspace.mapper.ts
 │   ├── local-workspaces.repository.ts
+│   ├── local-workspace-access.repository.ts
 │   └── local-workspaces-repository.module.ts
 ├── presenters/http/
 │   ├── workspaces.controller.ts
@@ -149,8 +139,12 @@ document processing. The workspace repository owns only the assignment rows;
 the referenced entity modules remain responsible for entity access and
 processing.
 
-The repository port is deliberately not exported — cross-module access goes
-through the exported use cases.
+The repository ports are deliberately not exported — cross-module access goes
+through exported use cases. `GetWorkspaceAccessUseCase` resolves direct,
+team-derived and organization access into one effective role and is the public
+authorization boundary for modules that operate on workspace children. Team
+membership is resolved through `ListMyTeamsUseCase` from IAM; access persistence
+never reads IAM repositories directly.
 
 Workspace context list endpoints use dedicated paginated use cases. Candidate
 and attached lists apply search, access checks, workspace assignments, ordering,

--- a/ayunis-core-backend/src/domain/workspaces/application/ports/workspace-access-repository.port.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/ports/workspace-access-repository.port.ts
@@ -1,0 +1,25 @@
+import type { UUID } from 'crypto';
+import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import type {
+  DirectMembershipCandidate,
+  TeamGrantCandidate,
+} from 'src/domain/workspaces/application/services/workspace-access-policy.service';
+
+export interface FindWorkspaceAccessParams {
+  workspaceId: UUID;
+  orgId: UUID;
+  userId: UUID;
+  teamIds: UUID[];
+}
+
+export interface WorkspaceAccessSnapshot {
+  workspace: Workspace;
+  directMembership?: DirectMembershipCandidate;
+  teamGrants: TeamGrantCandidate[];
+}
+
+export abstract class WorkspaceAccessRepository {
+  abstract findAccessSnapshot(
+    params: FindWorkspaceAccessParams,
+  ): Promise<WorkspaceAccessSnapshot | null>;
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/services/workspace-access.service.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/services/workspace-access.service.spec.ts
@@ -1,0 +1,114 @@
+import { getLoggerToken } from 'nestjs-pino';
+import { Test } from '@nestjs/testing';
+import { randomUUID, type UUID } from 'crypto';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { ContextService } from 'src/common/context/services/context.service';
+import { WorkspaceAccessRepository } from 'src/domain/workspaces/application/ports/workspace-access-repository.port';
+import {
+  WorkspaceInsufficientAccessLevelError,
+  WorkspaceNotFoundError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { WorkspaceAccessPolicyService } from './workspace-access-policy.service';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { ListMyTeamsUseCase } from 'src/iam/teams/application/use-cases/list-my-teams/list-my-teams.use-case';
+import type { Team } from 'src/iam/teams/domain/team.entity';
+import {
+  aWorkspace,
+  TEST_ORG_ID,
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+
+const TEAM_ID = '44444444-4444-4444-8444-444444444444' as UUID;
+
+describe('WorkspaceAccessService', () => {
+  const repository = { findAccessSnapshot: jest.fn() };
+  const listMyTeams = { execute: jest.fn() };
+  const contextService = { get: jest.fn() };
+  let service: WorkspaceAccessService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    contextService.get.mockImplementation((key: string) => {
+      if (key === 'userId') return TEST_USER_ID;
+      if (key === 'orgId') return TEST_ORG_ID;
+      return undefined;
+    });
+    listMyTeams.execute.mockResolvedValue([{ id: TEAM_ID }] as Team[]);
+
+    const module = await Test.createTestingModule({
+      providers: [
+        WorkspaceAccessService,
+        WorkspaceAccessPolicyService,
+        { provide: WorkspaceAccessRepository, useValue: repository },
+        { provide: ListMyTeamsUseCase, useValue: listMyTeams },
+        { provide: ContextService, useValue: contextService },
+        {
+          provide: getLoggerToken(WorkspaceAccessService.name),
+          useValue: { info: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get(WorkspaceAccessService);
+  });
+
+  it('resolves the highest access level from direct and team access', async () => {
+    repository.findAccessSnapshot.mockResolvedValue({
+      workspace: aWorkspace({ userId: randomUUID() }),
+      directMembership: {
+        accessLevel: WorkspaceAccessLevel.USE,
+        status: WorkspaceMemberStatus.ACTIVE,
+      },
+      teamGrants: [{ teamId: TEAM_ID, accessLevel: WorkspaceAccessLevel.EDIT }],
+    });
+
+    await expect(service.resolve(TEST_WORKSPACE_ID)).resolves.toMatchObject({
+      accessLevel: WorkspaceAccessLevel.EDIT,
+      sources: [{ type: 'direct' }, { type: 'team', teamId: TEAM_ID }],
+    });
+    expect(repository.findAccessSnapshot).toHaveBeenCalledWith({
+      workspaceId: TEST_WORKSPACE_ID,
+      orgId: TEST_ORG_ID,
+      userId: TEST_USER_ID,
+      teamIds: [TEAM_ID],
+    });
+  });
+
+  it('rejects an accessible workspace when the access level is insufficient', async () => {
+    repository.findAccessSnapshot.mockResolvedValue({
+      workspace: aWorkspace({ userId: randomUUID() }),
+      directMembership: {
+        accessLevel: WorkspaceAccessLevel.USE,
+        status: WorkspaceMemberStatus.ACTIVE,
+      },
+      teamGrants: [],
+    });
+
+    await expect(
+      service.requireAccessLevel(TEST_WORKSPACE_ID, WorkspaceAccessLevel.EDIT),
+    ).rejects.toBeInstanceOf(WorkspaceInsufficientAccessLevelError);
+  });
+
+  it('hides a workspace when the caller has no access', async () => {
+    repository.findAccessSnapshot.mockResolvedValue({
+      workspace: aWorkspace({ userId: randomUUID() }),
+      teamGrants: [],
+    });
+
+    await expect(
+      service.requireAccessLevel(TEST_WORKSPACE_ID, WorkspaceAccessLevel.USE),
+    ).rejects.toBeInstanceOf(WorkspaceNotFoundError);
+  });
+
+  it('rejects missing request context before querying access', async () => {
+    contextService.get.mockReturnValue(undefined);
+
+    await expect(service.resolve(TEST_WORKSPACE_ID)).rejects.toBeInstanceOf(
+      UnauthorizedAccessError,
+    );
+    expect(repository.findAccessSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/services/workspace-access.service.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/services/workspace-access.service.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import type { UUID } from 'crypto';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { WorkspaceAccessRepository } from 'src/domain/workspaces/application/ports/workspace-access-repository.port';
+import {
+  WorkspaceInsufficientAccessLevelError,
+  WorkspaceNotFoundError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import {
+  WorkspaceAccessPolicyService,
+  type WorkspaceAccessResolution,
+} from './workspace-access-policy.service';
+import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { WorkspaceVisibility } from 'src/domain/workspaces/domain/value-objects/workspace-visibility.enum';
+import { ListMyTeamsUseCase } from 'src/iam/teams/application/use-cases/list-my-teams/list-my-teams.use-case';
+
+export interface ResolvedWorkspaceAccess extends WorkspaceAccessResolution {
+  workspace: Workspace;
+}
+
+@Injectable()
+export class WorkspaceAccessService {
+  constructor(
+    @InjectPinoLogger(WorkspaceAccessService.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: WorkspaceAccessRepository,
+    private readonly policy: WorkspaceAccessPolicyService,
+    private readonly listMyTeamsUseCase: ListMyTeamsUseCase,
+    private readonly contextService: ContextService,
+  ) {}
+
+  async resolve(workspaceId: UUID): Promise<ResolvedWorkspaceAccess | null> {
+    const { userId, orgId } = this.getContext();
+    this.logger.info({ workspaceId }, 'Resolving workspace access');
+    const teams = await this.listMyTeamsUseCase.execute();
+    const snapshot = await this.repository.findAccessSnapshot({
+      workspaceId,
+      orgId,
+      userId,
+      teamIds: teams.map(({ id }) => id),
+    });
+    if (!snapshot) return null;
+
+    const resolution = this.policy.resolve({
+      isOwner: snapshot.workspace.userId === userId,
+      directMembership: snapshot.directMembership,
+      teamGrants: snapshot.teamGrants,
+      organizationVisible:
+        snapshot.workspace.visibility === WorkspaceVisibility.ORGANIZATION,
+    });
+    return resolution ? { workspace: snapshot.workspace, ...resolution } : null;
+  }
+
+  async requireAccessLevel(
+    workspaceId: UUID,
+    minimumAccessLevel: WorkspaceAccessLevel,
+  ): Promise<ResolvedWorkspaceAccess> {
+    const access = await this.resolve(workspaceId);
+    if (!access) throw new WorkspaceNotFoundError(workspaceId);
+    if (
+      !this.policy.hasMinimumAccessLevel(access.accessLevel, minimumAccessLevel)
+    ) {
+      throw new WorkspaceInsufficientAccessLevelError(
+        workspaceId,
+        minimumAccessLevel,
+        access.accessLevel,
+      );
+    }
+    return access;
+  }
+
+  private getContext(): { userId: UUID; orgId: UUID } {
+    const userId = this.contextService.get('userId');
+    const orgId = this.contextService.get('orgId');
+    if (!userId || !orgId) throw new UnauthorizedAccessError();
+    return { userId, orgId };
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-access/get-workspace-access.query.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-access/get-workspace-access.query.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+import type { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+
+export class GetWorkspaceAccessQuery {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly minimumAccessLevel: WorkspaceAccessLevel,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-access/get-workspace-access.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-access/get-workspace-access.use-case.spec.ts
@@ -1,0 +1,38 @@
+import { Test } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { GetWorkspaceAccessQuery } from 'src/domain/workspaces/application/use-cases/get-workspace-access/get-workspace-access.query';
+import { GetWorkspaceAccessUseCase } from 'src/domain/workspaces/application/use-cases/get-workspace-access/get-workspace-access.use-case';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { TEST_WORKSPACE_ID } from 'src/domain/workspaces/application/testing/workspace.fixtures';
+
+describe('GetWorkspaceAccessUseCase', () => {
+  it('returns access after enforcing the requested minimum access level', async () => {
+    const access = { accessLevel: WorkspaceAccessLevel.EDIT };
+    const service = { requireAccessLevel: jest.fn().mockResolvedValue(access) };
+    const module = await Test.createTestingModule({
+      providers: [
+        GetWorkspaceAccessUseCase,
+        { provide: WorkspaceAccessService, useValue: service },
+        {
+          provide: getLoggerToken(GetWorkspaceAccessUseCase.name),
+          useValue: { info: jest.fn() },
+        },
+      ],
+    }).compile();
+    const useCase = module.get(GetWorkspaceAccessUseCase);
+
+    await expect(
+      useCase.execute(
+        new GetWorkspaceAccessQuery(
+          TEST_WORKSPACE_ID,
+          WorkspaceAccessLevel.EDIT,
+        ),
+      ),
+    ).resolves.toBe(access);
+    expect(service.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.EDIT,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-access/get-workspace-access.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-access/get-workspace-access.use-case.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import {
+  WorkspaceAccessService,
+  type ResolvedWorkspaceAccess,
+} from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { GetWorkspaceAccessQuery } from './get-workspace-access.query';
+
+@Injectable()
+export class GetWorkspaceAccessUseCase {
+  constructor(
+    @InjectPinoLogger(GetWorkspaceAccessUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly workspaceAccessService: WorkspaceAccessService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(
+    query: GetWorkspaceAccessQuery,
+  ): Promise<ResolvedWorkspaceAccess> {
+    this.logger.info(
+      {
+        workspaceId: query.workspaceId,
+        minimumAccessLevel: query.minimumAccessLevel,
+      },
+      'Getting workspace access',
+    );
+    return this.workspaceAccessService.requireAccessLevel(
+      query.workspaceId,
+      query.minimumAccessLevel,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/workspaces.errors.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/workspaces.errors.ts
@@ -8,6 +8,7 @@ export enum WorkspaceErrorCode {
   WORKSPACE_INVALID_APPEARANCE = 'WORKSPACE_INVALID_APPEARANCE',
   MISSING_FILE = 'MISSING_FILE',
   WORKSPACE_SOURCE_LIMIT_EXCEEDED = 'WORKSPACE_SOURCE_LIMIT_EXCEEDED',
+  WORKSPACE_INSUFFICIENT_ROLE = 'WORKSPACE_INSUFFICIENT_ROLE',
   UNEXPECTED_WORKSPACE_ERROR = 'UNEXPECTED_WORKSPACE_ERROR',
 }
 
@@ -87,6 +88,22 @@ export class WorkspaceSourceLimitExceededError extends WorkspaceError {
       WorkspaceErrorCode.WORKSPACE_SOURCE_LIMIT_EXCEEDED,
       400,
       { maxSources, ...metadata },
+    );
+  }
+}
+
+export class WorkspaceInsufficientAccessLevelError extends WorkspaceError {
+  constructor(
+    workspaceId: string,
+    requiredAccessLevel: string,
+    actualAccessLevel: string,
+    metadata?: ErrorMetadata,
+  ) {
+    super(
+      `Workspace access level '${requiredAccessLevel}' is required`,
+      WorkspaceErrorCode.WORKSPACE_INSUFFICIENT_ROLE,
+      403,
+      { workspaceId, requiredAccessLevel, actualAccessLevel, ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-access.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-access.repository.spec.ts
@@ -1,0 +1,121 @@
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Test } from '@nestjs/testing';
+import type { UUID } from 'crypto';
+import { WorkspaceMapper } from 'src/domain/workspaces/infrastructure/persistence/local/mappers/workspace.mapper';
+import { LocalWorkspaceAccessRepository } from 'src/domain/workspaces/infrastructure/persistence/local/local-workspace-access.repository';
+import { WorkspaceMemberRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace-member.record';
+import { WorkspaceRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace.record';
+import { WorkspaceTeamGrantRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace-team-grant.record';
+import { WorkspaceTeamMemberOverrideRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace-team-member-override.record';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import {
+  aWorkspace,
+  TEST_ORG_ID,
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+
+const TEAM_ID = '44444444-4444-4444-8444-444444444444' as UUID;
+const TEAM_GRANT_ID = '55555555-5555-4555-8555-555555555555' as UUID;
+
+describe('LocalWorkspaceAccessRepository', () => {
+  const workspaceRepo = { findOne: jest.fn() };
+  const memberRepo = { findOne: jest.fn() };
+  const teamGrantRepo = { find: jest.fn() };
+  const overrideRepo = { find: jest.fn() };
+  const mapper = { toDomain: jest.fn() };
+  let repository: LocalWorkspaceAccessRepository;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module = await Test.createTestingModule({
+      providers: [
+        LocalWorkspaceAccessRepository,
+        {
+          provide: getRepositoryToken(WorkspaceRecord),
+          useValue: workspaceRepo,
+        },
+        {
+          provide: getRepositoryToken(WorkspaceMemberRecord),
+          useValue: memberRepo,
+        },
+        {
+          provide: getRepositoryToken(WorkspaceTeamGrantRecord),
+          useValue: teamGrantRepo,
+        },
+        {
+          provide: getRepositoryToken(WorkspaceTeamMemberOverrideRecord),
+          useValue: overrideRepo,
+        },
+        { provide: WorkspaceMapper, useValue: mapper },
+      ],
+    }).compile();
+    repository = module.get(LocalWorkspaceAccessRepository);
+  });
+
+  it('returns direct and team access candidates within the organization', async () => {
+    const workspace = aWorkspace();
+    const workspaceRecord = { id: TEST_WORKSPACE_ID } as WorkspaceRecord;
+    workspaceRepo.findOne.mockResolvedValue(workspaceRecord);
+    mapper.toDomain.mockReturnValue(workspace);
+    memberRepo.findOne.mockResolvedValue({
+      accessLevel: WorkspaceAccessLevel.USE,
+      status: WorkspaceMemberStatus.ACTIVE,
+    });
+    teamGrantRepo.find.mockResolvedValue([
+      {
+        id: TEAM_GRANT_ID,
+        teamId: TEAM_ID,
+        accessLevel: WorkspaceAccessLevel.EDIT,
+      },
+    ]);
+    overrideRepo.find.mockResolvedValue([
+      {
+        teamGrantId: TEAM_GRANT_ID,
+        accessLevel: WorkspaceAccessLevel.FULL,
+        excluded: false,
+      },
+    ]);
+
+    await expect(
+      repository.findAccessSnapshot({
+        workspaceId: TEST_WORKSPACE_ID,
+        orgId: TEST_ORG_ID,
+        userId: TEST_USER_ID,
+        teamIds: [TEAM_ID],
+      }),
+    ).resolves.toEqual({
+      workspace,
+      directMembership: {
+        accessLevel: WorkspaceAccessLevel.USE,
+        status: WorkspaceMemberStatus.ACTIVE,
+      },
+      teamGrants: [
+        {
+          teamId: TEAM_ID,
+          accessLevel: WorkspaceAccessLevel.EDIT,
+          override: { accessLevel: WorkspaceAccessLevel.FULL, excluded: false },
+        },
+      ],
+    });
+    expect(workspaceRepo.findOne).toHaveBeenCalledWith({
+      where: { id: TEST_WORKSPACE_ID, orgId: TEST_ORG_ID },
+    });
+  });
+
+  it('returns null without querying grants when the workspace is outside the org', async () => {
+    workspaceRepo.findOne.mockResolvedValue(null);
+
+    await expect(
+      repository.findAccessSnapshot({
+        workspaceId: TEST_WORKSPACE_ID,
+        orgId: TEST_ORG_ID,
+        userId: TEST_USER_ID,
+        teamIds: [TEAM_ID],
+      }),
+    ).resolves.toBeNull();
+    expect(memberRepo.findOne).not.toHaveBeenCalled();
+    expect(teamGrantRepo.find).not.toHaveBeenCalled();
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-access.repository.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-access.repository.ts
@@ -1,0 +1,87 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import type { UUID } from 'crypto';
+import {
+  WorkspaceAccessRepository,
+  type FindWorkspaceAccessParams,
+  type WorkspaceAccessSnapshot,
+} from 'src/domain/workspaces/application/ports/workspace-access-repository.port';
+import type { TeamGrantCandidate } from 'src/domain/workspaces/application/services/workspace-access-policy.service';
+import { WorkspaceMapper } from './mappers/workspace.mapper';
+import { WorkspaceMemberRecord } from './schema/workspace-member.record';
+import { WorkspaceRecord } from './schema/workspace.record';
+import { WorkspaceTeamGrantRecord } from './schema/workspace-team-grant.record';
+import { WorkspaceTeamMemberOverrideRecord } from './schema/workspace-team-member-override.record';
+
+@Injectable()
+export class LocalWorkspaceAccessRepository extends WorkspaceAccessRepository {
+  constructor(
+    @InjectRepository(WorkspaceRecord)
+    private readonly workspaceRepo: Repository<WorkspaceRecord>,
+    @InjectRepository(WorkspaceMemberRecord)
+    private readonly memberRepo: Repository<WorkspaceMemberRecord>,
+    @InjectRepository(WorkspaceTeamGrantRecord)
+    private readonly teamGrantRepo: Repository<WorkspaceTeamGrantRecord>,
+    @InjectRepository(WorkspaceTeamMemberOverrideRecord)
+    private readonly overrideRepo: Repository<WorkspaceTeamMemberOverrideRecord>,
+    private readonly mapper: WorkspaceMapper,
+  ) {
+    super();
+  }
+
+  async findAccessSnapshot(
+    params: FindWorkspaceAccessParams,
+  ): Promise<WorkspaceAccessSnapshot | null> {
+    const workspaceRecord = await this.workspaceRepo.findOne({
+      where: { id: params.workspaceId, orgId: params.orgId },
+    });
+    if (!workspaceRecord) return null;
+
+    const [member, teamGrants] = await Promise.all([
+      this.memberRepo.findOne({
+        where: { workspaceId: params.workspaceId, userId: params.userId },
+      }),
+      this.findTeamGrants(params.workspaceId, params.teamIds),
+    ]);
+    const overrides = await this.findOverrides(teamGrants, params.userId);
+
+    return {
+      workspace: this.mapper.toDomain(workspaceRecord),
+      directMembership: member
+        ? { accessLevel: member.accessLevel, status: member.status }
+        : undefined,
+      teamGrants: teamGrants.map((grant) => ({
+        teamId: grant.teamId,
+        accessLevel: grant.accessLevel,
+        override: overrides.get(grant.id),
+      })),
+    };
+  }
+
+  private async findTeamGrants(
+    workspaceId: UUID,
+    teamIds: UUID[],
+  ): Promise<WorkspaceTeamGrantRecord[]> {
+    if (teamIds.length === 0) return [];
+    return this.teamGrantRepo.find({
+      where: { workspaceId, teamId: In(teamIds) },
+    });
+  }
+
+  private async findOverrides(
+    teamGrants: WorkspaceTeamGrantRecord[],
+    userId: UUID,
+  ): Promise<Map<UUID, TeamGrantCandidate['override']>> {
+    if (teamGrants.length === 0) return new Map();
+    const records = await this.overrideRepo.find({
+      where: { teamGrantId: In(teamGrants.map(({ id }) => id)), userId },
+    });
+    return new Map(
+      records.map((record) => [
+        record.teamGrantId,
+        { accessLevel: record.accessLevel, excluded: record.excluded },
+      ]),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces-repository.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces-repository.module.ts
@@ -9,6 +9,7 @@ import { WorkspaceMapper } from './mappers/workspace.mapper';
 import { WorkspaceMemberRecord } from './schema/workspace-member.record';
 import { WorkspaceTeamGrantRecord } from './schema/workspace-team-grant.record';
 import { WorkspaceTeamMemberOverrideRecord } from './schema/workspace-team-member-override.record';
+import { LocalWorkspaceAccessRepository } from './local-workspace-access.repository';
 
 @Module({
   imports: [
@@ -22,7 +23,11 @@ import { WorkspaceTeamMemberOverrideRecord } from './schema/workspace-team-membe
       WorkspaceTeamMemberOverrideRecord,
     ]),
   ],
-  providers: [LocalWorkspacesRepository, WorkspaceMapper],
-  exports: [LocalWorkspacesRepository],
+  providers: [
+    LocalWorkspacesRepository,
+    LocalWorkspaceAccessRepository,
+    WorkspaceMapper,
+  ],
+  exports: [LocalWorkspacesRepository, LocalWorkspaceAccessRepository],
 })
 export class LocalWorkspacesRepositoryModule {}

--- a/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
@@ -29,6 +29,12 @@ import { ListWorkspaceKnowledgeBaseCandidatesUseCase } from './application/use-c
 import { ListWorkspaceSkillsUseCase } from './application/use-cases/list-workspace-skills/list-workspace-skills.use-case';
 import { ListWorkspaceKnowledgeBasesUseCase } from './application/use-cases/list-workspace-knowledge-bases/list-workspace-knowledge-bases.use-case';
 import { ListWorkspaceDocumentsUseCase } from './application/use-cases/list-workspace-documents/list-workspace-documents.use-case';
+import { TeamsModule } from 'src/iam/teams/teams.module';
+import { WorkspaceAccessRepository } from './application/ports/workspace-access-repository.port';
+import { LocalWorkspaceAccessRepository } from './infrastructure/persistence/local/local-workspace-access.repository';
+import { WorkspaceAccessService } from './application/services/workspace-access.service';
+import { WorkspaceAccessPolicyService } from './application/services/workspace-access-policy.service';
+import { GetWorkspaceAccessUseCase } from './application/use-cases/get-workspace-access/get-workspace-access.use-case';
 
 @Module({
   imports: [
@@ -37,6 +43,7 @@ import { ListWorkspaceDocumentsUseCase } from './application/use-cases/list-work
     forwardRef(() => SkillsModule),
     forwardRef(() => KnowledgeBasesModule),
     SourcesModule,
+    TeamsModule,
   ],
   controllers: [WorkspacesController, WorkspaceContextController],
   providers: [
@@ -44,6 +51,13 @@ import { ListWorkspaceDocumentsUseCase } from './application/use-cases/list-work
       provide: WorkspacesRepository,
       useExisting: LocalWorkspacesRepository,
     },
+    {
+      provide: WorkspaceAccessRepository,
+      useExisting: LocalWorkspaceAccessRepository,
+    },
+    WorkspaceAccessPolicyService,
+    WorkspaceAccessService,
+    GetWorkspaceAccessUseCase,
     CreateWorkspaceUseCase,
     FindAllWorkspacesUseCase,
     FindWorkspaceUseCase,
@@ -74,6 +88,7 @@ import { ListWorkspaceDocumentsUseCase } from './application/use-cases/list-work
     UpdateWorkspaceUseCase,
     DeleteWorkspaceUseCase,
     BuildWorkspaceRunContextUseCase,
+    GetWorkspaceAccessUseCase,
   ],
 })
 export class WorkspacesModule {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New authorization boundary affects how workspace access is enforced; mistakes could over-grant or incorrectly hide/reject access, though behavior is covered by unit tests and reuses existing policy logic.
> 
> **Overview**
> Introduces a **central workspace authorization path** that loads membership data, merges direct/team/org access via the existing policy, and exposes it as **`GetWorkspaceAccessUseCase`** for other modules.
> 
> **`WorkspaceAccessService`** reads request context (`userId`/`orgId`), loads the caller’s teams through IAM’s **`ListMyTeamsUseCase`** (no direct IAM repo access), and calls **`WorkspaceAccessRepository.findAccessSnapshot`**. **`LocalWorkspaceAccessRepository`** loads the org-scoped workspace, direct member row, team grants for the user’s teams, and per-user team overrides. Policy resolution picks the effective access level; **`requireAccessLevel`** returns 404 when there is no access (hide existence) and **`WorkspaceInsufficientAccessLevelError`** (403, `WORKSPACE_INSUFFICIENT_ROLE`) when the level is too low.
> 
> Wiring: **`TeamsModule`** import, access repository binding in **`workspaces.module`**, export of **`GetWorkspaceAccessUseCase`**. Unit tests cover the service, use case, and local repository. **`SUMMARY.md`** documents the new public boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d937366e1daa1965b98b6eae8180f70c3f1dcf93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->