### PR TITLE
ci(deps): move dependabot npm updates to the workspace root (AYC-000)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
-  # Root package.json (husky, etc.)
+  # pnpm workspace: a single root entry covers every workspace package
+  # (backend, frontend, packages/*, e2e). Dependabot can only update the
+  # shared root pnpm-lock.yaml from the directory that contains it, so
+  # per-package entries produce PRs that fail `pnpm install --frozen-lockfile`.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -10,31 +13,13 @@ updates:
       prefix: "chore(deps)"
     labels:
       - "dependencies"
-    open-pull-requests-limit: 5
-    groups:
-      root-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-
-  # Backend (NestJS)
-  - package-ecosystem: "npm"
-    directory: "/ayunis-core-backend"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    commit-message:
-      prefix: "chore(deps-backend)"
-    labels:
-      - "dependencies"
-      - "backend"
-    open-pull-requests-limit: 8
+    open-pull-requests-limit: 10
     groups:
       nest:
         patterns:
           - "@nestjs/*"
+          - "nestjs-*"
+          - "@nestjs-cls/*"
         update-types:
           - "minor"
           - "patch"
@@ -51,29 +36,11 @@ updates:
           - "jest"
           - "@jest/*"
           - "supertest"
+          - "vitest"
+          - "@playwright/*"
         update-types:
           - "minor"
           - "patch"
-      other:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-
-  # Frontend (React/Vite)
-  - package-ecosystem: "npm"
-    directory: "/ayunis-core-frontend"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    commit-message:
-      prefix: "chore(deps-frontend)"
-    labels:
-      - "dependencies"
-      - "frontend"
-    open-pull-requests-limit: 8
-    groups:
       react:
         patterns:
           - "react"
@@ -102,26 +69,6 @@ updates:
           - "minor"
           - "patch"
       other:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-
-  # UI design-system package
-  - package-ecosystem: "npm"
-    directory: "/packages/ui"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    commit-message:
-      prefix: "chore(deps-ui)"
-    labels:
-      - "dependencies"
-      - "frontend"
-    open-pull-requests-limit: 8
-    groups:
-      ui-dependencies:
         patterns:
           - "*"
         update-types:


### PR DESCRIPTION
Per-package npm entries (backend, frontend, packages/ui) bumped their
package.json but could not update the shared root pnpm-lock.yaml, so
every resulting PR failed `pnpm install --frozen-lockfile`. The root
entry already updates workspace package.json files together with the
lockfile (see #950), so it now carries the merged dependency groups.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Dependabot configuration; no runtime or application code changes, only how dependency update PRs are scoped.
> 
> **Overview**
> **Consolidates npm Dependabot** from separate root, backend, frontend, and `packages/ui` entries into **one update at `/`**, so PRs can refresh the shared **`pnpm-lock.yaml`** and pass **`pnpm install --frozen-lockfile`** in CI.
> 
> The root entry keeps weekly scheduling and **`chore(deps)`** labeling, raises **`open-pull-requests-limit`** to **10**, and **merges** the former per-app **groups** (Nest, TypeScript, testing, React, TanStack, Radix, Vite, catch-all **other**). Group patterns are **expanded** for Nest (`nestjs-*`, `@nestjs-cls/*`) and testing (**vitest**, **@playwright/***). Inline comments document the pnpm workspace constraint. **Python/uv** and other non-npm ecosystems in the file are unchanged by this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 569583b3083cdfb8312521fadce008653cbb827e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->