### PR TITLE
fix(ui): stop persisting sidebar cookie (AYC-000)

### DIFF
--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -23,8 +23,6 @@ import {
   TooltipTrigger,
 } from '@ayunis/ui/components/tooltip';
 
-const SIDEBAR_COOKIE_NAME = 'sidebar_state';
-const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = '16rem';
 const SIDEBAR_WIDTH_MOBILE = '18rem';
 const SIDEBAR_WIDTH_ICON = '3rem';
@@ -188,9 +186,6 @@ function SidebarProvider({
       } else {
         _setOpen(openState);
       }
-
-      // This sets the cookie to keep the sidebar state.
-      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
     },
     [setOpenProp, open],
   );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small UX change in shared UI with no auth or data handling; users may see the default sidebar state again after reload unless the app controls it.
> 
> **Overview**
> **Stops writing a `sidebar_state` browser cookie** when the desktop sidebar is expanded or collapsed.
> 
> The `SidebarProvider` `setOpen` handler no longer sets `document.cookie` on toggle, and the related `SIDEBAR_COOKIE_NAME` / `SIDEBAR_COOKIE_MAX_AGE` constants are removed. Open/collapsed state still updates in React (including controlled `open` / `onOpenChange`); it just **won’t be restored from a cookie** on later visits unless something else persists it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85f483860e1beed2a59c838c3cf904a2758803d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->