### PR TITLE
feat(academy): replace certificate with teilnahmebestätigung (AYC-000)

### DIFF
--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-certificate/get-academy-certificate.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-certificate/get-academy-certificate.use-case.spec.ts
@@ -73,7 +73,7 @@ describe('GetAcademyCertificateUseCase', () => {
     expect(certificateRenderer.render).not.toHaveBeenCalled();
   });
 
-  it('renders the certificate with the user name and German date line', async () => {
+  it('renders the Teilnahmebestätigung with the user name and German date line', async () => {
     completionRepository.findByUser.mockResolvedValue(
       new AcademyCompletion({
         userId,
@@ -89,11 +89,11 @@ describe('GetAcademyCertificateUseCase', () => {
 
     expect(certificateRenderer.render).toHaveBeenCalledWith({
       userName: 'Käthe Müller',
-      dateLine: '15. Juli 2026, München',
+      dateLine: '15.07.2026, München',
     });
     expect(result.buffer.toString()).toBe('%PDF-fake');
     expect(result.fileName).toBe(
-      'Ayunis-Core-KI-Schulung-nach-EU-AI-Act-Zertifikat.pdf',
+      'Teilnahmebestaetigung_Ayunis_Core_KI-Schulung.pdf',
     );
     expect(result.mimeType).toBe('application/pdf');
   });

--- a/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-certificate/get-academy-certificate.use-case.ts
+++ b/ayunis-core-backend/src/domain/academy/application/use-cases/get-academy-certificate/get-academy-certificate.use-case.ts
@@ -17,12 +17,12 @@ export interface AcademyCertificateFile {
 }
 
 export const CERTIFICATE_FILE_NAME =
-  'Ayunis-Core-KI-Schulung-nach-EU-AI-Act-Zertifikat.pdf';
+  'Teilnahmebestaetigung_Ayunis_Core_KI-Schulung.pdf';
 
 const CERTIFICATE_DATE_FORMAT = new Intl.DateTimeFormat('de-DE', {
   timeZone: 'Europe/Berlin',
-  day: 'numeric',
-  month: 'long',
+  day: '2-digit',
+  month: '2-digit',
   year: 'numeric',
 });
 

--- a/ayunis-core-backend/src/domain/academy/infrastructure/certificate/certificate-template.spec.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/certificate/certificate-template.spec.ts
@@ -1,14 +1,16 @@
 import { buildCertificateHtml } from './certificate-template';
 
 describe('buildCertificateHtml', () => {
-  it('names the completed course KI-Schulung nach EU AI Act', () => {
+  it('confirms participation in the KI-Schulung nach EU AI Act', () => {
     const html = buildCertificateHtml({
       userName: 'Käthe Müller',
-      dateLine: '15. Juli 2026, München',
+      dateLine: '15.07.2026, München',
     });
 
+    expect(html).toContain('Teilnahmebest&auml;tigung');
     expect(html).toContain(
-      'die <strong>Ayunis Core KI-Schulung nach EU AI Act</strong> erfolgreich',
+      'an der <strong>Ayunis Core KI-Schulung nach EU AI Act</strong>',
     );
+    expect(html).toContain('teilgenommen hat.');
   });
 });

--- a/ayunis-core-backend/src/domain/academy/infrastructure/certificate/certificate-template.ts
+++ b/ayunis-core-backend/src/domain/academy/infrastructure/certificate/certificate-template.ts
@@ -11,7 +11,7 @@ export interface CertificateTemplateInput {
 }
 
 /**
- * Layout metrics are taken from the official certificate template PDF
+ * Layout metrics are taken from the official Teilnahmebestätigung template PDF
  * (A4 portrait, all measurements converted from PDF points to mm).
  * This HTML is rendered without sanitization because the template is
  * fully owned by us — the user name is the only untrusted value and is
@@ -55,7 +55,7 @@ const CERTIFICATE_HTML = `<!DOCTYPE html>
   }
   .title {
     position: absolute;
-    top: 44mm;
+    top: 48mm;
     left: 0;
     right: 0;
     font-size: 48pt;
@@ -63,7 +63,7 @@ const CERTIFICATE_HTML = `<!DOCTYPE html>
   }
   .intro {
     position: absolute;
-    top: 81mm;
+    top: 82.9mm;
     left: 0;
     right: 0;
     font-size: 15.3pt;
@@ -71,7 +71,7 @@ const CERTIFICATE_HTML = `<!DOCTYPE html>
   }
   .name {
     position: absolute;
-    top: 97.5mm;
+    top: 100.4mm;
     left: 0;
     right: 0;
     font-size: 22pt;
@@ -79,7 +79,7 @@ const CERTIFICATE_HTML = `<!DOCTYPE html>
   }
   .body-text {
     position: absolute;
-    top: 119.5mm;
+    top: 125.6mm;
     left: 25mm;
     right: 25mm;
     font-size: 15.3pt;
@@ -88,19 +88,19 @@ const CERTIFICATE_HTML = `<!DOCTYPE html>
   }
   .mark {
     position: absolute;
-    top: 157.6mm;
+    top: 152.4mm;
     left: 78.2mm;
     width: 53.6mm;
   }
   .signature {
     position: absolute;
-    top: 225.1mm;
+    top: 219.9mm;
     left: 83mm;
     width: 36.9mm;
   }
   .signatory {
     position: absolute;
-    top: 250.5mm;
+    top: 246.3mm;
     left: 0;
     right: 0;
     font-size: 13.3pt;
@@ -108,7 +108,7 @@ const CERTIFICATE_HTML = `<!DOCTYPE html>
   }
   .date-line {
     position: absolute;
-    top: 258.1mm;
+    top: 253.8mm;
     left: 0;
     right: 0;
     font-size: 13.3pt;
@@ -119,12 +119,12 @@ const CERTIFICATE_HTML = `<!DOCTYPE html>
 <body>
 <div class="page">
   <img class="wordmark" src="${AYUNIS_CORE_WORDMARK_DATA_URI}" alt="">
-  <div class="title">ZERTIFIKAT</div>
+  <div class="title">Teilnahmebest&auml;tigung</div>
   <div class="intro">Hiermit wird best&auml;tigt, dass</div>
   <div class="name">{{userName}}</div>
   <div class="body-text">
-    die <strong>Ayunis Core KI-Schulung nach EU AI Act</strong> erfolgreich
-    abgeschlossen und die abschlie&szlig;ende Pr&uuml;fung bestanden hat.
+    an der <strong>Ayunis Core KI-Schulung nach EU AI Act</strong>
+    teilgenommen hat.
   </div>
   <img class="mark" src="${AYC_MARK_DATA_URI}" alt="">
   <img class="signature" src="${SIGNATURE_DATA_URI}" alt="">

--- a/ayunis-core-frontend/src/features/academy/useDownloadCertificate.ts
+++ b/ayunis-core-frontend/src/features/academy/useDownloadCertificate.ts
@@ -4,7 +4,7 @@ import { academyCertificateControllerGetCertificate } from '@/shared/api';
 import { showError } from '@/shared/lib/toast';
 
 const CERTIFICATE_FILE_NAME =
-  'Ayunis-Core-KI-Schulung-nach-EU-AI-Act-Zertifikat.pdf';
+  'Teilnahmebestaetigung_Ayunis_Core_KI-Schulung.pdf';
 
 export function useDownloadCertificate() {
   const { t } = useTranslation('academy');

--- a/ayunis-core-frontend/src/shared/locales/de/academy.json
+++ b/ayunis-core-frontend/src/shared/locales/de/academy.json
@@ -62,8 +62,8 @@
     "renewalDue": "Erneuerung fällig"
   },
   "certificate": {
-    "downloadError": "Das Zertifikat konnte nicht heruntergeladen werden. Bitte versuchen Sie es erneut.",
-    "download": "Zertifikat herunterladen"
+    "downloadError": "Die Teilnahmebestätigung konnte nicht heruntergeladen werden. Bitte versuchen Sie es erneut.",
+    "download": "Teilnahmebestätigung herunterladen"
   },
   "expiry": {
     "title_one": "Ihre KI-Schulung nach EU AI Act muss in {{count}} Tag erneuert werden",
@@ -90,10 +90,10 @@
     }
   },
   "gate": {
-    "title": "Zertifikat erforderlich",
+    "title": "KI-Schulung erforderlich",
     "description": "Ihre Organisation setzt den Abschluss der KI-Schulung nach EU AI Act voraus, bevor Sie den Ayunis Core Chat nutzen können. Schließen Sie die Academy ab, um den Chat freizuschalten — Ihre bisherigen Chats bleiben in der Zwischenzeit lesbar.",
     "action": "Zur Academy",
     "emptyTitle": "Noch keine Academy-Inhalte",
-    "emptyDescription": "Der Chat ist gesperrt, bis Sie das Zertifikat bestanden haben, aber es wurden noch keine Kapitel veröffentlicht. Bitte wenden Sie sich an Ihre Administration."
+    "emptyDescription": "Der Chat ist gesperrt, bis Sie die KI-Schulung abgeschlossen haben, aber es wurden noch keine Kapitel veröffentlicht. Bitte wenden Sie sich an Ihre Administration."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-academy.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-academy.json
@@ -2,8 +2,8 @@
   "requirement": {
     "title": "Pflicht zur KI-Schulung nach EU AI Act",
     "description": "Legen Sie fest, ob Benutzer Ihrer Organisation die KI-Schulung nach EU AI Act in der Academy abschließen müssen, bevor sie den Ayunis Core Chat nutzen können. Das Lesen bestehender Chats wird nie blockiert.",
-    "saved": "Zertifikatspflicht aktualisiert",
-    "error": "Zertifikatspflicht konnte nicht aktualisiert werden",
+    "saved": "Schulungspflicht aktualisiert",
+    "error": "Schulungspflicht konnte nicht aktualisiert werden",
     "errorUnexpected": "Beim Speichern ist etwas schiefgelaufen. Bitte versuchen Sie es erneut.",
     "modes": {
       "unrestricted": {
@@ -21,8 +21,8 @@
     }
   },
   "overview": {
-    "title": "Zertifikatsstatus je Benutzer",
-    "description": "Wer die KI-Schulung nach EU AI Act abgeschlossen hat, wann sie abgeschlossen wurde und bei wem Handlungsbedarf besteht. Zertifikate, die innerhalb von 30 Tagen ablaufen, gelten als bald ablaufend.",
+    "title": "Schulungsstatus je Benutzer",
+    "description": "Wer die KI-Schulung nach EU AI Act abgeschlossen hat, wann sie abgeschlossen wurde und bei wem Handlungsbedarf besteht. Abschlüsse, die innerhalb von 30 Tagen ablaufen, gelten als bald ablaufend.",
     "searchPlaceholder": "Nach Name oder E-Mail suchen",
     "empty": "Keine Benutzer entsprechen diesen Filtern",
     "emptyDescription": "Setzen Sie die Suche oder den Statusfilter zurück, um alle Benutzer zu sehen.",

--- a/ayunis-core-frontend/src/shared/locales/en/academy.json
+++ b/ayunis-core-frontend/src/shared/locales/en/academy.json
@@ -62,16 +62,16 @@
     "renewalDue": "Renewal due"
   },
   "certificate": {
-    "downloadError": "The certificate could not be downloaded. Please try again.",
-    "download": "Download certificate"
+    "downloadError": "The confirmation of participation could not be downloaded. Please try again.",
+    "download": "Download confirmation of participation"
   },
   "expiry": {
-    "title_one": "Your AI certificate expires in {{count}} day",
-    "title_other": "Your AI certificate expires in {{count}} days",
+    "title_one": "Your EU AI Act training must be renewed in {{count}} day",
+    "title_other": "Your EU AI Act training must be renewed in {{count}} days",
     "description": "Renew it in the Academy to keep using Ayunis Core chat without interruption.",
-    "urgentDescription": "Renew it now — once it expires, Ayunis Core chat is locked until you pass the certificate again.",
-    "banner_one": "Your AI certificate expires in {{count}} day. Chat will be locked afterwards.",
-    "banner_other": "Your AI certificate expires in {{count}} days. Chat will be locked afterwards.",
+    "urgentDescription": "Renew it now — once it lapses, Ayunis Core chat is locked until you complete the EU AI Act training again.",
+    "banner_one": "Your EU AI Act training must be renewed in {{count}} day. Chat will be locked afterwards.",
+    "banner_other": "Your EU AI Act training must be renewed in {{count}} days. Chat will be locked afterwards.",
     "later": "Later",
     "action": "Go to the academy"
   },
@@ -80,7 +80,7 @@
     "lastPassed": "Last passed:",
     "nextRenewal": "Next renewal due:",
     "expiredOn": "Expired on:",
-    "notPassedDescription": "You haven't earned the certificate yet.",
+    "notPassedDescription": "You haven't completed the EU AI Act training yet.",
     "action": "Go to the academy",
     "status": {
       "valid": "Valid",
@@ -90,10 +90,10 @@
     }
   },
   "gate": {
-    "title": "Certificate required",
+    "title": "Training required",
     "description": "Your organization requires you to complete the EU AI Act training before you can use Ayunis Core chat. Complete the Academy to unlock chat — your existing chats stay readable in the meantime.",
     "action": "Go to the academy",
     "emptyTitle": "No academy content yet",
-    "emptyDescription": "Chat is locked until you pass the certificate, but no chapters have been published yet. Please contact your administrator."
+    "emptyDescription": "Chat is locked until you complete the EU AI Act training, but no chapters have been published yet. Please contact your administrator."
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-academy.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-academy.json
@@ -2,8 +2,8 @@
   "requirement": {
     "title": "EU AI Act training requirement",
     "description": "Decide whether members of your organization need to complete the EU AI Act training in the Academy before they can use Ayunis Core chat. Reading existing chats is never blocked.",
-    "saved": "Certificate requirement updated",
-    "error": "Could not update the certificate requirement",
+    "saved": "Training requirement updated",
+    "error": "Could not update the training requirement",
     "errorUnexpected": "Something went wrong while saving. Please try again.",
     "modes": {
       "unrestricted": {
@@ -12,17 +12,17 @@
       },
       "requiredOnce": {
         "label": "Required once",
-        "description": "Members must pass the certificate before using chat. Once passed, it never expires."
+        "description": "Members must complete the EU AI Act training before using chat. Once completed, it never expires."
       },
       "requiredAnnually": {
         "label": "Required every year",
-        "description": "Members must pass the certificate before using chat and renew it every 12 months. Renewing means completing the whole Academy again."
+        "description": "Members must complete the EU AI Act training before using chat and renew it every 12 months. Renewing means completing the whole Academy again."
       }
     }
   },
   "overview": {
-    "title": "Certificate status by member",
-    "description": "Who has passed the AI certificate, when they passed, and whose certificate needs attention. Members whose certificate is due within 30 days count as expiring soon.",
+    "title": "Training status by member",
+    "description": "Who has completed the EU AI Act training, when they completed it, and who needs attention. Members whose renewal is due within 30 days count as expiring soon.",
     "searchPlaceholder": "Search by name or email",
     "empty": "No members match these filters",
     "emptyDescription": "Clear the search or status filter to see everyone.",

--- a/ayunis-core-frontend/src/shared/locales/en/chat.json
+++ b/ayunis-core-frontend/src/shared/locales/en/chat.json
@@ -245,7 +245,7 @@
         "other": "Personal data"
       }
     },
-    "academyCertificateRequiredError": "Your organization requires the AI certificate before you can send messages. Complete the academy to unlock chat."
+    "academyCertificateRequiredError": "Your organization requires the EU AI Act training before you can send messages. Complete the academy to unlock chat."
   },
   "newChat": {
     "newChat": "New Chat",


### PR DESCRIPTION
The academy no longer issues a "Zertifikat" — the downloaded document is now the official **Teilnahmebestätigung** (confirmation of participation), matching the new template PDF provided by Customer Success.

## Changes

- **Rendered document** (`certificate-template.ts`): title "Teilnahmebestätigung", body wording changed from "erfolgreich abgeschlossen und die abschließende Prüfung bestanden hat" to "an der … teilgenommen hat", date line switched to numeric format (`26.08.2026, München`), layout metrics recalibrated against the new official template PDF.
- **Download filename** (backend + frontend): `Teilnahmebestaetigung_Ayunis_Core_KI-Schulung.pdf` (was `Ayunis-Core-KI-Schulung-nach-EU-AI-Act-Zertifikat.pdf`).
- **Locales**: remaining user-facing "Zertifikat"/"certificate" mentions reworded to the EU AI Act training / Teilnahmebestätigung (download button, gate, expiry notices, admin overview).

## Verification

- Rendered the updated template with the real puppeteer pipeline and compared it against the official template PDF at 200 DPI: all ink bands (title, intro, name, body, logo, signature, signatory, date) align within ±0.4 mm; visual side-by-side is indistinguishable.
- `pnpm test -- --testPathPatterns "get-academy-certificate|certificate-template"` — 4/4 pass.
- ESLint clean on all touched files; locale JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eu23a6yze3pGJEBuBL6mFo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing PDF content and i18n only; download and gating behavior are unchanged aside from wording and the new document template.
> 
> **Overview**
> Replaces the Academy **completion certificate** with an official **Teilnahmebestätigung** (confirmation of participation) in the generated PDF and across product copy.
> 
> **Backend PDF:** Title changes from `ZERTIFIKAT` to Teilnahmebestätigung; body text now states participation in the EU AI Act training instead of successful completion and passing the final exam. The date line uses **numeric** `de-DE` formatting (`15.07.2026`) instead of spelled-out months, and layout positions are adjusted to match the new template. Download filename is **`Teilnahmebestaetigung_Ayunis_Core_KI-Schulung.pdf`** (backend constant and tests updated).
> 
> **Frontend:** The download hook uses the same filename. German and English locales reword “certificate” / Zertifikat to **EU AI Act training** / Teilnahmebestätigung (download labels, expiry banners, chat gate, admin training requirement and status overview, and the chat error when training is required).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd3872956d5fb3e49d15be7c95d9790a78f3c69e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->