### PR TITLE
fix(runs): report a failed tool-result flush once (AYC-904)

### DIFF
--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/hooks/persistence-hook.factory.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/hooks/persistence-hook.factory.spec.ts
@@ -98,6 +98,35 @@ describe('PersistenceHookFactory', () => {
     expect(addMessage).not.toHaveBeenCalled();
   });
 
+  // A failed flush used to stay in the pending buffer, so the runEnd flush
+  // retried the same poisoned contents and failed a second time. Because the
+  // hook is runEndFailureMode 'critical', that second failure surfaced as
+  // "Agent runtime finalization failed" and became the AppSignal incident
+  // signature, hiding the real cause of the first one (AYC-904).
+  it('does not retry a failed tool-result write when the run ends', async () => {
+    const failure = new Error(
+      'Failed to create tool message: invalid input syntax for type json',
+    );
+    const createToolResult = jest.fn().mockRejectedValue(failure);
+    const { hook } = buildHook(jest.fn(), createToolResult);
+    const context = RunContext.create();
+
+    await expect(
+      hook.afterToolCall?.({
+        context,
+        iteration: 0,
+        toolCall: { id: 'call-1', name: 'website_content', input: {} },
+        result: 'scraped page',
+        isLastToolCall: true,
+      } as never),
+    ).rejects.toBe(failure);
+
+    await expect(
+      hook.runEnd?.({ context, messages: [], status: 'error' } as never),
+    ).resolves.toBeUndefined();
+    expect(createToolResult).toHaveBeenCalledTimes(1);
+  });
+
   it('does not persist an empty assistant message after interruption', async () => {
     const save = jest.fn().mockResolvedValue(undefined);
     const { hook, addMessage } = buildHook(save);

--- a/ayunis-core-backend/src/domain/runs/application/agent-runtime/hooks/persistence-hook.factory.ts
+++ b/ayunis-core-backend/src/domain/runs/application/agent-runtime/hooks/persistence-hook.factory.ts
@@ -139,6 +139,14 @@ export class PersistenceHookFactory {
     if (!pending || pending.contents.length === 0) {
       return;
     }
+    // Drained before the write, not after it: the runEnd flush exists to
+    // persist contents no earlier phase attempted, not to retry a write that
+    // already failed. Retrying one turned every persistence failure into a
+    // second, critical finalization failure that hid the real cause (AYC-904).
+    context.set(PENDING_TOOL_RESULTS, {
+      iteration: pending.iteration,
+      contents: [],
+    });
     const saved = await this.createToolResultMessageUseCase.execute(
       new CreateToolResultMessageCommand(
         thread.id,
@@ -147,10 +155,6 @@ export class PersistenceHookFactory {
       ),
     );
     if (!saved) {
-      context.set(PENDING_TOOL_RESULTS, {
-        iteration: pending.iteration,
-        contents: [],
-      });
       throw new RunAbortedError(
         'Run aborted because the thread no longer exists',
       );
@@ -158,9 +162,5 @@ export class PersistenceHookFactory {
     this.addMessageToThreadUseCase.execute(
       new AddMessageCommand(thread, saved),
     );
-    context.set(PENDING_TOOL_RESULTS, {
-      iteration: pending.iteration,
-      contents: [],
-    });
   }
 }

--- a/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/use-cases/execute-run/execute-run.use-case.spec.ts
@@ -820,7 +820,9 @@ describe('ExecuteRunUseCase', () => {
     );
 
     expect(execute).toHaveBeenCalledTimes(50);
-    expect(createToolResult).toHaveBeenCalledTimes(51);
+    // 50, not 51: the failed 50th write is not re-attempted by the runEnd
+    // flush, so the failure is reported once instead of twice (AYC-904).
+    expect(createToolResult).toHaveBeenCalledTimes(50);
     expect(cleanup).toHaveBeenCalledWith(threadId);
   });
 


### PR DESCRIPTION
Closes AYC-904. Follow-up to [#1613](https://github.com/ayunis-core/ayunis-core/pull/1613) (AYC-902): that PR fixed the *cause* of AppSignal incident #548, this one fixes why the incident was undiagnosable.

## Problem

`PersistenceHookFactory.flushToolResults` drained the `PENDING_TOOL_RESULTS` run-context buffer only *after* a successful write. A write that threw left its contents in place, so the `runEnd` flush re-attempted the very same batch. Since the hook declares `runEndFailureMode: 'critical'`, that second failure became `RunExecutionFailedError('Agent runtime finalization failed')` — and, firing last, it is the one that reached AppSignal as the incident signature, while the first report carried the real cause.

That is why incident #548 (83 occurrences on `POST /api/runs/send-message`) could only be diagnosed from correlated log lines. Every failing request logged the identical message twice:

```
phase: afterToolCall   Hook 'ayunis-persistence' failed in afterToolCall: … invalid input syntax for type json
phase: runEnd          Hook 'ayunis-persistence' failed in runEnd:        … invalid input syntax for type json
```

Confirmed at 2026-09-07T08:23:53, 2026-09-03T07:35:52, 2026-08-28T12:50:15 and 2026-08-26T12:28:57 (production `6a611f0dd841ff7c22841fb2`).

## Change

The `runEnd` flush exists to persist contents that no earlier phase attempted — an iteration whose `afterToolCall` never saw `isLastToolCall`, for instance — not to retry one that failed. So the buffer is drained *before* the write. That replaces the two post-write clears, making the method shorter: three `context.set` calls become one.

Nothing is lost by dropping the retry. The throw ends the run regardless, and `MessageCleanupService` deletes the turn's trailing messages either way — so even a retry that succeeded had its message deleted moments later. It also removes a latent duplicate-key hazard: `toolResultMessageId` is deterministic, so retrying a write that had already committed before failing downstream would have collided on the primary key.

## One pre-existing test asserted the retry

`execute-run.use-case.spec.ts › cleans up the final tool-use turn when its max-iteration flush fails` expected `createToolResult` to be called **51** times for 50 iterations — the 51st being the runEnd retry of the failed 50th write. Both the test and that number arrived together in `1bd9740d7` (`refactor(runs): remove legacy agent orchestration path (AYC-769)`, #1565) with no comment justifying it, so it codified observed behaviour rather than an intended contract. It is 50 now, with a comment saying why.

Its other assertions are unchanged and still pass: the run still rejects with `Run execution failed`, and `cleanup` is still called with the thread id. The only observable difference is one fewer write attempt.

## Scope item dropped after checking

The ticket asked whether the surviving error should carry the cause as `ErrorMetadata`. It should not — `reportUnexpectedError` calls `setError(error)` with no `setCustomData`/`setTags`, so `ApplicationError` metadata never reaches AppSignal. That matches incident #548's error traces, which carried only `exception.type` and `exception.message` while the structured attributes lived on the log line. Adding metadata would have changed nothing observable, so it is not in this PR.

The real cause is already on the surviving report: `mapRunError`'s fallback logs `code`, `message` and `details` before returning the generic error, which is exactly what the diagnosis of AYC-902 was built from.

## Verification

- **Red before green** — the new spec drives `afterToolCall` into a failing write, then calls `runEnd`. Pre-fix, `runEnd` rejected with the identical error (`Received promise rejected instead of resolved`); post-fix it resolves and `createToolResult` is called exactly once.
- **Full backend suite**: 747 suites, 5032 tests passed.
- `tsc --noEmit -p tsconfig.json` clean; `eslint --max-warnings=0` clean on all 3 changed files; all pre-commit gates green.

Note on deployment: like #1613, merging this does not put it in production. Production runs tag **v2.36.0** (revision `2e5d6a505`); release PR #1611 is what ships these.
