### PR TITLE
docs(workflow): place backend responsibilities before coding (AYC-000)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -51,6 +51,7 @@ When an access path or tool fails, report the blocker immediately. Do not keep s
 ### 4. Respect Boundaries
 
 - Read the target module's SUMMARY.md before making changes
+- Before adding a backend file, inspect the target layer's existing directories and two closest analogues. Place validation, orchestration, policy, domain invariants, and persistence in their established layer-specific locations; controllers only map validated HTTP input and orchestrate use cases.
 - Respect module boundaries — the `ayunis-core-backend` skill documents how cross-module work is done (application-layer code uses exported use cases from the target module, not ports/adapters; TypeORM schema records may reference records in other modules to declare foreign-key relations — see the `typeorm-migrations` skill)
 - Never edit generated code (e.g., the frontend API client)
 

--- a/.claude/skills/ayunis-core-backend/SKILL.md
+++ b/.claude/skills/ayunis-core-backend/SKILL.md
@@ -32,6 +32,21 @@ Cross-module communication uses **exported use cases**, not ports/adapters. When
 
 Before modifying any module, read its `SUMMARY.md`. See [ARCHITECTURE.md](../../ARCHITECTURE.md) for the complete module index.
 
+## Place Responsibilities Before Writing Code
+
+Before adding a backend file, inventory the target module's existing directories and inspect the two closest analogues. Follow the module's established vocabulary and placement; do not create a file directly under a layer root such as `application/` when its role belongs in an existing subdirectory.
+
+Assign each responsibility to one layer before implementation:
+
+- **Presenter DTOs** validate transport input completely, including conditional requirements and exact confirmation values.
+- **Controllers** translate validated HTTP input, invoke use cases, and translate results. They do not repeat DTO validation, make business decisions, or query repositories.
+- **Application models** hold data and behavior shared across commands or use cases without becoming domain state. Put them under `application/models/`.
+- **Application services/use cases** coordinate policy decisions and cross-module calls. Prefer a service when multiple entry points enforce the same policy.
+- **Domain objects** own business invariants intrinsic to persisted domain state.
+- **Infrastructure records and mappers** mirror persistence; they do not decide application policy.
+
+Before finalizing the design, check for the same policy or entity lookup in adjacent controllers and use cases. Consolidate duplicated decisions at the narrowest shared application boundary and avoid loading the same entity twice in one request path.
+
 ## ConfigService access — match the `registerAs` namespace
 
 Backend config is loaded via `registerAs('<namespace>', () => ({...}))` factories. **The lookup key must be prefixed with the namespace**, or `ConfigService.get(...)` returns `undefined` and the call site silently uses a missing value (e.g. `apiKey: undefined` → 401 at runtime, not at boot).


### PR DESCRIPTION
## Summary

- require inspecting the module structure and nearby analogues before adding backend files
- define where transport validation, orchestration, policy, domain invariants, and persistence belong
- keep controllers limited to mapping validated input and orchestrating use cases

## Validation

- `git diff --check`
- skill frontmatter unchanged; no scaffold placeholders introduced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent skills and guidelines; no runtime, API, or security behavior is modified.
> 
> **Overview**
> Adds agent workflow guidance so new backend work is placed in the right hexagonal layers **before** implementation, instead of defaulting files under layer roots or duplicating policy in controllers.
> 
> **`CLAUDE.md`** extends **Respect Boundaries** with a pre-file checklist: inspect the target layer’s directories and two closest analogues, and keep validation, orchestration, policy, domain invariants, and persistence in their established locations while controllers only map validated HTTP input and orchestrate use cases.
> 
> **`ayunis-core-backend` skill** adds a **Place Responsibilities Before Writing Code** section that spells out per-layer duties (presenter DTOs, controllers, application models/services, domain, infrastructure) and asks authors to consolidate duplicated policy lookups and avoid loading the same entity twice on one request path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1fa89b7f474b264afc7fbe6f39c5b184ea32a63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->