### PR TITLE
fix(sso): hide local auth settings for SSO users (AYC-861)

### DIFF
--- a/ayunis-core-e2e/tests/settings/account.spec.ts
+++ b/ayunis-core-e2e/tests/settings/account.spec.ts
@@ -1,17 +1,77 @@
+import {
+  confirmEmail,
+  login,
+  registerOrg,
+} from '../../src/clients/api/auth.client';
+import { generatedApi } from '../../src/clients/api/generated-api';
 import { expect, test } from '../../src/fixtures/test';
 
-test('does not expose self-service organization SSO linking', async ({
+test('shows password and two-factor settings for local users', async ({
   page,
 }) => {
-  const discoveryRequests: string[] = [];
-  page.on('request', (request) => {
-    if (new URL(request.url()).pathname.endsWith('/auth/sso/discover')) {
-      discoveryRequests.push(request.url());
-    }
-  });
+  const discoveryResponse = page.waitForResponse((response) =>
+    new URL(response.url()).pathname.endsWith('/auth/sso/discover'),
+  );
 
   await page.goto('/settings/account');
 
   await expect(page.getByTestId('account-settings-page')).toBeVisible();
-  expect(discoveryRequests).toEqual([]);
+  await expect(page.getByTestId('account-password-settings')).toBeVisible();
+  await expect(page.getByTestId('account-two-factor-settings')).toBeVisible();
+  expect((await discoveryResponse).ok()).toBe(true);
+});
+
+test('hides password and two-factor settings for SSO users', async ({
+  mail,
+  page,
+  publicApi,
+}) => {
+  const key = Date.now().toString(36);
+  const domain = `account-${key}.e2e.local`;
+  const email = `admin@${domain}`;
+  const password = 'E2e-Password-1';
+  await registerOrg(publicApi, {
+    email,
+    password,
+    orgName: `SSO Account ${key}`,
+    userName: `SSO Account Admin ${key}`,
+  });
+  const token = await mail.extractLinkToken(email, '/confirm-email');
+  await confirmEmail(publicApi, token);
+  await login(publicApi, email, password);
+  const currentUser = await generatedApi.authenticationControllerMe({
+    api: publicApi,
+  });
+  const userCookies = (await publicApi.storageState()).cookies;
+
+  await login(publicApi, 'admin@demo.local', 'admin');
+  const zitadelOrgId = `zitadel-${key}`;
+  await generatedApi.superAdminSsoConnectionsControllerConfigure(
+    currentUser.orgId,
+    {
+      emailDomains: [domain],
+      zitadelOrgId,
+      domainVerified: true,
+    },
+    { api: publicApi },
+  );
+  await generatedApi.superAdminSsoConnectionsControllerSetEnabled(
+    currentUser.orgId,
+    {
+      enabled: true,
+      confirmed: true,
+      reviewedEmailDomains: [domain],
+      reviewedZitadelOrgId: zitadelOrgId,
+    },
+    { api: publicApi },
+  );
+
+  await page.context().clearCookies();
+  await page.context().addCookies(userCookies);
+
+  await page.goto('/settings/account');
+
+  await expect(page.getByTestId('account-settings-page')).toBeVisible();
+  await expect(page.getByTestId('account-password-settings')).toHaveCount(0);
+  await expect(page.getByTestId('account-two-factor-settings')).toHaveCount(0);
 });

--- a/ayunis-core-frontend/src/app/routes/_authenticated/settings.account.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/settings.account.tsx
@@ -3,6 +3,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import {
   authenticationControllerMe,
   getAuthenticationControllerMeQueryKey,
+  ssoLoginControllerDiscover,
 } from '@/shared/api';
 import { queryOptions } from '@tanstack/react-query';
 
@@ -14,17 +15,21 @@ export const Route = createFileRoute('/_authenticated/settings/account')({
         queryFn: () => authenticationControllerMe(),
       }),
     );
+    const sso = await ssoLoginControllerDiscover({
+      email: data.email,
+    }).catch(() => ({ available: false, orgId: undefined }));
     return {
       user: {
         name: data.name,
         email: data.email,
       },
+      isSsoEnabled: sso.available && sso.orgId === data.orgId,
     };
   },
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  const { user } = Route.useLoaderData();
-  return <AccountSettingsPage user={user} />;
+  const { user, isSsoEnabled } = Route.useLoaderData();
+  return <AccountSettingsPage user={user} isSsoEnabled={isSsoEnabled} />;
 }

--- a/ayunis-core-frontend/src/pages/settings/account-settings/ui/AccountSettingsPage.test.tsx
+++ b/ayunis-core-frontend/src/pages/settings/account-settings/ui/AccountSettingsPage.test.tsx
@@ -10,10 +10,10 @@ vi.mock('@/pages/settings/account-settings/ui/ProfileInformationCard', () => ({
   ProfileInformationCard: () => null,
 }));
 vi.mock('@/pages/settings/account-settings/ui/PasswordSettingsPage', () => ({
-  default: () => null,
+  default: () => <div data-testid="password-settings" />,
 }));
 vi.mock('@/pages/settings/account-settings/ui/TwoFactorCard', () => ({
-  TwoFactorCard: () => null,
+  TwoFactorCard: () => <div data-testid="two-factor-settings" />,
 }));
 vi.mock('@/pages/settings/account-settings/ui/AcademyCertificateCard', () => ({
   AcademyCertificateCard: () => null,
@@ -24,10 +24,35 @@ vi.mock('react-i18next', () => ({
 }));
 
 describe(AccountSettingsPage.name, () => {
+  it('shows password and two-factor settings for local users', () => {
+    render(
+      <AccountSettingsPage
+        user={{ name: 'Admin', email: 'admin@stadt.example' }}
+        isSsoEnabled={false}
+      />,
+    );
+
+    expect(screen.getByTestId('password-settings')).toBeTruthy();
+    expect(screen.getByTestId('two-factor-settings')).toBeTruthy();
+  });
+
+  it('hides password and two-factor settings for SSO users', () => {
+    render(
+      <AccountSettingsPage
+        user={{ name: 'Admin', email: 'admin@stadt.example' }}
+        isSsoEnabled
+      />,
+    );
+
+    expect(screen.queryByTestId('password-settings')).toBeNull();
+    expect(screen.queryByTestId('two-factor-settings')).toBeNull();
+  });
+
   it('does not offer organization SSO account linking', () => {
     render(
       <AccountSettingsPage
         user={{ name: 'Admin', email: 'admin@stadt.example' }}
+        isSsoEnabled
       />,
     );
 

--- a/ayunis-core-frontend/src/pages/settings/account-settings/ui/AccountSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/settings/account-settings/ui/AccountSettingsPage.tsx
@@ -15,8 +15,10 @@ import { AcademyCertificateCard } from '@/pages/settings/account-settings/ui/Aca
 
 export default function AccountSettingsPage({
   user,
+  isSsoEnabled,
 }: Readonly<{
   user: { name: string; email: string };
+  isSsoEnabled: boolean;
 }>) {
   const { t } = useTranslation('settings');
 
@@ -27,8 +29,16 @@ export default function AccountSettingsPage({
     >
       <div className="space-y-4" data-testid="account-settings-page">
         <ProfileInformationCard user={user} />
-        <PasswordSettingsPage />
-        <TwoFactorCard />
+        {!isSsoEnabled && (
+          <>
+            <div data-testid="account-password-settings">
+              <PasswordSettingsPage />
+            </div>
+            <div data-testid="account-two-factor-settings">
+              <TwoFactorCard />
+            </div>
+          </>
+        )}
         <AcademyCertificateCard />
         {/* Account Actions */}
         <Card>


### PR DESCRIPTION
## Summary

- hide password and built-in two-factor settings when the signed-in user's email resolves to an enabled SSO connection for the same organization
- keep both settings visible for local users
- cover AYC-861 and AYC-862 with component tests and a real-stack Playwright journey

## Validation

- focused account-settings component tests (3 passed)
- frontend production build and focused ESLint
- E2E lint and TypeScript typecheck
- focused real-stack Playwright run against slot 6 (3 passed)