### PR TITLE
docs(tooling): require feature flag on and off contracts (AYC-000)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -145,6 +145,12 @@ Required:
 
 The workflow level controls local implementation and validation breadth. It does not weaken **A Submitted PR Is Not Complete**: once a PR is created or updated, CI and Cursor Bugbot must still be clean on the latest submitted revision.
 
+### 11. Feature Flags Have Two Contracts
+
+Every feature-gated change must define and verify behavior with the flag both enabled and disabled. Identify existing workflows that share routes, controllers, navigation, services, or persisted state with the gated feature; disabling new entry points must not disable shared behavior unless that is explicitly part of the contract.
+
+Flags resolve from `process.env` at boot, so mocking the guard or the config proves wiring, not the disabled-state contract — a second instance started with the flag off is what proves it. Load the `feature-toggles` skill for the two-state verification recipe.
+
 ---
 
 ## Forbidden Actions

--- a/.claude/skills/feature-toggles/SKILL.md
+++ b/.claude/skills/feature-toggles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: feature-toggles
-description: Add, modify, or remove feature toggles. Use when gating new features or changing toggle defaults.
+description: Add, modify, remove, or review feature toggles. Use when gating a feature, changing a toggle default, or changing behavior shared with a feature-gated path.
 ---
 
 # Feature Toggles
@@ -12,6 +12,14 @@ description: Add, modify, or remove feature toggles. Use when gating new feature
 - Endpoint: `ayunis-core-backend/src/app/presenters/http/app.controller.ts` — `GET /feature-toggles`
 - Response DTO: `ayunis-core-backend/src/app/presenters/http/dto/feature-toggles-response.dto.ts`
 - Frontend hooks: `ayunis-core-frontend/src/features/feature-toggles/`
+
+## Define both contracts first
+
+Before implementation, state the observable behavior with the flag enabled and disabled. Identify any existing workflow that shares a route, controller, navigation action, service, or persisted state with the gated feature.
+
+- Gate the narrowest new entry point that satisfies the product contract.
+- Keep shared cleanup, revocation, logout, recovery, and existing-user paths available unless the disabled-state contract explicitly removes them.
+- Do not switch an existing shared consumer to a gated endpoint without proving its flag-off behavior.
 
 ## Adding a new toggle
 
@@ -33,7 +41,27 @@ description: Add, modify, or remove feature toggles. Use when gating new feature
 
 ## Changing a default
 
-Edit the default value in `features.config.ts`. That's it — production never sets env vars, so the code default is the production value.
+Edit the default value in `features.config.ts`. `parseBooleanWithDefault` uses the default only when `FEATURE_<NAME>_ENABLED` is unset or empty, so the code default is the deployed value only if that host's `ayunis-core-backend/.env` does not set the var. Check the host file before claiming an environment flipped (`DEPLOYMENT.md` → Configuration Updates); CI sets several of these explicitly (`.github/workflows/e2e-tests.yml`).
+
+## Verification
+
+1. **Config** — add the default and the explicit-`true` case to `ayunis-core-backend/src/config/features.config.spec.ts`.
+2. **Flag ON** — the normal e2e run; enable the flag in the backend `.env` heredoc in `.github/workflows/e2e-tests.yml`.
+3. **Flag OFF** — required when the gate lands on something that already existed: a route, controller, navigation entry, or persisted state an existing workflow already depends on. If the gate covers only new code, OFF means "feature absent" and no OFF test is needed. One focused spec when it is needed, never a duplicated suite.
+
+### Flag-off e2e recipe
+
+The flag resolves from `process.env` at boot, so one stack cannot serve both states — the OFF spec needs its own backend. Copy the `sso-disabled` setup from AYC-367; all three pieces are in-tree:
+
+- `.github/workflows/e2e-tests.yml` — steps `Start backend with SSO login disabled` and `Test logout lifecycle with SSO login disabled`: the same build artifact started again with the flag off on a spare port, health-polled, log added to the `backend-log` artifact. Same job as the flag-on run: one extra process and one spec, not a matrix.
+- `ayunis-core-e2e/playwright.config.ts` — the `sso-disabled` project. The spec must also be listed in the `chromium` project's `testIgnore`, or it runs in both states.
+- `ayunis-core-e2e/tests/auth/sso-disabled-logout.spec.ts` — prove the feature is gone first (gated route 404s; `publicApi` fixture for unauthenticated endpoints), then exercise the shared workflow that must stay available.
+
+Locally: `FEATURE_<NAME>_ENABLED=false pnpm run start:dev` in a second slot. Shell env wins over `.env.dev` and `.env`; never hand-edit the generated `.env.dev`.
+
+Mocked guards, mocked API clients, and direct controller invocation exercise wiring, not runtime composition: they do not satisfy the OFF contract for a shared path.
+
+Record both ON and OFF results in the PR validation summary.
 
 ## Guard behavior
 


### PR DESCRIPTION
## Summary

- require feature-gated changes to define enabled and disabled contracts
- replace the abstract \"test both states\" guidance with the concrete flag-off recipe that works here: second backend on a free port + dedicated Playwright project, modelled on the `sso-disabled` setup from #1519
- explain why mocking the guard/config is not proof: flags resolve from `process.env` at boot
- keep the detail in the `feature-toggles` skill; `.claude/CLAUDE.md` keeps the rule plus a pointer instead of a second copy
- fix the \"changing a default\" note to name where the deployed value actually lives (host `ayunis-core-backend/.env`)

## Validation

- restacked onto `main` @ 688f67e9d so the cited harness (`sso-disabled` project, `publicApi` fixture, `/api/health` poll) exists in-tree
- every cited path/endpoint verified present: `features.config.spec.ts`, `playwright.config.ts` `sso-disabled` project, `src/fixtures/test.ts` `publicApi`, `app.controller.ts` `@Get('health')`, `DEPLOYMENT.md` → Configuration Updates
- env precedence claim verified against `appsignal.cjs` (dotenv does not overwrite already-set vars, so shell env wins over `.env.dev` and `.env`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to agent guidelines and the feature-toggles skill; no runtime, auth, or deployment code changes.
> 
> **Overview**
> Codifies **two-state feature flag contracts** for agents: every gated change must define and verify behavior with the flag on and off, protect shared routes/workflows when new entry points are gated, and treat boot-time `process.env` resolution as the reason mocks are not enough for the disabled contract.
> 
> **`CLAUDE.md`** adds principle **§11** with the rule and a pointer to the skill so the long recipe is not duplicated.
> 
> **`feature-toggles` skill** expands with *define both contracts first*, a corrected *changing a default* note (host `ayunis-core-backend/.env`, CI e2e workflow), and a **Verification** section: config spec, flag-on e2e, when flag-off is required, and the concrete **flag-off e2e recipe** (second backend on a spare port, dedicated Playwright project, modeled on `sso-disabled`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8bdc1829f20a5356021bcb90c480d91fb3b5e45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->