### PR TITLE
wip(workspaces): authorize content mutations (AYC-703)

### DIFF
--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -48,8 +48,8 @@ to update it or browse attachment candidates.
   reference-only join rows into shared module-owned records. Attaching requires
   `edit` workspace access plus access to the referenced resource; detaching only
   requires `edit` workspace access. Direct workspace documents are owned
-  uploads: adding one creates a source and a
-  workspace-source assignment, while removal/deletion passes that source
+  uploads: editors can add or remove them, and adding one creates a source and a
+  workspace-source assignment. Removal or deletion passes that source
   through `DeleteSourceUseCase` so indexed data and object-storage files are
   purged.
 - **Run context** — `BuildWorkspaceRunContextUseCase` requires `use` access and

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/add-document-to-workspace/add-document-to-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/add-document-to-workspace/add-document-to-workspace.use-case.spec.ts
@@ -1,0 +1,51 @@
+import { randomUUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import {
+  TEST_WORKSPACE_ID,
+  aWorkspace,
+  createMockWorkspacesRepository,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { AddDocumentToWorkspaceCommand } from './add-document-to-workspace.command';
+import { AddDocumentToWorkspaceUseCase } from './add-document-to-workspace.use-case';
+
+describe('AddDocumentToWorkspaceUseCase', () => {
+  it('uploads and attaches a document with edit access', async () => {
+    const sourceId = randomUUID();
+    const source = { id: sourceId };
+    const repository = createMockWorkspacesRepository();
+    const processor = { execute: jest.fn().mockResolvedValue(source) };
+    const deleteSource = { execute: jest.fn() };
+    const accessService = {
+      requireAccessLevel: jest
+        .fn()
+        .mockResolvedValue({ workspace: aWorkspace() }),
+    };
+    const useCase = new AddDocumentToWorkspaceUseCase(
+      createPinoLoggerMock(),
+      repository,
+      processor as never,
+      deleteSource as never,
+      accessService as never,
+    );
+
+    const result = await useCase.execute(
+      new AddDocumentToWorkspaceCommand(
+        TEST_WORKSPACE_ID,
+        Buffer.from('document'),
+        'policy.pdf',
+        'application/pdf',
+      ),
+    );
+
+    expect(result).toBe(source);
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.EDIT,
+    );
+    expect(repository.attachSource).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      sourceId,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/add-document-to-workspace/add-document-to-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/add-document-to-workspace/add-document-to-workspace.use-case.ts
@@ -2,20 +2,19 @@ import type { UUID } from 'crypto';
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { DeleteSourceCommand } from 'src/domain/sources/application/use-cases/delete-source/delete-source.command';
 import { DeleteSourceUseCase } from 'src/domain/sources/application/use-cases/delete-source/delete-source.use-case';
-import { StartDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case';
 import { StartDocumentProcessingCommand } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.command';
+import { StartDocumentProcessingUseCase } from 'src/domain/sources/application/use-cases/start-document-processing/start-document-processing.use-case';
 import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
-import { WORKSPACE_MAX_SOURCES } from 'src/domain/workspaces/domain/workspaces.constants';
-import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
 import {
   UnexpectedWorkspaceError,
-  WorkspaceNotFoundError,
   WorkspaceSourceLimitExceededError,
-} from '../../workspaces.errors';
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { WORKSPACE_MAX_SOURCES } from 'src/domain/workspaces/domain/workspaces.constants';
 import { AddDocumentToWorkspaceCommand } from './add-document-to-workspace.command';
 
 @Injectable()
@@ -26,29 +25,20 @@ export class AddDocumentToWorkspaceUseCase {
     private readonly workspacesRepository: WorkspacesRepository,
     private readonly startDocumentProcessingUseCase: StartDocumentProcessingUseCase,
     private readonly deleteSourceUseCase: DeleteSourceUseCase,
-    private readonly contextService: ContextService,
+    private readonly accessService: WorkspaceAccessService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(command: AddDocumentToWorkspaceCommand): Promise<FileSource> {
     this.logger.info(
-      {
-        workspaceId: command.workspaceId,
-        fileName: command.fileName,
-      },
+      { workspaceId: command.workspaceId, fileName: command.fileName },
       'addDocumentToWorkspace',
     );
-    const userId = this.contextService.get('userId');
-    if (!userId) throw new UnauthorizedAccessError();
-
-    const workspace = await this.workspacesRepository.findById(
-      userId,
+    const { workspace } = await this.accessService.requireAccessLevel(
       command.workspaceId,
+      WorkspaceAccessLevel.EDIT,
     );
-    if (!workspace) throw new WorkspaceNotFoundError(command.workspaceId);
-
     await this.assertSourceCapacity(command.workspaceId);
-
     const source = await this.startDocumentProcessingUseCase.execute(
       new StartDocumentProcessingCommand({
         fileData: command.fileData,

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-document-from-workspace/remove-document-from-workspace.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-document-from-workspace/remove-document-from-workspace.use-case.spec.ts
@@ -1,0 +1,48 @@
+import { randomUUID } from 'crypto';
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import { DeleteSourceCommand } from 'src/domain/sources/application/use-cases/delete-source/delete-source.command';
+import {
+  TEST_ORG_ID,
+  TEST_WORKSPACE_ID,
+  aWorkspace,
+  createMockWorkspacesRepository,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { RemoveDocumentFromWorkspaceCommand } from './remove-document-from-workspace.command';
+import { RemoveDocumentFromWorkspaceUseCase } from './remove-document-from-workspace.use-case';
+
+describe('RemoveDocumentFromWorkspaceUseCase', () => {
+  it('deletes an attached document with edit access', async () => {
+    const sourceId = randomUUID();
+    const repository = createMockWorkspacesRepository();
+    repository.getContextRefs.mockResolvedValue({
+      skillIds: [],
+      knowledgeBases: [],
+      sourceIds: [sourceId],
+    });
+    const deleteSource = { execute: jest.fn().mockResolvedValue(undefined) };
+    const accessService = {
+      requireAccessLevel: jest
+        .fn()
+        .mockResolvedValue({ workspace: aWorkspace() }),
+    };
+    const useCase = new RemoveDocumentFromWorkspaceUseCase(
+      createPinoLoggerMock(),
+      repository,
+      deleteSource as never,
+      accessService as never,
+    );
+
+    await useCase.execute(
+      new RemoveDocumentFromWorkspaceCommand(TEST_WORKSPACE_ID, sourceId),
+    );
+
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.EDIT,
+    );
+    expect(deleteSource.execute).toHaveBeenCalledWith(
+      new DeleteSourceCommand(sourceId, TEST_ORG_ID),
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-document-from-workspace/remove-document-from-workspace.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/remove-document-from-workspace/remove-document-from-workspace.use-case.ts
@@ -1,15 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { DeleteSourceCommand } from 'src/domain/sources/application/use-cases/delete-source/delete-source.command';
 import { DeleteSourceUseCase } from 'src/domain/sources/application/use-cases/delete-source/delete-source.use-case';
-import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
-import {
-  UnexpectedWorkspaceError,
-  WorkspaceNotFoundError,
-} from '../../workspaces.errors';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { RemoveDocumentFromWorkspaceCommand } from './remove-document-from-workspace.command';
 
 @Injectable()
@@ -19,27 +16,19 @@ export class RemoveDocumentFromWorkspaceUseCase {
     private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
     private readonly deleteSourceUseCase: DeleteSourceUseCase,
-    private readonly contextService: ContextService,
+    private readonly accessService: WorkspaceAccessService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(command: RemoveDocumentFromWorkspaceCommand): Promise<void> {
     this.logger.info(
-      {
-        workspaceId: command.workspaceId,
-        sourceId: command.sourceId,
-      },
+      { workspaceId: command.workspaceId, sourceId: command.sourceId },
       'removeDocumentFromWorkspace',
     );
-    const userId = this.contextService.get('userId');
-    if (!userId) throw new UnauthorizedAccessError();
-
-    const workspace = await this.workspacesRepository.findById(
-      userId,
+    const { workspace } = await this.accessService.requireAccessLevel(
       command.workspaceId,
+      WorkspaceAccessLevel.EDIT,
     );
-    if (!workspace) throw new WorkspaceNotFoundError(command.workspaceId);
-
     const refs = await this.workspacesRepository.getContextRefs(
       command.workspaceId,
     );

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-instruction/update-workspace-instruction.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-instruction/update-workspace-instruction.use-case.spec.ts
@@ -1,21 +1,24 @@
 import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import {
-  createMockContextService,
-  createMockWorkspacesRepository,
   TEST_WORKSPACE_ID,
   aWorkspace,
-} from '../../testing/workspace.fixtures';
+  createMockWorkspacesRepository,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { UpdateWorkspaceInstructionCommand } from './update-workspace-instruction.command';
 import { UpdateWorkspaceInstructionUseCase } from './update-workspace-instruction.use-case';
 
 describe('UpdateWorkspaceInstructionUseCase', () => {
-  it('stores trimmed project instructions', async () => {
+  it('stores trimmed project instructions with edit access', async () => {
     const repository = createMockWorkspacesRepository();
-    repository.findById.mockResolvedValue(aWorkspace());
+    const workspace = aWorkspace();
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({ workspace }),
+    };
     const useCase = new UpdateWorkspaceInstructionUseCase(
       createPinoLoggerMock(),
       repository,
-      createMockContextService(),
+      accessService as never,
     );
 
     const result = await useCase.execute(
@@ -26,6 +29,10 @@ describe('UpdateWorkspaceInstructionUseCase', () => {
     );
 
     expect(result.instruction).toBe('Use building department wording.');
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.EDIT,
+    );
     expect(repository.save).toHaveBeenCalledWith(
       expect.objectContaining({
         instruction: 'Use building department wording.',
@@ -35,13 +42,16 @@ describe('UpdateWorkspaceInstructionUseCase', () => {
 
   it('clears blank project instructions', async () => {
     const repository = createMockWorkspacesRepository();
-    repository.findById.mockResolvedValue(
-      aWorkspace({ instruction: 'Use building department wording.' }),
-    );
+    const workspace = aWorkspace({
+      instruction: 'Use building department wording.',
+    });
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({ workspace }),
+    };
     const useCase = new UpdateWorkspaceInstructionUseCase(
       createPinoLoggerMock(),
       repository,
-      createMockContextService(),
+      accessService as never,
     );
 
     const result = await useCase.execute(

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-instruction/update-workspace-instruction.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-instruction/update-workspace-instruction.use-case.ts
@@ -1,14 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
-import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
-import {
-  UnexpectedWorkspaceError,
-  WorkspaceNotFoundError,
-} from '../../workspaces.errors';
 import { UpdateWorkspaceInstructionCommand } from './update-workspace-instruction.command';
 
 @Injectable()
@@ -17,7 +14,7 @@ export class UpdateWorkspaceInstructionUseCase {
     @InjectPinoLogger(UpdateWorkspaceInstructionUseCase.name)
     private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
-    private readonly contextService: ContextService,
+    private readonly accessService: WorkspaceAccessService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
@@ -25,20 +22,13 @@ export class UpdateWorkspaceInstructionUseCase {
     command: UpdateWorkspaceInstructionCommand,
   ): Promise<Workspace> {
     this.logger.info(
-      {
-        workspaceId: command.workspaceId,
-      },
+      { workspaceId: command.workspaceId },
       'updateWorkspaceInstruction',
     );
-    const userId = this.contextService.get('userId');
-    if (!userId) throw new UnauthorizedAccessError();
-
-    const workspace = await this.workspacesRepository.findById(
-      userId,
+    const { workspace } = await this.accessService.requireAccessLevel(
       command.workspaceId,
+      WorkspaceAccessLevel.EDIT,
     );
-    if (!workspace) throw new WorkspaceNotFoundError(command.workspaceId);
-
     workspace.instruct(command.instruction?.trim() || null);
     return this.workspacesRepository.save(workspace);
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Authorization behavior changes from owner-only repository lookup to collaboration-aware edit checks; incorrect policy wiring could block legitimate editors or allow unauthorized mutations.
> 
> **Overview**
> Workspace **content mutations** now enforce **`edit`** access through `WorkspaceAccessService.requireAccessLevel` instead of loading the workspace with `ContextService` + `findById` (owner-scoped lookup).
> 
> **`AddDocumentToWorkspaceUseCase`**, **`RemoveDocumentFromWorkspaceUseCase`**, and **`UpdateWorkspaceInstructionUseCase`** all gate on `WorkspaceAccessLevel.EDIT` before upload/attach, delete, or instruction updates. Import paths for repository/errors are normalized to absolute `application/` paths.
> 
> **`SUMMARY.md`** clarifies that editors can add or remove direct workspace document uploads. **Unit tests** mock `WorkspaceAccessService` and assert the edit check; new specs cover add/remove document flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27d55e039e366202a231c4e2e957a9fe240d8bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->