### PR TITLE
wip(workspaces): authorize shared reads and updates (AYC-703)

### DIFF
--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -21,7 +21,8 @@ The whole module sits behind the `workspacesEnabled` feature flag
 
 ## Domain Concepts
 
-- **Workspace** — owned by exactly one user and scoped to their org.
+- **Workspace** — owned by exactly one user and scoped to their org. Shared
+  users need `use` to read workspace metadata and `edit` to update it.
 - **Per-user favorite state** — owned by the favorites module; a workspace row
   carries no pin or order state. Access checks stay with the workspace use
   cases — favorites trusts its callers.

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspace/find-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspace/find-workspace.use-case.spec.ts
@@ -1,25 +1,21 @@
 import { Test } from '@nestjs/testing';
 import { getLoggerToken } from 'nestjs-pino';
 import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
-import { ContextService } from 'src/common/context/services/context.service';
-import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
-import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
 import {
-  aWorkspace,
-  createMockContextService,
-  createMockWorkspacesRepository,
-  TEST_USER_ID,
   TEST_WORKSPACE_ID,
+  aWorkspace,
 } from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { FindWorkspaceQuery } from './find-workspace.query';
 import { FindWorkspaceUseCase } from './find-workspace.use-case';
 
 describe('FindWorkspaceUseCase', () => {
-  let useCase: FindWorkspaceUseCase;
-  let repository: jest.Mocked<WorkspacesRepository>;
-
-  beforeEach(async () => {
-    repository = createMockWorkspacesRepository();
+  it('returns a workspace available with use access', async () => {
+    const workspace = aWorkspace();
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({ workspace }),
+    };
     const module = await Test.createTestingModule({
       providers: [
         FindWorkspaceUseCase,
@@ -27,35 +23,17 @@ describe('FindWorkspaceUseCase', () => {
           provide: getLoggerToken(FindWorkspaceUseCase.name),
           useValue: createPinoLoggerMock(),
         },
-        { provide: WorkspacesRepository, useValue: repository },
-        { provide: ContextService, useValue: createMockContextService() },
+        { provide: WorkspaceAccessService, useValue: accessService },
       ],
     }).compile();
-    useCase = module.get(FindWorkspaceUseCase);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('returns the workspace scoped to the caller', async () => {
-    const workspace = aWorkspace();
-    repository.findById.mockResolvedValue(workspace);
+    const useCase = module.get(FindWorkspaceUseCase);
 
     await expect(
       useCase.execute(new FindWorkspaceQuery(TEST_WORKSPACE_ID)),
     ).resolves.toBe(workspace);
-    expect(repository.findById).toHaveBeenCalledWith(
-      TEST_USER_ID,
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
       TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.USE,
     );
-  });
-
-  it('throws when the workspace does not belong to the caller', async () => {
-    repository.findById.mockResolvedValue(null);
-
-    await expect(
-      useCase.execute(new FindWorkspaceQuery(TEST_WORKSPACE_ID)),
-    ).rejects.toThrow(WorkspaceNotFoundError);
   });
 });

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspace/find-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspace/find-workspace.use-case.ts
@@ -1,15 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
-import type { UUID } from 'crypto';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
-import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
-import {
-  UnexpectedWorkspaceError,
-  WorkspaceNotFoundError,
-} from 'src/domain/workspaces/application/workspaces.errors';
 import { FindWorkspaceQuery } from './find-workspace.query';
 
 @Injectable()
@@ -17,29 +12,16 @@ export class FindWorkspaceUseCase {
   constructor(
     @InjectPinoLogger(FindWorkspaceUseCase.name)
     private readonly logger: PinoLogger,
-    private readonly workspacesRepository: WorkspacesRepository,
-    private readonly contextService: ContextService,
+    private readonly accessService: WorkspaceAccessService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(query: FindWorkspaceQuery): Promise<Workspace> {
     this.logger.info({ workspaceId: query.id }, 'Finding workspace');
-
-    const workspace = await this.workspacesRepository.findById(
-      this.resolveUserId(),
+    const { workspace } = await this.accessService.requireAccessLevel(
       query.id,
+      WorkspaceAccessLevel.USE,
     );
-    if (!workspace) {
-      throw new WorkspaceNotFoundError(query.id);
-    }
     return workspace;
-  }
-
-  private resolveUserId(): UUID {
-    const userId = this.contextService.get('userId');
-    if (!userId) {
-      throw new UnauthorizedAccessError();
-    }
-    return userId;
   }
 }

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace/update-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace/update-workspace.use-case.spec.ts
@@ -1,18 +1,19 @@
 import { Test } from '@nestjs/testing';
 import { getLoggerToken } from 'nestjs-pino';
 import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
-import { ContextService } from 'src/common/context/services/context.service';
 import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
 import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
 import {
   InvalidWorkspaceAppearanceError,
   InvalidWorkspaceDescriptionError,
 } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { WORKSPACE_DESCRIPTION_MAX_LENGTH } from 'src/domain/workspaces/domain/workspaces.constants';
 import {
   aWorkspace,
-  createMockContextService,
   createMockWorkspacesRepository,
+  TEST_USER_ID,
   TEST_WORKSPACE_ID,
 } from 'src/domain/workspaces/application/testing/workspace.fixtures';
 import { UpdateWorkspaceCommand } from './update-workspace.command';
@@ -21,9 +22,15 @@ import { UpdateWorkspaceUseCase } from './update-workspace.use-case';
 describe('UpdateWorkspaceUseCase', () => {
   let useCase: UpdateWorkspaceUseCase;
   let repository: jest.Mocked<WorkspacesRepository>;
+  let accessService: { requireAccessLevel: jest.Mock };
 
   beforeEach(async () => {
     repository = createMockWorkspacesRepository();
+    accessService = {
+      requireAccessLevel: jest.fn().mockImplementation(async () => ({
+        workspace: await repository.findById(TEST_USER_ID, TEST_WORKSPACE_ID),
+      })),
+    };
     const module = await Test.createTestingModule({
       providers: [
         UpdateWorkspaceUseCase,
@@ -32,7 +39,7 @@ describe('UpdateWorkspaceUseCase', () => {
           useValue: createPinoLoggerMock(),
         },
         { provide: WorkspacesRepository, useValue: repository },
-        { provide: ContextService, useValue: createMockContextService() },
+        { provide: WorkspaceAccessService, useValue: accessService },
       ],
     }).compile();
     useCase = module.get(UpdateWorkspaceUseCase);
@@ -59,6 +66,10 @@ describe('UpdateWorkspaceUseCase', () => {
     expect(updated.color).toBe('#112233');
     expect(updated.description).toBe('Beschreibung');
     expect(updated.icon).toBe('folder');
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.EDIT,
+    );
   });
 
   it('clears the description when null is sent', async () => {
@@ -134,8 +145,10 @@ describe('UpdateWorkspaceUseCase', () => {
     expect(updated.updatedAt).toEqual(before);
   });
 
-  it('throws when the workspace does not belong to the caller', async () => {
-    repository.findById.mockResolvedValue(null);
+  it('throws when the workspace is unavailable to the caller', async () => {
+    accessService.requireAccessLevel.mockRejectedValue(
+      new WorkspaceNotFoundError(TEST_WORKSPACE_ID),
+    );
 
     await expect(
       useCase.execute(

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace/update-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace/update-workspace.use-case.ts
@@ -1,16 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
-import type { UUID } from 'crypto';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
-import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
-import {
-  UnexpectedWorkspaceError,
-  WorkspaceNotFoundError,
-} from 'src/domain/workspaces/application/workspaces.errors';
-import { assertValidWorkspaceFields } from '../../util/workspace-fields';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { assertValidWorkspaceFields } from 'src/domain/workspaces/application/util/workspace-fields';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import { UpdateWorkspaceCommand } from './update-workspace.command';
 
 @Injectable()
@@ -19,21 +15,16 @@ export class UpdateWorkspaceUseCase {
     @InjectPinoLogger(UpdateWorkspaceUseCase.name)
     private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
-    private readonly contextService: ContextService,
+    private readonly accessService: WorkspaceAccessService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(command: UpdateWorkspaceCommand): Promise<Workspace> {
     this.logger.info({ workspaceId: command.id }, 'Updating workspace');
-
-    const workspace = await this.workspacesRepository.findById(
-      this.resolveUserId(),
+    const { workspace } = await this.accessService.requireAccessLevel(
       command.id,
+      WorkspaceAccessLevel.EDIT,
     );
-    if (!workspace) {
-      throw new WorkspaceNotFoundError(command.id);
-    }
-
     assertValidWorkspaceFields(command);
 
     if (command.name !== undefined) {
@@ -47,13 +38,5 @@ export class UpdateWorkspaceUseCase {
     }
 
     return await this.workspacesRepository.save(workspace);
-  }
-
-  private resolveUserId(): UUID {
-    const userId = this.contextService.get('userId');
-    if (!userId) {
-      throw new UnauthorizedAccessError();
-    }
-    return userId;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes authorization for workspace read/update from owner-scoped repository lookups to shared-access policy, which affects who can see or mutate workspace metadata.
> 
> **Overview**
> **Find** and **update workspace** no longer load rows only for the owning user via `WorkspacesRepository.findById` and `ContextService`. Both use cases now go through `WorkspaceAccessService.requireAccessLevel` with **`USE`** for reads and **`EDIT`** for metadata updates, so shared members with sufficient grants can read or edit workspace fields under the collaboration policy.
> 
> Per-use-case user resolution and not-found checks tied to ownership are removed in favor of centralized access resolution (owner, direct membership, team grants, org visibility). Tests mock `WorkspaceAccessService` and assert the required access levels; module docs note that shared users need `use` / `edit` for these operations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e36192d57bb89658ff2898f20803b20ea606def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->