### PR TITLE
fix(mcp): bound capability discovery latency (AYC-825)

### DIFF
--- a/ayunis-core-backend/src/domain/mcp/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/mcp/SUMMARY.md
@@ -17,7 +17,7 @@ The MCP module manages connections to external Model Context Protocol servers at
 - `EnableMcpIntegrationUseCase` / `DisableMcpIntegrationUseCase` — Toggles integration enabled state
 - `ValidateMcpIntegrationUseCase` — Validates connection to the MCP server
 - `ListPredefinedMcpIntegrationConfigsUseCase` — Lists available predefined integration configurations
-- `DiscoverMcpCapabilitiesUseCase` — Discovers tools, resources, and prompts from a server
+- `DiscoverMcpCapabilitiesUseCase` — Discovers tools, resources, and prompts with a 10-second request and connection budget so an unavailable integration cannot delay run preparation for the full 30-second validation/runtime-operation timeout
 - `ExecuteMcpToolUseCase` — Executes a tool on a remote MCP server
 - `RetrieveMcpResourceUseCase` — Retrieves a resource from a remote MCP server
 - `GetMcpPromptUseCase` — Fetches a prompt from a remote MCP server
@@ -26,8 +26,8 @@ The MCP module manages connections to external Model Context Protocol servers at
 
 **Services:**
 
-- `McpClientService` — Handles authenticated server communication through the MCP SDK adapter
-- `McpClientPoolService` — Pools SDK connections per tenant, integration, user, and configuration; keeps at most 100 idle clients and invalidates sessions when integration or user credentials change
+- `McpClientService` — Handles authenticated server communication through the MCP SDK adapter and forwards caller-selected capability-list timeout budgets
+- `McpClientPoolService` — Pools SDK connections per tenant, integration, user, configuration, and connection timeout budget; keeps at most 100 idle clients and invalidates sessions when integration or user credentials change
 - `McpCapabilityCacheService` — In-process TTL cache for discovered capabilities (per integration and user); invalidated on integration update, delete, and user-config changes
 - `McpConfigService` — Validates schemas and merges, encrypts, and retains organization/user config values
 - `ConnectionValidationService` — Validates MCP server connectivity, used by `ValidateMcpIntegrationUseCase`

--- a/ayunis-core-backend/src/domain/mcp/application/ports/mcp-client.port.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/ports/mcp-client.port.ts
@@ -74,34 +74,49 @@ export interface McpToolResult {
   isError: boolean;
 }
 
+export interface McpRequestOptions {
+  timeout: number;
+}
+
 /**
  * Port interface for MCP client operations.
  * Abstracts the MCP SDK to allow testing and alternative implementations.
  *
  * Connections may be reused across operations with equivalent configuration.
- * All operations enforce a 30-second timeout.
+ * Capability discovery uses a shorter timeout than explicit validation and
+ * runtime tool/resource operations.
  */
 export abstract class McpClientPort {
   /**
    * List all tools available on the MCP server
    */
-  abstract listTools(config: McpConnectionConfig): Promise<McpTool[]>;
+  abstract listTools(
+    config: McpConnectionConfig,
+    options?: McpRequestOptions,
+  ): Promise<McpTool[]>;
 
   /**
    * List all resources available on the MCP server
    */
-  abstract listResources(config: McpConnectionConfig): Promise<McpResource[]>;
+  abstract listResources(
+    config: McpConnectionConfig,
+    options?: McpRequestOptions,
+  ): Promise<McpResource[]>;
 
   /**
    * List all resource templates available on the MCP server
    */
   abstract listResourceTemplates(
     config: McpConnectionConfig,
+    options?: McpRequestOptions,
   ): Promise<McpResource[]>;
   /**
    * List all prompt templates available on the MCP server
    */
-  abstract listPrompts(config: McpConnectionConfig): Promise<McpPrompt[]>;
+  abstract listPrompts(
+    config: McpConnectionConfig,
+    options?: McpRequestOptions,
+  ): Promise<McpPrompt[]>;
 
   /**
    * Execute a tool on the MCP server

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.ts
@@ -9,23 +9,24 @@ import {
   McpPrompt,
   McpToolCall,
   McpToolResult,
-} from '../ports/mcp-client.port';
-import { McpCredentialEncryptionPort } from '../ports/mcp-credential-encryption.port';
-import { McpIntegrationUserConfigRepositoryPort } from '../ports/mcp-integration-user-config.repository.port';
-import { McpIntegration } from '../../domain/mcp-integration.entity';
-import { SchemaConfiguredMcpIntegration } from '../../domain/integrations/schema-configured-mcp-integration.entity';
+  McpRequestOptions,
+} from 'src/domain/mcp/application/ports/mcp-client.port';
+import { McpCredentialEncryptionPort } from 'src/domain/mcp/application/ports/mcp-credential-encryption.port';
+import { McpIntegrationUserConfigRepositoryPort } from 'src/domain/mcp/application/ports/mcp-integration-user-config.repository.port';
+import { McpIntegration } from 'src/domain/mcp/domain/mcp-integration.entity';
+import { SchemaConfiguredMcpIntegration } from 'src/domain/mcp/domain/integrations/schema-configured-mcp-integration.entity';
 import {
   ConfigField,
   isSystemFixedField,
-} from '../../domain/value-objects/integration-config-schema';
-import { BearerMcpIntegrationAuth } from '../../domain/auth/bearer-mcp-integration-auth.entity';
-import { CustomHeaderMcpIntegrationAuth } from '../../domain/auth/custom-header-mcp-integration-auth.entity';
-import { OAuthMcpIntegrationAuth } from '../../domain/auth/oauth-mcp-integration-auth.entity';
+} from 'src/domain/mcp/domain/value-objects/integration-config-schema';
+import { BearerMcpIntegrationAuth } from 'src/domain/mcp/domain/auth/bearer-mcp-integration-auth.entity';
+import { CustomHeaderMcpIntegrationAuth } from 'src/domain/mcp/domain/auth/custom-header-mcp-integration-auth.entity';
+import { OAuthMcpIntegrationAuth } from 'src/domain/mcp/domain/auth/oauth-mcp-integration-auth.entity';
 import {
   McpAuthenticationError,
   McpUserAuthorizationRequiredError,
-} from '../mcp.errors';
-import { McpOAuthUserTokenRepositoryPort } from '../ports/mcp-oauth-user-token.repository.port';
+} from 'src/domain/mcp/application/mcp.errors';
+import { McpOAuthUserTokenRepositoryPort } from 'src/domain/mcp/application/ports/mcp-oauth-user-token.repository.port';
 import { McpCapabilityCacheService } from './mcp-capability-cache.service';
 import { handleMcpOperationError } from './mcp-operation-error';
 
@@ -302,11 +303,12 @@ export class McpClientService {
   async listTools(
     integration: McpIntegration,
     userId?: UUID,
+    options?: McpRequestOptions,
   ): Promise<McpTool[]> {
     const config = await this.buildConnectionConfig(integration, userId);
 
     try {
-      return await this.mcpClient.listTools(config);
+      return await this.mcpClient.listTools(config, options);
     } catch (error) {
       if (this.isMethodNotFoundError(error)) return [];
       await this.handleOperationError(error, integration, 'listTools', userId);
@@ -317,11 +319,12 @@ export class McpClientService {
   async listResources(
     integration: McpIntegration,
     userId?: UUID,
+    options?: McpRequestOptions,
   ): Promise<McpResource[]> {
     const config = await this.buildConnectionConfig(integration, userId);
 
     try {
-      return await this.mcpClient.listResources(config);
+      return await this.mcpClient.listResources(config, options);
     } catch (error) {
       if (this.isMethodNotFoundError(error)) return [];
       await this.handleOperationError(
@@ -344,11 +347,12 @@ export class McpClientService {
   async listResourceTemplates(
     integration: McpIntegration,
     userId?: UUID,
+    options?: McpRequestOptions,
   ): Promise<McpResource[]> {
     const config = await this.buildConnectionConfig(integration, userId);
 
     try {
-      return await this.mcpClient.listResourceTemplates(config);
+      return await this.mcpClient.listResourceTemplates(config, options);
     } catch (error) {
       if (this.isMethodNotFoundError(error)) return [];
       await this.handleOperationError(
@@ -371,11 +375,12 @@ export class McpClientService {
   async listPrompts(
     integration: McpIntegration,
     userId?: UUID,
+    options?: McpRequestOptions,
   ): Promise<McpPrompt[]> {
     const config = await this.buildConnectionConfig(integration, userId);
 
     try {
-      return await this.mcpClient.listPrompts(config);
+      return await this.mcpClient.listPrompts(config, options);
     } catch (error) {
       if (this.isMethodNotFoundError(error)) return [];
       await this.handleOperationError(

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.spec.ts
@@ -7,9 +7,9 @@ import { PinoLogger } from 'nestjs-pino';
 import { randomUUID } from 'crypto';
 import { DiscoverMcpCapabilitiesUseCase } from './discover-mcp-capabilities.use-case';
 import { DiscoverMcpCapabilitiesQuery } from './discover-mcp-capabilities.query';
-import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
-import { McpClientService } from '../../services/mcp-client.service';
-import { McpCapabilityCacheService } from '../../services/mcp-capability-cache.service';
+import { McpIntegrationsRepositoryPort } from 'src/domain/mcp/application/ports/mcp-integrations.repository.port';
+import { McpClientService } from 'src/domain/mcp/application/services/mcp-client.service';
+import { McpCapabilityCacheService } from 'src/domain/mcp/application/services/mcp-capability-cache.service';
 import { ContextService } from 'src/common/context/services/context.service';
 import {
   McpIntegrationNotFoundError,
@@ -17,7 +17,7 @@ import {
   McpIntegrationDisabledError,
   McpConnectionTimeoutError,
   UnexpectedMcpError,
-} from '../../mcp.errors';
+} from 'src/domain/mcp/application/mcp.errors';
 import { PredefinedMcpIntegration } from 'src/domain/mcp/domain/integrations/predefined-mcp-integration.entity';
 import type { CustomMcpIntegration } from 'src/domain/mcp/domain/integrations/custom-mcp-integration.entity';
 import { aCustomMcpIntegration } from 'src/domain/mcp/application/testing/mcp-integration.fixtures';
@@ -37,6 +37,7 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
   const mockOrgId = randomUUID();
   const mockUserId = randomUUID();
   const mockIntegrationId = randomUUID();
+  const capabilityDiscoveryOptions = { timeout: 10000 };
 
   const mockContextGet = (key?: string | symbol) => {
     if (key === 'orgId') return mockOrgId;
@@ -192,10 +193,12 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
       expect(mcpClientService.listTools).toHaveBeenCalledWith(
         integration,
         mockUserId,
+        capabilityDiscoveryOptions,
       );
       expect(mcpClientService.listResourceTemplates).toHaveBeenCalledWith(
         integration,
         mockUserId,
+        capabilityDiscoveryOptions,
       );
       expect(logger.info).toHaveBeenCalledWith(
         {
@@ -229,14 +232,17 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
       expect(mcpClientService.listTools).toHaveBeenCalledWith(
         integration,
         mockUserId,
+        capabilityDiscoveryOptions,
       );
       expect(mcpClientService.listResources).toHaveBeenCalledWith(
         integration,
         mockUserId,
+        capabilityDiscoveryOptions,
       );
       expect(mcpClientService.listPrompts).toHaveBeenCalledWith(
         integration,
         mockUserId,
+        capabilityDiscoveryOptions,
       );
     });
 
@@ -369,10 +375,12 @@ describe('DiscoverMcpCapabilitiesUseCase', () => {
       expect(mcpClientService.listTools).toHaveBeenCalledWith(
         updatedIntegration,
         mockUserId,
+        capabilityDiscoveryOptions,
       );
       expect(mcpClientService.listPrompts).toHaveBeenCalledWith(
         updatedIntegration,
         mockUserId,
+        capabilityDiscoveryOptions,
       );
     });
 

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/discover-mcp-capabilities/discover-mcp-capabilities.use-case.ts
@@ -1,37 +1,43 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 import { DiscoverMcpCapabilitiesQuery } from './discover-mcp-capabilities.query';
-import { McpIntegrationsRepositoryPort } from '../../ports/mcp-integrations.repository.port';
+import { McpIntegrationsRepositoryPort } from 'src/domain/mcp/application/ports/mcp-integrations.repository.port';
 import {
   McpTool as McpToolDto,
   McpResource as McpResourceDto,
   McpPrompt as McpPromptDto,
-} from '../../ports/mcp-client.port';
-import { McpClientService } from '../../services/mcp-client.service';
+  McpRequestOptions,
+} from 'src/domain/mcp/application/ports/mcp-client.port';
+import { McpClientService } from 'src/domain/mcp/application/services/mcp-client.service';
 import {
   DiscoveredCapabilities,
   McpCapabilityCacheService,
-} from '../../services/mcp-capability-cache.service';
+} from 'src/domain/mcp/application/services/mcp-capability-cache.service';
 import { ContextService } from 'src/common/context/services/context.service';
 import {
   McpIntegrationNotFoundError,
   McpIntegrationAccessDeniedError,
   McpIntegrationDisabledError,
   UnexpectedMcpError,
-} from '../../mcp.errors';
+} from 'src/domain/mcp/application/mcp.errors';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
-import { McpIntegration } from '../../../domain/mcp-integration.entity';
-import { McpTool } from '../../../domain/mcp-tool.entity';
+import { McpIntegration } from 'src/domain/mcp/domain/mcp-integration.entity';
+import { McpTool } from 'src/domain/mcp/domain/mcp-tool.entity';
 import {
   McpResource,
   ResourceArgument,
-} from '../../../domain/mcp-resource.entity';
-import { McpPrompt, PromptArgument } from '../../../domain/mcp-prompt.entity';
+} from 'src/domain/mcp/domain/mcp-resource.entity';
+import {
+  McpPrompt,
+  PromptArgument,
+} from 'src/domain/mcp/domain/mcp-prompt.entity';
 import { UUID } from 'crypto';
 
 /**
  * Result interface containing discovered capabilities
  */
+const CAPABILITY_DISCOVERY_OPTIONS: McpRequestOptions = { timeout: 10000 };
+
 export interface CapabilitiesResult {
   tools: McpTool[];
   resources: McpResource[];
@@ -117,10 +123,26 @@ export class DiscoverMcpCapabilitiesUseCase {
     }
 
     const [tools, resources, resourceTemplates, prompts] = await Promise.all([
-      this.mcpClientService.listTools(integration, userId),
-      this.mcpClientService.listResources(integration, userId),
-      this.mcpClientService.listResourceTemplates(integration, userId),
-      this.mcpClientService.listPrompts(integration, userId),
+      this.mcpClientService.listTools(
+        integration,
+        userId,
+        CAPABILITY_DISCOVERY_OPTIONS,
+      ),
+      this.mcpClientService.listResources(
+        integration,
+        userId,
+        CAPABILITY_DISCOVERY_OPTIONS,
+      ),
+      this.mcpClientService.listResourceTemplates(
+        integration,
+        userId,
+        CAPABILITY_DISCOVERY_OPTIONS,
+      ),
+      this.mcpClientService.listPrompts(
+        integration,
+        userId,
+        CAPABILITY_DISCOVERY_OPTIONS,
+      ),
     ]);
 
     return { tools, resources, resourceTemplates, prompts };

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-client-pool.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-client-pool.service.spec.ts
@@ -1,7 +1,7 @@
 import { createPinoLoggerMock } from 'src/common/testing/pino-logger.mock';
 import type { Client } from '@modelcontextprotocol/client';
 import { randomUUID } from 'crypto';
-import type { McpConnectionConfig } from '../../application/ports/mcp-client.port';
+import type { McpConnectionConfig } from 'src/domain/mcp/application/ports/mcp-client.port';
 import { McpClientPoolService } from './mcp-client-pool.service';
 
 describe('McpClientPoolService', () => {
@@ -38,6 +38,17 @@ describe('McpClientPoolService', () => {
 
     expect(createClient).toHaveBeenCalledTimes(1);
     expect(close).not.toHaveBeenCalled();
+  });
+
+  it('isolates clients with different connection timeout budgets', async () => {
+    await pool.withClient(config, createClient, async () => undefined, {
+      connectTimeout: 10000,
+    });
+    await pool.withClient(config, createClient, async () => undefined, {
+      connectTimeout: 30000,
+    });
+
+    expect(createClient).toHaveBeenCalledTimes(2);
   });
 
   it('reuses a client when equivalent headers have different insertion order', async () => {

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-client-pool.service.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-client-pool.service.ts
@@ -5,10 +5,14 @@ import { createHash } from 'crypto';
 import type {
   McpConnectionConfig,
   McpConnectionScope,
-} from '../../application/ports/mcp-client.port';
+} from 'src/domain/mcp/application/ports/mcp-client.port';
 
 const CLIENT_IDLE_TIMEOUT_MS = 60_000;
 const MAX_IDLE_CLIENTS = 100;
+
+interface McpClientPoolOptions {
+  connectTimeout: number;
+}
 
 interface CachedClient {
   key: string;
@@ -42,8 +46,9 @@ export class McpClientPoolService implements OnModuleDestroy {
     config: McpConnectionConfig,
     createClient: () => Promise<Client>,
     operation: (client: Client) => Promise<T>,
+    options?: McpClientPoolOptions,
   ): Promise<T> {
-    const cached = this.acquireClient(config, createClient);
+    const cached = this.acquireClient(config, createClient, options);
     try {
       return await operation(await cached.client);
     } catch (error) {
@@ -69,11 +74,12 @@ export class McpClientPoolService implements OnModuleDestroy {
   private acquireClient(
     config: McpConnectionConfig,
     createClient: () => Promise<Client>,
+    options?: McpClientPoolOptions,
   ): CachedClient {
     if (this.shuttingDown) {
       throw new Error('MCP client pool is shutting down');
     }
-    const key = this.connectionKey(config);
+    const key = this.connectionKey(config, options);
     const cached = this.clients.get(key);
     if (cached) {
       if (cached.idleTimer) clearTimeout(cached.idleTimer);
@@ -171,7 +177,10 @@ export class McpClientPoolService implements OnModuleDestroy {
     return client.closePromise;
   }
 
-  private connectionKey(config: McpConnectionConfig): string {
+  private connectionKey(
+    config: McpConnectionConfig,
+    options?: McpClientPoolOptions,
+  ): string {
     const headers = Object.entries(config.headers ?? {}).sort(
       ([left], [right]) => left.localeCompare(right),
     );
@@ -184,7 +193,15 @@ export class McpClientPoolService implements OnModuleDestroy {
       ? [config.oauth.integrationId, config.oauth.userId, config.oauth.orgId]
       : null;
     return createHash('sha256')
-      .update(JSON.stringify([config.serverUrl, headers, scope, oauth]))
+      .update(
+        JSON.stringify([
+          config.serverUrl,
+          headers,
+          scope,
+          oauth,
+          options?.connectTimeout ?? null,
+        ]),
+      )
       .digest('base64url');
   }
 

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.spec.ts
@@ -5,13 +5,13 @@ import {
 } from '@modelcontextprotocol/client';
 import { McpSdkClientAdapter } from './mcp-sdk-client.adapter';
 import { McpClientPoolService } from './mcp-client-pool.service';
-import type { McpConnectionConfig } from '../../application/ports/mcp-client.port';
+import type { McpConnectionConfig } from 'src/domain/mcp/application/ports/mcp-client.port';
 import {
   McpConnectionFailedError,
   McpConnectionTimeoutError,
-} from '../../application/mcp.errors';
-import { MarketplaceMcpIntegration } from '../../domain/integrations/marketplace-mcp-integration.entity';
-import { NoAuthMcpIntegrationAuth } from '../../domain/auth/no-auth-mcp-integration-auth.entity';
+} from 'src/domain/mcp/application/mcp.errors';
+import { MarketplaceMcpIntegration } from 'src/domain/mcp/domain/integrations/marketplace-mcp-integration.entity';
+import { NoAuthMcpIntegrationAuth } from 'src/domain/mcp/domain/auth/no-auth-mcp-integration-auth.entity';
 import { randomUUID } from 'crypto';
 
 jest.mock('@modelcontextprotocol/client', () => ({
@@ -20,6 +20,7 @@ jest.mock('@modelcontextprotocol/client', () => ({
 }));
 
 const REQUEST_TIMEOUT = { timeout: 30000 };
+const CAPABILITY_DISCOVERY_TIMEOUT = { timeout: 10000 };
 
 describe('McpSdkClientAdapter', () => {
   let adapter: McpSdkClientAdapter;
@@ -152,7 +153,7 @@ describe('McpSdkClientAdapter', () => {
       );
     });
 
-    it('enforces the timeout through the SDK request options', async () => {
+    it('uses the full timeout unless the caller supplies a shorter budget', async () => {
       await adapter.listTools(config);
 
       expect(clientMock.connect).toHaveBeenCalledWith(
@@ -164,33 +165,46 @@ describe('McpSdkClientAdapter', () => {
         REQUEST_TIMEOUT,
       );
     });
+
+    it('enforces a caller-supplied discovery timeout', async () => {
+      await adapter.listTools(config, CAPABILITY_DISCOVERY_TIMEOUT);
+
+      expect(clientMock.connect).toHaveBeenCalledWith(
+        expect.anything(),
+        CAPABILITY_DISCOVERY_TIMEOUT,
+      );
+      expect(clientMock.listTools).toHaveBeenCalledWith(
+        undefined,
+        CAPABILITY_DISCOVERY_TIMEOUT,
+      );
+    });
   });
 
   describe('request timeout forwarding', () => {
     it('passes the timeout to listResources', async () => {
-      await adapter.listResources(config);
+      await adapter.listResources(config, CAPABILITY_DISCOVERY_TIMEOUT);
 
       expect(clientMock.listResources).toHaveBeenCalledWith(
         undefined,
-        REQUEST_TIMEOUT,
+        CAPABILITY_DISCOVERY_TIMEOUT,
       );
     });
 
     it('passes the timeout to listResourceTemplates', async () => {
-      await adapter.listResourceTemplates(config);
+      await adapter.listResourceTemplates(config, CAPABILITY_DISCOVERY_TIMEOUT);
 
       expect(clientMock.listResourceTemplates).toHaveBeenCalledWith(
         undefined,
-        REQUEST_TIMEOUT,
+        CAPABILITY_DISCOVERY_TIMEOUT,
       );
     });
 
     it('passes the timeout to listPrompts', async () => {
-      await adapter.listPrompts(config);
+      await adapter.listPrompts(config, CAPABILITY_DISCOVERY_TIMEOUT);
 
       expect(clientMock.listPrompts).toHaveBeenCalledWith(
         undefined,
-        REQUEST_TIMEOUT,
+        CAPABILITY_DISCOVERY_TIMEOUT,
       );
     });
 
@@ -278,12 +292,12 @@ describe('McpSdkClientAdapter', () => {
       );
     });
 
-    it('produces a user-presentable message naming the 30s budget', async () => {
+    it('produces a user-presentable message naming the discovery budget', async () => {
       clientMock.listTools.mockRejectedValue(buildDomAbortError());
 
-      await expect(adapter.listTools(config)).rejects.toThrow(
-        /did not respond within 30s/,
-      );
+      await expect(
+        adapter.listTools(config, CAPABILITY_DISCOVERY_TIMEOUT),
+      ).rejects.toThrow(/did not respond within 10s/);
     });
 
     it('keeps the original error on the non-serialized cause', async () => {
@@ -396,6 +410,19 @@ describe('McpSdkClientAdapter', () => {
   });
 
   describe('validateConnection', () => {
+    it('keeps the full request timeout for explicit validation', async () => {
+      await adapter.validateConnection(config);
+
+      expect(clientMock.connect).toHaveBeenCalledWith(
+        expect.anything(),
+        REQUEST_TIMEOUT,
+      );
+      expect(clientMock.listTools).toHaveBeenCalledWith(
+        undefined,
+        REQUEST_TIMEOUT,
+      );
+    });
+
     it('reports the connection as valid when all listings succeed', async () => {
       await expect(adapter.validateConnection(config)).resolves.toEqual({
         valid: true,

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/clients/mcp-sdk-client.adapter.ts
@@ -13,16 +13,17 @@ import {
   McpPrompt,
   McpToolCall,
   McpToolResult,
-} from '../../application/ports/mcp-client.port';
+  McpRequestOptions,
+} from 'src/domain/mcp/application/ports/mcp-client.port';
 import { McpOAuthProviderFactory } from './mcp-oauth-provider.factory';
-import { McpIntegrationsRepositoryPort } from '../../application/ports/mcp-integrations.repository.port';
-import { SchemaConfiguredMcpIntegration } from '../../domain/integrations/schema-configured-mcp-integration.entity';
+import { McpIntegrationsRepositoryPort } from 'src/domain/mcp/application/ports/mcp-integrations.repository.port';
+import { SchemaConfiguredMcpIntegration } from 'src/domain/mcp/domain/integrations/schema-configured-mcp-integration.entity';
 import type { UUID } from 'crypto';
-import { McpOAuthFetchPort } from '../../application/ports/mcp-oauth-fetch.port';
+import { McpOAuthFetchPort } from 'src/domain/mcp/application/ports/mcp-oauth-fetch.port';
 import {
   McpConnectionFailedError,
   McpConnectionTimeoutError,
-} from '../../application/mcp.errors';
+} from 'src/domain/mcp/application/mcp.errors';
 import { classifyTransportError } from 'src/common/errors/provider-transport-error.classifier';
 import { ProviderFailureClass } from 'src/common/errors/provider.errors';
 import { McpClientPoolService } from './mcp-client-pool.service';
@@ -71,8 +72,9 @@ function isTimeoutOrAbortError(error: unknown, depth = 0): boolean {
  * Adapter that wraps @modelcontextprotocol/sdk to provide MCP client functionality.
  *
  * Reuses connections with the same server and authentication configuration,
- * closing them after one minute without an active operation. Each request
- * still has a 30-second SDK timeout.
+ * closing them after one minute without an active operation. Capability
+ * discovery uses a 10-second timeout so an unavailable integration does not
+ * hold up a run; explicit validation and runtime operations retain 30 seconds.
  *
  * Uses Streamable HTTP transport for HTTP-based connections (MCP protocol 2024-11-05+).
  */
@@ -94,23 +96,35 @@ export class McpSdkClientAdapter extends McpClientPort {
   /**
    * List all tools available on the MCP server
    */
-  async listTools(config: McpConnectionConfig): Promise<McpTool[]> {
-    return this.withClient(config, async (client) => {
-      const result = await client.listTools(undefined, this.requestOptions);
-
-      return result.tools;
-    });
+  async listTools(
+    config: McpConnectionConfig,
+    options: McpRequestOptions = this.requestOptions,
+  ): Promise<McpTool[]> {
+    return this.withClient(
+      config,
+      async (client) => {
+        const result = await client.listTools(undefined, options);
+        return result.tools;
+      },
+      options,
+    );
   }
 
   /**
    * List all resources available on the MCP server
    */
-  async listResources(config: McpConnectionConfig): Promise<McpResource[]> {
-    return this.withClient(config, async (client) => {
-      const result = await client.listResources(undefined, this.requestOptions);
-
-      return result.resources;
-    });
+  async listResources(
+    config: McpConnectionConfig,
+    options: McpRequestOptions = this.requestOptions,
+  ): Promise<McpResource[]> {
+    return this.withClient(
+      config,
+      async (client) => {
+        const result = await client.listResources(undefined, options);
+        return result.resources;
+      },
+      options,
+    );
   }
 
   /**
@@ -118,31 +132,38 @@ export class McpSdkClientAdapter extends McpClientPort {
    */
   async listResourceTemplates(
     config: McpConnectionConfig,
+    options: McpRequestOptions = this.requestOptions,
   ): Promise<McpResource[]> {
-    return this.withClient(config, async (client) => {
-      const result = await client.listResourceTemplates(
-        undefined,
-        this.requestOptions,
-      );
-
-      return result.resourceTemplates.map((resourceTemplate) => ({
-        uri: resourceTemplate.uriTemplate,
-        name: resourceTemplate.name,
-        description: resourceTemplate.description,
-        mimeType: resourceTemplate.mimeType,
-      }));
-    });
+    return this.withClient(
+      config,
+      async (client) => {
+        const result = await client.listResourceTemplates(undefined, options);
+        return result.resourceTemplates.map((resourceTemplate) => ({
+          uri: resourceTemplate.uriTemplate,
+          name: resourceTemplate.name,
+          description: resourceTemplate.description,
+          mimeType: resourceTemplate.mimeType,
+        }));
+      },
+      options,
+    );
   }
 
   /**
    * List all prompt templates available on the MCP server
    */
-  async listPrompts(config: McpConnectionConfig): Promise<McpPrompt[]> {
-    return this.withClient(config, async (client) => {
-      const result = await client.listPrompts(undefined, this.requestOptions);
-
-      return result.prompts;
-    });
+  async listPrompts(
+    config: McpConnectionConfig,
+    options: McpRequestOptions = this.requestOptions,
+  ): Promise<McpPrompt[]> {
+    return this.withClient(
+      config,
+      async (client) => {
+        const result = await client.listPrompts(undefined, options);
+        return result.prompts;
+      },
+      options,
+    );
   }
 
   /**
@@ -226,21 +247,24 @@ export class McpSdkClientAdapter extends McpClientPort {
   private async withClient<T>(
     config: McpConnectionConfig,
     operation: (client: Client) => Promise<T>,
+    requestOptions = this.requestOptions,
   ): Promise<T> {
     try {
       return await this.clientPool.withClient(
         config,
-        () => this.createClient(config),
+        () => this.createClient(config, requestOptions),
         operation,
+        { connectTimeout: requestOptions.timeout },
       );
     } catch (error) {
-      throw this.toOperationError(error, config);
+      throw this.toOperationError(error, config, requestOptions.timeout);
     }
   }
 
   private toOperationError(
     error: unknown,
     config: McpConnectionConfig,
+    timeoutMs: number,
   ): unknown {
     // Transport errnos (timeouts beyond the SDK's own codes, DNS, reset,
     // broken pipe) must not escape raw either: their raw span duplicates
@@ -251,11 +275,7 @@ export class McpSdkClientAdapter extends McpClientPort {
       isTimeoutOrAbortError(error) ||
       transport?.failureClass === ProviderFailureClass.TIMEOUT
     ) {
-      return new McpConnectionTimeoutError(
-        config.serverUrl,
-        this.requestOptions.timeout,
-        error,
-      );
+      return new McpConnectionTimeoutError(config.serverUrl, timeoutMs, error);
     }
     if (transport?.failureClass === ProviderFailureClass.CONNECTION) {
       return new McpConnectionFailedError(config.serverUrl, error);
@@ -299,7 +319,10 @@ export class McpSdkClientAdapter extends McpClientPort {
   /**
    * Create and connect a new MCP client
    */
-  private async createClient(config: McpConnectionConfig): Promise<Client> {
+  private async createClient(
+    config: McpConnectionConfig,
+    requestOptions: { timeout: number },
+  ): Promise<Client> {
     // Create Streamable HTTP transport (MCP protocol 2024-11-05+)
     // Only pass requestInit with headers when we have headers to add
     // Otherwise, let the SDK handle the default headers (Accept, Content-Type, etc.)
@@ -325,7 +348,7 @@ export class McpSdkClientAdapter extends McpClientPort {
     );
 
     // Connect to server (covers the initialize handshake with the same timeout)
-    await client.connect(transport, this.requestOptions);
+    await client.connect(transport, requestOptions);
 
     return client;
   }


### PR DESCRIPTION
- Limit capability listing and initial connection attempts to 10 seconds
- Preserve the 30-second budget for validation and runtime operations

Refs: AYC-823

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared MCP client pooling and timeout/error mapping used on the run-preparation path; mis-pooled connections or wrong defaults could affect discovery vs validation behavior, but scope is limited and well covered by tests.
> 
> **Overview**
> **Capability discovery** now uses a **10-second** request and connect budget so slow or unreachable MCP servers cannot block run preparation for the full **30-second** window used elsewhere.
> 
> The change threads optional `McpRequestOptions` through `McpClientPort`, `McpClientService`, and the SDK adapter so listing operations (`listTools`, `listResources`, `listResourceTemplates`, `listPrompts`) honor caller-selected timeouts on both SDK requests and the initialize handshake. `DiscoverMcpCapabilitiesUseCase` passes `{ timeout: 10000 }` for all parallel capability fetches; validation (`validateConnection`) and runtime paths (`callTool`, `readResource`, `getPrompt`) still default to 30s.
> 
> `McpClientPoolService` includes **connection timeout** in its pool key so 10s and 30s sessions are not reused for the same integration. Timeout errors surface user-facing messages that reflect the **actual** budget (e.g. 10s vs 30s). Docs and tests were updated accordingly; several MCP files switched to absolute `src/...` imports without behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4af70b3a2f588a1fe4af9cc0d6cd6f14b047f2a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->