### PR TITLE
chore(skills): sync reconciled agent guidance (AYC-000)

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -45,7 +45,7 @@ In parallel, collect:
 - Any `CLAUDE.md` files in the repo root and in affected directories
 - A short summary of what the changes do (read the diff)
 
-If the diff changes repositories, finders, QueryBuilder code, or database calls in loops, load the `persistence-query-review` skill. Trace the affected call paths and include the resulting SQL statements and round-trip count in the review context.
+If the `persistence-query-review` skill is available and the diff changes repositories, finders, QueryBuilder code, or database calls in loops, load it. Trace the affected call paths and include the resulting SQL statements and round-trip count in the review context.
 
 ### 3. Launch review agents
 
@@ -84,7 +84,7 @@ Check for unnecessary complexity in the changes:
 - Over-engineering (abstractions for single use, premature generalization)
 - Code that could be simplified without losing clarity
 - Dead code or unused imports introduced by the change
-- For persistence changes, apply `persistence-query-review`: flag avoidable reads or reloads, check-then-act races, N+1 access, and writes that could use one atomic database operation
+- When `persistence-query-review` is available, apply it to persistence changes: flag avoidable reads or reloads, check-then-act races, N+1 access, and writes that could use one atomic database operation
 
 #### Agent 5 — Security & Data Integrity
 
@@ -99,11 +99,11 @@ Check the changes for security and data concerns:
 
 For each issue found across all agents, assign a confidence score (0–100):
 
-| Score | Meaning |
-|-------|---------|
-| 0–25  | Likely false positive or pre-existing issue |
-| 26–50 | Might be real but could be a nitpick |
-| 51–75 | Probably real, worth a look |
+| Score  | Meaning                                           |
+| ------ | ------------------------------------------------- |
+| 0–25   | Likely false positive or pre-existing issue       |
+| 26–50  | Might be real but could be a nitpick              |
+| 51–75  | Probably real, worth a look                       |
 | 76–100 | High confidence — real issue that should be fixed |
 
 **Discard anything scoring below 60.**

--- a/.claude/skills/finish-pr/SKILL.md
+++ b/.claude/skills/finish-pr/SKILL.md
@@ -21,11 +21,33 @@ Use the remote `headRefOid` as the revision under verification. If the remote he
 
 ## 2. Wait for CI and Bugbot
 
-Wait for all checks on every submitted PR:
+Wait for all checks on every submitted PR. For an ordinary PR:
 
 ```bash
 gh pr checks <pr-number> --watch --interval 30
 ```
+
+### Graphite downstack sentinel — do not use `--watch`
+
+On a stacked PR, Graphite deliberately keeps `Graphite / mergeability_check` in progress until every downstack PR merges. `gh pr checks --watch` waits for that sentinel forever even after all real verification has passed.
+
+Before watching a stacked PR, inspect the check run on the recorded head SHA:
+
+```bash
+gh api repos/{owner}/{repo}/commits/<head-sha>/check-runs \
+  --jq '.check_runs[] | select(.name == "Graphite / mergeability_check") |
+    {status, conclusion, title: .output.title, summary: .output.summary}'
+```
+
+Treat it as an intentional pending sentinel **only** when its current-SHA output explicitly says that it will pass when downstack PRs merge (and names the downstack dependency). Do not ignore the check merely because its name contains `Graphite`; any other output or a failed conclusion requires investigation.
+
+When the sentinel is confirmed, do not run `gh pr checks --watch` for that PR. Poll the JSON state instead and evaluate every check except that exact sentinel:
+
+```bash
+gh pr checks <pr-number> --json name,bucket,state,link
+```
+
+Continue while any non-sentinel check is pending; handle any non-sentinel failure or cancellation normally. Once all non-sentinel checks have passed or intentionally skipped, record the sentinel and its downstack PR in the verification report and continue to Bugbot comment triage. The sentinel is expected stack state, not a blocker and not evidence that CI is still running.
 
 If no checks are visible immediately after submission, wait 30 seconds and query again. Do not interpret absent checks as success.
 
@@ -99,7 +121,7 @@ For valid findings, amend the existing PR rather than creating a separate fix PR
 Do not declare the task complete until all of these are true for every submitted PR:
 
 - The recorded remote head SHA is still the PR's current head.
-- Every CI check has completed successfully, or was intentionally skipped with a documented reason.
+- Every CI check has completed successfully or was intentionally skipped with a documented reason; a current-SHA Graphite downstack sentinel verified as described in §2 is also acceptable and must be documented.
 - Cursor Bugbot completed on the current head.
 - All Bugbot comments across the submitted stack were triaged and no actionable finding remains.
 - The local worktree is clean and the submitted branches contain every fix.

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -9,7 +9,7 @@ This project uses **Graphite** for stacked PRs. Always use `gt`, never raw `git 
 
 | Situation | Read first |
 | --- | --- |
-| New PR, new branch, "based on main", or a follow-up that depends on unmerged work | `references/starting-work.md` — verify the base **before** the first edit |
+| Starting or resuming any work in a stacked-PR context—including amendments—or choosing a base for a new/follow-up PR | `references/starting-work.md` — sync and verify the base **before** the first edit |
 | A `gt` command aborted, warned, or no-op'd (untracked branch, must-restack, worktree collision, remote divergence) | `references/submit-troubleshooting.md` |
 
 ## Commit Message Format
@@ -70,6 +70,10 @@ Only the last PR uses `feat:` — that's the single changelog entry. Use a seman
 
 The worktree branch (if using worktrees) is the **base branch**; Graphite stacks are built on top of it. Being clean is not the same as being on `main`, and the default base is **not** always `main` — verify per `references/starting-work.md` before editing.
 
+### Working-tree hygiene
+
+Before staging for `gt create` or `gt modify`, and again before `gt submit`, run `git status --short` and review the working tree. If files you didn't touch in this session are modified (formatter passes, watcher artifacts, removed comments, or other unrelated changes), surface them to the user explicitly before staging. Restore them or get explicit confirmation that they belong in the commit; never bundle them silently.
+
 ### New commit → new stacked branch
 
 Each logical unit of work gets its own `gt create`:
@@ -101,13 +105,10 @@ gt modify              # amends, keeps the message, restacks descendants
 Pre-flight, every time — `--force` overwrites remote commits, and under `--no-interactive` the warning does not halt:
 
 ```bash
-git status --short                            # unrelated modified files? surface them, never bundle silently
 git fetch origin
 gt log short                                  # list every branch in the stack
 git log --oneline HEAD..origin/<branch>       # remote-only commits — for EACH branch, not just the edited ones
 ```
-
-Modified files you didn't touch this session (formatter passes, watcher artifacts) → `git restore` them or get explicit confirmation they belong in the commit; never bundle them silently.
 
 Any commits in `HEAD..origin/<branch>` → **stop and reconcile** (`git pull --rebase` or `gt restack`). Never `--force` past them: Cursor agent autofixes, CI commits, and teammate pushes routinely land on branches you didn't touch this session.
 

--- a/.claude/skills/git-workflow/references/starting-work.md
+++ b/.claude/skills/git-workflow/references/starting-work.md
@@ -1,6 +1,6 @@
 # Starting Work — Choosing and Verifying the Base
 
-Read this **before the first edit** of any new PR, new branch, or follow-up on unmerged work.
+Read this **before the first edit** when starting or resuming any work in a stacked-PR context—including amendments—or choosing a base for a new/follow-up PR.
 
 ## Before starting new work — sync main and restack
 

--- a/.claude/skills/linear-implement/SKILL.md
+++ b/.claude/skills/linear-implement/SKILL.md
@@ -57,9 +57,9 @@ Do the work. This is deliberately open-ended — the ticket may ask for a code c
 - Follow the ticket's instructions and referenced patterns
 - Use the right skills/tools for the job (e.g. `ayunis-core-backend`, `typeorm-migrations`, `code-review`, etc.)
 - Run validation (tests, build, lint, manual check) when applicable
-- User-facing feature or behaviour change? Load the `e2e` skill — done means
-  the journey spec in `ayunis-core-e2e/` exists/is updated and runs green
-  (`pnpm --filter ayunis-core-e2e test --grep "<feature>"`)
+- If the `e2e` skill is available, a user-facing feature or behaviour change
+  is done only when its journey spec exists/is updated and runs green. Follow
+  that skill's project-specific test command.
 - If execution surfaces a blocker, a wrong premise, or a decision that needs Daniel, stop and surface it — don't plow through
 
 ### 5. Summarize

--- a/.claude/skills/nestjs-hexagonal-backend/SKILL.md
+++ b/.claude/skills/nestjs-hexagonal-backend/SKILL.md
@@ -164,7 +164,7 @@ For schema changes, use the `typeorm-migrations` skill. Never write migrations b
 
 ## Persistence Queries
 
-When creating or modifying repositories, finders, QueryBuilder code, or database calls in loops, load the `persistence-query-review` skill. Count the complete call path's database round trips and prefer an atomic database operation when it preserves the same behavior.
+When creating or modifying repositories, finders, QueryBuilder code, or database calls in loops, load the `persistence-query-review` skill when it is available. Count the complete call path's database round trips and prefer an atomic database operation when it preserves the same behavior.
 
 ## Completion Checklist
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent skills; no runtime application or CI workflow code is modified.
> 
> **Overview**
> Updates several Claude agent skills so stacked-PR and optional-skill behavior matches how agents actually run in this repo.
> 
> **`finish-pr`** adds explicit handling for Graphite’s `Graphite / mergeability_check` downstack sentinel: agents must not use `gh pr checks --watch` on stacked PRs (it can hang forever), must confirm the sentinel via the check-run API on the current head SHA, poll JSON for non-sentinel checks, and may treat a verified sentinel as acceptable in the completion gate when documented.
> 
> **`git-workflow`** and **`starting-work`** broaden when to sync base and read starting guidance to any stacked-PR work (including amendments), and centralize **working-tree hygiene** (`git status --short` before create/modify/submit; never silently bundle unrelated edits).
> 
> **`code-review`**, **`nestjs-hexagonal-backend`**, and **`linear-implement`** gate `persistence-query-review` and **`e2e`** behind “when the skill is available” instead of assuming they always exist; **`code-review`** also reformats the confidence-score table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a29a34984a78b914f0bf1eb27b6343638c3792b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->