### PR TITLE
fix(email): block MJML template injection (AYC-890)

### DIFF
--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/_layout.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/_layout.ts
@@ -119,7 +119,7 @@ function renderBannerSection(
   return bannerUrl
     ? `<mj-section background-color="${COLOR.card}" padding="16px 32px 0 32px">
          <mj-column>
-           <mj-image src="${bannerUrl}" alt="${escapeAttr(bannerAlt ?? '')}" width="496px" border-radius="10px" padding="0" />
+           <mj-image src="${bannerUrl}" alt="${escapeAttribute(bannerAlt ?? '')}" width="496px" border-radius="10px" padding="0" />
          </mj-column>
        </mj-section>`
     : '';
@@ -220,6 +220,6 @@ export function escapeText(input: string): string {
     .replace(/>/g, '&gt;');
 }
 
-function escapeAttr(input: string): string {
+export function escapeAttribute(input: string): string {
   return escapeText(input).replace(/"/g, '&quot;');
 }

--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/budget-warning.template.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/budget-warning.template.ts
@@ -1,7 +1,6 @@
-import mjml2html from 'mjml';
 import type { MJMLParseResults } from 'mjml-core';
 
-import type { BudgetWarningTemplateContent } from '../../../domain/email-template.entity';
+import type { BudgetWarningTemplateContent } from 'src/common/email-templates/domain/email-template.entity';
 import {
   buildBudgetWarningMessage,
   type BudgetWarningMessage,
@@ -15,6 +14,7 @@ import {
   renderLayout,
   teamSignoff,
 } from './_layout';
+import { renderMjml } from './render-mjml';
 
 function normalizeInlineText(value: string): string {
   return value.trim().replace(/\s+/g, ' ');
@@ -89,7 +89,7 @@ export function budgetWarningHtml(
     teamSignoff(template.teamUrl),
   ].join('\n');
 
-  return mjml2html(
+  return renderMjml(
     renderLayout({
       title: `${message.headline} · ${normalizeInlineText(template.productName)}`,
       preheader: message.preheader,

--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/email-confirmation.template.spec.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/email-confirmation.template.spec.ts
@@ -1,0 +1,29 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { emailConfirmationHtml } from './email-confirmation.template';
+
+describe('email confirmation template', () => {
+  it('renders an MJML include payload in an email address as inert text', () => {
+    const fixtureDirectory = mkdtempSync(join(tmpdir(), 'ayunis-mjml-'));
+    const fixturePath = join(fixtureDirectory, 'include.html');
+    const includedMarker = 'AYUNIS_MJML_INCLUDE_MUST_NOT_RENDER';
+    writeFileSync(fixturePath, includedMarker);
+
+    try {
+      const maliciousEmail = `"</mj-text><mj-include type=html path=${fixturePath}>"@x.io`;
+      const rendered = emailConfirmationHtml({
+        confirmationUrl: 'https://app.ayunis.test/confirm?token=safe-token',
+        userEmail: maliciousEmail,
+        currentYear: '2026',
+        companyName: 'Ayunis',
+      });
+
+      expect(rendered.html).not.toContain(includedMarker);
+      expect(rendered.html).toContain('&lt;/mj-text&gt;');
+    } finally {
+      rmSync(fixtureDirectory, { recursive: true, force: true });
+    }
+  });
+});

--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/email-confirmation.template.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/email-confirmation.template.ts
@@ -1,6 +1,7 @@
-import mjml2html from 'mjml';
 import type { MJMLParseResults } from 'mjml-core';
 import type { EmailConfirmationTemplateContent } from 'src/common/email-templates/domain/email-template.entity';
+import { escapeAttribute, escapeText } from './_layout';
+import { renderMjml } from './render-mjml';
 
 export function emailConfirmationText(
   template: EmailConfirmationTemplateContent,
@@ -24,7 +25,12 @@ export function emailConfirmationText(
 export function emailConfirmationHtml(
   template: EmailConfirmationTemplateContent,
 ): MJMLParseResults {
-  return mjml2html(`
+  const confirmationUrl = escapeAttribute(template.confirmationUrl);
+  const userEmail = escapeText(template.userEmail);
+  const currentYear = escapeText(template.currentYear);
+  const companyName = escapeText(template.companyName);
+
+  return renderMjml(`
 <mjml>
   <mj-head>
     <mj-title>E-Mail-Adresse bestätigen</mj-title>
@@ -63,7 +69,7 @@ export function emailConfirmationHtml(
           font-size="16px"
           font-weight="600"
           border-radius="8px"
-          href="${template.confirmationUrl}"
+          href="${confirmationUrl}"
           css-class="confirmation-button"
         >
           E-Mail-Adresse bestätigen
@@ -86,7 +92,7 @@ export function emailConfirmationHtml(
         <mj-divider border-color="#e5e7eb" border-width="1px" padding-bottom="24px" />
 
         <mj-text align="center" color="#6b7280" font-size="14px" padding-bottom="8px">
-          Diese E-Mail wurde gesendet an ${template.userEmail}
+          Diese E-Mail wurde gesendet an ${userEmail}
         </mj-text>
 
         <mj-text align="center" color="#6b7280" font-size="14px" padding-bottom="16px">
@@ -94,7 +100,7 @@ export function emailConfirmationHtml(
         </mj-text>
 
         <mj-text align="center" color="#9ca3af" font-size="12px">
-          © ${template.currentYear} ${template.companyName} . Alle Rechte vorbehalten.
+          © ${currentYear} ${companyName} . Alle Rechte vorbehalten.
         </mj-text>
       </mj-column>
     </mj-section>

--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/invitation.template.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/invitation.template.ts
@@ -1,4 +1,3 @@
-import mjml2html from 'mjml';
 import type { MJMLParseResults } from 'mjml-core';
 import type { InvitationTemplateContent } from 'src/common/email-templates/domain/email-template.entity';
 import {
@@ -11,6 +10,7 @@ import {
   renderLayout,
   teamSignoff,
 } from './_layout';
+import { renderMjml } from './render-mjml';
 
 function preheader(template: InvitationTemplateContent): string {
   return template.adminName
@@ -67,7 +67,7 @@ export function invitationHtml(
     teamSignoff(template.teamUrl),
   ].join('\n');
 
-  return mjml2html(
+  return renderMjml(
     renderLayout({
       title: `Einladung zu ${template.invitingCompanyName} · ${template.productName}`,
       preheader: preheader(template),

--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/password-reset.template.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/password-reset.template.ts
@@ -1,4 +1,3 @@
-import mjml2html from 'mjml';
 import type { MJMLParseResults } from 'mjml-core';
 import type { PasswordResetTemplateContent } from 'src/common/email-templates/domain/email-template.entity';
 import {
@@ -11,6 +10,7 @@ import {
   renderLayout,
   teamSignoff,
 } from './_layout';
+import { renderMjml } from './render-mjml';
 
 export function passwordResetText(
   template: PasswordResetTemplateContent,
@@ -60,7 +60,7 @@ export function passwordResetHtml(
     teamSignoff(template.teamUrl),
   ].join('\n');
 
-  return mjml2html(
+  return renderMjml(
     renderLayout({
       title: `Passwort zurücksetzen · ${template.productName}`,
       preheader:

--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/render-mjml.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/render-mjml.ts
@@ -1,0 +1,6 @@
+import mjml2html from 'mjml';
+import type { MJMLParseResults } from 'mjml-core';
+
+export function renderMjml(source: string): MJMLParseResults {
+  return mjml2html(source, { ignoreIncludes: true });
+}

--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/set-initial-password.template.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/set-initial-password.template.ts
@@ -1,4 +1,3 @@
-import mjml2html from 'mjml';
 import type { MJMLParseResults } from 'mjml-core';
 import type { SetInitialPasswordTemplateContent } from 'src/common/email-templates/domain/email-template.entity';
 import {
@@ -11,6 +10,7 @@ import {
   renderLayout,
   teamSignoff,
 } from './_layout';
+import { renderMjml } from './render-mjml';
 
 export function setInitialPasswordText(
   template: SetInitialPasswordTemplateContent,
@@ -50,7 +50,7 @@ export function setInitialPasswordHtml(
     teamSignoff(template.teamUrl),
   ].join('\n');
 
-  return mjml2html(
+  return renderMjml(
     renderLayout({
       title: `Ihr Konto bei ${template.invitingCompanyName} · ${template.productName}`,
       preheader: `Wir haben ein Konto für Sie angelegt. Legen Sie jetzt Ihr Passwort fest.`,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Security-sensitive email rendering changes; behavior is narrowed (no MJML includes) and escaping is added, with limited blast radius if options are applied consistently across templates.
> 
> **Overview**
> Hardens MJML email rendering against **template injection** when user-controlled strings are interpolated into markup.
> 
> All templates now compile MJML through a shared **`renderMjml`** helper that calls `mjml2html` with **`ignoreIncludes: true`**, so injected `<mj-include>` tags cannot pull in arbitrary files. **`escapeAttribute`** is exported (replacing the private `escapeAttr`) and used for banner alt text; the **email confirmation** template additionally escapes `confirmationUrl`, `userEmail`, `currentYear`, and `companyName` before they appear in attributes or body text.
> 
> A regression test feeds a malicious `userEmail` containing a crafted `mj-include` payload and asserts the included file content never appears in the output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b79b0312322002fef5034fd205f8ebacfc8aa4f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->