### PR TITLE
wip(workspaces): add team member overrides (AYC-703)

### DIFF
--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -12,8 +12,8 @@ the workspace. User-specific favorites and their order are owned by the
 User-facing copy calls them "Projekte"; the code, tables and routes say
 `workspace` throughout. See AYC-700 / AYC-701 in the Workspaces/Projects plan.
 Workspace collaboration is being introduced in stack layers. Direct member
-invitations and team-grant access-level management now exist at the application
-boundary; member overrides, HTTP and frontend sharing flows follow later.
+invitations, team grants and team-member overrides now exist at the application
+boundary; HTTP and frontend sharing flows follow later.
 
 The whole module sits behind the `workspacesEnabled` feature flag
 (`FEATURE_WORKSPACES_ENABLED`, off by default), applied at the controller.
@@ -31,8 +31,8 @@ The whole module sits behind the `workspacesEnabled` feature flag
 - **Collaboration** — workspaces persist private/organization visibility.
   Direct-member use cases manage pending invitations, acceptance, access levels
   and removal. Team-grant use cases add, update and remove immediate team
-  access. Team-scoped member-override records provide the next sharing layer's
-  persistence foundation; HTTP sharing endpoints follow later.
+  access. Team-scoped member overrides can replace or exclude a member's grant
+  without affecting other team members; HTTP sharing endpoints follow later.
 - **Deletion** — `DeleteWorkspaceUseCase` emits `WorkspaceDeletionRequestedEvent`
   _before_ the row delete and drains the listeners' deferred cleanup only after
   it succeeds, so a failed delete loses nothing. The favorites module listens
@@ -67,6 +67,7 @@ workspaces/
 │   ├── ports/workspace-access-repository.port.ts
 │   ├── ports/workspace-members-repository.port.ts
 │   ├── ports/workspace-team-grants-repository.port.ts
+│   ├── ports/workspace-team-member-overrides-repository.port.ts
 │   ├── testing/workspace.fixtures.ts
 │   └── use-cases/
 │       ├── create-workspace/
@@ -76,6 +77,8 @@ workspaces/
 │       ├── remove-workspace-member/
 │       ├── add-workspace-team-grant/ / update-workspace-team-grant-access-level/
 │       ├── remove-workspace-team-grant/
+│       ├── set-workspace-team-member-override/
+│       ├── reset-workspace-team-member-override/
 │       ├── find-all-workspaces/ / find-workspaces-by-ids/ / find-workspace/
 │       ├── update-workspace/ / update-workspace-instruction/
 │       ├── attach-skill-to-workspace/ / detach-skill-from-workspace/
@@ -97,12 +100,15 @@ workspaces/
 │   ├── mappers/workspace.mapper.ts
 │   ├── mappers/workspace-member.mapper.ts
 │   ├── mappers/workspace-team-grant.mapper.ts
+│   ├── mappers/workspace-team-member-override.mapper.ts
 │   ├── local-workspaces.repository.ts
 │   ├── local-workspace-access.repository.ts
 │   ├── local-workspace-members.repository.ts
 │   ├── local-workspace-members-repository.module.ts
 │   ├── local-workspace-team-grants.repository.ts
 │   ├── local-workspace-team-grants-repository.module.ts
+│   ├── local-workspace-team-member-overrides.repository.ts
+│   ├── local-workspace-team-member-overrides-repository.module.ts
 │   └── local-workspaces-repository.module.ts
 ├── presenters/http/
 │   ├── workspaces.controller.ts
@@ -158,9 +164,10 @@ The repository ports are deliberately not exported — cross-module access goes
 through exported use cases. `GetWorkspaceAccessUseCase` resolves direct,
 team-derived and organization access into one effective access level and is the
 public authorization boundary for modules that operate on workspace children.
-Team membership is resolved through `ListMyTeamsUseCase` from IAM, while team
-grant creation uses `GetTeamUseCase` to keep grants inside the caller's
-organization; access persistence never reads IAM repositories directly. Direct
+Team membership is resolved through `ListMyTeamsUseCase` from IAM, team grant
+creation uses `GetTeamUseCase` to keep grants inside the caller's organization,
+and team-member overrides use `CheckUserTeamMembershipUseCase` to validate the
+target member. Access persistence never reads IAM repositories directly. Direct
 invitations use exported `FindUsersByIdsUseCase` to constrain invitees to the
 caller's organization.
 

--- a/ayunis-core-backend/src/domain/workspaces/application/ports/workspace-team-member-overrides-repository.port.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/ports/workspace-team-member-overrides-repository.port.ts
@@ -1,0 +1,28 @@
+import type { UUID } from 'crypto';
+import type { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+
+export interface WorkspaceTeamMemberOverride {
+  teamGrantId: UUID;
+  userId: UUID;
+  accessLevel: WorkspaceAccessLevel | null;
+  excluded: boolean;
+}
+
+export type WorkspaceTeamMemberOverrideInput = Omit<
+  WorkspaceTeamMemberOverride,
+  'teamGrantId'
+>;
+
+export abstract class WorkspaceTeamMemberOverridesRepository {
+  abstract upsertOverride(
+    workspaceId: UUID,
+    teamId: UUID,
+    override: WorkspaceTeamMemberOverrideInput,
+  ): Promise<WorkspaceTeamMemberOverride | null>;
+
+  abstract deleteOverride(
+    workspaceId: UUID,
+    teamId: UUID,
+    userId: UUID,
+  ): Promise<boolean>;
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/reset-workspace-team-member-override/reset-workspace-team-member-override.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/reset-workspace-team-member-override/reset-workspace-team-member-override.command.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+
+export class ResetWorkspaceTeamMemberOverrideCommand {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly teamId: UUID,
+    public readonly userId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/reset-workspace-team-member-override/reset-workspace-team-member-override.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/reset-workspace-team-member-override/reset-workspace-team-member-override.use-case.spec.ts
@@ -1,0 +1,54 @@
+import {
+  TEST_TEAM_ID,
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { ResetWorkspaceTeamMemberOverrideCommand } from './reset-workspace-team-member-override.command';
+import { ResetWorkspaceTeamMemberOverrideUseCase } from './reset-workspace-team-member-override.use-case';
+
+describe('ResetWorkspaceTeamMemberOverrideUseCase', () => {
+  it('removes an override with full workspace access', async () => {
+    const repository = { deleteOverride: jest.fn().mockResolvedValue(true) };
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({}),
+    };
+    const useCase = new ResetWorkspaceTeamMemberOverrideUseCase(
+      { info: jest.fn() } as never,
+      repository as never,
+      accessService as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new ResetWorkspaceTeamMemberOverrideCommand(
+          TEST_WORKSPACE_ID,
+          TEST_TEAM_ID,
+          TEST_USER_ID,
+        ),
+      ),
+    ).resolves.toBeUndefined();
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.FULL,
+    );
+  });
+
+  it('rejects a missing override', async () => {
+    const useCase = new ResetWorkspaceTeamMemberOverrideUseCase(
+      { info: jest.fn() } as never,
+      { deleteOverride: jest.fn().mockResolvedValue(false) } as never,
+      { requireAccessLevel: jest.fn().mockResolvedValue({}) } as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new ResetWorkspaceTeamMemberOverrideCommand(
+          TEST_WORKSPACE_ID,
+          TEST_TEAM_ID,
+          TEST_USER_ID,
+        ),
+      ),
+    ).rejects.toThrow('Workspace team member override not found');
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/reset-workspace-team-member-override/reset-workspace-team-member-override.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/reset-workspace-team-member-override/reset-workspace-team-member-override.use-case.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { WorkspaceTeamMemberOverridesRepository } from 'src/domain/workspaces/application/ports/workspace-team-member-overrides-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceTeamOverrideNotFoundError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { ResetWorkspaceTeamMemberOverrideCommand } from './reset-workspace-team-member-override.command';
+
+@Injectable()
+export class ResetWorkspaceTeamMemberOverrideUseCase {
+  constructor(
+    @InjectPinoLogger(ResetWorkspaceTeamMemberOverrideUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: WorkspaceTeamMemberOverridesRepository,
+    private readonly accessService: WorkspaceAccessService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(
+    command: ResetWorkspaceTeamMemberOverrideCommand,
+  ): Promise<void> {
+    this.logger.info(
+      {
+        workspaceId: command.workspaceId,
+        teamId: command.teamId,
+        userId: command.userId,
+      },
+      'Resetting workspace team member override',
+    );
+    await this.accessService.requireAccessLevel(
+      command.workspaceId,
+      WorkspaceAccessLevel.FULL,
+    );
+    const deleted = await this.repository.deleteOverride(
+      command.workspaceId,
+      command.teamId,
+      command.userId,
+    );
+    if (!deleted) {
+      throw new WorkspaceTeamOverrideNotFoundError(
+        command.teamId,
+        command.userId,
+      );
+    }
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/set-workspace-team-member-override/set-workspace-team-member-override.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/set-workspace-team-member-override/set-workspace-team-member-override.command.ts
@@ -1,0 +1,15 @@
+import type { UUID } from 'crypto';
+import type { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+
+export type WorkspaceTeamMemberOverrideValue =
+  | { accessLevel: WorkspaceAccessLevel; excluded: false }
+  | { accessLevel: null; excluded: true };
+
+export class SetWorkspaceTeamMemberOverrideCommand {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly teamId: UUID,
+    public readonly userId: UUID,
+    public readonly value: WorkspaceTeamMemberOverrideValue,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/set-workspace-team-member-override/set-workspace-team-member-override.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/set-workspace-team-member-override/set-workspace-team-member-override.use-case.spec.ts
@@ -1,0 +1,88 @@
+import {
+  TEST_TEAM_ID,
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { SetWorkspaceTeamMemberOverrideCommand } from './set-workspace-team-member-override.command';
+import { SetWorkspaceTeamMemberOverrideUseCase } from './set-workspace-team-member-override.use-case';
+
+describe('SetWorkspaceTeamMemberOverrideUseCase', () => {
+  it('sets an access-level override for a member of the granted team', async () => {
+    const repository = {
+      upsertOverride: jest.fn().mockResolvedValue({
+        teamGrantId: 'grant-id',
+        userId: TEST_USER_ID,
+        accessLevel: WorkspaceAccessLevel.FULL,
+        excluded: false,
+      }),
+    };
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({}),
+    };
+    const membershipUseCase = { execute: jest.fn().mockResolvedValue(true) };
+    const useCase = new SetWorkspaceTeamMemberOverrideUseCase(
+      { info: jest.fn() } as never,
+      repository as never,
+      accessService as never,
+      membershipUseCase as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new SetWorkspaceTeamMemberOverrideCommand(
+          TEST_WORKSPACE_ID,
+          TEST_TEAM_ID,
+          TEST_USER_ID,
+          { accessLevel: WorkspaceAccessLevel.FULL, excluded: false },
+        ),
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({ accessLevel: WorkspaceAccessLevel.FULL }),
+    );
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.FULL,
+    );
+  });
+
+  it('rejects a user outside the granted team', async () => {
+    const useCase = new SetWorkspaceTeamMemberOverrideUseCase(
+      { info: jest.fn() } as never,
+      {} as never,
+      { requireAccessLevel: jest.fn().mockResolvedValue({}) } as never,
+      { execute: jest.fn().mockResolvedValue(false) } as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new SetWorkspaceTeamMemberOverrideCommand(
+          TEST_WORKSPACE_ID,
+          TEST_TEAM_ID,
+          TEST_USER_ID,
+          { accessLevel: null, excluded: true },
+        ),
+      ),
+    ).rejects.toThrow('must belong to the granted team');
+  });
+
+  it('rejects a missing team grant', async () => {
+    const useCase = new SetWorkspaceTeamMemberOverrideUseCase(
+      { info: jest.fn() } as never,
+      { upsertOverride: jest.fn().mockResolvedValue(null) } as never,
+      { requireAccessLevel: jest.fn().mockResolvedValue({}) } as never,
+      { execute: jest.fn().mockResolvedValue(true) } as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new SetWorkspaceTeamMemberOverrideCommand(
+          TEST_WORKSPACE_ID,
+          TEST_TEAM_ID,
+          TEST_USER_ID,
+          { accessLevel: null, excluded: true },
+        ),
+      ),
+    ).rejects.toThrow('Workspace team grant not found');
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/set-workspace-team-member-override/set-workspace-team-member-override.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/set-workspace-team-member-override/set-workspace-team-member-override.use-case.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import {
+  WorkspaceTeamMemberOverridesRepository,
+  type WorkspaceTeamMemberOverride,
+} from 'src/domain/workspaces/application/ports/workspace-team-member-overrides-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceTeamGrantNotFoundError,
+  WorkspaceTeamOverrideUserNotEligibleError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { CheckUserTeamMembershipQuery } from 'src/iam/teams/application/use-cases/check-user-team-membership/check-user-team-membership.query';
+import { CheckUserTeamMembershipUseCase } from 'src/iam/teams/application/use-cases/check-user-team-membership/check-user-team-membership.use-case';
+import { SetWorkspaceTeamMemberOverrideCommand } from './set-workspace-team-member-override.command';
+
+@Injectable()
+export class SetWorkspaceTeamMemberOverrideUseCase {
+  constructor(
+    @InjectPinoLogger(SetWorkspaceTeamMemberOverrideUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: WorkspaceTeamMemberOverridesRepository,
+    private readonly accessService: WorkspaceAccessService,
+    private readonly checkMembershipUseCase: CheckUserTeamMembershipUseCase,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(
+    command: SetWorkspaceTeamMemberOverrideCommand,
+  ): Promise<WorkspaceTeamMemberOverride> {
+    this.logger.info(
+      {
+        workspaceId: command.workspaceId,
+        teamId: command.teamId,
+        userId: command.userId,
+      },
+      'Setting workspace team member override',
+    );
+    await this.accessService.requireAccessLevel(
+      command.workspaceId,
+      WorkspaceAccessLevel.FULL,
+    );
+    const isTeamMember = await this.checkMembershipUseCase.execute(
+      new CheckUserTeamMembershipQuery({
+        teamId: command.teamId,
+        userId: command.userId,
+      }),
+    );
+    if (!isTeamMember) {
+      throw new WorkspaceTeamOverrideUserNotEligibleError(
+        command.teamId,
+        command.userId,
+      );
+    }
+    const override = await this.repository.upsertOverride(
+      command.workspaceId,
+      command.teamId,
+      { userId: command.userId, ...command.value },
+    );
+    if (!override) {
+      throw new WorkspaceTeamGrantNotFoundError(
+        command.workspaceId,
+        command.teamId,
+      );
+    }
+    return override;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/workspaces.errors.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/workspaces.errors.ts
@@ -16,6 +16,8 @@ export enum WorkspaceErrorCode {
   WORKSPACE_INVITATION_NOT_FOUND = 'WORKSPACE_INVITATION_NOT_FOUND',
   WORKSPACE_TEAM_GRANT_ALREADY_EXISTS = 'WORKSPACE_TEAM_GRANT_ALREADY_EXISTS',
   WORKSPACE_TEAM_GRANT_NOT_FOUND = 'WORKSPACE_TEAM_GRANT_NOT_FOUND',
+  WORKSPACE_TEAM_OVERRIDE_USER_NOT_ELIGIBLE = 'WORKSPACE_TEAM_OVERRIDE_USER_NOT_ELIGIBLE',
+  WORKSPACE_TEAM_OVERRIDE_NOT_FOUND = 'WORKSPACE_TEAM_OVERRIDE_NOT_FOUND',
   UNEXPECTED_WORKSPACE_ERROR = 'UNEXPECTED_WORKSPACE_ERROR',
 }
 
@@ -188,6 +190,28 @@ export class WorkspaceTeamGrantNotFoundError extends WorkspaceError {
       WorkspaceErrorCode.WORKSPACE_TEAM_GRANT_NOT_FOUND,
       404,
       { workspaceId, teamId, ...metadata },
+    );
+  }
+}
+
+export class WorkspaceTeamOverrideUserNotEligibleError extends WorkspaceError {
+  constructor(teamId: string, userId: string, metadata?: ErrorMetadata) {
+    super(
+      'Workspace team override users must belong to the granted team',
+      WorkspaceErrorCode.WORKSPACE_TEAM_OVERRIDE_USER_NOT_ELIGIBLE,
+      400,
+      { teamId, userId, ...metadata },
+    );
+  }
+}
+
+export class WorkspaceTeamOverrideNotFoundError extends WorkspaceError {
+  constructor(teamId: string, userId: string, metadata?: ErrorMetadata) {
+    super(
+      'Workspace team member override not found',
+      WorkspaceErrorCode.WORKSPACE_TEAM_OVERRIDE_NOT_FOUND,
+      404,
+      { teamId, userId, ...metadata },
     );
   }
 }

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-team-member-overrides-repository.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-team-member-overrides-repository.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { LocalWorkspaceTeamMemberOverridesRepository } from './local-workspace-team-member-overrides.repository';
+import { WorkspaceTeamMemberOverrideMapper } from './mappers/workspace-team-member-override.mapper';
+import { WorkspaceTeamGrantRecord } from './schema/workspace-team-grant.record';
+import { WorkspaceTeamMemberOverrideRecord } from './schema/workspace-team-member-override.record';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      WorkspaceTeamGrantRecord,
+      WorkspaceTeamMemberOverrideRecord,
+    ]),
+  ],
+  providers: [
+    LocalWorkspaceTeamMemberOverridesRepository,
+    WorkspaceTeamMemberOverrideMapper,
+  ],
+  exports: [LocalWorkspaceTeamMemberOverridesRepository],
+})
+export class LocalWorkspaceTeamMemberOverridesRepositoryModule {}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-team-member-overrides.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-team-member-overrides.repository.spec.ts
@@ -1,0 +1,101 @@
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Test } from '@nestjs/testing';
+import {
+  TEST_TEAM_ID,
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { LocalWorkspaceTeamMemberOverridesRepository } from './local-workspace-team-member-overrides.repository';
+import { WorkspaceTeamMemberOverrideMapper } from './mappers/workspace-team-member-override.mapper';
+import { WorkspaceTeamGrantRecord } from './schema/workspace-team-grant.record';
+import { WorkspaceTeamMemberOverrideRecord } from './schema/workspace-team-member-override.record';
+
+const GRANT_ID = '55555555-5555-4555-8555-555555555555' as const;
+
+describe('LocalWorkspaceTeamMemberOverridesRepository', () => {
+  const builder = {
+    insert: jest.fn().mockReturnThis(),
+    values: jest.fn().mockReturnThis(),
+    orUpdate: jest.fn().mockReturnThis(),
+    execute: jest.fn(),
+  };
+  const grantRepository = { findOne: jest.fn() };
+  const overrideRepository = {
+    createQueryBuilder: jest.fn().mockReturnValue(builder),
+    delete: jest.fn(),
+  };
+  const mapper = { toRecord: jest.fn(), toDomain: jest.fn() };
+  let repository: LocalWorkspaceTeamMemberOverridesRepository;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module = await Test.createTestingModule({
+      providers: [
+        LocalWorkspaceTeamMemberOverridesRepository,
+        {
+          provide: getRepositoryToken(WorkspaceTeamGrantRecord),
+          useValue: grantRepository,
+        },
+        {
+          provide: getRepositoryToken(WorkspaceTeamMemberOverrideRecord),
+          useValue: overrideRepository,
+        },
+        { provide: WorkspaceTeamMemberOverrideMapper, useValue: mapper },
+      ],
+    }).compile();
+    repository = module.get(LocalWorkspaceTeamMemberOverridesRepository);
+  });
+
+  it('upserts an override for an existing team grant', async () => {
+    const override = {
+      teamGrantId: GRANT_ID,
+      userId: TEST_USER_ID,
+      accessLevel: WorkspaceAccessLevel.EDIT,
+      excluded: false,
+    };
+    grantRepository.findOne.mockResolvedValue({ id: GRANT_ID });
+    mapper.toRecord.mockReturnValue({ id: 'override-id' });
+    mapper.toDomain.mockReturnValue(override);
+    builder.execute.mockResolvedValue({});
+
+    await expect(
+      repository.upsertOverride(TEST_WORKSPACE_ID, TEST_TEAM_ID, {
+        userId: TEST_USER_ID,
+        accessLevel: WorkspaceAccessLevel.EDIT,
+        excluded: false,
+      }),
+    ).resolves.toEqual(override);
+    expect(builder.orUpdate).toHaveBeenCalledWith(
+      ['role', 'excluded'],
+      ['teamGrantId', 'userId'],
+    );
+  });
+
+  it('returns null when the team grant does not exist', async () => {
+    grantRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      repository.upsertOverride(TEST_WORKSPACE_ID, TEST_TEAM_ID, {
+        userId: TEST_USER_ID,
+        accessLevel: null,
+        excluded: true,
+      }),
+    ).resolves.toBeNull();
+    expect(overrideRepository.createQueryBuilder).not.toHaveBeenCalled();
+  });
+
+  it('reports whether an override was deleted', async () => {
+    grantRepository.findOne.mockResolvedValue({ id: GRANT_ID });
+    overrideRepository.delete
+      .mockResolvedValueOnce({ affected: 1 })
+      .mockResolvedValueOnce({ affected: 0 });
+
+    await expect(
+      repository.deleteOverride(TEST_WORKSPACE_ID, TEST_TEAM_ID, TEST_USER_ID),
+    ).resolves.toBe(true);
+    await expect(
+      repository.deleteOverride(TEST_WORKSPACE_ID, TEST_TEAM_ID, TEST_USER_ID),
+    ).resolves.toBe(false);
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-team-member-overrides.repository.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-team-member-overrides.repository.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import type { UUID } from 'crypto';
+import { Repository } from 'typeorm';
+import {
+  WorkspaceTeamMemberOverridesRepository,
+  type WorkspaceTeamMemberOverride,
+  type WorkspaceTeamMemberOverrideInput,
+} from 'src/domain/workspaces/application/ports/workspace-team-member-overrides-repository.port';
+import { WorkspaceTeamMemberOverrideMapper } from './mappers/workspace-team-member-override.mapper';
+import { WorkspaceTeamGrantRecord } from './schema/workspace-team-grant.record';
+import { WorkspaceTeamMemberOverrideRecord } from './schema/workspace-team-member-override.record';
+
+@Injectable()
+export class LocalWorkspaceTeamMemberOverridesRepository extends WorkspaceTeamMemberOverridesRepository {
+  constructor(
+    @InjectRepository(WorkspaceTeamGrantRecord)
+    private readonly grantRepository: Repository<WorkspaceTeamGrantRecord>,
+    @InjectRepository(WorkspaceTeamMemberOverrideRecord)
+    private readonly overrideRepository: Repository<WorkspaceTeamMemberOverrideRecord>,
+    private readonly mapper: WorkspaceTeamMemberOverrideMapper,
+  ) {
+    super();
+  }
+
+  async upsertOverride(
+    workspaceId: UUID,
+    teamId: UUID,
+    input: WorkspaceTeamMemberOverrideInput,
+  ): Promise<WorkspaceTeamMemberOverride | null> {
+    const teamGrantId = await this.findTeamGrantId(workspaceId, teamId);
+    if (!teamGrantId) return null;
+    const record = this.mapper.toRecord({ teamGrantId, ...input });
+    await this.overrideRepository
+      .createQueryBuilder()
+      .insert()
+      .values(record)
+      .orUpdate(['role', 'excluded'], ['teamGrantId', 'userId'])
+      .execute();
+    return this.mapper.toDomain(record);
+  }
+
+  async deleteOverride(
+    workspaceId: UUID,
+    teamId: UUID,
+    userId: UUID,
+  ): Promise<boolean> {
+    const teamGrantId = await this.findTeamGrantId(workspaceId, teamId);
+    if (!teamGrantId) return false;
+    const result = await this.overrideRepository.delete({
+      teamGrantId,
+      userId,
+    });
+    return result.affected === 1;
+  }
+
+  private async findTeamGrantId(
+    workspaceId: UUID,
+    teamId: UUID,
+  ): Promise<UUID | null> {
+    const grant = await this.grantRepository.findOne({
+      select: { id: true },
+      where: { workspaceId, teamId },
+    });
+    return grant?.id ?? null;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-team-member-override.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-team-member-override.mapper.spec.ts
@@ -1,0 +1,20 @@
+import {
+  TEST_TEAM_ID,
+  TEST_USER_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { WorkspaceTeamMemberOverrideMapper } from './workspace-team-member-override.mapper';
+
+describe('WorkspaceTeamMemberOverrideMapper', () => {
+  it('round-trips a workspace team member override', () => {
+    const mapper = new WorkspaceTeamMemberOverrideMapper();
+    const override = {
+      teamGrantId: TEST_TEAM_ID,
+      userId: TEST_USER_ID,
+      accessLevel: WorkspaceAccessLevel.EDIT,
+      excluded: false,
+    };
+
+    expect(mapper.toDomain(mapper.toRecord(override))).toEqual(override);
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-team-member-override.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-team-member-override.mapper.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import type { WorkspaceTeamMemberOverride } from 'src/domain/workspaces/application/ports/workspace-team-member-overrides-repository.port';
+import { WorkspaceTeamMemberOverrideRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace-team-member-override.record';
+
+@Injectable()
+export class WorkspaceTeamMemberOverrideMapper {
+  toDomain(
+    record: WorkspaceTeamMemberOverrideRecord,
+  ): WorkspaceTeamMemberOverride {
+    return {
+      teamGrantId: record.teamGrantId,
+      userId: record.userId,
+      accessLevel: record.accessLevel,
+      excluded: record.excluded,
+    };
+  }
+
+  toRecord(
+    override: WorkspaceTeamMemberOverride,
+  ): WorkspaceTeamMemberOverrideRecord {
+    const record = new WorkspaceTeamMemberOverrideRecord();
+    record.id = randomUUID();
+    record.teamGrantId = override.teamGrantId;
+    record.userId = override.userId;
+    record.accessLevel = override.accessLevel;
+    record.excluded = override.excluded;
+    return record;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
@@ -50,12 +50,18 @@ import { LocalWorkspaceTeamGrantsRepositoryModule } from './infrastructure/persi
 import { AddWorkspaceTeamGrantUseCase } from './application/use-cases/add-workspace-team-grant/add-workspace-team-grant.use-case';
 import { UpdateWorkspaceTeamGrantAccessLevelUseCase } from './application/use-cases/update-workspace-team-grant-access-level/update-workspace-team-grant-access-level.use-case';
 import { RemoveWorkspaceTeamGrantUseCase } from './application/use-cases/remove-workspace-team-grant/remove-workspace-team-grant.use-case';
+import { WorkspaceTeamMemberOverridesRepository } from './application/ports/workspace-team-member-overrides-repository.port';
+import { LocalWorkspaceTeamMemberOverridesRepository } from './infrastructure/persistence/local/local-workspace-team-member-overrides.repository';
+import { LocalWorkspaceTeamMemberOverridesRepositoryModule } from './infrastructure/persistence/local/local-workspace-team-member-overrides-repository.module';
+import { SetWorkspaceTeamMemberOverrideUseCase } from './application/use-cases/set-workspace-team-member-override/set-workspace-team-member-override.use-case';
+import { ResetWorkspaceTeamMemberOverrideUseCase } from './application/use-cases/reset-workspace-team-member-override/reset-workspace-team-member-override.use-case';
 
 @Module({
   imports: [
     LocalWorkspacesRepositoryModule,
     LocalWorkspaceMembersRepositoryModule,
     LocalWorkspaceTeamGrantsRepositoryModule,
+    LocalWorkspaceTeamMemberOverridesRepositoryModule,
     forwardRef(() => FavoritesModule),
     forwardRef(() => SkillsModule),
     forwardRef(() => KnowledgeBasesModule),
@@ -81,6 +87,10 @@ import { RemoveWorkspaceTeamGrantUseCase } from './application/use-cases/remove-
       provide: WorkspaceTeamGrantsRepository,
       useExisting: LocalWorkspaceTeamGrantsRepository,
     },
+    {
+      provide: WorkspaceTeamMemberOverridesRepository,
+      useExisting: LocalWorkspaceTeamMemberOverridesRepository,
+    },
     WorkspaceAccessPolicyService,
     WorkspaceAccessService,
     GetWorkspaceAccessUseCase,
@@ -92,6 +102,8 @@ import { RemoveWorkspaceTeamGrantUseCase } from './application/use-cases/remove-
     AddWorkspaceTeamGrantUseCase,
     UpdateWorkspaceTeamGrantAccessLevelUseCase,
     RemoveWorkspaceTeamGrantUseCase,
+    SetWorkspaceTeamMemberOverrideUseCase,
+    ResetWorkspaceTeamMemberOverrideUseCase,
     CreateWorkspaceUseCase,
     FindAllWorkspacesUseCase,
     FindWorkspaceUseCase,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces authorization-adjacent persistence and validation (FULL gate, team membership checks) without HTTP exposure yet; effective access resolution must stay in sync when overrides are consumed later.
> 
> **Overview**
> Adds **application-layer support** for per-user overrides on workspace team grants: callers with **FULL** access can set a different access level for one team member or mark them **excluded** without changing the grant for everyone else, and can **reset** overrides back to the team default.
> 
> **Set** validates the target via `CheckUserTeamMembershipUseCase`, upserts through a new `WorkspaceTeamMemberOverridesRepository` port (local TypeORM implementation keyed off the workspace team grant), and surfaces new errors for ineligible users or missing grants/overrides. **Reset** deletes the override row. Module wiring and `SUMMARY.md` are updated; **HTTP APIs and frontend sharing are explicitly out of scope** for this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da57c618f228f05f07a28d806f188d7a18c9b45d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->