### PR TITLE
fix(messages): drop lone surrogates before jsonb writes (AYC-902)

### DIFF
--- a/ayunis-core-backend/src/common/util/unicode-sanitizer.spec.ts
+++ b/ayunis-core-backend/src/common/util/unicode-sanitizer.spec.ts
@@ -15,6 +15,23 @@ describe('sanitizeUnicodeEscapes', () => {
     expect(sanitizeUnicodeEscapes('abc\\u0')).toBe('abc');
   });
 
+  // A tool result scraped from the web can arrive with a UTF-16 surrogate pair
+  // broken in half. JSON.stringify escapes the survivor as \udXXX, which
+  // Postgres rejects when the messages.content jsonb row is written ("invalid
+  // input syntax for type json"), failing the whole run (AYC-902).
+  it('replaces a lone surrogate with the replacement character', () => {
+    expect(sanitizeUnicodeEscapes(`ok${String.fromCharCode(0xd83d)} end`)).toBe(
+      'ok\uFFFD end',
+    );
+    expect(sanitizeUnicodeEscapes(`ok${String.fromCharCode(0xdc00)} end`)).toBe(
+      'ok\uFFFD end',
+    );
+  });
+
+  it('keeps an intact emoji unchanged', () => {
+    expect(sanitizeUnicodeEscapes('done \u{1F600}')).toBe('done \u{1F600}');
+  });
+
   it('preserves ordinary strings, paths, and valid escapes', () => {
     expect(sanitizeUnicodeEscapes('C:\\Users\\name')).toBe('C:\\Users\\name');
     expect(sanitizeUnicodeEscapes('emoji \\u1F600 ok')).toBe(
@@ -66,6 +83,12 @@ describe('sanitizeObject', () => {
     );
 
     expect(({} as { polluted?: unknown }).polluted).toBeUndefined();
+  });
+
+  it('replaces lone surrogates in nested tool params', () => {
+    expect(
+      sanitizeObject({ query: { terms: [`a${String.fromCharCode(0xd83d)}`] } }),
+    ).toEqual({ query: { terms: ['a\uFFFD'] } });
   });
 
   it('is idempotent over nested structures', () => {

--- a/ayunis-core-backend/src/common/util/unicode-sanitizer.ts
+++ b/ayunis-core-backend/src/common/util/unicode-sanitizer.ts
@@ -7,7 +7,7 @@
  * No complex regex, just targets the exact problems we've seen in production.
  *
  * @param input - The string to sanitize
- * @returns The sanitized string
+ * @returns The sanitized string, well-formed per {@link toWellFormedText}
  */
 export function sanitizeUnicodeEscapes(input: unknown): string {
   if (input === null || input === undefined || typeof input !== 'string') {
@@ -24,7 +24,10 @@ export function sanitizeUnicodeEscapes(input: unknown): string {
     current = next;
     next = sanitizeUnicodeEscapesOnce(current);
   }
-  return next;
+  // Runs after the fixpoint, not inside it: replacing a lone surrogate keeps
+  // the length, so it would break the loop's "every changing pass shortens
+  // the string" termination argument. U+FFFD is inert for the escape passes.
+  return toWellFormedText(next);
 }
 
 function sanitizeUnicodeEscapesOnce(input: string): string {


### PR DESCRIPTION
## Problem

AppSignal production [incident #548](https://appsignal.com/ayunis/sites/6a611f0dd841ff7c22841fb2/exceptions/incidents/548) — `RUN_EXECUTION_FAILED` on `POST /api/runs/send-message`, 83 occurrences, still firing (last seen 2026-09-07T08:23). The user loses the whole assistant turn.

The generic mapping in `run-event-stream.adapter.ts` is reached through its **critical finalization** branch, not an unknown event code. Structured log attributes for the latest occurrence (v2 logs API — `appsignal-cli` renders `attributes: null` for these lines):

```
hookName: ayunis-persistence   critical: true   phase: runEnd   originalOutcome: error
message: Hook 'ayunis-persistence' failed in runEnd:
         Failed to create tool message: invalid input syntax for type json
```

## Root cause

An **unpaired UTF-16 surrogate** in tool-result text reaches the `messages.content` `jsonb` column. `JSON.stringify` escapes the survivor as `\udXXX`, and Postgres rejects the row.

Verified against a real Postgres 16 through the `pg` driver:

| jsonb value | result |
| --- | --- |
| lone high surrogate | `[22P02] invalid input syntax for type json` — DETAIL: *Unicode low surrogate must follow a high surrogate* |
| lone low surrogate | `[22P02] invalid input syntax for type json` |
| NUL character | `[22P05] unsupported Unicode escape sequence` — a **different** message, so NUL is ruled out |
| well-formed pair | passes |

An unpaired surrogate is the only value reachable from `JSON.stringify` that produces production's exact message. A `text` column tolerates the same input (silent U+FFFD); only `jsonb` rejects it.

### Why it slipped through an existing sanitizer

`ToolResultMessageContent` already sanitizes its `result` — but with `sanitizeUnicodeEscapes`, which only repairs broken `\u…` escape *text* and strips NULs. The helper that handles lone surrogates, `toWellFormedText`, was added to the same file for incident #536 (Mistral embeddings rejecting `\udXXX` with a 400) and wired into exactly one call site: `embed-text.use-case.ts`. The five message-content entities were never migrated.

## Change

One line at the shared choke point: `sanitizeUnicodeEscapes` now returns `toWellFormedText(...)` of its result. That covers all five message-content types and `sanitizeObject`'s recursion over nested tool params, instead of patching five call sites.

It runs *after* the escape fixpoint loop rather than inside it: replacing a lone surrogate is length-preserving, which would break the loop's "every changing pass shortens the string" termination argument. U+FFFD is inert for the escape passes, so the function stays idempotent — message contents are re-sanitized on every copy.

## Verification

- **Red first** — the two new surrogate assertions failed before the change, pass after. `unicode-sanitizer.spec.ts`: 20/20.
- **Full backend suite on fresh `main`**: 747 suites, 5031 tests passed.
- `tsc --noEmit -p tsconfig.json` clean; `eslint --max-warnings=0` clean on both changed files; all pre-commit gates green (complexity, dependency-cruiser, duplication, file size).
- **End-to-end against live Postgres 16** (throwaway spec, not committed): a `ToolResultMessage` carrying a scraped string whose emoji lost its low surrogate, mapped through `MessageMapper.toRecord`, is rejected with `invalid input syntax for type json` unsanitized, and after the fix inserts and reads back with the broken half replaced by U+FFFD.

## Out of scope — filed separately

Two independent defects surfaced during the investigation; neither is touched here.

1. **[AYC-904](https://linear.app/ayunis/issue/AYC-904) — `runEnd` retries a failed tool-result flush.** `PersistenceHookFactory.flushToolResults` clears `PENDING_TOOL_RESULTS` only on success or on a null (thread-missing) result. When the write *throws*, the buffer survives and the `runEnd` hook re-flushes the same contents. Every write failure is therefore reported twice — once as a recoverable `afterToolCall` `HOOK_FAILED` carrying the real cause, then as the *critical* finalization error that became this incident's signature and hid it. Confirmed in the log pairs at 2026-09-07T08:23:53, 2026-09-03T07:35:52, 2026-08-28T12:50:15 and 2026-08-26T12:28:57.
2. **[AYC-905](https://linear.app/ayunis/issue/AYC-905) — Presidio offsets are code points, applied as UTF-16 code units.** `presidio_service.py` returns Python string indices; `toDetection`, `apply-replacements.ts` and `apply-mask-replacements.ts` use them with `substring`/`slice`. Any astral character shifts every later PII span, so the wrong text is masked and the stored mask value will not round-trip through de-anonymization. The 2026-09-07 request logged 30000 code units against 29990 code points — 10 astral characters. `countCodePoints` already exists in that provider for the length check, so the distinction was known for validation but not for offsets.

`truncateToolResult`'s `slice(0, MAX_ANONYMIZATION_TEXT_LENGTH)` can also split a surrogate pair, but two occurrences were well under the cap (3832 and 13846 chars), so it is not the cause — and the sanitizer now repairs it regardless.

Closes AYC-902.
