### PR TITLE
fix(email): block MJML template injection (AYC-890)

### DIFF
--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/_layout.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/_layout.ts
@@ -119,7 +119,7 @@ function renderBannerSection(
   return bannerUrl
     ? `<mj-section background-color="${COLOR.card}" padding="16px 32px 0 32px">
          <mj-column>
-           <mj-image src="${bannerUrl}" alt="${escapeAttr(bannerAlt ?? '')}" width="496px" border-radius="10px" padding="0" />
+           <mj-image src="${bannerUrl}" alt="${escapeAttribute(bannerAlt ?? '')}" width="496px" border-radius="10px" padding="0" />
          </mj-column>
        </mj-section>`
     : '';
@@ -220,6 +220,6 @@ export function escapeText(input: string): string {
     .replace(/>/g, '&gt;');
 }
 
-function escapeAttr(input: string): string {
+export function escapeAttribute(input: string): string {
   return escapeText(input).replace(/"/g, '&quot;');
 }

--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/budget-warning.template.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/budget-warning.template.ts
@@ -1,7 +1,6 @@
-import mjml2html from 'mjml';
 import type { MJMLParseResults } from 'mjml-core';
 
-import type { BudgetWarningTemplateContent } from '../../../domain/email-template.entity';
+import type { BudgetWarningTemplateContent } from 'src/common/email-templates/domain/email-template.entity';
 import {
   buildBudgetWarningMessage,
   type BudgetWarningMessage,
@@ -15,6 +14,7 @@ import {
   renderLayout,
   teamSignoff,
 } from './_layout';
+import { renderMjml } from './render-mjml';
 
 function normalizeInlineText(value: string): string {
   return value.trim().replace(/\s+/g, ' ');
@@ -89,7 +89,7 @@ export function budgetWarningHtml(
     teamSignoff(template.teamUrl),
   ].join('\n');
 
-  return mjml2html(
+  return renderMjml(
     renderLayout({
       title: `${message.headline} · ${normalizeInlineText(template.productName)}`,
       preheader: message.preheader,

--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/email-confirmation.template.spec.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/email-confirmation.template.spec.ts
@@ -1,0 +1,29 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { emailConfirmationHtml } from './email-confirmation.template';
+
+describe('email confirmation template', () => {
+  it('renders an MJML include payload in an email address as inert text', () => {
+    const fixtureDirectory = mkdtempSync(join(tmpdir(), 'ayunis-mjml-'));
+    const fixturePath = join(fixtureDirectory, 'include.html');
+    const includedMarker = 'AYUNIS_MJML_INCLUDE_MUST_NOT_RENDER';
+    writeFileSync(fixturePath, includedMarker);
+
+    try {
+      const maliciousEmail = `"</mj-text><mj-include type=html path=${fixturePath}>"@x.io`;
+      const rendered = emailConfirmationHtml({
+        confirmationUrl: 'https://app.ayunis.test/confirm?token=safe-token',
+        userEmail: maliciousEmail,
+        currentYear: '2026',
+        companyName: 'Ayunis',
+      });
+
+      expect(rendered.html).not.toContain(includedMarker);
+      expect(rendered.html).toContain('&lt;/mj-text&gt;');
+    } finally {
+      rmSync(fixtureDirectory, { recursive: true, force: true });
+    }
+  });
+});

--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/email-confirmation.template.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/email-confirmation.template.ts
@@ -1,6 +1,7 @@
-import mjml2html from 'mjml';
 import type { MJMLParseResults } from 'mjml-core';
 import type { EmailConfirmationTemplateContent } from 'src/common/email-templates/domain/email-template.entity';
+import { escapeAttribute, escapeText } from './_layout';
+import { renderMjml } from './render-mjml';
 
 export function emailConfirmationText(
   template: EmailConfirmationTemplateContent,
@@ -24,7 +25,12 @@ export function emailConfirmationText(
 export function emailConfirmationHtml(
   template: EmailConfirmationTemplateContent,
 ): MJMLParseResults {
-  return mjml2html(`
+  const confirmationUrl = escapeAttribute(template.confirmationUrl);
+  const userEmail = escapeText(template.userEmail);
+  const currentYear = escapeText(template.currentYear);
+  const companyName = escapeText(template.companyName);
+
+  return renderMjml(`
 <mjml>
   <mj-head>
     <mj-title>E-Mail-Adresse bestätigen</mj-title>
@@ -63,7 +69,7 @@ export function emailConfirmationHtml(
           font-size="16px"
           font-weight="600"
           border-radius="8px"
-          href="${template.confirmationUrl}"
+          href="${confirmationUrl}"
           css-class="confirmation-button"
         >
           E-Mail-Adresse bestätigen
@@ -86,7 +92,7 @@ export function emailConfirmationHtml(
         <mj-divider border-color="#e5e7eb" border-width="1px" padding-bottom="24px" />
 
         <mj-text align="center" color="#6b7280" font-size="14px" padding-bottom="8px">
-          Diese E-Mail wurde gesendet an ${template.userEmail}
+          Diese E-Mail wurde gesendet an ${userEmail}
         </mj-text>
 
         <mj-text align="center" color="#6b7280" font-size="14px" padding-bottom="16px">
@@ -94,7 +100,7 @@ export function emailConfirmationHtml(
         </mj-text>
 
         <mj-text align="center" color="#9ca3af" font-size="12px">
-          © ${template.currentYear} ${template.companyName} . Alle Rechte vorbehalten.
+          © ${currentYear} ${companyName} . Alle Rechte vorbehalten.
         </mj-text>
       </mj-column>
     </mj-section>

--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/invitation.template.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/invitation.template.ts
@@ -1,4 +1,3 @@
-import mjml2html from 'mjml';
 import type { MJMLParseResults } from 'mjml-core';
 import type { InvitationTemplateContent } from 'src/common/email-templates/domain/email-template.entity';
 import {
@@ -11,6 +10,7 @@ import {
   renderLayout,
   teamSignoff,
 } from './_layout';
+import { renderMjml } from './render-mjml';
 
 function preheader(template: InvitationTemplateContent): string {
   return template.adminName
@@ -67,7 +67,7 @@ export function invitationHtml(
     teamSignoff(template.teamUrl),
   ].join('\n');
 
-  return mjml2html(
+  return renderMjml(
     renderLayout({
       title: `Einladung zu ${template.invitingCompanyName} · ${template.productName}`,
       preheader: preheader(template),

--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/password-reset.template.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/password-reset.template.ts
@@ -1,4 +1,3 @@
-import mjml2html from 'mjml';
 import type { MJMLParseResults } from 'mjml-core';
 import type { PasswordResetTemplateContent } from 'src/common/email-templates/domain/email-template.entity';
 import {
@@ -11,6 +10,7 @@ import {
   renderLayout,
   teamSignoff,
 } from './_layout';
+import { renderMjml } from './render-mjml';
 
 export function passwordResetText(
   template: PasswordResetTemplateContent,
@@ -60,7 +60,7 @@ export function passwordResetHtml(
     teamSignoff(template.teamUrl),
   ].join('\n');
 
-  return mjml2html(
+  return renderMjml(
     renderLayout({
       title: `Passwort zurücksetzen · ${template.productName}`,
       preheader:

--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/render-mjml.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/render-mjml.ts
@@ -1,0 +1,6 @@
+import mjml2html from 'mjml';
+import type { MJMLParseResults } from 'mjml-core';
+
+export function renderMjml(source: string): MJMLParseResults {
+  return mjml2html(source, { ignoreIncludes: true });
+}

--- a/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/set-initial-password.template.ts
+++ b/ayunis-core-backend/src/common/email-templates/infrastructure/mjml/templates/set-initial-password.template.ts
@@ -1,4 +1,3 @@
-import mjml2html from 'mjml';
 import type { MJMLParseResults } from 'mjml-core';
 import type { SetInitialPasswordTemplateContent } from 'src/common/email-templates/domain/email-template.entity';
 import {
@@ -11,6 +10,7 @@ import {
   renderLayout,
   teamSignoff,
 } from './_layout';
+import { renderMjml } from './render-mjml';
 
 export function setInitialPasswordText(
   template: SetInitialPasswordTemplateContent,
@@ -50,7 +50,7 @@ export function setInitialPasswordHtml(
     teamSignoff(template.teamUrl),
   ].join('\n');
 
-  return mjml2html(
+  return renderMjml(
     renderLayout({
       title: `Ihr Konto bei ${template.invitingCompanyName} · ${template.productName}`,
       preheader: `Wir haben ein Konto für Sie angelegt. Legen Sie jetzt Ihr Passwort fest.`,


### PR DESCRIPTION
Re-lands **PR #1598** (AYC-890). GitHub reports that PR as merged, but its content never reached `main`, and therefore never reached any release.

Production currently runs revision `2e5d6a505` = tag **v2.36.0** (from `appsignal.config.revision` on traces through 2026-09-07T10:38Z). `render-mjml.ts` is absent from v2.36.0 and from every earlier tag checked back to v2.33.0, so the guard is absent from the code actually deployed — not merely absent from `main`.

## Why the original fix is missing

#1598's base was the stacked parent `09-03-fix_invites_require_tenant_admin_for_invitations_ayc-889_`, not `main`. The order of events:

| Time (2026-09-03) | Event |
| --- | --- |
| `13:05:10Z` | #1597 (the parent, base `main`) squash-merged → `b1327e67c`. That squash contains **zero** email-template files. |
| `13:25:52Z` | #1598 merged into the parent branch — 20 minutes after the parent had already been squashed away. |

Merge commit `e7dd0406` is reachable only from the now-stale `origin/09-03-…ayc-889_`; `git merge-base --is-ancestor e7dd0406 origin/main` is false. On `main` today there is no `render-mjml.ts`, no `ignoreIncludes`, and all five templates call `mjml2html(...)` directly.

## Confirmed by execution, not inferred

Before applying anything, the reproduction spec was run against unpatched `main`. `main` is a strict descendant of the deployed v2.36.0 for these six files — all are byte-identical between the two — so this reproduction speaks for the deployed code:

```
● email confirmation template › renders an MJML include payload in an email address as inert text
  expect(rendered.html).not.toContain(includedMarker)
  Tests: 1 failed, 1 total
```

The assertion that failed is the one checking a local file's contents are **absent** from the rendered email. So on current `main`, an `mj-include` smuggled through an RFC-style quoted-local-part email address breaks out of the surrounding `mj-text` and causes `mjml2html` to read a local file and embed it in outbound mail. That is arbitrary local-file disclosure to an email recipient.

## Change

Cherry-picked unchanged from `b79b03123`; it applied to current `main` without conflict, because `main`'s versions of all six touched files are still identical to the pre-fix state the original was written against.

- **`render-mjml.ts`** (new) — wraps `mjml2html(source, { ignoreIncludes: true })`. All five templates render through it, so `mj-include` can no longer resolve local paths.
- **`email-confirmation.template.ts`** — escapes `confirmationUrl`, `userEmail`, `currentYear` and `companyName`. This was the one template interpolating user-controlled values into MJML source unescaped; the other four already went through the `_layout` helpers.
- **`_layout.ts`** — `escapeAttr` renamed to `escapeAttribute` and exported for the above.

Defence in depth: `ignoreIncludes` blocks the file read, escaping blocks the element breakout. Either alone would stop this specific payload; both are kept, as in the original.

## Verification

- **Red before green** — the spec failed on unpatched `main` (output above), passes after.
- **Full backend suite**: 748 suites, 5032 tests passed.
- `tsc --noEmit -p tsconfig.json` clean; `eslint --max-warnings=0` clean on all 8 changed files; all pre-commit gates green.
- Base is `main` this time, verified after submission — that was the whole failure mode last time.

Refs AYC-890, supersedes #1598.
