### PR TITLE
wip(workspaces): authorize context assignments (AYC-703)

### DIFF
--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -44,7 +44,14 @@ to update it or browse attachment candidates.
   purge their object-storage assets, which no database cascade can reach.
 - **Creation** — `CreateWorkspaceUseCase` saves the workspace, then calls
   `AddFavoriteUseCase` so new workspaces appear in the user's favorites.
-- **Context assignments** — workspace skills and knowledge bases are reference-only join rows into shared module-owned records. Direct workspace documents are owned uploads: adding one creates a source and a workspace-source assignment, while removal/deletion passes that source through `DeleteSourceUseCase` so indexed data and object-storage files are purged.
+- **Context assignments** — workspace skills and knowledge bases are
+  reference-only join rows into shared module-owned records. Attaching requires
+  `edit` workspace access plus access to the referenced resource; detaching only
+  requires `edit` workspace access. Direct workspace documents are owned
+  uploads: adding one creates a source and a
+  workspace-source assignment, while removal/deletion passes that source
+  through `DeleteSourceUseCase` so indexed data and object-storage files are
+  purged.
 - **Run context** — `BuildWorkspaceRunContextUseCase` requires `use` access and
   resolves the workspace's instruction, skills, knowledge bases, documents and
   MCP integrations through `WorkspaceRunContextResolverService`. The

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/attach-knowledge-base-to-workspace/attach-knowledge-base-to-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/attach-knowledge-base-to-workspace/attach-knowledge-base-to-workspace.use-case.spec.ts
@@ -1,0 +1,46 @@
+import { randomUUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { TEST_WORKSPACE_ID } from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { AttachKnowledgeBaseToWorkspaceCommand } from './attach-knowledge-base-to-workspace.command';
+import { AttachKnowledgeBaseToWorkspaceUseCase } from './attach-knowledge-base-to-workspace.use-case';
+
+describe('AttachKnowledgeBaseToWorkspaceUseCase', () => {
+  it('attaches an accessible knowledge base with edit access', async () => {
+    const knowledgeBaseId = randomUUID();
+    const repository = {
+      attachKnowledgeBase: jest.fn().mockResolvedValue(undefined),
+    };
+    const knowledgeBaseAccessService = {
+      findAccessibleKnowledgeBase: jest.fn().mockResolvedValue({
+        id: knowledgeBaseId,
+      }),
+    };
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({}),
+    };
+    const useCase = new AttachKnowledgeBaseToWorkspaceUseCase(
+      createPinoLoggerMock(),
+      repository as never,
+      knowledgeBaseAccessService as never,
+      accessService as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new AttachKnowledgeBaseToWorkspaceCommand(
+          TEST_WORKSPACE_ID,
+          knowledgeBaseId,
+        ),
+      ),
+    ).resolves.toBeUndefined();
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.EDIT,
+    );
+    expect(repository.attachKnowledgeBase).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      knowledgeBaseId,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/attach-knowledge-base-to-workspace/attach-knowledge-base-to-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/attach-knowledge-base-to-workspace/attach-knowledge-base-to-workspace.use-case.ts
@@ -1,14 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { KnowledgeBaseAccessService } from 'src/domain/knowledge-bases/application/services/knowledge-base-access.service';
-import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
-import {
-  UnexpectedWorkspaceError,
-  WorkspaceNotFoundError,
-} from '../../workspaces.errors';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { AttachKnowledgeBaseToWorkspaceCommand } from './attach-knowledge-base-to-workspace.command';
 
 @Injectable()
@@ -18,7 +15,7 @@ export class AttachKnowledgeBaseToWorkspaceUseCase {
     private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
     private readonly knowledgeBaseAccessService: KnowledgeBaseAccessService,
-    private readonly contextService: ContextService,
+    private readonly accessService: WorkspaceAccessService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
@@ -30,15 +27,10 @@ export class AttachKnowledgeBaseToWorkspaceUseCase {
       },
       'attachKnowledgeBaseToWorkspace',
     );
-    const userId = this.contextService.get('userId');
-    if (!userId) throw new UnauthorizedAccessError();
-
-    const workspace = await this.workspacesRepository.findById(
-      userId,
+    await this.accessService.requireAccessLevel(
       command.workspaceId,
+      WorkspaceAccessLevel.EDIT,
     );
-    if (!workspace) throw new WorkspaceNotFoundError(command.workspaceId);
-
     await this.knowledgeBaseAccessService.findAccessibleKnowledgeBase(
       command.knowledgeBaseId,
     );

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/attach-skill-to-workspace/attach-skill-to-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/attach-skill-to-workspace/attach-skill-to-workspace.use-case.spec.ts
@@ -1,0 +1,39 @@
+import { randomUUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { TEST_WORKSPACE_ID } from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { AttachSkillToWorkspaceCommand } from './attach-skill-to-workspace.command';
+import { AttachSkillToWorkspaceUseCase } from './attach-skill-to-workspace.use-case';
+
+describe('AttachSkillToWorkspaceUseCase', () => {
+  it('attaches an accessible skill with edit access', async () => {
+    const skillId = randomUUID();
+    const repository = { attachSkill: jest.fn().mockResolvedValue(undefined) };
+    const skillAccessService = {
+      findAccessibleSkill: jest.fn().mockResolvedValue({ id: skillId }),
+    };
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({}),
+    };
+    const useCase = new AttachSkillToWorkspaceUseCase(
+      createPinoLoggerMock(),
+      repository as never,
+      skillAccessService as never,
+      accessService as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new AttachSkillToWorkspaceCommand(TEST_WORKSPACE_ID, skillId),
+      ),
+    ).resolves.toBeUndefined();
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.EDIT,
+    );
+    expect(repository.attachSkill).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      skillId,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/attach-skill-to-workspace/attach-skill-to-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/attach-skill-to-workspace/attach-skill-to-workspace.use-case.ts
@@ -1,14 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
-import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
-import {
-  WorkspaceNotFoundError,
-  UnexpectedWorkspaceError,
-} from '../../workspaces.errors';
 import { SkillAccessService } from 'src/domain/skills/application/services/skill-access.service';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { AttachSkillToWorkspaceCommand } from './attach-skill-to-workspace.command';
 
 @Injectable()
@@ -18,27 +15,19 @@ export class AttachSkillToWorkspaceUseCase {
     private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
     private readonly skillAccessService: SkillAccessService,
-    private readonly contextService: ContextService,
+    private readonly accessService: WorkspaceAccessService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(command: AttachSkillToWorkspaceCommand): Promise<void> {
     this.logger.info(
-      {
-        workspaceId: command.workspaceId,
-        skillId: command.skillId,
-      },
+      { workspaceId: command.workspaceId, skillId: command.skillId },
       'attachSkillToWorkspace',
     );
-    const userId = this.contextService.get('userId');
-    if (!userId) throw new UnauthorizedAccessError();
-
-    const workspace = await this.workspacesRepository.findById(
-      userId,
+    await this.accessService.requireAccessLevel(
       command.workspaceId,
+      WorkspaceAccessLevel.EDIT,
     );
-    if (!workspace) throw new WorkspaceNotFoundError(command.workspaceId);
-
     await this.skillAccessService.findAccessibleSkill(command.skillId);
     await this.workspacesRepository.attachSkill(
       command.workspaceId,

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/detach-knowledge-base-from-workspace/detach-knowledge-base-from-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/detach-knowledge-base-from-workspace/detach-knowledge-base-from-workspace.use-case.spec.ts
@@ -1,0 +1,40 @@
+import { randomUUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { TEST_WORKSPACE_ID } from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { DetachKnowledgeBaseFromWorkspaceCommand } from './detach-knowledge-base-from-workspace.command';
+import { DetachKnowledgeBaseFromWorkspaceUseCase } from './detach-knowledge-base-from-workspace.use-case';
+
+describe('DetachKnowledgeBaseFromWorkspaceUseCase', () => {
+  it('detaches a knowledge base with edit access', async () => {
+    const knowledgeBaseId = randomUUID();
+    const repository = {
+      detachKnowledgeBase: jest.fn().mockResolvedValue(undefined),
+    };
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({}),
+    };
+    const useCase = new DetachKnowledgeBaseFromWorkspaceUseCase(
+      createPinoLoggerMock(),
+      repository as never,
+      accessService as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new DetachKnowledgeBaseFromWorkspaceCommand(
+          TEST_WORKSPACE_ID,
+          knowledgeBaseId,
+        ),
+      ),
+    ).resolves.toBeUndefined();
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.EDIT,
+    );
+    expect(repository.detachKnowledgeBase).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      knowledgeBaseId,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/detach-knowledge-base-from-workspace/detach-knowledge-base-from-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/detach-knowledge-base-from-workspace/detach-knowledge-base-from-workspace.use-case.ts
@@ -1,13 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
-import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
-import {
-  UnexpectedWorkspaceError,
-  WorkspaceNotFoundError,
-} from '../../workspaces.errors';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { DetachKnowledgeBaseFromWorkspaceCommand } from './detach-knowledge-base-from-workspace.command';
 
 @Injectable()
@@ -16,7 +13,7 @@ export class DetachKnowledgeBaseFromWorkspaceUseCase {
     @InjectPinoLogger(DetachKnowledgeBaseFromWorkspaceUseCase.name)
     private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
-    private readonly contextService: ContextService,
+    private readonly accessService: WorkspaceAccessService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
@@ -30,15 +27,10 @@ export class DetachKnowledgeBaseFromWorkspaceUseCase {
       },
       'detachKnowledgeBaseFromWorkspace',
     );
-    const userId = this.contextService.get('userId');
-    if (!userId) throw new UnauthorizedAccessError();
-
-    const workspace = await this.workspacesRepository.findById(
-      userId,
+    await this.accessService.requireAccessLevel(
       command.workspaceId,
+      WorkspaceAccessLevel.EDIT,
     );
-    if (!workspace) throw new WorkspaceNotFoundError(command.workspaceId);
-
     await this.workspacesRepository.detachKnowledgeBase(
       command.workspaceId,
       command.knowledgeBaseId,

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/detach-skill-from-workspace/detach-skill-from-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/detach-skill-from-workspace/detach-skill-from-workspace.use-case.spec.ts
@@ -1,0 +1,35 @@
+import { randomUUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { TEST_WORKSPACE_ID } from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { DetachSkillFromWorkspaceCommand } from './detach-skill-from-workspace.command';
+import { DetachSkillFromWorkspaceUseCase } from './detach-skill-from-workspace.use-case';
+
+describe('DetachSkillFromWorkspaceUseCase', () => {
+  it('detaches a skill with edit access', async () => {
+    const skillId = randomUUID();
+    const repository = { detachSkill: jest.fn().mockResolvedValue(undefined) };
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({}),
+    };
+    const useCase = new DetachSkillFromWorkspaceUseCase(
+      createPinoLoggerMock(),
+      repository as never,
+      accessService as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new DetachSkillFromWorkspaceCommand(TEST_WORKSPACE_ID, skillId),
+      ),
+    ).resolves.toBeUndefined();
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.EDIT,
+    );
+    expect(repository.detachSkill).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      skillId,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/detach-skill-from-workspace/detach-skill-from-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/detach-skill-from-workspace/detach-skill-from-workspace.use-case.ts
@@ -1,13 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
-import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
-import {
-  UnexpectedWorkspaceError,
-  WorkspaceNotFoundError,
-} from '../../workspaces.errors';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { DetachSkillFromWorkspaceCommand } from './detach-skill-from-workspace.command';
 
 @Injectable()
@@ -16,27 +13,19 @@ export class DetachSkillFromWorkspaceUseCase {
     @InjectPinoLogger(DetachSkillFromWorkspaceUseCase.name)
     private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
-    private readonly contextService: ContextService,
+    private readonly accessService: WorkspaceAccessService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(command: DetachSkillFromWorkspaceCommand): Promise<void> {
     this.logger.info(
-      {
-        workspaceId: command.workspaceId,
-        skillId: command.skillId,
-      },
+      { workspaceId: command.workspaceId, skillId: command.skillId },
       'detachSkillFromWorkspace',
     );
-    const userId = this.contextService.get('userId');
-    if (!userId) throw new UnauthorizedAccessError();
-
-    const workspace = await this.workspacesRepository.findById(
-      userId,
+    await this.accessService.requireAccessLevel(
       command.workspaceId,
+      WorkspaceAccessLevel.EDIT,
     );
-    if (!workspace) throw new WorkspaceNotFoundError(command.workspaceId);
-
     await this.workspacesRepository.detachSkill(
       command.workspaceId,
       command.skillId,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Authorization behavior changes for shared workspaces—users who could not pass owner-scoped `findById` may now attach/detach with edit access, which is intended but security-sensitive.
> 
> **Overview**
> Workspace **skill** and **knowledge base** attach/detach flows now go through `WorkspaceAccessService.requireAccessLevel(..., EDIT)` instead of loading the workspace with `findById` for the current user only. That aligns context mutations with the collaboration model so collaborators with edit rights can change assignments, not just the owner.
> 
> **Attach** still checks that the skill or knowledge base is accessible to the caller (`SkillAccessService` / `KnowledgeBaseAccessService`) before writing join rows; **detach** only requires workspace edit access. Module docs in `SUMMARY.md` spell out those rules, and unit specs assert the edit gate and repository calls for all four use cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42f0e0ed3aabcb2a4e70adb4764a53e8aed96cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->