### PR TITLE
fix(super-admin): guard every super admin route at the layout (AYC-000)

### DIFF
--- a/ayunis-core-e2e/tests/super-admin/access-control.spec.ts
+++ b/ayunis-core-e2e/tests/super-admin/access-control.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '../../src/fixtures/test';
+
+// Every super-admin route, including the ones that used to carry no route
+// guard and surfaced the backend 403 as the generic error screen.
+const SUPER_ADMIN_ROUTES = [
+  '/super-admin-settings',
+  '/super-admin-settings/orgs',
+  '/super-admin-settings/orgs/00000000-0000-0000-0000-000000000000',
+  '/super-admin-settings/users',
+  '/super-admin-settings/skills',
+  '/super-admin-settings/super-admins',
+  '/super-admin-settings/models-catalog',
+  '/super-admin-settings/platform-config',
+  '/super-admin-settings/academy',
+  '/super-admin-settings/anonymization',
+  '/super-admin-settings/app-alerts',
+];
+
+test('org admin without the super admin system role is redirected off every super admin route', async ({
+  page,
+}) => {
+  for (const route of SUPER_ADMIN_ROUTES) {
+    await page.goto(route);
+    await expect(page).toHaveURL(/\/chat/);
+  }
+});

--- a/ayunis-core-frontend/src/app/routeTree.gen.ts
+++ b/ayunis-core-frontend/src/app/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthenticatedSuperAdminSettingsRouteImport } from './routes/_authenticated/super-admin-settings'
 import { Route as AuthenticatedInstallRouteImport } from './routes/_authenticated/install'
 import { Route as AuthenticatedAdminSettingsRouteImport } from './routes/_authenticated/admin-settings'
 import { Route as onboardingTwoFactorRouteImport } from './routes/(onboarding)/two-factor'
@@ -82,6 +83,12 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AuthenticatedSuperAdminSettingsRoute =
+  AuthenticatedSuperAdminSettingsRouteImport.update({
+    id: '/super-admin-settings',
+    path: '/super-admin-settings',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedInstallRoute = AuthenticatedInstallRouteImport.update({
   id: '/install',
   path: '/install',
@@ -136,9 +143,9 @@ const AuthenticatedWorkspacesIndexRoute =
   } as any)
 const AuthenticatedSuperAdminSettingsIndexRoute =
   AuthenticatedSuperAdminSettingsIndexRouteImport.update({
-    id: '/super-admin-settings/',
-    path: '/super-admin-settings/',
-    getParentRoute: () => AuthenticatedRoute,
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedSuperAdminSettingsRoute,
   } as any)
 const AuthenticatedSkillsIndexRoute =
   AuthenticatedSkillsIndexRouteImport.update({
@@ -339,57 +346,57 @@ const onboardingAccountActivateRoute =
   } as any)
 const AuthenticatedSuperAdminSettingsUsersIndexRoute =
   AuthenticatedSuperAdminSettingsUsersIndexRouteImport.update({
-    id: '/super-admin-settings/users/',
-    path: '/super-admin-settings/users/',
-    getParentRoute: () => AuthenticatedRoute,
+    id: '/users/',
+    path: '/users/',
+    getParentRoute: () => AuthenticatedSuperAdminSettingsRoute,
   } as any)
 const AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute =
   AuthenticatedSuperAdminSettingsSuperAdminsIndexRouteImport.update({
-    id: '/super-admin-settings/super-admins/',
-    path: '/super-admin-settings/super-admins/',
-    getParentRoute: () => AuthenticatedRoute,
+    id: '/super-admins/',
+    path: '/super-admins/',
+    getParentRoute: () => AuthenticatedSuperAdminSettingsRoute,
   } as any)
 const AuthenticatedSuperAdminSettingsSkillsIndexRoute =
   AuthenticatedSuperAdminSettingsSkillsIndexRouteImport.update({
-    id: '/super-admin-settings/skills/',
-    path: '/super-admin-settings/skills/',
-    getParentRoute: () => AuthenticatedRoute,
+    id: '/skills/',
+    path: '/skills/',
+    getParentRoute: () => AuthenticatedSuperAdminSettingsRoute,
   } as any)
 const AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute =
   AuthenticatedSuperAdminSettingsPlatformConfigIndexRouteImport.update({
-    id: '/super-admin-settings/platform-config/',
-    path: '/super-admin-settings/platform-config/',
-    getParentRoute: () => AuthenticatedRoute,
+    id: '/platform-config/',
+    path: '/platform-config/',
+    getParentRoute: () => AuthenticatedSuperAdminSettingsRoute,
   } as any)
 const AuthenticatedSuperAdminSettingsOrgsIndexRoute =
   AuthenticatedSuperAdminSettingsOrgsIndexRouteImport.update({
-    id: '/super-admin-settings/orgs/',
-    path: '/super-admin-settings/orgs/',
-    getParentRoute: () => AuthenticatedRoute,
+    id: '/orgs/',
+    path: '/orgs/',
+    getParentRoute: () => AuthenticatedSuperAdminSettingsRoute,
   } as any)
 const AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute =
   AuthenticatedSuperAdminSettingsModelsCatalogIndexRouteImport.update({
-    id: '/super-admin-settings/models-catalog/',
-    path: '/super-admin-settings/models-catalog/',
-    getParentRoute: () => AuthenticatedRoute,
+    id: '/models-catalog/',
+    path: '/models-catalog/',
+    getParentRoute: () => AuthenticatedSuperAdminSettingsRoute,
   } as any)
 const AuthenticatedSuperAdminSettingsAppAlertsIndexRoute =
   AuthenticatedSuperAdminSettingsAppAlertsIndexRouteImport.update({
-    id: '/super-admin-settings/app-alerts/',
-    path: '/super-admin-settings/app-alerts/',
-    getParentRoute: () => AuthenticatedRoute,
+    id: '/app-alerts/',
+    path: '/app-alerts/',
+    getParentRoute: () => AuthenticatedSuperAdminSettingsRoute,
   } as any)
 const AuthenticatedSuperAdminSettingsAnonymizationIndexRoute =
   AuthenticatedSuperAdminSettingsAnonymizationIndexRouteImport.update({
-    id: '/super-admin-settings/anonymization/',
-    path: '/super-admin-settings/anonymization/',
-    getParentRoute: () => AuthenticatedRoute,
+    id: '/anonymization/',
+    path: '/anonymization/',
+    getParentRoute: () => AuthenticatedSuperAdminSettingsRoute,
   } as any)
 const AuthenticatedSuperAdminSettingsAcademyIndexRoute =
   AuthenticatedSuperAdminSettingsAcademyIndexRouteImport.update({
-    id: '/super-admin-settings/academy/',
-    path: '/super-admin-settings/academy/',
-    getParentRoute: () => AuthenticatedRoute,
+    id: '/academy/',
+    path: '/academy/',
+    getParentRoute: () => AuthenticatedSuperAdminSettingsRoute,
   } as any)
 const AuthenticatedAdminSettingsTeamsIndexRoute =
   AuthenticatedAdminSettingsTeamsIndexRouteImport.update({
@@ -405,9 +412,9 @@ const AuthenticatedAdminSettingsLetterheadsIndexRoute =
   } as any)
 const AuthenticatedSuperAdminSettingsOrgsIdRoute =
   AuthenticatedSuperAdminSettingsOrgsIdRouteImport.update({
-    id: '/super-admin-settings/orgs/$id',
-    path: '/super-admin-settings/orgs/$id',
-    getParentRoute: () => AuthenticatedRoute,
+    id: '/orgs/$id',
+    path: '/orgs/$id',
+    getParentRoute: () => AuthenticatedSuperAdminSettingsRoute,
   } as any)
 const AuthenticatedAdminSettingsTeamsIdRoute =
   AuthenticatedAdminSettingsTeamsIdRouteImport.update({
@@ -445,6 +452,7 @@ export interface FileRoutesByFullPath {
   '/two-factor': typeof onboardingTwoFactorRoute
   '/admin-settings': typeof AuthenticatedAdminSettingsRouteWithChildren
   '/install': typeof AuthenticatedInstallRoute
+  '/super-admin-settings': typeof AuthenticatedSuperAdminSettingsRouteWithChildren
   '/account/activate': typeof onboardingAccountActivateRoute
   '/password/forgot': typeof onboardingPasswordForgotRoute
   '/password/reset': typeof onboardingPasswordResetRoute
@@ -574,6 +582,7 @@ export interface FileRoutesById {
   '/(onboarding)/two-factor': typeof onboardingTwoFactorRoute
   '/_authenticated/admin-settings': typeof AuthenticatedAdminSettingsRouteWithChildren
   '/_authenticated/install': typeof AuthenticatedInstallRoute
+  '/_authenticated/super-admin-settings': typeof AuthenticatedSuperAdminSettingsRouteWithChildren
   '/(onboarding)/account/activate': typeof onboardingAccountActivateRoute
   '/(onboarding)/password/forgot': typeof onboardingPasswordForgotRoute
   '/(onboarding)/password/reset': typeof onboardingPasswordResetRoute
@@ -640,6 +649,7 @@ export interface FileRouteTypes {
     | '/two-factor'
     | '/admin-settings'
     | '/install'
+    | '/super-admin-settings'
     | '/account/activate'
     | '/password/forgot'
     | '/password/reset'
@@ -768,6 +778,7 @@ export interface FileRouteTypes {
     | '/(onboarding)/two-factor'
     | '/_authenticated/admin-settings'
     | '/_authenticated/install'
+    | '/_authenticated/super-admin-settings'
     | '/(onboarding)/account/activate'
     | '/(onboarding)/password/forgot'
     | '/(onboarding)/password/reset'
@@ -856,6 +867,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_authenticated/super-admin-settings': {
+      id: '/_authenticated/super-admin-settings'
+      path: '/super-admin-settings'
+      fullPath: '/super-admin-settings'
+      preLoaderRoute: typeof AuthenticatedSuperAdminSettingsRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/install': {
       id: '/_authenticated/install'
       path: '/install'
@@ -928,10 +946,10 @@ declare module '@tanstack/react-router' {
     }
     '/_authenticated/super-admin-settings/': {
       id: '/_authenticated/super-admin-settings/'
-      path: '/super-admin-settings'
+      path: '/'
       fullPath: '/super-admin-settings/'
       preLoaderRoute: typeof AuthenticatedSuperAdminSettingsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+      parentRoute: typeof AuthenticatedSuperAdminSettingsRoute
     }
     '/_authenticated/skills/': {
       id: '/_authenticated/skills/'
@@ -1173,66 +1191,66 @@ declare module '@tanstack/react-router' {
     }
     '/_authenticated/super-admin-settings/users/': {
       id: '/_authenticated/super-admin-settings/users/'
-      path: '/super-admin-settings/users'
+      path: '/users'
       fullPath: '/super-admin-settings/users/'
       preLoaderRoute: typeof AuthenticatedSuperAdminSettingsUsersIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+      parentRoute: typeof AuthenticatedSuperAdminSettingsRoute
     }
     '/_authenticated/super-admin-settings/super-admins/': {
       id: '/_authenticated/super-admin-settings/super-admins/'
-      path: '/super-admin-settings/super-admins'
+      path: '/super-admins'
       fullPath: '/super-admin-settings/super-admins/'
       preLoaderRoute: typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+      parentRoute: typeof AuthenticatedSuperAdminSettingsRoute
     }
     '/_authenticated/super-admin-settings/skills/': {
       id: '/_authenticated/super-admin-settings/skills/'
-      path: '/super-admin-settings/skills'
+      path: '/skills'
       fullPath: '/super-admin-settings/skills/'
       preLoaderRoute: typeof AuthenticatedSuperAdminSettingsSkillsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+      parentRoute: typeof AuthenticatedSuperAdminSettingsRoute
     }
     '/_authenticated/super-admin-settings/platform-config/': {
       id: '/_authenticated/super-admin-settings/platform-config/'
-      path: '/super-admin-settings/platform-config'
+      path: '/platform-config'
       fullPath: '/super-admin-settings/platform-config/'
       preLoaderRoute: typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+      parentRoute: typeof AuthenticatedSuperAdminSettingsRoute
     }
     '/_authenticated/super-admin-settings/orgs/': {
       id: '/_authenticated/super-admin-settings/orgs/'
-      path: '/super-admin-settings/orgs'
+      path: '/orgs'
       fullPath: '/super-admin-settings/orgs/'
       preLoaderRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+      parentRoute: typeof AuthenticatedSuperAdminSettingsRoute
     }
     '/_authenticated/super-admin-settings/models-catalog/': {
       id: '/_authenticated/super-admin-settings/models-catalog/'
-      path: '/super-admin-settings/models-catalog'
+      path: '/models-catalog'
       fullPath: '/super-admin-settings/models-catalog/'
       preLoaderRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+      parentRoute: typeof AuthenticatedSuperAdminSettingsRoute
     }
     '/_authenticated/super-admin-settings/app-alerts/': {
       id: '/_authenticated/super-admin-settings/app-alerts/'
-      path: '/super-admin-settings/app-alerts'
+      path: '/app-alerts'
       fullPath: '/super-admin-settings/app-alerts/'
       preLoaderRoute: typeof AuthenticatedSuperAdminSettingsAppAlertsIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+      parentRoute: typeof AuthenticatedSuperAdminSettingsRoute
     }
     '/_authenticated/super-admin-settings/anonymization/': {
       id: '/_authenticated/super-admin-settings/anonymization/'
-      path: '/super-admin-settings/anonymization'
+      path: '/anonymization'
       fullPath: '/super-admin-settings/anonymization/'
       preLoaderRoute: typeof AuthenticatedSuperAdminSettingsAnonymizationIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+      parentRoute: typeof AuthenticatedSuperAdminSettingsRoute
     }
     '/_authenticated/super-admin-settings/academy/': {
       id: '/_authenticated/super-admin-settings/academy/'
-      path: '/super-admin-settings/academy'
+      path: '/academy'
       fullPath: '/super-admin-settings/academy/'
       preLoaderRoute: typeof AuthenticatedSuperAdminSettingsAcademyIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
+      parentRoute: typeof AuthenticatedSuperAdminSettingsRoute
     }
     '/_authenticated/admin-settings/teams/': {
       id: '/_authenticated/admin-settings/teams/'
@@ -1250,10 +1268,10 @@ declare module '@tanstack/react-router' {
     }
     '/_authenticated/super-admin-settings/orgs/$id': {
       id: '/_authenticated/super-admin-settings/orgs/$id'
-      path: '/super-admin-settings/orgs/$id'
+      path: '/orgs/$id'
       fullPath: '/super-admin-settings/orgs/$id'
       preLoaderRoute: typeof AuthenticatedSuperAdminSettingsOrgsIdRouteImport
-      parentRoute: typeof AuthenticatedRoute
+      parentRoute: typeof AuthenticatedSuperAdminSettingsRoute
     }
     '/_authenticated/admin-settings/teams/$id': {
       id: '/_authenticated/admin-settings/teams/$id'
@@ -1342,9 +1360,55 @@ const AuthenticatedAdminSettingsRouteWithChildren =
     AuthenticatedAdminSettingsRouteChildren,
   )
 
+interface AuthenticatedSuperAdminSettingsRouteChildren {
+  AuthenticatedSuperAdminSettingsIndexRoute: typeof AuthenticatedSuperAdminSettingsIndexRoute
+  AuthenticatedSuperAdminSettingsOrgsIdRoute: typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
+  AuthenticatedSuperAdminSettingsAcademyIndexRoute: typeof AuthenticatedSuperAdminSettingsAcademyIndexRoute
+  AuthenticatedSuperAdminSettingsAnonymizationIndexRoute: typeof AuthenticatedSuperAdminSettingsAnonymizationIndexRoute
+  AuthenticatedSuperAdminSettingsAppAlertsIndexRoute: typeof AuthenticatedSuperAdminSettingsAppAlertsIndexRoute
+  AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
+  AuthenticatedSuperAdminSettingsOrgsIndexRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
+  AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute: typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
+  AuthenticatedSuperAdminSettingsSkillsIndexRoute: typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
+  AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute: typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
+  AuthenticatedSuperAdminSettingsUsersIndexRoute: typeof AuthenticatedSuperAdminSettingsUsersIndexRoute
+}
+
+const AuthenticatedSuperAdminSettingsRouteChildren: AuthenticatedSuperAdminSettingsRouteChildren =
+  {
+    AuthenticatedSuperAdminSettingsIndexRoute:
+      AuthenticatedSuperAdminSettingsIndexRoute,
+    AuthenticatedSuperAdminSettingsOrgsIdRoute:
+      AuthenticatedSuperAdminSettingsOrgsIdRoute,
+    AuthenticatedSuperAdminSettingsAcademyIndexRoute:
+      AuthenticatedSuperAdminSettingsAcademyIndexRoute,
+    AuthenticatedSuperAdminSettingsAnonymizationIndexRoute:
+      AuthenticatedSuperAdminSettingsAnonymizationIndexRoute,
+    AuthenticatedSuperAdminSettingsAppAlertsIndexRoute:
+      AuthenticatedSuperAdminSettingsAppAlertsIndexRoute,
+    AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute:
+      AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute,
+    AuthenticatedSuperAdminSettingsOrgsIndexRoute:
+      AuthenticatedSuperAdminSettingsOrgsIndexRoute,
+    AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute:
+      AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute,
+    AuthenticatedSuperAdminSettingsSkillsIndexRoute:
+      AuthenticatedSuperAdminSettingsSkillsIndexRoute,
+    AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute:
+      AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute,
+    AuthenticatedSuperAdminSettingsUsersIndexRoute:
+      AuthenticatedSuperAdminSettingsUsersIndexRoute,
+  }
+
+const AuthenticatedSuperAdminSettingsRouteWithChildren =
+  AuthenticatedSuperAdminSettingsRoute._addFileChildren(
+    AuthenticatedSuperAdminSettingsRouteChildren,
+  )
+
 interface AuthenticatedRouteChildren {
   AuthenticatedAdminSettingsRoute: typeof AuthenticatedAdminSettingsRouteWithChildren
   AuthenticatedInstallRoute: typeof AuthenticatedInstallRoute
+  AuthenticatedSuperAdminSettingsRoute: typeof AuthenticatedSuperAdminSettingsRouteWithChildren
   AuthenticatedAcademyChapterIdRoute: typeof AuthenticatedAcademyChapterIdRoute
   AuthenticatedChatsThreadIdRoute: typeof AuthenticatedChatsThreadIdRoute
   AuthenticatedKnowledgeBasesIdRoute: typeof AuthenticatedKnowledgeBasesIdRoute
@@ -1361,25 +1425,16 @@ interface AuthenticatedRouteChildren {
   AuthenticatedKnowledgeBasesIndexRoute: typeof AuthenticatedKnowledgeBasesIndexRoute
   AuthenticatedSettingsIndexRoute: typeof AuthenticatedSettingsIndexRoute
   AuthenticatedSkillsIndexRoute: typeof AuthenticatedSkillsIndexRoute
-  AuthenticatedSuperAdminSettingsIndexRoute: typeof AuthenticatedSuperAdminSettingsIndexRoute
   AuthenticatedWorkspacesIndexRoute: typeof AuthenticatedWorkspacesIndexRoute
   AuthenticatedAcademyChapterIdQuizRoute: typeof AuthenticatedAcademyChapterIdQuizRoute
-  AuthenticatedSuperAdminSettingsOrgsIdRoute: typeof AuthenticatedSuperAdminSettingsOrgsIdRoute
-  AuthenticatedSuperAdminSettingsAcademyIndexRoute: typeof AuthenticatedSuperAdminSettingsAcademyIndexRoute
-  AuthenticatedSuperAdminSettingsAnonymizationIndexRoute: typeof AuthenticatedSuperAdminSettingsAnonymizationIndexRoute
-  AuthenticatedSuperAdminSettingsAppAlertsIndexRoute: typeof AuthenticatedSuperAdminSettingsAppAlertsIndexRoute
-  AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute: typeof AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute
-  AuthenticatedSuperAdminSettingsOrgsIndexRoute: typeof AuthenticatedSuperAdminSettingsOrgsIndexRoute
-  AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute: typeof AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute
-  AuthenticatedSuperAdminSettingsSkillsIndexRoute: typeof AuthenticatedSuperAdminSettingsSkillsIndexRoute
-  AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute: typeof AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute
-  AuthenticatedSuperAdminSettingsUsersIndexRoute: typeof AuthenticatedSuperAdminSettingsUsersIndexRoute
   AuthenticatedSettingsIntegrationsOauthCallbackRoute: typeof AuthenticatedSettingsIntegrationsOauthCallbackRoute
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedAdminSettingsRoute: AuthenticatedAdminSettingsRouteWithChildren,
   AuthenticatedInstallRoute: AuthenticatedInstallRoute,
+  AuthenticatedSuperAdminSettingsRoute:
+    AuthenticatedSuperAdminSettingsRouteWithChildren,
   AuthenticatedAcademyChapterIdRoute: AuthenticatedAcademyChapterIdRoute,
   AuthenticatedChatsThreadIdRoute: AuthenticatedChatsThreadIdRoute,
   AuthenticatedKnowledgeBasesIdRoute: AuthenticatedKnowledgeBasesIdRoute,
@@ -1398,31 +1453,9 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedKnowledgeBasesIndexRoute: AuthenticatedKnowledgeBasesIndexRoute,
   AuthenticatedSettingsIndexRoute: AuthenticatedSettingsIndexRoute,
   AuthenticatedSkillsIndexRoute: AuthenticatedSkillsIndexRoute,
-  AuthenticatedSuperAdminSettingsIndexRoute:
-    AuthenticatedSuperAdminSettingsIndexRoute,
   AuthenticatedWorkspacesIndexRoute: AuthenticatedWorkspacesIndexRoute,
   AuthenticatedAcademyChapterIdQuizRoute:
     AuthenticatedAcademyChapterIdQuizRoute,
-  AuthenticatedSuperAdminSettingsOrgsIdRoute:
-    AuthenticatedSuperAdminSettingsOrgsIdRoute,
-  AuthenticatedSuperAdminSettingsAcademyIndexRoute:
-    AuthenticatedSuperAdminSettingsAcademyIndexRoute,
-  AuthenticatedSuperAdminSettingsAnonymizationIndexRoute:
-    AuthenticatedSuperAdminSettingsAnonymizationIndexRoute,
-  AuthenticatedSuperAdminSettingsAppAlertsIndexRoute:
-    AuthenticatedSuperAdminSettingsAppAlertsIndexRoute,
-  AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute:
-    AuthenticatedSuperAdminSettingsModelsCatalogIndexRoute,
-  AuthenticatedSuperAdminSettingsOrgsIndexRoute:
-    AuthenticatedSuperAdminSettingsOrgsIndexRoute,
-  AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute:
-    AuthenticatedSuperAdminSettingsPlatformConfigIndexRoute,
-  AuthenticatedSuperAdminSettingsSkillsIndexRoute:
-    AuthenticatedSuperAdminSettingsSkillsIndexRoute,
-  AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute:
-    AuthenticatedSuperAdminSettingsSuperAdminsIndexRoute,
-  AuthenticatedSuperAdminSettingsUsersIndexRoute:
-    AuthenticatedSuperAdminSettingsUsersIndexRoute,
   AuthenticatedSettingsIntegrationsOauthCallbackRoute:
     AuthenticatedSettingsIntegrationsOauthCallbackRoute,
 }

--- a/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.academy.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.academy.index.tsx
@@ -1,6 +1,5 @@
-import { createFileRoute, redirect } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
 import AcademyPage from '@/pages/super-admin-settings/academy';
-import { MeResponseDtoSystemRole } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import {
   getSuperAdminAcademyChaptersControllerGetChaptersQueryKey,
   superAdminAcademyChaptersControllerGetChapters,
@@ -10,11 +9,6 @@ export const Route = createFileRoute(
   '/_authenticated/super-admin-settings/academy/',
 )({
   component: RouteComponent,
-  beforeLoad: ({ context: { user } }) => {
-    if (user.systemRole !== MeResponseDtoSystemRole.super_admin) {
-      throw redirect({ to: '/' });
-    }
-  },
   loader: async ({ context: { queryClient } }) => {
     return {
       chapters: await queryClient.fetchQuery({

--- a/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.anonymization.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.anonymization.index.tsx
@@ -1,16 +1,10 @@
-import { createFileRoute, redirect } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
 import AnonymizationWhitelistPage from '@/pages/super-admin-settings/anonymization-whitelist';
-import { MeResponseDtoSystemRole } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 
 export const Route = createFileRoute(
   '/_authenticated/super-admin-settings/anonymization/',
 )({
   component: RouteComponent,
-  beforeLoad: ({ context: { user } }) => {
-    if (user.systemRole !== MeResponseDtoSystemRole.super_admin) {
-      throw redirect({ to: '/' });
-    }
-  },
 });
 
 function RouteComponent() {

--- a/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.app-alerts.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.app-alerts.index.tsx
@@ -1,16 +1,10 @@
-import { createFileRoute, redirect } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
 import AppAlertsPage from '@/pages/super-admin-settings/app-alerts';
-import { MeResponseDtoSystemRole } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 
 export const Route = createFileRoute(
   '/_authenticated/super-admin-settings/app-alerts/',
 )({
   component: RouteComponent,
-  beforeLoad: ({ context: { user } }) => {
-    if (user.systemRole !== MeResponseDtoSystemRole.super_admin) {
-      throw redirect({ to: '/' });
-    }
-  },
 });
 
 function RouteComponent() {

--- a/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.index.tsx
@@ -1,12 +1,7 @@
-import { MeResponseDtoSystemRole } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { createFileRoute, redirect } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/_authenticated/super-admin-settings/')({
-  beforeLoad: ({ context: { user } }) => {
-    if (user.systemRole !== MeResponseDtoSystemRole.super_admin) {
-      throw redirect({ to: '/' });
-    }
-
+  beforeLoad: () => {
     throw redirect({ to: '/super-admin-settings/orgs' });
   },
 });

--- a/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/super-admin-settings.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute, redirect, Outlet } from '@tanstack/react-router';
+import { MeResponseDtoSystemRole } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+
+function SuperAdminSettingsLayout() {
+  return <Outlet />;
+}
+
+export const Route = createFileRoute('/_authenticated/super-admin-settings')({
+  component: SuperAdminSettingsLayout,
+  // Every super-admin sub-route flows through here, so the role check lives in
+  // one place. Without it a non-super-admin's loader hits the API and the 403
+  // surfaces as the generic "unexpected error" screen.
+  beforeLoad: ({ context: { user } }) => {
+    if (user.systemRole !== MeResponseDtoSystemRole.super_admin) {
+      throw redirect({ to: '/' });
+    }
+  },
+});


### PR DESCRIPTION
## Problem

Seven of eleven super-admin routes carried no role guard. A regular user opening one by URL ran the route loader, hit the backend 403, and landed on the generic error screen — whose only affordance is a reload that fails identically.

| Route | Guard before | Behaviour for a non-super-admin |
| --- | --- | --- |
| `/super-admin-settings` | ✅ | redirect `/` |
| `academy`, `anonymization`, `app-alerts` | ✅ | redirect `/` |
| `users`, `orgs`, `orgs/$id`, `skills`, `super-admins`, `models-catalog` | ❌ | loader 403 → "Ein unerwarteter Fehler ist aufgetreten" |
| `platform-config` | ❌ | no loader either — rendered a broken super-admin page shell |

The backend was always correct: `SystemRolesGuard` returns 403 and audit-logs the denial. The sidebar entry is also correctly gated, so the way in is a direct URL — a bookmark, a shared link, or a demoted super-admin.

Root cause: the guard was copy-pasted per route instead of living on a shared parent, so new routes silently shipped without it.

## Fix

Adds `super-admin-settings.tsx` — a layout route mirroring the existing `admin-settings.tsx` pattern: `Outlet` plus one `beforeLoad` role check. All eleven routes now hang off it, and the four duplicated guards are gone. `beforeLoad` runs before any child loader, so the 403 never happens.

No new 403 page: `admin-settings` redirects home rather than explaining, and a user who cannot see the sidebar link has no reason to be told the section exists.

## Verification

- New e2e spec `tests/super-admin/access-control.spec.ts` — org admin (non-super-admin) hits all eleven routes, asserts redirect to `/chat`.
- **Confirmed the spec fails without the fix.** With the layout route removed, the failure artifact captures the reported bug verbatim: heading `Ein Fehler ist aufgetreten`, body `Ein unerwarteter Fehler ist aufgetreten. Bitte laden Sie die Seite neu, um fortzufahren.`
- Allow-path regression covered by the existing `users-list.spec.ts` and `account-lockout.spec.ts`, which log in as a real super admin — both still pass.
- `vite build`, `tsc --noEmit`, `eslint --max-warnings=0`, e2e lint + typecheck all clean.

```
✓ tests/super-admin/access-control.spec.ts  — redirected off every super admin route
✓ tests/super-admin/users-list.spec.ts      — super admin searches users and opens their organization
✓ tests/super-admin/account-lockout.spec.ts — super admin sees and unlocks a locked account
4 passed
```

## Before / after

Same principal both sides: an org admin **without** the `super_admin` system role, opening `/super-admin-settings/users` directly. Captured locally against a seeded e2e stack; the "before" column is this branch with the new layout route removed.

| Before | After |
| --- | --- |
| ![before desktop](https://raw.githubusercontent.com/ayunis-core/ayunis-core/1a4c4d9a8d1699db4e0b1ec1bf2549bf7ccc7562/docs/pr-media/pr-1583/denied-before--desktop.png) | ![after desktop](https://raw.githubusercontent.com/ayunis-core/ayunis-core/1a4c4d9a8d1699db4e0b1ec1bf2549bf7ccc7562/docs/pr-media/pr-1583/denied-after--desktop.png) |

<details><summary>Mobile (375px)</summary>

| Before | After |
| --- | --- |
| ![before mobile](https://raw.githubusercontent.com/ayunis-core/ayunis-core/1a4c4d9a8d1699db4e0b1ec1bf2549bf7ccc7562/docs/pr-media/pr-1583/denied-before--mobile.png) | ![after mobile](https://raw.githubusercontent.com/ayunis-core/ayunis-core/1a4c4d9a8d1699db4e0b1ec1bf2549bf7ccc7562/docs/pr-media/pr-1583/denied-after--mobile.png) |

</details>

The automated PR-media comment below adds the desktop/mobile GIF of the `platform-config` redirect.
