### PR TITLE
fix(tooling): make bundle-frontend.sh work in the pnpm workspace (AYC-000)

### DIFF
--- a/ayunis-core-backend/scripts/bundle-frontend.sh
+++ b/ayunis-core-backend/scripts/bundle-frontend.sh
@@ -1,70 +1,23 @@
 #!/bin/bash
+# Local mirror of the frontend bundling steps in the root Dockerfile: build the
+# frontend and place it where the backend serves it from (ayunis-core-backend/frontend,
+# gitignored). Run from anywhere; needs pnpm.
+set -euo pipefail
 
-# Exit on any error
-set -e
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FRONTEND_DIST="$PROJECT_ROOT/ayunis-core-frontend/dist"
+TARGET_DIR="$PROJECT_ROOT/ayunis-core-backend/frontend"
 
-# Colors for output
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-RED='\033[0;31m'
-NC='\033[0m' # No Color
+cd "$PROJECT_ROOT"
+echo "Installing workspace dependencies..."
+pnpm install --frozen-lockfile
 
-echo -e "${BLUE}Starting frontend build and bundle process...${NC}"
+echo "Building frontend..."
+pnpm --filter core-frontend-tanstack run build
 
-# Get the script directory and project root
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-FRONTEND_DIR="$PROJECT_ROOT/core-frontend"
-BACKEND_FRONTEND_DIR="$PROJECT_ROOT/core-backend/frontend"
+echo "Replacing $TARGET_DIR with the new build..."
+rm -rf "$TARGET_DIR"
+cp -r "$FRONTEND_DIST" "$TARGET_DIR"
 
-echo -e "${BLUE}Project root: $PROJECT_ROOT${NC}"
-echo -e "${BLUE}Frontend source: $FRONTEND_DIR${NC}"
-echo -e "${BLUE}Backend frontend target: $BACKEND_FRONTEND_DIR${NC}"
-
-# Check if frontend directory exists
-if [ ! -d "$FRONTEND_DIR" ]; then
-    echo -e "${RED}Error: Frontend directory not found at $FRONTEND_DIR${NC}"
-    exit 1
-fi
-
-# Navigate to frontend directory
-echo -e "${BLUE}Navigating to frontend directory...${NC}"
-cd "$FRONTEND_DIR"
-
-# Install dependencies if node_modules doesn't exist
-if [ ! -d "node_modules" ]; then
-    echo -e "${BLUE}Installing frontend dependencies...${NC}"
-    npm install
-fi
-
-# Build the frontend
-echo -e "${BLUE}Building frontend...${NC}"
-npm run build
-
-# Check if build was successful (dist directory should exist)
-if [ ! -d "dist" ]; then
-    echo -e "${RED}Error: Build failed - dist directory not found${NC}"
-    exit 1
-fi
-
-# Navigate back to script directory
-cd "$SCRIPT_DIR"
-
-# Delete content of backend frontend directory
-echo -e "${BLUE}Deleting content of backend frontend directory...${NC}"
-rm -rf "$BACKEND_FRONTEND_DIR/*"
-
-# Copy the built frontend to backend frontend directory
-echo -e "${BLUE}Copying built frontend to backend...${NC}"
-cp -r "$FRONTEND_DIR/dist" "$BACKEND_FRONTEND_DIR"
-
-# Verify the copy was successful
-if [ -d "$BACKEND_FRONTEND_DIR" ] && [ -f "$BACKEND_FRONTEND_DIR/index.html" ]; then
-    echo -e "${GREEN}✅ Frontend successfully built and bundled!${NC}"
-    echo -e "${GREEN}Built frontend is now available at: $BACKEND_FRONTEND_DIR${NC}"
-else
-    echo -e "${RED}❌ Error: Failed to copy frontend build to backend${NC}"
-    exit 1
-fi
-
-echo -e "${GREEN}✅ Bundle process completed successfully!${NC}"
+[ -f "$TARGET_DIR/index.html" ] || { echo "Error: $TARGET_DIR/index.html missing after copy" >&2; exit 1; }
+echo "Frontend bundled into $TARGET_DIR"


### PR DESCRIPTION
The script still pointed at the pre-merge core-frontend/core-backend
directories and installed with npm, so it failed on its first cd and
would have left a stray package-lock.json if the paths had existed.
Rewrite it to mirror the Dockerfile: pnpm install at the workspace root,
build the frontend with --filter, copy dist into ayunis-core-backend/frontend.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect a local dev helper script; no runtime, auth, or deployment logic is modified.
> 
> **Overview**
> **Rewrites `bundle-frontend.sh`** so local frontend bundling matches the monorepo layout and root Dockerfile instead of the old `core-frontend` / `core-backend` paths.
> 
> The script now resolves `ayunis-core-frontend/dist` and copies it into `ayunis-core-backend/frontend`, runs **`pnpm install --frozen-lockfile`** at the workspace root, and builds with **`pnpm --filter core-frontend-tanstack run build`**. It drops the previous per-package **`npm install` / `npm run build`** flow, colored logging, and extra directory checks in favor of **`set -euo pipefail`** and a single post-copy **`index.html`** guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 596e39206ea3dbd4745dcbc77e016376768c3345. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->