### PR TITLE
wip(workspaces): list pending invitations (AYC-703)

### DIFF
--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -13,8 +13,8 @@ User-facing copy calls them "Projekte"; the code, tables and routes say
 `workspace` throughout. See AYC-700 / AYC-701 in the Workspaces/Projects plan.
 Workspace collaboration is being introduced in stack layers. Direct member
 invitations, team grants and team-member overrides now exist at the application
-boundary. The sharing read boundary returns hydrated members, grants and
-overrides; HTTP and frontend sharing flows follow later.
+boundary. Read boundaries return hydrated sharing state and the current user's
+pending invitations; HTTP and frontend sharing flows follow later.
 
 The whole module sits behind the `workspacesEnabled` feature flag
 (`FEATURE_WORKSPACES_ENABLED`, off by default), applied at the controller.
@@ -70,6 +70,7 @@ workspaces/
 │   ├── ports/workspace-team-grants-repository.port.ts
 │   ├── ports/workspace-team-member-overrides-repository.port.ts
 │   ├── ports/workspace-sharing-read-repository.port.ts
+│   ├── ports/workspace-invitations-read-repository.port.ts
 │   ├── testing/workspace.fixtures.ts
 │   └── use-cases/
 │       ├── create-workspace/
@@ -81,7 +82,7 @@ workspaces/
 │       ├── remove-workspace-team-grant/
 │       ├── set-workspace-team-member-override/
 │       ├── reset-workspace-team-member-override/
-│       ├── get-workspace-sharing/
+│       ├── get-workspace-sharing/ / list-my-workspace-invitations/
 │       ├── find-all-workspaces/ / find-workspaces-by-ids/ / find-workspace/
 │       ├── update-workspace/ / update-workspace-instruction/
 │       ├── attach-skill-to-workspace/ / detach-skill-from-workspace/
@@ -105,6 +106,7 @@ workspaces/
 │   ├── mappers/workspace-team-grant.mapper.ts
 │   ├── mappers/workspace-team-member-override.mapper.ts
 │   ├── mappers/workspace-sharing.mapper.ts
+│   ├── mappers/workspace-invitation.mapper.ts
 │   ├── local-workspaces.repository.ts
 │   ├── local-workspace-access.repository.ts
 │   ├── local-workspace-members.repository.ts
@@ -115,6 +117,8 @@ workspaces/
 │   ├── local-workspace-team-member-overrides-repository.module.ts
 │   ├── local-workspace-sharing-read.repository.ts
 │   ├── local-workspace-sharing-read-repository.module.ts
+│   ├── local-workspace-invitations-read.repository.ts
+│   ├── local-workspace-invitations-read-repository.module.ts
 │   └── local-workspaces-repository.module.ts
 ├── presenters/http/
 │   ├── workspaces.controller.ts

--- a/ayunis-core-backend/src/domain/workspaces/application/ports/workspace-invitations-read-repository.port.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/ports/workspace-invitations-read-repository.port.ts
@@ -1,0 +1,15 @@
+import type { UUID } from 'crypto';
+import type { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+
+export interface WorkspaceInvitation {
+  workspace: Workspace;
+  accessLevel: WorkspaceAccessLevel;
+}
+
+export abstract class WorkspaceInvitationsReadRepository {
+  abstract findPendingByUser(
+    userId: UUID,
+    orgId: UUID,
+  ): Promise<WorkspaceInvitation[]>;
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-my-workspace-invitations/list-my-workspace-invitations.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-my-workspace-invitations/list-my-workspace-invitations.use-case.spec.ts
@@ -1,0 +1,41 @@
+import type { ContextService } from 'src/common/context/services/context.service';
+import {
+  TEST_ORG_ID,
+  TEST_USER_ID,
+  aWorkspace,
+  createMockContextService,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { ListMyWorkspaceInvitationsUseCase } from './list-my-workspace-invitations.use-case';
+
+describe('ListMyWorkspaceInvitationsUseCase', () => {
+  it('lists pending invitations for the current user and organization', async () => {
+    const invitations = [
+      { workspace: aWorkspace(), accessLevel: WorkspaceAccessLevel.EDIT },
+    ];
+    const repository = {
+      findPendingByUser: jest.fn().mockResolvedValue(invitations),
+    };
+    const useCase = new ListMyWorkspaceInvitationsUseCase(
+      { info: jest.fn() } as never,
+      repository,
+      createMockContextService(),
+    );
+
+    await expect(useCase.execute()).resolves.toEqual(invitations);
+    expect(repository.findPendingByUser).toHaveBeenCalledWith(
+      TEST_USER_ID,
+      TEST_ORG_ID,
+    );
+  });
+
+  it('rejects requests without an authenticated user', async () => {
+    const useCase = new ListMyWorkspaceInvitationsUseCase(
+      { info: jest.fn() } as never,
+      {} as never,
+      { get: jest.fn() } as unknown as ContextService,
+    );
+
+    await expect(useCase.execute()).rejects.toThrow('Unauthorized');
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-my-workspace-invitations/list-my-workspace-invitations.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-my-workspace-invitations/list-my-workspace-invitations.use-case.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { ContextService } from 'src/common/context/services/context.service';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import {
+  WorkspaceInvitationsReadRepository,
+  type WorkspaceInvitation,
+} from 'src/domain/workspaces/application/ports/workspace-invitations-read-repository.port';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+
+@Injectable()
+export class ListMyWorkspaceInvitationsUseCase {
+  constructor(
+    @InjectPinoLogger(ListMyWorkspaceInvitationsUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: WorkspaceInvitationsReadRepository,
+    private readonly contextService: ContextService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(): Promise<WorkspaceInvitation[]> {
+    const userId = this.contextService.get('userId');
+    const orgId = this.contextService.get('orgId');
+    if (!userId || !orgId) throw new UnauthorizedAccessError();
+    this.logger.info({ userId, orgId }, 'Listing workspace invitations');
+    return this.repository.findPendingByUser(userId, orgId);
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-invitations-read-repository.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-invitations-read-repository.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { LocalWorkspaceInvitationsReadRepository } from './local-workspace-invitations-read.repository';
+import { WorkspaceInvitationMapper } from './mappers/workspace-invitation.mapper';
+import { WorkspaceMapper } from './mappers/workspace.mapper';
+import { WorkspaceMemberRecord } from './schema/workspace-member.record';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([WorkspaceMemberRecord])],
+  providers: [
+    LocalWorkspaceInvitationsReadRepository,
+    WorkspaceInvitationMapper,
+    WorkspaceMapper,
+  ],
+  exports: [LocalWorkspaceInvitationsReadRepository],
+})
+export class LocalWorkspaceInvitationsReadRepositoryModule {}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-invitations-read.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-invitations-read.repository.spec.ts
@@ -1,0 +1,52 @@
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Test } from '@nestjs/testing';
+import {
+  TEST_ORG_ID,
+  TEST_USER_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { LocalWorkspaceInvitationsReadRepository } from './local-workspace-invitations-read.repository';
+import { WorkspaceInvitationMapper } from './mappers/workspace-invitation.mapper';
+import { WorkspaceMemberRecord } from './schema/workspace-member.record';
+
+describe('LocalWorkspaceInvitationsReadRepository', () => {
+  const typeormRepository = { find: jest.fn() };
+  const mapper = { toView: jest.fn() };
+  let repository: LocalWorkspaceInvitationsReadRepository;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module = await Test.createTestingModule({
+      providers: [
+        LocalWorkspaceInvitationsReadRepository,
+        {
+          provide: getRepositoryToken(WorkspaceMemberRecord),
+          useValue: typeormRepository,
+        },
+        { provide: WorkspaceInvitationMapper, useValue: mapper },
+      ],
+    }).compile();
+    repository = module.get(LocalWorkspaceInvitationsReadRepository);
+  });
+
+  it('lists only pending invitations in the current organization', async () => {
+    const records = [{ id: 'invitation-record' }];
+    const invitations = [
+      { workspace: { id: 'workspace-id' }, accessLevel: 'edit' },
+    ];
+    typeormRepository.find.mockResolvedValue(records);
+    mapper.toView.mockReturnValue(invitations[0]);
+
+    await expect(
+      repository.findPendingByUser(TEST_USER_ID, TEST_ORG_ID),
+    ).resolves.toEqual(invitations);
+    expect(typeormRepository.find).toHaveBeenCalledWith({
+      relations: { workspace: true },
+      where: {
+        userId: TEST_USER_ID,
+        status: WorkspaceMemberStatus.PENDING,
+        workspace: { orgId: TEST_ORG_ID },
+      },
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-invitations-read.repository.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-invitations-read.repository.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import type { UUID } from 'crypto';
+import { Repository } from 'typeorm';
+import {
+  WorkspaceInvitationsReadRepository,
+  type WorkspaceInvitation,
+} from 'src/domain/workspaces/application/ports/workspace-invitations-read-repository.port';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceInvitationMapper } from './mappers/workspace-invitation.mapper';
+import { WorkspaceMemberRecord } from './schema/workspace-member.record';
+
+@Injectable()
+export class LocalWorkspaceInvitationsReadRepository extends WorkspaceInvitationsReadRepository {
+  constructor(
+    @InjectRepository(WorkspaceMemberRecord)
+    private readonly repository: Repository<WorkspaceMemberRecord>,
+    private readonly mapper: WorkspaceInvitationMapper,
+  ) {
+    super();
+  }
+
+  async findPendingByUser(
+    userId: UUID,
+    orgId: UUID,
+  ): Promise<WorkspaceInvitation[]> {
+    const records = await this.repository.find({
+      relations: { workspace: true },
+      where: {
+        userId,
+        status: WorkspaceMemberStatus.PENDING,
+        workspace: { orgId },
+      },
+    });
+    return records.map((record) => this.mapper.toView(record));
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-invitation.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-invitation.mapper.spec.ts
@@ -1,0 +1,26 @@
+import {
+  TEST_USER_ID,
+  aWorkspace,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { WorkspaceMemberRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace-member.record';
+import { WorkspaceInvitationMapper } from './workspace-invitation.mapper';
+import { WorkspaceMapper } from './workspace.mapper';
+
+describe('WorkspaceInvitationMapper', () => {
+  it('maps an invitation record and its workspace', () => {
+    const workspace = aWorkspace();
+    const record = new WorkspaceMemberRecord();
+    record.workspace = new WorkspaceMapper().toRecord(workspace);
+    record.userId = TEST_USER_ID;
+    record.accessLevel = WorkspaceAccessLevel.EDIT;
+    record.status = WorkspaceMemberStatus.PENDING;
+    const mapper = new WorkspaceInvitationMapper(new WorkspaceMapper());
+
+    expect(mapper.toView(record)).toEqual({
+      workspace,
+      accessLevel: WorkspaceAccessLevel.EDIT,
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-invitation.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/mappers/workspace-invitation.mapper.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import type { WorkspaceInvitation } from 'src/domain/workspaces/application/ports/workspace-invitations-read-repository.port';
+import { WorkspaceMemberRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace-member.record';
+import { WorkspaceMapper } from './workspace.mapper';
+
+@Injectable()
+export class WorkspaceInvitationMapper {
+  constructor(private readonly workspaceMapper: WorkspaceMapper) {}
+
+  toView(record: WorkspaceMemberRecord): WorkspaceInvitation {
+    return {
+      workspace: this.workspaceMapper.toDomain(record.workspace),
+      accessLevel: record.accessLevel,
+    };
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
@@ -59,6 +59,10 @@ import { WorkspaceSharingReadRepository } from './application/ports/workspace-sh
 import { LocalWorkspaceSharingReadRepository } from './infrastructure/persistence/local/local-workspace-sharing-read.repository';
 import { LocalWorkspaceSharingReadRepositoryModule } from './infrastructure/persistence/local/local-workspace-sharing-read-repository.module';
 import { GetWorkspaceSharingUseCase } from './application/use-cases/get-workspace-sharing/get-workspace-sharing.use-case';
+import { WorkspaceInvitationsReadRepository } from './application/ports/workspace-invitations-read-repository.port';
+import { LocalWorkspaceInvitationsReadRepository } from './infrastructure/persistence/local/local-workspace-invitations-read.repository';
+import { LocalWorkspaceInvitationsReadRepositoryModule } from './infrastructure/persistence/local/local-workspace-invitations-read-repository.module';
+import { ListMyWorkspaceInvitationsUseCase } from './application/use-cases/list-my-workspace-invitations/list-my-workspace-invitations.use-case';
 
 @Module({
   imports: [
@@ -67,6 +71,7 @@ import { GetWorkspaceSharingUseCase } from './application/use-cases/get-workspac
     LocalWorkspaceTeamGrantsRepositoryModule,
     LocalWorkspaceTeamMemberOverridesRepositoryModule,
     LocalWorkspaceSharingReadRepositoryModule,
+    LocalWorkspaceInvitationsReadRepositoryModule,
     forwardRef(() => FavoritesModule),
     forwardRef(() => SkillsModule),
     forwardRef(() => KnowledgeBasesModule),
@@ -100,6 +105,10 @@ import { GetWorkspaceSharingUseCase } from './application/use-cases/get-workspac
       provide: WorkspaceSharingReadRepository,
       useExisting: LocalWorkspaceSharingReadRepository,
     },
+    {
+      provide: WorkspaceInvitationsReadRepository,
+      useExisting: LocalWorkspaceInvitationsReadRepository,
+    },
     WorkspaceAccessPolicyService,
     WorkspaceAccessService,
     GetWorkspaceAccessUseCase,
@@ -114,6 +123,7 @@ import { GetWorkspaceSharingUseCase } from './application/use-cases/get-workspac
     SetWorkspaceTeamMemberOverrideUseCase,
     ResetWorkspaceTeamMemberOverrideUseCase,
     GetWorkspaceSharingUseCase,
+    ListMyWorkspaceInvitationsUseCase,
     CreateWorkspaceUseCase,
     FindAllWorkspacesUseCase,
     FindWorkspaceUseCase,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Read-only, org-scoped listing keyed off the authenticated user context; no new HTTP surface or invitation state mutations.
> 
> **Overview**
> Adds an application-layer **read path** so the signed-in user can load their **pending workspace invitations** (workspace + offered access level), ahead of HTTP/frontend sharing UI.
> 
> Introduces `WorkspaceInvitationsReadRepository` and `ListMyWorkspaceInvitationsUseCase`, which reads `userId`/`orgId` from request context and returns `Unauthorized` when either is missing. The local TypeORM implementation treats **pending** `workspace_members` rows as invitations, loads the related workspace, and filters by the current organization.
> 
> Wiring includes `WorkspaceInvitationMapper`, a dedicated Nest persistence module, and unit tests for the use case, repository query, and mapper. **`SUMMARY.md`** documents the new read boundary; there is **no new HTTP route** in this change, and the use case is registered in `WorkspacesModule` but not exported yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4004e0856200f8b3abf76d08efa9ed8c45b2d6c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->