### PR TITLE
chore(tooling): ignore local .pnpm-store directory (AYC-000)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ tsconfig.?????????*.json
 .claude/worktrees/
 .claude/**/*.local.*
 .claude/scheduled_tasks.lock
+
+# Local pnpm content-addressable store (created when pnpm runs with a store-dir inside the checkout)
+.pnpm-store/


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Gitignore-only change with no runtime or security impact.
> 
> **Overview**
> Adds **`.pnpm-store/`** to `.gitignore` so a pnpm content-addressable store created inside the repo (when `store-dir` points at the checkout) is not tracked by git.
> 
> Includes a short comment explaining when that directory appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0766f8d462b945bbf41846fe6e0cf299942d31b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->