### PR TITLE
fix(inference): normalize unsupported strict tool schemas (AYC-000)

### DIFF
--- a/packages/provider-openai/src/normalize-schema.spec.ts
+++ b/packages/provider-openai/src/normalize-schema.spec.ts
@@ -79,7 +79,7 @@ describe('normalizeSchemaForOpenAI', () => {
     });
   });
 
-  it('adds a null branch to optional oneOf properties', () => {
+  it('converts optional oneOf properties to nullable anyOf', () => {
     expect(
       normalizeSchemaForOpenAI({
         type: 'object',
@@ -93,13 +93,13 @@ describe('normalizeSchemaForOpenAI', () => {
       required: ['value'],
       properties: {
         value: {
-          oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'null' }],
+          anyOf: [{ type: 'string' }, { type: 'number' }, { type: 'null' }],
         },
       },
     });
   });
 
-  it('leaves oneOf properties that already allow null unchanged', () => {
+  it('converts oneOf properties that already allow null to anyOf', () => {
     expect(
       normalizeSchemaForOpenAI({
         type: 'object',
@@ -112,7 +112,7 @@ describe('normalizeSchemaForOpenAI', () => {
       additionalProperties: false,
       required: ['value'],
       properties: {
-        value: { oneOf: [{ type: 'string' }, { type: 'null' }] },
+        value: { anyOf: [{ type: 'string' }, { type: 'null' }] },
       },
     });
   });
@@ -446,6 +446,22 @@ describe('normalizeSchemaForOpenAI', () => {
     expect(
       normalizeSchemaForOpenAI({ type: 'string', format: 'date-time' }),
     ).toEqual({ type: 'string', format: 'date-time' });
+  });
+
+  it('removes unsupported object property-count constraints', () => {
+    expect(
+      normalizeSchemaForOpenAI({
+        type: 'object',
+        minProperties: 1,
+        maxProperties: 50,
+        properties: { label: { type: 'string' } },
+      }),
+    ).toEqual({
+      type: 'object',
+      additionalProperties: false,
+      required: ['label'],
+      properties: { label: { type: ['string', 'null'] } },
+    });
   });
 
   it('recurses into array items', () => {

--- a/packages/provider-openai/src/normalize-schema.ts
+++ b/packages/provider-openai/src/normalize-schema.ts
@@ -28,10 +28,21 @@ const walker = new SchemaWalker((node) => {
   ) {
     delete node.format;
   }
+  convertOneOfToAnyOf(node);
+  delete node.minProperties;
+  delete node.maxProperties;
   convertDraft04ExclusiveBoundsNode(node);
   normalizeObjectType(node);
   return node;
 });
+
+// Strict function schemas reject `oneOf`; `anyOf` is the supported equivalent
+// for the disjoint alternatives used by our tools and provider integrations.
+function convertOneOfToAnyOf(schema: MutableSchema): void {
+  if (!Array.isArray(schema.oneOf)) return;
+  schema.anyOf = schema.oneOf;
+  delete schema.oneOf;
+}
 
 // Strict mode treats any schema declaring `properties` as an object, even when
 // an explicit `type: 'object'` is omitted (common in MCP-style schemas).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped to OpenAI schema normalization for tool/structured output; behavior change is intentional compatibility with strict mode, with unit test coverage.
> 
> **Overview**
> Extends **`normalizeSchemaForOpenAI`** so tool schemas pass OpenAI strict structured-output rules that reject **`oneOf`** and object **`minProperties` / `maxProperties`**.
> 
> During the schema walk, every **`oneOf`** is renamed to **`anyOf`** (same branches), including before optional fields get their null escape hatch. **`minProperties`** and **`maxProperties`** are removed from object nodes. Tests now expect nullable optional unions as **`anyOf`** instead of **`oneOf`**, and cover stripping property-count constraints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cc9ef534e3c6e36bf17d140c409196771278f33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->