### PR TITLE
fix(dev): terminate the full process tree on ./dev down (AYC-877)

### DIFF
--- a/dev
+++ b/dev
@@ -433,6 +433,20 @@ cmd_down() {
   # Stop Docker infrastructure
   dc down
 
+  local entry label port pids leftovers=""
+  for entry in "Backend:$BACKEND_PORT" "Frontend:$FRONTEND_PORT"; do
+    label="${entry%%:*}"
+    port="${entry##*:}"
+    pids="$(_listener_pids "$port")"
+    if [ -n "$pids" ]; then
+      leftovers="$leftovers $label port $port (PID $pids);"
+    fi
+  done
+
+  if [ -n "$leftovers" ]; then
+    die "Slot $SLOT is still occupied —$leftovers stop those processes or use another slot."
+  fi
+
   info "Slot $SLOT stopped."
 }
 
@@ -669,15 +683,35 @@ _service_healthy() {
     && _url_healthy "$url"
 }
 
+# The process that owns the port sits three to four levels below the pidfile pid
+# (infisical run -> pnpm shim -> pnpm -> node), so `pkill -P` reaches only the
+# middle of the chain and the leaf keeps listening.
+_descendant_pids() {
+  local pid="$1" child
+  while IFS= read -r child; do
+    [[ "$child" =~ ^[0-9]+$ ]] || continue
+    _descendant_pids "$child"
+    printf '%s\n' "$child"
+  done < <(pgrep -P "$pid" 2>/dev/null || true)
+}
+
+# Deepest-first, so a supervising parent (nest --watch) cannot respawn a leaf
+# after we signalled it. The process-group kill stays because a descendant that
+# has already been reparented away is invisible to the pgrep walk.
+_signal_process_tree() {
+  local signal="$1" pid="$2" descendant
+  while IFS= read -r descendant; do
+    kill -"$signal" "$descendant" 2>/dev/null || true
+  done < <(_descendant_pids "$pid")
+  kill -"$signal" -- -"$pid" 2>/dev/null || true
+  kill -"$signal" "$pid" 2>/dev/null || true
+}
+
 _terminate_process_tree() {
   local pid="$1"
-  kill -TERM -- -"$pid" 2>/dev/null || true
-  pkill -TERM -P "$pid" 2>/dev/null || true
-  kill -TERM "$pid" 2>/dev/null || true
+  _signal_process_tree TERM "$pid"
   sleep 1
-  kill -9 -- -"$pid" 2>/dev/null || true
-  pkill -9 -P "$pid" 2>/dev/null || true
-  kill -9 "$pid" 2>/dev/null || true
+  _signal_process_tree KILL "$pid"
 }
 
 _kill_pid() {

--- a/scripts/dev-status.test.sh
+++ b/scripts/dev-status.test.sh
@@ -93,7 +93,9 @@ fi
 cat >/dev/null
 EOF
 
-cat > "$TEST_DIR/bin/pkill" <<'EOF'
+# The termination walk enumerates descendants of the pidfile pid, so clearing
+# the marker here stands in for the surviving leaf process dying.
+cat > "$TEST_DIR/bin/pgrep" <<'EOF'
 #!/usr/bin/env bash
 if [[ -n "${FAKE_SURVIVING_LISTENER:-}" && "$*" == *"-P 999998"* ]]; then
   rm -f "$FAKE_SURVIVING_LISTENER"
@@ -105,7 +107,7 @@ chmod +x \
   "$TEST_DIR/bin/docker" \
   "$TEST_DIR/bin/curl" \
   "$TEST_DIR/bin/lsof" \
-  "$TEST_DIR/bin/pkill" \
+  "$TEST_DIR/bin/pgrep" \
   "$TEST_DIR/bin/xargs"
 
 failures=0
@@ -388,15 +390,66 @@ if [[ "$output" != *"Backend:   stopped  port 3970 occupied by unmanaged PID 999
   failures=$((failures + 1))
 fi
 
-PATH="$TEST_DIR/bin:$PATH" \
-  FAKE_LISTENER_PID=999997 \
-  FAKE_LISTENER_PORT=3970 \
-  FAKE_XARGS_CALLS="$TEST_DIR/xargs-calls" \
-  "$DOWN_DIR/dev" down >/dev/null 2>&1
+set +e
+output="$(
+  PATH="$TEST_DIR/bin:$PATH" \
+    FAKE_LISTENER_PID=999997 \
+    FAKE_LISTENER_PORT=3970 \
+    FAKE_XARGS_CALLS="$TEST_DIR/xargs-calls" \
+    "$DOWN_DIR/dev" down 2>&1
+)"
+status=$?
+set -e
 
 if [[ -s "$TEST_DIR/xargs-calls" ]]; then
   printf 'Expected dev down not to kill an unmanaged listener on the slot port.\n' >&2
   failures=$((failures + 1))
+fi
+
+if [[ $status -eq 0 || "$output" != *"Backend port 3970 (PID 999997)"* ]]; then
+  printf 'Expected dev down to fail loudly while a slot port is still held.\n%s\n' "$output" >&2
+  failures=$((failures + 1))
+fi
+
+# A real process chain: `dev down` must reach the grandchild, which is where the
+# port-owning node process actually sits. Only docker and lsof are faked here so
+# the kill runs against real pgrep/ps/kill.
+TREE_DIR="$TEST_DIR/tree"
+mkdir -p "$TREE_DIR/.dev/slot-97" "$TREE_DIR/bin"
+cp "$REPO_DIR/dev" "$TREE_DIR/dev"
+chmod +x "$TREE_DIR/dev"
+printf '97\n' > "$TREE_DIR/.dev/slot"
+cp "$TEST_DIR/bin/docker" "$TREE_DIR/bin/docker"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$TREE_DIR/bin/lsof"
+chmod +x "$TREE_DIR/bin/lsof"
+
+# The trailing `:` in each layer stops bash from exec-collapsing the level away.
+bash -c 'bash -c "sleep 300; :" ; :' &
+tree_root=$!
+disown "$tree_root" 2>/dev/null || true
+printf '%s\n' "$tree_root" > "$TREE_DIR/.dev/slot-97/backend.pid"
+
+tree_leaf=""
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  tree_middle="$(pgrep -P "$tree_root" 2>/dev/null | head -n 1 || true)"
+  if [[ -n "$tree_middle" ]]; then
+    tree_leaf="$(pgrep -P "$tree_middle" 2>/dev/null | head -n 1 || true)"
+    [[ -n "$tree_leaf" ]] && break
+  fi
+  sleep 0.2
+done
+
+if [[ -z "$tree_leaf" ]]; then
+  printf 'Test setup failed: could not build a three-level process chain.\n' >&2
+  failures=$((failures + 1))
+else
+  PATH="$TREE_DIR/bin:$PATH" "$TREE_DIR/dev" down >/dev/null 2>&1 || true
+  if kill -0 "$tree_leaf" 2>/dev/null; then
+    printf 'Expected dev down to terminate the grandchild holding the port (PID %s survived).\n' \
+      "$tree_leaf" >&2
+    failures=$((failures + 1))
+    kill -9 "$tree_leaf" 2>/dev/null || true
+  fi
 fi
 
 set +e


### PR DESCRIPTION
Fixes AYC-877.

## Problem

`./dev down` printed `Slot N stopped.` while the backend and frontend node
processes stayed alive and listening, so the next `./dev up --slot N` failed with
`port 3080 is occupied by PID … not managed by this checkout`.

Two independent defects:

1. `_terminate_process_tree` used `pkill -TERM -P "$pid"`, which is single-level.
   The launch chain is three to four levels deep (`infisical run` → pnpm shim →
   pnpm → node), so the leaf that owns the socket never received a signal. The
   process-group kill alongside it only helps when `$pid` is the group leader,
   which is not reliable — in the non-tmux `nohup … &` branch the background job
   inherits the `dev` script's own process group, so `kill -- -$pid` fails with
   ESRCH.
2. `cmd_down` never checked whether the ports actually freed, so the failure was
   silent until the next `up`.

## Fix

- `_descendant_pids` walks the full descendant tree via `pgrep -P`, emitting
  deepest-first so a supervising parent (`nest --watch`) cannot respawn a leaf
  after it was signalled. The process-group kill is kept: a descendant already
  reparented away is invisible to the `pgrep` walk but still in the group.
- `cmd_down` verifies both slot ports with the existing `_listener_pids` helper
  and exits non-zero naming the holding PIDs instead of claiming success.

Chose the descendant walk over `setsid` because `setsid` is not available on
macOS by default, which is the primary platform for this script.

## Verification

`bash scripts/dev-status.test.sh` — full suite passes on the fix and both new
assertions fail on unmodified `dev`, reproducing the ticket:

```
# against HEAD's dev (before the fix):
Expected dev down to fail loudly while a slot port is still held.
Expected dev down to terminate the grandchild holding the port (PID 49295 survived).
exit 1

# against the fixed dev:
dev script tests passed
exit 0
```

New coverage:

- A real three-level process chain (`bash` → `bash` → `sleep`) with only `docker`
  and `lsof` faked, so the termination runs against real `pgrep`/`ps`/`kill`. It
  asserts the grandchild — the position the port-owning node process occupies — is
  dead after `./dev down`.
- `dev down` exits non-zero and reports `Backend port 3970 (PID 999997)` while a
  listener still holds a slot port.

Ran on macOS (darwin 25.6.0), local worktree, no dev stack booted.

### Not verified

I could not reproduce the port-level symptom (`lsof … -sTCP:LISTEN` after `down`)
in this environment: a listener spawned from the agent's process tree shows up in
`lsof` as `(CLOSED)` rather than `LISTEN`, so `_listener_pids` cannot observe it.
The tests above cover the causal mechanism instead — the leaf surviving the
signal is exactly why the socket stayed held.

## Known limit (pre-existing, not addressed)

If a pidfile holds a stale PID that the OS has since reused, teardown now kills
that process's whole subtree rather than just it and its direct children. Adding
an ownership check to `_kill_pid` would change `up`'s restart path too, so I left
it alone rather than growing the fix.

## Follow-up

`scripts/dev-status.test.sh` runs in no CI workflow or hook — only manually. I
drafted wiring it into `deploy-script-tests.yml` but dropped it: I can't verify
that suite passes on `ubuntu-latest` from here, and shipping a possibly-red job
isn't worth it in this PR. Worth a separate ticket.
