### PR TITLE
fix(workspaces): repair project listing queries (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill-knowledge-base-ids.finder.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill-knowledge-base-ids.finder.ts
@@ -18,10 +18,10 @@ export class LocalSkillKnowledgeBaseIdsFinder {
       .innerJoin(
         'knowledge_bases',
         'knowledgeBase',
-        'knowledgeBase.id = skb."knowledgeBasesId"',
+        '"knowledgeBase".id = skb."knowledgeBasesId"',
       )
       .where('skill.id IN (:...skillIds)', { skillIds })
-      .andWhere('knowledgeBase."userId" = skill."userId"')
+      .andWhere('"knowledgeBase"."userId" = skill."userId"')
       .distinct(true)
       .getRawMany<{ knowledgeBaseId: UUID }>();
 

--- a/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/skills/infrastructure/persistence/local/local-skill.repository.spec.ts
@@ -174,8 +174,13 @@ describe('LocalSkillRepository', () => {
     await expect(
       repository.findKnowledgeBaseIdsBySkillIds([skillId]),
     ).resolves.toEqual(linkedKnowledgeBaseIds);
+    expect(queryBuilder.innerJoin).toHaveBeenCalledWith(
+      'knowledge_bases',
+      'knowledgeBase',
+      '"knowledgeBase".id = skb."knowledgeBasesId"',
+    );
     expect(queryBuilder.andWhere).toHaveBeenCalledWith(
-      'knowledgeBase."userId" = skill."userId"',
+      '"knowledgeBase"."userId" = skill."userId"',
     );
   });
 

--- a/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/local-source.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/local-source.repository.spec.ts
@@ -20,6 +20,7 @@ describe('LocalSourceRepository', () => {
       leftJoinAndSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
       orderBy: jest.fn().mockReturnThis(),
       addOrderBy: jest.fn().mockReturnThis(),
       skip: jest.fn().mockReturnThis(),
@@ -53,6 +54,14 @@ describe('LocalSourceRepository', () => {
     expect(result.total).toBe(3);
     expect(result.limit).toBe(1);
     expect(result.offset).toBe(2);
+    expect(queryBuilder.addSelect).toHaveBeenCalledWith(
+      'LOWER(source.name)',
+      'lower_source_name',
+    );
+    expect(queryBuilder.orderBy).toHaveBeenCalledWith(
+      'lower_source_name',
+      'ASC',
+    );
     expect(queryBuilder.skip).toHaveBeenCalledWith(2);
     expect(queryBuilder.take).toHaveBeenCalledWith(1);
     expect(queryBuilder.getManyAndCount).toHaveBeenCalledTimes(1);

--- a/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/local-source.repository.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/persistence/local/local-source.repository.ts
@@ -139,7 +139,8 @@ export class LocalSourceRepository extends SourceRepository {
     }
 
     const [records, total] = await queryBuilder
-      .orderBy('LOWER(source.name)', 'ASC')
+      .addSelect('LOWER(source.name)', 'lower_source_name')
+      .orderBy('lower_source_name', 'ASC')
       .addOrderBy('source.id', 'ASC')
       .skip(options.offset)
       .take(options.limit)

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.spec.ts
@@ -8,7 +8,7 @@ import type { WorkspaceKnowledgeBaseAssignmentRecord } from './schema/workspace-
 import type { WorkspaceSourceAssignmentRecord } from './schema/workspace-source-assignment.record';
 
 describe('LocalWorkspacesRepository', () => {
-  it('quotes the computed activity alias for PostgreSQL ordering', async () => {
+  it('uses a PostgreSQL-safe activity alias for paginated ordering', async () => {
     const countQuery = {
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
@@ -49,8 +49,12 @@ describe('LocalWorkspacesRepository', () => {
       offset: 0,
     });
 
+    expect(listQuery.addSelect).toHaveBeenCalledWith(
+      expect.any(String),
+      'effective_activity_at',
+    );
     expect(listQuery.orderBy).toHaveBeenCalledWith(
-      '"effectiveActivityAt"',
+      'effective_activity_at',
       'DESC',
     );
   });

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.ts
@@ -118,9 +118,9 @@ export class LocalWorkspacesRepository extends WorkspacesRepository {
              workspace."updatedAt"
            )
          )`,
-        'effectiveActivityAt',
+        'effective_activity_at',
       )
-      .orderBy('"effectiveActivityAt"', 'DESC');
+      .orderBy('effective_activity_at', 'DESC');
   }
 
   async findAllByIds(userId: UUID, ids: UUID[]): Promise<Workspace[]> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches listing SQL for workspaces, sources, and skill knowledge-base joins. Query-alias mistakes can break pagination or return wrong rows, but there is no auth or schema change.
> 
> **Overview**
> Fixes listing queries that TypeORM generated with invalid PostgreSQL identifiers.
> 
> Workspace activity sort now selects `effective_activity_at` and orders on that alias instead of a quoted camelCase name. Source pagination adds `LOWER(source.name)` as `lower_source_name` and sorts on the alias. Skill knowledge-base lookup quotes the `knowledgeBase` alias in join and user-id filters so the join is valid.
> 
> Tests assert the new aliases and quoted join conditions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc817a47b754e73948ddcdea28f882913eaa0c51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->