### PR TITLE
docs(tooling): replace stale npm commands with pnpm (AYC-000)

### DIFF
--- a/.claude/skills/backend-test-fixtures/SKILL.md
+++ b/.claude/skills/backend-test-fixtures/SKILL.md
@@ -98,6 +98,6 @@ repository.findByUserId.mockResolvedValue(existing);   // override per test
 
 ```bash
 pnpm jest src/<module>                                  # specs still green
-npx tsc -p tsconfig.build.json --noEmit                 # testing/ NOT compiled
-npx eslint --max-warnings=0 <changed files>             # mirrors pre-commit
+pnpm exec tsc -p tsconfig.build.json --noEmit                 # testing/ NOT compiled
+pnpm exec eslint --max-warnings=0 <changed files>             # mirrors pre-commit
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Ayunis Core is a comprehensive AI platform that enables intelligent conversation
 ### Prerequisites
 
 - Node.js (v24 or higher)
-- npm
+- pnpm (run `corepack enable` to get the version pinned in package.json)
 - Docker and Docker Compose
 
 ### Installation
@@ -177,9 +177,9 @@ All super admin endpoints require JWT authentication with a user that has the `S
 ```bash
 cd ayunis-core-backend
 # Look up the user's ID by email
-npm run cli:ts -- users:get --email <email>
+pnpm run cli:ts -- users:get --email <email>
 # Promote that user to super admin
-npm run cli:ts -- users:make-super-admin --userId <userId>
+pnpm run cli:ts -- users:make-super-admin --userId <userId>
 ```
 
 Then use the authenticated API to manage the model catalog. See the full endpoint documentation at `/api/docs` under the **Super Admin Models** tag.
@@ -278,7 +278,7 @@ This project uses [Husky](https://typicode.github.io/husky/) to manage Git hooks
 When you clone the repository, Git hooks are automatically set up when you run:
 
 ```bash
-npm install
+pnpm install
 ```
 
 This installs Husky and configures Git to use the hooks in the `.husky/` directory.
@@ -316,8 +316,8 @@ Valid types: `feat`, `feature`, `fix`, `chore`, `refactor`, `docs`, `style`, `pe
 If hooks aren't working, you can manually set them up:
 
 ```bash
-npm install
-npx husky install
+pnpm install
+pnpm exec husky install
 ```
 
 **Note**: On some systems (especially Windows), Git may not preserve executable permissions for hook files. If hooks aren't running, ensure the hook files are executable:

--- a/ayunis-core-backend/README.md
+++ b/ayunis-core-backend/README.md
@@ -24,7 +24,7 @@ This is the core backend for the Ayunis platform, built with NestJS and followin
 ## Prerequisites
 
 - Node.js (v24+)
-- npm or yarn
+- pnpm
 - Docker and Docker Compose
 - PostgreSQL with pgvector extension
 
@@ -94,13 +94,13 @@ Manual setup:
 
 ```bash
 # Install dependencies
-npm install
+pnpm install
 
 # Build the application
-npm run build
+pnpm run build
 
 # Start the production server
-npm run start:prod
+pnpm run start:prod
 ```
 
 ## Environment Variables
@@ -201,8 +201,8 @@ The API documentation is available at `/api` using Swagger UI when the applicati
 
 ```bash
 # Run unit tests
-npm run test
+pnpm run test
 
 # Generate test coverage report
-npm run test:cov
+pnpm run test:cov
 ```

--- a/ayunis-core-frontend/README.md
+++ b/ayunis-core-frontend/README.md
@@ -5,8 +5,8 @@ Welcome to your new TanStack app!
 To run this application:
 
 ```bash
-npm install
-npm run start  
+pnpm install
+pnpm run start  
 ```
 
 # Building For Production
@@ -14,7 +14,7 @@ npm run start
 To build this application for production:
 
 ```bash
-npm run build
+pnpm run build
 ```
 
 ## Testing
@@ -22,7 +22,7 @@ npm run build
 This project uses [Vitest](https://vitest.dev/) for testing. You can run the tests with:
 
 ```bash
-npm run test
+pnpm run test
 ```
 
 ## Styling
@@ -174,7 +174,7 @@ React-Query is an excellent addition or alternative to route loading and integra
 First add your dependencies:
 
 ```bash
-npm install @tanstack/react-query @tanstack/react-query-devtools
+pnpm add @tanstack/react-query @tanstack/react-query-devtools
 ```
 
 Next we'll need to create a query client and provider. We recommend putting those in `main.tsx`.
@@ -255,7 +255,7 @@ Another common requirement for React applications is state management. There are
 First you need to add TanStack Store as a dependency:
 
 ```bash
-npm install @tanstack/store
+pnpm add @tanstack/store
 ```
 
 Now let's create a simple counter in the `src/App.tsx` file as a demonstration.

--- a/ayunis-core-frontend/src/shared/api/README.md
+++ b/ayunis-core-frontend/src/shared/api/README.md
@@ -29,9 +29,9 @@ import type { User, CreateUserDto } from "@/lib/api";
 
 ## Scripts
 
-- `npm run openapi:fetch` - Fetch the latest OpenAPI schema from the backend
-- `npm run openapi:generate` - Generate TypeScript types and React Query hooks
-- `npm run openapi:update` - Fetch schema and generate types (recommended)
+- `pnpm run openapi:fetch` - Fetch the latest OpenAPI schema from the backend
+- `pnpm run openapi:generate` - Generate TypeScript types and React Query hooks
+- `pnpm run openapi:update` - Fetch schema and generate types (recommended)
 
 ## Configuration
 


### PR DESCRIPTION
The workspace has used pnpm since AYC-150; the READMEs and one skill
still told readers to run npm/npx, which creates a stray package-lock.json
inside a workspace package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only command updates; no runtime, build, or dependency changes.
> 
> **Overview**
> Aligns contributor-facing docs with the **pnpm** workspace (since AYC-150) so copy-paste commands no longer suggest `npm`/`npx`, which can create stray `package-lock.json` files in workspace packages.
> 
> Updates **Quick Start** prerequisites to list **pnpm** (with `corepack enable`), **Husky** setup (`pnpm install`, `pnpm exec husky install`), and super-admin **CLI** examples. Backend and frontend READMEs now use `pnpm install`, `pnpm run build/test`, and `pnpm add` where applicable. The frontend API README documents OpenAPI scripts with `pnpm run`. The **backend-test-fixtures** skill’s validate section uses `pnpm exec tsc` and `pnpm exec eslint` instead of `npx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 654c56f7dd2ab3536143698bf2412f07642c3d26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->