### PR TITLE
fix(sources): stop resurrecting deleted sources in document and url jobs (AYC-594)

### DIFF
--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.spec.ts
@@ -160,6 +160,22 @@ describe('DocumentProcessingConsumer', () => {
     expect(deleteObjectUseCase.execute).toHaveBeenCalled();
   });
 
+  it('hands the content write a refreshed processingStartedAt', async () => {
+    const loadedAt = new Date('2026-01-01T00:00:00.000Z');
+    const source = makeSource();
+    source.processingStartedAt = loadedAt;
+    sourceRepository.findById.mockResolvedValue(source);
+
+    await consumer.process(makeJob());
+
+    // A stale timestamp written back here would let the cleanup cron reap the
+    // job right after its content landed.
+    const [savedSource] = sourceRepository.saveTextSource.mock.calls[0];
+    expect(savedSource.processingStartedAt?.getTime()).toBeGreaterThan(
+      loadedAt.getTime(),
+    );
+  });
+
   it('never resurrects a source deleted between load and heartbeat', async () => {
     sourceRepository.findById.mockResolvedValue(makeSource());
     // The guarded UPDATE affects zero rows — the source row is gone.

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.spec.ts
@@ -5,7 +5,9 @@ import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
 import { TextType } from 'src/domain/sources/domain/source-type.enum';
 import { FileType } from 'src/domain/sources/domain/source-type.enum';
 import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
-import type { DocumentProcessingJobData } from '../../application/ports/document-processing.port';
+import type { DocumentProcessingJobData } from 'src/domain/sources/application/ports/document-processing.port';
+import type { SourceRepository } from 'src/domain/sources/application/ports/source.repository';
+import { createMockSourceRepository } from 'src/domain/sources/application/testing/source.fixtures';
 import { FileTooLargeError } from 'src/domain/retrievers/file-retrievers/application/file-retriever.errors';
 import { DocumentProcessingConsumer } from './document-processing.consumer';
 
@@ -85,15 +87,6 @@ const downloadObjectUseCase = {
 
 const deleteObjectUseCase = { execute: jest.fn().mockResolvedValue(undefined) };
 
-const sourceRepository = {
-  findById: jest.fn(),
-  save: jest.fn().mockImplementation((s: unknown) => Promise.resolve(s)),
-  saveTextSource: jest
-    .fn()
-    .mockImplementation((s: unknown) => Promise.resolve(s)),
-  updateStatusConditionally: jest.fn(),
-};
-
 const helper = {
   index: jest.fn().mockResolvedValue(undefined),
   markFailed: jest.fn().mockResolvedValue(undefined),
@@ -106,9 +99,11 @@ const helper = {
 
 describe('DocumentProcessingConsumer', () => {
   let consumer: DocumentProcessingConsumer;
+  let sourceRepository: jest.Mocked<SourceRepository>;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    sourceRepository = createMockSourceRepository();
 
     consumer = new DocumentProcessingConsumer(
       createPinoLoggerMock(),
@@ -117,7 +112,7 @@ describe('DocumentProcessingConsumer', () => {
       splitTextUseCase as never,
       downloadObjectUseCase as never,
       deleteObjectUseCase as never,
-      sourceRepository as never,
+      sourceRepository,
       helper as never,
     );
   });
@@ -162,6 +157,20 @@ describe('DocumentProcessingConsumer', () => {
     // Completing rather than throwing is what keeps it out of AppSignal.
     await expect(consumer.process(makeJob())).resolves.toBeUndefined();
     expect(helper.markFailed).toHaveBeenCalled();
+    expect(deleteObjectUseCase.execute).toHaveBeenCalled();
+  });
+
+  it('never resurrects a source deleted between load and heartbeat', async () => {
+    sourceRepository.findById.mockResolvedValue(makeSource());
+    // The guarded UPDATE affects zero rows — the source row is gone.
+    sourceRepository.refreshProcessingHeartbeat.mockResolvedValue(false);
+
+    await consumer.process(makeJob());
+
+    expect(sourceRepository.save).not.toHaveBeenCalled();
+    expect(retrieveFileContentUseCase.execute).not.toHaveBeenCalled();
+    expect(sourceRepository.saveTextSource).not.toHaveBeenCalled();
+    expect(sourceRepository.updateStatusConditionally).not.toHaveBeenCalled();
     expect(deleteObjectUseCase.execute).toHaveBeenCalled();
   });
 
@@ -215,6 +224,10 @@ describe('DocumentProcessingConsumer', () => {
 
     await consumer.process(makeJob());
 
+    expect(sourceRepository.refreshProcessingHeartbeat).toHaveBeenCalledWith(
+      SOURCE_ID,
+    );
+    expect(sourceRepository.save).not.toHaveBeenCalled();
     expect(sourceRepository.saveTextSource).toHaveBeenCalled();
     expect(sourceRepository.updateStatusConditionally).toHaveBeenCalledWith(
       SOURCE_ID,

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.ts
@@ -16,13 +16,13 @@ import { TextSourceContentChunk } from 'src/domain/sources/domain/source-content
 import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
 import { SplitterType } from 'src/domain/rag/splitters/domain/splitter-type.enum';
 import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
-import type { DocumentProcessingJobData } from '../../application/ports/document-processing.port';
-import { DOCUMENT_PROCESSING_QUEUE } from './document-processing.constants';
-import { classifyJobFailure } from './bullmq-job.helpers';
+import type { DocumentProcessingJobData } from 'src/domain/sources/application/ports/document-processing.port';
 import {
   cleanupMinioProcessingFile,
   downloadMinioFile,
-} from '../../application/util/minio-processing-file.helpers';
+} from 'src/domain/sources/application/util/minio-processing-file.helpers';
+import { DOCUMENT_PROCESSING_QUEUE } from './document-processing.constants';
+import { classifyJobFailure } from './bullmq-job.helpers';
 
 @Processor(DOCUMENT_PROCESSING_QUEUE, { concurrency: 2 })
 export class DocumentProcessingConsumer extends WorkerHost {
@@ -130,9 +130,16 @@ export class DocumentProcessingConsumer extends WorkerHost {
     }
 
     // Reset processingStartedAt on every attempt so the stale-cleanup
-    // cron doesn't race with BullMQ retries on long-running jobs.
-    source.processingStartedAt = new Date();
-    await this.sourceRepository.save(source);
+    // cron doesn't race with BullMQ retries on long-running jobs. Guarded
+    // UPDATE, not save(): save() would re-insert a row deleted since the
+    // findById above.
+    const alive =
+      await this.sourceRepository.refreshProcessingHeartbeat(sourceId);
+    if (!alive) {
+      this.logger.warn({ sourceId }, 'Source deleted mid-load, skipping');
+      await this.cleanupMinioFile(minioPath);
+      return null;
+    }
 
     return source;
   }

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/document-processing.consumer.ts
@@ -140,6 +140,10 @@ export class DocumentProcessingConsumer extends WorkerHost {
       await this.cleanupMinioFile(minioPath);
       return null;
     }
+    // saveTextSource persists the whole entity later on, so mirror the
+    // refreshed timestamp here — otherwise that write puts the stale value
+    // back and re-exposes the in-flight job to the stale-cleanup cron.
+    source.processingStartedAt = new Date();
 
     return source;
   }

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.spec.ts
@@ -23,7 +23,9 @@ import {
   UrlRetrieverTimeoutError,
   UrlRetrieverUnsupportedContentTypeError,
 } from 'src/domain/retrievers/url-retrievers/application/url-retriever.errors';
-import type { UrlCrawlJobData } from '../../application/ports/url-crawl-processing.port';
+import type { UrlCrawlJobData } from 'src/domain/sources/application/ports/url-crawl-processing.port';
+import type { SourceRepository } from 'src/domain/sources/application/ports/source.repository';
+import { createMockSourceRepository } from 'src/domain/sources/application/testing/source.fixtures';
 import { UrlCrawlConsumer } from './url-crawl.consumer';
 
 const SOURCE_ID = '00000000-0000-0000-0000-000000000001' as UUID;
@@ -84,15 +86,6 @@ const splitTextUseCase = {
   })),
 };
 
-const sourceRepository = {
-  findById: jest.fn(),
-  save: jest.fn().mockImplementation((s: unknown) => Promise.resolve(s)),
-  saveTextSource: jest
-    .fn()
-    .mockImplementation((s: unknown) => Promise.resolve(s)),
-  updateStatusConditionally: jest.fn(),
-};
-
 const indexer = {
   index: jest.fn().mockResolvedValue(undefined),
   cleanupIndex: jest.fn().mockResolvedValue(undefined),
@@ -101,15 +94,17 @@ const indexer = {
 
 describe('UrlCrawlConsumer', () => {
   let consumer: UrlCrawlConsumer;
+  let sourceRepository: jest.Mocked<SourceRepository>;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    sourceRepository = createMockSourceRepository();
     consumer = new UrlCrawlConsumer(
       createPinoLoggerMock(),
       contextService as never,
       crawlUrlUseCase as never,
       splitTextUseCase as never,
-      sourceRepository as never,
+      sourceRepository,
       indexer as never,
     );
   });
@@ -123,9 +118,10 @@ describe('UrlCrawlConsumer', () => {
 
     const [, content] = sourceRepository.saveTextSource.mock.calls[0];
     expect(content.text).toBe('root content\n\nabout content');
-    expect(
-      content.chunks.map((c: { meta: { url: string } }) => c.meta.url),
-    ).toEqual(['https://acme.test/', 'https://acme.test/about']);
+    expect(content.chunks.map((chunk) => chunk.meta.url)).toEqual([
+      'https://acme.test/',
+      'https://acme.test/about',
+    ]);
   });
 
   it("updates the source name to the root page's title", async () => {
@@ -146,12 +142,29 @@ describe('UrlCrawlConsumer', () => {
 
     await consumer.process(makeJob());
 
+    expect(sourceRepository.refreshProcessingHeartbeat).toHaveBeenCalledWith(
+      SOURCE_ID,
+    );
+    expect(sourceRepository.save).not.toHaveBeenCalled();
     expect(sourceRepository.updateStatusConditionally).toHaveBeenCalledWith(
       SOURCE_ID,
       SourceStatus.PROCESSING,
       SourceStatus.READY,
       { processingError: null },
     );
+  });
+
+  it('never resurrects a source deleted between load and heartbeat', async () => {
+    sourceRepository.findById.mockResolvedValue(makeSource());
+    // The guarded UPDATE affects zero rows — the source row is gone.
+    sourceRepository.refreshProcessingHeartbeat.mockResolvedValue(false);
+
+    await consumer.process(makeJob());
+
+    expect(sourceRepository.save).not.toHaveBeenCalled();
+    expect(crawlUrlUseCase.execute).not.toHaveBeenCalled();
+    expect(sourceRepository.saveTextSource).not.toHaveBeenCalled();
+    expect(sourceRepository.updateStatusConditionally).not.toHaveBeenCalled();
   });
 
   it('skips writing content when the source is deleted mid-crawl', async () => {

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.spec.ts
@@ -154,6 +154,18 @@ describe('UrlCrawlConsumer', () => {
     );
   });
 
+  it('hands the content write a refreshed processingStartedAt', async () => {
+    const source = makeSource();
+    // A queued crawl carries no timestamp until a worker picks it up.
+    source.processingStartedAt = null;
+    sourceRepository.findById.mockResolvedValue(source);
+
+    await consumer.process(makeJob());
+
+    const [savedSource] = sourceRepository.saveTextSource.mock.calls[0];
+    expect(savedSource.processingStartedAt).toBeInstanceOf(Date);
+  });
+
   it('never resurrects a source deleted between load and heartbeat', async () => {
     sourceRepository.findById.mockResolvedValue(makeSource());
     // The guarded UPDATE affects zero rows — the source row is gone.

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.ts
@@ -113,6 +113,11 @@ export class UrlCrawlConsumer extends WorkerHost {
       this.logger.warn({ sourceId }, 'Source deleted mid-load, skipping');
       return null;
     }
+    // saveTextSource persists the whole entity later on, so mirror the
+    // refreshed timestamp here — otherwise that write puts back the value the
+    // source was loaded with (null until the worker picks the job up) and
+    // re-exposes the in-flight crawl to the stale-cleanup cron.
+    source.processingStartedAt = new Date();
 
     return source;
   }

--- a/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.ts
+++ b/ayunis-core-backend/src/domain/sources/infrastructure/queue/url-crawl.consumer.ts
@@ -15,7 +15,7 @@ import { TextSourceContentChunk } from 'src/domain/sources/domain/source-content
 import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
 import { SplitterType } from 'src/domain/rag/splitters/domain/splitter-type.enum';
 import { TextSource } from 'src/domain/sources/domain/sources/text-source.entity';
-import type { UrlCrawlJobData } from '../../application/ports/url-crawl-processing.port';
+import type { UrlCrawlJobData } from 'src/domain/sources/application/ports/url-crawl-processing.port';
 import { URL_CRAWL_QUEUE } from './url-crawl.constants';
 import { classifyJobFailure } from './bullmq-job.helpers';
 
@@ -104,9 +104,15 @@ export class UrlCrawlConsumer extends WorkerHost {
     }
 
     // Reset processingStartedAt on every attempt so the stale-cleanup cron
-    // doesn't race with BullMQ retries on long-running jobs.
-    source.processingStartedAt = new Date();
-    await this.sourceRepository.save(source);
+    // doesn't race with BullMQ retries on long-running jobs. Guarded UPDATE,
+    // not save(): save() would re-insert a row deleted since the findById
+    // above.
+    const alive =
+      await this.sourceRepository.refreshProcessingHeartbeat(sourceId);
+    if (!alive) {
+      this.logger.warn({ sourceId }, 'Source deleted mid-load, skipping');
+      return null;
+    }
 
     return source;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`DocumentProcessingConsumer.loadSourceOrSkip` and `UrlCrawlConsumer.loadSourceOrSkip` bumped `processingStartedAt` with `findById` + `sourceRepository.save(source)`. Because TypeORM's `save()` is an upsert, a source deleted in that window was re-inserted in `PROCESSING` and lingered until the stale-processing cron reaped it.

Both now use the guarded `SourceRepository.refreshProcessingHeartbeat(sourceId)` (`UPDATE ... WHERE id = :id AND status = 'PROCESSING'`) introduced in AYC-491, and skip the job when it reports the row is gone — logging `Source deleted mid-load, skipping` and, for documents, cleaning up the MinIO upload. This mirrors `DataSourceProcessingConsumer`, so there is now a single idiom for this operation.

Both consumers also mirror the refreshed timestamp on the in-memory entity. `saveTextSource` persists the whole entity later in the job, so without that the content write would put back the value the source was loaded with (the creation timestamp for documents, `null` for a queued crawl), undoing the heartbeat and re-exposing an in-flight job to the stale-processing cron. Caught by Bugbot on the first revision.

## Changes

- `document-processing.consumer.ts`: guarded heartbeat + skip-and-cleanup branch instead of `save()`, plus in-memory timestamp sync
- `url-crawl.consumer.ts`: guarded heartbeat + skip branch instead of `save()`, plus in-memory timestamp sync
- Both consumer specs: new deleted-mid-load and refreshed-timestamp tests, plus assertions that the happy path calls `refreshProcessingHeartbeat` and never `save()`; specs moved onto the shared `createMockSourceRepository()` fixture
- Converted the `../` imports in the four touched files to `src/...` aliases

## Acceptance criteria

- [x] Neither consumer calls `sourceRepository.save()` to bump `processingStartedAt`
- [x] A source deleted between `findById` and the heartbeat is not re-inserted; the job logs a skip and exits cleanly
- [x] Consumer specs cover the deleted-mid-load path

## Validation

- `pnpm jest src/domain/sources --runInBand` → 26 suites / 161 tests pass
- Verified the new tests are meaningful: reverting only the consumer changes fails them (heartbeat never called, `save()` called, crawl/extraction proceeds); reverting only the timestamp sync fails the two refreshed-timestamp tests
- `tsc --noEmit` clean for the changed files (unrelated pre-existing errors remain in `src/domain/runs/**` from unbuilt `@ayunis/*` workspace deps)
- ESLint (incl. `eslint.complexity.config.mjs`), Prettier, and `scripts/check-file-size.sh` clean on the changed files — only the pre-existing, non-gated `max-params` warnings on the DI constructors
- Full CI green on the first revision (`a7cc4d3`); re-running on `3f043bf`

Behaviour note: the heartbeat is guarded on `PROCESSING`, and both flows (`CreateProcessingSourceUseCase`, `CreateProcessingUrlSourceUseCase`) create the source as `PROCESSING` before enqueueing, so no legitimate job is skipped. A source whose status changed (deleted, or reaped to `FAILED` by the cron) now exits early instead of running to the existing mid-processing guard.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-594](https://linear.app/ayunis/issue/AYC-594/use-refreshprocessingheartbeat-in-document-and-url-crawl-consumers)

<div><a href="https://cursor.com/agents/bc-09c37db8-6c69-47fd-a5fe-037ef9fa1cd8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09c37db8-6c69-47fd-a5fe-037ef9fa1cd8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

