### PR TITLE
wip(workspaces): authorize shared runtime context (AYC-703)

### DIFF
--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -44,8 +44,9 @@ The whole module sits behind the `workspacesEnabled` feature flag
 - **Creation** — `CreateWorkspaceUseCase` saves the workspace, then calls
   `AddFavoriteUseCase` so new workspaces appear in the user's favorites.
 - **Context assignments** — workspace skills and knowledge bases are reference-only join rows into shared module-owned records. Direct workspace documents are owned uploads: adding one creates a source and a workspace-source assignment, while removal/deletion passes that source through `DeleteSourceUseCase` so indexed data and object-storage files are purged.
-- **Run context** — `BuildWorkspaceRunContextUseCase` resolves the workspace's
-  instruction, skills, knowledge bases, documents and MCP integrations. The
+- **Run context** — `BuildWorkspaceRunContextUseCase` requires `use` access and
+  resolves the workspace's instruction, skills, knowledge bases, documents and
+  MCP integrations through `WorkspaceRunContextResolverService`. The
   runs module merges that context into tool assembly and the system prompt for
   chats whose `Thread.workspaceId` is set.
 
@@ -65,6 +66,7 @@ workspaces/
 │   ├── events/
 │   │   └── workspace-deletion-requested.event.ts
 │   ├── services/workspace-access.service.ts
+│   ├── services/workspace-run-context-resolver.service.ts
 │   ├── ports/workspaces-repository.port.ts
 │   ├── ports/workspace-access-repository.port.ts
 │   ├── ports/workspace-members-repository.port.ts

--- a/ayunis-core-backend/src/domain/workspaces/application/services/workspace-run-context-resolver.service.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/services/workspace-run-context-resolver.service.spec.ts
@@ -1,0 +1,27 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { WorkspaceRunContextResolverService } from './workspace-run-context-resolver.service';
+
+describe('WorkspaceRunContextResolverService', () => {
+  it('resolves empty workspace references', async () => {
+    const service = new WorkspaceRunContextResolverService(
+      createPinoLoggerMock(),
+      { execute: jest.fn() } as never,
+      { execute: jest.fn().mockResolvedValue([]) } as never,
+      { execute: jest.fn().mockResolvedValue([]) } as never,
+      {
+        countSourcesByKnowledgeBaseIds: jest.fn().mockResolvedValue(new Map()),
+      } as never,
+    );
+
+    await expect(
+      service.resolve({ skillIds: [], knowledgeBases: [], sourceIds: [] }),
+    ).resolves.toEqual({
+      skills: [],
+      knowledgeBases: [],
+      sources: [],
+      runtimeKnowledgeBases: [],
+      runtimeSources: [],
+      mcpIntegrationIds: [],
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/services/workspace-run-context-resolver.service.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/services/workspace-run-context-resolver.service.ts
@@ -1,0 +1,160 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import type { UUID } from 'crypto';
+import { KnowledgeBaseNotFoundError } from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
+import { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
+import { GetKnowledgeBasesByIdsQuery } from 'src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.query';
+import { GetKnowledgeBasesByIdsUseCase } from 'src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.use-case';
+import { SkillNotFoundError } from 'src/domain/skills/application/skills.errors';
+import { FindOneSkillQuery } from 'src/domain/skills/application/use-cases/find-one-skill/find-one-skill.query';
+import { FindOneSkillUseCase } from 'src/domain/skills/application/use-cases/find-one-skill/find-one-skill.use-case';
+import type { Skill } from 'src/domain/skills/domain/skill.entity';
+import { GetSourcesByIdsQuery } from 'src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.query';
+import { GetSourcesByIdsUseCase } from 'src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case';
+import type { WorkspaceContextRefs } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import type {
+  WorkspaceKnowledgeBaseContext,
+  WorkspaceRunContext,
+} from 'src/domain/workspaces/domain/workspace-run-context.entity';
+
+type WorkspaceRunResources = Omit<WorkspaceRunContext, 'instruction'>;
+
+@Injectable()
+export class WorkspaceRunContextResolverService {
+  constructor(
+    @InjectPinoLogger(WorkspaceRunContextResolverService.name)
+    private readonly logger: PinoLogger,
+    private readonly findOneSkillUseCase: FindOneSkillUseCase,
+    private readonly getSourcesByIdsUseCase: GetSourcesByIdsUseCase,
+    private readonly getKnowledgeBasesByIdsUseCase: GetKnowledgeBasesByIdsUseCase,
+    private readonly knowledgeBaseAccessService: KnowledgeBaseAccessService,
+  ) {}
+
+  async resolve(refs: WorkspaceContextRefs): Promise<WorkspaceRunResources> {
+    const [skills, knowledgeBases] = await Promise.all([
+      this.findAssignedSkills(refs.skillIds),
+      this.findAssignedKnowledgeBases(refs.knowledgeBases),
+    ]);
+    const sourceIds = this.unique([
+      ...refs.sourceIds,
+      ...skills.flatMap((skill) => skill.sourceIds),
+    ]);
+    const [runtimeSources, skillKnowledgeBases] = await Promise.all([
+      this.getSourcesByIdsUseCase.execute(new GetSourcesByIdsQuery(sourceIds)),
+      this.getSkillKnowledgeBases(skills),
+    ]);
+    const workspaceSourceIds = new Set(refs.sourceIds);
+    return {
+      skills,
+      knowledgeBases,
+      sources: runtimeSources.filter((source) =>
+        workspaceSourceIds.has(source.id),
+      ),
+      runtimeKnowledgeBases: this.mergeKnowledgeBases(
+        knowledgeBases,
+        skillKnowledgeBases,
+      ),
+      runtimeSources,
+      mcpIntegrationIds: this.unique(
+        skills.flatMap((skill) => skill.mcpIntegrationIds),
+      ),
+    };
+  }
+
+  private async findAssignedSkills(skillIds: UUID[]): Promise<Skill[]> {
+    const results = await Promise.all(
+      skillIds.map((skillId) => this.findAssignedSkill(skillId)),
+    );
+    return results.filter((skill): skill is Skill => skill !== null);
+  }
+
+  private async findAssignedSkill(skillId: UUID): Promise<Skill | null> {
+    try {
+      const result = await this.findOneSkillUseCase.execute(
+        new FindOneSkillQuery(skillId),
+      );
+      return result.skill;
+    } catch (error) {
+      if (!(error instanceof SkillNotFoundError)) throw error;
+      this.logger.warn('Skipping inaccessible workspace skill assignment', {
+        skillId,
+      });
+      return null;
+    }
+  }
+
+  private async findAssignedKnowledgeBases(
+    knowledgeBases: WorkspaceKnowledgeBaseContext[],
+  ): Promise<WorkspaceKnowledgeBaseContext[]> {
+    const results = await Promise.all(
+      knowledgeBases.map((knowledgeBase) =>
+        this.findAssignedKnowledgeBase(knowledgeBase),
+      ),
+    );
+    const accessible = results.filter(
+      (knowledgeBase): knowledgeBase is WorkspaceKnowledgeBaseContext =>
+        knowledgeBase !== null,
+    );
+    return this.withDocumentCounts(accessible);
+  }
+
+  private async findAssignedKnowledgeBase(
+    knowledgeBase: WorkspaceKnowledgeBaseContext,
+  ): Promise<WorkspaceKnowledgeBaseContext | null> {
+    try {
+      await this.knowledgeBaseAccessService.findAccessibleKnowledgeBase(
+        knowledgeBase.id,
+      );
+      return knowledgeBase;
+    } catch (error) {
+      if (!(error instanceof KnowledgeBaseNotFoundError)) throw error;
+      this.logger.warn('Skipping inaccessible workspace knowledge base', {
+        knowledgeBaseId: knowledgeBase.id,
+      });
+      return null;
+    }
+  }
+
+  private async withDocumentCounts(
+    knowledgeBases: WorkspaceKnowledgeBaseContext[],
+  ): Promise<WorkspaceKnowledgeBaseContext[]> {
+    const counts =
+      await this.knowledgeBaseAccessService.countSourcesByKnowledgeBaseIds(
+        knowledgeBases.map(({ id }) => id),
+      );
+    return knowledgeBases.map((knowledgeBase) => ({
+      ...knowledgeBase,
+      documentCount: counts.get(knowledgeBase.id) ?? 0,
+    }));
+  }
+
+  private async getSkillKnowledgeBases(
+    skills: Skill[],
+  ): Promise<WorkspaceKnowledgeBaseContext[]> {
+    const ids = this.unique(skills.flatMap((skill) => skill.knowledgeBaseIds));
+    const knowledgeBases = await this.getKnowledgeBasesByIdsUseCase.execute(
+      new GetKnowledgeBasesByIdsQuery(ids),
+    );
+    return knowledgeBases.map((knowledgeBase) => ({
+      id: knowledgeBase.id,
+      name: knowledgeBase.name,
+      description: knowledgeBase.description,
+      documentCount: 0,
+    }));
+  }
+
+  private mergeKnowledgeBases(
+    workspaceKnowledgeBases: WorkspaceKnowledgeBaseContext[],
+    skillKnowledgeBases: WorkspaceKnowledgeBaseContext[],
+  ): WorkspaceKnowledgeBaseContext[] {
+    const seen = new Set(workspaceKnowledgeBases.map(({ id }) => id));
+    return [
+      ...workspaceKnowledgeBases,
+      ...skillKnowledgeBases.filter(({ id }) => !seen.has(id)),
+    ];
+  }
+
+  private unique(ids: UUID[]): UUID[] {
+    return [...new Set(ids)];
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/build-workspace-run-context/build-workspace-run-context.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/build-workspace-run-context/build-workspace-run-context.use-case.spec.ts
@@ -7,13 +7,14 @@ import type { FindOneSkillUseCase } from 'src/domain/skills/application/use-case
 import type { GetKnowledgeBasesByIdsUseCase } from 'src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.use-case';
 import type { GetSourcesByIdsUseCase } from 'src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case';
 import type { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
+import { WorkspaceRunContextResolverService } from 'src/domain/workspaces/application/services/workspace-run-context-resolver.service';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import {
-  createMockContextService,
   createMockWorkspacesRepository,
   TEST_USER_ID,
   TEST_WORKSPACE_ID,
   aWorkspace,
-} from '../../testing/workspace.fixtures';
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
 import { BuildWorkspaceRunContextQuery } from './build-workspace-run-context.query';
 import { BuildWorkspaceRunContextUseCase } from './build-workspace-run-context.use-case';
 
@@ -66,14 +67,25 @@ describe('BuildWorkspaceRunContextUseCase', () => {
       findAccessibleKnowledgeBase: jest.fn().mockResolvedValue({}),
       countSourcesByKnowledgeBaseIds: jest.fn().mockResolvedValue(new Map()),
     } as unknown as jest.Mocked<KnowledgeBaseAccessService>;
-    const useCase = new BuildWorkspaceRunContextUseCase(
+    const resolver = new WorkspaceRunContextResolverService(
       createPinoLoggerMock(),
-      repository,
       findOneSkillUseCase,
       getSourcesByIdsUseCase,
       getKnowledgeBasesByIdsUseCase,
       knowledgeBaseAccessService,
-      createMockContextService(),
+    );
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({
+        workspace: aWorkspace({
+          instruction: 'Use building department wording.',
+        }),
+      }),
+    };
+    const useCase = new BuildWorkspaceRunContextUseCase(
+      createPinoLoggerMock(),
+      repository,
+      accessService as never,
+      resolver,
     );
 
     const result = await useCase.execute(
@@ -81,6 +93,10 @@ describe('BuildWorkspaceRunContextUseCase', () => {
     );
 
     expect(result.instruction).toBe('Use building department wording.');
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.USE,
+    );
     expect(result.skills).toEqual([skill]);
     expect(result.knowledgeBases).toHaveLength(1);
     expect(result.sources).toEqual([source]);
@@ -125,14 +141,22 @@ describe('BuildWorkspaceRunContextUseCase', () => {
       findAccessibleKnowledgeBase: jest.fn().mockResolvedValue({}),
       countSourcesByKnowledgeBaseIds: jest.fn().mockResolvedValue(new Map()),
     } as unknown as jest.Mocked<KnowledgeBaseAccessService>;
-    const useCase = new BuildWorkspaceRunContextUseCase(
+    const resolver = new WorkspaceRunContextResolverService(
       createPinoLoggerMock(),
-      repository,
       findOneSkillUseCase,
       getSourcesByIdsUseCase,
       getKnowledgeBasesByIdsUseCase,
       knowledgeBaseAccessService,
-      createMockContextService(),
+    );
+    const useCase = new BuildWorkspaceRunContextUseCase(
+      createPinoLoggerMock(),
+      repository,
+      {
+        requireAccessLevel: jest
+          .fn()
+          .mockResolvedValue({ workspace: aWorkspace() }),
+      } as never,
+      resolver,
     );
 
     const result = await useCase.execute(
@@ -183,14 +207,22 @@ describe('BuildWorkspaceRunContextUseCase', () => {
         ),
       countSourcesByKnowledgeBaseIds: jest.fn().mockResolvedValue(new Map()),
     } as unknown as jest.Mocked<KnowledgeBaseAccessService>;
-    const useCase = new BuildWorkspaceRunContextUseCase(
+    const resolver = new WorkspaceRunContextResolverService(
       createPinoLoggerMock(),
-      repository,
       findOneSkillUseCase,
       getSourcesByIdsUseCase,
       getKnowledgeBasesByIdsUseCase,
       knowledgeBaseAccessService,
-      createMockContextService(),
+    );
+    const useCase = new BuildWorkspaceRunContextUseCase(
+      createPinoLoggerMock(),
+      repository,
+      {
+        requireAccessLevel: jest
+          .fn()
+          .mockResolvedValue({ workspace: aWorkspace() }),
+      } as never,
+      resolver,
     );
 
     const result = await useCase.execute(

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/build-workspace-run-context/build-workspace-run-context.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/build-workspace-run-context/build-workspace-run-context.use-case.ts
@@ -1,29 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
-import type { UUID } from 'crypto';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
-import { FindOneSkillUseCase } from 'src/domain/skills/application/use-cases/find-one-skill/find-one-skill.use-case';
-import { FindOneSkillQuery } from 'src/domain/skills/application/use-cases/find-one-skill/find-one-skill.query';
-import { GetKnowledgeBasesByIdsUseCase } from 'src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.use-case';
-import { GetKnowledgeBasesByIdsQuery } from 'src/domain/knowledge-bases/application/use-cases/get-knowledge-bases-by-ids/get-knowledge-bases-by-ids.query';
-import { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
-import { KnowledgeBaseNotFoundError } from 'src/domain/knowledge-bases/application/knowledge-bases.errors';
-import { GetSourcesByIdsUseCase } from 'src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.use-case';
-import { GetSourcesByIdsQuery } from 'src/domain/sources/application/use-cases/get-sources-by-ids/get-sources-by-ids.query';
-import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
-import type { Skill } from 'src/domain/skills/domain/skill.entity';
-import { SkillNotFoundError } from 'src/domain/skills/application/skills.errors';
-import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
-import type {
-  WorkspaceKnowledgeBaseContext,
-  WorkspaceRunContext,
-} from 'src/domain/workspaces/domain/workspace-run-context.entity';
-import {
-  UnexpectedWorkspaceError,
-  WorkspaceNotFoundError,
-} from '../../workspaces.errors';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { WorkspaceRunContextResolverService } from 'src/domain/workspaces/application/services/workspace-run-context-resolver.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import type { WorkspaceRunContext } from 'src/domain/workspaces/domain/workspace-run-context.entity';
 import { BuildWorkspaceRunContextQuery } from './build-workspace-run-context.query';
 
 @Injectable()
@@ -32,11 +15,8 @@ export class BuildWorkspaceRunContextUseCase {
     @InjectPinoLogger(BuildWorkspaceRunContextUseCase.name)
     private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
-    private readonly findOneSkillUseCase: FindOneSkillUseCase,
-    private readonly getSourcesByIdsUseCase: GetSourcesByIdsUseCase,
-    private readonly getKnowledgeBasesByIdsUseCase: GetKnowledgeBasesByIdsUseCase,
-    private readonly knowledgeBaseAccessService: KnowledgeBaseAccessService,
-    private readonly contextService: ContextService,
+    private readonly accessService: WorkspaceAccessService,
+    private readonly resolver: WorkspaceRunContextResolverService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
@@ -47,157 +27,14 @@ export class BuildWorkspaceRunContextUseCase {
       { workspaceId: query.workspaceId },
       'buildWorkspaceRunContext',
     );
-    const workspace = await this.findWorkspace(query.workspaceId);
-
+    const { workspace } = await this.accessService.requireAccessLevel(
+      query.workspaceId,
+      WorkspaceAccessLevel.USE,
+    );
     const refs = await this.workspacesRepository.getContextRefs(
       query.workspaceId,
     );
-    const [skills, knowledgeBases] = await Promise.all([
-      this.findAssignedSkills(refs.skillIds),
-      this.findAssignedKnowledgeBases(refs.knowledgeBases),
-    ]);
-    const sourceIds = this.collectRuntimeSourceIds(refs.sourceIds, skills);
-    const [runtimeSources, skillKnowledgeBases] = await Promise.all([
-      this.getSourcesByIdsUseCase.execute(new GetSourcesByIdsQuery(sourceIds)),
-      this.getSkillKnowledgeBases(skills),
-    ]);
-    const workspaceSourceIds = new Set(refs.sourceIds);
-    const workspaceSources = runtimeSources.filter((source) =>
-      workspaceSourceIds.has(source.id),
-    );
-    const runtimeKnowledgeBases = this.mergeKnowledgeBases(
-      knowledgeBases,
-      skillKnowledgeBases,
-    );
-
-    return {
-      instruction: workspace.instruction,
-      skills,
-      knowledgeBases,
-      sources: workspaceSources,
-      runtimeKnowledgeBases,
-      runtimeSources,
-      mcpIntegrationIds: this.unique(
-        skills.flatMap((skill) => skill.mcpIntegrationIds),
-      ),
-    };
-  }
-
-  private async findWorkspace(workspaceId: UUID): Promise<Workspace> {
-    const userId = this.contextService.get('userId');
-    if (!userId) throw new UnauthorizedAccessError();
-
-    const workspace = await this.workspacesRepository.findById(
-      userId,
-      workspaceId,
-    );
-    if (!workspace) throw new WorkspaceNotFoundError(workspaceId);
-    return workspace;
-  }
-
-  private collectRuntimeSourceIds(sourceIds: UUID[], skills: Skill[]): UUID[] {
-    return this.unique([
-      ...sourceIds,
-      ...skills.flatMap((skill) => skill.sourceIds),
-    ]);
-  }
-
-  private async findAssignedSkills(skillIds: UUID[]): Promise<Skill[]> {
-    const skillResults = await Promise.all(
-      skillIds.map((skillId) => this.findAssignedSkill(skillId)),
-    );
-    return skillResults.filter((skill): skill is Skill => skill !== null);
-  }
-
-  private async findAssignedSkill(skillId: UUID): Promise<Skill | null> {
-    try {
-      const result = await this.findOneSkillUseCase.execute(
-        new FindOneSkillQuery(skillId),
-      );
-      return result.skill;
-    } catch (error) {
-      if (!(error instanceof SkillNotFoundError)) throw error;
-      this.logger.warn('Skipping inaccessible workspace skill assignment', {
-        skillId,
-      });
-      return null;
-    }
-  }
-
-  private async findAssignedKnowledgeBases(
-    knowledgeBases: WorkspaceKnowledgeBaseContext[],
-  ): Promise<WorkspaceKnowledgeBaseContext[]> {
-    const results = await Promise.all(
-      knowledgeBases.map((knowledgeBase) =>
-        this.findAssignedKnowledgeBase(knowledgeBase),
-      ),
-    );
-    const accessibleKnowledgeBases = results.filter(
-      (knowledgeBase): knowledgeBase is WorkspaceKnowledgeBaseContext =>
-        knowledgeBase !== null,
-    );
-    return this.withDocumentCounts(accessibleKnowledgeBases);
-  }
-
-  private async findAssignedKnowledgeBase(
-    knowledgeBase: WorkspaceKnowledgeBaseContext,
-  ): Promise<WorkspaceKnowledgeBaseContext | null> {
-    try {
-      await this.knowledgeBaseAccessService.findAccessibleKnowledgeBase(
-        knowledgeBase.id,
-      );
-      return knowledgeBase;
-    } catch (error) {
-      if (!(error instanceof KnowledgeBaseNotFoundError)) throw error;
-      this.logger.warn('Skipping inaccessible workspace knowledge base', {
-        knowledgeBaseId: knowledgeBase.id,
-      });
-      return null;
-    }
-  }
-
-  private async withDocumentCounts(
-    knowledgeBases: WorkspaceKnowledgeBaseContext[],
-  ): Promise<WorkspaceKnowledgeBaseContext[]> {
-    const documentCounts =
-      await this.knowledgeBaseAccessService.countSourcesByKnowledgeBaseIds(
-        knowledgeBases.map((knowledgeBase) => knowledgeBase.id),
-      );
-    return knowledgeBases.map((knowledgeBase) => ({
-      ...knowledgeBase,
-      documentCount: documentCounts.get(knowledgeBase.id) ?? 0,
-    }));
-  }
-
-  private async getSkillKnowledgeBases(
-    skills: Skill[],
-  ): Promise<WorkspaceKnowledgeBaseContext[]> {
-    const knowledgeBaseIds = this.unique(
-      skills.flatMap((skill) => skill.knowledgeBaseIds),
-    );
-    const knowledgeBases = await this.getKnowledgeBasesByIdsUseCase.execute(
-      new GetKnowledgeBasesByIdsQuery(knowledgeBaseIds),
-    );
-    return knowledgeBases.map((kb) => ({
-      id: kb.id,
-      name: kb.name,
-      description: kb.description,
-      documentCount: 0,
-    }));
-  }
-
-  private mergeKnowledgeBases(
-    workspaceKnowledgeBases: WorkspaceKnowledgeBaseContext[],
-    skillKnowledgeBases: WorkspaceKnowledgeBaseContext[],
-  ): WorkspaceKnowledgeBaseContext[] {
-    const seen = new Set(workspaceKnowledgeBases.map((kb) => kb.id));
-    return [
-      ...workspaceKnowledgeBases,
-      ...skillKnowledgeBases.filter((kb) => !seen.has(kb.id)),
-    ];
-  }
-
-  private unique(ids: UUID[]): UUID[] {
-    return [...new Set(ids)];
+    const resources = await this.resolver.resolve(refs);
+    return { instruction: workspace.instruction, ...resources };
   }
 }

--- a/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
@@ -24,6 +24,7 @@ import { AddDocumentToWorkspaceUseCase } from './application/use-cases/add-docum
 import { RemoveDocumentFromWorkspaceUseCase } from './application/use-cases/remove-document-from-workspace/remove-document-from-workspace.use-case';
 import { UpdateWorkspaceInstructionUseCase } from './application/use-cases/update-workspace-instruction/update-workspace-instruction.use-case';
 import { BuildWorkspaceRunContextUseCase } from './application/use-cases/build-workspace-run-context/build-workspace-run-context.use-case';
+import { WorkspaceRunContextResolverService } from './application/services/workspace-run-context-resolver.service';
 import { ListWorkspaceSkillCandidatesUseCase } from './application/use-cases/list-workspace-skill-candidates/list-workspace-skill-candidates.use-case';
 import { ListWorkspaceKnowledgeBaseCandidatesUseCase } from './application/use-cases/list-workspace-knowledge-base-candidates/list-workspace-knowledge-base-candidates.use-case';
 import { ListWorkspaceSkillsUseCase } from './application/use-cases/list-workspace-skills/list-workspace-skills.use-case';
@@ -137,6 +138,7 @@ import { ListMyWorkspaceInvitationsUseCase } from './application/use-cases/list-
     AddDocumentToWorkspaceUseCase,
     RemoveDocumentFromWorkspaceUseCase,
     UpdateWorkspaceInstructionUseCase,
+    WorkspaceRunContextResolverService,
     BuildWorkspaceRunContextUseCase,
     ListWorkspaceSkillCandidatesUseCase,
     ListWorkspaceKnowledgeBaseCandidatesUseCase,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes authorization on a path consumed by chat runs: users who previously failed owner-only lookup may now succeed with shared access, and denied callers get access-policy errors instead of not-found.
> 
> **Overview**
> **Build workspace run context** now gates on **`WorkspaceAccessService.requireAccessLevel`** with **`USE`** instead of loading the workspace via **`findById` for the current user only**, so collaborators with shared access can build runtime context the same way owners can.
> 
> Resolution of skills, knowledge bases, sources, merged runtime KBs, and MCP IDs is moved into new **`WorkspaceRunContextResolverService`** (same skip-inaccessible-assignment behavior as before). **`BuildWorkspaceRunContextUseCase`** only enforces access, loads context refs, calls the resolver, and attaches the workspace instruction. The workspaces module registers the resolver; docs and specs are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 857ba74be8ce5e77ade65cffc7b11375a3401eb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->