### PR TITLE
wip(workspaces): authorize shared context reads (AYC-703)

### DIFF
--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -22,7 +22,8 @@ The whole module sits behind the `workspacesEnabled` feature flag
 ## Domain Concepts
 
 - **Workspace** — owned by exactly one user and scoped to their org. Shared
-  users need `use` to read workspace metadata and `edit` to update it.
+  users need `use` to read workspace metadata and attached context, and `edit`
+to update it.
 - **Per-user favorite state** — owned by the favorites module; a workspace row
   carries no pin or order state. Access checks stay with the workspace use
   cases — favorites trusts its callers.

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-documents/list-workspace-documents.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-documents/list-workspace-documents.use-case.spec.ts
@@ -1,10 +1,9 @@
 import type { UUID } from 'crypto';
-import type { ContextService } from 'src/common/context/services/context.service';
 import { Paginated } from 'src/common/pagination/paginated.entity';
 import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { ListSourcesByWorkspaceUseCase } from 'src/domain/sources/application/use-cases/list-sources-by-workspace/list-sources-by-workspace.use-case';
 import type { Source } from 'src/domain/sources/domain/source.entity';
-import type { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { ListWorkspaceDocumentsUseCase } from './list-workspace-documents.use-case';
 import { ListWorkspaceDocumentsQuery } from './list-workspace-documents.query';
 
@@ -17,20 +16,16 @@ describe('ListWorkspaceDocumentsUseCase', () => {
       offset: 4,
       total: 5,
     });
-    const workspacesRepository = {
-      findById: jest.fn().mockResolvedValue({}),
-    } as unknown as jest.Mocked<WorkspacesRepository>;
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({}),
+    };
     const listSourcesByWorkspaceUseCase = {
       execute: jest.fn().mockResolvedValue(page),
     } as unknown as jest.Mocked<ListSourcesByWorkspaceUseCase>;
-    const contextService = {
-      get: jest.fn().mockReturnValue('223e4567-e89b-12d3-a456-426614174001'),
-    } as unknown as jest.Mocked<ContextService>;
     const useCase = new ListWorkspaceDocumentsUseCase(
       createPinoLoggerMock(),
-      workspacesRepository,
       listSourcesByWorkspaceUseCase,
-      contextService,
+      accessService as never,
     );
 
     const result = await useCase.execute(
@@ -43,6 +38,10 @@ describe('ListWorkspaceDocumentsUseCase', () => {
     );
 
     expect(result).toBe(page);
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      workspaceId,
+      WorkspaceAccessLevel.USE,
+    );
     expect(listSourcesByWorkspaceUseCase.execute).toHaveBeenCalledWith(
       expect.objectContaining({
         workspaceId,

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-documents/list-workspace-documents.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-documents/list-workspace-documents.use-case.ts
@@ -1,17 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { Paginated } from 'src/common/pagination/paginated.entity';
-import { ListSourcesByWorkspaceUseCase } from 'src/domain/sources/application/use-cases/list-sources-by-workspace/list-sources-by-workspace.use-case';
 import { ListSourcesByWorkspaceQuery } from 'src/domain/sources/application/use-cases/list-sources-by-workspace/list-sources-by-workspace.query';
+import { ListSourcesByWorkspaceUseCase } from 'src/domain/sources/application/use-cases/list-sources-by-workspace/list-sources-by-workspace.use-case';
 import type { Source } from 'src/domain/sources/domain/source.entity';
-import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
-import {
-  UnexpectedWorkspaceError,
-  WorkspaceNotFoundError,
-} from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { ListWorkspaceDocumentsQuery } from './list-workspace-documents.query';
 
 @Injectable()
@@ -19,28 +15,22 @@ export class ListWorkspaceDocumentsUseCase {
   constructor(
     @InjectPinoLogger(ListWorkspaceDocumentsUseCase.name)
     private readonly logger: PinoLogger,
-    private readonly workspacesRepository: WorkspacesRepository,
     private readonly listSourcesByWorkspaceUseCase: ListSourcesByWorkspaceUseCase,
-    private readonly contextService: ContextService,
+    private readonly accessService: WorkspaceAccessService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(
     query: ListWorkspaceDocumentsQuery,
   ): Promise<Paginated<Source>> {
-    const userId = this.contextService.get('userId');
-    if (!userId) throw new UnauthorizedAccessError();
-
     this.logger.info(
       { workspaceId: query.workspaceId },
       'listWorkspaceDocuments',
     );
-    const workspace = await this.workspacesRepository.findById(
-      userId,
+    await this.accessService.requireAccessLevel(
       query.workspaceId,
+      WorkspaceAccessLevel.USE,
     );
-    if (!workspace) throw new WorkspaceNotFoundError(query.workspaceId);
-
     return this.listSourcesByWorkspaceUseCase.execute(
       new ListSourcesByWorkspaceQuery({
         workspaceId: query.workspaceId,

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-bases/list-workspace-knowledge-bases.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-bases/list-workspace-knowledge-bases.use-case.spec.ts
@@ -1,10 +1,9 @@
 import type { UUID } from 'crypto';
-import type { ContextService } from 'src/common/context/services/context.service';
 import { Paginated } from 'src/common/pagination/paginated.entity';
 import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
-import type { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { ListWorkspaceKnowledgeBasesUseCase } from './list-workspace-knowledge-bases.use-case';
 import { ListWorkspaceKnowledgeBasesQuery } from './list-workspace-knowledge-bases.query';
 
@@ -24,23 +23,19 @@ describe('ListWorkspaceKnowledgeBasesUseCase', () => {
       offset: 4,
       total: 5,
     });
-    const workspacesRepository = {
-      findById: jest.fn().mockResolvedValue({}),
-    } as unknown as jest.Mocked<WorkspacesRepository>;
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({}),
+    };
     const knowledgeBaseAccessService = {
       findAllAccessiblePaginated: jest.fn().mockResolvedValue(page),
       countSourcesByKnowledgeBaseIds: jest
         .fn()
         .mockResolvedValue(new Map([[knowledgeBase.id, 3]])),
     } as unknown as jest.Mocked<KnowledgeBaseAccessService>;
-    const contextService = {
-      get: jest.fn().mockReturnValue('523e4567-e89b-12d3-a456-426614174004'),
-    } as unknown as jest.Mocked<ContextService>;
     const useCase = new ListWorkspaceKnowledgeBasesUseCase(
       createPinoLoggerMock(),
-      workspacesRepository,
       knowledgeBaseAccessService,
-      contextService,
+      accessService as never,
     );
 
     const result = await useCase.execute(
@@ -61,6 +56,10 @@ describe('ListWorkspaceKnowledgeBasesUseCase', () => {
       },
     ]);
     expect(result.total).toBe(5);
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      workspaceId,
+      WorkspaceAccessLevel.USE,
+    );
     expect(
       knowledgeBaseAccessService.findAllAccessiblePaginated,
     ).toHaveBeenCalledWith(workspaceId, {

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-bases/list-workspace-knowledge-bases.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-bases/list-workspace-knowledge-bases.use-case.ts
@@ -1,16 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { Paginated } from 'src/common/pagination/paginated.entity';
 import { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import type { WorkspaceKnowledgeBaseContext } from 'src/domain/workspaces/domain/workspace-run-context.entity';
-import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
-import {
-  UnexpectedWorkspaceError,
-  WorkspaceNotFoundError,
-} from 'src/domain/workspaces/application/workspaces.errors';
 import { ListWorkspaceKnowledgeBasesQuery } from './list-workspace-knowledge-bases.query';
 
 @Injectable()
@@ -18,28 +14,22 @@ export class ListWorkspaceKnowledgeBasesUseCase {
   constructor(
     @InjectPinoLogger(ListWorkspaceKnowledgeBasesUseCase.name)
     private readonly logger: PinoLogger,
-    private readonly workspacesRepository: WorkspacesRepository,
     private readonly knowledgeBaseAccessService: KnowledgeBaseAccessService,
-    private readonly contextService: ContextService,
+    private readonly accessService: WorkspaceAccessService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(
     query: ListWorkspaceKnowledgeBasesQuery,
   ): Promise<Paginated<WorkspaceKnowledgeBaseContext>> {
-    const userId = this.contextService.get('userId');
-    if (!userId) throw new UnauthorizedAccessError();
-
     this.logger.info(
       { workspaceId: query.workspaceId },
       'listWorkspaceKnowledgeBases',
     );
-    const workspace = await this.workspacesRepository.findById(
-      userId,
+    await this.accessService.requireAccessLevel(
       query.workspaceId,
+      WorkspaceAccessLevel.USE,
     );
-    if (!workspace) throw new WorkspaceNotFoundError(query.workspaceId);
-
     const page =
       await this.knowledgeBaseAccessService.findAllAccessiblePaginated(
         query.workspaceId,

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skills/list-workspace-skills.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skills/list-workspace-skills.use-case.spec.ts
@@ -1,10 +1,9 @@
 import type { UUID } from 'crypto';
-import type { ContextService } from 'src/common/context/services/context.service';
 import { Paginated } from 'src/common/pagination/paginated.entity';
 import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { ListAccessibleSkillsUseCase } from 'src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.use-case';
 import { Skill } from 'src/domain/skills/domain/skill.entity';
-import type { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { ListWorkspaceSkillsUseCase } from './list-workspace-skills.use-case';
 import { ListWorkspaceSkillsQuery } from './list-workspace-skills.query';
 
@@ -24,20 +23,16 @@ describe('ListWorkspaceSkillsUseCase', () => {
       offset: 4,
       total: 5,
     });
-    const workspacesRepository = {
-      findById: jest.fn().mockResolvedValue({}),
-    } as unknown as jest.Mocked<WorkspacesRepository>;
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({}),
+    };
     const listAccessibleSkillsUseCase = {
       execute: jest.fn().mockResolvedValue(page),
     } as unknown as jest.Mocked<ListAccessibleSkillsUseCase>;
-    const contextService = {
-      get: jest.fn().mockReturnValue('423e4567-e89b-12d3-a456-426614174003'),
-    } as unknown as jest.Mocked<ContextService>;
     const useCase = new ListWorkspaceSkillsUseCase(
       createPinoLoggerMock(),
-      workspacesRepository,
       listAccessibleSkillsUseCase,
-      contextService,
+      accessService as never,
     );
 
     const result = await useCase.execute(
@@ -50,6 +45,10 @@ describe('ListWorkspaceSkillsUseCase', () => {
     );
 
     expect(result).toBe(page);
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      workspaceId,
+      WorkspaceAccessLevel.USE,
+    );
     expect(listAccessibleSkillsUseCase.execute).toHaveBeenCalledWith(
       expect.objectContaining({
         search: 'citizen',

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skills/list-workspace-skills.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skills/list-workspace-skills.use-case.ts
@@ -1,17 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { Paginated } from 'src/common/pagination/paginated.entity';
-import { ListAccessibleSkillsUseCase } from 'src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.use-case';
 import { ListAccessibleSkillsQuery } from 'src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.query';
+import { ListAccessibleSkillsUseCase } from 'src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.use-case';
 import type { Skill } from 'src/domain/skills/domain/skill.entity';
-import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
-import {
-  UnexpectedWorkspaceError,
-  WorkspaceNotFoundError,
-} from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { ListWorkspaceSkillsQuery } from './list-workspace-skills.query';
 
 @Injectable()
@@ -19,23 +15,17 @@ export class ListWorkspaceSkillsUseCase {
   constructor(
     @InjectPinoLogger(ListWorkspaceSkillsUseCase.name)
     private readonly logger: PinoLogger,
-    private readonly workspacesRepository: WorkspacesRepository,
     private readonly listAccessibleSkillsUseCase: ListAccessibleSkillsUseCase,
-    private readonly contextService: ContextService,
+    private readonly accessService: WorkspaceAccessService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(query: ListWorkspaceSkillsQuery): Promise<Paginated<Skill>> {
-    const userId = this.contextService.get('userId');
-    if (!userId) throw new UnauthorizedAccessError();
-
     this.logger.info({ workspaceId: query.workspaceId }, 'listWorkspaceSkills');
-    const workspace = await this.workspacesRepository.findById(
-      userId,
+    await this.accessService.requireAccessLevel(
       query.workspaceId,
+      WorkspaceAccessLevel.USE,
     );
-    if (!workspace) throw new WorkspaceNotFoundError(query.workspaceId);
-
     return this.listAccessibleSkillsUseCase.execute(
       new ListAccessibleSkillsQuery({
         workspaceId: query.workspaceId,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes authorization on workspace context read APIs; behavior shifts for shared/team/org access and may expose lists to users who were previously denied under owner-only lookup.
> 
> **Overview**
> **Workspace context list endpoints** (`list-workspace-documents`, `list-workspace-knowledge-bases`, `list-workspace-skills`) now gate reads through `WorkspaceAccessService.requireAccessLevel(..., USE)` instead of loading the workspace via `WorkspacesRepository.findById` for the current user only.
> 
> That aligns paginated skills, knowledge bases, and documents with the collaboration model so **shared collaborators with `use` access** can read attached context, not just the owner. Unit tests mock the access service and assert the `USE` requirement.
> 
> **Docs:** `SUMMARY.md` states that `use` covers workspace metadata **and** attached context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 511d363c3d6199165478f487e3e255178585106c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->