### PR TITLE
feat(auth): show returning SSO sign-in (AYC-856)

### DIFF
--- a/ayunis-core-e2e/tests/auth/sso-remembered-login.spec.ts
+++ b/ayunis-core-e2e/tests/auth/sso-remembered-login.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '../../src/fixtures/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const rememberedOrgIdKey = 'ayunis.sso.rememberedOrgId';
+const rememberedOrgId = 'f4fcdc42-176e-4d32-bd5b-6dad8d2426b4';
+
+test('offers the remembered organization without asking for an email', async ({
+  page,
+}) => {
+  await page.goto('/login?redirect=%2Fsettings%2Faccount');
+  await page.evaluate(
+    ({ key, orgId }) => window.sessionStorage.setItem(key, orgId),
+    { key: rememberedOrgIdKey, orgId: rememberedOrgId },
+  );
+  await page.reload();
+
+  await expect(page.getByTestId('login-remembered-sso')).toBeVisible();
+  await expect(page.getByTestId('email')).toHaveCount(0);
+
+  const startRequest = page.waitForRequest((request) =>
+    request.url().includes(`/auth/sso/organizations/${rememberedOrgId}/start`),
+  );
+  await page.getByTestId('login-remembered-sso').click();
+
+  await expect(startRequest).resolves.toBeTruthy();
+});
+
+test('clears the remembered organization when another account is chosen', async ({
+  page,
+}) => {
+  await page.goto('/login');
+  await page.evaluate(
+    ({ key, orgId }) => window.sessionStorage.setItem(key, orgId),
+    { key: rememberedOrgIdKey, orgId: rememberedOrgId },
+  );
+  await page.reload();
+
+  await page.getByTestId('login-use-another-account').click();
+
+  await expect(page.getByTestId('email')).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (key) => window.sessionStorage.getItem(key),
+        rememberedOrgIdKey,
+      ),
+    )
+    .toBeNull();
+
+  await page.reload();
+  await expect(page.getByTestId('email')).toBeVisible();
+  await expect(page.getByTestId('login-remembered-sso')).toHaveCount(0);
+});

--- a/ayunis-core-frontend/src/pages/auth/login/ui/LoginPage.test.tsx
+++ b/ayunis-core-frontend/src/pages/auth/login/ui/LoginPage.test.tsx
@@ -7,6 +7,8 @@ const {
   beginSso,
   discover,
   discoveryState,
+  forgetRememberedSsoOrgId,
+  getRememberedSsoOrgId,
   login,
   loginState,
   navigate,
@@ -15,6 +17,8 @@ const {
   beginSso: vi.fn(),
   discover: vi.fn(),
   discoveryState: { isPending: false },
+  forgetRememberedSsoOrgId: vi.fn(),
+  getRememberedSsoOrgId: vi.fn(),
   login: vi.fn(),
   loginState: { isPending: false },
   navigate: vi.fn(),
@@ -23,6 +27,8 @@ const {
 
 vi.mock('@/features/sso', () => ({
   beginSso,
+  forgetRememberedSsoOrgId,
+  getRememberedSsoOrgId,
   useDiscoverSso: () => ({ discover, isPending: discoveryState.isPending }),
 }));
 
@@ -56,7 +62,50 @@ describe(LoginPage.name, () => {
   beforeEach(() => {
     vi.clearAllMocks();
     discoveryState.isPending = false;
+    getRememberedSsoOrgId.mockReturnValue(null);
     loginState.isPending = false;
+  });
+
+  it('offers the remembered organization before asking for an email', () => {
+    getRememberedSsoOrgId.mockReturnValue(
+      'f4fcdc42-176e-4d32-bd5b-6dad8d2426b4',
+    );
+
+    render(<LoginPage redirect="/settings/account" ssoLoginEnabled />);
+
+    expect(screen.queryByTestId('email')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('login-remembered-sso'));
+
+    expect(beginSso).toHaveBeenCalledWith(
+      'f4fcdc42-176e-4d32-bd5b-6dad8d2426b4',
+      '/settings/account',
+    );
+  });
+
+  it('forgets the organization when another account is chosen', () => {
+    getRememberedSsoOrgId.mockReturnValue(
+      'f4fcdc42-176e-4d32-bd5b-6dad8d2426b4',
+    );
+    render(<LoginPage ssoLoginEnabled />);
+
+    fireEvent.click(screen.getByTestId('login-use-another-account'));
+
+    expect(forgetRememberedSsoOrgId).toHaveBeenCalledOnce();
+    expect(screen.getByTestId('email')).toBeTruthy();
+    expect(screen.getByTestId('login-continue')).toBeTruthy();
+  });
+
+  it('ignores remembered SSO when SSO login is disabled', () => {
+    getRememberedSsoOrgId.mockReturnValue(
+      'f4fcdc42-176e-4d32-bd5b-6dad8d2426b4',
+    );
+
+    render(<LoginPage ssoLoginEnabled={false} />);
+
+    expect(screen.getByTestId('email')).toBeTruthy();
+    expect(screen.getByTestId('password')).toBeTruthy();
+    expect(screen.queryByTestId('login-remembered-sso')).toBeNull();
   });
 
   it('keeps the existing password login when SSO login is disabled', async () => {

--- a/ayunis-core-frontend/src/pages/auth/login/ui/LoginPage.tsx
+++ b/ayunis-core-frontend/src/pages/auth/login/ui/LoginPage.tsx
@@ -15,7 +15,12 @@ import { useLogin } from '@/pages/auth/login/api/useLogin';
 import { useTranslation } from 'react-i18next';
 import { Link } from '@tanstack/react-router';
 import { useRedirectNotification } from '@/features/useRedirectNotification';
-import { beginSso, useDiscoverSso } from '@/features/sso';
+import {
+  beginSso,
+  forgetRememberedSsoOrgId,
+  getRememberedSsoOrgId,
+  useDiscoverSso,
+} from '@/features/sso';
 import { useState } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 import type { LoginFormFields } from '@/pages/auth/login/model/login-form';
@@ -35,6 +40,10 @@ export function LoginPage({
   const { t } = useTranslation('auth');
   const [showMethods, setShowMethods] = useState(!ssoLoginEnabled);
   const [ssoOrgId, setSsoOrgId] = useState<string | null>(null);
+  const [rememberedSsoOrgId, setRememberedSsoOrgId] = useState(() =>
+    ssoLoginEnabled ? getRememberedSsoOrgId() : null,
+  );
+  const showRememberedSso = rememberedSsoOrgId !== null;
 
   useRedirectNotification({
     show: emailVerified ?? false,
@@ -65,10 +74,19 @@ export function LoginPage({
     setSsoOrgId(null);
   }
 
+  function useAnotherAccount() {
+    forgetRememberedSsoOrgId();
+    setRememberedSsoOrgId(null);
+  }
+
   return (
     <OnboardingLayout
       title={t('login.title')}
-      description={t('login.description')}
+      description={t(
+        showRememberedSso
+          ? 'login.rememberedSsoDescription'
+          : 'login.description',
+      )}
       footer={
         <>
           {t('login.noAccount')}{' '}
@@ -78,45 +96,86 @@ export function LoginPage({
         </>
       }
     >
-      <Form {...form}>
-        <form
-          onSubmit={(e) => {
-            if (ssoLoginEnabled && !showMethods) {
-              e.preventDefault();
-              void continueWithEmail();
-              return;
-            }
-            void form.handleSubmit(onSubmit)(e);
-          }}
-          className="space-y-4"
-        >
-          <EmailField
-            form={form}
-            disabled={ssoLoginEnabled && (showMethods || isDiscovering)}
-          />
-          {showMethods ? (
-            <LoginMethods
+      {showRememberedSso ? (
+        <RememberedSsoLogin
+          orgId={rememberedSsoOrgId}
+          redirect={redirect}
+          onUseAnotherAccount={useAnotherAccount}
+        />
+      ) : (
+        <Form {...form}>
+          <form
+            onSubmit={(e) => {
+              if (ssoLoginEnabled && !showMethods) {
+                e.preventDefault();
+                void continueWithEmail();
+                return;
+              }
+              void form.handleSubmit(onSubmit)(e);
+            }}
+            className="space-y-4"
+          >
+            <EmailField
               form={form}
-              ssoOrgId={ssoOrgId}
-              redirect={redirect}
-              isLoading={isLoading}
-              onChangeEmail={changeEmail}
-              showChangeEmail={ssoLoginEnabled}
+              disabled={ssoLoginEnabled && (showMethods || isDiscovering)}
             />
-          ) : (
-            <Button
-              type="button"
-              className="w-full"
-              disabled={isDiscovering}
-              onClick={() => void continueWithEmail()}
-              data-testid="login-continue"
-            >
-              {isDiscovering ? t('login.checkingEmail') : t('login.continue')}
-            </Button>
-          )}
-        </form>
-      </Form>
+            {showMethods ? (
+              <LoginMethods
+                form={form}
+                ssoOrgId={ssoOrgId}
+                redirect={redirect}
+                isLoading={isLoading}
+                onChangeEmail={changeEmail}
+                showChangeEmail={ssoLoginEnabled}
+              />
+            ) : (
+              <Button
+                type="button"
+                className="w-full"
+                disabled={isDiscovering}
+                onClick={() => void continueWithEmail()}
+                data-testid="login-continue"
+              >
+                {isDiscovering ? t('login.checkingEmail') : t('login.continue')}
+              </Button>
+            )}
+          </form>
+        </Form>
+      )}
     </OnboardingLayout>
+  );
+}
+
+function RememberedSsoLogin({
+  orgId,
+  redirect,
+  onUseAnotherAccount,
+}: Readonly<{
+  orgId: string;
+  redirect?: string;
+  onUseAnotherAccount: () => void;
+}>) {
+  const { t } = useTranslation('auth');
+  return (
+    <div className="space-y-2">
+      <Button
+        type="button"
+        className="w-full"
+        onClick={() => beginSso(orgId, redirect)}
+        data-testid="login-remembered-sso"
+      >
+        {t('login.signInWithSso')}
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        className="w-full"
+        onClick={onUseAnotherAccount}
+        data-testid="login-use-another-account"
+      >
+        {t('login.useAnotherAccount')}
+      </Button>
+    </div>
   );
 }
 

--- a/ayunis-core-frontend/src/shared/locales/de/auth.json
+++ b/ayunis-core-frontend/src/shared/locales/de/auth.json
@@ -2,6 +2,7 @@
   "login": {
     "title": "Willkommen!",
     "description": "Geben Sie Ihre E-Mail-Adresse ein, um die Anmeldeoptionen Ihrer Organisation zu sehen",
+    "rememberedSsoDescription": "Melden Sie sich direkt über Ihre Organisation an oder verwenden Sie ein anderes Konto",
     "noAccount": "Haben Sie noch kein Konto?",
     "createAccount": "Hier erstellen",
     "email": "E-Mail",
@@ -24,6 +25,7 @@
     "checkingEmail": "Anmeldeoptionen werden geprüft...",
     "changeEmail": "Andere E-Mail-Adresse verwenden",
     "signInWithSso": "Mit Ihrer Organisation anmelden",
+    "useAnotherAccount": "Anderes Konto verwenden",
     "orUsePassword": "oder Ayunis-Passwort verwenden",
     "ssoDiscoveryFailed": "Die Anmeldeoptionen Ihrer Organisation konnten nicht geprüft werden. Sie können weiterhin Ihr Ayunis-Passwort verwenden."
   },

--- a/ayunis-core-frontend/src/shared/locales/en/auth.json
+++ b/ayunis-core-frontend/src/shared/locales/en/auth.json
@@ -2,6 +2,7 @@
   "login": {
     "title": "Welcome!",
     "description": "Enter your email to see the sign-in options for your organization",
+    "rememberedSsoDescription": "Continue with your organization's sign-in, or use another account",
     "noAccount": "Don't have an account?",
     "createAccount": "Create one here",
     "email": "Email",
@@ -24,6 +25,7 @@
     "checkingEmail": "Checking sign-in options...",
     "changeEmail": "Use another email",
     "signInWithSso": "Sign in with your organization",
+    "useAnotherAccount": "Use another account",
     "orUsePassword": "or use your Ayunis password",
     "ssoDiscoveryFailed": "We could not check your organization's sign-in options. You can still use your Ayunis password."
   },


### PR DESCRIPTION
## Summary

- Show returning SSO users a direct **Sign in with SSO** action on the normal login page.
- Keep the flow explicit: no automatic redirect to the identity provider.
- Add **Use another account** to forget the tab-scoped hint and restore the existing email/password flow.
- Keep first-time and password users unchanged.

## QA

- Real browser QA on local slot 6 with SSO enabled: 3/3 Playwright setup/journey tests passed.
- Verified the remembered action starts the correct organization SSO request.
- Verified **Use another account** clears the hint, restores the email form, and stays cleared after reload.
- Full frontend suite: 92 suites / 508 tests passed.
- Frontend production build, TypeScript, ESLint, dependency checks, and e2e lint/typecheck passed.

## Stack

- Depends on the SSO-memory foundation PR directly below this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the primary login entry path for returning SSO users on the auth page, but remains opt-in per click and is gated by SSO being enabled and session storage only.
> 
> **Overview**
> When SSO is enabled and a **tab-scoped remembered org id** exists (from the prior SSO-memory work), the login page now opens on a **returning-user** path instead of the email step: **Sign in with your organization** calls `beginSso` with the stored org (and preserves `redirect`), with **no automatic IdP redirect**.
> 
> **Use another account** clears the remembered hint via `forgetRememberedSsoOrgId`, restores the normal email/discovery flow, and updates copy via new `rememberedSsoDescription` / `useAnotherAccount` strings (EN/DE). Remembered SSO is skipped when `ssoLoginEnabled` is false.
> 
> Coverage adds **LoginPage** unit cases and a new **Playwright** spec for the remembered UI, SSO start request, and persistence after reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cb87d2bd264d4707fb8ab0bee207ae02da09b9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->