### PR TITLE
docs(workflow): add proportional validation paths (AYC-000)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,13 +27,13 @@ ayunis-core/
 
 ### 1. Validation-First
 
-Do NOT trust your own assessment of code correctness. Verify through observable behavior — lint, type-check, tests, and runtime. See the development skills below for specific validation sequences.
+Do NOT trust your own assessment of code correctness. Verify through observable behavior using the smallest set of checks that covers the change's credible failure modes. See **Proportional Workflow** below for the required depth and the development skills for surface-specific patterns.
 
 ### 2. Evidence Before Diagnosis
 
 Principle 1 governs code you wrote. This one governs everything you *assert*: root causes, config values, provider behavior, "this is already fixed", "this should work".
 
-- **Reproduce before diagnosing.** A "likely root cause" derived from reading code and config is not an answer. Run the stack, trigger the failure, then explain it. Passing unit tests are not a substitute for one live request against the actual configured environment.
+- **Reproduce before diagnosing.** A "likely root cause" derived from reading code and config is not an answer. Reproduce the failure at the smallest layer where it is observable, then explain it. For runtime, configuration, or integration failures, passing unit tests are not a substitute for one live request against the actual configured environment.
 - **Never recommend a config value you haven't verified.** An example value found in the repo (an API version, endpoint, model id) is not "the fix". Check it against current provider documentation and the deployed environment, or label it explicitly as unverified.
 - **Name the environment.** Staging and production run different config and different model deployments. State which environment/app your evidence came from before drawing a conclusion; evidence from the wrong environment invalidates the whole analysis.
 - **Report only failure modes the evidence supports.** Do not append extra suspected bugs or "regressions" inferred from general model knowledge to an incident report. If you have a hypothesis, label it as one to check — an unsupported claim presented alongside real findings costs more trust than it buys.
@@ -43,10 +43,10 @@ When an access path or tool fails, report the blocker immediately. Do not keep s
 
 ### 3. Incremental Progress
 
-- Make one change at a time
-- Validate after each change
-- Commit after each validated change
-- Never batch multiple logical changes
+- Make one logical change at a time
+- Validate each logical change in proportion to its risk
+- Commit after each validated logical change
+- Never batch unrelated changes; do not create ceremonial commits for intermediate steps of one coherent change
 
 ### 4. Respect Boundaries
 
@@ -87,6 +87,62 @@ Any change that affects sharing, permissions, visibility, organization scope, te
 - Treat the scenario as incomplete until the focused E2E test passes in CI. Record the exact command and environment when reporting verification.
 
 For access-control regressions, the test must preserve the causal order: verify the denied state first, apply the share or permission change second, and verify the allowed state last. This prevents a test from passing because the resource was visible for an unrelated reason.
+
+### 10. Proportional Workflow
+
+Validation-first does not mean running every available check for every change. Use the lightest workflow that produces credible evidence for the change's actual failure modes. Classify by blast radius, reversibility, and observability — not by diff size, estimated effort, or urgency. A five-line authorization fix is high-risk; a larger isolated copy-and-layout change may use the Fast Path.
+
+If a change matches more than one level, use the highest. If it is unclear whether an ordinary low-risk change qualifies for the Fast Path, use the Standard Path. If uncertainty involves security, data integrity, infrastructure, reversibility, or the boundary between Standard and High-Risk, use the High-Risk Path.
+
+#### Fast Path
+
+Use only when all of these are true:
+
+- The change is isolated and easy to reverse.
+- It does not alter a public contract, persistent data, security boundary, or cross-module interaction.
+- Its behavior can be demonstrated with a focused check at one layer.
+- It does not touch authentication, authorization, sharing, tenant boundaries, migrations, infrastructure, secrets, billing, or external-provider configuration.
+
+Typical examples are documentation, copy, static styling, test-only maintenance, behavior-preserving refactors, and narrow bug fixes with one understood failure mode.
+
+Required:
+
+1. For a behavior bug, first reproduce it with the smallest practical failing test.
+2. Run a focused test when behavior or test code changed, plus any lint or type check applicable to the changed files.
+3. Render and inspect a visible UI change when automated checks cannot prove its result.
+4. Inspect the final diff for unintended changes.
+
+The Fast Path does **not automatically require** starting the full stack, broad package or repository suites, E2E coverage when a lower layer proves the behavior, PR media that adds no review value, or separate commits for mechanical steps within the same logical change. Run any of these when it is the only credible way to test a failure mode.
+
+#### Standard Path
+
+This is the default for ordinary features and behavior changes, including work that spans components or layers.
+
+Required:
+
+1. Define the observable acceptance criteria; reproduce bugs before fixing them.
+2. Use test-driven development for changed logic or behavior.
+3. Run the relevant unit or integration tests.
+4. Run lint and type-check or build for each affected package.
+5. Add E2E coverage when a browser journey or system boundary changes and lower-level tests do not sufficiently prove it.
+6. Capture PR media when it materially helps a reviewer evaluate a visible change.
+7. Exercise the real runtime when the reported failure or changed behavior only exists there.
+
+#### High-Risk Path
+
+Use for authentication, authorization, sharing, tenant isolation, migrations or data transformations, destructive or difficult-to-reverse data operations, public API/schema contracts, security-sensitive input or secret handling, billing, infrastructure/CI/deployment changes, external-provider configuration, cross-module persistence, concurrency-sensitive background work, and production incidents.
+
+Required:
+
+- Follow all applicable specialized skills and their safety checks.
+- Validate configuration and integration behavior against the actual named environment.
+- Exercise affected behavior end-to-end when it has a user-facing or system-boundary path.
+- Run the full relevant validation suite, including distinct-principal tests for access control.
+- Report the exact environment and commands used as evidence.
+
+#### Pull Requests
+
+The workflow level controls local implementation and validation breadth. It does not weaken **A Submitted PR Is Not Complete**: once a PR is created or updated, CI and Cursor Bugbot must still be clean on the latest submitted revision.
 
 ---
 
@@ -136,7 +192,7 @@ The following rules are enforced by ESLint, pre-commit hooks, and CI. Violations
 
 ## Development Skills
 
-For detailed development workflows, patterns, and validation checklists, load the appropriate skill. Skills are listed with descriptions in the system prompt — pick the one that matches the task.
+Load the implementation skills for the files and surfaces being changed. Load validation workflow skills such as `e2e`, `pr-media`, or `qa` when required by the classification above, by a credible failure mode, or by the user's explicit request. Surface-specific safety rules remain mandatory; the proportional workflow controls the breadth of otherwise generic validation checklists.
 
 ---
 

--- a/.claude/skills/ayunis-core-backend/SKILL.md
+++ b/.claude/skills/ayunis-core-backend/SKILL.md
@@ -106,9 +106,9 @@ pnpm test <path-or-pattern>    # a subset
 
 **Those failures are an artifact of the wrong invocation, not a real regression.** Do not report them as "pre-existing failures on main" or hang caveats on a PR summary because of them — re-run with `pnpm test` and they pass. A suite that fails under `pnpm test` is a genuine signal worth investigating.
 
-## Health Check
+## Runtime Health Check
 
-After changes, verify the service responds:
+When runtime validation is required by the repository's Proportional Workflow, verify the service responds before exercising the changed behavior:
 
 ```bash
 curl http://localhost:PORT/api/health

--- a/.claude/skills/ayunis-core-frontend-dev/SKILL.md
+++ b/.claude/skills/ayunis-core-frontend-dev/SKILL.md
@@ -17,21 +17,29 @@ Before modifying any layer, read its `SUMMARY.md` in `src/[layer]/SUMMARY.md`. T
 
 ## Validation Sequence
 
+Choose validation breadth using the repository's Proportional Workflow.
+
+For Standard and High-Risk changes:
+
 ```bash
 pnpm run build                 # Must succeed
 pnpm run lint                  # Must pass
 ```
 
-**User-facing change?** The definition of done includes e2e coverage — load
-the `e2e` skill: add/update the journey spec in `ayunis-core-e2e/` and run it
-green before submitting. Add `data-testid`s to touched components in the same
-PR (`<feature>-<element>`, kebab-case) — text selectors are banned because
-the UI is i18n'd.
+For Fast Path changes, run the narrowest relevant test when behavior or test
+code changed, plus any lint/type check applicable to the touched files. Run the
+build when imports, types, dependencies, bundling, or other compile-time
+behavior could be affected.
 
-**Visible UI change?** After the product PR exists, add temporary PR media by
-loading the `pr-media` skill and publishing scenes to `pr-media/pr-<number>`.
-This is required unless the user explicitly says not to add PR media. Do not
-commit media scenes to the product branch.
+**Browser journey or system boundary changed?** Load the `e2e` skill when
+lower-level tests do not sufficiently prove the behavior. Add `data-testid`s
+needed by the journey to touched components in the same PR
+(`<feature>-<element>`, kebab-case) — text selectors are banned because the UI
+is i18n'd.
+
+**Would visual evidence materially help review?** After the product PR exists,
+load the `pr-media` skill and publish the smallest useful scene set to
+`pr-media/pr-<number>`. Do not commit media scenes to the product branch.
 
 ## Architecture (Feature-Sliced Design)
 
@@ -111,13 +119,14 @@ For hooks that back a form (create/update dialogs), load the **frontend-form-pat
 
 ## Verifying in the Browser
 
-Use your harness's browser tooling to check the page renders and the console is clean. A render failure shows the React dev-server error overlay — the element `#webpack-dev-server-client-overlay` must not exist. The frontend URL depends on the dev slot (see `dev-environment`); seeded login credentials are in `seed-database`.
+When the change affects rendered UI or browser behavior, use your harness's browser tooling to check the affected page renders and the console is clean. A render failure shows the React dev-server error overlay — the element `#webpack-dev-server-client-overlay` must not exist. The frontend URL depends on the dev slot (see `dev-environment`); seeded login credentials are in `seed-database`.
 
 ## Completion Checklist
 
-- [ ] `pnpm run build` succeeds
-- [ ] `pnpm run lint` passes
-- [ ] Page renders without console errors
+- [ ] Validation matches the repository's Proportional Workflow
+- [ ] Relevant focused tests pass when behavior or test code changed
+- [ ] Build and package lint pass for Standard and High-Risk changes
+- [ ] Affected page renders without console errors when UI or browser behavior changed
 - [ ] No `any` types introduced
 - [ ] Import rules respected (no upward imports)
 - [ ] UI primitives use public `@ayunis/ui` subpaths

--- a/.claude/skills/backend-debugging/SKILL.md
+++ b/.claude/skills/backend-debugging/SKILL.md
@@ -101,9 +101,4 @@ import { DataSource } from 'typeorm';
 2. Wait for `nest --watch` to reload (or check `./dev logs backend` for compilation errors)
 3. Re-run the curl command from Step 2
 4. Check `./dev logs backend` to confirm no new errors
-5. Run the validation sequence:
-
-```bash
-cd ayunis-core-backend
-pnpm run lint && pnpm exec tsc --noEmit && pnpm run test
-```
+5. Load `nestjs-hexagonal-backend` and run its validation sequence at the level required by the repository's Proportional Workflow.

--- a/.claude/skills/e2e/SKILL.md
+++ b/.claude/skills/e2e/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: e2e
-description: Write and run Playwright e2e tests in ayunis-core-e2e. MUST be loaded when a user-facing feature is built or changed — the definition of done includes a green e2e spec — and whenever running, writing, or debugging browser tests.
+description: Write and run Playwright e2e tests in ayunis-core-e2e. Use when writing, running, or debugging browser tests; when a browser journey or system boundary changes and lower-level tests do not sufficiently prove it; or when the High-Risk Path affects user-facing behavior. Not automatic for copy, isolated visual-only work, or behavior already proven at a lower layer.
 ---
 
 # E2E Tests — ayunis-core-e2e
 
-Browser tests against the real stack with deterministic LLM mocks. A
-user-facing feature is **done when its e2e spec passes** — no manual browser
-check needed. Architecture and history: `ayunis-core-e2e/PLAN.md`.
+Browser tests against the real stack with deterministic LLM mocks. When the
+Proportional Workflow requires browser coverage, the change is **done when its
+focused e2e spec passes**. Use E2E for journeys and boundaries that lower-level
+tests cannot credibly prove; do not add an E2E test merely because a change is
+visible to a user. Architecture and history: `ayunis-core-e2e/PLAN.md`.
 
 ## Stack setup (once per session)
 
@@ -43,7 +45,7 @@ Non-default slot: `E2E_BASE_URL=http://localhost:30N1 pnpm --filter ...`
 
 Temporary PR-review screenshots/GIFs use `pnpm --filter ayunis-core-e2e run pr-media:capture`. Scene definitions are not committed to product branches; use the `pr-media` skill to put `.pr-media/scenes.ts` on the disposable `pr-media/pr-<n>` branch for the PR.
 
-For visible frontend changes, PR media is part of the post-submit workflow: after the product PR exists, create temporary PR media unless the user explicitly opts out. Include desktop and mobile screenshots of the changed UI, plus a short GIF for changed interactions, dialogs, menus, or flows.
+For visually meaningful frontend changes, use the `pr-media` skill when the result materially helps reviewers evaluate the PR. Include only the viewports and interactions needed to demonstrate the change.
 
 ## Fixtures — import from `src/fixtures/test`, never `@playwright/test`
 
@@ -108,7 +110,7 @@ tests/<domain>/     Product journeys, one journey per spec file
    - Admin mutation with API assertion: `tests/admin/instructions.spec.ts`
 2. Prefer generated endpoint calls behind `src/clients/api/`; do not hardcode backend routes in specs. Compose test data in `src/factories/`, reusable UI journeys in `src/flows/`, and assert behaviour through the UI.
 3. Unique data per test (`Date.now()` suffixes) — tests share the worker org.
-4. Run the spec, then the full suite, then lint + typecheck.
+4. Run the focused spec, lint, and typecheck. Run the full suite when the change affects shared fixtures, flows, clients, or broad behavior; otherwise rely on CI for the full-suite gate.
 
 ## Debugging a failure
 

--- a/.claude/skills/linear-implement/SKILL.md
+++ b/.claude/skills/linear-implement/SKILL.md
@@ -56,10 +56,8 @@ Do the work. This is deliberately open-ended — the ticket may ask for a code c
 
 - Follow the ticket's instructions and referenced patterns
 - Use the right skills/tools for the job (e.g. `ayunis-core-backend`, `typeorm-migrations`, `code-review`, etc.)
-- Run validation (tests, build, lint, manual check) when applicable
-- User-facing feature or behaviour change? Load the `e2e` skill — done means
-  the journey spec in `ayunis-core-e2e/` exists/is updated and runs green
-  (`pnpm --filter ayunis-core-e2e test --grep "<feature>"`)
+- Classify the work using the repository's Proportional Workflow and run the corresponding validation
+- Browser journey or system boundary changed without sufficient lower-level coverage? Load the `e2e` skill; done means the focused journey spec exists or is updated and runs green (`pnpm --filter ayunis-core-e2e test --grep "<feature>"`)
 - If execution surfaces a blocker, a wrong premise, or a decision that needs Daniel, stop and surface it — don't plow through
 
 ### 5. Summarize

--- a/.claude/skills/nestjs-hexagonal-backend/SKILL.md
+++ b/.claude/skills/nestjs-hexagonal-backend/SKILL.md
@@ -7,20 +7,19 @@ description: Backend development with NestJS, TypeORM, and hexagonal architectur
 
 ## Red-Green TDD Workflow
 
-Every change follows red-green TDD. Do NOT write production code without a failing test first.
+Behavior and logic changes, including bug fixes, follow red-green TDD. Do NOT write production code for changed behavior without a failing test first. For a behavior-preserving refactor, identify and run the focused existing tests before editing, then keep them green; do not invent a new failing test when no behavior should change.
 
 ### Cycle
 
 1. **Red** — Write a test that captures the desired behavior. Run it. It MUST fail.
    - If the test passes immediately, it's not testing anything new — delete it or rethink.
 2. **Green** — Write the minimum production code to make the test pass. Nothing more.
-3. **Refactor** — Clean up while keeping tests green. Run the full validation sequence.
+3. **Refactor** — Clean up while keeping tests green. Run the validation required by the repository's Proportional Workflow.
 4. **Repeat** — Next behavior, next test.
 
 ```bash
 # During each cycle:
 pnpm run test -- --testPathPatterns=<module>  # Run focused tests (red → green)
-pnpm exec eslint <touched-files> && pnpm exec tsc --noEmit && pnpm run test  # Full validation (refactor step)
 ```
 
 > The Jest flag is `--testPathPatterns` (plural). The singular `--testPathPattern` was removed and now errors out: `Option testPathPattern was replaced by --testPathPatterns`.
@@ -58,15 +57,29 @@ it("should work", async () => {
 
 ## Validation Sequence
 
+Choose validation breadth using the repository's Proportional Workflow.
+
+Fast Path:
+
+```bash
+pnpm exec eslint <touched-files>              # Lint without rewriting unrelated files
+```
+
+Run `pnpm run test -- --testPathPatterns=<module>` when behavior or test code changed. Also run `pnpm exec tsc --noEmit` when types, imports, dependency injection, or other compile-time behavior could be affected.
+
+Standard Path:
+
 ```bash
 pnpm exec eslint <touched-files>     # Lint without rewriting unrelated files
 pnpm exec tsc --noEmit               # 0 type errors
-pnpm run test                        # All tests pass
+pnpm run test -- --testPathPatterns=<module>  # Affected module suites pass
 ```
+
+High-Risk changes and changes to shared test infrastructure or broad behavior also run `pnpm run test` for the full suite.
 
 > ⚠ **`pnpm run lint` is wired with `--fix`** in `ayunis-core-backend/package.json` — running it as a verification step will auto-rewrite unrelated files (migrations, fixtures, entities) and leave them in the working tree. Prefer `pnpm exec eslint <paths>` for verification. If you do run `pnpm run lint`, immediately check `git status --short` and `git restore` any files outside your change set.
 
-For an architecture cross-check before declaring done (catches the no-cross-module-port-imports / no-domain-imports-presenters rules that the pre-commit hook enforces), also run dep-cruiser:
+When module boundaries or imports change, run dep-cruiser as an architecture cross-check (it catches the no-cross-module-port-imports / no-domain-imports-presenters rules that the pre-commit hook enforces):
 
 ```bash
 pnpm exec depcruise src        # or whatever the project's depcheck script is
@@ -169,9 +182,8 @@ When creating or modifying repositories, finders, QueryBuilder code, or database
 ## Completion Checklist
 
 - [ ] `pnpm exec eslint <touched-files>` passes (avoid `pnpm run lint` — it's wired with `--fix`)
-- [ ] `pnpm exec tsc --noEmit` shows 0 errors
-- [ ] `pnpm run test` all pass
-- [ ] `pnpm exec depcruise src` reports no new violations (catches cross-module port/presenter imports the pre-commit hook will reject)
+- [ ] Focused regression or module tests pass when behavior or test code changed
+- [ ] Type-check, full suite, and dep-cruiser run when required by the Proportional Workflow and affected failure modes
 - [ ] `git status --short` shows only files you intended to change
 - [ ] No `any` types introduced
 - [ ] DTOs have validation decorators

--- a/.claude/skills/pr-media/SKILL.md
+++ b/.claude/skills/pr-media/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: pr-media
-description: Create temporary PR-specific screenshots and short GIF demos without committing scene code to the product branch. Use when the user asks for PR screenshots/videos/demos/media, and after visible frontend changes unless explicitly opted out.
+description: Create temporary PR-specific screenshots and short GIF demos without committing scene code to the product branch. Use when the user requests PR media or when a visually meaningful frontend change materially benefits from visual review. It is not automatic for every frontend diff.
 ---
 
 # PR Media
 
 PR media scenes are temporary review aids. Never commit scene definitions to the product PR. Store them on the disposable `pr-media/pr-<number>` branch; the App Integration workflow deletes that branch when the PR closes.
 
-For visible frontend changes, PR media is required after the product PR is created or updated unless the user explicitly says not to add PR media. Minimum coverage is a desktop screenshot and a mobile screenshot of the changed UI. Add a short GIF when the change affects an interaction, dialog, menu, transition, or multi-step flow.
+Use the Proportional Workflow to decide whether PR media adds meaningful review evidence. When it does, capture only the affected viewports and states: use desktop and mobile when responsive behavior is relevant, and add a short GIF when motion or interaction cannot be judged from a static screenshot. Do not create media as ceremony for changes the diff and focused tests already make clear.
 
 ## Workflow
 
@@ -55,7 +55,7 @@ Guidelines:
 - Keep scene and demo names kebab-case (`^[a-z0-9]+(?:-[a-z0-9]+)*$`); CI rejects unsafe names before publishing. Output is `scene-name--viewport.png` and `scene-name--demo-name--viewport.gif`.
 - Use `getByTestId` / `getByRole`; avoid text selectors where possible because the UI is localized.
 - Prefer short, deterministic interactions. No `waitForTimeout`; wait on locators or assertions.
-- Include only scenes the reviewer asked for.
+- Include only the scenes needed to demonstrate the changed UI; do not capture unrelated pages or states.
 
 ## Verify
 

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -7,7 +7,7 @@ description: Behaviour QA of a PR/branch before merge in ayunis-core — spin up
 
 Verify that a PR actually behaves to spec by **exercising it in the running app**, then leave the machine exactly as it was. This is behaviour verification, not code review — pair it with `/code-review` for the diff.
 
-Scripted regression coverage lives in `ayunis-core-e2e/` (see the `e2e` skill) — run the relevant specs first (`pnpm --filter ayunis-core-e2e test --grep "<area>"`, needs an `--e2e` stack); a green spec is evidence for its criterion. Spend manual QA effort on what the suite doesn't cover: the PR-specific behaviours, visuals, and edge cases. If the PR added a feature without a spec, flag it — that's a definition-of-done gap.
+Scripted regression coverage lives in `ayunis-core-e2e/` (see the `e2e` skill). When an applicable spec exists or the repository's Proportional Workflow requires browser coverage, run the focused spec first (`pnpm --filter ayunis-core-e2e test --grep "<area>"`, needs an `--e2e` stack); a green spec is evidence for its criterion. Spend manual QA effort on what lower-level and E2E coverage do not prove: the PR-specific behaviours, visuals, and edge cases. Missing E2E coverage is a definition-of-done gap only when the change's classification or failure modes require it.
 
 ## Input
 
@@ -145,88 +145,15 @@ for (const [name, width] of [['mobile',375],['tablet',768],['desktop',1280]]) {
 - Eyeball each shot for the mobile essentials: no clipped controls, nav collapses to its hamburger/drawer, dialogs and tables stay usable.
 - The three `resp-*.png` count as evidence and can double as PR media (step 4b).
 
-## 4b. Frontend PR media (REQUIRED when the diff touches the frontend)
+## 4b. Frontend PR media (when it adds review evidence)
 
-Standing rule: **any PR that changes `ayunis-core-frontend/` must ship with a screenshot (and a short GIF) of the change.** Since the app is already running from step 2, capture it here. Delivery is **automated** and follows the repo's existing convention (PRs #989/#1007): media lives on a dedicated orphan `pr-media/<ticket-lc>` branch at `docs/pr-media/<ticket-lc>/`, embedded into the PR body via `gh` (repo is public, so `raw.githubusercontent.com` URLs render). No manual drag-drop; media never lands in the feature branch or `main`.
+Use the repository's Proportional Workflow to decide whether media materially helps reviewers evaluate the visible result. QA screenshots remain local evidence even when publication adds no value.
 
-Save everything under a run dir, e.g. `<scratchpad>/pr-media/`.
-
-### Screenshots — key states
-
-Drive the changed UI to each meaningful state and `page.screenshot({ path, fullPage: true })`:
-
-- before/after, or empty/filled, or toggle off/on — whatever states the change introduces.
-- Name them descriptively: `01-toggle-off.png`, `02-toggle-on.png`.
-
-### Short GIF — the interaction (needs ffmpeg)
-
-Record the interaction with CDP screencast, then assemble with ffmpeg:
-
-```js
-// during the scripted interaction:
-const client = await page.target().createCDPSession();
-let n = 0; const dir = '<scratchpad>/pr-media/frames';
-await client.send('Page.startScreencast', { format: 'jpeg', quality: 80, everyNthFrame: 1 });
-client.on('Page.screencastFrame', async ({ data, sessionId }) => {
-  fs.writeFileSync(`${dir}/f-${String(n++).padStart(4,'0')}.jpg`, Buffer.from(data, 'base64'));
-  await client.send('Page.screencastFrameAck', { sessionId });
-});
-// ... perform the clicks/typing you want to show, with small awaited pauses ...
-await client.send('Page.stopScreencast');
-```
-
-```bash
-# frames -> optimized gif (~10 fps, 1000px wide)
-ffmpeg -y -framerate 10 -pattern_type glob -i '<dir>/f-*.jpg' \
-  -vf "fps=10,scale=1000:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" \
-  <scratchpad>/pr-media/demo.gif
-```
-
-If `ffmpeg` is missing, deliver screenshots only and note the GIF was skipped (offer to `brew install ffmpeg`).
-
-### Publish & embed — host on the `pr-media` branch, append to the PR
-
-Push the media to a dedicated orphan branch (media only, no code — kept out of the PR diff and `main`) at the conventional path, then edit the PR body to embed it. Needs the PR number and the ticket id (lowercased); if there's no ticket, use the PR number in its place.
-
-```bash
-PR=<n>; TK=<ticket-lc>          # e.g. ayc-2 ; fall back to the PR number if none
-BR=pr-media/$TK; DIR=docs/pr-media/$TK
-RAW=https://raw.githubusercontent.com/ayunis-core/ayunis-core/$BR/$DIR
-SRC=<scratchpad>/pr-media          # whatever you actually captured lives here
-MW=$(mktemp -d)
-cd "$REPO"                                                     # git worktree ops must run from the checkout, not the scratchpad CWD
-git worktree prune; git branch -D "$BR" 2>/dev/null || true   # so re-runs on the same ticket don't hit "branch already exists"
-git worktree add --orphan -b "$BR" "$MW"            # unborn branch, empty tree
-mkdir -p "$MW/$DIR"
-# copy only the media that exists (screenshots always; gif only if ffmpeg produced one)
-find "$SRC" -maxdepth 1 -type f \( -name '*.png' -o -name '*.gif' \) -exec cp {} "$MW/$DIR"/ \;
-cd "$MW" && git add -A && git commit -q -m "docs(pr-media): $TK" && git push -fu origin "$BR"
-cd "$REPO" && git worktree remove "$MW" --force     # local worktree only; remote branch STAYS
-
-# embed EXACTLY the files that were published — never hardcode names, or you get 404s
-# read the current body FIRST; abort if it fails, so a transient gh error can't overwrite the description with only the media block
-OLD=$(gh pr view "$PR" --json body -q '.body // ""') || { echo "could not read PR body — skipping embed" >&2; exit 1; }
-{ printf '%s\n' "$OLD" | sed '/^### Screenshots \/ demo$/,$d'
-  printf '\n### Screenshots / demo\n\n'
-  for f in $(cd "$SRC" && ls *.png 2>/dev/null | sort); do
-    curl -sfI "$RAW/$f" >/dev/null && echo "raw url OK: $f" >&2 || echo "raw url NOT reachable: $f" >&2
-    printf '![%s](%s/%s)\n\n' "${f%.png}" "$RAW" "$f"
-  done
-  for g in $(cd "$SRC" && ls *.gif 2>/dev/null); do
-    printf '![demo](%s/%s)\n\n' "$RAW" "$g"     # only emitted if a gif exists
-  done
-  printf '> Media hosted on the `%s` branch (not part of this PR'\''s diff); safe to delete after merge.\n' "$BR"
-} > /tmp/qa-body.md
-gh pr edit "$PR" --body-file /tmp/qa-body.md
-```
-
-- The `pr-media/<ticket>` branch is **not** part of the diff and is **exempt from teardown** — leave it until the PR merges (deleting it while the PR is open breaks the images).
-- Re-runs `push -f` to the same branch and the `sed` strips the old block, so repeat QA keeps the PR body clean.
-- Verify the images actually render: `gh pr view $PR --web` (the `curl -I` above already confirms the raw URL resolves).
+When PR media is warranted, load the `pr-media` skill and follow its current publication workflow. Capture only the affected states and viewports. Add a GIF only when an interaction, transition, or multi-step flow cannot be judged from static screenshots. Do not duplicate the publishing implementation here; `pr-media` is the source of truth for its branch naming, automation, and verification.
 
 ## 5. Report
 
-Present the acceptance-criteria checklist, each ✅/❌ with its evidence (asserted values, screenshot path). If anything failed, say so plainly with the observed vs expected — do not soften it. This is the whole point. For frontend PRs, confirm the media was published to `pr-media/<ticket>` and embedded in the PR body (step 4b), with the PR link.
+Present the acceptance-criteria checklist, each ✅/❌ with its evidence (asserted values, screenshot path). If anything failed, say so plainly with the observed vs expected — do not soften it. This is the whole point. When PR media was warranted, confirm the `pr-media` workflow published and verified it.
 
 ## 6. Tear down — leave the machine exactly as found
 

--- a/.claude/skills/test-driven-development/SKILL.md
+++ b/.claude/skills/test-driven-development/SKILL.md
@@ -33,7 +33,7 @@ When a bug is reported, **don't start by trying to fix it**. Start by writing a 
 2. The failing test confirms the bug exists and that you understand it.
 3. Implement the fix.
 4. The test now passes — fix proven, regression guarded.
-5. Run the full suite. No new failures.
+5. Run the additional validation required by the repository's Proportional Workflow and the applicable surface-specific skill.
 
 If you can't write a failing test for the bug, you don't understand the bug yet. Stop and figure it out before touching the code.
 
@@ -167,7 +167,7 @@ it('validates titles correctly', () => {
 After implementation:
 
 - [ ] Every new behavior has a corresponding test
-- [ ] All tests pass — and the test runner's output proves it
+- [ ] All tests required by the Proportional Workflow pass — and the test runner's output proves it
 - [ ] Bug fixes include a reproduction test that failed before the fix
 - [ ] Test names describe behavior, not implementation
 - [ ] No skipped or disabled tests


### PR DESCRIPTION
## Summary

- add Fast, Standard, and High-Risk workflow paths to the canonical repository guidance
- align backend, frontend, E2E, QA, PR-media, Linear, and TDD skills with proportional validation
- preserve strict safety gates for security, data, infrastructure, and submitted PR verification

## Validation

- local five-lens self-review completed with no remaining actionable findings
- Markdown lint passed for all ten changed files in the pre-commit hook
- modified skill frontmatter parsed successfully as YAML

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit da91acc63b5d4a8771e3176f275227f82badba21. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
