### PR TITLE
wip(workspaces): add direct member invitation lifecycle (AYC-703)

### DIFF
--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -11,8 +11,9 @@ the workspace. User-specific favorites and their order are owned by the
 
 User-facing copy calls them "Projekte"; the code, tables and routes say
 `workspace` throughout. See AYC-700 / AYC-701 in the Workspaces/Projects plan.
-Workspaces are not shareable yet, but they can carry a private instruction and
-attached skills, knowledge bases and documents for their owner's chats.
+Workspace collaboration is being introduced in stack layers. Direct member
+invitations and access-level management now exist at the application boundary; HTTP and
+frontend sharing flows follow in later layers.
 
 The whole module sits behind the `workspacesEnabled` feature flag
 (`FEATURE_WORKSPACES_ENABLED`, off by default), applied at the controller.
@@ -27,10 +28,11 @@ The whole module sits behind the `workspacesEnabled` feature flag
   catalogue. The backend only guards their shape (`WORKSPACE_ICON_PATTERN`,
   `WORKSPACE_COLOR_PATTERN`); `color` is either a palette key or a `#rrggbb`
   literal produced by the custom-colour picker.
-- **Collaboration foundation** — workspaces persist private/organization
-  visibility. Direct member, team grant, and team-scoped member-override
-  records provide the access-level schema; the sharing API and use-case
-  authorization are added in the following stack layers.
+- **Collaboration** — workspaces persist private/organization visibility.
+  Direct-member use cases manage pending invitations, acceptance, access levels
+  and removal. Team grant and team-scoped member-override records provide the
+  next sharing layer's persistence foundation; HTTP sharing endpoints follow
+  later.
 - **Deletion** — `DeleteWorkspaceUseCase` emits `WorkspaceDeletionRequestedEvent`
   _before_ the row delete and drains the listeners' deferred cleanup only after
   it succeeds, so a failed delete loses nothing. The favorites module listens
@@ -63,10 +65,14 @@ workspaces/
 │   ├── services/workspace-access.service.ts
 │   ├── ports/workspaces-repository.port.ts
 │   ├── ports/workspace-access-repository.port.ts
+│   ├── ports/workspace-members-repository.port.ts
 │   ├── testing/workspace.fixtures.ts
 │   └── use-cases/
 │       ├── create-workspace/
 │       ├── get-workspace-access/
+│       ├── invite-workspace-member/ / accept-workspace-invitation/
+│       ├── decline-workspace-invitation/ / update-workspace-member-access-level/
+│       ├── remove-workspace-member/
 │       ├── find-all-workspaces/ / find-workspaces-by-ids/ / find-workspace/
 │       ├── update-workspace/ / update-workspace-instruction/
 │       ├── attach-skill-to-workspace/ / detach-skill-from-workspace/
@@ -86,8 +92,11 @@ workspaces/
 │   ├── schema/workspace-team-grant.record.ts
 │   ├── schema/workspace-team-member-override.record.ts
 │   ├── mappers/workspace.mapper.ts
+│   ├── mappers/workspace-member.mapper.ts
 │   ├── local-workspaces.repository.ts
 │   ├── local-workspace-access.repository.ts
+│   ├── local-workspace-members.repository.ts
+│   ├── local-workspace-members-repository.module.ts
 │   └── local-workspaces-repository.module.ts
 ├── presenters/http/
 │   ├── workspaces.controller.ts
@@ -141,10 +150,11 @@ processing.
 
 The repository ports are deliberately not exported — cross-module access goes
 through exported use cases. `GetWorkspaceAccessUseCase` resolves direct,
-team-derived and organization access into one effective role and is the public
+team-derived and organization access into one effective access level and is the public
 authorization boundary for modules that operate on workspace children. Team
 membership is resolved through `ListMyTeamsUseCase` from IAM; access persistence
-never reads IAM repositories directly.
+never reads IAM repositories directly. Direct invitations use exported
+`FindUsersByIdsUseCase` to constrain invitees to the caller's organization.
 
 Workspace context list endpoints use dedicated paginated use cases. Candidate
 and attached lists apply search, access checks, workspace assignments, ordering,

--- a/ayunis-core-backend/src/domain/workspaces/application/ports/workspace-members-repository.port.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/ports/workspace-members-repository.port.ts
@@ -1,0 +1,47 @@
+import type { UUID } from 'crypto';
+import type { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import type { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+
+export interface WorkspaceMember {
+  workspaceId: UUID;
+  userId: UUID;
+  accessLevel: WorkspaceAccessLevel;
+  status: WorkspaceMemberStatus;
+}
+
+export abstract class WorkspaceMembersRepository {
+  abstract findMember(
+    workspaceId: UUID,
+    userId: UUID,
+  ): Promise<WorkspaceMember | null>;
+
+  abstract findInvitation(
+    workspaceId: UUID,
+    userId: UUID,
+    orgId: UUID,
+  ): Promise<WorkspaceMember | null>;
+
+  abstract createMember(
+    member: WorkspaceMember,
+  ): Promise<WorkspaceMember | null>;
+
+  abstract activateInvitation(
+    workspaceId: UUID,
+    userId: UUID,
+    orgId: UUID,
+  ): Promise<WorkspaceMember | null>;
+
+  abstract declineInvitation(
+    workspaceId: UUID,
+    userId: UUID,
+    orgId: UUID,
+  ): Promise<boolean>;
+
+  abstract updateMemberAccessLevel(
+    workspaceId: UUID,
+    userId: UUID,
+    accessLevel: WorkspaceAccessLevel,
+  ): Promise<WorkspaceMember | null>;
+
+  abstract deleteMember(workspaceId: UUID, userId: UUID): Promise<void>;
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/accept-workspace-invitation/accept-workspace-invitation.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/accept-workspace-invitation/accept-workspace-invitation.command.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class AcceptWorkspaceInvitationCommand {
+  constructor(public readonly workspaceId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/accept-workspace-invitation/accept-workspace-invitation.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/accept-workspace-invitation/accept-workspace-invitation.use-case.spec.ts
@@ -1,0 +1,32 @@
+import {
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+  createMockContextService,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { AcceptWorkspaceInvitationUseCase } from './accept-workspace-invitation.use-case';
+
+const member = {
+  workspaceId: TEST_WORKSPACE_ID,
+  userId: TEST_USER_ID,
+  accessLevel: WorkspaceAccessLevel.EDIT,
+  status: WorkspaceMemberStatus.ACTIVE,
+};
+
+describe('AcceptWorkspaceInvitationUseCase', () => {
+  it('accepts the current user pending invitation', async () => {
+    const repository = {
+      activateInvitation: jest.fn().mockResolvedValue(member),
+    };
+    const useCase = new AcceptWorkspaceInvitationUseCase(
+      { info: jest.fn() } as never,
+      repository as never,
+      createMockContextService(),
+    );
+
+    await expect(
+      useCase.execute({ workspaceId: TEST_WORKSPACE_ID }),
+    ).resolves.toEqual(member);
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/accept-workspace-invitation/accept-workspace-invitation.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/accept-workspace-invitation/accept-workspace-invitation.use-case.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { ContextService } from 'src/common/context/services/context.service';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import {
+  WorkspaceMembersRepository,
+  type WorkspaceMember,
+} from 'src/domain/workspaces/application/ports/workspace-members-repository.port';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceInvitationNotFoundError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { AcceptWorkspaceInvitationCommand } from './accept-workspace-invitation.command';
+
+@Injectable()
+export class AcceptWorkspaceInvitationUseCase {
+  constructor(
+    @InjectPinoLogger(AcceptWorkspaceInvitationUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: WorkspaceMembersRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(
+    command: AcceptWorkspaceInvitationCommand,
+  ): Promise<WorkspaceMember> {
+    const userId = this.contextService.get('userId');
+    const orgId = this.contextService.get('orgId');
+    if (!userId || !orgId) throw new UnauthorizedAccessError();
+    this.logger.info(
+      { workspaceId: command.workspaceId },
+      'Accepting workspace invitation',
+    );
+    const member = await this.repository.activateInvitation(
+      command.workspaceId,
+      userId,
+      orgId,
+    );
+    if (!member) {
+      throw new WorkspaceInvitationNotFoundError(command.workspaceId);
+    }
+    return member;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/decline-workspace-invitation/decline-workspace-invitation.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/decline-workspace-invitation/decline-workspace-invitation.command.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class DeclineWorkspaceInvitationCommand {
+  constructor(public readonly workspaceId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/decline-workspace-invitation/decline-workspace-invitation.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/decline-workspace-invitation/decline-workspace-invitation.use-case.spec.ts
@@ -1,0 +1,29 @@
+import {
+  TEST_ORG_ID,
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+  createMockContextService,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { DeclineWorkspaceInvitationUseCase } from './decline-workspace-invitation.use-case';
+
+describe('DeclineWorkspaceInvitationUseCase', () => {
+  it('declines the current user pending invitation', async () => {
+    const repository = {
+      declineInvitation: jest.fn().mockResolvedValue(true),
+    };
+    const useCase = new DeclineWorkspaceInvitationUseCase(
+      { info: jest.fn() } as never,
+      repository as never,
+      createMockContextService(),
+    );
+
+    await expect(
+      useCase.execute({ workspaceId: TEST_WORKSPACE_ID }),
+    ).resolves.toBeUndefined();
+    expect(repository.declineInvitation).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      TEST_USER_ID,
+      TEST_ORG_ID,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/decline-workspace-invitation/decline-workspace-invitation.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/decline-workspace-invitation/decline-workspace-invitation.use-case.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { ContextService } from 'src/common/context/services/context.service';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { WorkspaceMembersRepository } from 'src/domain/workspaces/application/ports/workspace-members-repository.port';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceInvitationNotFoundError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { DeclineWorkspaceInvitationCommand } from './decline-workspace-invitation.command';
+
+@Injectable()
+export class DeclineWorkspaceInvitationUseCase {
+  constructor(
+    @InjectPinoLogger(DeclineWorkspaceInvitationUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: WorkspaceMembersRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(command: DeclineWorkspaceInvitationCommand): Promise<void> {
+    const userId = this.contextService.get('userId');
+    const orgId = this.contextService.get('orgId');
+    if (!userId || !orgId) throw new UnauthorizedAccessError();
+    this.logger.info(
+      { workspaceId: command.workspaceId },
+      'Declining workspace invitation',
+    );
+    const declined = await this.repository.declineInvitation(
+      command.workspaceId,
+      userId,
+      orgId,
+    );
+    if (!declined) {
+      throw new WorkspaceInvitationNotFoundError(command.workspaceId);
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/invite-workspace-member/invite-workspace-member.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/invite-workspace-member/invite-workspace-member.command.ts
@@ -1,0 +1,10 @@
+import type { UUID } from 'crypto';
+import type { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+
+export class InviteWorkspaceMemberCommand {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly userId: UUID,
+    public readonly accessLevel: WorkspaceAccessLevel,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/invite-workspace-member/invite-workspace-member.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/invite-workspace-member/invite-workspace-member.use-case.spec.ts
@@ -1,0 +1,152 @@
+import { Test } from '@nestjs/testing';
+import { getLoggerToken } from 'nestjs-pino';
+import { ContextService } from 'src/common/context/services/context.service';
+import { WorkspaceMembersRepository } from 'src/domain/workspaces/application/ports/workspace-members-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import {
+  TEST_ORG_ID,
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+  aWorkspace,
+  createMockContextService,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { FindUsersByIdsUseCase } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case';
+import { InviteWorkspaceMemberCommand } from './invite-workspace-member.command';
+import { InviteWorkspaceMemberUseCase } from './invite-workspace-member.use-case';
+
+const TARGET_USER_ID = '44444444-4444-4444-8444-444444444444' as const;
+
+describe('InviteWorkspaceMemberUseCase', () => {
+  it('creates a pending direct membership for a user in the caller organization', async () => {
+    const repository = {
+      createMember: jest
+        .fn()
+        .mockImplementation((member) => Promise.resolve(member)),
+    };
+    const accessService = {
+      requireAccessLevel: jest
+        .fn()
+        .mockResolvedValue({ workspace: aWorkspace() }),
+    };
+    const findUsers = {
+      execute: jest
+        .fn()
+        .mockResolvedValue([{ id: TARGET_USER_ID, orgId: TEST_ORG_ID }]),
+    };
+    const module = await Test.createTestingModule({
+      providers: [
+        InviteWorkspaceMemberUseCase,
+        { provide: WorkspaceMembersRepository, useValue: repository },
+        { provide: WorkspaceAccessService, useValue: accessService },
+        { provide: FindUsersByIdsUseCase, useValue: findUsers },
+        { provide: ContextService, useValue: createMockContextService() },
+        {
+          provide: getLoggerToken(InviteWorkspaceMemberUseCase.name),
+          useValue: { info: jest.fn() },
+        },
+      ],
+    }).compile();
+    const useCase = module.get(InviteWorkspaceMemberUseCase);
+
+    await expect(
+      useCase.execute(
+        new InviteWorkspaceMemberCommand(
+          TEST_WORKSPACE_ID,
+          TARGET_USER_ID,
+          WorkspaceAccessLevel.EDIT,
+        ),
+      ),
+    ).resolves.toEqual({
+      workspaceId: TEST_WORKSPACE_ID,
+      userId: TARGET_USER_ID,
+      accessLevel: WorkspaceAccessLevel.EDIT,
+      status: WorkspaceMemberStatus.PENDING,
+    });
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.FULL,
+    );
+  });
+
+  it('rejects a target outside the caller organization', async () => {
+    const useCase = new InviteWorkspaceMemberUseCase(
+      { info: jest.fn() } as never,
+      {} as never,
+      {
+        requireAccessLevel: jest
+          .fn()
+          .mockResolvedValue({ workspace: aWorkspace() }),
+      } as never,
+      { execute: jest.fn().mockResolvedValue([]) } as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new InviteWorkspaceMemberCommand(
+          TEST_WORKSPACE_ID,
+          TARGET_USER_ID,
+          WorkspaceAccessLevel.EDIT,
+        ),
+      ),
+    ).rejects.toThrow('Workspace members must belong to the same organization');
+  });
+
+  it('rejects a duplicate direct membership or invitation', async () => {
+    const useCase = new InviteWorkspaceMemberUseCase(
+      { info: jest.fn() } as never,
+      { createMember: jest.fn().mockResolvedValue(null) } as never,
+      {
+        requireAccessLevel: jest
+          .fn()
+          .mockResolvedValue({ workspace: aWorkspace() }),
+      } as never,
+      {
+        execute: jest.fn().mockResolvedValue([{ id: TARGET_USER_ID }]),
+      } as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new InviteWorkspaceMemberCommand(
+          TEST_WORKSPACE_ID,
+          TARGET_USER_ID,
+          WorkspaceAccessLevel.EDIT,
+        ),
+      ),
+    ).rejects.toThrow('already has a direct workspace membership');
+  });
+
+  it('does not allow inviting the workspace owner', async () => {
+    const accessService = {
+      requireAccessLevel: jest
+        .fn()
+        .mockResolvedValue({ workspace: aWorkspace() }),
+    };
+    const module = await Test.createTestingModule({
+      providers: [
+        InviteWorkspaceMemberUseCase,
+        { provide: WorkspaceMembersRepository, useValue: {} },
+        { provide: WorkspaceAccessService, useValue: accessService },
+        { provide: FindUsersByIdsUseCase, useValue: {} },
+        { provide: ContextService, useValue: createMockContextService() },
+        {
+          provide: getLoggerToken(InviteWorkspaceMemberUseCase.name),
+          useValue: { info: jest.fn() },
+        },
+      ],
+    }).compile();
+    const useCase = module.get(InviteWorkspaceMemberUseCase);
+
+    await expect(
+      useCase.execute(
+        new InviteWorkspaceMemberCommand(
+          TEST_WORKSPACE_ID,
+          TEST_USER_ID,
+          WorkspaceAccessLevel.EDIT,
+        ),
+      ),
+    ).rejects.toThrow('Workspace owner access cannot be changed');
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/invite-workspace-member/invite-workspace-member.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/invite-workspace-member/invite-workspace-member.use-case.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import {
+  WorkspaceMembersRepository,
+  type WorkspaceMember,
+} from 'src/domain/workspaces/application/ports/workspace-members-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceMemberAlreadyExistsError,
+  WorkspaceMemberNotEligibleError,
+  WorkspaceOwnerAccessImmutableError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { FindUsersByIdsQuery } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.query';
+import { FindUsersByIdsUseCase } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case';
+import { InviteWorkspaceMemberCommand } from './invite-workspace-member.command';
+
+@Injectable()
+export class InviteWorkspaceMemberUseCase {
+  constructor(
+    @InjectPinoLogger(InviteWorkspaceMemberUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: WorkspaceMembersRepository,
+    private readonly accessService: WorkspaceAccessService,
+    private readonly findUsersByIdsUseCase: FindUsersByIdsUseCase,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(
+    command: InviteWorkspaceMemberCommand,
+  ): Promise<WorkspaceMember> {
+    this.logger.info(
+      { workspaceId: command.workspaceId, userId: command.userId },
+      'Inviting workspace member',
+    );
+    const { workspace } = await this.accessService.requireAccessLevel(
+      command.workspaceId,
+      WorkspaceAccessLevel.FULL,
+    );
+    if (workspace.userId === command.userId) {
+      throw new WorkspaceOwnerAccessImmutableError(command.workspaceId);
+    }
+
+    const users = await this.findUsersByIdsUseCase.execute(
+      new FindUsersByIdsQuery([command.userId]),
+    );
+    if (users.length !== 1) {
+      throw new WorkspaceMemberNotEligibleError(command.userId);
+    }
+    const member = await this.repository.createMember({
+      workspaceId: command.workspaceId,
+      userId: command.userId,
+      accessLevel: command.accessLevel,
+      status: WorkspaceMemberStatus.PENDING,
+    });
+    if (!member) {
+      throw new WorkspaceMemberAlreadyExistsError(
+        command.workspaceId,
+        command.userId,
+      );
+    }
+    return member;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-workspace-member/remove-workspace-member.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-workspace-member/remove-workspace-member.command.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class RemoveWorkspaceMemberCommand {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly userId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-workspace-member/remove-workspace-member.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-workspace-member/remove-workspace-member.use-case.spec.ts
@@ -1,0 +1,40 @@
+import {
+  TEST_WORKSPACE_ID,
+  aWorkspace,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { RemoveWorkspaceMemberUseCase } from './remove-workspace-member.use-case';
+
+const MEMBER_USER_ID = '44444444-4444-4444-8444-444444444444' as const;
+
+describe('RemoveWorkspaceMemberUseCase', () => {
+  it('removes a direct member with full workspace access', async () => {
+    const repository = {
+      findMember: jest.fn().mockResolvedValue({
+        workspaceId: TEST_WORKSPACE_ID,
+        userId: MEMBER_USER_ID,
+        accessLevel: WorkspaceAccessLevel.EDIT,
+        status: WorkspaceMemberStatus.ACTIVE,
+      }),
+      deleteMember: jest.fn().mockResolvedValue(undefined),
+    };
+    const accessService = {
+      requireAccessLevel: jest
+        .fn()
+        .mockResolvedValue({ workspace: aWorkspace() }),
+    };
+    const useCase = new RemoveWorkspaceMemberUseCase(
+      { info: jest.fn() } as never,
+      repository as never,
+      accessService as never,
+    );
+
+    await expect(
+      useCase.execute({
+        workspaceId: TEST_WORKSPACE_ID,
+        userId: MEMBER_USER_ID,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-workspace-member/remove-workspace-member.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-workspace-member/remove-workspace-member.use-case.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { WorkspaceMembersRepository } from 'src/domain/workspaces/application/ports/workspace-members-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceMemberNotFoundError,
+  WorkspaceOwnerAccessImmutableError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { RemoveWorkspaceMemberCommand } from './remove-workspace-member.command';
+
+@Injectable()
+export class RemoveWorkspaceMemberUseCase {
+  constructor(
+    @InjectPinoLogger(RemoveWorkspaceMemberUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: WorkspaceMembersRepository,
+    private readonly accessService: WorkspaceAccessService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(command: RemoveWorkspaceMemberCommand): Promise<void> {
+    this.logger.info(
+      { workspaceId: command.workspaceId, userId: command.userId },
+      'Removing workspace member',
+    );
+    const { workspace } = await this.accessService.requireAccessLevel(
+      command.workspaceId,
+      WorkspaceAccessLevel.FULL,
+    );
+    if (workspace.userId === command.userId) {
+      throw new WorkspaceOwnerAccessImmutableError(command.workspaceId);
+    }
+    const member = await this.repository.findMember(
+      command.workspaceId,
+      command.userId,
+    );
+    if (!member)
+      throw new WorkspaceMemberNotFoundError(
+        command.workspaceId,
+        command.userId,
+      );
+    await this.repository.deleteMember(command.workspaceId, command.userId);
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-member-access-level/update-workspace-member-access-level.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-member-access-level/update-workspace-member-access-level.command.ts
@@ -1,0 +1,10 @@
+import type { UUID } from 'crypto';
+import type { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+
+export class UpdateWorkspaceMemberAccessLevelCommand {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly userId: UUID,
+    public readonly accessLevel: WorkspaceAccessLevel,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-member-access-level/update-workspace-member-access-level.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-member-access-level/update-workspace-member-access-level.use-case.spec.ts
@@ -1,0 +1,40 @@
+import {
+  TEST_WORKSPACE_ID,
+  aWorkspace,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { UpdateWorkspaceMemberAccessLevelUseCase } from './update-workspace-member-access-level.use-case';
+
+const MEMBER_USER_ID = '44444444-4444-4444-8444-444444444444' as const;
+
+describe('UpdateWorkspaceMemberAccessLevelUseCase', () => {
+  it('updates an active direct member access level with full workspace access', async () => {
+    const repository = {
+      updateMemberAccessLevel: jest.fn().mockResolvedValue({
+        workspaceId: TEST_WORKSPACE_ID,
+        userId: MEMBER_USER_ID,
+        accessLevel: WorkspaceAccessLevel.FULL,
+        status: WorkspaceMemberStatus.ACTIVE,
+      }),
+    };
+    const accessService = {
+      requireAccessLevel: jest
+        .fn()
+        .mockResolvedValue({ workspace: aWorkspace() }),
+    };
+    const useCase = new UpdateWorkspaceMemberAccessLevelUseCase(
+      { info: jest.fn() } as never,
+      repository as never,
+      accessService as never,
+    );
+
+    await expect(
+      useCase.execute({
+        workspaceId: TEST_WORKSPACE_ID,
+        userId: MEMBER_USER_ID,
+        accessLevel: WorkspaceAccessLevel.FULL,
+      }),
+    ).resolves.toMatchObject({ accessLevel: WorkspaceAccessLevel.FULL });
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-member-access-level/update-workspace-member-access-level.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-member-access-level/update-workspace-member-access-level.use-case.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import {
+  WorkspaceMembersRepository,
+  type WorkspaceMember,
+} from 'src/domain/workspaces/application/ports/workspace-members-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceMemberNotFoundError,
+  WorkspaceOwnerAccessImmutableError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { UpdateWorkspaceMemberAccessLevelCommand } from './update-workspace-member-access-level.command';
+
+@Injectable()
+export class UpdateWorkspaceMemberAccessLevelUseCase {
+  constructor(
+    @InjectPinoLogger(UpdateWorkspaceMemberAccessLevelUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: WorkspaceMembersRepository,
+    private readonly accessService: WorkspaceAccessService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(
+    command: UpdateWorkspaceMemberAccessLevelCommand,
+  ): Promise<WorkspaceMember> {
+    this.logger.info(
+      { workspaceId: command.workspaceId, userId: command.userId },
+      'Updating workspace member access level',
+    );
+    const { workspace } = await this.accessService.requireAccessLevel(
+      command.workspaceId,
+      WorkspaceAccessLevel.FULL,
+    );
+    if (workspace.userId === command.userId) {
+      throw new WorkspaceOwnerAccessImmutableError(command.workspaceId);
+    }
+    const member = await this.repository.updateMemberAccessLevel(
+      command.workspaceId,
+      command.userId,
+      command.accessLevel,
+    );
+    if (!member)
+      throw new WorkspaceMemberNotFoundError(
+        command.workspaceId,
+        command.userId,
+      );
+    return member;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/workspaces.errors.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/workspaces.errors.ts
@@ -9,6 +9,11 @@ export enum WorkspaceErrorCode {
   MISSING_FILE = 'MISSING_FILE',
   WORKSPACE_SOURCE_LIMIT_EXCEEDED = 'WORKSPACE_SOURCE_LIMIT_EXCEEDED',
   WORKSPACE_INSUFFICIENT_ROLE = 'WORKSPACE_INSUFFICIENT_ROLE',
+  WORKSPACE_OWNER_ACCESS_IMMUTABLE = 'WORKSPACE_OWNER_ACCESS_IMMUTABLE',
+  WORKSPACE_MEMBER_NOT_ELIGIBLE = 'WORKSPACE_MEMBER_NOT_ELIGIBLE',
+  WORKSPACE_MEMBER_ALREADY_EXISTS = 'WORKSPACE_MEMBER_ALREADY_EXISTS',
+  WORKSPACE_MEMBER_NOT_FOUND = 'WORKSPACE_MEMBER_NOT_FOUND',
+  WORKSPACE_INVITATION_NOT_FOUND = 'WORKSPACE_INVITATION_NOT_FOUND',
   UNEXPECTED_WORKSPACE_ERROR = 'UNEXPECTED_WORKSPACE_ERROR',
 }
 
@@ -104,6 +109,61 @@ export class WorkspaceInsufficientAccessLevelError extends WorkspaceError {
       WorkspaceErrorCode.WORKSPACE_INSUFFICIENT_ROLE,
       403,
       { workspaceId, requiredAccessLevel, actualAccessLevel, ...metadata },
+    );
+  }
+}
+
+export class WorkspaceOwnerAccessImmutableError extends WorkspaceError {
+  constructor(workspaceId: string, metadata?: ErrorMetadata) {
+    super(
+      'Workspace owner access cannot be changed',
+      WorkspaceErrorCode.WORKSPACE_OWNER_ACCESS_IMMUTABLE,
+      400,
+      { workspaceId, ...metadata },
+    );
+  }
+}
+
+export class WorkspaceMemberNotEligibleError extends WorkspaceError {
+  constructor(userId: string, metadata?: ErrorMetadata) {
+    super(
+      'Workspace members must belong to the same organization',
+      WorkspaceErrorCode.WORKSPACE_MEMBER_NOT_ELIGIBLE,
+      400,
+      { userId, ...metadata },
+    );
+  }
+}
+
+export class WorkspaceMemberAlreadyExistsError extends WorkspaceError {
+  constructor(workspaceId: string, userId: string, metadata?: ErrorMetadata) {
+    super(
+      'The user already has a direct workspace membership or invitation',
+      WorkspaceErrorCode.WORKSPACE_MEMBER_ALREADY_EXISTS,
+      409,
+      { workspaceId, userId, ...metadata },
+    );
+  }
+}
+
+export class WorkspaceMemberNotFoundError extends WorkspaceError {
+  constructor(workspaceId: string, userId: string, metadata?: ErrorMetadata) {
+    super(
+      'Workspace member not found',
+      WorkspaceErrorCode.WORKSPACE_MEMBER_NOT_FOUND,
+      404,
+      { workspaceId, userId, ...metadata },
+    );
+  }
+}
+
+export class WorkspaceInvitationNotFoundError extends WorkspaceError {
+  constructor(workspaceId: string, metadata?: ErrorMetadata) {
+    super(
+      'Pending workspace invitation not found',
+      WorkspaceErrorCode.WORKSPACE_INVITATION_NOT_FOUND,
+      404,
+      { workspaceId, ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-members-repository.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-members-repository.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { LocalWorkspaceMembersRepository } from './local-workspace-members.repository';
+import { WorkspaceMemberRecord } from './schema/workspace-member.record';
+import { WorkspaceRecord } from './schema/workspace.record';
+import { WorkspaceMemberMapper } from './mappers/workspace-member.mapper';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([WorkspaceRecord, WorkspaceMemberRecord])],
+  providers: [LocalWorkspaceMembersRepository, WorkspaceMemberMapper],
+  exports: [LocalWorkspaceMembersRepository],
+})
+export class LocalWorkspaceMembersRepositoryModule {}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-members.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-members.repository.spec.ts
@@ -1,0 +1,115 @@
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Test } from '@nestjs/testing';
+import { LocalWorkspaceMembersRepository } from './local-workspace-members.repository';
+import { WorkspaceMemberRecord } from './schema/workspace-member.record';
+import { WorkspaceRecord } from './schema/workspace.record';
+import { WorkspaceMemberMapper } from './mappers/workspace-member.mapper';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import {
+  TEST_ORG_ID,
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+
+describe('LocalWorkspaceMembersRepository', () => {
+  const workspaceRepo = { findOne: jest.fn() };
+  const memberRepo = {
+    findOne: jest.fn(),
+    insert: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  };
+  let repository: LocalWorkspaceMembersRepository;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module = await Test.createTestingModule({
+      providers: [
+        LocalWorkspaceMembersRepository,
+        WorkspaceMemberMapper,
+        {
+          provide: getRepositoryToken(WorkspaceRecord),
+          useValue: workspaceRepo,
+        },
+        {
+          provide: getRepositoryToken(WorkspaceMemberRecord),
+          useValue: memberRepo,
+        },
+      ],
+    }).compile();
+    repository = module.get(LocalWorkspaceMembersRepository);
+  });
+
+  it('atomically creates a direct workspace member', async () => {
+    memberRepo.insert.mockResolvedValue({ identifiers: [] });
+    const member = {
+      workspaceId: TEST_WORKSPACE_ID,
+      userId: TEST_USER_ID,
+      accessLevel: WorkspaceAccessLevel.EDIT,
+      status: WorkspaceMemberStatus.PENDING,
+    };
+
+    await expect(repository.createMember(member)).resolves.toEqual(member);
+    expect(memberRepo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.any(String), ...member }),
+    );
+  });
+
+  it('does not recreate an invitation deleted before activation', async () => {
+    workspaceRepo.findOne.mockResolvedValue({ id: TEST_WORKSPACE_ID });
+    memberRepo.findOne.mockResolvedValue({
+      workspaceId: TEST_WORKSPACE_ID,
+      userId: TEST_USER_ID,
+      accessLevel: WorkspaceAccessLevel.EDIT,
+      status: WorkspaceMemberStatus.PENDING,
+    });
+    memberRepo.update.mockResolvedValue({ affected: 0 });
+
+    await expect(
+      repository.activateInvitation(
+        TEST_WORKSPACE_ID,
+        TEST_USER_ID,
+        TEST_ORG_ID,
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it('only finds invitations through a workspace in the caller organization', async () => {
+    workspaceRepo.findOne.mockResolvedValue(null);
+
+    await expect(
+      repository.findInvitation(TEST_WORKSPACE_ID, TEST_USER_ID, TEST_ORG_ID),
+    ).resolves.toBeNull();
+    expect(memberRepo.findOne).not.toHaveBeenCalled();
+  });
+
+  it('does not decline a membership accepted concurrently', async () => {
+    workspaceRepo.findOne.mockResolvedValue({ id: TEST_WORKSPACE_ID });
+    memberRepo.delete.mockResolvedValue({ affected: 0 });
+
+    await expect(
+      repository.declineInvitation(
+        TEST_WORKSPACE_ID,
+        TEST_USER_ID,
+        TEST_ORG_ID,
+      ),
+    ).resolves.toBe(false);
+    expect(memberRepo.delete).toHaveBeenCalledWith({
+      workspaceId: TEST_WORKSPACE_ID,
+      userId: TEST_USER_ID,
+      status: WorkspaceMemberStatus.PENDING,
+    });
+  });
+
+  it('deletes a direct workspace member', async () => {
+    memberRepo.delete.mockResolvedValue({ affected: 1 });
+
+    await repository.deleteMember(TEST_WORKSPACE_ID, TEST_USER_ID);
+
+    expect(memberRepo.delete).toHaveBeenCalledWith({
+      workspaceId: TEST_WORKSPACE_ID,
+      userId: TEST_USER_ID,
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-members.repository.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-members.repository.ts
@@ -1,0 +1,114 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import type { UUID } from 'crypto';
+import { Repository } from 'typeorm';
+import {
+  WorkspaceMembersRepository,
+  type WorkspaceMember,
+} from 'src/domain/workspaces/application/ports/workspace-members-repository.port';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { WorkspaceMemberRecord } from './schema/workspace-member.record';
+import { WorkspaceRecord } from './schema/workspace.record';
+import { WorkspaceMemberMapper } from './mappers/workspace-member.mapper';
+
+@Injectable()
+export class LocalWorkspaceMembersRepository extends WorkspaceMembersRepository {
+  constructor(
+    @InjectRepository(WorkspaceRecord)
+    private readonly workspaceRepo: Repository<WorkspaceRecord>,
+    @InjectRepository(WorkspaceMemberRecord)
+    private readonly memberRepo: Repository<WorkspaceMemberRecord>,
+    private readonly mapper: WorkspaceMemberMapper,
+  ) {
+    super();
+  }
+
+  async findMember(
+    workspaceId: UUID,
+    userId: UUID,
+  ): Promise<WorkspaceMember | null> {
+    const record = await this.memberRepo.findOne({
+      where: { workspaceId, userId },
+    });
+    return record ? this.mapper.toDomain(record) : null;
+  }
+
+  async findInvitation(
+    workspaceId: UUID,
+    userId: UUID,
+    orgId: UUID,
+  ): Promise<WorkspaceMember | null> {
+    const workspace = await this.workspaceRepo.findOne({
+      where: { id: workspaceId, orgId },
+    });
+    if (!workspace) return null;
+    return this.findMember(workspaceId, userId);
+  }
+
+  async createMember(member: WorkspaceMember): Promise<WorkspaceMember | null> {
+    try {
+      await this.memberRepo.insert(this.mapper.toRecord(member));
+      return member;
+    } catch (error: unknown) {
+      if (!this.isUniqueViolation(error)) throw error;
+      return null;
+    }
+  }
+
+  async activateInvitation(
+    workspaceId: UUID,
+    userId: UUID,
+    orgId: UUID,
+  ): Promise<WorkspaceMember | null> {
+    const member = await this.findInvitation(workspaceId, userId, orgId);
+    if (member?.status !== WorkspaceMemberStatus.PENDING) return null;
+    const result = await this.memberRepo.update(
+      { workspaceId, userId, status: WorkspaceMemberStatus.PENDING },
+      { status: WorkspaceMemberStatus.ACTIVE },
+    );
+    return result.affected === 1
+      ? { ...member, status: WorkspaceMemberStatus.ACTIVE }
+      : null;
+  }
+
+  async declineInvitation(
+    workspaceId: UUID,
+    userId: UUID,
+    orgId: UUID,
+  ): Promise<boolean> {
+    const workspace = await this.workspaceRepo.findOne({
+      where: { id: workspaceId, orgId },
+    });
+    if (!workspace) return false;
+    const result = await this.memberRepo.delete({
+      workspaceId,
+      userId,
+      status: WorkspaceMemberStatus.PENDING,
+    });
+    return result.affected === 1;
+  }
+
+  async updateMemberAccessLevel(
+    workspaceId: UUID,
+    userId: UUID,
+    accessLevel: WorkspaceAccessLevel,
+  ): Promise<WorkspaceMember | null> {
+    const result = await this.memberRepo.update(
+      { workspaceId, userId },
+      { accessLevel },
+    );
+    if (result.affected !== 1) return null;
+    return this.findMember(workspaceId, userId);
+  }
+
+  async deleteMember(workspaceId: UUID, userId: UUID): Promise<void> {
+    await this.memberRepo.delete({ workspaceId, userId });
+  }
+
+  private isUniqueViolation(error: unknown): boolean {
+    const driverError = (error as { driverError?: { code?: unknown } })
+      .driverError;
+    return driverError?.code === '23505';
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-member.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-member.mapper.spec.ts
@@ -1,0 +1,22 @@
+import {
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { WorkspaceMemberMapper } from './workspace-member.mapper';
+
+describe('WorkspaceMemberMapper', () => {
+  const mapper = new WorkspaceMemberMapper();
+
+  it('round-trips a workspace member', () => {
+    const member = {
+      workspaceId: TEST_WORKSPACE_ID,
+      userId: TEST_USER_ID,
+      accessLevel: WorkspaceAccessLevel.EDIT,
+      status: WorkspaceMemberStatus.PENDING,
+    };
+
+    expect(mapper.toDomain(mapper.toRecord(member))).toEqual(member);
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-member.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-member.mapper.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import type { WorkspaceMember } from 'src/domain/workspaces/application/ports/workspace-members-repository.port';
+import { WorkspaceMemberRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace-member.record';
+
+@Injectable()
+export class WorkspaceMemberMapper {
+  toDomain(record: WorkspaceMemberRecord): WorkspaceMember {
+    return {
+      workspaceId: record.workspaceId,
+      userId: record.userId,
+      accessLevel: record.accessLevel,
+      status: record.status,
+    };
+  }
+
+  toRecord(member: WorkspaceMember): WorkspaceMemberRecord {
+    const record = new WorkspaceMemberRecord();
+    record.id = randomUUID();
+    record.workspaceId = member.workspaceId;
+    record.userId = member.userId;
+    record.accessLevel = member.accessLevel;
+    record.status = member.status;
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
@@ -35,15 +35,26 @@ import { LocalWorkspaceAccessRepository } from './infrastructure/persistence/loc
 import { WorkspaceAccessService } from './application/services/workspace-access.service';
 import { WorkspaceAccessPolicyService } from './application/services/workspace-access-policy.service';
 import { GetWorkspaceAccessUseCase } from './application/use-cases/get-workspace-access/get-workspace-access.use-case';
+import { UsersModule } from 'src/iam/users/users.module';
+import { InviteWorkspaceMemberUseCase } from './application/use-cases/invite-workspace-member/invite-workspace-member.use-case';
+import { AcceptWorkspaceInvitationUseCase } from './application/use-cases/accept-workspace-invitation/accept-workspace-invitation.use-case';
+import { DeclineWorkspaceInvitationUseCase } from './application/use-cases/decline-workspace-invitation/decline-workspace-invitation.use-case';
+import { UpdateWorkspaceMemberAccessLevelUseCase } from './application/use-cases/update-workspace-member-access-level/update-workspace-member-access-level.use-case';
+import { RemoveWorkspaceMemberUseCase } from './application/use-cases/remove-workspace-member/remove-workspace-member.use-case';
+import { WorkspaceMembersRepository } from './application/ports/workspace-members-repository.port';
+import { LocalWorkspaceMembersRepository } from './infrastructure/persistence/local/local-workspace-members.repository';
+import { LocalWorkspaceMembersRepositoryModule } from './infrastructure/persistence/local/local-workspace-members-repository.module';
 
 @Module({
   imports: [
     LocalWorkspacesRepositoryModule,
+    LocalWorkspaceMembersRepositoryModule,
     forwardRef(() => FavoritesModule),
     forwardRef(() => SkillsModule),
     forwardRef(() => KnowledgeBasesModule),
     SourcesModule,
     TeamsModule,
+    UsersModule,
   ],
   controllers: [WorkspacesController, WorkspaceContextController],
   providers: [
@@ -55,9 +66,18 @@ import { GetWorkspaceAccessUseCase } from './application/use-cases/get-workspace
       provide: WorkspaceAccessRepository,
       useExisting: LocalWorkspaceAccessRepository,
     },
+    {
+      provide: WorkspaceMembersRepository,
+      useExisting: LocalWorkspaceMembersRepository,
+    },
     WorkspaceAccessPolicyService,
     WorkspaceAccessService,
     GetWorkspaceAccessUseCase,
+    InviteWorkspaceMemberUseCase,
+    AcceptWorkspaceInvitationUseCase,
+    DeclineWorkspaceInvitationUseCase,
+    UpdateWorkspaceMemberAccessLevelUseCase,
+    RemoveWorkspaceMemberUseCase,
     CreateWorkspaceUseCase,
     FindAllWorkspacesUseCase,
     FindWorkspaceUseCase,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes workspace authorization boundaries and cross-org invitation rules; mistakes could grant or deny access incorrectly, though behavior is gated behind existing access checks and is not yet exposed via HTTP.
> 
> **Overview**
> Introduces the **application and persistence layer** for direct workspace collaboration: invite org users, accept/decline pending invitations, change member access levels, and remove direct members. HTTP and UI sharing are explicitly deferred.
> 
> A new `WorkspaceMembersRepository` port and `LocalWorkspaceMembersRepository` back `workspace_member` rows with org-scoped invitation lookup, unique-constraint handling for duplicates, and status-conditioned activate/decline to avoid races. Five use cases enforce **FULL** access for admin actions via `WorkspaceAccessService`, block owner changes, and validate invitees through IAM `FindUsersByIdsUseCase`. Dedicated workspace errors cover ineligible users, duplicates, missing members, and missing invitations.
> 
> `WorkspacesModule` registers the repository and use cases (and imports `UsersModule`) but does not export the new use cases yet. `SUMMARY.md` is updated to describe the layered collaboration rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4a8c2d4a73fa5b7ddc6917197f5bae1cd62c6a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->