### PR TITLE
wip(workspaces): expose sharing API (AYC-703)

### DIFF
--- a/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/workspaces/SUMMARY.md
@@ -11,10 +11,10 @@ the workspace. User-specific favorites and their order are owned by the
 
 User-facing copy calls them "Projekte"; the code, tables and routes say
 `workspace` throughout. See AYC-700 / AYC-701 in the Workspaces/Projects plan.
-Workspace collaboration is being introduced in stack layers. Direct member
-invitations, team grants and team-member overrides now exist at the application
-boundary. Read boundaries return hydrated sharing state and the current user's
-pending invitations; HTTP and frontend sharing flows follow later.
+Workspace collaboration supports direct invitations, team grants,
+team-member overrides, organization visibility, effective-access-level
+authorization, and HTTP sharing and invitation flows. The frontend sharing experience follows
+later.
 
 The whole module sits behind the `workspacesEnabled` feature flag
 (`FEATURE_WORKSPACES_ENABLED`, off by default), applied at the controller.
@@ -37,7 +37,8 @@ The whole module sits behind the `workspacesEnabled` feature flag
   Direct-member use cases manage pending invitations, acceptance, access levels
   and removal. Team-grant use cases add, update and remove immediate team
   access. Team-scoped member overrides can replace or exclude a member's grant
-  without affecting other team members; HTTP sharing endpoints follow later.
+  without affecting other team members. Full-access users manage these settings
+  through the sharing HTTP API.
 - **Deletion** — `DeleteWorkspaceUseCase` emits `WorkspaceDeletionRequestedEvent`
   _before_ the row delete and drains the listeners' deferred cleanup only after
   it succeeds, so a failed delete loses nothing. The favorites module listens
@@ -98,6 +99,7 @@ workspaces/
 │       ├── get-workspace-sharing/ / list-my-workspace-invitations/
 │       ├── find-all-workspaces/ / find-workspaces-by-ids/ / find-workspace/
 │       ├── update-workspace/ / update-workspace-instruction/
+│       ├── update-workspace-visibility/
 │       ├── attach-skill-to-workspace/ / detach-skill-from-workspace/
 │       ├── attach-knowledge-base-to-workspace/ / detach-knowledge-base-from-workspace/
 │       ├── add-document-to-workspace/ / remove-document-from-workspace/
@@ -135,8 +137,10 @@ workspaces/
 │   ├── local-workspace-invitations-read-repository.module.ts
 │   └── local-workspaces-repository.module.ts
 ├── presenters/http/
-│   ├── workspaces.controller.ts
-│   ├── workspace-context.controller.ts
+│   ├── workspaces.controller.ts / workspace-context.controller.ts
+│   ├── workspace-sharing.controller.ts / workspace-members.controller.ts
+│   ├── workspace-team-grants.controller.ts
+│   ├── workspace-invitations.controller.ts
 │   ├── dtos/
 │   └── mappers/
 └── workspaces.module.ts
@@ -144,24 +148,33 @@ workspaces/
 
 ## HTTP API
 
-| Method        | Route                                                      | Purpose                                               |
-| ------------- | ---------------------------------------------------------- | ----------------------------------------------------- |
-| POST          | `/workspaces`                                              | Create a workspace                                    |
-| GET           | `/workspaces`                                              | List accessible workspaces                            |
-| GET           | `/workspaces/:id`                                          | Read one                                              |
-| PATCH         | `/workspaces/:id`                                          | Update name / description / icon / colour             |
-| DELETE        | `/workspaces/:id`                                          | Delete the workspace and its chats                    |
-| GET           | `/workspaces/:id/context`                                  | Read the full runtime context                         |
-| GET           | `/workspaces/:id/context/skill-candidates`                 | List accessible skills with attachment state          |
-| GET           | `/workspaces/:id/context/knowledge-base-candidates`        | List accessible knowledge bases with attachment state |
-| GET           | `/workspaces/:id/context/skills`                           | List attached skills                                  |
-| GET           | `/workspaces/:id/context/knowledge-bases`                  | List attached knowledge bases                         |
-| GET           | `/workspaces/:id/context/documents`                        | List attached documents                               |
-| POST / DELETE | `/workspaces/:id/context/skills/:skillId`                  | Attach or detach a skill                              |
-| POST / DELETE | `/workspaces/:id/context/knowledge-bases/:knowledgeBaseId` | Attach or detach a knowledge base                     |
-| POST          | `/workspaces/:id/context/documents`                        | Upload and attach a document                          |
-| DELETE        | `/workspaces/:id/context/documents/:documentId`            | Remove an attached document                           |
-| PATCH         | `/workspaces/:id/context/instruction`                      | Update the workspace instruction                      |
+| Method                | Route                                                      | Purpose                                                |
+| --------------------- | ---------------------------------------------------------- | ------------------------------------------------------ |
+| POST                  | `/workspaces`                                              | Create a workspace                                     |
+| GET                   | `/workspaces`                                              | List accessible workspaces                             |
+| GET                   | `/workspaces/:id`                                          | Read one                                               |
+| PATCH                 | `/workspaces/:id`                                          | Update name / description / icon / colour              |
+| DELETE                | `/workspaces/:id`                                          | Delete the workspace and its chats                     |
+| GET                   | `/workspaces/:id/context`                                  | Read the full runtime context                          |
+| GET                   | `/workspaces/:id/context/skill-candidates`                 | List accessible skills with attachment state           |
+| GET                   | `/workspaces/:id/context/knowledge-base-candidates`        | List accessible knowledge bases with attachment state  |
+| GET                   | `/workspaces/:id/context/skills`                           | List attached skills                                   |
+| GET                   | `/workspaces/:id/context/knowledge-bases`                  | List attached knowledge bases                          |
+| GET                   | `/workspaces/:id/context/documents`                        | List attached documents                                |
+| POST / DELETE         | `/workspaces/:id/context/skills/:skillId`                  | Attach or detach a skill                               |
+| POST / DELETE         | `/workspaces/:id/context/knowledge-bases/:knowledgeBaseId` | Attach or detach a knowledge base                      |
+| POST                  | `/workspaces/:id/context/documents`                        | Upload and attach a document                           |
+| DELETE                | `/workspaces/:id/context/documents/:documentId`            | Remove an attached document                            |
+| PATCH                 | `/workspaces/:id/context/instruction`                      | Update the workspace instruction                       |
+| GET                   | `/workspaces/:id/sharing`                                  | Read visibility, members, teams and overrides          |
+| PATCH                 | `/workspaces/:id/sharing/visibility`                       | Change private or organization visibility              |
+| POST / PATCH / DELETE | `/workspaces/:id/members[/:userId]`                        | Manage direct invitations and members                  |
+| POST / PATCH / DELETE | `/workspaces/:id/team-grants[/:teamId]`                    | Manage team grants                                     |
+| GET                   | `/workspaces/:id/team-grants/:teamId/members`              | List members of a granted team for override management |
+| PUT / DELETE          | `/workspaces/:id/team-grants/:teamId/overrides/:userId`    | Set or reset a team-member override                    |
+| GET                   | `/workspace-invitations`                                   | List the current user's pending invitations            |
+| POST                  | `/workspace-invitations/:workspaceId/accept`               | Accept an invitation                                   |
+| POST                  | `/workspace-invitations/:workspaceId/decline`              | Decline an invitation                                  |
 
 ## Cross-Module Boundaries
 

--- a/ayunis-core-backend/src/domain/workspaces/application/ports/workspace-team-member-overrides-repository.port.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/ports/workspace-team-member-overrides-repository.port.ts
@@ -14,6 +14,8 @@ export type WorkspaceTeamMemberOverrideInput = Omit<
 >;
 
 export abstract class WorkspaceTeamMemberOverridesRepository {
+  abstract hasTeamGrant(workspaceId: UUID, teamId: UUID): Promise<boolean>;
+
   abstract upsertOverride(
     workspaceId: UUID,
     teamId: UUID,

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.spec.ts
@@ -22,7 +22,7 @@ describe('FindAllWorkspacesUseCase', () => {
             {
               workspace,
               accessLevel: WorkspaceAccessLevel.EDIT,
-              sources: [],
+              sources: [{ type: 'owner' }],
             },
           ],
           limit: 20,
@@ -43,6 +43,7 @@ describe('FindAllWorkspacesUseCase', () => {
           {
             workspace,
             accessLevel: WorkspaceAccessLevel.EDIT,
+            isOwner: true,
             chatCount: 3,
             lastActivityAt: workspace.updatedAt,
           },
@@ -88,6 +89,7 @@ describe('FindAllWorkspacesUseCase', () => {
 
     expect(data[0]).toMatchObject({
       accessLevel: WorkspaceAccessLevel.USE,
+      isOwner: false,
       chatCount: 1,
       lastActivityAt: chatActivity,
     });

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case.ts
@@ -12,6 +12,7 @@ import { FindAllWorkspacesQuery } from './find-all-workspaces.query';
 export interface WorkspaceListItem {
   workspace: Workspace;
   accessLevel: WorkspaceAccessLevel;
+  isOwner: boolean;
   chatCount: number;
   lastActivityAt: Date;
 }
@@ -35,12 +36,13 @@ export class FindAllWorkspacesUseCase {
       page.data.map(({ workspace }) => workspace.id),
     );
     return new Paginated({
-      data: page.data.map(({ workspace, accessLevel }) => {
+      data: page.data.map(({ workspace, accessLevel, sources }) => {
         const threadStats = stats.get(workspace.id);
         const chatActivity = threadStats?.lastActivityAt;
         return {
           workspace,
           accessLevel,
+          isOwner: sources.some(({ type }) => type === 'owner'),
           chatCount: threadStats?.chatCount ?? 0,
           lastActivityAt:
             chatActivity && chatActivity > workspace.updatedAt

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-sharing/get-workspace-sharing.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-sharing/get-workspace-sharing.use-case.spec.ts
@@ -1,3 +1,4 @@
+import type { UUID } from 'crypto';
 import {
   TEST_TEAM_ID,
   TEST_USER_ID,
@@ -5,10 +6,13 @@ import {
 } from 'src/domain/workspaces/application/testing/workspace.fixtures';
 import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
 import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { WorkspaceVisibility } from 'src/domain/workspaces/domain/value-objects/workspace-visibility.enum';
 import { GetWorkspaceSharingQuery } from './get-workspace-sharing.query';
 import { GetWorkspaceSharingUseCase } from './get-workspace-sharing.use-case';
 
 const GRANT_ID = '55555555-5555-4555-8555-555555555555' as const;
+const OWNER_ID = '66666666-6666-4666-8666-666666666666' as UUID;
+const AVAILABLE_TEAM_ID = '77777777-7777-4777-8777-777777777777' as UUID;
 
 describe('GetWorkspaceSharingUseCase', () => {
   it('hydrates direct members, team grants and overrides', async () => {
@@ -41,17 +45,27 @@ describe('GetWorkspaceSharingUseCase', () => {
       }),
     };
     const accessService = {
-      requireAccessLevel: jest.fn().mockResolvedValue({}),
+      requireAccessLevel: jest.fn().mockResolvedValue({
+        workspace: {
+          userId: OWNER_ID,
+          visibility: WorkspaceVisibility.ORGANIZATION,
+        },
+      }),
     };
     const findUsers = {
-      execute: jest.fn().mockResolvedValue([{ id: TEST_USER_ID, name: 'Ada' }]),
+      execute: jest.fn().mockResolvedValue([
+        { id: OWNER_ID, name: 'Owner' },
+        { id: TEST_USER_ID, name: 'Ada' },
+      ]),
     };
     const listTeams = {
-      execute: jest
-        .fn()
-        .mockResolvedValue([
-          { team: { id: TEST_TEAM_ID, name: 'Service' }, memberCount: 2 },
-        ]),
+      execute: jest.fn().mockResolvedValue([
+        { team: { id: TEST_TEAM_ID, name: 'Service' }, memberCount: 2 },
+        {
+          team: { id: AVAILABLE_TEAM_ID, name: 'Planning' },
+          memberCount: 3,
+        },
+      ]),
     };
     const useCase = new GetWorkspaceSharingUseCase(
       { info: jest.fn() } as never,
@@ -64,6 +78,14 @@ describe('GetWorkspaceSharingUseCase', () => {
     await expect(
       useCase.execute(new GetWorkspaceSharingQuery(TEST_WORKSPACE_ID)),
     ).resolves.toEqual({
+      visibility: WorkspaceVisibility.ORGANIZATION,
+      owner: { id: OWNER_ID, name: 'Owner' },
+      availableTeams: [
+        {
+          team: { id: AVAILABLE_TEAM_ID, name: 'Planning' },
+          memberCount: 3,
+        },
+      ],
       members: [
         {
           user: { id: TEST_USER_ID, name: 'Ada' },

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-sharing/get-workspace-sharing.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-sharing/get-workspace-sharing.use-case.ts
@@ -1,12 +1,16 @@
 import { Injectable } from '@nestjs/common';
+import type { UUID } from 'crypto';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import type { WorkspaceMember } from 'src/domain/workspaces/application/ports/workspace-members-repository.port';
 import {
   WorkspaceSharingReadRepository,
   type WorkspaceSharingSnapshot,
+  type WorkspaceTeamGrantSharing,
 } from 'src/domain/workspaces/application/ports/workspace-sharing-read-repository.port';
 import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
 import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { ListTeamsUseCase } from 'src/iam/teams/application/use-cases/list-teams/list-teams.use-case';
 import type { TeamWithMemberCount } from 'src/iam/teams/application/use-cases/list-teams/team-with-member-count.view';
@@ -14,7 +18,12 @@ import { FindUsersByIdsQuery } from 'src/iam/users/application/use-cases/find-us
 import { FindUsersByIdsUseCase } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case';
 import type { User } from 'src/iam/users/domain/user.entity';
 import { GetWorkspaceSharingQuery } from './get-workspace-sharing.query';
-import type { WorkspaceSharingView } from './workspace-sharing.view';
+import type {
+  WorkspaceSharingMemberView,
+  WorkspaceSharingOverrideView,
+  WorkspaceSharingTeamGrantView,
+  WorkspaceSharingView,
+} from './workspace-sharing.view';
 
 @Injectable()
 export class GetWorkspaceSharingUseCase {
@@ -35,20 +44,26 @@ export class GetWorkspaceSharingUseCase {
       { workspaceId: query.workspaceId },
       'Getting workspace sharing',
     );
-    await this.accessService.requireAccessLevel(
+    const { workspace } = await this.accessService.requireAccessLevel(
       query.workspaceId,
       WorkspaceAccessLevel.FULL,
     );
-    const snapshot = await this.repository.findSharing(query.workspaceId);
-    const [users, teams] = await Promise.all([
-      this.findUsers(snapshot),
+    const [snapshot, teams] = await Promise.all([
+      this.repository.findSharing(query.workspaceId),
       this.listTeamsUseCase.execute(),
     ]);
-    return this.toView(snapshot, users, teams);
+    const users = await this.findUsers(snapshot, workspace.userId);
+    return toWorkspaceSharingView({ workspace, snapshot, users, teams });
   }
 
-  private findUsers(snapshot: WorkspaceSharingSnapshot): Promise<User[]> {
-    const ids = new Set(snapshot.members.map(({ userId }) => userId));
+  private findUsers(
+    snapshot: WorkspaceSharingSnapshot,
+    ownerId: UUID,
+  ): Promise<User[]> {
+    const ids = new Set([
+      ownerId,
+      ...snapshot.members.map(({ userId }) => userId),
+    ]);
     for (const grant of snapshot.teamGrants) {
       grant.overrides.forEach(({ userId }) => ids.add(userId));
     }
@@ -56,43 +71,81 @@ export class GetWorkspaceSharingUseCase {
       new FindUsersByIdsQuery([...ids]),
     );
   }
+}
 
-  private toView(
-    snapshot: WorkspaceSharingSnapshot,
-    users: User[],
-    teams: TeamWithMemberCount[],
-  ): WorkspaceSharingView {
-    const usersById = new Map(users.map((user) => [user.id, user]));
-    const teamsById = new Map(teams.map((team) => [team.team.id, team]));
-    return {
-      members: snapshot.members.flatMap((member) => {
-        const user = usersById.get(member.userId);
-        return user
-          ? [{ user, accessLevel: member.accessLevel, status: member.status }]
-          : [];
-      }),
-      teamGrants: snapshot.teamGrants.flatMap((grant) => {
-        const team = teamsById.get(grant.teamId);
-        if (!team) return [];
-        return [
-          {
-            ...team,
-            accessLevel: grant.accessLevel,
-            overrides: grant.overrides.flatMap((override) => {
-              const user = usersById.get(override.userId);
-              return user
-                ? [
-                    {
-                      user,
-                      accessLevel: override.accessLevel,
-                      excluded: override.excluded,
-                    },
-                  ]
-                : [];
-            }),
-          },
-        ];
-      }),
-    };
-  }
+interface WorkspaceSharingViewInput {
+  workspace: Pick<Workspace, 'userId' | 'visibility'>;
+  snapshot: WorkspaceSharingSnapshot;
+  users: User[];
+  teams: TeamWithMemberCount[];
+}
+
+function toWorkspaceSharingView({
+  workspace,
+  snapshot,
+  users,
+  teams,
+}: WorkspaceSharingViewInput): WorkspaceSharingView {
+  const usersById = new Map(users.map((user) => [user.id, user]));
+  const owner = usersById.get(workspace.userId);
+  if (!owner) throw new Error('Workspace owner was not hydrated');
+  const grantedTeamIds = new Set(
+    snapshot.teamGrants.map(({ teamId }) => teamId),
+  );
+  return {
+    visibility: workspace.visibility,
+    owner,
+    availableTeams: teams.filter(({ team }) => !grantedTeamIds.has(team.id)),
+    members: mapMembers(snapshot.members, usersById),
+    teamGrants: mapTeamGrants(snapshot.teamGrants, teams, usersById),
+  };
+}
+
+function mapMembers(
+  members: WorkspaceMember[],
+  usersById: Map<UUID, User>,
+): WorkspaceSharingMemberView[] {
+  return members.flatMap((member) => {
+    const user = usersById.get(member.userId);
+    return user
+      ? [{ user, accessLevel: member.accessLevel, status: member.status }]
+      : [];
+  });
+}
+
+function mapTeamGrants(
+  grants: WorkspaceTeamGrantSharing[],
+  teams: TeamWithMemberCount[],
+  usersById: Map<UUID, User>,
+): WorkspaceSharingTeamGrantView[] {
+  const teamsById = new Map(teams.map((team) => [team.team.id, team]));
+  return grants.flatMap((grant) => {
+    const team = teamsById.get(grant.teamId);
+    if (!team) return [];
+    return [
+      {
+        ...team,
+        accessLevel: grant.accessLevel,
+        overrides: grant.overrides.flatMap((override) =>
+          mapOverride(override, usersById),
+        ),
+      },
+    ];
+  });
+}
+
+function mapOverride(
+  override: WorkspaceTeamGrantSharing['overrides'][number],
+  usersById: Map<UUID, User>,
+): WorkspaceSharingOverrideView[] {
+  const user = usersById.get(override.userId);
+  return user
+    ? [
+        {
+          user,
+          accessLevel: override.accessLevel,
+          excluded: override.excluded,
+        },
+      ]
+    : [];
 }

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-sharing/workspace-sharing.view.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/get-workspace-sharing/workspace-sharing.view.ts
@@ -1,5 +1,6 @@
 import type { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
 import type { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import type { WorkspaceVisibility } from 'src/domain/workspaces/domain/value-objects/workspace-visibility.enum';
 import type { Team } from 'src/iam/teams/domain/team.entity';
 import type { User } from 'src/iam/users/domain/user.entity';
 
@@ -22,7 +23,15 @@ export interface WorkspaceSharingTeamGrantView {
   overrides: WorkspaceSharingOverrideView[];
 }
 
+export interface WorkspaceSharingAvailableTeamView {
+  team: Team;
+  memberCount: number;
+}
+
 export interface WorkspaceSharingView {
+  visibility: WorkspaceVisibility;
+  owner: User;
+  availableTeams: WorkspaceSharingAvailableTeamView[];
   members: WorkspaceSharingMemberView[];
   teamGrants: WorkspaceSharingTeamGrantView[];
 }

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-team-members/list-workspace-team-members.query.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-team-members/list-workspace-team-members.query.ts
@@ -1,0 +1,8 @@
+import type { UUID } from 'crypto';
+
+export class ListWorkspaceTeamMembersQuery {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly teamId: UUID,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-team-members/list-workspace-team-members.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-team-members/list-workspace-team-members.use-case.spec.ts
@@ -1,0 +1,44 @@
+import {
+  TEST_TEAM_ID,
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { ListWorkspaceTeamMembersQuery } from './list-workspace-team-members.query';
+import { ListWorkspaceTeamMembersUseCase } from './list-workspace-team-members.use-case';
+
+describe('ListWorkspaceTeamMembersUseCase', () => {
+  it('hydrates members of a granted team with full access', async () => {
+    const repository = {
+      findSharing: jest.fn().mockResolvedValue({
+        members: [],
+        teamGrants: [{ teamId: TEST_TEAM_ID }],
+      }),
+    };
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({}),
+    };
+    const findUserIds = {
+      execute: jest.fn().mockResolvedValue([TEST_USER_ID]),
+    };
+    const users = [{ id: TEST_USER_ID, name: 'Ada' }];
+    const findUsers = { execute: jest.fn().mockResolvedValue(users) };
+    const useCase = new ListWorkspaceTeamMembersUseCase(
+      { info: jest.fn() } as never,
+      repository as never,
+      accessService as never,
+      findUserIds as never,
+      findUsers as never,
+    );
+
+    await expect(
+      useCase.execute(
+        new ListWorkspaceTeamMembersQuery(TEST_WORKSPACE_ID, TEST_TEAM_ID),
+      ),
+    ).resolves.toEqual(users);
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.FULL,
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-team-members/list-workspace-team-members.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/list-workspace-team-members/list-workspace-team-members.use-case.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { WorkspaceSharingReadRepository } from 'src/domain/workspaces/application/ports/workspace-sharing-read-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import {
+  UnexpectedWorkspaceError,
+  WorkspaceTeamGrantNotFoundError,
+} from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { FindAllUserIdsByTeamIdQuery } from 'src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.query';
+import { FindAllUserIdsByTeamIdUseCase } from 'src/iam/teams/application/use-cases/find-all-user-ids-by-team-id/find-all-user-ids-by-team-id.use-case';
+import { FindUsersByIdsQuery } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.query';
+import { FindUsersByIdsUseCase } from 'src/iam/users/application/use-cases/find-users-by-ids/find-users-by-ids.use-case';
+import type { User } from 'src/iam/users/domain/user.entity';
+import { ListWorkspaceTeamMembersQuery } from './list-workspace-team-members.query';
+
+@Injectable()
+export class ListWorkspaceTeamMembersUseCase {
+  constructor(
+    @InjectPinoLogger(ListWorkspaceTeamMembersUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly repository: WorkspaceSharingReadRepository,
+    private readonly accessService: WorkspaceAccessService,
+    private readonly findUserIds: FindAllUserIdsByTeamIdUseCase,
+    private readonly findUsers: FindUsersByIdsUseCase,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(query: ListWorkspaceTeamMembersQuery): Promise<User[]> {
+    this.logger.info(
+      { workspaceId: query.workspaceId, teamId: query.teamId },
+      'Listing workspace team members',
+    );
+    await this.accessService.requireAccessLevel(
+      query.workspaceId,
+      WorkspaceAccessLevel.FULL,
+    );
+    const sharing = await this.repository.findSharing(query.workspaceId);
+    if (!sharing.teamGrants.some(({ teamId }) => teamId === query.teamId)) {
+      throw new WorkspaceTeamGrantNotFoundError(
+        query.workspaceId,
+        query.teamId,
+      );
+    }
+    const userIds = await this.findUserIds.execute(
+      new FindAllUserIdsByTeamIdQuery(query.teamId),
+    );
+    return this.findUsers.execute(new FindUsersByIdsQuery(userIds));
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/set-workspace-team-member-override/set-workspace-team-member-override.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/set-workspace-team-member-override/set-workspace-team-member-override.use-case.spec.ts
@@ -10,6 +10,7 @@ import { SetWorkspaceTeamMemberOverrideUseCase } from './set-workspace-team-memb
 describe('SetWorkspaceTeamMemberOverrideUseCase', () => {
   it('sets an access-level override for a member of the granted team', async () => {
     const repository = {
+      hasTeamGrant: jest.fn().mockResolvedValue(true),
       upsertOverride: jest.fn().mockResolvedValue({
         teamGrantId: 'grant-id',
         userId: TEST_USER_ID,
@@ -49,7 +50,7 @@ describe('SetWorkspaceTeamMemberOverrideUseCase', () => {
   it('rejects a user outside the granted team', async () => {
     const useCase = new SetWorkspaceTeamMemberOverrideUseCase(
       { info: jest.fn() } as never,
-      {} as never,
+      { hasTeamGrant: jest.fn().mockResolvedValue(true) } as never,
       { requireAccessLevel: jest.fn().mockResolvedValue({}) } as never,
       { execute: jest.fn().mockResolvedValue(false) } as never,
     );
@@ -66,12 +67,13 @@ describe('SetWorkspaceTeamMemberOverrideUseCase', () => {
     ).rejects.toThrow('must belong to the granted team');
   });
 
-  it('rejects a missing team grant', async () => {
+  it('rejects a missing team grant before checking team membership', async () => {
+    const membershipUseCase = { execute: jest.fn() };
     const useCase = new SetWorkspaceTeamMemberOverrideUseCase(
       { info: jest.fn() } as never,
-      { upsertOverride: jest.fn().mockResolvedValue(null) } as never,
+      { hasTeamGrant: jest.fn().mockResolvedValue(false) } as never,
       { requireAccessLevel: jest.fn().mockResolvedValue({}) } as never,
-      { execute: jest.fn().mockResolvedValue(true) } as never,
+      membershipUseCase as never,
     );
 
     await expect(
@@ -84,5 +86,6 @@ describe('SetWorkspaceTeamMemberOverrideUseCase', () => {
         ),
       ),
     ).rejects.toThrow('Workspace team grant not found');
+    expect(membershipUseCase.execute).not.toHaveBeenCalled();
   });
 });

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/set-workspace-team-member-override/set-workspace-team-member-override.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/set-workspace-team-member-override/set-workspace-team-member-override.use-case.ts
@@ -42,6 +42,7 @@ export class SetWorkspaceTeamMemberOverrideUseCase {
       command.workspaceId,
       WorkspaceAccessLevel.FULL,
     );
+    await this.ensureTeamGrantExists(command);
     const isTeamMember = await this.checkMembershipUseCase.execute(
       new CheckUserTeamMembershipQuery({
         teamId: command.teamId,
@@ -66,5 +67,20 @@ export class SetWorkspaceTeamMemberOverrideUseCase {
       );
     }
     return override;
+  }
+
+  private async ensureTeamGrantExists(
+    command: SetWorkspaceTeamMemberOverrideCommand,
+  ): Promise<void> {
+    const exists = await this.repository.hasTeamGrant(
+      command.workspaceId,
+      command.teamId,
+    );
+    if (!exists) {
+      throw new WorkspaceTeamGrantNotFoundError(
+        command.workspaceId,
+        command.teamId,
+      );
+    }
   }
 }

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-visibility/update-workspace-visibility.command.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-visibility/update-workspace-visibility.command.ts
@@ -1,0 +1,9 @@
+import type { UUID } from 'crypto';
+import type { WorkspaceVisibility } from 'src/domain/workspaces/domain/value-objects/workspace-visibility.enum';
+
+export class UpdateWorkspaceVisibilityCommand {
+  constructor(
+    public readonly workspaceId: UUID,
+    public readonly visibility: WorkspaceVisibility,
+  ) {}
+}

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-visibility/update-workspace-visibility.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-visibility/update-workspace-visibility.use-case.spec.ts
@@ -1,0 +1,39 @@
+import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
+import {
+  TEST_WORKSPACE_ID,
+  aWorkspace,
+  createMockWorkspacesRepository,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { WorkspaceVisibility } from 'src/domain/workspaces/domain/value-objects/workspace-visibility.enum';
+import { UpdateWorkspaceVisibilityCommand } from './update-workspace-visibility.command';
+import { UpdateWorkspaceVisibilityUseCase } from './update-workspace-visibility.use-case';
+
+describe('UpdateWorkspaceVisibilityUseCase', () => {
+  it('changes visibility with full access', async () => {
+    const workspace = aWorkspace();
+    const repository = createMockWorkspacesRepository();
+    const accessService = {
+      requireAccessLevel: jest.fn().mockResolvedValue({ workspace }),
+    };
+    const useCase = new UpdateWorkspaceVisibilityUseCase(
+      createPinoLoggerMock(),
+      repository,
+      accessService as never,
+    );
+
+    const result = await useCase.execute(
+      new UpdateWorkspaceVisibilityCommand(
+        TEST_WORKSPACE_ID,
+        WorkspaceVisibility.ORGANIZATION,
+      ),
+    );
+
+    expect(accessService.requireAccessLevel).toHaveBeenCalledWith(
+      TEST_WORKSPACE_ID,
+      WorkspaceAccessLevel.FULL,
+    );
+    expect(result.visibility).toBe(WorkspaceVisibility.ORGANIZATION);
+    expect(repository.save).toHaveBeenCalledWith(workspace);
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-visibility/update-workspace-visibility.use-case.ts
+++ b/ayunis-core-backend/src/domain/workspaces/application/use-cases/update-workspace-visibility/update-workspace-visibility.use-case.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
+import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
+import { WorkspacesRepository } from 'src/domain/workspaces/application/ports/workspaces-repository.port';
+import { WorkspaceAccessService } from 'src/domain/workspaces/application/services/workspace-access.service';
+import { UnexpectedWorkspaceError } from 'src/domain/workspaces/application/workspaces.errors';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
+import { UpdateWorkspaceVisibilityCommand } from './update-workspace-visibility.command';
+
+@Injectable()
+export class UpdateWorkspaceVisibilityUseCase {
+  constructor(
+    @InjectPinoLogger(UpdateWorkspaceVisibilityUseCase.name)
+    private readonly logger: PinoLogger,
+    private readonly workspacesRepository: WorkspacesRepository,
+    private readonly accessService: WorkspaceAccessService,
+  ) {}
+
+  @HandleUnexpectedErrors(UnexpectedWorkspaceError)
+  async execute(command: UpdateWorkspaceVisibilityCommand): Promise<Workspace> {
+    this.logger.info(
+      { workspaceId: command.workspaceId, visibility: command.visibility },
+      'Updating workspace visibility',
+    );
+    const { workspace } = await this.accessService.requireAccessLevel(
+      command.workspaceId,
+      WorkspaceAccessLevel.FULL,
+    );
+    workspace.changeVisibility(command.visibility);
+    return this.workspacesRepository.save(workspace);
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-team-member-overrides.repository.ts
+++ b/ayunis-core-backend/src/domain/workspaces/infrastructure/persistence/local/local-workspace-team-member-overrides.repository.ts
@@ -23,6 +23,10 @@ export class LocalWorkspaceTeamMemberOverridesRepository extends WorkspaceTeamMe
     super();
   }
 
+  async hasTeamGrant(workspaceId: UUID, teamId: UUID): Promise<boolean> {
+    return (await this.findTeamGrantId(workspaceId, teamId)) !== null;
+  }
+
   async upsertOverride(
     workspaceId: UUID,
     teamId: UUID,

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/add-workspace-team-grant.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/add-workspace-team-grant.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsUUID } from 'class-validator';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+
+export class AddWorkspaceTeamGrantDto {
+  @ApiProperty({ format: 'uuid' })
+  @IsUUID()
+  teamId: string;
+
+  @ApiProperty({ enum: WorkspaceAccessLevel })
+  @IsEnum(WorkspaceAccessLevel)
+  accessLevel: WorkspaceAccessLevel;
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/invite-workspace-member.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/invite-workspace-member.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsUUID } from 'class-validator';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+
+export class InviteWorkspaceMemberDto {
+  @ApiProperty({ format: 'uuid' })
+  @IsUUID()
+  userId: string;
+
+  @ApiProperty({ enum: WorkspaceAccessLevel })
+  @IsEnum(WorkspaceAccessLevel)
+  accessLevel: WorkspaceAccessLevel;
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/set-workspace-team-member-override.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/set-workspace-team-member-override.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDefined, IsEnum, ValidateIf } from 'class-validator';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+
+export class SetWorkspaceTeamMemberOverrideDto {
+  @ApiProperty({ enum: WorkspaceAccessLevel, nullable: true })
+  @IsDefined()
+  @ValidateIf((_object, value: unknown) => value !== null)
+  @IsEnum(WorkspaceAccessLevel)
+  accessLevel: WorkspaceAccessLevel | null;
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/update-workspace-visibility.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/update-workspace-visibility.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { WorkspaceVisibility } from 'src/domain/workspaces/domain/value-objects/workspace-visibility.enum';
+
+export class UpdateWorkspaceVisibilityDto {
+  @ApiProperty({ enum: WorkspaceVisibility })
+  @IsEnum(WorkspaceVisibility)
+  visibility: WorkspaceVisibility;
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-access-level.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-access-level.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+
+export class WorkspaceAccessLevelDto {
+  @ApiProperty({ enum: WorkspaceAccessLevel })
+  @IsEnum(WorkspaceAccessLevel)
+  accessLevel: WorkspaceAccessLevel;
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-access-response.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-access-response.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+
+export class WorkspaceAccessResponseDto {
+  @ApiProperty({ enum: WorkspaceAccessLevel })
+  accessLevel: WorkspaceAccessLevel;
+
+  @ApiProperty()
+  isOwner: boolean;
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-invitation-response.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-invitation-response.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+
+export class WorkspaceInvitationWorkspaceDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  icon: string;
+
+  @ApiProperty()
+  color: string;
+}
+
+export class WorkspaceInvitationResponseDto {
+  @ApiProperty({ type: WorkspaceInvitationWorkspaceDto })
+  workspace: WorkspaceInvitationWorkspaceDto;
+
+  @ApiProperty({ enum: WorkspaceAccessLevel })
+  accessLevel: WorkspaceAccessLevel;
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-response.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-response.dto.ts
@@ -61,6 +61,11 @@ export class WorkspaceResponseDto {
   accessLevel?: WorkspaceAccessLevel;
 
   @ApiPropertyOptional({
+    description: 'Whether the caller owns the workspace',
+  })
+  isOwner?: boolean;
+
+  @ApiPropertyOptional({
     description:
       'Number of chats filed under the workspace (list responses only)',
     example: 3,

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-sharing-response.dto.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/dtos/workspace-sharing-response.dto.ts
@@ -1,0 +1,82 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { WorkspaceVisibility } from 'src/domain/workspaces/domain/value-objects/workspace-visibility.enum';
+
+export class WorkspaceSharingUserDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty({ format: 'email' })
+  email: string;
+}
+
+export class WorkspaceSharingMemberDto {
+  @ApiProperty({ type: WorkspaceSharingUserDto })
+  user: WorkspaceSharingUserDto;
+
+  @ApiProperty({ enum: WorkspaceAccessLevel })
+  accessLevel: WorkspaceAccessLevel;
+
+  @ApiProperty({ enum: WorkspaceMemberStatus })
+  status: WorkspaceMemberStatus;
+}
+
+export class WorkspaceSharingOverrideDto {
+  @ApiProperty({ type: WorkspaceSharingUserDto })
+  user: WorkspaceSharingUserDto;
+
+  @ApiProperty({ enum: WorkspaceAccessLevel, nullable: true })
+  accessLevel: WorkspaceAccessLevel | null;
+
+  @ApiProperty()
+  excluded: boolean;
+}
+
+export class WorkspaceSharingAvailableTeamDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  memberCount: number;
+}
+
+export class WorkspaceSharingTeamGrantDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  memberCount: number;
+
+  @ApiProperty({ enum: WorkspaceAccessLevel })
+  accessLevel: WorkspaceAccessLevel;
+
+  @ApiProperty({ type: [WorkspaceSharingOverrideDto] })
+  overrides: WorkspaceSharingOverrideDto[];
+}
+
+export class WorkspaceSharingResponseDto {
+  @ApiProperty({ enum: WorkspaceVisibility })
+  visibility: WorkspaceVisibility;
+
+  @ApiProperty({ type: WorkspaceSharingUserDto })
+  owner: WorkspaceSharingUserDto;
+
+  @ApiProperty({ type: [WorkspaceSharingAvailableTeamDto] })
+  availableTeams: WorkspaceSharingAvailableTeamDto[];
+
+  @ApiProperty({ type: [WorkspaceSharingMemberDto] })
+  members: WorkspaceSharingMemberDto[];
+
+  @ApiProperty({ type: [WorkspaceSharingTeamGrantDto] })
+  teamGrants: WorkspaceSharingTeamGrantDto[];
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.spec.ts
@@ -6,6 +6,17 @@ import { WorkspaceDtoMapper } from './workspace-dto.mapper';
 describe('WorkspaceDtoMapper', () => {
   const mapper = new WorkspaceDtoMapper();
 
+  it('maps detail access metadata when provided', () => {
+    const workspace = aWorkspace();
+
+    expect(
+      mapper.toDto(workspace, {
+        accessLevel: WorkspaceAccessLevel.USE,
+        isOwner: false,
+      }),
+    ).toMatchObject({ accessLevel: WorkspaceAccessLevel.USE, isOwner: false });
+  });
+
   it('maps a paginated workspace list with chat activity metadata', () => {
     const workspace = aWorkspace({
       name: 'Council Documents',
@@ -19,6 +30,7 @@ describe('WorkspaceDtoMapper', () => {
           {
             workspace,
             accessLevel: WorkspaceAccessLevel.EDIT,
+            isOwner: true,
             chatCount: 4,
             lastActivityAt,
           },
@@ -41,6 +53,7 @@ describe('WorkspaceDtoMapper', () => {
           createdAt: workspace.createdAt.toISOString(),
           updatedAt: workspace.updatedAt.toISOString(),
           accessLevel: WorkspaceAccessLevel.EDIT,
+          isOwner: true,
           chatCount: 4,
           lastActivityAt: lastActivityAt.toISOString(),
         },

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-dto.mapper.ts
@@ -2,12 +2,16 @@ import { Injectable } from '@nestjs/common';
 import type { Paginated } from 'src/common/pagination/paginated.entity';
 import type { Workspace } from 'src/domain/workspaces/domain/workspace.entity';
 import type { WorkspaceListItem } from 'src/domain/workspaces/application/use-cases/find-all-workspaces/find-all-workspaces.use-case';
+import type { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
 import { WorkspaceResponseDto } from 'src/domain/workspaces/presenters/http/dtos/workspace-response.dto';
 import { WorkspaceListResponseDto } from 'src/domain/workspaces/presenters/http/dtos/workspace-list-response.dto';
 
 @Injectable()
 export class WorkspaceDtoMapper {
-  toDto(workspace: Workspace): WorkspaceResponseDto {
+  toDto(
+    workspace: Workspace,
+    access?: { accessLevel: WorkspaceAccessLevel; isOwner: boolean },
+  ): WorkspaceResponseDto {
     const dto = new WorkspaceResponseDto();
     dto.id = workspace.id;
     dto.name = workspace.name;
@@ -17,12 +21,16 @@ export class WorkspaceDtoMapper {
     dto.color = workspace.color;
     dto.createdAt = workspace.createdAt.toISOString();
     dto.updatedAt = workspace.updatedAt.toISOString();
+    dto.accessLevel = access?.accessLevel;
+    dto.isOwner = access?.isOwner;
     return dto;
   }
 
   toListItemDto(item: WorkspaceListItem): WorkspaceResponseDto {
-    const dto = this.toDto(item.workspace);
-    dto.accessLevel = item.accessLevel;
+    const dto = this.toDto(item.workspace, {
+      accessLevel: item.accessLevel,
+      isOwner: item.isOwner,
+    });
     dto.chatCount = item.chatCount;
     dto.lastActivityAt = item.lastActivityAt.toISOString();
     return dto;

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-sharing-dto.mapper.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-sharing-dto.mapper.spec.ts
@@ -1,0 +1,97 @@
+import {
+  TEST_TEAM_ID,
+  TEST_USER_ID,
+  aWorkspace,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceMemberStatus } from 'src/domain/workspaces/domain/value-objects/workspace-member-status.enum';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { WorkspaceVisibility } from 'src/domain/workspaces/domain/value-objects/workspace-visibility.enum';
+import { WorkspaceSharingDtoMapper } from './workspace-sharing-dto.mapper';
+
+describe('WorkspaceSharingDtoMapper', () => {
+  const mapper = new WorkspaceSharingDtoMapper();
+
+  it('exposes only sharing-safe user and team fields', () => {
+    const user = {
+      id: TEST_USER_ID,
+      name: 'Ada',
+      email: 'ada@example.org',
+      passwordHash: 'secret',
+    };
+
+    expect(
+      mapper.toSharingDto({
+        visibility: WorkspaceVisibility.PRIVATE,
+        owner: user as never,
+        availableTeams: [
+          {
+            team: { id: TEST_TEAM_ID, name: 'Service' } as never,
+            memberCount: 2,
+          },
+        ],
+        members: [
+          {
+            user: user as never,
+            accessLevel: WorkspaceAccessLevel.EDIT,
+            status: WorkspaceMemberStatus.ACTIVE,
+          },
+        ],
+        teamGrants: [
+          {
+            team: { id: TEST_TEAM_ID, name: 'Service' } as never,
+            memberCount: 2,
+            accessLevel: WorkspaceAccessLevel.USE,
+            overrides: [
+              { user: user as never, accessLevel: null, excluded: true },
+            ],
+          },
+        ],
+      }),
+    ).toEqual({
+      visibility: WorkspaceVisibility.PRIVATE,
+      owner: { id: TEST_USER_ID, name: 'Ada', email: 'ada@example.org' },
+      availableTeams: [{ id: TEST_TEAM_ID, name: 'Service', memberCount: 2 }],
+      members: [
+        {
+          user: { id: TEST_USER_ID, name: 'Ada', email: 'ada@example.org' },
+          accessLevel: WorkspaceAccessLevel.EDIT,
+          status: WorkspaceMemberStatus.ACTIVE,
+        },
+      ],
+      teamGrants: [
+        {
+          id: TEST_TEAM_ID,
+          name: 'Service',
+          memberCount: 2,
+          accessLevel: WorkspaceAccessLevel.USE,
+          overrides: [
+            {
+              user: { id: TEST_USER_ID, name: 'Ada', email: 'ada@example.org' },
+              accessLevel: null,
+              excluded: true,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('maps pending invitations', () => {
+    const workspace = aWorkspace();
+
+    expect(
+      mapper.toInvitationDto({
+        workspace,
+        accessLevel: WorkspaceAccessLevel.USE,
+      }),
+    ).toEqual({
+      workspace: {
+        id: workspace.id,
+        name: workspace.name,
+        icon: workspace.icon,
+        color: workspace.color,
+      },
+      accessLevel: WorkspaceAccessLevel.USE,
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-sharing-dto.mapper.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/mappers/workspace-sharing-dto.mapper.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@nestjs/common';
+import type { WorkspaceInvitation } from 'src/domain/workspaces/application/ports/workspace-invitations-read-repository.port';
+import type {
+  WorkspaceSharingOverrideView,
+  WorkspaceSharingView,
+} from 'src/domain/workspaces/application/use-cases/get-workspace-sharing/workspace-sharing.view';
+import type { User } from 'src/iam/users/domain/user.entity';
+import type { WorkspaceInvitationResponseDto } from 'src/domain/workspaces/presenters/http/dtos/workspace-invitation-response.dto';
+import type {
+  WorkspaceSharingOverrideDto,
+  WorkspaceSharingResponseDto,
+  WorkspaceSharingUserDto,
+} from 'src/domain/workspaces/presenters/http/dtos/workspace-sharing-response.dto';
+
+@Injectable()
+export class WorkspaceSharingDtoMapper {
+  toSharingDto(view: WorkspaceSharingView): WorkspaceSharingResponseDto {
+    return {
+      visibility: view.visibility,
+      owner: this.toUserDto(view.owner),
+      availableTeams: view.availableTeams.map(({ team, memberCount }) => ({
+        id: team.id,
+        name: team.name,
+        memberCount,
+      })),
+      members: view.members.map((member) => ({
+        user: this.toUserDto(member.user),
+        accessLevel: member.accessLevel,
+        status: member.status,
+      })),
+      teamGrants: view.teamGrants.map((grant) => ({
+        id: grant.team.id,
+        name: grant.team.name,
+        memberCount: grant.memberCount,
+        accessLevel: grant.accessLevel,
+        overrides: grant.overrides.map((override) =>
+          this.toOverrideDto(override),
+        ),
+      })),
+    };
+  }
+
+  toInvitationDto(
+    invitation: WorkspaceInvitation,
+  ): WorkspaceInvitationResponseDto {
+    return {
+      workspace: {
+        id: invitation.workspace.id,
+        name: invitation.workspace.name,
+        icon: invitation.workspace.icon,
+        color: invitation.workspace.color,
+      },
+      accessLevel: invitation.accessLevel,
+    };
+  }
+
+  toUserDtos(users: User[]): WorkspaceSharingUserDto[] {
+    return users.map((user) => this.toUserDto(user));
+  }
+
+  private toUserDto(user: User): WorkspaceSharingUserDto {
+    return { id: user.id, name: user.name, email: user.email };
+  }
+
+  private toOverrideDto(
+    override: WorkspaceSharingOverrideView,
+  ): WorkspaceSharingOverrideDto {
+    return {
+      user: this.toUserDto(override.user),
+      accessLevel: override.accessLevel,
+      excluded: override.excluded,
+    };
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/workspace-invitations.controller.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/workspace-invitations.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { RequireFeature } from 'src/common/guards/feature.guard';
+import { FeatureFlag } from 'src/config/features.config';
+import { AcceptWorkspaceInvitationCommand } from 'src/domain/workspaces/application/use-cases/accept-workspace-invitation/accept-workspace-invitation.command';
+import { AcceptWorkspaceInvitationUseCase } from 'src/domain/workspaces/application/use-cases/accept-workspace-invitation/accept-workspace-invitation.use-case';
+import { DeclineWorkspaceInvitationCommand } from 'src/domain/workspaces/application/use-cases/decline-workspace-invitation/decline-workspace-invitation.command';
+import { DeclineWorkspaceInvitationUseCase } from 'src/domain/workspaces/application/use-cases/decline-workspace-invitation/decline-workspace-invitation.use-case';
+import { ListMyWorkspaceInvitationsUseCase } from 'src/domain/workspaces/application/use-cases/list-my-workspace-invitations/list-my-workspace-invitations.use-case';
+import { WorkspaceInvitationResponseDto } from './dtos/workspace-invitation-response.dto';
+import { WorkspaceSharingDtoMapper } from './mappers/workspace-sharing-dto.mapper';
+
+@ApiTags('workspace-invitations')
+@Controller('workspace-invitations')
+@RequireFeature(FeatureFlag.Workspaces)
+export class WorkspaceInvitationsController {
+  constructor(
+    private readonly listMyWorkspaceInvitationsUseCase: ListMyWorkspaceInvitationsUseCase,
+    private readonly acceptWorkspaceInvitationUseCase: AcceptWorkspaceInvitationUseCase,
+    private readonly declineWorkspaceInvitationUseCase: DeclineWorkspaceInvitationUseCase,
+    private readonly mapper: WorkspaceSharingDtoMapper,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List my pending workspace invitations' })
+  @ApiResponse({ status: 200, type: [WorkspaceInvitationResponseDto] })
+  async list(): Promise<WorkspaceInvitationResponseDto[]> {
+    const invitations = await this.listMyWorkspaceInvitationsUseCase.execute();
+    return invitations.map((invitation) =>
+      this.mapper.toInvitationDto(invitation),
+    );
+  }
+
+  @Post(':workspaceId/accept')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Accept a workspace invitation' })
+  @ApiResponse({ status: 204 })
+  async accept(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: UUID,
+  ): Promise<void> {
+    await this.acceptWorkspaceInvitationUseCase.execute(
+      new AcceptWorkspaceInvitationCommand(workspaceId),
+    );
+  }
+
+  @Post(':workspaceId/decline')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Decline a workspace invitation' })
+  @ApiResponse({ status: 204 })
+  async decline(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: UUID,
+  ): Promise<void> {
+    await this.declineWorkspaceInvitationUseCase.execute(
+      new DeclineWorkspaceInvitationCommand(workspaceId),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/workspace-members.controller.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/workspace-members.controller.ts
@@ -1,0 +1,85 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { RequireFeature } from 'src/common/guards/feature.guard';
+import { FeatureFlag } from 'src/config/features.config';
+import { RequirePermission } from 'src/iam/authorization/application/decorators/permissions.decorator';
+import { Permission } from 'src/iam/permissions/domain/value-objects/permission.enum';
+import { InviteWorkspaceMemberCommand } from 'src/domain/workspaces/application/use-cases/invite-workspace-member/invite-workspace-member.command';
+import { InviteWorkspaceMemberUseCase } from 'src/domain/workspaces/application/use-cases/invite-workspace-member/invite-workspace-member.use-case';
+import { RemoveWorkspaceMemberCommand } from 'src/domain/workspaces/application/use-cases/remove-workspace-member/remove-workspace-member.command';
+import { RemoveWorkspaceMemberUseCase } from 'src/domain/workspaces/application/use-cases/remove-workspace-member/remove-workspace-member.use-case';
+import { UpdateWorkspaceMemberAccessLevelCommand } from 'src/domain/workspaces/application/use-cases/update-workspace-member-access-level/update-workspace-member-access-level.command';
+import { UpdateWorkspaceMemberAccessLevelUseCase } from 'src/domain/workspaces/application/use-cases/update-workspace-member-access-level/update-workspace-member-access-level.use-case';
+import { InviteWorkspaceMemberDto } from './dtos/invite-workspace-member.dto';
+import { WorkspaceAccessLevelDto } from './dtos/workspace-access-level.dto';
+
+@ApiTags('workspace-sharing')
+@Controller('workspaces/:workspaceId/members')
+@RequireFeature(FeatureFlag.Workspaces)
+@RequirePermission(Permission.ASSIGN_USERS_TO_TEAMS)
+export class WorkspaceMembersController {
+  constructor(
+    private readonly inviteWorkspaceMemberUseCase: InviteWorkspaceMemberUseCase,
+    private readonly updateWorkspaceMemberAccessLevelUseCase: UpdateWorkspaceMemberAccessLevelUseCase,
+    private readonly removeWorkspaceMemberUseCase: RemoveWorkspaceMemberUseCase,
+  ) {}
+
+  @Post()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Invite a workspace member' })
+  @ApiResponse({ status: 204 })
+  async invite(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: UUID,
+    @Body() dto: InviteWorkspaceMemberDto,
+  ): Promise<void> {
+    await this.inviteWorkspaceMemberUseCase.execute(
+      new InviteWorkspaceMemberCommand(
+        workspaceId,
+        dto.userId as UUID,
+        dto.accessLevel,
+      ),
+    );
+  }
+
+  @Patch(':userId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Update a workspace member access level' })
+  @ApiResponse({ status: 204 })
+  async updateAccessLevel(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: UUID,
+    @Param('userId', ParseUUIDPipe) userId: UUID,
+    @Body() dto: WorkspaceAccessLevelDto,
+  ): Promise<void> {
+    await this.updateWorkspaceMemberAccessLevelUseCase.execute(
+      new UpdateWorkspaceMemberAccessLevelCommand(
+        workspaceId,
+        userId,
+        dto.accessLevel,
+      ),
+    );
+  }
+
+  @Delete(':userId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remove a workspace member or invitation' })
+  @ApiResponse({ status: 204 })
+  async remove(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: UUID,
+    @Param('userId', ParseUUIDPipe) userId: UUID,
+  ): Promise<void> {
+    await this.removeWorkspaceMemberUseCase.execute(
+      new RemoveWorkspaceMemberCommand(workspaceId, userId),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/workspace-sharing.controller.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/workspace-sharing.controller.ts
@@ -1,0 +1,81 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { RequireFeature } from 'src/common/guards/feature.guard';
+import { FeatureFlag } from 'src/config/features.config';
+import { RequirePermission } from 'src/iam/authorization/application/decorators/permissions.decorator';
+import { Permission } from 'src/iam/permissions/domain/value-objects/permission.enum';
+import { GetWorkspaceAccessQuery } from 'src/domain/workspaces/application/use-cases/get-workspace-access/get-workspace-access.query';
+import { GetWorkspaceAccessUseCase } from 'src/domain/workspaces/application/use-cases/get-workspace-access/get-workspace-access.use-case';
+import { GetWorkspaceSharingQuery } from 'src/domain/workspaces/application/use-cases/get-workspace-sharing/get-workspace-sharing.query';
+import { GetWorkspaceSharingUseCase } from 'src/domain/workspaces/application/use-cases/get-workspace-sharing/get-workspace-sharing.use-case';
+import { UpdateWorkspaceVisibilityCommand } from 'src/domain/workspaces/application/use-cases/update-workspace-visibility/update-workspace-visibility.command';
+import { UpdateWorkspaceVisibilityUseCase } from 'src/domain/workspaces/application/use-cases/update-workspace-visibility/update-workspace-visibility.use-case';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { UpdateWorkspaceVisibilityDto } from './dtos/update-workspace-visibility.dto';
+import { WorkspaceAccessResponseDto } from './dtos/workspace-access-response.dto';
+import { WorkspaceSharingResponseDto } from './dtos/workspace-sharing-response.dto';
+import { WorkspaceSharingDtoMapper } from './mappers/workspace-sharing-dto.mapper';
+
+@ApiTags('workspace-sharing')
+@Controller('workspaces/:workspaceId')
+@RequireFeature(FeatureFlag.Workspaces)
+export class WorkspaceSharingController {
+  constructor(
+    private readonly getWorkspaceAccessUseCase: GetWorkspaceAccessUseCase,
+    private readonly getWorkspaceSharingUseCase: GetWorkspaceSharingUseCase,
+    private readonly updateWorkspaceVisibilityUseCase: UpdateWorkspaceVisibilityUseCase,
+    private readonly mapper: WorkspaceSharingDtoMapper,
+  ) {}
+
+  @Get('access')
+  @ApiOperation({ summary: 'Get the current user workspace access' })
+  @ApiResponse({ status: 200, type: WorkspaceAccessResponseDto })
+  async getAccess(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: UUID,
+  ): Promise<WorkspaceAccessResponseDto> {
+    const access = await this.getWorkspaceAccessUseCase.execute(
+      new GetWorkspaceAccessQuery(workspaceId, WorkspaceAccessLevel.USE),
+    );
+    return {
+      accessLevel: access.accessLevel,
+      isOwner: access.sources.some(({ type }) => type === 'owner'),
+    };
+  }
+
+  @Get('sharing')
+  @RequirePermission(Permission.ASSIGN_USERS_TO_TEAMS)
+  @ApiOperation({ summary: 'Get workspace sharing settings' })
+  @ApiResponse({ status: 200, type: WorkspaceSharingResponseDto })
+  async getSharing(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: UUID,
+  ): Promise<WorkspaceSharingResponseDto> {
+    const view = await this.getWorkspaceSharingUseCase.execute(
+      new GetWorkspaceSharingQuery(workspaceId),
+    );
+    return this.mapper.toSharingDto(view);
+  }
+
+  @Patch('sharing/visibility')
+  @RequirePermission(Permission.ASSIGN_USERS_TO_TEAMS)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Update workspace visibility' })
+  @ApiResponse({ status: 204 })
+  async updateVisibility(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: UUID,
+    @Body() dto: UpdateWorkspaceVisibilityDto,
+  ): Promise<void> {
+    await this.updateWorkspaceVisibilityUseCase.execute(
+      new UpdateWorkspaceVisibilityCommand(workspaceId, dto.visibility),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/workspace-sharing.controllers.spec.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/workspace-sharing.controllers.spec.ts
@@ -1,0 +1,226 @@
+import {
+  TEST_TEAM_ID,
+  TEST_USER_ID,
+  TEST_WORKSPACE_ID,
+} from 'src/domain/workspaces/application/testing/workspace.fixtures';
+import { WorkspaceAccessLevel } from 'src/domain/workspaces/domain/value-objects/workspace-access-level.enum';
+import { WorkspaceVisibility } from 'src/domain/workspaces/domain/value-objects/workspace-visibility.enum';
+import { REQUIRE_PERMISSION_KEY } from 'src/iam/authorization/application/decorators/permissions.decorator';
+import { Permission } from 'src/iam/permissions/domain/value-objects/permission.enum';
+import { WorkspaceInvitationsController } from './workspace-invitations.controller';
+import { WorkspaceMembersController } from './workspace-members.controller';
+import { WorkspaceSharingController } from './workspace-sharing.controller';
+import { WorkspaceTeamGrantMembersController } from './workspace-team-grant-members.controller';
+import { WorkspaceTeamGrantsController } from './workspace-team-grants.controller';
+
+describe('workspace sharing HTTP controllers', () => {
+  it('requires team-assignment permission for sharing directory access', () => {
+    const expected = [Permission.ASSIGN_USERS_TO_TEAMS];
+
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_PERMISSION_KEY,
+        WorkspaceSharingController.prototype.getSharing,
+      ),
+    ).toEqual(expected);
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_PERMISSION_KEY,
+        WorkspaceSharingController.prototype.updateVisibility,
+      ),
+    ).toEqual(expected);
+    expect(
+      Reflect.getMetadata(REQUIRE_PERMISSION_KEY, WorkspaceMembersController),
+    ).toEqual(expected);
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_PERMISSION_KEY,
+        WorkspaceTeamGrantsController,
+      ),
+    ).toEqual(expected);
+    expect(
+      Reflect.getMetadata(
+        REQUIRE_PERMISSION_KEY,
+        WorkspaceTeamGrantMembersController,
+      ),
+    ).toEqual(expected);
+  });
+
+  it('maps sharing reads and visibility updates', async () => {
+    const access = {
+      execute: jest.fn().mockResolvedValue({
+        accessLevel: WorkspaceAccessLevel.FULL,
+        sources: [{ type: 'owner' }],
+      }),
+    };
+    const sharing = { execute: jest.fn().mockResolvedValue({ members: [] }) };
+    const visibility = { execute: jest.fn().mockResolvedValue(undefined) };
+    const mapper = { toSharingDto: jest.fn().mockReturnValue({ members: [] }) };
+    const controller = new WorkspaceSharingController(
+      access as never,
+      sharing as never,
+      visibility as never,
+      mapper as never,
+    );
+
+    await expect(controller.getAccess(TEST_WORKSPACE_ID)).resolves.toEqual({
+      accessLevel: WorkspaceAccessLevel.FULL,
+      isOwner: true,
+    });
+    await expect(controller.getSharing(TEST_WORKSPACE_ID)).resolves.toEqual({
+      members: [],
+    });
+    await controller.updateVisibility(TEST_WORKSPACE_ID, {
+      visibility: WorkspaceVisibility.ORGANIZATION,
+    });
+
+    expect(sharing.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: TEST_WORKSPACE_ID }),
+    );
+    expect(visibility.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: TEST_WORKSPACE_ID,
+        visibility: WorkspaceVisibility.ORGANIZATION,
+      }),
+    );
+  });
+
+  it('maps direct member lifecycle commands', async () => {
+    const invite = { execute: jest.fn().mockResolvedValue(undefined) };
+    const update = { execute: jest.fn().mockResolvedValue(undefined) };
+    const remove = { execute: jest.fn().mockResolvedValue(undefined) };
+    const controller = new WorkspaceMembersController(
+      invite as never,
+      update as never,
+      remove as never,
+    );
+
+    await controller.invite(TEST_WORKSPACE_ID, {
+      userId: TEST_USER_ID,
+      accessLevel: WorkspaceAccessLevel.USE,
+    });
+    await controller.updateAccessLevel(TEST_WORKSPACE_ID, TEST_USER_ID, {
+      accessLevel: WorkspaceAccessLevel.EDIT,
+    });
+    await controller.remove(TEST_WORKSPACE_ID, TEST_USER_ID);
+
+    expect(invite.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: TEST_WORKSPACE_ID,
+        userId: TEST_USER_ID,
+        accessLevel: WorkspaceAccessLevel.USE,
+      }),
+    );
+    expect(update.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ accessLevel: WorkspaceAccessLevel.EDIT }),
+    );
+    expect(remove.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: TEST_USER_ID }),
+    );
+  });
+
+  it('maps team grant and override lifecycle commands', async () => {
+    const add = { execute: jest.fn().mockResolvedValue(undefined) };
+    const update = { execute: jest.fn().mockResolvedValue(undefined) };
+    const remove = { execute: jest.fn().mockResolvedValue(undefined) };
+    const setOverride = { execute: jest.fn().mockResolvedValue(undefined) };
+    const resetOverride = { execute: jest.fn().mockResolvedValue(undefined) };
+    const controller = new WorkspaceTeamGrantsController(
+      add as never,
+      update as never,
+      remove as never,
+      setOverride as never,
+      resetOverride as never,
+    );
+
+    await controller.add(TEST_WORKSPACE_ID, {
+      teamId: TEST_TEAM_ID,
+      accessLevel: WorkspaceAccessLevel.USE,
+    });
+    await controller.updateAccessLevel(TEST_WORKSPACE_ID, TEST_TEAM_ID, {
+      accessLevel: WorkspaceAccessLevel.EDIT,
+    });
+    await controller.remove(TEST_WORKSPACE_ID, TEST_TEAM_ID);
+    await controller.setOverride(
+      TEST_WORKSPACE_ID,
+      TEST_TEAM_ID,
+      TEST_USER_ID,
+      { accessLevel: null },
+    );
+    await controller.resetOverride(
+      TEST_WORKSPACE_ID,
+      TEST_TEAM_ID,
+      TEST_USER_ID,
+    );
+
+    expect(add.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: TEST_TEAM_ID,
+        accessLevel: WorkspaceAccessLevel.USE,
+      }),
+    );
+    expect(update.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ accessLevel: WorkspaceAccessLevel.EDIT }),
+    );
+    expect(remove.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ teamId: TEST_TEAM_ID }),
+    );
+    expect(setOverride.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ value: { accessLevel: null, excluded: true } }),
+    );
+    expect(resetOverride.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: TEST_USER_ID }),
+    );
+  });
+
+  it('maps granted team members to safe user DTOs', async () => {
+    const list = {
+      execute: jest.fn().mockResolvedValue([{ id: TEST_USER_ID }]),
+    };
+    const mapper = {
+      toUserDtos: jest.fn().mockReturnValue([{ id: TEST_USER_ID }]),
+    };
+    const controller = new WorkspaceTeamGrantMembersController(
+      list as never,
+      mapper as never,
+    );
+
+    await expect(
+      controller.list(TEST_WORKSPACE_ID, TEST_TEAM_ID),
+    ).resolves.toEqual([{ id: TEST_USER_ID }]);
+    expect(list.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: TEST_WORKSPACE_ID,
+        teamId: TEST_TEAM_ID,
+      }),
+    );
+  });
+
+  it('maps the current user invitation lifecycle', async () => {
+    const list = {
+      execute: jest.fn().mockResolvedValue([{ accessLevel: 'use' }]),
+    };
+    const accept = { execute: jest.fn().mockResolvedValue(undefined) };
+    const decline = { execute: jest.fn().mockResolvedValue(undefined) };
+    const mapper = {
+      toInvitationDto: jest.fn().mockReturnValue({ accessLevel: 'use' }),
+    };
+    const controller = new WorkspaceInvitationsController(
+      list as never,
+      accept as never,
+      decline as never,
+      mapper as never,
+    );
+
+    await expect(controller.list()).resolves.toEqual([{ accessLevel: 'use' }]);
+    await controller.accept(TEST_WORKSPACE_ID);
+    await controller.decline(TEST_WORKSPACE_ID);
+
+    expect(accept.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: TEST_WORKSPACE_ID }),
+    );
+    expect(decline.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: TEST_WORKSPACE_ID }),
+    );
+  });
+});

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/workspace-team-grant-members.controller.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/workspace-team-grant-members.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, Param, ParseUUIDPipe } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { RequireFeature } from 'src/common/guards/feature.guard';
+import { FeatureFlag } from 'src/config/features.config';
+import { RequirePermission } from 'src/iam/authorization/application/decorators/permissions.decorator';
+import { Permission } from 'src/iam/permissions/domain/value-objects/permission.enum';
+import { ListWorkspaceTeamMembersQuery } from 'src/domain/workspaces/application/use-cases/list-workspace-team-members/list-workspace-team-members.query';
+import { ListWorkspaceTeamMembersUseCase } from 'src/domain/workspaces/application/use-cases/list-workspace-team-members/list-workspace-team-members.use-case';
+import { WorkspaceSharingUserDto } from './dtos/workspace-sharing-response.dto';
+import { WorkspaceSharingDtoMapper } from './mappers/workspace-sharing-dto.mapper';
+
+@ApiTags('workspace-sharing')
+@Controller('workspaces/:workspaceId/team-grants/:teamId/members')
+@RequireFeature(FeatureFlag.Workspaces)
+@RequirePermission(Permission.ASSIGN_USERS_TO_TEAMS)
+export class WorkspaceTeamGrantMembersController {
+  constructor(
+    private readonly listWorkspaceTeamMembersUseCase: ListWorkspaceTeamMembersUseCase,
+    private readonly mapper: WorkspaceSharingDtoMapper,
+  ) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List members of a granted workspace team' })
+  @ApiResponse({ status: 200, type: [WorkspaceSharingUserDto] })
+  async list(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: UUID,
+    @Param('teamId', ParseUUIDPipe) teamId: UUID,
+  ): Promise<WorkspaceSharingUserDto[]> {
+    const users = await this.listWorkspaceTeamMembersUseCase.execute(
+      new ListWorkspaceTeamMembersQuery(workspaceId, teamId),
+    );
+    return this.mapper.toUserDtos(users);
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/presenters/http/workspace-team-grants.controller.ts
+++ b/ayunis-core-backend/src/domain/workspaces/presenters/http/workspace-team-grants.controller.ts
@@ -1,0 +1,129 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Put,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import type { UUID } from 'crypto';
+import { RequireFeature } from 'src/common/guards/feature.guard';
+import { FeatureFlag } from 'src/config/features.config';
+import { RequirePermission } from 'src/iam/authorization/application/decorators/permissions.decorator';
+import { Permission } from 'src/iam/permissions/domain/value-objects/permission.enum';
+import { AddWorkspaceTeamGrantCommand } from 'src/domain/workspaces/application/use-cases/add-workspace-team-grant/add-workspace-team-grant.command';
+import { AddWorkspaceTeamGrantUseCase } from 'src/domain/workspaces/application/use-cases/add-workspace-team-grant/add-workspace-team-grant.use-case';
+import { RemoveWorkspaceTeamGrantCommand } from 'src/domain/workspaces/application/use-cases/remove-workspace-team-grant/remove-workspace-team-grant.command';
+import { RemoveWorkspaceTeamGrantUseCase } from 'src/domain/workspaces/application/use-cases/remove-workspace-team-grant/remove-workspace-team-grant.use-case';
+import { ResetWorkspaceTeamMemberOverrideCommand } from 'src/domain/workspaces/application/use-cases/reset-workspace-team-member-override/reset-workspace-team-member-override.command';
+import { ResetWorkspaceTeamMemberOverrideUseCase } from 'src/domain/workspaces/application/use-cases/reset-workspace-team-member-override/reset-workspace-team-member-override.use-case';
+import { SetWorkspaceTeamMemberOverrideCommand } from 'src/domain/workspaces/application/use-cases/set-workspace-team-member-override/set-workspace-team-member-override.command';
+import { SetWorkspaceTeamMemberOverrideUseCase } from 'src/domain/workspaces/application/use-cases/set-workspace-team-member-override/set-workspace-team-member-override.use-case';
+import { UpdateWorkspaceTeamGrantAccessLevelCommand } from 'src/domain/workspaces/application/use-cases/update-workspace-team-grant-access-level/update-workspace-team-grant-access-level.command';
+import { UpdateWorkspaceTeamGrantAccessLevelUseCase } from 'src/domain/workspaces/application/use-cases/update-workspace-team-grant-access-level/update-workspace-team-grant-access-level.use-case';
+import { AddWorkspaceTeamGrantDto } from './dtos/add-workspace-team-grant.dto';
+import { SetWorkspaceTeamMemberOverrideDto } from './dtos/set-workspace-team-member-override.dto';
+import { WorkspaceAccessLevelDto } from './dtos/workspace-access-level.dto';
+
+@ApiTags('workspace-sharing')
+@Controller('workspaces/:workspaceId/team-grants')
+@RequireFeature(FeatureFlag.Workspaces)
+@RequirePermission(Permission.ASSIGN_USERS_TO_TEAMS)
+export class WorkspaceTeamGrantsController {
+  constructor(
+    private readonly addWorkspaceTeamGrantUseCase: AddWorkspaceTeamGrantUseCase,
+    private readonly updateWorkspaceTeamGrantAccessLevelUseCase: UpdateWorkspaceTeamGrantAccessLevelUseCase,
+    private readonly removeWorkspaceTeamGrantUseCase: RemoveWorkspaceTeamGrantUseCase,
+    private readonly setWorkspaceTeamMemberOverrideUseCase: SetWorkspaceTeamMemberOverrideUseCase,
+    private readonly resetWorkspaceTeamMemberOverrideUseCase: ResetWorkspaceTeamMemberOverrideUseCase,
+  ) {}
+
+  @Post()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Grant a team workspace access' })
+  @ApiResponse({ status: 204 })
+  async add(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: UUID,
+    @Body() dto: AddWorkspaceTeamGrantDto,
+  ): Promise<void> {
+    await this.addWorkspaceTeamGrantUseCase.execute(
+      new AddWorkspaceTeamGrantCommand(
+        workspaceId,
+        dto.teamId as UUID,
+        dto.accessLevel,
+      ),
+    );
+  }
+
+  @Patch(':teamId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Update a workspace team access level' })
+  @ApiResponse({ status: 204 })
+  async updateAccessLevel(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: UUID,
+    @Param('teamId', ParseUUIDPipe) teamId: UUID,
+    @Body() dto: WorkspaceAccessLevelDto,
+  ): Promise<void> {
+    await this.updateWorkspaceTeamGrantAccessLevelUseCase.execute(
+      new UpdateWorkspaceTeamGrantAccessLevelCommand(
+        workspaceId,
+        teamId,
+        dto.accessLevel,
+      ),
+    );
+  }
+
+  @Delete(':teamId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remove a workspace team grant' })
+  @ApiResponse({ status: 204 })
+  async remove(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: UUID,
+    @Param('teamId', ParseUUIDPipe) teamId: UUID,
+  ): Promise<void> {
+    await this.removeWorkspaceTeamGrantUseCase.execute(
+      new RemoveWorkspaceTeamGrantCommand(workspaceId, teamId),
+    );
+  }
+
+  @Put(':teamId/overrides/:userId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Set a team member workspace override' })
+  @ApiResponse({ status: 204 })
+  async setOverride(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: UUID,
+    @Param('teamId', ParseUUIDPipe) teamId: UUID,
+    @Param('userId', ParseUUIDPipe) userId: UUID,
+    @Body() dto: SetWorkspaceTeamMemberOverrideDto,
+  ): Promise<void> {
+    await this.setWorkspaceTeamMemberOverrideUseCase.execute(
+      new SetWorkspaceTeamMemberOverrideCommand(
+        workspaceId,
+        teamId,
+        userId,
+        dto.accessLevel === null
+          ? { accessLevel: null, excluded: true }
+          : { accessLevel: dto.accessLevel, excluded: false },
+      ),
+    );
+  }
+
+  @Delete(':teamId/overrides/:userId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Reset a team member workspace override' })
+  @ApiResponse({ status: 204 })
+  async resetOverride(
+    @Param('workspaceId', ParseUUIDPipe) workspaceId: UUID,
+    @Param('teamId', ParseUUIDPipe) teamId: UUID,
+    @Param('userId', ParseUUIDPipe) userId: UUID,
+  ): Promise<void> {
+    await this.resetWorkspaceTeamMemberOverrideUseCase.execute(
+      new ResetWorkspaceTeamMemberOverrideCommand(workspaceId, teamId, userId),
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
+++ b/ayunis-core-backend/src/domain/workspaces/workspaces.module.ts
@@ -64,6 +64,14 @@ import { WorkspaceInvitationsReadRepository } from './application/ports/workspac
 import { LocalWorkspaceInvitationsReadRepository } from './infrastructure/persistence/local/local-workspace-invitations-read.repository';
 import { LocalWorkspaceInvitationsReadRepositoryModule } from './infrastructure/persistence/local/local-workspace-invitations-read-repository.module';
 import { ListMyWorkspaceInvitationsUseCase } from './application/use-cases/list-my-workspace-invitations/list-my-workspace-invitations.use-case';
+import { UpdateWorkspaceVisibilityUseCase } from './application/use-cases/update-workspace-visibility/update-workspace-visibility.use-case';
+import { WorkspaceSharingController } from './presenters/http/workspace-sharing.controller';
+import { WorkspaceMembersController } from './presenters/http/workspace-members.controller';
+import { WorkspaceTeamGrantsController } from './presenters/http/workspace-team-grants.controller';
+import { WorkspaceInvitationsController } from './presenters/http/workspace-invitations.controller';
+import { WorkspaceSharingDtoMapper } from './presenters/http/mappers/workspace-sharing-dto.mapper';
+import { ListWorkspaceTeamMembersUseCase } from './application/use-cases/list-workspace-team-members/list-workspace-team-members.use-case';
+import { WorkspaceTeamGrantMembersController } from './presenters/http/workspace-team-grant-members.controller';
 
 @Module({
   imports: [
@@ -80,7 +88,15 @@ import { ListMyWorkspaceInvitationsUseCase } from './application/use-cases/list-
     TeamsModule,
     UsersModule,
   ],
-  controllers: [WorkspacesController, WorkspaceContextController],
+  controllers: [
+    WorkspacesController,
+    WorkspaceContextController,
+    WorkspaceSharingController,
+    WorkspaceMembersController,
+    WorkspaceTeamGrantsController,
+    WorkspaceInvitationsController,
+    WorkspaceTeamGrantMembersController,
+  ],
   providers: [
     {
       provide: WorkspacesRepository,
@@ -125,6 +141,8 @@ import { ListMyWorkspaceInvitationsUseCase } from './application/use-cases/list-
     ResetWorkspaceTeamMemberOverrideUseCase,
     GetWorkspaceSharingUseCase,
     ListMyWorkspaceInvitationsUseCase,
+    ListWorkspaceTeamMembersUseCase,
+    UpdateWorkspaceVisibilityUseCase,
     CreateWorkspaceUseCase,
     FindAllWorkspacesUseCase,
     FindWorkspaceUseCase,
@@ -147,6 +165,7 @@ import { ListMyWorkspaceInvitationsUseCase } from './application/use-cases/list-
     ListWorkspaceDocumentsUseCase,
     WorkspaceDtoMapper,
     WorkspaceContextDtoMapper,
+    WorkspaceSharingDtoMapper,
   ],
   exports: [
     CreateWorkspaceUseCase,

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3526,6 +3526,8 @@ export interface WorkspaceResponseDto {
   updatedAt: string;
   /** Effective access level for the caller (list responses only) */
   accessLevel?: WorkspaceResponseDtoAccessLevel;
+  /** Whether the caller owns the workspace */
+  isOwner?: boolean;
   /** Number of chats filed under the workspace (list responses only) */
   chatCount?: number;
   /** Later of the last edit and the most recent chat activity (list responses only) */
@@ -3673,6 +3675,210 @@ export interface UpdateWorkspaceInstructionDto {
    * @nullable
    */
   instruction: string | null;
+}
+
+export type WorkspaceAccessResponseDtoAccessLevel = typeof WorkspaceAccessResponseDtoAccessLevel[keyof typeof WorkspaceAccessResponseDtoAccessLevel];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WorkspaceAccessResponseDtoAccessLevel = {
+  use: 'use',
+  edit: 'edit',
+  full: 'full',
+} as const;
+
+export interface WorkspaceAccessResponseDto {
+  accessLevel: WorkspaceAccessResponseDtoAccessLevel;
+  isOwner: boolean;
+}
+
+export interface WorkspaceSharingUserDto {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export interface WorkspaceSharingAvailableTeamDto {
+  id: string;
+  name: string;
+  memberCount: number;
+}
+
+export type WorkspaceSharingMemberDtoAccessLevel = typeof WorkspaceSharingMemberDtoAccessLevel[keyof typeof WorkspaceSharingMemberDtoAccessLevel];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WorkspaceSharingMemberDtoAccessLevel = {
+  use: 'use',
+  edit: 'edit',
+  full: 'full',
+} as const;
+
+export type WorkspaceSharingMemberDtoStatus = typeof WorkspaceSharingMemberDtoStatus[keyof typeof WorkspaceSharingMemberDtoStatus];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WorkspaceSharingMemberDtoStatus = {
+  pending: 'pending',
+  active: 'active',
+} as const;
+
+export interface WorkspaceSharingMemberDto {
+  user: WorkspaceSharingUserDto;
+  accessLevel: WorkspaceSharingMemberDtoAccessLevel;
+  status: WorkspaceSharingMemberDtoStatus;
+}
+
+/**
+ * @nullable
+ */
+export type WorkspaceSharingOverrideDtoAccessLevel = typeof WorkspaceSharingOverrideDtoAccessLevel[keyof typeof WorkspaceSharingOverrideDtoAccessLevel] | null;
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WorkspaceSharingOverrideDtoAccessLevel = {
+  use: 'use',
+  edit: 'edit',
+  full: 'full',
+} as const;
+
+export interface WorkspaceSharingOverrideDto {
+  user: WorkspaceSharingUserDto;
+  /** @nullable */
+  accessLevel: WorkspaceSharingOverrideDtoAccessLevel;
+  excluded: boolean;
+}
+
+export type WorkspaceSharingTeamGrantDtoAccessLevel = typeof WorkspaceSharingTeamGrantDtoAccessLevel[keyof typeof WorkspaceSharingTeamGrantDtoAccessLevel];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WorkspaceSharingTeamGrantDtoAccessLevel = {
+  use: 'use',
+  edit: 'edit',
+  full: 'full',
+} as const;
+
+export interface WorkspaceSharingTeamGrantDto {
+  id: string;
+  name: string;
+  memberCount: number;
+  accessLevel: WorkspaceSharingTeamGrantDtoAccessLevel;
+  overrides: WorkspaceSharingOverrideDto[];
+}
+
+export type WorkspaceSharingResponseDtoVisibility = typeof WorkspaceSharingResponseDtoVisibility[keyof typeof WorkspaceSharingResponseDtoVisibility];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WorkspaceSharingResponseDtoVisibility = {
+  private: 'private',
+  organization: 'organization',
+} as const;
+
+export interface WorkspaceSharingResponseDto {
+  visibility: WorkspaceSharingResponseDtoVisibility;
+  owner: WorkspaceSharingUserDto;
+  availableTeams: WorkspaceSharingAvailableTeamDto[];
+  members: WorkspaceSharingMemberDto[];
+  teamGrants: WorkspaceSharingTeamGrantDto[];
+}
+
+export type UpdateWorkspaceVisibilityDtoVisibility = typeof UpdateWorkspaceVisibilityDtoVisibility[keyof typeof UpdateWorkspaceVisibilityDtoVisibility];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const UpdateWorkspaceVisibilityDtoVisibility = {
+  private: 'private',
+  organization: 'organization',
+} as const;
+
+export interface UpdateWorkspaceVisibilityDto {
+  visibility: UpdateWorkspaceVisibilityDtoVisibility;
+}
+
+export type InviteWorkspaceMemberDtoAccessLevel = typeof InviteWorkspaceMemberDtoAccessLevel[keyof typeof InviteWorkspaceMemberDtoAccessLevel];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const InviteWorkspaceMemberDtoAccessLevel = {
+  use: 'use',
+  edit: 'edit',
+  full: 'full',
+} as const;
+
+export interface InviteWorkspaceMemberDto {
+  userId: string;
+  accessLevel: InviteWorkspaceMemberDtoAccessLevel;
+}
+
+export type WorkspaceAccessLevelDtoAccessLevel = typeof WorkspaceAccessLevelDtoAccessLevel[keyof typeof WorkspaceAccessLevelDtoAccessLevel];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WorkspaceAccessLevelDtoAccessLevel = {
+  use: 'use',
+  edit: 'edit',
+  full: 'full',
+} as const;
+
+export interface WorkspaceAccessLevelDto {
+  accessLevel: WorkspaceAccessLevelDtoAccessLevel;
+}
+
+export type AddWorkspaceTeamGrantDtoAccessLevel = typeof AddWorkspaceTeamGrantDtoAccessLevel[keyof typeof AddWorkspaceTeamGrantDtoAccessLevel];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const AddWorkspaceTeamGrantDtoAccessLevel = {
+  use: 'use',
+  edit: 'edit',
+  full: 'full',
+} as const;
+
+export interface AddWorkspaceTeamGrantDto {
+  teamId: string;
+  accessLevel: AddWorkspaceTeamGrantDtoAccessLevel;
+}
+
+/**
+ * @nullable
+ */
+export type SetWorkspaceTeamMemberOverrideDtoAccessLevel = typeof SetWorkspaceTeamMemberOverrideDtoAccessLevel[keyof typeof SetWorkspaceTeamMemberOverrideDtoAccessLevel] | null;
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const SetWorkspaceTeamMemberOverrideDtoAccessLevel = {
+  use: 'use',
+  edit: 'edit',
+  full: 'full',
+} as const;
+
+export interface SetWorkspaceTeamMemberOverrideDto {
+  /** @nullable */
+  accessLevel: SetWorkspaceTeamMemberOverrideDtoAccessLevel;
+}
+
+export interface WorkspaceInvitationWorkspaceDto {
+  id: string;
+  name: string;
+  icon: string;
+  color: string;
+}
+
+export type WorkspaceInvitationResponseDtoAccessLevel = typeof WorkspaceInvitationResponseDtoAccessLevel[keyof typeof WorkspaceInvitationResponseDtoAccessLevel];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const WorkspaceInvitationResponseDtoAccessLevel = {
+  use: 'use',
+  edit: 'edit',
+  full: 'full',
+} as const;
+
+export interface WorkspaceInvitationResponseDto {
+  workspace: WorkspaceInvitationWorkspaceDto;
+  accessLevel: WorkspaceInvitationResponseDtoAccessLevel;
 }
 
 export type WorkspaceFavoriteResponseDtoReferenceType = typeof WorkspaceFavoriteResponseDtoReferenceType[keyof typeof WorkspaceFavoriteResponseDtoReferenceType];

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.ts
@@ -35,6 +35,7 @@ import type {
   AddGlobalPiiWhitelistWordRequestDto,
   AddTeamMemberDto,
   AddUrlToKnowledgeBaseDto,
+  AddWorkspaceTeamGrantDto,
   AddonStatusResponseDto,
   AdminUpdateUserDto,
   ApiKeyResponseDto,
@@ -105,6 +106,7 @@ import type {
   InstallMarketplaceIntegrationDto,
   InstallSkillFromMarketplaceDto,
   InviteDetailResponseDto,
+  InviteWorkspaceMemberDto,
   InvitesControllerGetInvitesParams,
   IpAllowlistResponseDto,
   IsCloudResponseDto,
@@ -181,6 +183,7 @@ import type {
   SetTeamDefaultModelDto,
   SetUserConfigDto,
   SetUserDefaultModelDto,
+  SetWorkspaceTeamMemberOverrideDto,
   ShareResponseDto,
   SharesControllerGetSharesParams,
   SkillResponseDto,
@@ -257,6 +260,7 @@ import type {
   UpdateUserRoleDto,
   UpdateWorkspaceDto,
   UpdateWorkspaceInstructionDto,
+  UpdateWorkspaceVisibilityDto,
   UpsertOrgAcademyAccessSettingsDto,
   UpsertOrgChatSettingsDto,
   UpsertOrgSystemPromptDto,
@@ -277,6 +281,8 @@ import type {
   UserSystemPromptResponseDto,
   UserUsageResponseDto,
   ValidationResponseDto,
+  WorkspaceAccessLevelDto,
+  WorkspaceAccessResponseDto,
   WorkspaceContextControllerAddDocumentBody,
   WorkspaceContextControllerListDocumentsParams,
   WorkspaceContextControllerListKnowledgeBaseCandidatesParams,
@@ -286,10 +292,13 @@ import type {
   WorkspaceContextResponseDto,
   WorkspaceDocumentListResponseDto,
   WorkspaceDocumentResponseDto,
+  WorkspaceInvitationResponseDto,
   WorkspaceKnowledgeBaseCandidateListResponseDto,
   WorkspaceKnowledgeBaseListResponseDto,
   WorkspaceListResponseDto,
   WorkspaceResponseDto,
+  WorkspaceSharingResponseDto,
+  WorkspaceSharingUserDto,
   WorkspaceSkillCandidateListResponseDto,
   WorkspaceSkillListResponseDto,
   WorkspacesControllerFindAllParams
@@ -14580,6 +14589,1097 @@ const {mutation: mutationOptions} = options ?
       return useMutation(mutationOptions, queryClient);
     }
     
+/**
+ * @summary Get the current user workspace access
+ */
+export const workspaceSharingControllerGetAccess = (
+    workspaceId: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<WorkspaceAccessResponseDto>(
+      {url: `/workspaces/${workspaceId}/access`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getWorkspaceSharingControllerGetAccessQueryKey = (workspaceId?: string,) => {
+    return [
+    `/workspaces/${workspaceId}/access`
+    ] as const;
+    }
+
+    
+export const getWorkspaceSharingControllerGetAccessQueryOptions = <TData = Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>, TError = unknown>(workspaceId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getWorkspaceSharingControllerGetAccessQueryKey(workspaceId);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>> = ({ signal }) => workspaceSharingControllerGetAccess(workspaceId, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(workspaceId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type WorkspaceSharingControllerGetAccessQueryResult = NonNullable<Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>>
+export type WorkspaceSharingControllerGetAccessQueryError = unknown
+
+
+export function useWorkspaceSharingControllerGetAccess<TData = Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>, TError = unknown>(
+ workspaceId: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceSharingControllerGetAccess<TData = Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>, TError = unknown>(
+ workspaceId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceSharingControllerGetAccess<TData = Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>, TError = unknown>(
+ workspaceId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get the current user workspace access
+ */
+
+export function useWorkspaceSharingControllerGetAccess<TData = Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>, TError = unknown>(
+ workspaceId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceSharingControllerGetAccess>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getWorkspaceSharingControllerGetAccessQueryOptions(workspaceId,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Get workspace sharing settings
+ */
+export const workspaceSharingControllerGetSharing = (
+    workspaceId: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<WorkspaceSharingResponseDto>(
+      {url: `/workspaces/${workspaceId}/sharing`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getWorkspaceSharingControllerGetSharingQueryKey = (workspaceId?: string,) => {
+    return [
+    `/workspaces/${workspaceId}/sharing`
+    ] as const;
+    }
+
+    
+export const getWorkspaceSharingControllerGetSharingQueryOptions = <TData = Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>, TError = unknown>(workspaceId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getWorkspaceSharingControllerGetSharingQueryKey(workspaceId);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>> = ({ signal }) => workspaceSharingControllerGetSharing(workspaceId, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(workspaceId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type WorkspaceSharingControllerGetSharingQueryResult = NonNullable<Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>>
+export type WorkspaceSharingControllerGetSharingQueryError = unknown
+
+
+export function useWorkspaceSharingControllerGetSharing<TData = Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>, TError = unknown>(
+ workspaceId: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceSharingControllerGetSharing<TData = Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>, TError = unknown>(
+ workspaceId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceSharingControllerGetSharing<TData = Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>, TError = unknown>(
+ workspaceId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary Get workspace sharing settings
+ */
+
+export function useWorkspaceSharingControllerGetSharing<TData = Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>, TError = unknown>(
+ workspaceId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceSharingControllerGetSharing>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getWorkspaceSharingControllerGetSharingQueryOptions(workspaceId,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Update workspace visibility
+ */
+export const workspaceSharingControllerUpdateVisibility = (
+    workspaceId: string,
+    updateWorkspaceVisibilityDto: UpdateWorkspaceVisibilityDto,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspaces/${workspaceId}/sharing/visibility`, method: 'PATCH',
+      headers: {'Content-Type': 'application/json', },
+      data: updateWorkspaceVisibilityDto
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceSharingControllerUpdateVisibilityMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceSharingControllerUpdateVisibility>>, TError,{workspaceId: string;data: UpdateWorkspaceVisibilityDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceSharingControllerUpdateVisibility>>, TError,{workspaceId: string;data: UpdateWorkspaceVisibilityDto}, TContext> => {
+
+const mutationKey = ['workspaceSharingControllerUpdateVisibility'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceSharingControllerUpdateVisibility>>, {workspaceId: string;data: UpdateWorkspaceVisibilityDto}> = (props) => {
+          const {workspaceId,data} = props ?? {};
+
+          return  workspaceSharingControllerUpdateVisibility(workspaceId,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceSharingControllerUpdateVisibilityMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceSharingControllerUpdateVisibility>>>
+    export type WorkspaceSharingControllerUpdateVisibilityMutationBody = UpdateWorkspaceVisibilityDto
+    export type WorkspaceSharingControllerUpdateVisibilityMutationError = unknown
+
+    /**
+ * @summary Update workspace visibility
+ */
+export const useWorkspaceSharingControllerUpdateVisibility = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceSharingControllerUpdateVisibility>>, TError,{workspaceId: string;data: UpdateWorkspaceVisibilityDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceSharingControllerUpdateVisibility>>,
+        TError,
+        {workspaceId: string;data: UpdateWorkspaceVisibilityDto},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceSharingControllerUpdateVisibilityMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Invite a workspace member
+ */
+export const workspaceMembersControllerInvite = (
+    workspaceId: string,
+    inviteWorkspaceMemberDto: InviteWorkspaceMemberDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspaces/${workspaceId}/members`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: inviteWorkspaceMemberDto, signal
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceMembersControllerInviteMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceMembersControllerInvite>>, TError,{workspaceId: string;data: InviteWorkspaceMemberDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceMembersControllerInvite>>, TError,{workspaceId: string;data: InviteWorkspaceMemberDto}, TContext> => {
+
+const mutationKey = ['workspaceMembersControllerInvite'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceMembersControllerInvite>>, {workspaceId: string;data: InviteWorkspaceMemberDto}> = (props) => {
+          const {workspaceId,data} = props ?? {};
+
+          return  workspaceMembersControllerInvite(workspaceId,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceMembersControllerInviteMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceMembersControllerInvite>>>
+    export type WorkspaceMembersControllerInviteMutationBody = InviteWorkspaceMemberDto
+    export type WorkspaceMembersControllerInviteMutationError = unknown
+
+    /**
+ * @summary Invite a workspace member
+ */
+export const useWorkspaceMembersControllerInvite = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceMembersControllerInvite>>, TError,{workspaceId: string;data: InviteWorkspaceMemberDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceMembersControllerInvite>>,
+        TError,
+        {workspaceId: string;data: InviteWorkspaceMemberDto},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceMembersControllerInviteMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Update a workspace member access level
+ */
+export const workspaceMembersControllerUpdateAccessLevel = (
+    workspaceId: string,
+    userId: string,
+    workspaceAccessLevelDto: WorkspaceAccessLevelDto,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspaces/${workspaceId}/members/${userId}`, method: 'PATCH',
+      headers: {'Content-Type': 'application/json', },
+      data: workspaceAccessLevelDto
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceMembersControllerUpdateAccessLevelMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceMembersControllerUpdateAccessLevel>>, TError,{workspaceId: string;userId: string;data: WorkspaceAccessLevelDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceMembersControllerUpdateAccessLevel>>, TError,{workspaceId: string;userId: string;data: WorkspaceAccessLevelDto}, TContext> => {
+
+const mutationKey = ['workspaceMembersControllerUpdateAccessLevel'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceMembersControllerUpdateAccessLevel>>, {workspaceId: string;userId: string;data: WorkspaceAccessLevelDto}> = (props) => {
+          const {workspaceId,userId,data} = props ?? {};
+
+          return  workspaceMembersControllerUpdateAccessLevel(workspaceId,userId,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceMembersControllerUpdateAccessLevelMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceMembersControllerUpdateAccessLevel>>>
+    export type WorkspaceMembersControllerUpdateAccessLevelMutationBody = WorkspaceAccessLevelDto
+    export type WorkspaceMembersControllerUpdateAccessLevelMutationError = unknown
+
+    /**
+ * @summary Update a workspace member access level
+ */
+export const useWorkspaceMembersControllerUpdateAccessLevel = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceMembersControllerUpdateAccessLevel>>, TError,{workspaceId: string;userId: string;data: WorkspaceAccessLevelDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceMembersControllerUpdateAccessLevel>>,
+        TError,
+        {workspaceId: string;userId: string;data: WorkspaceAccessLevelDto},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceMembersControllerUpdateAccessLevelMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Remove a workspace member or invitation
+ */
+export const workspaceMembersControllerRemove = (
+    workspaceId: string,
+    userId: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspaces/${workspaceId}/members/${userId}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceMembersControllerRemoveMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceMembersControllerRemove>>, TError,{workspaceId: string;userId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceMembersControllerRemove>>, TError,{workspaceId: string;userId: string}, TContext> => {
+
+const mutationKey = ['workspaceMembersControllerRemove'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceMembersControllerRemove>>, {workspaceId: string;userId: string}> = (props) => {
+          const {workspaceId,userId} = props ?? {};
+
+          return  workspaceMembersControllerRemove(workspaceId,userId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceMembersControllerRemoveMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceMembersControllerRemove>>>
+    
+    export type WorkspaceMembersControllerRemoveMutationError = unknown
+
+    /**
+ * @summary Remove a workspace member or invitation
+ */
+export const useWorkspaceMembersControllerRemove = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceMembersControllerRemove>>, TError,{workspaceId: string;userId: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceMembersControllerRemove>>,
+        TError,
+        {workspaceId: string;userId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceMembersControllerRemoveMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Grant a team workspace access
+ */
+export const workspaceTeamGrantsControllerAdd = (
+    workspaceId: string,
+    addWorkspaceTeamGrantDto: AddWorkspaceTeamGrantDto,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspaces/${workspaceId}/team-grants`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: addWorkspaceTeamGrantDto, signal
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceTeamGrantsControllerAddMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceTeamGrantsControllerAdd>>, TError,{workspaceId: string;data: AddWorkspaceTeamGrantDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceTeamGrantsControllerAdd>>, TError,{workspaceId: string;data: AddWorkspaceTeamGrantDto}, TContext> => {
+
+const mutationKey = ['workspaceTeamGrantsControllerAdd'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceTeamGrantsControllerAdd>>, {workspaceId: string;data: AddWorkspaceTeamGrantDto}> = (props) => {
+          const {workspaceId,data} = props ?? {};
+
+          return  workspaceTeamGrantsControllerAdd(workspaceId,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceTeamGrantsControllerAddMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceTeamGrantsControllerAdd>>>
+    export type WorkspaceTeamGrantsControllerAddMutationBody = AddWorkspaceTeamGrantDto
+    export type WorkspaceTeamGrantsControllerAddMutationError = unknown
+
+    /**
+ * @summary Grant a team workspace access
+ */
+export const useWorkspaceTeamGrantsControllerAdd = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceTeamGrantsControllerAdd>>, TError,{workspaceId: string;data: AddWorkspaceTeamGrantDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceTeamGrantsControllerAdd>>,
+        TError,
+        {workspaceId: string;data: AddWorkspaceTeamGrantDto},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceTeamGrantsControllerAddMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Update a workspace team access level
+ */
+export const workspaceTeamGrantsControllerUpdateAccessLevel = (
+    workspaceId: string,
+    teamId: string,
+    workspaceAccessLevelDto: WorkspaceAccessLevelDto,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspaces/${workspaceId}/team-grants/${teamId}`, method: 'PATCH',
+      headers: {'Content-Type': 'application/json', },
+      data: workspaceAccessLevelDto
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceTeamGrantsControllerUpdateAccessLevelMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceTeamGrantsControllerUpdateAccessLevel>>, TError,{workspaceId: string;teamId: string;data: WorkspaceAccessLevelDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceTeamGrantsControllerUpdateAccessLevel>>, TError,{workspaceId: string;teamId: string;data: WorkspaceAccessLevelDto}, TContext> => {
+
+const mutationKey = ['workspaceTeamGrantsControllerUpdateAccessLevel'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceTeamGrantsControllerUpdateAccessLevel>>, {workspaceId: string;teamId: string;data: WorkspaceAccessLevelDto}> = (props) => {
+          const {workspaceId,teamId,data} = props ?? {};
+
+          return  workspaceTeamGrantsControllerUpdateAccessLevel(workspaceId,teamId,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceTeamGrantsControllerUpdateAccessLevelMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceTeamGrantsControllerUpdateAccessLevel>>>
+    export type WorkspaceTeamGrantsControllerUpdateAccessLevelMutationBody = WorkspaceAccessLevelDto
+    export type WorkspaceTeamGrantsControllerUpdateAccessLevelMutationError = unknown
+
+    /**
+ * @summary Update a workspace team access level
+ */
+export const useWorkspaceTeamGrantsControllerUpdateAccessLevel = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceTeamGrantsControllerUpdateAccessLevel>>, TError,{workspaceId: string;teamId: string;data: WorkspaceAccessLevelDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceTeamGrantsControllerUpdateAccessLevel>>,
+        TError,
+        {workspaceId: string;teamId: string;data: WorkspaceAccessLevelDto},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceTeamGrantsControllerUpdateAccessLevelMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Remove a workspace team grant
+ */
+export const workspaceTeamGrantsControllerRemove = (
+    workspaceId: string,
+    teamId: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspaces/${workspaceId}/team-grants/${teamId}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceTeamGrantsControllerRemoveMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceTeamGrantsControllerRemove>>, TError,{workspaceId: string;teamId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceTeamGrantsControllerRemove>>, TError,{workspaceId: string;teamId: string}, TContext> => {
+
+const mutationKey = ['workspaceTeamGrantsControllerRemove'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceTeamGrantsControllerRemove>>, {workspaceId: string;teamId: string}> = (props) => {
+          const {workspaceId,teamId} = props ?? {};
+
+          return  workspaceTeamGrantsControllerRemove(workspaceId,teamId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceTeamGrantsControllerRemoveMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceTeamGrantsControllerRemove>>>
+    
+    export type WorkspaceTeamGrantsControllerRemoveMutationError = unknown
+
+    /**
+ * @summary Remove a workspace team grant
+ */
+export const useWorkspaceTeamGrantsControllerRemove = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceTeamGrantsControllerRemove>>, TError,{workspaceId: string;teamId: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceTeamGrantsControllerRemove>>,
+        TError,
+        {workspaceId: string;teamId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceTeamGrantsControllerRemoveMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Set a team member workspace override
+ */
+export const workspaceTeamGrantsControllerSetOverride = (
+    workspaceId: string,
+    teamId: string,
+    userId: string,
+    setWorkspaceTeamMemberOverrideDto: SetWorkspaceTeamMemberOverrideDto,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspaces/${workspaceId}/team-grants/${teamId}/overrides/${userId}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: setWorkspaceTeamMemberOverrideDto
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceTeamGrantsControllerSetOverrideMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceTeamGrantsControllerSetOverride>>, TError,{workspaceId: string;teamId: string;userId: string;data: SetWorkspaceTeamMemberOverrideDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceTeamGrantsControllerSetOverride>>, TError,{workspaceId: string;teamId: string;userId: string;data: SetWorkspaceTeamMemberOverrideDto}, TContext> => {
+
+const mutationKey = ['workspaceTeamGrantsControllerSetOverride'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceTeamGrantsControllerSetOverride>>, {workspaceId: string;teamId: string;userId: string;data: SetWorkspaceTeamMemberOverrideDto}> = (props) => {
+          const {workspaceId,teamId,userId,data} = props ?? {};
+
+          return  workspaceTeamGrantsControllerSetOverride(workspaceId,teamId,userId,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceTeamGrantsControllerSetOverrideMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceTeamGrantsControllerSetOverride>>>
+    export type WorkspaceTeamGrantsControllerSetOverrideMutationBody = SetWorkspaceTeamMemberOverrideDto
+    export type WorkspaceTeamGrantsControllerSetOverrideMutationError = unknown
+
+    /**
+ * @summary Set a team member workspace override
+ */
+export const useWorkspaceTeamGrantsControllerSetOverride = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceTeamGrantsControllerSetOverride>>, TError,{workspaceId: string;teamId: string;userId: string;data: SetWorkspaceTeamMemberOverrideDto}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceTeamGrantsControllerSetOverride>>,
+        TError,
+        {workspaceId: string;teamId: string;userId: string;data: SetWorkspaceTeamMemberOverrideDto},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceTeamGrantsControllerSetOverrideMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Reset a team member workspace override
+ */
+export const workspaceTeamGrantsControllerResetOverride = (
+    workspaceId: string,
+    teamId: string,
+    userId: string,
+ ) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspaces/${workspaceId}/team-grants/${teamId}/overrides/${userId}`, method: 'DELETE'
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceTeamGrantsControllerResetOverrideMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceTeamGrantsControllerResetOverride>>, TError,{workspaceId: string;teamId: string;userId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceTeamGrantsControllerResetOverride>>, TError,{workspaceId: string;teamId: string;userId: string}, TContext> => {
+
+const mutationKey = ['workspaceTeamGrantsControllerResetOverride'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceTeamGrantsControllerResetOverride>>, {workspaceId: string;teamId: string;userId: string}> = (props) => {
+          const {workspaceId,teamId,userId} = props ?? {};
+
+          return  workspaceTeamGrantsControllerResetOverride(workspaceId,teamId,userId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceTeamGrantsControllerResetOverrideMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceTeamGrantsControllerResetOverride>>>
+    
+    export type WorkspaceTeamGrantsControllerResetOverrideMutationError = unknown
+
+    /**
+ * @summary Reset a team member workspace override
+ */
+export const useWorkspaceTeamGrantsControllerResetOverride = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceTeamGrantsControllerResetOverride>>, TError,{workspaceId: string;teamId: string;userId: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceTeamGrantsControllerResetOverride>>,
+        TError,
+        {workspaceId: string;teamId: string;userId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceTeamGrantsControllerResetOverrideMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary List my pending workspace invitations
+ */
+export const workspaceInvitationsControllerList = (
+    
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<WorkspaceInvitationResponseDto[]>(
+      {url: `/workspace-invitations`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getWorkspaceInvitationsControllerListQueryKey = () => {
+    return [
+    `/workspace-invitations`
+    ] as const;
+    }
+
+    
+export const getWorkspaceInvitationsControllerListQueryOptions = <TData = Awaited<ReturnType<typeof workspaceInvitationsControllerList>>, TError = unknown>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceInvitationsControllerList>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getWorkspaceInvitationsControllerListQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof workspaceInvitationsControllerList>>> = ({ signal }) => workspaceInvitationsControllerList(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof workspaceInvitationsControllerList>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type WorkspaceInvitationsControllerListQueryResult = NonNullable<Awaited<ReturnType<typeof workspaceInvitationsControllerList>>>
+export type WorkspaceInvitationsControllerListQueryError = unknown
+
+
+export function useWorkspaceInvitationsControllerList<TData = Awaited<ReturnType<typeof workspaceInvitationsControllerList>>, TError = unknown>(
+  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceInvitationsControllerList>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceInvitationsControllerList>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceInvitationsControllerList>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceInvitationsControllerList<TData = Awaited<ReturnType<typeof workspaceInvitationsControllerList>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceInvitationsControllerList>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceInvitationsControllerList>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceInvitationsControllerList>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceInvitationsControllerList<TData = Awaited<ReturnType<typeof workspaceInvitationsControllerList>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceInvitationsControllerList>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary List my pending workspace invitations
+ */
+
+export function useWorkspaceInvitationsControllerList<TData = Awaited<ReturnType<typeof workspaceInvitationsControllerList>>, TError = unknown>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceInvitationsControllerList>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getWorkspaceInvitationsControllerListQueryOptions(options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
+/**
+ * @summary Accept a workspace invitation
+ */
+export const workspaceInvitationsControllerAccept = (
+    workspaceId: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspace-invitations/${workspaceId}/accept`, method: 'POST', signal
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceInvitationsControllerAcceptMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceInvitationsControllerAccept>>, TError,{workspaceId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceInvitationsControllerAccept>>, TError,{workspaceId: string}, TContext> => {
+
+const mutationKey = ['workspaceInvitationsControllerAccept'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceInvitationsControllerAccept>>, {workspaceId: string}> = (props) => {
+          const {workspaceId} = props ?? {};
+
+          return  workspaceInvitationsControllerAccept(workspaceId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceInvitationsControllerAcceptMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceInvitationsControllerAccept>>>
+    
+    export type WorkspaceInvitationsControllerAcceptMutationError = unknown
+
+    /**
+ * @summary Accept a workspace invitation
+ */
+export const useWorkspaceInvitationsControllerAccept = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceInvitationsControllerAccept>>, TError,{workspaceId: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceInvitationsControllerAccept>>,
+        TError,
+        {workspaceId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceInvitationsControllerAcceptMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary Decline a workspace invitation
+ */
+export const workspaceInvitationsControllerDecline = (
+    workspaceId: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<void>(
+      {url: `/workspace-invitations/${workspaceId}/decline`, method: 'POST', signal
+    },
+      );
+    }
+  
+
+
+export const getWorkspaceInvitationsControllerDeclineMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceInvitationsControllerDecline>>, TError,{workspaceId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof workspaceInvitationsControllerDecline>>, TError,{workspaceId: string}, TContext> => {
+
+const mutationKey = ['workspaceInvitationsControllerDecline'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof workspaceInvitationsControllerDecline>>, {workspaceId: string}> = (props) => {
+          const {workspaceId} = props ?? {};
+
+          return  workspaceInvitationsControllerDecline(workspaceId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type WorkspaceInvitationsControllerDeclineMutationResult = NonNullable<Awaited<ReturnType<typeof workspaceInvitationsControllerDecline>>>
+    
+    export type WorkspaceInvitationsControllerDeclineMutationError = unknown
+
+    /**
+ * @summary Decline a workspace invitation
+ */
+export const useWorkspaceInvitationsControllerDecline = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof workspaceInvitationsControllerDecline>>, TError,{workspaceId: string}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof workspaceInvitationsControllerDecline>>,
+        TError,
+        {workspaceId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getWorkspaceInvitationsControllerDeclineMutationOptions(options);
+
+      return useMutation(mutationOptions, queryClient);
+    }
+    
+/**
+ * @summary List members of a granted workspace team
+ */
+export const workspaceTeamGrantMembersControllerList = (
+    workspaceId: string,
+    teamId: string,
+ signal?: AbortSignal
+) => {
+      
+      
+      return customAxiosInstance<WorkspaceSharingUserDto[]>(
+      {url: `/workspaces/${workspaceId}/team-grants/${teamId}/members`, method: 'GET', signal
+    },
+      );
+    }
+  
+
+
+
+export const getWorkspaceTeamGrantMembersControllerListQueryKey = (workspaceId?: string,
+    teamId?: string,) => {
+    return [
+    `/workspaces/${workspaceId}/team-grants/${teamId}/members`
+    ] as const;
+    }
+
+    
+export const getWorkspaceTeamGrantMembersControllerListQueryOptions = <TData = Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>, TError = unknown>(workspaceId: string,
+    teamId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>, TError, TData>>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getWorkspaceTeamGrantMembersControllerListQueryKey(workspaceId,teamId);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>> = ({ signal }) => workspaceTeamGrantMembersControllerList(workspaceId,teamId, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(workspaceId && teamId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type WorkspaceTeamGrantMembersControllerListQueryResult = NonNullable<Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>>
+export type WorkspaceTeamGrantMembersControllerListQueryError = unknown
+
+
+export function useWorkspaceTeamGrantMembersControllerList<TData = Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>, TError = unknown>(
+ workspaceId: string,
+    teamId: string, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceTeamGrantMembersControllerList<TData = Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>, TError = unknown>(
+ workspaceId: string,
+    teamId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>,
+          TError,
+          Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>
+        > , 'initialData'
+      >, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+export function useWorkspaceTeamGrantMembersControllerList<TData = Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>, TError = unknown>(
+ workspaceId: string,
+    teamId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>, TError, TData>>, }
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+/**
+ * @summary List members of a granted workspace team
+ */
+
+export function useWorkspaceTeamGrantMembersControllerList<TData = Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>, TError = unknown>(
+ workspaceId: string,
+    teamId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof workspaceTeamGrantMembersControllerList>>, TError, TData>>, }
+ , queryClient?: QueryClient 
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+
+  const queryOptions = getWorkspaceTeamGrantMembersControllerListQueryOptions(workspaceId,teamId,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+
+
 /**
  * @summary Get the current user favorites
  */

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -7196,6 +7196,487 @@
         "tags": ["workspaces"]
       }
     },
+    "/workspaces/{workspaceId}/access": {
+      "get": {
+        "operationId": "WorkspaceSharingController_getAccess",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceAccessResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get the current user workspace access",
+        "tags": ["workspace-sharing"]
+      }
+    },
+    "/workspaces/{workspaceId}/sharing": {
+      "get": {
+        "operationId": "WorkspaceSharingController_getSharing",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceSharingResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get workspace sharing settings",
+        "tags": ["workspace-sharing"]
+      }
+    },
+    "/workspaces/{workspaceId}/sharing/visibility": {
+      "patch": {
+        "operationId": "WorkspaceSharingController_updateVisibility",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWorkspaceVisibilityDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "summary": "Update workspace visibility",
+        "tags": ["workspace-sharing"]
+      }
+    },
+    "/workspaces/{workspaceId}/members": {
+      "post": {
+        "operationId": "WorkspaceMembersController_invite",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InviteWorkspaceMemberDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "summary": "Invite a workspace member",
+        "tags": ["workspace-sharing"]
+      }
+    },
+    "/workspaces/{workspaceId}/members/{userId}": {
+      "patch": {
+        "operationId": "WorkspaceMembersController_updateAccessLevel",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceAccessLevelDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "summary": "Update a workspace member access level",
+        "tags": ["workspace-sharing"]
+      },
+      "delete": {
+        "operationId": "WorkspaceMembersController_remove",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "summary": "Remove a workspace member or invitation",
+        "tags": ["workspace-sharing"]
+      }
+    },
+    "/workspaces/{workspaceId}/team-grants": {
+      "post": {
+        "operationId": "WorkspaceTeamGrantsController_add",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddWorkspaceTeamGrantDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "summary": "Grant a team workspace access",
+        "tags": ["workspace-sharing"]
+      }
+    },
+    "/workspaces/{workspaceId}/team-grants/{teamId}": {
+      "patch": {
+        "operationId": "WorkspaceTeamGrantsController_updateAccessLevel",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "teamId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceAccessLevelDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "summary": "Update a workspace team access level",
+        "tags": ["workspace-sharing"]
+      },
+      "delete": {
+        "operationId": "WorkspaceTeamGrantsController_remove",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "teamId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "summary": "Remove a workspace team grant",
+        "tags": ["workspace-sharing"]
+      }
+    },
+    "/workspaces/{workspaceId}/team-grants/{teamId}/overrides/{userId}": {
+      "put": {
+        "operationId": "WorkspaceTeamGrantsController_setOverride",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "teamId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetWorkspaceTeamMemberOverrideDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "summary": "Set a team member workspace override",
+        "tags": ["workspace-sharing"]
+      },
+      "delete": {
+        "operationId": "WorkspaceTeamGrantsController_resetOverride",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "teamId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "summary": "Reset a team member workspace override",
+        "tags": ["workspace-sharing"]
+      }
+    },
+    "/workspace-invitations": {
+      "get": {
+        "operationId": "WorkspaceInvitationsController_list",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkspaceInvitationResponseDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "List my pending workspace invitations",
+        "tags": ["workspace-invitations"]
+      }
+    },
+    "/workspace-invitations/{workspaceId}/accept": {
+      "post": {
+        "operationId": "WorkspaceInvitationsController_accept",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "summary": "Accept a workspace invitation",
+        "tags": ["workspace-invitations"]
+      }
+    },
+    "/workspace-invitations/{workspaceId}/decline": {
+      "post": {
+        "operationId": "WorkspaceInvitationsController_decline",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "summary": "Decline a workspace invitation",
+        "tags": ["workspace-invitations"]
+      }
+    },
+    "/workspaces/{workspaceId}/team-grants/{teamId}/members": {
+      "get": {
+        "operationId": "WorkspaceTeamGrantMembersController_list",
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "teamId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkspaceSharingUserDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "List members of a granted workspace team",
+        "tags": ["workspace-sharing"]
+      }
+    },
     "/favorites": {
       "get": {
         "operationId": "FavoritesController_findAll",
@@ -16828,6 +17309,10 @@
             "description": "Effective access level for the caller (list responses only)",
             "enum": ["use", "edit", "full"]
           },
+          "isOwner": {
+            "type": "boolean",
+            "description": "Whether the caller owns the workspace"
+          },
           "chatCount": {
             "type": "number",
             "description": "Number of chats filed under the workspace (list responses only)",
@@ -17129,6 +17614,240 @@
           }
         },
         "required": ["instruction"]
+      },
+      "WorkspaceAccessResponseDto": {
+        "type": "object",
+        "properties": {
+          "accessLevel": {
+            "type": "string",
+            "enum": ["use", "edit", "full"]
+          },
+          "isOwner": {
+            "type": "boolean"
+          }
+        },
+        "required": ["accessLevel", "isOwner"]
+      },
+      "WorkspaceSharingUserDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          }
+        },
+        "required": ["id", "name", "email"]
+      },
+      "WorkspaceSharingAvailableTeamDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "memberCount": {
+            "type": "number"
+          }
+        },
+        "required": ["id", "name", "memberCount"]
+      },
+      "WorkspaceSharingMemberDto": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/WorkspaceSharingUserDto"
+          },
+          "accessLevel": {
+            "type": "string",
+            "enum": ["use", "edit", "full"]
+          },
+          "status": {
+            "type": "string",
+            "enum": ["pending", "active"]
+          }
+        },
+        "required": ["user", "accessLevel", "status"]
+      },
+      "WorkspaceSharingOverrideDto": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/WorkspaceSharingUserDto"
+          },
+          "accessLevel": {
+            "type": "string",
+            "enum": ["use", "edit", "full"],
+            "nullable": true
+          },
+          "excluded": {
+            "type": "boolean"
+          }
+        },
+        "required": ["user", "accessLevel", "excluded"]
+      },
+      "WorkspaceSharingTeamGrantDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "memberCount": {
+            "type": "number"
+          },
+          "accessLevel": {
+            "type": "string",
+            "enum": ["use", "edit", "full"]
+          },
+          "overrides": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceSharingOverrideDto"
+            }
+          }
+        },
+        "required": ["id", "name", "memberCount", "accessLevel", "overrides"]
+      },
+      "WorkspaceSharingResponseDto": {
+        "type": "object",
+        "properties": {
+          "visibility": {
+            "type": "string",
+            "enum": ["private", "organization"]
+          },
+          "owner": {
+            "$ref": "#/components/schemas/WorkspaceSharingUserDto"
+          },
+          "availableTeams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceSharingAvailableTeamDto"
+            }
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceSharingMemberDto"
+            }
+          },
+          "teamGrants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceSharingTeamGrantDto"
+            }
+          }
+        },
+        "required": [
+          "visibility",
+          "owner",
+          "availableTeams",
+          "members",
+          "teamGrants"
+        ]
+      },
+      "UpdateWorkspaceVisibilityDto": {
+        "type": "object",
+        "properties": {
+          "visibility": {
+            "type": "string",
+            "enum": ["private", "organization"]
+          }
+        },
+        "required": ["visibility"]
+      },
+      "InviteWorkspaceMemberDto": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "accessLevel": {
+            "type": "string",
+            "enum": ["use", "edit", "full"]
+          }
+        },
+        "required": ["userId", "accessLevel"]
+      },
+      "WorkspaceAccessLevelDto": {
+        "type": "object",
+        "properties": {
+          "accessLevel": {
+            "type": "string",
+            "enum": ["use", "edit", "full"]
+          }
+        },
+        "required": ["accessLevel"]
+      },
+      "AddWorkspaceTeamGrantDto": {
+        "type": "object",
+        "properties": {
+          "teamId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "accessLevel": {
+            "type": "string",
+            "enum": ["use", "edit", "full"]
+          }
+        },
+        "required": ["teamId", "accessLevel"]
+      },
+      "SetWorkspaceTeamMemberOverrideDto": {
+        "type": "object",
+        "properties": {
+          "accessLevel": {
+            "type": "string",
+            "enum": ["use", "edit", "full"],
+            "nullable": true
+          }
+        },
+        "required": ["accessLevel"]
+      },
+      "WorkspaceInvitationWorkspaceDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          }
+        },
+        "required": ["id", "name", "icon", "color"]
+      },
+      "WorkspaceInvitationResponseDto": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "$ref": "#/components/schemas/WorkspaceInvitationWorkspaceDto"
+          },
+          "accessLevel": {
+            "type": "string",
+            "enum": ["use", "edit", "full"]
+          }
+        },
+        "required": ["workspace", "accessLevel"]
       },
       "WorkspaceFavoriteResponseDto": {
         "type": "object",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds authorization-sensitive sharing and invitation endpoints and org-wide visibility changes; misconfiguration could over-share workspaces, though use cases enforce FULL access and IAM permissions on mutating routes.
> 
> **Overview**
> Exposes **workspace collaboration over HTTP** so clients can manage sharing without relying on application-layer use cases alone. New routes cover caller access (`GET /workspaces/:id/access`), sharing state (`GET /sharing`), **private vs organization visibility** (`PATCH /sharing/visibility`), direct members, team grants and per-member overrides, granted-team member listing for override UI, and the current user’s invitation list plus accept/decline.
> 
> **Read models are expanded for the sharing UI:** `GetWorkspaceSharing` now returns visibility, hydrated owner, org teams not yet granted, plus existing members/grants/overrides. Workspace **list responses include `isOwner`** (derived from access sources). DTO mappers strip sensitive user fields to id/name/email for sharing payloads.
> 
> Application tweaks: **`UpdateWorkspaceVisibilityUseCase`** and **`ListWorkspaceTeamMembersUseCase`**; team override setup checks **`hasTeamGrant`** before team membership so missing grants fail fast. Controllers stay behind the workspaces feature flag; sharing management endpoints require **`ASSIGN_USERS_TO_TEAMS`**.
> 
> OpenAPI and the **generated frontend API client** are updated for all new endpoints and types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e87bba90c430b31d2ff6cd2827f706d9878a9b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->