### PR TITLE
wip(workspaces): authorize context candidates (AYC-703)

### DIFF
--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -23,7 +23,7 @@ The whole module sits behind the `workspacesEnabled` feature flag
 
 - **Workspace** — owned by exactly one user and scoped to their org. Shared
   users need `use` to read workspace metadata and attached context, and `edit`
-to update it.
+to update it or browse attachment candidates.
 - **Per-user favorite state** — owned by the favorites module; a workspace row
   carries no pin or order state. Access checks stay with the workspace use
   cases — favorites trusts its callers.

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-base-candidates/list-workspace-knowledge-base-candidates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-base-candidates/list-workspace-knowledge-base-candidates.use-case.spec.ts
@@ -1,10 +1,10 @@
 import type { UUID } from 'crypto';
-import type { ContextService } from 'src/common/context/services/context.service';
 import { Paginated } from 'src/common/pagination/paginated.entity';
 import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
 import { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
 import type { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { ListWorkspaceKnowledgeBaseCandidatesUseCase } from './list-workspace-knowledge-base-candidates.use-case';
 import { ListWorkspaceKnowledgeBaseCandidatesQuery } from './list-workspace-knowledge-base-candidates.query';
 
@@ -46,14 +46,14 @@ describe('ListWorkspaceKnowledgeBaseCandidatesUseCase', () => {
         .fn()
         .mockResolvedValue(new Map([[knowledgeBaseId, 0]])),
     } as unknown as jest.Mocked<KnowledgeBaseAccessService>;
-    const contextService = {
-      get: jest.fn().mockReturnValue('523e4567-e89b-12d3-a456-426614174004'),
-    } as unknown as jest.Mocked<ContextService>;
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({}),
+    };
     const useCase = new ListWorkspaceKnowledgeBaseCandidatesUseCase(
       createPinoLoggerMock(),
       workspacesRepository,
       knowledgeBaseAccessService,
-      contextService,
+      accessService as never,
     );
 
     const result = await useCase.execute(
@@ -69,6 +69,10 @@ describe('ListWorkspaceKnowledgeBaseCandidatesUseCase', () => {
       { knowledgeBase, documentCount: 0, isAttached: true },
     ]);
     expect(result.total).toBe(5);
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      workspaceId,
+      WorkspaceAccessLevel.EDIT,
+    );
     expect(
       knowledgeBaseAccessService.findAllAccessiblePaginated,
     ).toHaveBeenCalledWith(undefined, {

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-base-candidates/list-workspace-knowledge-base-candidates.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-knowledge-base-candidates/list-workspace-knowledge-base-candidates.use-case.ts
@@ -1,16 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { Paginated } from 'src/common/pagination/paginated.entity';
 import { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
 import type { KnowledgeBase } from 'src/domain/knowledge-bases/domain/knowledge-base.entity';
-import { Paginated } from 'src/common/pagination/paginated.entity';
 import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
-import {
-  UnexpectedWorkspaceError,
-  WorkspaceNotFoundError,
-} from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { ListWorkspaceKnowledgeBaseCandidatesQuery } from './list-workspace-knowledge-base-candidates.query';
 
 export interface WorkspaceKnowledgeBaseCandidate {
@@ -26,7 +23,7 @@ export class ListWorkspaceKnowledgeBaseCandidatesUseCase {
     private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
     private readonly knowledgeBaseAccessService: KnowledgeBaseAccessService,
-    private readonly contextService: ContextService,
+    private readonly accessService: WorkspaceAccessService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
@@ -34,20 +31,13 @@ export class ListWorkspaceKnowledgeBaseCandidatesUseCase {
     query: ListWorkspaceKnowledgeBaseCandidatesQuery,
   ): Promise<Paginated<WorkspaceKnowledgeBaseCandidate>> {
     this.logger.info(
-      {
-        workspaceId: query.workspaceId,
-      },
+      { workspaceId: query.workspaceId },
       'listWorkspaceKnowledgeBaseCandidates',
     );
-    const userId = this.contextService.get('userId');
-    if (!userId) throw new UnauthorizedAccessError();
-
-    const workspace = await this.workspacesRepository.findById(
-      userId,
+    await this.accessService.requireAccessLevel(
       query.workspaceId,
+      WorkspaceAccessLevel.EDIT,
     );
-    if (!workspace) throw new WorkspaceNotFoundError(query.workspaceId);
-
     const [accessible, refs] = await Promise.all([
       this.knowledgeBaseAccessService.findAllAccessiblePaginated(undefined, {
         search: query.search,

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skill-candidates/list-workspace-skill-candidates.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skill-candidates/list-workspace-skill-candidates.use-case.spec.ts
@@ -1,10 +1,10 @@
 import type { UUID } from 'crypto';
-import type { ContextService } from 'src/common/context/services/context.service';
 import { Paginated } from 'src/common/pagination/paginated.entity';
 import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { ListAccessibleSkillsUseCase } from 'src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.use-case';
 import { Skill } from 'src/domain/skills/domain/skill.entity';
 import type { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { ListWorkspaceSkillCandidatesUseCase } from './list-workspace-skill-candidates.use-case';
 import { ListWorkspaceSkillCandidatesQuery } from './list-workspace-skill-candidates.query';
 
@@ -36,14 +36,14 @@ describe('ListWorkspaceSkillCandidatesUseCase', () => {
     const listAccessibleSkillsUseCase = {
       execute: jest.fn().mockResolvedValue(page),
     } as unknown as jest.Mocked<ListAccessibleSkillsUseCase>;
-    const contextService = {
-      get: jest.fn().mockReturnValue('423e4567-e89b-12d3-a456-426614174003'),
-    } as unknown as jest.Mocked<ContextService>;
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({}),
+    };
     const useCase = new ListWorkspaceSkillCandidatesUseCase(
       createPinoLoggerMock(),
       workspacesRepository,
       listAccessibleSkillsUseCase,
-      contextService,
+      accessService as never,
     );
 
     const result = await useCase.execute(
@@ -57,6 +57,10 @@ describe('ListWorkspaceSkillCandidatesUseCase', () => {
 
     expect(result.data).toEqual([{ skill, isAttached: true }]);
     expect(result.total).toBe(5);
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      workspaceId,
+      WorkspaceAccessLevel.EDIT,
+    );
     expect(listAccessibleSkillsUseCase.execute).toHaveBeenCalledWith(
       expect.objectContaining({
         search: 'citizen',

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skill-candidates/list-workspace-skill-candidates.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-skill-candidates/list-workspace-skill-candidates.use-case.ts
@@ -1,17 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
-import { ListAccessibleSkillsUseCase } from 'src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.use-case';
-import { ListAccessibleSkillsQuery } from 'src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.query';
 import { Paginated } from 'src/common/pagination/paginated.entity';
+import { ListAccessibleSkillsQuery } from 'src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.query';
+import { ListAccessibleSkillsUseCase } from 'src/domain/skills/application/use-cases/list-accessible-skills/list-accessible-skills.use-case';
 import type { Skill } from 'src/domain/skills/domain/skill.entity';
 import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
-import {
-  UnexpectedWorkspaceError,
-  WorkspaceNotFoundError,
-} from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { ListWorkspaceSkillCandidatesQuery } from './list-workspace-skill-candidates.query';
 
 export interface WorkspaceSkillCandidate {
@@ -26,7 +23,7 @@ export class ListWorkspaceSkillCandidatesUseCase {
     private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
     private readonly listAccessibleSkillsUseCase: ListAccessibleSkillsUseCase,
-    private readonly contextService: ContextService,
+    private readonly accessService: WorkspaceAccessService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
@@ -34,20 +31,13 @@ export class ListWorkspaceSkillCandidatesUseCase {
     query: ListWorkspaceSkillCandidatesQuery,
   ): Promise<Paginated<WorkspaceSkillCandidate>> {
     this.logger.info(
-      {
-        workspaceId: query.workspaceId,
-      },
+      { workspaceId: query.workspaceId },
       'listWorkspaceSkillCandidates',
     );
-    const userId = this.contextService.get('userId');
-    if (!userId) throw new UnauthorizedAccessError();
-
-    const workspace = await this.workspacesRepository.findById(
-      userId,
+    await this.accessService.requireAccessLevel(
       query.workspaceId,
+      WorkspaceAccessLevel.EDIT,
     );
-    if (!workspace) throw new WorkspaceNotFoundError(query.workspaceId);
-
     const [skills, refs] = await Promise.all([
       this.listAccessibleSkillsUseCase.execute(
         new ListAccessibleSkillsQuery({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Authorization behavior changes: callers need EDIT (not merely workspace visibility via the old findById path), which may block some shared users who could previously hit these endpoints.
> 
> **Overview**
> **Skill and knowledge-base candidate listing** now goes through `WorkspaceAccessService.requireAccessLevel` with **`WorkspaceAccessLevel.EDIT`** instead of ad hoc `ContextService` + `workspacesRepository.findById` checks.
> 
> That aligns candidate browse with the documented rule that **`edit`** is required to update a workspace **or** browse attachment candidates, and reuses the same collaboration-aware resolution (members, team grants, org visibility) as other workspace mutations. Unit tests mock `WorkspaceAccessService` and assert the EDIT gate is invoked.
> 
> `SUMMARY.md` is updated to mention browsing candidates under the **`edit`** permission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 026fe41d7324a0bf69c1deef17c732a6b7714ba4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->