### PR TITLE
fix(observability): suppress raw ERR_SOCKET_TIMEOUT duplicates (AYC-767)

### DIFF
--- a/ayunis-core-backend/appsignal-hooks.cjs
+++ b/ayunis-core-backend/appsignal-hooks.cjs
@@ -203,6 +203,18 @@ const SUPPRESSIONS = [
     exceptionType: 'ETIMEDOUT',
   },
   {
+    id: 'transport-socket-timeout',
+    lever: 'ignoreErrors',
+    ticket: 'AYC-767',
+    reason:
+      'Idle-socket deadline raised by the keep-alive agent the OpenAI SDK ' +
+      'ships (agentkeepalive lib/agent.js, message "Socket timeout"). The ' +
+      'SDK retries it, and where it still fails a request the taxonomy ' +
+      'classifies it as PROVIDER_UNAVAILABLE_TIMEOUT_*; the raw http span ' +
+      'exception on the inference span is a duplicate (incident #333).',
+    exceptionType: 'ERR_SOCKET_TIMEOUT',
+  },
+  {
     id: 'transport-broken-pipe',
     lever: 'ignoreErrors',
     ticket: 'AYC-616',

--- a/ayunis-core-backend/src/common/util/appsignal-hooks.spec.ts
+++ b/ayunis-core-backend/src/common/util/appsignal-hooks.spec.ts
@@ -2,8 +2,9 @@
 // the app boots; require() mirrors how it is consumed there.
 import createHttpError from 'http-errors';
 import { errors as undiciErrors } from 'undici';
-import { JobRetryScheduledError } from '../../domain/sources/infrastructure/queue/bullmq-job.helpers';
-import { MarketplaceUnavailableError } from '../../domain/marketplace/application/marketplace.errors';
+import { JobRetryScheduledError } from 'src/domain/sources/infrastructure/queue/bullmq-job.helpers';
+import { MarketplaceUnavailableError } from 'src/domain/marketplace/application/marketplace.errors';
+import { ProviderTimeoutError } from 'src/common/errors/provider.errors';
 
 type UndiciRequest = {
   method?: string;
@@ -185,6 +186,13 @@ const ERROR_SAMPLES: Record<string, () => Error> = {
     Object.assign(new Error('timeout of 60000ms exceeded'), {
       code: 'ETIMEDOUT',
     }),
+  // agentkeepalive destroys an idle socket with this exact shape — the
+  // keep-alive agent the OpenAI SDK uses (incident #333).
+  'transport-socket-timeout': () =>
+    Object.assign(new Error('Socket timeout'), {
+      code: 'ERR_SOCKET_TIMEOUT',
+      timeout: 300000,
+    }),
   'transport-broken-pipe': () =>
     Object.assign(new Error('write EPIPE'), {
       code: 'EPIPE',
@@ -257,6 +265,20 @@ describe('SUPPRESSIONS registry', () => {
         expect(exceptionTypeOf(sample())).toBe(suppression.exceptionType);
       },
     );
+
+    // The other half of the raw-duplicate suppressions: dropping the errno
+    // must not touch the classified taxonomy the alerting relies on, which
+    // reports under PROVIDER_UNAVAILABLE_<CLASS>_<PROVIDER> (AYC-767).
+    it('leaves the classified provider taxonomy reporting', () => {
+      const classified = new ProviderTimeoutError({
+        provider: 'openai',
+        underlyingCode: 'ERR_SOCKET_TIMEOUT',
+      });
+      expect(exceptionTypeOf(classified)).toBe(
+        'PROVIDER_UNAVAILABLE_TIMEOUT_OPENAI',
+      );
+      expect(ignoredErrorTypes).not.toContain(exceptionTypeOf(classified));
+    });
   });
 
   describe('disableInstrumentation entries', () => {


### PR DESCRIPTION
Closes AYC-767. AppSignal incident [#333](https://appsignal.com/ayunis/sites/6a611f0dd841ff7c22841fb2/exceptions/incidents/333) (`ERR_SOCKET_TIMEOUT`, `POST /api/runs/send-message`).

`ERR_SOCKET_TIMEOUT` is minted by `agentkeepalive` (`lib/agent.js`, message `Socket timeout`) — the keep-alive agent the OpenAI SDK v4 ships — when it destroys an idle socket. The SDK retries it, and where it still fails a request `classifyTransportError` already classifies it as a `TIMEOUT` and `wrapProviderFailure` reports it as `PROVIDER_UNAVAILABLE_TIMEOUT_*`. The http instrumentation still records the raw errno on the span underneath the handled retry, so each occurrence double-reports — the same pattern already suppressed for `UND_ERR_HEADERS_TIMEOUT`, `ETIMEDOUT`, `ECONNRESET` et al. (AYC-616).

## Changes

- `appsignal-hooks.cjs`: one `transport-socket-timeout` entry in the `SUPPRESSIONS` registry (`ignoreErrors`, `ERR_SOCKET_TIMEOUT`), carrying its reason and ticket like every other suppression.
- `appsignal-hooks.spec.ts`: a real agentkeepalive error sample, so the registry test asserts the suppression matches the `exceptionType` OpenTelemetry actually derives; plus a test that the classified `PROVIDER_UNAVAILABLE_TIMEOUT_*` taxonomy is *not* in `ignoredErrorTypes`.

Classified reporting and the `provider_unavailable_count` metric are untouched — only the raw errno duplicate is dropped.

## Verification

- `jest src/common/util/appsignal-hooks.spec.ts` — 63 passed.
- Negative control: flipping the entry's `exceptionType` to `ERR_SOCKET_TIMEOUT_X` fails `transport-socket-timeout suppresses the type its error actually reports`.
- Post-deploy: incident #333 should stop taking new occurrences while `PROVIDER_UNAVAILABLE_TIMEOUT_*` keeps recording them.