### PR TITLE
test(e2e): cover shared skill knowledge base access (AYC-13)

### DIFF
--- a/ayunis-core-e2e/src/clients/api/invites.client.ts
+++ b/ayunis-core-e2e/src/clients/api/invites.client.ts
@@ -1,4 +1,5 @@
 import type { APIRequestContext } from '@playwright/test';
+import type { AcceptInviteDto } from '../generated/ayunisCoreAPI.schemas';
 import { CreateInviteDtoRole } from '../generated/ayunisCoreAPI.schemas';
 import { generatedApi } from './generated-api';
 
@@ -8,4 +9,11 @@ export async function inviteUser(
   role: CreateInviteDtoRole = CreateInviteDtoRole.user,
 ): Promise<void> {
   await generatedApi.invitesControllerCreate({ email, role }, { api });
+}
+
+export async function acceptInvite(
+  api: APIRequestContext,
+  input: AcceptInviteDto,
+): Promise<void> {
+  await generatedApi.invitesControllerAcceptInvite(input, { api });
 }

--- a/ayunis-core-e2e/src/clients/api/shares.client.ts
+++ b/ayunis-core-e2e/src/clients/api/shares.client.ts
@@ -1,0 +1,16 @@
+import type { APIRequestContext } from '@playwright/test';
+import { CreateSkillShareDtoEntityType } from '../generated/ayunisCoreAPI.schemas';
+import { generatedApi } from './generated-api';
+
+export async function createOrgSkillShare(
+  api: APIRequestContext,
+  skillId: string,
+): Promise<void> {
+  await generatedApi.sharesControllerCreateSkillShare(
+    {
+      entityType: CreateSkillShareDtoEntityType.skill,
+      skillId,
+    },
+    { api },
+  );
+}

--- a/ayunis-core-e2e/src/factories/shared-skill-access.factory.ts
+++ b/ayunis-core-e2e/src/factories/shared-skill-access.factory.ts
@@ -1,0 +1,93 @@
+import { request } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
+import { config } from '../config';
+import { acceptInvite, inviteUser } from '../clients/api/invites.client';
+import { login } from '../clients/api/auth.client';
+import { skipChatPersonalization } from '../clients/api/chat-settings.client';
+import { generatedApi } from '../clients/api/generated-api';
+import { dismissWelcomeVideo } from '../clients/api/onboarding.client';
+import { createOrgSkillShare } from '../clients/api/shares.client';
+import type { MailcatcherClient } from '../clients/mailcatcher.client';
+
+const MEMBER_PASSWORD = 'E2e-Password-1';
+
+export interface SharedSkillAccessFixture {
+  skill: { id: string; name: string };
+  knowledgeBase: { id: string; name: string };
+  workspace: { id: string; name: string };
+  memberApi: APIRequestContext;
+  shareSkill: () => Promise<void>;
+}
+
+export async function createSharedSkillAccessFixture(
+  adminApi: APIRequestContext,
+  mail: MailcatcherClient,
+  suffix: string,
+): Promise<SharedSkillAccessFixture> {
+  const skill = await generatedApi.skillsControllerCreate(
+    {
+      name: `Shared civic knowledge ${suffix}`,
+      shortDescription: 'Provides shared civic knowledge for organization members',
+      instructions: 'Use the linked civic knowledge base for relevant questions.',
+      isActive: true,
+    },
+    { api: adminApi },
+  );
+  const knowledgeBase = await generatedApi.knowledgeBasesControllerCreate(
+    {
+      name: `Shared civic knowledge base ${suffix}`,
+      description: 'Knowledge base shared through a skill',
+    },
+    { api: adminApi },
+  );
+  await generatedApi.skillKnowledgeBasesControllerAssignKnowledgeBase(
+    skill.id,
+    knowledgeBase.id,
+    { api: adminApi },
+  );
+
+  const memberEmail = `e2e-shared-skill-${suffix}@e2e.local`;
+  await inviteUser(adminApi, memberEmail);
+  const inviteToken = await mail.extractLinkToken(
+    memberEmail,
+    '/accept-invite',
+  );
+  const memberApi = await request.newContext({ baseURL: config.apiURL });
+
+  try {
+    await acceptInvite(memberApi, {
+      inviteToken,
+      userName: `Shared Skill Viewer ${suffix}`,
+      password: MEMBER_PASSWORD,
+      hasAcceptedMarketing: false,
+    });
+    await login(memberApi, memberEmail, MEMBER_PASSWORD);
+    await dismissWelcomeVideo(memberApi);
+    await skipChatPersonalization(memberApi);
+    const workspace = await generatedApi.workspacesControllerCreate(
+      {
+        name: `Shared skill workspace ${suffix}`,
+        description: 'Workspace for shared skill access coverage',
+        icon: 'building-2',
+      },
+      { api: memberApi },
+    );
+    const shareSkill = async (): Promise<void> => {
+      await createOrgSkillShare(adminApi, skill.id);
+    };
+
+    return {
+      skill: { id: skill.id, name: skill.name },
+      knowledgeBase: {
+        id: knowledgeBase.id,
+        name: knowledgeBase.name,
+      },
+      workspace: { id: workspace.id, name: workspace.name },
+      memberApi,
+      shareSkill,
+    };
+  } catch (error) {
+    await memberApi.dispose();
+    throw error;
+  }
+}

--- a/ayunis-core-e2e/tests/knowledge-bases/shared-skill-access.spec.ts
+++ b/ayunis-core-e2e/tests/knowledge-bases/shared-skill-access.spec.ts
@@ -1,0 +1,81 @@
+import type { BrowserContext, Page } from '@playwright/test';
+import { generatedApi } from '../../src/clients/api/generated-api';
+import { createSharedSkillAccessFixture } from '../../src/factories/shared-skill-access.factory';
+import { test, expect } from '../../src/fixtures/test';
+
+test('shows a knowledge base linked to a skill shared with another user', async ({
+  api,
+  browser,
+  mail,
+}) => {
+  const fixture = await createSharedSkillAccessFixture(
+    api,
+    mail,
+    `${Date.now()}`,
+  );
+  let memberContext: BrowserContext | undefined;
+  let memberPage: Page | undefined;
+  const pageErrors: string[] = [];
+
+  try {
+    memberContext = await browser.newContext({
+      storageState: await fixture.memberApi.storageState(),
+    });
+    memberPage = await memberContext.newPage();
+    memberPage.on('pageerror', (error) => pageErrors.push(error.message));
+
+    const knowledgeBasesBeforeShare =
+      await generatedApi.knowledgeBasesControllerFindAll({
+        api: fixture.memberApi,
+      });
+    expect(knowledgeBasesBeforeShare.data).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: fixture.knowledgeBase.id }),
+      ]),
+    );
+
+    await fixture.shareSkill();
+
+    const knowledgeBases =
+      await generatedApi.knowledgeBasesControllerFindAll({
+        api: fixture.memberApi,
+      });
+    expect(knowledgeBases.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: fixture.knowledgeBase.id,
+          isShared: true,
+        }),
+      ]),
+    );
+
+    await memberPage.goto('/knowledge-bases');
+    await memberPage.getByTestId('knowledge-base-tab-shared').click();
+    await expect(
+      memberPage.getByTestId(`knowledge-base-card-${fixture.knowledgeBase.id}`),
+    ).toBeVisible();
+    await expect(
+      memberPage.getByTestId(
+        `knowledge-base-shared-badge-${fixture.knowledgeBase.id}`,
+      ),
+    ).toBeVisible();
+
+    await memberPage.goto(`/workspaces/${fixture.workspace.id}`);
+    await expect(memberPage.getByTestId('workspace-page')).toBeVisible();
+    await memberPage.getByTestId('workspace-tab-knowledge').click();
+    await expect(
+      memberPage.getByTestId('workspace-knowledge-add').first(),
+    ).toBeVisible();
+    await memberPage.getByTestId('workspace-knowledge-add').first().click();
+    await expect(
+      memberPage.getByTestId(
+        `workspace-add-dialog-item-${fixture.knowledgeBase.id}`,
+      ),
+    ).toBeVisible();
+    expect(pageErrors).toEqual([]);
+  } finally {
+    await memberPage?.close();
+    await memberContext?.close();
+    await fixture.memberApi.dispose();
+  }
+});

--- a/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBaseCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBaseCard.tsx
@@ -1,11 +1,11 @@
 import { Button } from '@ayunis/ui/components/button';
 import { Badge } from '@ayunis/ui/components/badge';
 import { Trash2 } from 'lucide-react';
-import { useDeleteKnowledgeBase } from '../api/useDeleteKnowledgeBase';
+import { useDeleteKnowledgeBase } from '@/pages/knowledge-bases/api/useDeleteKnowledgeBase';
 import { PermissionGate } from '@/features/permissions';
 import { useConfirmation } from '@/widgets/confirmation-modal';
 import { useTranslation } from 'react-i18next';
-import type { KnowledgeBase } from '../model/openapi';
+import type { KnowledgeBase } from '@/pages/knowledge-bases/model/openapi';
 import { useRouter } from '@tanstack/react-router';
 import {
   Item,
@@ -48,6 +48,7 @@ export default function KnowledgeBaseCard({
     <Item
       variant="outline"
       className="cursor-pointer"
+      data-testid={`knowledge-base-card-${knowledgeBase.id}`}
       onClick={() =>
         void router.navigate({
           to: '/knowledge-bases/$id',
@@ -59,7 +60,11 @@ export default function KnowledgeBaseCard({
         <ItemTitle>
           <span>{knowledgeBase.name}</span>
           {isShared && (
-            <Badge variant="secondary" className="ml-2 text-xs">
+            <Badge
+              variant="secondary"
+              className="ml-2 text-xs"
+              data-testid={`knowledge-base-shared-badge-${knowledgeBase.id}`}
+            >
               {t('shared.badge')}
             </Badge>
           )}

--- a/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBasesPage.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBasesPage.tsx
@@ -6,7 +6,7 @@ import CreateKnowledgeBaseDialog from './CreateKnowledgeBaseDialog';
 import KnowledgeBaseCard from './KnowledgeBaseCard';
 import KnowledgeBasesEmptyState from './KnowledgeBasesEmptyState';
 import FullScreenMessageLayout from '@/layouts/full-screen-message-layout/ui/FullScreenMessageLayout';
-import type { KnowledgeBase } from '../model/openapi';
+import type { KnowledgeBase } from '@/pages/knowledge-bases/model/openapi';
 import { useTranslation } from 'react-i18next';
 import { useMyPermissions } from '@/features/permissions';
 import { HelpLink } from '@/shared/ui/help-link/HelpLink';
@@ -76,7 +76,12 @@ export default function KnowledgeBasesPage({
           <Tabs defaultValue="personal" className="w-full">
             <TabsList>
               <TabsTrigger value="personal">{t('tabs.personal')}</TabsTrigger>
-              <TabsTrigger value="shared">{t('tabs.shared')}</TabsTrigger>
+              <TabsTrigger
+                value="shared"
+                data-testid="knowledge-base-tab-shared"
+              >
+                {t('tabs.shared')}
+              </TabsTrigger>
             </TabsList>
             <TabsContent value="personal" className="mt-4">
               {personalKnowledgeBases.length === 0 ? (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test infrastructure and `data-testid` attributes only; no production access-control or API logic changes in this diff.
> 
> **Overview**
> Adds **end-to-end coverage** for org-wide skill sharing: when an admin shares a skill linked to a knowledge base, another org member should see that KB as shared via API and in the UI.
> 
> New Playwright helpers include **`acceptInvite`**, **`createOrgSkillShare`**, and a **`createSharedSkillAccessFixture`** factory that provisions skill + KB, onboards a second user via invite email, and exposes a deferred **`shareSkill`** step so the spec can assert visibility before and after sharing. The spec checks `knowledgeBasesControllerFindAll` (`isShared: true`), the Knowledge Bases **Shared** tab (card + badge), and that the shared KB appears in the workspace **add knowledge** dialog, with no client page errors.
> 
> On the frontend, **`KnowledgeBaseCard`** and **`KnowledgeBasesPage`** gain stable **`data-testid`** hooks for the shared tab, cards, and shared badges; import paths on those files switch to `@/pages/knowledge-bases/...` aliases (no behavior change beyond testability).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbbf5b98fe0b40610a73c4381dbdefc8c0e73f80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->