### PR TITLE
wip(workspaces): add team grant lifecycle (AYC-703)

### DIFF
--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -12,8 +12,8 @@ the workspace. User-specific favorites and their order are owned by the
 User-facing copy calls them "Projekte"; the code, tables and routes say
 `workspace` throughout. See AYC-700 / AYC-701 in the Workspaces/Projects plan.
 Workspace collaboration is being introduced in stack layers. Direct member
-invitations and access-level management now exist at the application boundary; HTTP and
-frontend sharing flows follow in later layers.
+invitations and team-grant access-level management now exist at the application
+boundary; member overrides, HTTP and frontend sharing flows follow later.
 
 The whole module sits behind the `workspacesEnabled` feature flag
 (`FEATURE_WORKSPACES_ENABLED`, off by default), applied at the controller.
@@ -30,9 +30,9 @@ The whole module sits behind the `workspacesEnabled` feature flag
   literal produced by the custom-colour picker.
 - **Collaboration** — workspaces persist private/organization visibility.
   Direct-member use cases manage pending invitations, acceptance, access levels
-  and removal. Team grant and team-scoped member-override records provide the
-  next sharing layer's persistence foundation; HTTP sharing endpoints follow
-  later.
+  and removal. Team-grant use cases add, update and remove immediate team
+  access. Team-scoped member-override records provide the next sharing layer's
+  persistence foundation; HTTP sharing endpoints follow later.
 - **Deletion** — `DeleteWorkspaceUseCase` emits `WorkspaceDeletionRequestedEvent`
   _before_ the row delete and drains the listeners' deferred cleanup only after
   it succeeds, so a failed delete loses nothing. The favorites module listens
@@ -66,6 +66,7 @@ workspaces/
 │   ├── ports/workspaces-repository.port.ts
 │   ├── ports/workspace-access-repository.port.ts
 │   ├── ports/workspace-members-repository.port.ts
+│   ├── ports/workspace-team-grants-repository.port.ts
 │   ├── testing/workspace.fixtures.ts
 │   └── use-cases/
 │       ├── create-workspace/
@@ -73,6 +74,8 @@ workspaces/
 │       ├── invite-workspace-member/ / accept-workspace-invitation/
 │       ├── decline-workspace-invitation/ / update-workspace-member-access-level/
 │       ├── remove-workspace-member/
+│       ├── add-workspace-team-grant/ / update-workspace-team-grant-access-level/
+│       ├── remove-workspace-team-grant/
 │       ├── find-all-workspaces/ / find-workspaces-by-ids/ / find-workspace/
 │       ├── update-workspace/ / update-workspace-instruction/
 │       ├── attach-skill-to-workspace/ / detach-skill-from-workspace/
@@ -93,10 +96,13 @@ workspaces/
 │   ├── schema/workspace-team-member-override.record.ts
 │   ├── mappers/workspace.mapper.ts
 │   ├── mappers/workspace-member.mapper.ts
+│   ├── mappers/workspace-team-grant.mapper.ts
 │   ├── local-workspaces.repository.ts
 │   ├── local-workspace-access.repository.ts
 │   ├── local-workspace-members.repository.ts
 │   ├── local-workspace-members-repository.module.ts
+│   ├── local-workspace-team-grants.repository.ts
+│   ├── local-workspace-team-grants-repository.module.ts
 │   └── local-workspaces-repository.module.ts
 ├── presenters/http/
 │   ├── workspaces.controller.ts
@@ -150,11 +156,13 @@ processing.
 
 The repository ports are deliberately not exported — cross-module access goes
 through exported use cases. `GetWorkspaceAccessUseCase` resolves direct,
-team-derived and organization access into one effective access level and is the public
-authorization boundary for modules that operate on workspace children. Team
-membership is resolved through `ListMyTeamsUseCase` from IAM; access persistence
-never reads IAM repositories directly. Direct invitations use exported
-`FindUsersByIdsUseCase` to constrain invitees to the caller's organization.
+team-derived and organization access into one effective access level and is the
+public authorization boundary for modules that operate on workspace children.
+Team membership is resolved through `ListMyTeamsUseCase` from IAM, while team
+grant creation uses `GetTeamUseCase` to keep grants inside the caller's
+organization; access persistence never reads IAM repositories directly. Direct
+invitations use exported `FindUsersByIdsUseCase` to constrain invitees to the
+caller's organization.
 
 Workspace context list endpoints use dedicated paginated use cases. Candidate
 and attached lists apply search, access checks, workspace assignments, ordering,

--- a/ayunis-core-backend/src/domain/workspaces/application/ports/workspace-team-grants-repository.port.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/ports/workspace-team-grants-repository.port.ts
@@ -1,0 +1,22 @@
+import type { UUID } from 'crypto';
+import type { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+
+export interface WorkspaceTeamGrant {
+  workspaceId: UUID;
+  teamId: UUID;
+  accessLevel: WorkspaceAccessLevel;
+}
+
+export abstract class WorkspaceTeamGrantsRepository {
+  abstract createGrant(
+    grant: WorkspaceTeamGrant,
+  ): Promise<WorkspaceTeamGrant | null>;
+
+  abstract updateGrantAccessLevel(
+    workspaceId: UUID,
+    teamId: UUID,
+    accessLevel: WorkspaceAccessLevel,
+  ): Promise<WorkspaceTeamGrant | null>;
+
+  abstract deleteGrant(workspaceId: UUID, teamId: UUID): Promise<boolean>;
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/testing/workspace.fixtures.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/testing/workspace.fixtures.ts
@@ -6,6 +6,7 @@ import type { WorkspacesRepository } from 'src/domain/workspaces/application/por
 export const TEST_USER_ID = '11111111-1111-4111-8111-111111111111' as UUID;
 export const TEST_ORG_ID = '22222222-2222-4222-8222-222222222222' as UUID;
 export const TEST_WORKSPACE_ID = '33333333-3333-4333-8333-333333333333' as UUID;
+export const TEST_TEAM_ID = '44444444-4444-4444-8444-444444444444' as UUID;
 
 export function aWorkspace(overrides: Partial<Workspace> = {}): Workspace {
   return new Workspace({

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/add-workspace-team-grant/add-workspace-team-grant.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/add-workspace-team-grant/add-workspace-team-grant.command.ts
@@ -1,0 +1,10 @@
+import type { UUID } from 'crypto';
+import type { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+
+export class AddWorkspaceTeamGrantCommand {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly teamId: UUID,
+    public readonly accessLevel: WorkspaceAccessLevel,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/add-workspace-team-grant/add-workspace-team-grant.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/add-workspace-team-grant/add-workspace-team-grant.use-case.spec.ts
@@ -1,0 +1,67 @@
+import {
+  TEST_TEAM_ID as TEAM_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { AddWorkspaceTeamGrantCommand } from './add-workspace-team-grant.command';
+import { AddWorkspaceTeamGrantUseCase } from './add-workspace-team-grant.use-case';
+
+describe('AddWorkspaceTeamGrantUseCase', () => {
+  it('grants a team access after validating full access and organization scope', async () => {
+    const repository = {
+      createGrant: jest.fn().mockImplementation((grant) => grant),
+    };
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({}),
+    };
+    const getTeamUseCase = {
+      execute: jest.fn().mockResolvedValue({ id: TEAM_ID }),
+    };
+    const useCase = new AddWorkspaceTeamGrantUseCase(
+      { info: jest.fn() } as never,
+      repository as never,
+      accessService as never,
+      getTeamUseCase as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new AddWorkspaceTeamGrantCommand(
+          TEST_WORKSPACE_ID,
+          TEAM_ID,
+          WorkspaceAccessLevel.EDIT,
+        ),
+      ),
+    ).resolves.toEqual({
+      workspaceId: TEST_WORKSPACE_ID,
+      teamId: TEAM_ID,
+      accessLevel: WorkspaceAccessLevel.EDIT,
+    });
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.FULL,
+    );
+    expect(getTeamUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ teamId: TEAM_ID }),
+    );
+  });
+
+  it('rejects a duplicate team grant', async () => {
+    const useCase = new AddWorkspaceTeamGrantUseCase(
+      { info: jest.fn() } as never,
+      { createGrant: jest.fn().mockResolvedValue(null) } as never,
+      { requireAccessLevel: jest.fn().mockResolvedValue({}) } as never,
+      { execute: jest.fn().mockResolvedValue({ id: TEAM_ID }) } as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new AddWorkspaceTeamGrantCommand(
+          TEST_WORKSPACE_ID,
+          TEAM_ID,
+          WorkspaceAccessLevel.USE,
+        ),
+      ),
+    ).rejects.toThrow('already has access to the workspace');
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/add-workspace-team-grant/add-workspace-team-grant.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/add-workspace-team-grant/add-workspace-team-grant.use-case.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import {
+  WorkspaceTeamGrantsRepository,
+  type WorkspaceTeamGrant,
+} from 'src/domain/workspaces/application/ports/workspace-team-grants-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceTeamGrantAlreadyExistsError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { GetTeamQuery } from 'src/iam/teams/application/use-cases/get-team/get-team.query';
+import { GetTeamUseCase } from 'src/iam/teams/application/use-cases/get-team/get-team.use-case';
+import { AddWorkspaceTeamGrantCommand } from './add-workspace-team-grant.command';
+
+@Injectable()
+export class AddWorkspaceTeamGrantUseCase {
+  constructor(
+    @InjectPinoLogger(AddWorkspaceTeamGrantUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: WorkspaceTeamGrantsRepository,
+    private readonly accessService: WorkspaceAccessService,
+    private readonly getTeamUseCase: GetTeamUseCase,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(
+    command: AddWorkspaceTeamGrantCommand,
+  ): Promise<WorkspaceTeamGrant> {
+    this.logger.info(
+      { workspaceId: command.workspaceId, teamId: command.teamId },
+      'Adding workspace team grant',
+    );
+    await this.accessService.requireAccessLevel(
+      command.workspaceId,
+      WorkspaceAccessLevel.FULL,
+    );
+    await this.getTeamUseCase.execute(new GetTeamQuery(command.teamId));
+    const grant = await this.repository.createGrant({
+      workspaceId: command.workspaceId,
+      teamId: command.teamId,
+      accessLevel: command.accessLevel,
+    });
+    if (!grant) {
+      throw new WorkspaceTeamGrantAlreadyExistsError(
+        command.workspaceId,
+        command.teamId,
+      );
+    }
+    return grant;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-workspace-team-grant/remove-workspace-team-grant.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-workspace-team-grant/remove-workspace-team-grant.command.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class RemoveWorkspaceTeamGrantCommand {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly teamId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-workspace-team-grant/remove-workspace-team-grant.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-workspace-team-grant/remove-workspace-team-grant.use-case.spec.ts
@@ -1,0 +1,45 @@
+import {
+  TEST_TEAM_ID as TEAM_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { RemoveWorkspaceTeamGrantCommand } from './remove-workspace-team-grant.command';
+import { RemoveWorkspaceTeamGrantUseCase } from './remove-workspace-team-grant.use-case';
+
+describe('RemoveWorkspaceTeamGrantUseCase', () => {
+  it('removes a team grant with full workspace access', async () => {
+    const repository = { deleteGrant: jest.fn().mockResolvedValue(true) };
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({}),
+    };
+    const useCase = new RemoveWorkspaceTeamGrantUseCase(
+      { info: jest.fn() } as never,
+      repository as never,
+      accessService as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new RemoveWorkspaceTeamGrantCommand(TEST_WORKSPACE_ID, TEAM_ID),
+      ),
+    ).resolves.toBeUndefined();
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.FULL,
+    );
+  });
+
+  it('rejects a missing team grant', async () => {
+    const useCase = new RemoveWorkspaceTeamGrantUseCase(
+      { info: jest.fn() } as never,
+      { deleteGrant: jest.fn().mockResolvedValue(false) } as never,
+      { requireAccessLevel: jest.fn().mockResolvedValue({}) } as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new RemoveWorkspaceTeamGrantCommand(TEST_WORKSPACE_ID, TEAM_ID),
+      ),
+    ).rejects.toThrow('Workspace team grant not found');
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-workspace-team-grant/remove-workspace-team-grant.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-workspace-team-grant/remove-workspace-team-grant.use-case.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { WorkspaceTeamGrantsRepository } from 'src/domain/workspaces/application/ports/workspace-team-grants-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceTeamGrantNotFoundError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { RemoveWorkspaceTeamGrantCommand } from './remove-workspace-team-grant.command';
+
+@Injectable()
+export class RemoveWorkspaceTeamGrantUseCase {
+  constructor(
+    @InjectPinoLogger(RemoveWorkspaceTeamGrantUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: WorkspaceTeamGrantsRepository,
+    private readonly accessService: WorkspaceAccessService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(command: RemoveWorkspaceTeamGrantCommand): Promise<void> {
+    this.logger.info(
+      { workspaceId: command.workspaceId, teamId: command.teamId },
+      'Removing workspace team grant',
+    );
+    await this.accessService.requireAccessLevel(
+      command.workspaceId,
+      WorkspaceAccessLevel.FULL,
+    );
+    const deleted = await this.repository.deleteGrant(
+      command.workspaceId,
+      command.teamId,
+    );
+    if (!deleted) {
+      throw new WorkspaceTeamGrantNotFoundError(
+        command.workspaceId,
+        command.teamId,
+      );
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-team-grant-access-level/update-workspace-team-grant-access-level.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-team-grant-access-level/update-workspace-team-grant-access-level.command.ts
@@ -1,0 +1,10 @@
+import type { UUID } from 'crypto';
+import type { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+
+export class UpdateWorkspaceTeamGrantAccessLevelCommand {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly teamId: UUID,
+    public readonly accessLevel: WorkspaceAccessLevel,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-team-grant-access-level/update-workspace-team-grant-access-level.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-team-grant-access-level/update-workspace-team-grant-access-level.use-case.spec.ts
@@ -1,0 +1,63 @@
+import {
+  TEST_TEAM_ID as TEAM_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { UpdateWorkspaceTeamGrantAccessLevelCommand } from './update-workspace-team-grant-access-level.command';
+import { UpdateWorkspaceTeamGrantAccessLevelUseCase } from './update-workspace-team-grant-access-level.use-case';
+
+describe('UpdateWorkspaceTeamGrantAccessLevelUseCase', () => {
+  it('updates a team grant access level with full workspace access', async () => {
+    const repository = {
+      updateGrantAccessLevel: jest.fn().mockResolvedValue({
+        workspaceId: TEST_WORKSPACE_ID,
+        teamId: TEAM_ID,
+        accessLevel: WorkspaceAccessLevel.FULL,
+      }),
+    };
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({}),
+    };
+    const useCase = new UpdateWorkspaceTeamGrantAccessLevelUseCase(
+      { info: jest.fn() } as never,
+      repository as never,
+      accessService as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new UpdateWorkspaceTeamGrantAccessLevelCommand(
+          TEST_WORKSPACE_ID,
+          TEAM_ID,
+          WorkspaceAccessLevel.FULL,
+        ),
+      ),
+    ).resolves.toEqual({
+      workspaceId: TEST_WORKSPACE_ID,
+      teamId: TEAM_ID,
+      accessLevel: WorkspaceAccessLevel.FULL,
+    });
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.FULL,
+    );
+  });
+
+  it('rejects a missing team grant', async () => {
+    const useCase = new UpdateWorkspaceTeamGrantAccessLevelUseCase(
+      { info: jest.fn() } as never,
+      { updateGrantAccessLevel: jest.fn().mockResolvedValue(null) } as never,
+      { requireAccessLevel: jest.fn().mockResolvedValue({}) } as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new UpdateWorkspaceTeamGrantAccessLevelCommand(
+          TEST_WORKSPACE_ID,
+          TEAM_ID,
+          WorkspaceAccessLevel.EDIT,
+        ),
+      ),
+    ).rejects.toThrow('Workspace team grant not found');
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-team-grant-access-level/update-workspace-team-grant-access-level.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-team-grant-access-level/update-workspace-team-grant-access-level.use-case.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import {
+  WorkspaceTeamGrantsRepository,
+  type WorkspaceTeamGrant,
+} from 'src/domain/workspaces/application/ports/workspace-team-grants-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceTeamGrantNotFoundError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { UpdateWorkspaceTeamGrantAccessLevelCommand } from './update-workspace-team-grant-access-level.command';
+
+@Injectable()
+export class UpdateWorkspaceTeamGrantAccessLevelUseCase {
+  constructor(
+    @InjectPinoLogger(UpdateWorkspaceTeamGrantAccessLevelUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: WorkspaceTeamGrantsRepository,
+    private readonly accessService: WorkspaceAccessService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(
+    command: UpdateWorkspaceTeamGrantAccessLevelCommand,
+  ): Promise<WorkspaceTeamGrant> {
+    this.logger.info(
+      { workspaceId: command.workspaceId, teamId: command.teamId },
+      'Updating workspace team grant access level',
+    );
+    await this.accessService.requireAccessLevel(
+      command.workspaceId,
+      WorkspaceAccessLevel.FULL,
+    );
+    const grant = await this.repository.updateGrantAccessLevel(
+      command.workspaceId,
+      command.teamId,
+      command.accessLevel,
+    );
+    if (!grant) {
+      throw new WorkspaceTeamGrantNotFoundError(
+        command.workspaceId,
+        command.teamId,
+      );
+    }
+    return grant;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/workspaces.errors.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/workspaces.errors.ts
@@ -14,6 +14,8 @@ export enum WorkspaceErrorCode {
   WORKSPACE_MEMBER_ALREADY_EXISTS = 'WORKSPACE_MEMBER_ALREADY_EXISTS',
   WORKSPACE_MEMBER_NOT_FOUND = 'WORKSPACE_MEMBER_NOT_FOUND',
   WORKSPACE_INVITATION_NOT_FOUND = 'WORKSPACE_INVITATION_NOT_FOUND',
+  WORKSPACE_TEAM_GRANT_ALREADY_EXISTS = 'WORKSPACE_TEAM_GRANT_ALREADY_EXISTS',
+  WORKSPACE_TEAM_GRANT_NOT_FOUND = 'WORKSPACE_TEAM_GRANT_NOT_FOUND',
   UNEXPECTED_WORKSPACE_ERROR = 'UNEXPECTED_WORKSPACE_ERROR',
 }
 
@@ -164,6 +166,28 @@ export class WorkspaceInvitationNotFoundError extends WorkspaceError {
       WorkspaceErrorCode.WORKSPACE_INVITATION_NOT_FOUND,
       404,
       { workspaceId, ...metadata },
+    );
+  }
+}
+
+export class WorkspaceTeamGrantAlreadyExistsError extends WorkspaceError {
+  constructor(workspaceId: string, teamId: string, metadata?: ErrorMetadata) {
+    super(
+      'The team already has access to the workspace',
+      WorkspaceErrorCode.WORKSPACE_TEAM_GRANT_ALREADY_EXISTS,
+      409,
+      { workspaceId, teamId, ...metadata },
+    );
+  }
+}
+
+export class WorkspaceTeamGrantNotFoundError extends WorkspaceError {
+  constructor(workspaceId: string, teamId: string, metadata?: ErrorMetadata) {
+    super(
+      'Workspace team grant not found',
+      WorkspaceErrorCode.WORKSPACE_TEAM_GRANT_NOT_FOUND,
+      404,
+      { workspaceId, teamId, ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-team-grants-repository.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-team-grants-repository.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { LocalWorkspaceTeamGrantsRepository } from './local-workspace-team-grants.repository';
+import { WorkspaceTeamGrantMapper } from './mappers/workspace-team-grant.mapper';
+import { WorkspaceTeamGrantRecord } from './schema/workspace-team-grant.record';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([WorkspaceTeamGrantRecord])],
+  providers: [LocalWorkspaceTeamGrantsRepository, WorkspaceTeamGrantMapper],
+  exports: [LocalWorkspaceTeamGrantsRepository],
+})
+export class LocalWorkspaceTeamGrantsRepositoryModule {}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-team-grants.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-team-grants.repository.spec.ts
@@ -1,0 +1,103 @@
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Test } from '@nestjs/testing';
+import {
+  TEST_TEAM_ID as TEAM_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { LocalWorkspaceTeamGrantsRepository } from './local-workspace-team-grants.repository';
+import { WorkspaceTeamGrantMapper } from './mappers/workspace-team-grant.mapper';
+import { WorkspaceTeamGrantRecord } from './schema/workspace-team-grant.record';
+
+const grant = {
+  workspaceId: TEST_WORKSPACE_ID,
+  teamId: TEAM_ID,
+  accessLevel: WorkspaceAccessLevel.EDIT,
+};
+
+describe('LocalWorkspaceTeamGrantsRepository', () => {
+  const typeormRepository = {
+    insert: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  };
+  const mapper = {
+    toRecord: jest.fn(),
+  };
+  let repository: LocalWorkspaceTeamGrantsRepository;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module = await Test.createTestingModule({
+      providers: [
+        LocalWorkspaceTeamGrantsRepository,
+        {
+          provide: getRepositoryToken(WorkspaceTeamGrantRecord),
+          useValue: typeormRepository,
+        },
+        { provide: WorkspaceTeamGrantMapper, useValue: mapper },
+      ],
+    }).compile();
+    repository = module.get(LocalWorkspaceTeamGrantsRepository);
+    mapper.toRecord.mockReturnValue({ id: 'record-id' });
+  });
+
+  it('creates a team grant', async () => {
+    typeormRepository.insert.mockResolvedValue({});
+
+    await expect(repository.createGrant(grant)).resolves.toEqual(grant);
+  });
+
+  it('returns null when the team already has a grant', async () => {
+    typeormRepository.insert.mockRejectedValue({
+      driverError: { code: '23505' },
+    });
+
+    await expect(repository.createGrant(grant)).resolves.toBeNull();
+  });
+
+  it('rethrows unexpected insert errors', async () => {
+    const error = new Error('database unavailable');
+    typeormRepository.insert.mockRejectedValue(error);
+
+    await expect(repository.createGrant(grant)).rejects.toBe(error);
+  });
+
+  it('updates and returns a team grant', async () => {
+    const updatedGrant = { ...grant, accessLevel: WorkspaceAccessLevel.FULL };
+    typeormRepository.update.mockResolvedValue({ affected: 1 });
+
+    await expect(
+      repository.updateGrantAccessLevel(
+        TEST_WORKSPACE_ID,
+        TEAM_ID,
+        WorkspaceAccessLevel.FULL,
+      ),
+    ).resolves.toEqual(updatedGrant);
+  });
+
+  it('returns null when updating a missing team grant', async () => {
+    typeormRepository.update.mockResolvedValue({ affected: 0 });
+
+    await expect(
+      repository.updateGrantAccessLevel(
+        TEST_WORKSPACE_ID,
+        TEAM_ID,
+        WorkspaceAccessLevel.FULL,
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it('reports whether a team grant was deleted', async () => {
+    typeormRepository.delete
+      .mockResolvedValueOnce({ affected: 1 })
+      .mockResolvedValueOnce({ affected: 0 });
+
+    await expect(
+      repository.deleteGrant(TEST_WORKSPACE_ID, TEAM_ID),
+    ).resolves.toBe(true);
+    await expect(
+      repository.deleteGrant(TEST_WORKSPACE_ID, TEAM_ID),
+    ).resolves.toBe(false);
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-team-grants.repository.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-team-grants.repository.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import type { UUID } from 'crypto';
+import { Repository } from 'typeorm';
+import {
+  WorkspaceTeamGrantsRepository,
+  type WorkspaceTeamGrant,
+} from 'src/domain/workspaces/application/ports/workspace-team-grants-repository.port';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { WorkspaceTeamGrantMapper } from './mappers/workspace-team-grant.mapper';
+import { WorkspaceTeamGrantRecord } from './schema/workspace-team-grant.record';
+
+@Injectable()
+export class LocalWorkspaceTeamGrantsRepository extends WorkspaceTeamGrantsRepository {
+  constructor(
+    @InjectRepository(WorkspaceTeamGrantRecord)
+    private readonly repository: Repository<WorkspaceTeamGrantRecord>,
+    private readonly mapper: WorkspaceTeamGrantMapper,
+  ) {
+    super();
+  }
+
+  async createGrant(
+    grant: WorkspaceTeamGrant,
+  ): Promise<WorkspaceTeamGrant | null> {
+    try {
+      await this.repository.insert(this.mapper.toRecord(grant));
+      return grant;
+    } catch (error: unknown) {
+      if (!this.isUniqueViolation(error)) throw error;
+      return null;
+    }
+  }
+
+  async updateGrantAccessLevel(
+    workspaceId: UUID,
+    teamId: UUID,
+    accessLevel: WorkspaceAccessLevel,
+  ): Promise<WorkspaceTeamGrant | null> {
+    const result = await this.repository.update(
+      { workspaceId, teamId },
+      { accessLevel },
+    );
+    if (result.affected !== 1) return null;
+    return { workspaceId, teamId, accessLevel };
+  }
+
+  async deleteGrant(workspaceId: UUID, teamId: UUID): Promise<boolean> {
+    const result = await this.repository.delete({ workspaceId, teamId });
+    return result.affected === 1;
+  }
+
+  private isUniqueViolation(error: unknown): boolean {
+    const driverError = (error as { driverError?: { code?: unknown } })
+      .driverError;
+    return driverError?.code === '23505';
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-team-grant.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-team-grant.mapper.spec.ts
@@ -1,0 +1,19 @@
+import {
+  TEST_TEAM_ID as TEAM_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { WorkspaceTeamGrantMapper } from './workspace-team-grant.mapper';
+
+describe('WorkspaceTeamGrantMapper', () => {
+  it('round-trips a workspace team grant', () => {
+    const mapper = new WorkspaceTeamGrantMapper();
+    const grant = {
+      workspaceId: TEST_WORKSPACE_ID,
+      teamId: TEAM_ID,
+      accessLevel: WorkspaceAccessLevel.EDIT,
+    };
+
+    expect(mapper.toDomain(mapper.toRecord(grant))).toEqual(grant);
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-team-grant.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-team-grant.mapper.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import type { WorkspaceTeamGrant } from 'src/domain/workspaces/application/ports/workspace-team-grants-repository.port';
+import { WorkspaceTeamGrantRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace-team-grant.record';
+
+@Injectable()
+export class WorkspaceTeamGrantMapper {
+  toDomain(record: WorkspaceTeamGrantRecord): WorkspaceTeamGrant {
+    return {
+      workspaceId: record.workspaceId,
+      teamId: record.teamId,
+      accessLevel: record.accessLevel,
+    };
+  }
+
+  toRecord(grant: WorkspaceTeamGrant): WorkspaceTeamGrantRecord {
+    const record = new WorkspaceTeamGrantRecord();
+    record.id = randomUUID();
+    record.workspaceId = grant.workspaceId;
+    record.teamId = grant.teamId;
+    record.accessLevel = grant.accessLevel;
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
@@ -44,11 +44,18 @@ import { RemoveWorkspaceMemberUseCase } from './application/use-cases/remove-wor
 import { WorkspaceMembersRepository } from './application/ports/workspace-members-repository.port';
 import { LocalWorkspaceMembersRepository } from './infrastructure/persistence/local/local-workspace-members.repository';
 import { LocalWorkspaceMembersRepositoryModule } from './infrastructure/persistence/local/local-workspace-members-repository.module';
+import { WorkspaceTeamGrantsRepository } from './application/ports/workspace-team-grants-repository.port';
+import { LocalWorkspaceTeamGrantsRepository } from './infrastructure/persistence/local/local-workspace-team-grants.repository';
+import { LocalWorkspaceTeamGrantsRepositoryModule } from './infrastructure/persistence/local/local-workspace-team-grants-repository.module';
+import { AddWorkspaceTeamGrantUseCase } from './application/use-cases/add-workspace-team-grant/add-workspace-team-grant.use-case';
+import { UpdateWorkspaceTeamGrantAccessLevelUseCase } from './application/use-cases/update-workspace-team-grant-access-level/update-workspace-team-grant-access-level.use-case';
+import { RemoveWorkspaceTeamGrantUseCase } from './application/use-cases/remove-workspace-team-grant/remove-workspace-team-grant.use-case';
 
 @Module({
   imports: [
     LocalWorkspacesRepositoryModule,
     LocalWorkspaceMembersRepositoryModule,
+    LocalWorkspaceTeamGrantsRepositoryModule,
     forwardRef(() => FavoritesModule),
     forwardRef(() => SkillsModule),
     forwardRef(() => KnowledgeBasesModule),
@@ -70,6 +77,10 @@ import { LocalWorkspaceMembersRepositoryModule } from './infrastructure/persiste
       provide: WorkspaceMembersRepository,
       useExisting: LocalWorkspaceMembersRepository,
     },
+    {
+      provide: WorkspaceTeamGrantsRepository,
+      useExisting: LocalWorkspaceTeamGrantsRepository,
+    },
     WorkspaceAccessPolicyService,
     WorkspaceAccessService,
     GetWorkspaceAccessUseCase,
@@ -78,6 +89,9 @@ import { LocalWorkspaceMembersRepositoryModule } from './infrastructure/persiste
     DeclineWorkspaceInvitationUseCase,
     UpdateWorkspaceMemberAccessLevelUseCase,
     RemoveWorkspaceMemberUseCase,
+    AddWorkspaceTeamGrantUseCase,
+    UpdateWorkspaceTeamGrantAccessLevelUseCase,
+    RemoveWorkspaceTeamGrantUseCase,
     CreateWorkspaceUseCase,
     FindAllWorkspacesUseCase,
     FindWorkspaceUseCase,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes workspace authorization data paths (who can grant team access and at what level); mistakes could widen sharing before HTTP guards exist, though callers are internal and FULL access is enforced.
> 
> **Overview**
> Adds **application-layer lifecycle** for workspace team grants: create a grant with an access level, update that level, or remove the grant. This sits alongside existing direct-member collaboration; HTTP and member overrides are explicitly deferred.
> 
> A new **`WorkspaceTeamGrantsRepository`** port and **local TypeORM** implementation (mapper, insert/update/delete, duplicate-key → `null`) persist `(workspaceId, teamId, accessLevel)`. All three use cases require **`FULL`** workspace access via `WorkspaceAccessService`. **`AddWorkspaceTeamGrantUseCase`** also calls IAM **`GetTeamUseCase`** so the team is validated in the caller’s org before insert. Domain errors cover **409** duplicate grant and **404** missing grant.
> 
> **`workspaces.module.ts`** wires the repository module and use cases (not exported yet). **`SUMMARY.md`** and test fixtures (`TEST_TEAM_ID`) are updated to document the new stack layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2854be730072e82cae341be5f727009a4244f891. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->