### PR TITLE
wip(workspaces): add sharing read model (AYC-703)

### DIFF
--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -13,7 +13,8 @@ User-facing copy calls them "Projekte"; the code, tables and routes say
 `workspace` throughout. See AYC-700 / AYC-701 in the Workspaces/Projects plan.
 Workspace collaboration is being introduced in stack layers. Direct member
 invitations, team grants and team-member overrides now exist at the application
-boundary; HTTP and frontend sharing flows follow later.
+boundary. The sharing read boundary returns hydrated members, grants and
+overrides; HTTP and frontend sharing flows follow later.
 
 The whole module sits behind the `workspacesEnabled` feature flag
 (`FEATURE_WORKSPACES_ENABLED`, off by default), applied at the controller.
@@ -68,6 +69,7 @@ workspaces/
 │   ├── ports/workspace-members-repository.port.ts
 │   ├── ports/workspace-team-grants-repository.port.ts
 │   ├── ports/workspace-team-member-overrides-repository.port.ts
+│   ├── ports/workspace-sharing-read-repository.port.ts
 │   ├── testing/workspace.fixtures.ts
 │   └── use-cases/
 │       ├── create-workspace/
@@ -79,6 +81,7 @@ workspaces/
 │       ├── remove-workspace-team-grant/
 │       ├── set-workspace-team-member-override/
 │       ├── reset-workspace-team-member-override/
+│       ├── get-workspace-sharing/
 │       ├── find-all-workspaces/ / find-workspaces-by-ids/ / find-workspace/
 │       ├── update-workspace/ / update-workspace-instruction/
 │       ├── attach-skill-to-workspace/ / detach-skill-from-workspace/
@@ -101,6 +104,7 @@ workspaces/
 │   ├── mappers/workspace-member.mapper.ts
 │   ├── mappers/workspace-team-grant.mapper.ts
 │   ├── mappers/workspace-team-member-override.mapper.ts
+│   ├── mappers/workspace-sharing.mapper.ts
 │   ├── local-workspaces.repository.ts
 │   ├── local-workspace-access.repository.ts
 │   ├── local-workspace-members.repository.ts
@@ -109,6 +113,8 @@ workspaces/
 │   ├── local-workspace-team-grants-repository.module.ts
 │   ├── local-workspace-team-member-overrides.repository.ts
 │   ├── local-workspace-team-member-overrides-repository.module.ts
+│   ├── local-workspace-sharing-read.repository.ts
+│   ├── local-workspace-sharing-read-repository.module.ts
 │   └── local-workspaces-repository.module.ts
 ├── presenters/http/
 │   ├── workspaces.controller.ts

--- a/ayunis-core-backend/src/domain/workspaces/application/ports/workspace-sharing-read-repository.port.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/ports/workspace-sharing-read-repository.port.ts
@@ -1,0 +1,18 @@
+import type { UUID } from 'crypto';
+import type { WorkspaceMember } from 'src/domain/workspaces/application/ports/workspace-members-repository.port';
+import type { WorkspaceTeamGrant } from 'src/domain/workspaces/application/ports/workspace-team-grants-repository.port';
+import type { WorkspaceTeamMemberOverride } from 'src/domain/workspaces/application/ports/workspace-team-member-overrides-repository.port';
+
+export interface WorkspaceTeamGrantSharing extends WorkspaceTeamGrant {
+  id: UUID;
+  overrides: WorkspaceTeamMemberOverride[];
+}
+
+export interface WorkspaceSharingSnapshot {
+  members: WorkspaceMember[];
+  teamGrants: WorkspaceTeamGrantSharing[];
+}
+
+export abstract class WorkspaceSharingReadRepository {
+  abstract findSharing(workspaceId: UUID): Promise<WorkspaceSharingSnapshot>;
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-sharing/get-workspace-sharing.query.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-sharing/get-workspace-sharing.query.ts
@@ -1,0 +1,5 @@
+import type { UUID } from 'crypto';
+
+export class GetWorkspaceSharingQuery {
+  constructor(public readonly workspaceId: UUID) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-sharing/get-workspace-sharing.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-sharing/get-workspace-sharing.use-case.spec.ts
@@ -1,0 +1,94 @@
+import {
+  TEST_TEAM_ID,
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { GetWorkspaceSharingQuery } from './get-workspace-sharing.query';
+import { GetWorkspaceSharingUseCase } from './get-workspace-sharing.use-case';
+
+const GRANT_ID = '55555555-5555-4555-8555-555555555555' as const;
+
+describe('GetWorkspaceSharingUseCase', () => {
+  it('hydrates direct members, team grants and overrides', async () => {
+    const repository = {
+      findSharing: jest.fn().mockResolvedValue({
+        members: [
+          {
+            workspaceId: TEST_WORKSPACE_ID,
+            userId: TEST_USER_ID,
+            accessLevel: WorkspaceAccessLevel.EDIT,
+            status: WorkspaceMemberStatus.ACTIVE,
+          },
+        ],
+        teamGrants: [
+          {
+            id: GRANT_ID,
+            workspaceId: TEST_WORKSPACE_ID,
+            teamId: TEST_TEAM_ID,
+            accessLevel: WorkspaceAccessLevel.USE,
+            overrides: [
+              {
+                teamGrantId: GRANT_ID,
+                userId: TEST_USER_ID,
+                accessLevel: null,
+                excluded: true,
+              },
+            ],
+          },
+        ],
+      }),
+    };
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({}),
+    };
+    const findUsers = {
+      execute: jest.fn().mockResolvedValue([{ id: TEST_USER_ID, name: 'Ada' }]),
+    };
+    const listTeams = {
+      execute: jest
+        .fn()
+        .mockResolvedValue([
+          { team: { id: TEST_TEAM_ID, name: 'Service' }, memberCount: 2 },
+        ]),
+    };
+    const useCase = new GetWorkspaceSharingUseCase(
+      { info: jest.fn() } as never,
+      repository,
+      accessService as never,
+      findUsers as never,
+      listTeams as never,
+    );
+
+    await expect(
+      useCase.execute(new GetWorkspaceSharingQuery(TEST_WORKSPACE_ID)),
+    ).resolves.toEqual({
+      members: [
+        {
+          user: { id: TEST_USER_ID, name: 'Ada' },
+          accessLevel: WorkspaceAccessLevel.EDIT,
+          status: WorkspaceMemberStatus.ACTIVE,
+        },
+      ],
+      teamGrants: [
+        {
+          team: { id: TEST_TEAM_ID, name: 'Service' },
+          memberCount: 2,
+          accessLevel: WorkspaceAccessLevel.USE,
+          overrides: [
+            {
+              user: { id: TEST_USER_ID, name: 'Ada' },
+              accessLevel: null,
+              excluded: true,
+            },
+          ],
+        },
+      ],
+    });
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.FULL,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-sharing/get-workspace-sharing.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-sharing/get-workspace-sharing.use-case.ts
@@ -1,0 +1,98 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import {
+  WorkspaceSharingReadRepository,
+  type WorkspaceSharingSnapshot,
+} from 'src/domain/workspaces/application/ports/workspace-sharing-read-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { ListTeamsUseCase } from 'src/iam/teams/application/use-cases/list-teams/list-teams.use-case';
+import type { TeamWithMemberCount } from 'src/iam/teams/application/use-cases/list-teams/team-with-member-count.view';
+import { FindUsersByIdsQuery } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.query';
+import { FindUsersByIdsUseCase } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case';
+import type { User } from 'src/iam/users/domain/user.entity';
+import { GetWorkspaceSharingQuery } from './get-workspace-sharing.query';
+import type { WorkspaceSharingView } from './workspace-sharing.view';
+
+@Injectable()
+export class GetWorkspaceSharingUseCase {
+  constructor(
+    @InjectPinoLogger(GetWorkspaceSharingUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: WorkspaceSharingReadRepository,
+    private readonly accessService: WorkspaceAccessService,
+    private readonly findUsersByIdsUseCase: FindUsersByIdsUseCase,
+    private readonly listTeamsUseCase: ListTeamsUseCase,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(
+    query: GetWorkspaceSharingQuery,
+  ): Promise<WorkspaceSharingView> {
+    this.logger.info(
+      { workspaceId: query.workspaceId },
+      'Getting workspace sharing',
+    );
+    await this.accessService.requireAccessLevel(
+      query.workspaceId,
+      WorkspaceAccessLevel.FULL,
+    );
+    const snapshot = await this.repository.findSharing(query.workspaceId);
+    const [users, teams] = await Promise.all([
+      this.findUsers(snapshot),
+      this.listTeamsUseCase.execute(),
+    ]);
+    return this.toView(snapshot, users, teams);
+  }
+
+  private findUsers(snapshot: WorkspaceSharingSnapshot): Promise<User[]> {
+    const ids = new Set(snapshot.members.map(({ userId }) => userId));
+    for (const grant of snapshot.teamGrants) {
+      grant.overrides.forEach(({ userId }) => ids.add(userId));
+    }
+    return this.findUsersByIdsUseCase.execute(
+      new FindUsersByIdsQuery([...ids]),
+    );
+  }
+
+  private toView(
+    snapshot: WorkspaceSharingSnapshot,
+    users: User[],
+    teams: TeamWithMemberCount[],
+  ): WorkspaceSharingView {
+    const usersById = new Map(users.map((user) => [user.id, user]));
+    const teamsById = new Map(teams.map((team) => [team.team.id, team]));
+    return {
+      members: snapshot.members.flatMap((member) => {
+        const user = usersById.get(member.userId);
+        return user
+          ? [{ user, accessLevel: member.accessLevel, status: member.status }]
+          : [];
+      }),
+      teamGrants: snapshot.teamGrants.flatMap((grant) => {
+        const team = teamsById.get(grant.teamId);
+        if (!team) return [];
+        return [
+          {
+            ...team,
+            accessLevel: grant.accessLevel,
+            overrides: grant.overrides.flatMap((override) => {
+              const user = usersById.get(override.userId);
+              return user
+                ? [
+                    {
+                      user,
+                      accessLevel: override.accessLevel,
+                      excluded: override.excluded,
+                    },
+                  ]
+                : [];
+            }),
+          },
+        ];
+      }),
+    };
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-sharing/workspace-sharing.view.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-sharing/workspace-sharing.view.ts
@@ -1,0 +1,28 @@
+import type { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import type { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import type { Team } from 'src/iam/teams/domain/team.entity';
+import type { User } from 'src/iam/users/domain/user.entity';
+
+export interface WorkspaceSharingMemberView {
+  user: User;
+  accessLevel: WorkspaceAccessLevel;
+  status: WorkspaceMemberStatus;
+}
+
+export interface WorkspaceSharingOverrideView {
+  user: User;
+  accessLevel: WorkspaceAccessLevel | null;
+  excluded: boolean;
+}
+
+export interface WorkspaceSharingTeamGrantView {
+  team: Team;
+  memberCount: number;
+  accessLevel: WorkspaceAccessLevel;
+  overrides: WorkspaceSharingOverrideView[];
+}
+
+export interface WorkspaceSharingView {
+  members: WorkspaceSharingMemberView[];
+  teamGrants: WorkspaceSharingTeamGrantView[];
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-sharing-read-repository.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-sharing-read-repository.module.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { LocalWorkspaceSharingReadRepository } from './local-workspace-sharing-read.repository';
+import { WorkspaceMemberMapper } from './mappers/workspace-member.mapper';
+import { WorkspaceSharingMapper } from './mappers/workspace-sharing.mapper';
+import { WorkspaceTeamGrantMapper } from './mappers/workspace-team-grant.mapper';
+import { WorkspaceTeamMemberOverrideMapper } from './mappers/workspace-team-member-override.mapper';
+import { WorkspaceMemberRecord } from './schema/workspace-member.record';
+import { WorkspaceTeamGrantRecord } from './schema/workspace-team-grant.record';
+import { WorkspaceTeamMemberOverrideRecord } from './schema/workspace-team-member-override.record';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      WorkspaceMemberRecord,
+      WorkspaceTeamGrantRecord,
+      WorkspaceTeamMemberOverrideRecord,
+    ]),
+  ],
+  providers: [
+    LocalWorkspaceSharingReadRepository,
+    WorkspaceMemberMapper,
+    WorkspaceSharingMapper,
+    WorkspaceTeamGrantMapper,
+    WorkspaceTeamMemberOverrideMapper,
+  ],
+  exports: [LocalWorkspaceSharingReadRepository],
+})
+export class LocalWorkspaceSharingReadRepositoryModule {}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-sharing-read.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-sharing-read.repository.spec.ts
@@ -1,0 +1,58 @@
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Test } from '@nestjs/testing';
+import { TEST_WORKSPACE_ID } from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { LocalWorkspaceSharingReadRepository } from './local-workspace-sharing-read.repository';
+import { WorkspaceSharingMapper } from './mappers/workspace-sharing.mapper';
+import { WorkspaceMemberRecord } from './schema/workspace-member.record';
+import { WorkspaceTeamGrantRecord } from './schema/workspace-team-grant.record';
+import { WorkspaceTeamMemberOverrideRecord } from './schema/workspace-team-member-override.record';
+
+const GRANT_ID = '55555555-5555-4555-8555-555555555555' as const;
+
+describe('LocalWorkspaceSharingReadRepository', () => {
+  const memberRepository = { find: jest.fn() };
+  const grantRepository = { find: jest.fn() };
+  const overrideRepository = { find: jest.fn() };
+  const mapper = { toSnapshot: jest.fn() };
+  let repository: LocalWorkspaceSharingReadRepository;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module = await Test.createTestingModule({
+      providers: [
+        LocalWorkspaceSharingReadRepository,
+        {
+          provide: getRepositoryToken(WorkspaceMemberRecord),
+          useValue: memberRepository,
+        },
+        {
+          provide: getRepositoryToken(WorkspaceTeamGrantRecord),
+          useValue: grantRepository,
+        },
+        {
+          provide: getRepositoryToken(WorkspaceTeamMemberOverrideRecord),
+          useValue: overrideRepository,
+        },
+        { provide: WorkspaceSharingMapper, useValue: mapper },
+      ],
+    }).compile();
+    repository = module.get(LocalWorkspaceSharingReadRepository);
+  });
+
+  it('reads all sharing records without per-grant queries', async () => {
+    const members = [{ id: 'member-record' }];
+    const grants = [{ id: GRANT_ID }];
+    const overrides = [{ id: 'override-record', teamGrantId: GRANT_ID }];
+    const snapshot = { members: [], teamGrants: [] };
+    memberRepository.find.mockResolvedValue(members);
+    grantRepository.find.mockResolvedValue(grants);
+    overrideRepository.find.mockResolvedValue(overrides);
+    mapper.toSnapshot.mockReturnValue(snapshot);
+
+    await expect(repository.findSharing(TEST_WORKSPACE_ID)).resolves.toBe(
+      snapshot,
+    );
+    expect(mapper.toSnapshot).toHaveBeenCalledWith(members, grants, overrides);
+    expect(overrideRepository.find).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-sharing-read.repository.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-sharing-read.repository.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import type { UUID } from 'crypto';
+import { In, Repository } from 'typeorm';
+import {
+  WorkspaceSharingReadRepository,
+  type WorkspaceSharingSnapshot,
+} from 'src/domain/workspaces/application/ports/workspace-sharing-read-repository.port';
+import { WorkspaceSharingMapper } from './mappers/workspace-sharing.mapper';
+import { WorkspaceMemberRecord } from './schema/workspace-member.record';
+import { WorkspaceTeamGrantRecord } from './schema/workspace-team-grant.record';
+import { WorkspaceTeamMemberOverrideRecord } from './schema/workspace-team-member-override.record';
+
+@Injectable()
+export class LocalWorkspaceSharingReadRepository extends WorkspaceSharingReadRepository {
+  constructor(
+    @InjectRepository(WorkspaceMemberRecord)
+    private readonly memberRepository: Repository<WorkspaceMemberRecord>,
+    @InjectRepository(WorkspaceTeamGrantRecord)
+    private readonly grantRepository: Repository<WorkspaceTeamGrantRecord>,
+    @InjectRepository(WorkspaceTeamMemberOverrideRecord)
+    private readonly overrideRepository: Repository<WorkspaceTeamMemberOverrideRecord>,
+    private readonly mapper: WorkspaceSharingMapper,
+  ) {
+    super();
+  }
+
+  async findSharing(workspaceId: UUID): Promise<WorkspaceSharingSnapshot> {
+    const [members, grants] = await Promise.all([
+      this.memberRepository.find({ where: { workspaceId } }),
+      this.grantRepository.find({ where: { workspaceId } }),
+    ]);
+    const overrides = await this.findOverrides(grants);
+    return this.mapper.toSnapshot(members, grants, overrides);
+  }
+
+  private findOverrides(
+    grants: WorkspaceTeamGrantRecord[],
+  ): Promise<WorkspaceTeamMemberOverrideRecord[]> {
+    if (grants.length === 0) return Promise.resolve([]);
+    return this.overrideRepository.find({
+      where: { teamGrantId: In(grants.map(({ id }) => id)) },
+    });
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-sharing.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-sharing.mapper.spec.ts
@@ -1,0 +1,52 @@
+import {
+  TEST_TEAM_ID,
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { WorkspaceMemberMapper } from './workspace-member.mapper';
+import { WorkspaceSharingMapper } from './workspace-sharing.mapper';
+import { WorkspaceTeamGrantMapper } from './workspace-team-grant.mapper';
+import { WorkspaceTeamMemberOverrideMapper } from './workspace-team-member-override.mapper';
+
+const GRANT_ID = '55555555-5555-4555-8555-555555555555' as const;
+
+describe('WorkspaceSharingMapper', () => {
+  it('maps sharing records into a grouped snapshot', () => {
+    const mapper = new WorkspaceSharingMapper(
+      new WorkspaceMemberMapper(),
+      new WorkspaceTeamGrantMapper(),
+      new WorkspaceTeamMemberOverrideMapper(),
+    );
+    const member = new WorkspaceMemberMapper().toRecord({
+      workspaceId: TEST_WORKSPACE_ID,
+      userId: TEST_USER_ID,
+      accessLevel: WorkspaceAccessLevel.EDIT,
+      status: WorkspaceMemberStatus.ACTIVE,
+    });
+    const grant = new WorkspaceTeamGrantMapper().toRecord({
+      workspaceId: TEST_WORKSPACE_ID,
+      teamId: TEST_TEAM_ID,
+      accessLevel: WorkspaceAccessLevel.USE,
+    });
+    grant.id = GRANT_ID;
+    const override = new WorkspaceTeamMemberOverrideMapper().toRecord({
+      teamGrantId: GRANT_ID,
+      userId: TEST_USER_ID,
+      accessLevel: null,
+      excluded: true,
+    });
+
+    expect(mapper.toSnapshot([member], [grant], [override])).toEqual({
+      members: [expect.objectContaining({ userId: TEST_USER_ID })],
+      teamGrants: [
+        expect.objectContaining({
+          id: GRANT_ID,
+          teamId: TEST_TEAM_ID,
+          overrides: [expect.objectContaining({ excluded: true })],
+        }),
+      ],
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-sharing.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-sharing.mapper.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
+import type { WorkspaceSharingSnapshot } from 'src/domain/workspaces/application/ports/workspace-sharing-read-repository.port';
+import type { WorkspaceTeamMemberOverride } from 'src/domain/workspaces/application/ports/workspace-team-member-overrides-repository.port';
+import { WorkspaceMemberRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace-member.record';
+import { WorkspaceTeamGrantRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace-team-grant.record';
+import { WorkspaceTeamMemberOverrideRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace-team-member-override.record';
+import { WorkspaceMemberMapper } from './workspace-member.mapper';
+import { WorkspaceTeamGrantMapper } from './workspace-team-grant.mapper';
+import { WorkspaceTeamMemberOverrideMapper } from './workspace-team-member-override.mapper';
+
+@Injectable()
+export class WorkspaceSharingMapper {
+  constructor(
+    private readonly memberMapper: WorkspaceMemberMapper,
+    private readonly grantMapper: WorkspaceTeamGrantMapper,
+    private readonly overrideMapper: WorkspaceTeamMemberOverrideMapper,
+  ) {}
+
+  toSnapshot(
+    members: WorkspaceMemberRecord[],
+    grants: WorkspaceTeamGrantRecord[],
+    overrides: WorkspaceTeamMemberOverrideRecord[],
+  ): WorkspaceSharingSnapshot {
+    const overridesByGrantId = this.groupOverrides(overrides);
+    return {
+      members: members.map((record) => this.memberMapper.toDomain(record)),
+      teamGrants: grants.map((record) => ({
+        id: record.id,
+        ...this.grantMapper.toDomain(record),
+        overrides: overridesByGrantId.get(record.id) ?? [],
+      })),
+    };
+  }
+
+  private groupOverrides(
+    records: WorkspaceTeamMemberOverrideRecord[],
+  ): Map<UUID, WorkspaceTeamMemberOverride[]> {
+    const result = new Map<UUID, WorkspaceTeamMemberOverride[]>();
+    for (const record of records) {
+      const overrides = result.get(record.teamGrantId) ?? [];
+      overrides.push(this.overrideMapper.toDomain(record));
+      result.set(record.teamGrantId, overrides);
+    }
+    return result;
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
@@ -55,6 +55,10 @@ import { LocalWorkspaceTeamMemberOverridesRepository } from './infrastructure/pe
 import { LocalWorkspaceTeamMemberOverridesRepositoryModule } from './infrastructure/persistence/local/local-workspace-team-member-overrides-repository.module';
 import { SetWorkspaceTeamMemberOverrideUseCase } from './application/use-cases/set-workspace-team-member-override/set-workspace-team-member-override.use-case';
 import { ResetWorkspaceTeamMemberOverrideUseCase } from './application/use-cases/reset-workspace-team-member-override/reset-workspace-team-member-override.use-case';
+import { WorkspaceSharingReadRepository } from './application/ports/workspace-sharing-read-repository.port';
+import { LocalWorkspaceSharingReadRepository } from './infrastructure/persistence/local/local-workspace-sharing-read.repository';
+import { LocalWorkspaceSharingReadRepositoryModule } from './infrastructure/persistence/local/local-workspace-sharing-read-repository.module';
+import { GetWorkspaceSharingUseCase } from './application/use-cases/get-workspace-sharing/get-workspace-sharing.use-case';
 
 @Module({
   imports: [
@@ -62,6 +66,7 @@ import { ResetWorkspaceTeamMemberOverrideUseCase } from './application/use-cases
     LocalWorkspaceMembersRepositoryModule,
     LocalWorkspaceTeamGrantsRepositoryModule,
     LocalWorkspaceTeamMemberOverridesRepositoryModule,
+    LocalWorkspaceSharingReadRepositoryModule,
     forwardRef(() => FavoritesModule),
     forwardRef(() => SkillsModule),
     forwardRef(() => KnowledgeBasesModule),
@@ -91,6 +96,10 @@ import { ResetWorkspaceTeamMemberOverrideUseCase } from './application/use-cases
       provide: WorkspaceTeamMemberOverridesRepository,
       useExisting: LocalWorkspaceTeamMemberOverridesRepository,
     },
+    {
+      provide: WorkspaceSharingReadRepository,
+      useExisting: LocalWorkspaceSharingReadRepository,
+    },
     WorkspaceAccessPolicyService,
     WorkspaceAccessService,
     GetWorkspaceAccessUseCase,
@@ -104,6 +113,7 @@ import { ResetWorkspaceTeamMemberOverrideUseCase } from './application/use-cases
     RemoveWorkspaceTeamGrantUseCase,
     SetWorkspaceTeamMemberOverrideUseCase,
     ResetWorkspaceTeamMemberOverrideUseCase,
+    GetWorkspaceSharingUseCase,
     CreateWorkspaceUseCase,
     FindAllWorkspacesUseCase,
     FindWorkspaceUseCase,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a collaboration read path that will surface membership and team-grant data; access is gated on FULL workspace rights, but mis-wiring or a future HTTP layer would increase exposure of IAM-backed sharing state.
> 
> **Overview**
> Adds the **application-layer read model** for workspace sharing so callers can load direct members, team grants, and per-member overrides in one place—ahead of HTTP/frontend sharing UI.
> 
> Introduces `WorkspaceSharingReadRepository` and a local TypeORM implementation that loads members and team grants in parallel, then fetches all overrides in a **single batched query** (grouped onto grants via `WorkspaceSharingMapper`). **`GetWorkspaceSharingUseCase`** gates on `WorkspaceAccessLevel.FULL`, builds a `WorkspaceSharingView` by hydrating users (`FindUsersByIdsUseCase`) and teams (`ListTeamsUseCase`), and drops rows when the related user or team cannot be resolved.
> 
> Wires the new repository module and use case into `workspaces.module.ts` and updates `SUMMARY.md`. **No new HTTP routes** in this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22ed0717aa61a7e7d1e848f49ec317ec8f93e14e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->