### PR TITLE
wip(workspaces): list accessible workspaces (AYC-703)

### DIFF
--- a/ayunis-core-backend/src/domain/favorites/application/services/favorite-reference-resolver.service.ts
+++ b/ayunis-core-backend/src/domain/favorites/application/services/favorite-reference-resolver.service.ts
@@ -9,9 +9,9 @@ import { FindWorkspacesByIdsUseCase } from 'src/domain/workspaces/application/us
 import { WorkspaceNotFoundError } from 'src/domain/workspaces/application/workspaces.errors';
 import type { Thread } from 'src/domain/threads/domain/thread.entity';
 import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
-import { FavoriteReferenceType } from '../../domain/value-objects/favorite-reference-type.enum';
-import type { Favorite } from '../../domain/favorite.entity';
-import type { FavoriteResult } from '../use-cases/find-favorites/favorite.result';
+import { FavoriteReferenceType } from 'src/domain/favorites/domain/value-objects/favorite-reference-type.enum';
+import type { Favorite } from 'src/domain/favorites/domain/favorite.entity';
+import type { FavoriteResult } from 'src/domain/favorites/application/use-cases/find-favorites/favorite.result';
 
 @Injectable()
 export class FavoriteReferenceResolver {
@@ -29,7 +29,6 @@ export class FavoriteReferenceResolver {
     const [workspaces, threads] = await Promise.all([
       this.findWorkspacesByIdsUseCase.execute(
         new FindWorkspacesByIdsQuery(
-          userId,
           this.referenceIds(favorites, FavoriteReferenceType.Workspace),
         ),
       ),
@@ -68,7 +67,7 @@ export class FavoriteReferenceResolver {
   ): Promise<void> {
     if (referenceType === FavoriteReferenceType.Workspace) {
       const workspaces = await this.findWorkspacesByIdsUseCase.execute(
-        new FindWorkspacesByIdsQuery(userId, [referenceId]),
+        new FindWorkspacesByIdsQuery([referenceId]),
       );
       if (workspaces.length === 0) {
         throw new WorkspaceNotFoundError(referenceId);

--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -23,7 +23,9 @@ The whole module sits behind the `workspacesEnabled` feature flag
 
 - **Workspace** — owned by exactly one user and scoped to their org. Shared
   users need `use` to read workspace metadata and attached context, and `edit`
-to update it or browse attachment candidates.
+  to update it or browse attachment candidates. Listings batch owner, direct,
+  team, and organization access resolution and expose each effective access
+  level.
 - **Per-user favorite state** — owned by the favorites module; a workspace row
   carries no pin or order state. Access checks stay with the workspace use
   cases — favorites trusts its callers.
@@ -120,6 +122,7 @@ workspaces/
 │   ├── mappers/workspace-invitation.mapper.ts
 │   ├── local-workspaces.repository.ts
 │   ├── local-workspace-access.repository.ts
+│   ├── workspace-list-query.helpers.ts
 │   ├── local-workspace-members.repository.ts
 │   ├── local-workspace-members-repository.module.ts
 │   ├── local-workspace-team-grants.repository.ts
@@ -144,7 +147,7 @@ workspaces/
 | Method        | Route                                                      | Purpose                                               |
 | ------------- | ---------------------------------------------------------- | ----------------------------------------------------- |
 | POST          | `/workspaces`                                              | Create a workspace                                    |
-| GET           | `/workspaces`                                              | List by most recently updated                         |
+| GET           | `/workspaces`                                              | List accessible workspaces                            |
 | GET           | `/workspaces/:id`                                          | Read one                                              |
 | PATCH         | `/workspaces/:id`                                          | Update name / description / icon / colour             |
 | DELETE        | `/workspaces/:id`                                          | Delete the workspace and its chats                    |
@@ -169,8 +172,8 @@ importing favorites; `FavoritesModule` listens to clean up references.
 and listen for `WorkspaceDeletionRequestedEvent`. In the other direction the
 coupling is schema-level, not module-level: `getThreadStats` in the local
 repository reads the `threads` table directly (raw SQL) to derive per-workspace
-chat counts and last activity. Favorites resolves workspace
-metadata through the exported, user-scoped `FindWorkspacesByIdsUseCase`.
+chat counts and last activity. Favorites resolves accessible workspace metadata through the exported
+`FindWorkspacesByIdsUseCase`, including shared workspaces the user can pin.
 The runs module consumes the exported `BuildWorkspaceRunContextUseCase` to merge
 project context into chat execution. Assignment validation uses exported skills,
 knowledge-bases and sources application services/use cases.

--- a/ayunis-core-backend/src/domain/workspaces/application/ports/workspace-access-repository.port.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/ports/workspace-access-repository.port.ts
@@ -1,4 +1,6 @@
 import type { UUID } from 'crypto';
+import type { Paginated } from 'src/common/pagination/paginated.entity';
+import type { WorkspaceListOptions } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
 import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import type {
   DirectMembershipCandidate,
@@ -7,6 +9,12 @@ import type {
 
 export interface FindWorkspaceAccessParams {
   workspaceId: UUID;
+  orgId: UUID;
+  userId: UUID;
+  teamIds: UUID[];
+}
+
+export interface FindWorkspaceAccessListParams {
   orgId: UUID;
   userId: UUID;
   teamIds: UUID[];
@@ -22,4 +30,14 @@ export abstract class WorkspaceAccessRepository {
   abstract findAccessSnapshot(
     params: FindWorkspaceAccessParams,
   ): Promise<WorkspaceAccessSnapshot | null>;
+
+  abstract findAccessSnapshots(
+    params: FindWorkspaceAccessListParams,
+    query: WorkspaceListOptions,
+  ): Promise<Paginated<WorkspaceAccessSnapshot>>;
+
+  abstract findAccessSnapshotsByIds(
+    params: FindWorkspaceAccessListParams,
+    workspaceIds: UUID[],
+  ): Promise<WorkspaceAccessSnapshot[]>;
 }

--- a/ayunis-core-backend/src/domain/workspaces/application/services/workspace-access.service.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/services/workspace-access.service.spec.ts
@@ -1,6 +1,7 @@
 import { getLoggerToken } from 'nestjs-pino';
 import { Test } from '@nestjs/testing';
 import { randomUUID, type UUID } from 'crypto';
+import { Paginated } from 'src/common/pagination/paginated.entity';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import { ContextService } from 'src/common/context/services/context.service';
 import { WorkspaceAccessRepository } from 'src/domain/workspaces/application/ports/workspace-access-repository.port';
@@ -24,7 +25,11 @@ import {
 const TEAM_ID = '44444444-4444-4444-8444-444444444444' as UUID;
 
 describe('WorkspaceAccessService', () => {
-  const repository = { findAccessSnapshot: jest.fn() };
+  const repository = {
+    findAccessSnapshot: jest.fn(),
+    findAccessSnapshots: jest.fn(),
+    findAccessSnapshotsByIds: jest.fn(),
+  };
   const listMyTeams = { execute: jest.fn() };
   const contextService = { get: jest.fn() };
   let service: WorkspaceAccessService;
@@ -75,6 +80,99 @@ describe('WorkspaceAccessService', () => {
       userId: TEST_USER_ID,
       teamIds: [TEAM_ID],
     });
+  });
+
+  it('lists accessible workspaces with their effective access levels in one batch', async () => {
+    const workspace = aWorkspace({ userId: randomUUID() });
+    repository.findAccessSnapshots.mockResolvedValue(
+      new Paginated({
+        data: [
+          {
+            workspace,
+            directMembership: {
+              accessLevel: WorkspaceAccessLevel.USE,
+              status: WorkspaceMemberStatus.ACTIVE,
+            },
+            teamGrants: [
+              { teamId: TEAM_ID, accessLevel: WorkspaceAccessLevel.EDIT },
+            ],
+          },
+        ],
+        limit: 20,
+        offset: 0,
+        total: 1,
+      }),
+    );
+
+    await expect(
+      service.findAllAccessible({ limit: 20, offset: 0, sort: 'updatedAt' }),
+    ).resolves.toEqual(
+      new Paginated({
+        data: [
+          expect.objectContaining({
+            workspace,
+            accessLevel: WorkspaceAccessLevel.EDIT,
+          }),
+        ],
+        limit: 20,
+        offset: 0,
+        total: 1,
+      }),
+    );
+    expect(repository.findAccessSnapshots).toHaveBeenCalledWith(
+      {
+        orgId: TEST_ORG_ID,
+        userId: TEST_USER_ID,
+        teamIds: [TEAM_ID],
+      },
+      { limit: 20, offset: 0, sort: 'updatedAt' },
+    );
+  });
+
+  it('resolves accessible workspaces by ids in one batch', async () => {
+    const workspace = aWorkspace({ userId: randomUUID() });
+    repository.findAccessSnapshotsByIds.mockResolvedValue([
+      {
+        workspace,
+        directMembership: {
+          accessLevel: WorkspaceAccessLevel.USE,
+          status: WorkspaceMemberStatus.ACTIVE,
+        },
+        teamGrants: [],
+      },
+    ]);
+
+    await expect(
+      service.findAllAccessibleByIds([workspace.id]),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        workspace,
+        accessLevel: WorkspaceAccessLevel.USE,
+      }),
+    ]);
+    expect(repository.findAccessSnapshotsByIds).toHaveBeenCalledWith(
+      { orgId: TEST_ORG_ID, userId: TEST_USER_ID, teamIds: [TEAM_ID] },
+      [workspace.id],
+    );
+  });
+
+  it('omits a stale listing snapshot when its access has been removed', async () => {
+    repository.findAccessSnapshots.mockResolvedValue(
+      new Paginated({
+        data: [
+          { workspace: aWorkspace({ userId: randomUUID() }), teamGrants: [] },
+        ],
+        limit: 20,
+        offset: 0,
+        total: 1,
+      }),
+    );
+
+    await expect(
+      service.findAllAccessible({ limit: 20, offset: 0, sort: 'updatedAt' }),
+    ).resolves.toEqual(
+      new Paginated({ data: [], limit: 20, offset: 0, total: 1 }),
+    );
   });
 
   it('rejects an accessible workspace when the access level is insufficient', async () => {

--- a/ayunis-core-backend/src/domain/workspaces/application/services/workspace-access.service.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/services/workspace-access.service.ts
@@ -1,9 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import type { UUID } from 'crypto';
+import { Paginated } from 'src/common/pagination/paginated.entity';
 import { ContextService } from 'src/common/context/services/context.service';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
-import { WorkspaceAccessRepository } from 'src/domain/workspaces/application/ports/workspace-access-repository.port';
+import {
+  WorkspaceAccessRepository,
+  type WorkspaceAccessSnapshot,
+} from 'src/domain/workspaces/application/ports/workspace-access-repository.port';
+import type { WorkspaceListOptions } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
 import {
   WorkspaceInsufficientAccessLevelError,
   WorkspaceNotFoundError,
@@ -44,14 +49,36 @@ export class WorkspaceAccessService {
     });
     if (!snapshot) return null;
 
-    const resolution = this.policy.resolve({
-      isOwner: snapshot.workspace.userId === userId,
-      directMembership: snapshot.directMembership,
-      teamGrants: snapshot.teamGrants,
-      organizationVisible:
-        snapshot.workspace.visibility === WorkspaceVisibility.ORGANIZATION,
+    return this.resolveSnapshotOrNull(snapshot, userId);
+  }
+
+  async findAllAccessible(
+    query: WorkspaceListOptions,
+  ): Promise<Paginated<ResolvedWorkspaceAccess>> {
+    const { userId, orgId } = this.getContext();
+    const teams = await this.listMyTeamsUseCase.execute();
+    const page = await this.repository.findAccessSnapshots(
+      { orgId, userId, teamIds: teams.map(({ id }) => id) },
+      query,
+    );
+    return new Paginated({
+      data: this.resolveSnapshots(page.data, userId),
+      limit: page.limit,
+      offset: page.offset,
+      total: page.total,
     });
-    return resolution ? { workspace: snapshot.workspace, ...resolution } : null;
+  }
+
+  async findAllAccessibleByIds(
+    workspaceIds: UUID[],
+  ): Promise<ResolvedWorkspaceAccess[]> {
+    const { userId, orgId } = this.getContext();
+    const teams = await this.listMyTeamsUseCase.execute();
+    const snapshots = await this.repository.findAccessSnapshotsByIds(
+      { orgId, userId, teamIds: teams.map(({ id }) => id) },
+      workspaceIds,
+    );
+    return this.resolveSnapshots(snapshots, userId);
   }
 
   async requireAccessLevel(
@@ -70,6 +97,30 @@ export class WorkspaceAccessService {
       );
     }
     return access;
+  }
+
+  private resolveSnapshots(
+    snapshots: WorkspaceAccessSnapshot[],
+    userId: UUID,
+  ): ResolvedWorkspaceAccess[] {
+    return snapshots.flatMap((snapshot) => {
+      const resolution = this.resolveSnapshotOrNull(snapshot, userId);
+      return resolution ? [resolution] : [];
+    });
+  }
+
+  private resolveSnapshotOrNull(
+    snapshot: WorkspaceAccessSnapshot,
+    userId: UUID,
+  ): ResolvedWorkspaceAccess | null {
+    const resolution = this.policy.resolve({
+      isOwner: snapshot.workspace.userId === userId,
+      directMembership: snapshot.directMembership,
+      teamGrants: snapshot.teamGrants,
+      organizationVisible:
+        snapshot.workspace.visibility === WorkspaceVisibility.ORGANIZATION,
+    });
+    return resolution ? { workspace: snapshot.workspace, ...resolution } : null;
   }
 
   private getContext(): { userId: UUID; orgId: UUID } {

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.spec.ts
@@ -1,83 +1,60 @@
-import { Test } from '@nestjs/testing';
-import { getLoggerToken } from 'nestjs-pino';
+import { Paginated } from 'src/common/pagination/paginated.entity';
 import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
-import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
 import {
   aWorkspace,
-  createMockContextService,
   createMockWorkspacesRepository,
-  TEST_USER_ID,
 } from 'src/domain/workspaces/application/testing/workspace.fixtures';
-import { FindAllWorkspacesUseCase } from './find-all-workspaces.use-case';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { FindAllWorkspacesQuery } from './find-all-workspaces.query';
-import { Paginated } from 'src/common/pagination/paginated.entity';
+import { FindAllWorkspacesUseCase } from './find-all-workspaces.use-case';
 
 describe('FindAllWorkspacesUseCase', () => {
-  let useCase: FindAllWorkspacesUseCase;
-  let repository: jest.Mocked<WorkspacesRepository>;
-
-  async function setup(contextService = createMockContextService()) {
-    repository = createMockWorkspacesRepository();
-    const module = await Test.createTestingModule({
-      providers: [
-        FindAllWorkspacesUseCase,
-        {
-          provide: getLoggerToken(FindAllWorkspacesUseCase.name),
-          useValue: createPinoLoggerMock(),
-        },
-        { provide: WorkspacesRepository, useValue: repository },
-        { provide: ContextService, useValue: contextService },
-      ],
-    }).compile();
-    useCase = module.get(FindAllWorkspacesUseCase);
-  }
-
-  beforeEach(async () => {
-    await setup();
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('returns the caller’s workspaces with their chat stats', async () => {
+  it('returns accessible workspaces with effective access levels and chat stats', async () => {
     const workspace = aWorkspace();
-    repository.findAllByUserId.mockResolvedValue(
-      new Paginated({ data: [workspace], limit: 20, offset: 0, total: 1 }),
-    );
+    const repository = createMockWorkspacesRepository();
     repository.getThreadStats.mockResolvedValue(
       new Map([[workspace.id, { chatCount: 3, lastActivityAt: null }]]),
+    );
+    const accessService = {
+      findAllAccessible: jest.fn().mockResolvedValue(
+        new Paginated({
+          data: [
+            {
+              workspace,
+              accessLevel: WorkspaceAccessLevel.EDIT,
+              sources: [],
+            },
+          ],
+          limit: 20,
+          offset: 0,
+          total: 1,
+        }),
+      ),
+    };
+    const useCase = new FindAllWorkspacesUseCase(
+      createPinoLoggerMock(),
+      repository,
+      accessService as never,
     );
 
     await expect(useCase.execute()).resolves.toEqual(
       new Paginated({
         data: [
-          { workspace, chatCount: 3, lastActivityAt: workspace.updatedAt },
+          {
+            workspace,
+            accessLevel: WorkspaceAccessLevel.EDIT,
+            chatCount: 3,
+            lastActivityAt: workspace.updatedAt,
+          },
         ],
         limit: 20,
         offset: 0,
         total: 1,
       }),
     );
-    expect(repository.findAllByUserId).toHaveBeenCalledWith(
-      TEST_USER_ID,
+    expect(accessService.findAllAccessible).toHaveBeenCalledWith(
       expect.objectContaining({ limit: 20, offset: 0, sort: 'updatedAt' }),
     );
-  });
-
-  it('reports zero chats for a workspace without stats', async () => {
-    const workspace = aWorkspace();
-    repository.findAllByUserId.mockResolvedValue(
-      new Paginated({ data: [workspace], limit: 20, offset: 0, total: 1 }),
-    );
-
-    const { data } = await useCase.execute();
-    const [item] = data;
-
-    expect(item.chatCount).toBe(0);
-    expect(item.lastActivityAt).toEqual(workspace.updatedAt);
   });
 
   it('surfaces chat activity newer than the last edit', async () => {
@@ -85,49 +62,34 @@ describe('FindAllWorkspacesUseCase', () => {
       updatedAt: new Date('2026-08-02T10:00:00.000Z'),
     });
     const chatActivity = new Date('2026-08-05T10:00:00.000Z');
-    repository.findAllByUserId.mockResolvedValue(
-      new Paginated({ data: [workspace], limit: 20, offset: 0, total: 1 }),
-    );
+    const repository = createMockWorkspacesRepository();
     repository.getThreadStats.mockResolvedValue(
       new Map([[workspace.id, { chatCount: 1, lastActivityAt: chatActivity }]]),
     );
+    const accessService = {
+      findAllAccessible: jest.fn().mockResolvedValue(
+        new Paginated({
+          data: [
+            { workspace, accessLevel: WorkspaceAccessLevel.USE, sources: [] },
+          ],
+          limit: 20,
+          offset: 0,
+          total: 1,
+        }),
+      ),
+    };
+    const useCase = new FindAllWorkspacesUseCase(
+      createPinoLoggerMock(),
+      repository,
+      accessService as never,
+    );
 
-    const { data } = await useCase.execute();
-    const [item] = data;
+    const { data } = await useCase.execute(new FindAllWorkspacesQuery());
 
-    expect(item.lastActivityAt).toEqual(chatActivity);
-  });
-
-  it('keeps the edit timestamp when it is newer than chat activity', async () => {
-    const workspace = aWorkspace({
-      updatedAt: new Date('2026-08-09T10:00:00.000Z'),
+    expect(data[0]).toMatchObject({
+      accessLevel: WorkspaceAccessLevel.USE,
+      chatCount: 1,
+      lastActivityAt: chatActivity,
     });
-    repository.findAllByUserId.mockResolvedValue(
-      new Paginated({ data: [workspace], limit: 20, offset: 0, total: 1 }),
-    );
-    repository.getThreadStats.mockResolvedValue(
-      new Map([
-        [
-          workspace.id,
-          {
-            chatCount: 1,
-            lastActivityAt: new Date('2026-08-05T10:00:00.000Z'),
-          },
-        ],
-      ]),
-    );
-
-    const { data } = await useCase.execute();
-    const [item] = data;
-
-    expect(item.lastActivityAt).toEqual(workspace.updatedAt);
-  });
-
-  it('rejects an unauthenticated caller', async () => {
-    await setup(createMockContextService({}));
-
-    await expect(useCase.execute(new FindAllWorkspacesQuery())).rejects.toThrow(
-      UnauthorizedAccessError,
-    );
   });
 });

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.ts
@@ -1,19 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
-import type { UUID } from 'crypto';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { ContextService } from 'src/common/context/services/context.service';
-import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
-import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
-import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
-import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
 import { Paginated } from 'src/common/pagination/paginated.entity';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import { FindAllWorkspacesQuery } from './find-all-workspaces.query';
 
 export interface WorkspaceListItem {
   workspace: Workspace;
+  accessLevel: WorkspaceAccessLevel;
   chatCount: number;
-  /** Later of the workspace's own edit and its most recent chat activity. */
   lastActivityAt: Date;
 }
 
@@ -23,49 +22,35 @@ export class FindAllWorkspacesUseCase {
     @InjectPinoLogger(FindAllWorkspacesUseCase.name)
     private readonly logger: PinoLogger,
     private readonly workspacesRepository: WorkspacesRepository,
-    private readonly contextService: ContextService,
+    private readonly accessService: WorkspaceAccessService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(
     query: FindAllWorkspacesQuery = new FindAllWorkspacesQuery(),
   ): Promise<Paginated<WorkspaceListItem>> {
-    this.logger.info('Finding all workspaces');
-
-    const workspaces = await this.workspacesRepository.findAllByUserId(
-      this.resolveUserId(),
-      query,
-    );
+    this.logger.info('Finding all accessible workspaces');
+    const page = await this.accessService.findAllAccessible(query);
     const stats = await this.workspacesRepository.getThreadStats(
-      workspaces.data.map((workspace) => workspace.id),
+      page.data.map(({ workspace }) => workspace.id),
     );
-
-    const data = workspaces.data.map((workspace) => {
-      const threadStats = stats.get(workspace.id);
-      const chatActivity = threadStats?.lastActivityAt;
-      return {
-        workspace,
-        chatCount: threadStats?.chatCount ?? 0,
-        lastActivityAt:
-          chatActivity && chatActivity > workspace.updatedAt
-            ? chatActivity
-            : workspace.updatedAt,
-      };
-    });
-
     return new Paginated({
-      data,
-      limit: workspaces.limit,
-      offset: workspaces.offset,
-      total: workspaces.total,
+      data: page.data.map(({ workspace, accessLevel }) => {
+        const threadStats = stats.get(workspace.id);
+        const chatActivity = threadStats?.lastActivityAt;
+        return {
+          workspace,
+          accessLevel,
+          chatCount: threadStats?.chatCount ?? 0,
+          lastActivityAt:
+            chatActivity && chatActivity > workspace.updatedAt
+              ? chatActivity
+              : workspace.updatedAt,
+        };
+      }),
+      limit: page.limit,
+      offset: page.offset,
+      total: page.total,
     });
-  }
-
-  private resolveUserId(): UUID {
-    const userId = this.contextService.get('userId');
-    if (!userId) {
-      throw new UnauthorizedAccessError();
-    }
-    return userId;
   }
 }

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.query.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.query.ts
@@ -1,8 +1,5 @@
 import type { UUID } from 'crypto';
 
 export class FindWorkspacesByIdsQuery {
-  constructor(
-    public readonly userId: UUID,
-    public readonly ids: UUID[],
-  ) {}
+  constructor(public readonly ids: UUID[]) {}
 }

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case.spec.ts
@@ -1,27 +1,27 @@
 import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
-import type { UUID } from 'crypto';
-import type { WorkspacesRepository } from '../../ports/workspaces-repository.port';
+import type { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
 import { FindWorkspacesByIdsQuery } from './find-workspaces-by-ids.query';
 import { FindWorkspacesByIdsUseCase } from './find-workspaces-by-ids.use-case';
 
-const USER_ID = '11111111-1111-4111-8111-111111111111' as UUID;
-const WORKSPACE_ID = '22222222-2222-4222-8222-222222222222' as UUID;
+const WORKSPACE_ID = '22222222-2222-4222-8222-222222222222' as const;
 
 describe('FindWorkspacesByIdsUseCase', () => {
-  it('returns only workspaces owned by the requested user', async () => {
+  it('returns accessible workspaces requested by id', async () => {
     const workspaces = [{ id: WORKSPACE_ID }];
-    const repository = {
-      findAllByIds: jest.fn().mockResolvedValue(workspaces),
-    } as unknown as WorkspacesRepository;
+    const accessService = {
+      findAllAccessibleByIds: jest
+        .fn()
+        .mockResolvedValue(workspaces.map((workspace) => ({ workspace }))),
+    } as unknown as WorkspaceAccessService;
     const useCase = new FindWorkspacesByIdsUseCase(
       createPinoLoggerMock(),
-      repository,
+      accessService,
     );
 
     await expect(
-      useCase.execute(new FindWorkspacesByIdsQuery(USER_ID, [WORKSPACE_ID])),
-    ).resolves.toBe(workspaces);
-    expect(repository.findAllByIds).toHaveBeenCalledWith(USER_ID, [
+      useCase.execute(new FindWorkspacesByIdsQuery([WORKSPACE_ID])),
+    ).resolves.toEqual(workspaces);
+    expect(accessService.findAllAccessibleByIds).toHaveBeenCalledWith([
       WORKSPACE_ID,
     ]);
   });

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-workspaces-by-ids/find-workspaces-by-ids.use-case.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import type { Workspace } from '../../../domain/workspace.entity';
-import { UnexpectedWorkspaceError } from '../../workspaces.errors';
-import { WorkspacesRepository } from '../../ports/workspaces-repository.port';
+import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
 import type { FindWorkspacesByIdsQuery } from './find-workspaces-by-ids.query';
 
 @Injectable()
@@ -11,18 +11,13 @@ export class FindWorkspacesByIdsUseCase {
   constructor(
     @InjectPinoLogger(FindWorkspacesByIdsUseCase.name)
     private readonly logger: PinoLogger,
-    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly accessService: WorkspaceAccessService,
   ) {}
 
   @HandleUnexpectedErrors(UnexpectedWorkspaceError)
   async execute(query: FindWorkspacesByIdsQuery): Promise<Workspace[]> {
-    this.logger.debug(
-      {
-        userId: query.userId,
-        count: query.ids.length,
-      },
-      'Finding workspaces by ids',
-    );
-    return this.workspacesRepository.findAllByIds(query.userId, query.ids);
+    this.logger.debug({ count: query.ids.length }, 'Finding workspaces by ids');
+    const accesses = await this.accessService.findAllAccessibleByIds(query.ids);
+    return accesses.map(({ workspace }) => workspace);
   }
 }

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-access.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-access.repository.spec.ts
@@ -1,6 +1,6 @@
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Test } from '@nestjs/testing';
-import type { UUID } from 'crypto';
+import { randomUUID, type UUID } from 'crypto';
 import { WorkspaceMapper } from 'src/domain/workspaces/infrastructure/persistence/local/mappers/workspace.mapper';
 import { LocalWorkspaceAccessRepository } from 'src/domain/workspaces/infrastructure/persistence/local/local-workspace-access.repository';
 import { WorkspaceMemberRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace-member.record';
@@ -9,6 +9,7 @@ import { WorkspaceTeamGrantRecord } from 'src/domain/workspaces/infrastructure/p
 import { WorkspaceTeamMemberOverrideRecord } from 'src/domain/workspaces/infrastructure/persistence/local/schema/workspace-team-member-override.record';
 import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
 import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { WorkspaceVisibility } from 'src/domain/workspaces/domain/value-objects/workspace-visibility.enum';
 import {
   aWorkspace,
   TEST_ORG_ID,
@@ -19,9 +20,28 @@ import {
 const TEAM_ID = '44444444-4444-4444-8444-444444444444' as UUID;
 const TEAM_GRANT_ID = '55555555-5555-4555-8555-555555555555' as UUID;
 
+const createQueryBuilder = () => ({
+  leftJoin: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  andWhere: jest.fn().mockReturnThis(),
+  addGroupBy: jest.fn().mockReturnThis(),
+  addSelect: jest.fn().mockReturnThis(),
+  orderBy: jest.fn().mockReturnThis(),
+  addOrderBy: jest.fn().mockReturnThis(),
+  skip: jest.fn().mockReturnThis(),
+  take: jest.fn().mockReturnThis(),
+  getMany: jest.fn(),
+  getCount: jest.fn(),
+});
+
 describe('LocalWorkspaceAccessRepository', () => {
-  const workspaceRepo = { findOne: jest.fn() };
-  const memberRepo = { findOne: jest.fn() };
+  let listQueryBuilder = createQueryBuilder();
+  let countQueryBuilder = createQueryBuilder();
+  const workspaceRepo = {
+    findOne: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+  const memberRepo = { findOne: jest.fn(), find: jest.fn() };
   const teamGrantRepo = { find: jest.fn() };
   const overrideRepo = { find: jest.fn() };
   const mapper = { toDomain: jest.fn() };
@@ -29,6 +49,12 @@ describe('LocalWorkspaceAccessRepository', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    listQueryBuilder = createQueryBuilder();
+    countQueryBuilder = createQueryBuilder();
+    workspaceRepo.createQueryBuilder
+      .mockReset()
+      .mockReturnValueOnce(listQueryBuilder)
+      .mockReturnValueOnce(countQueryBuilder);
     const module = await Test.createTestingModule({
       providers: [
         LocalWorkspaceAccessRepository,
@@ -102,6 +128,107 @@ describe('LocalWorkspaceAccessRepository', () => {
     expect(workspaceRepo.findOne).toHaveBeenCalledWith({
       where: { id: TEST_WORKSPACE_ID, orgId: TEST_ORG_ID },
     });
+  });
+
+  it('lists and hydrates accessible workspaces with batched access queries', async () => {
+    const workspace = aWorkspace({
+      userId: randomUUID(),
+      visibility: WorkspaceVisibility.PRIVATE,
+    });
+    const workspaceRecord = {
+      id: TEST_WORKSPACE_ID,
+    } as WorkspaceRecord;
+    listQueryBuilder.getMany.mockResolvedValue([workspaceRecord]);
+    countQueryBuilder.getCount.mockResolvedValue(1);
+    mapper.toDomain.mockReturnValue(workspace);
+    memberRepo.find.mockResolvedValue([
+      {
+        workspaceId: TEST_WORKSPACE_ID,
+        accessLevel: WorkspaceAccessLevel.USE,
+        status: WorkspaceMemberStatus.ACTIVE,
+      },
+    ]);
+    teamGrantRepo.find.mockResolvedValue([
+      {
+        id: TEAM_GRANT_ID,
+        workspaceId: TEST_WORKSPACE_ID,
+        teamId: TEAM_ID,
+        accessLevel: WorkspaceAccessLevel.EDIT,
+      },
+    ]);
+    overrideRepo.find.mockResolvedValue([]);
+
+    await expect(
+      repository.findAccessSnapshots(
+        { orgId: TEST_ORG_ID, userId: TEST_USER_ID, teamIds: [TEAM_ID] },
+        { limit: 20, offset: 0, sort: 'updatedAt' },
+      ),
+    ).resolves.toMatchObject({
+      data: [
+        {
+          workspace,
+          directMembership: {
+            accessLevel: WorkspaceAccessLevel.USE,
+            status: WorkspaceMemberStatus.ACTIVE,
+          },
+          teamGrants: [
+            { teamId: TEAM_ID, accessLevel: WorkspaceAccessLevel.EDIT },
+          ],
+        },
+      ],
+      total: 1,
+    });
+    expect(listQueryBuilder.addSelect).toHaveBeenCalledWith(
+      expect.any(String),
+      'effective_activity_at',
+    );
+    expect(listQueryBuilder.orderBy).toHaveBeenCalledWith(
+      'effective_activity_at',
+      'DESC',
+    );
+    expect(countQueryBuilder.leftJoin).not.toHaveBeenCalled();
+    expect(countQueryBuilder.getCount).toHaveBeenCalled();
+    expect(memberRepo.find).toHaveBeenCalledTimes(1);
+    expect(teamGrantRepo.find).toHaveBeenCalledTimes(1);
+    expect(overrideRepo.find).toHaveBeenCalledTimes(1);
+  });
+
+  it('hydrates accessible workspaces requested by id in one batch', async () => {
+    const workspace = aWorkspace();
+    listQueryBuilder.getMany.mockResolvedValue([
+      { id: TEST_WORKSPACE_ID } as WorkspaceRecord,
+    ]);
+    mapper.toDomain.mockReturnValue(workspace);
+    memberRepo.find.mockResolvedValue([]);
+    teamGrantRepo.find.mockResolvedValue([]);
+
+    await expect(
+      repository.findAccessSnapshotsByIds(
+        { orgId: TEST_ORG_ID, userId: TEST_USER_ID, teamIds: [] },
+        [TEST_WORKSPACE_ID],
+      ),
+    ).resolves.toEqual([{ workspace, teamGrants: [] }]);
+    expect(listQueryBuilder.andWhere).toHaveBeenCalledWith(
+      'workspace.id IN (:...workspaceIds)',
+      { workspaceIds: [TEST_WORKSPACE_ID] },
+    );
+  });
+
+  it('does not join threads when sorting does not use activity', async () => {
+    listQueryBuilder.getMany.mockResolvedValue([]);
+    countQueryBuilder.getCount.mockResolvedValue(0);
+
+    await repository.findAccessSnapshots(
+      { orgId: TEST_ORG_ID, userId: TEST_USER_ID, teamIds: [] },
+      { limit: 20, offset: 0, sort: 'name' },
+    );
+
+    expect(listQueryBuilder.leftJoin).not.toHaveBeenCalled();
+    expect(listQueryBuilder.addGroupBy).not.toHaveBeenCalled();
+    expect(listQueryBuilder.orderBy).toHaveBeenCalledWith(
+      'LOWER(workspace.name)',
+      'ASC',
+    );
   });
 
   it('returns null without querying grants when the workspace is outside the org', async () => {

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-access.repository.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-access.repository.ts
@@ -1,18 +1,28 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { In, Repository, SelectQueryBuilder } from 'typeorm';
+import { Paginated } from 'src/common/pagination/paginated.entity';
 import type { UUID } from 'crypto';
 import {
   WorkspaceAccessRepository,
+  type FindWorkspaceAccessListParams,
   type FindWorkspaceAccessParams,
   type WorkspaceAccessSnapshot,
 } from 'src/domain/workspaces/application/ports/workspace-access-repository.port';
 import type { TeamGrantCandidate } from 'src/domain/workspaces/application/services/workspace-access-policy.service';
+import type { WorkspaceListOptions } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceVisibility } from 'src/domain/workspaces/domain/value-objects/workspace-visibility.enum';
 import { WorkspaceMapper } from './mappers/workspace.mapper';
 import { WorkspaceMemberRecord } from './schema/workspace-member.record';
 import { WorkspaceRecord } from './schema/workspace.record';
 import { WorkspaceTeamGrantRecord } from './schema/workspace-team-grant.record';
 import { WorkspaceTeamMemberOverrideRecord } from './schema/workspace-team-member-override.record';
+import {
+  applyWorkspaceSearch,
+  applyWorkspaceSort,
+  joinWorkspaceActivity,
+} from './workspace-list-query.helpers';
 
 @Injectable()
 export class LocalWorkspaceAccessRepository extends WorkspaceAccessRepository {
@@ -57,6 +67,153 @@ export class LocalWorkspaceAccessRepository extends WorkspaceAccessRepository {
         override: overrides.get(grant.id),
       })),
     };
+  }
+
+  async findAccessSnapshots(
+    params: FindWorkspaceAccessListParams,
+    query: WorkspaceListOptions,
+  ): Promise<Paginated<WorkspaceAccessSnapshot>> {
+    const listQuery = this.createAccessListQuery(params, query);
+    const countQuery = this.createAccessCountQuery(params, query);
+    const [records, total] = await Promise.all([
+      listQuery.skip(query.offset).take(query.limit).getMany(),
+      countQuery.getCount(),
+    ]);
+    const snapshots = await this.hydrateSnapshots(records, params);
+    return new Paginated({
+      data: snapshots,
+      limit: query.limit,
+      offset: query.offset,
+      total,
+    });
+  }
+
+  async findAccessSnapshotsByIds(
+    params: FindWorkspaceAccessListParams,
+    workspaceIds: UUID[],
+  ): Promise<WorkspaceAccessSnapshot[]> {
+    if (workspaceIds.length === 0) return [];
+    const records = await this.createAccessBaseQuery(params)
+      .andWhere('workspace.id IN (:...workspaceIds)', { workspaceIds })
+      .getMany();
+    return this.hydrateSnapshots(records, params);
+  }
+
+  private createAccessListQuery(
+    params: FindWorkspaceAccessListParams,
+    query: WorkspaceListOptions,
+  ): SelectQueryBuilder<WorkspaceRecord> {
+    let builder = this.createAccessBaseQuery(params);
+    if (query.sort === 'updatedAt') {
+      builder = joinWorkspaceActivity(builder);
+    }
+    applyWorkspaceSearch(builder, query.search);
+    applyWorkspaceSort(builder, query.sort);
+    return builder.addOrderBy('workspace.id', 'ASC');
+  }
+
+  private createAccessCountQuery(
+    params: FindWorkspaceAccessListParams,
+    query: Pick<WorkspaceListOptions, 'search'>,
+  ): SelectQueryBuilder<WorkspaceRecord> {
+    const builder = this.createAccessBaseQuery(params);
+    applyWorkspaceSearch(builder, query.search);
+    return builder;
+  }
+
+  private createAccessBaseQuery(
+    params: FindWorkspaceAccessListParams,
+  ): SelectQueryBuilder<WorkspaceRecord> {
+    return this.workspaceRepo
+      .createQueryBuilder('workspace')
+      .where('workspace."orgId" = :orgId', { orgId: params.orgId })
+      .andWhere(this.accessCondition(params), {
+        userId: params.userId,
+        visibility: WorkspaceVisibility.ORGANIZATION,
+        activeStatus: WorkspaceMemberStatus.ACTIVE,
+        teamIds: params.teamIds,
+      });
+  }
+
+  private accessCondition(params: FindWorkspaceAccessListParams): string {
+    const direct = `EXISTS (
+      SELECT 1 FROM workspace_members member
+      WHERE member."workspaceId" = workspace.id
+        AND member."userId" = :userId
+        AND member.status = :activeStatus
+    )`;
+    const sources = [
+      'workspace."userId" = :userId',
+      'workspace.visibility = :visibility',
+      direct,
+    ];
+    if (params.teamIds.length > 0) {
+      sources.push(`EXISTS (
+        SELECT 1 FROM workspace_team_grants team_grant
+        LEFT JOIN workspace_team_member_overrides member_override
+          ON member_override."teamGrantId" = team_grant.id
+          AND member_override."userId" = :userId
+        WHERE team_grant."workspaceId" = workspace.id
+          AND team_grant."teamId" IN (:...teamIds)
+          AND COALESCE(member_override.excluded, false) = false
+      )`);
+    }
+    return `(${sources.join(' OR ')})`;
+  }
+
+  private async hydrateSnapshots(
+    records: WorkspaceRecord[],
+    params: FindWorkspaceAccessListParams,
+  ): Promise<WorkspaceAccessSnapshot[]> {
+    if (records.length === 0) return [];
+    const workspaceIds = records.map(({ id }) => id);
+    const [members, teamGrants] = await Promise.all([
+      this.memberRepo.find({
+        where: { workspaceId: In(workspaceIds), userId: params.userId },
+      }),
+      params.teamIds.length === 0
+        ? []
+        : this.teamGrantRepo.find({
+            where: {
+              workspaceId: In(workspaceIds),
+              teamId: In(params.teamIds),
+            },
+          }),
+    ]);
+    const overrides = await this.findOverrides(teamGrants, params.userId);
+    const membersByWorkspaceId = new Map(
+      members.map((member) => [member.workspaceId, member]),
+    );
+    const grantsByWorkspaceId = this.groupTeamGrants(teamGrants);
+    return records.map((record) => ({
+      workspace: this.mapper.toDomain(record),
+      directMembership: this.mapMember(membersByWorkspaceId.get(record.id)),
+      teamGrants: (grantsByWorkspaceId.get(record.id) ?? []).map((grant) => ({
+        teamId: grant.teamId,
+        accessLevel: grant.accessLevel,
+        override: overrides.get(grant.id),
+      })),
+    }));
+  }
+
+  private mapMember(
+    member?: WorkspaceMemberRecord,
+  ): WorkspaceAccessSnapshot['directMembership'] {
+    return member
+      ? { accessLevel: member.accessLevel, status: member.status }
+      : undefined;
+  }
+
+  private groupTeamGrants(
+    grants: WorkspaceTeamGrantRecord[],
+  ): Map<UUID, WorkspaceTeamGrantRecord[]> {
+    const grantsByWorkspaceId = new Map<UUID, WorkspaceTeamGrantRecord[]>();
+    for (const grant of grants) {
+      const workspaceGrants = grantsByWorkspaceId.get(grant.workspaceId) ?? [];
+      workspaceGrants.push(grant);
+      grantsByWorkspaceId.set(grant.workspaceId, workspaceGrants);
+    }
+    return grantsByWorkspaceId;
   }
 
   private async findTeamGrants(

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspaces.repository.ts
@@ -15,10 +15,12 @@ import { WorkspaceSkillAssignmentRecord } from './schema/workspace-skill-assignm
 import { WorkspaceKnowledgeBaseAssignmentRecord } from './schema/workspace-knowledge-base-assignment.record';
 import { WorkspaceSourceAssignmentRecord } from './schema/workspace-source-assignment.record';
 import { Paginated } from 'src/common/pagination/paginated.entity';
-import type {
-  WorkspaceListOptions,
-  WorkspaceSortKey,
-} from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import type { WorkspaceListOptions } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import {
+  applyWorkspaceSearch,
+  applyWorkspaceSort,
+  joinWorkspaceActivity,
+} from './workspace-list-query.helpers';
 
 @Injectable()
 export class LocalWorkspacesRepository extends WorkspacesRepository {
@@ -67,7 +69,7 @@ export class LocalWorkspacesRepository extends WorkspacesRepository {
     const countQuery = this.repo
       .createQueryBuilder('workspace')
       .where('workspace.userId = :userId', { userId });
-    this.applyWorkspaceSearch(countQuery, query.search);
+    applyWorkspaceSearch(countQuery, query.search);
     return countQuery;
   }
 
@@ -75,52 +77,14 @@ export class LocalWorkspacesRepository extends WorkspacesRepository {
     userId: UUID,
     query: Pick<WorkspaceListOptions, 'search' | 'sort'>,
   ): SelectQueryBuilder<WorkspaceRecord> {
-    const listQuery = this.repo
-      .createQueryBuilder('workspace')
-      .leftJoin('threads', 'thread', 'thread."workspaceId" = workspace.id')
-      .where('workspace.userId = :userId', { userId })
-      .addGroupBy('workspace.id');
-
-    this.applyWorkspaceSearch(listQuery, query.search);
-    this.applyWorkspaceSort(listQuery, query.sort);
+    const listQuery = joinWorkspaceActivity(
+      this.repo
+        .createQueryBuilder('workspace')
+        .where('workspace.userId = :userId', { userId }),
+    );
+    applyWorkspaceSearch(listQuery, query.search);
+    applyWorkspaceSort(listQuery, query.sort);
     return listQuery;
-  }
-
-  private applyWorkspaceSearch(
-    query: SelectQueryBuilder<WorkspaceRecord>,
-    search?: string,
-  ): void {
-    if (search) {
-      query.andWhere('workspace.name ILIKE :search', {
-        search: `%${search}%`,
-      });
-    }
-  }
-
-  private applyWorkspaceSort(
-    query: SelectQueryBuilder<WorkspaceRecord>,
-    sort: WorkspaceSortKey,
-  ): void {
-    if (sort === 'name') {
-      query.orderBy('LOWER(workspace.name)', 'ASC');
-      return;
-    }
-    if (sort === 'createdAt') {
-      query.orderBy('workspace.createdAt', 'DESC');
-      return;
-    }
-    query
-      .addSelect(
-        `GREATEST(
-           workspace."updatedAt",
-           COALESCE(
-             MAX(COALESCE(thread."lastActivityAt", thread."createdAt")),
-             workspace."updatedAt"
-           )
-         )`,
-        'effective_activity_at',
-      )
-      .orderBy('effective_activity_at', 'DESC');
   }
 
   async findAllByIds(userId: UUID, ids: UUID[]): Promise<Workspace[]> {

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/workspace-list-query.helpers.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/workspace-list-query.helpers.ts
@@ -1,0 +1,44 @@
+import type { SelectQueryBuilder } from 'typeorm';
+import type { WorkspaceSortKey } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import type { WorkspaceRecord } from './schema/workspace.record';
+
+export function joinWorkspaceActivity(
+  query: SelectQueryBuilder<WorkspaceRecord>,
+): SelectQueryBuilder<WorkspaceRecord> {
+  return query
+    .leftJoin('threads', 'thread', 'thread."workspaceId" = workspace.id')
+    .addGroupBy('workspace.id');
+}
+
+export function applyWorkspaceSearch(
+  query: SelectQueryBuilder<WorkspaceRecord>,
+  search?: string,
+): void {
+  if (!search) return;
+  query.andWhere('workspace.name ILIKE :search', {
+    search: `%${search}%`,
+  });
+}
+
+export function applyWorkspaceSort(
+  query: SelectQueryBuilder<WorkspaceRecord>,
+  sort: WorkspaceSortKey,
+): void {
+  if (sort === 'name') {
+    query.orderBy('LOWER(workspace.name)', 'ASC');
+    return;
+  }
+  if (sort === 'createdAt') {
+    query.orderBy('workspace.createdAt', 'DESC');
+    return;
+  }
+  query
+    .addSelect(
+      `GREATEST(workspace."updatedAt", COALESCE(
+        MAX(COALESCE(thread."lastActivityAt", thread."createdAt")),
+        workspace."updatedAt"
+      ))`,
+      'effective_activity_at',
+    )
+    .orderBy('effective_activity_at', 'DESC');
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-response.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-response.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 
 export class WorkspaceResponseDto {
   @ApiProperty({
@@ -52,6 +53,12 @@ export class WorkspaceResponseDto {
     example: '2026-08-11T10:30:00.000Z',
   })
   updatedAt: string;
+
+  @ApiPropertyOptional({
+    description: 'Effective access level for the caller (list responses only)',
+    enum: WorkspaceAccessLevel,
+  })
+  accessLevel?: WorkspaceAccessLevel;
 
   @ApiPropertyOptional({
     description:

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.spec.ts
@@ -1,5 +1,6 @@
 import { Paginated } from 'src/common/pagination/paginated.entity';
 import { aWorkspace } from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { WorkspaceDtoMapper } from './workspace-dto.mapper';
 
 describe('WorkspaceDtoMapper', () => {
@@ -14,7 +15,14 @@ describe('WorkspaceDtoMapper', () => {
 
     const result = mapper.toPaginatedDto(
       new Paginated({
-        data: [{ workspace, chatCount: 4, lastActivityAt }],
+        data: [
+          {
+            workspace,
+            accessLevel: WorkspaceAccessLevel.EDIT,
+            chatCount: 4,
+            lastActivityAt,
+          },
+        ],
         limit: 20,
         offset: 0,
         total: 1,
@@ -32,6 +40,7 @@ describe('WorkspaceDtoMapper', () => {
           color: workspace.color,
           createdAt: workspace.createdAt.toISOString(),
           updatedAt: workspace.updatedAt.toISOString(),
+          accessLevel: WorkspaceAccessLevel.EDIT,
           chatCount: 4,
           lastActivityAt: lastActivityAt.toISOString(),
         },

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.ts
@@ -22,6 +22,7 @@ export class WorkspaceDtoMapper {
 
   toListItemDto(item: WorkspaceListItem): WorkspaceResponseDto {
     const dto = this.toDto(item.workspace);
+    dto.accessLevel = item.accessLevel;
     dto.chatCount = item.chatCount;
     dto.lastActivityAt = item.lastActivityAt.toISOString();
     return dto;

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3488,6 +3488,19 @@ export interface CreateWorkspaceDto {
   color?: string;
 }
 
+/**
+ * Effective access level for the caller (list responses only)
+ */
+export type WorkspaceResponseDtoAccessLevel = typeof WorkspaceResponseDtoAccessLevel[keyof typeof WorkspaceResponseDtoAccessLevel];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WorkspaceResponseDtoAccessLevel = {
+  use: 'use',
+  edit: 'edit',
+  full: 'full',
+} as const;
+
 export interface WorkspaceResponseDto {
   /** Unique identifier of the workspace */
   id: string;
@@ -3511,6 +3524,8 @@ export interface WorkspaceResponseDto {
   createdAt: string;
   /** When the workspace was last updated */
   updatedAt: string;
+  /** Effective access level for the caller (list responses only) */
+  accessLevel?: WorkspaceResponseDtoAccessLevel;
   /** Number of chats filed under the workspace (list responses only) */
   chatCount?: number;
   /** Later of the last edit and the most recent chat activity (list responses only) */

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -16823,6 +16823,11 @@
             "description": "When the workspace was last updated",
             "example": "2026-08-11T10:30:00.000Z"
           },
+          "accessLevel": {
+            "type": "string",
+            "description": "Effective access level for the caller (list responses only)",
+            "enum": ["use", "edit", "full"]
+          },
           "chatCount": {
             "type": "number",
             "description": "Number of chats filed under the workspace (list responses only)",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes workspace listing and ID resolution authorization paths; incorrect access SQL or policy filtering could expose or hide workspaces incorrectly, though behavior is covered by new unit tests.
> 
> **Overview**
> **GET `/workspaces`** now returns every workspace the caller can access (owner, direct member, team grant, org-visible), not only owned rows. Each list item includes the caller’s **effective `accessLevel`** alongside existing chat stats and activity sorting.
> 
> Access resolution is centralized: **`WorkspaceAccessService`** adds batched `findAllAccessible` / `findAllAccessibleByIds`, backed by new **`LocalWorkspaceAccessRepository`** list queries (SQL access predicates + batched membership/grant hydration). **`FindAllWorkspacesUseCase`** and **`FindWorkspacesByIdsUseCase`** route through that service instead of owner-scoped repository lookups.
> 
> **Favorites** workspace resolution uses the updated `FindWorkspacesByIdsQuery` (IDs only, request context for access), so pinned shared workspaces resolve correctly. List search/sort helpers are shared via **`workspace-list-query.helpers.ts`**. OpenAPI/generated frontend types add optional **`accessLevel`** on workspace list responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 904772d2c94881925967822f880c8a5594a3874f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->