### PR TITLE
fix(anonymization): translate presidio spans to utf-16 offsets (AYC-905)

### DIFF
--- a/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.spec.ts
+++ b/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.spec.ts
@@ -143,6 +143,29 @@ describe('PresidioAnonymizationProvider', () => {
     expect(mockAnalyzeTextAnalyzePost).not.toHaveBeenCalled();
   });
 
+  // Presidio returns Python string indices, which count code points — an emoji
+  // is 1 — while substring/slice count UTF-16 code units, where it is 2. Every
+  // span after an astral character used to resolve one unit short per emoji,
+  // masking the wrong text and storing a mask value that cannot round-trip
+  // through de-anonymization (AYC-905).
+  it('resolves spans past an emoji using code-point offsets', async () => {
+    const text = 'Hi \u{1F600} ich bin der Dani';
+    mockResults([{ entity_type: 'PERSON', start: 17, end: 21, score: 0.9 }]);
+
+    const detections = await provider.detect(text);
+
+    expect(detections[0]).toMatchObject({ text: 'Dani', start: 18, end: 22 });
+  });
+
+  it('leaves spans before any astral character untouched', async () => {
+    const text = 'Dani schrieb \u{1F600}';
+    mockResults([{ entity_type: 'PERSON', start: 0, end: 4, score: 0.9 }]);
+
+    const detections = await provider.detect(text);
+
+    expect(detections[0]).toMatchObject({ text: 'Dani', start: 0, end: 4 });
+  });
+
   it('counts Unicode code points like the anonymize service', async () => {
     const text = '😀'.repeat(30_000);
     mockResults([]);

--- a/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.ts
+++ b/ayunis-core-backend/src/common/anonymization/infrastructure/providers/presidio-anonymization.provider.ts
@@ -21,15 +21,24 @@ function backoff(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function countCodePoints(text: string): number {
-  let count = 0;
+/**
+ * The UTF-16 offset of every code point in `text`, plus a final entry for the
+ * end of the string. The anonymize service returns Python string indices,
+ * which count code points, so its spans have to be translated before
+ * substring/slice — those count UTF-16 code units, where an astral character
+ * is two (AYC-905). The table's length is the code point count the service
+ * sees, which is also what the input-size limit is measured in.
+ */
+function utf16OffsetsByCodePoint(text: string): number[] {
+  const offsets: number[] = [];
   for (let offset = 0; offset < text.length; offset += 1) {
-    count += 1;
+    offsets.push(offset);
     if ((text.codePointAt(offset) ?? 0) > 0xffff) {
       offset += 1;
     }
   }
-  return count;
+  offsets.push(text.length);
+  return offsets;
 }
 
 @Injectable()
@@ -41,7 +50,8 @@ export class PresidioAnonymizationProvider extends AnonymizationPort {
   }
 
   async detect(text: string, entities?: string[]): Promise<PiiDetection[]> {
-    const textLength = countCodePoints(text);
+    const utf16Offsets = utf16OffsetsByCodePoint(text);
+    const textLength = utf16Offsets.length - 1;
     if (textLength > MAX_ANONYMIZATION_TEXT_LENGTH) {
       throw new AnonymizationInputTooLongError(
         textLength,
@@ -56,7 +66,7 @@ export class PresidioAnonymizationProvider extends AnonymizationPort {
       const results = await this.detectWithRetry(text, entities, textLength);
       const nonOverlappingResults = this.dropOverlappingResults(results);
       const detections = nonOverlappingResults.map((result) =>
-        this.toDetection(text, result),
+        this.toDetection(text, result, utf16Offsets),
       );
 
       this.logDetectionComplete(textLength, detections.length, startedAt);
@@ -142,13 +152,20 @@ export class PresidioAnonymizationProvider extends AnonymizationPort {
     );
   }
 
-  private toDetection(text: string, result: RecognizerResult): PiiDetection {
+  private toDetection(
+    text: string,
+    result: RecognizerResult,
+    utf16Offsets: readonly number[],
+  ): PiiDetection {
+    // Clamped rather than trusted: the span comes from an external service.
+    const start = utf16Offsets[result.start] ?? text.length;
+    const end = utf16Offsets[result.end] ?? text.length;
     return {
       entityType: result.entity_type,
       category: mapPresidioEntityToCategory(result.entity_type),
-      text: text.substring(result.start, result.end),
-      start: result.start,
-      end: result.end,
+      text: text.substring(start, end),
+      start,
+      end,
       score: result.score,
     };
   }


### PR DESCRIPTION
Closes AYC-905. Found while diagnosing AYC-902; independent of it.

## Problem

The pipeline mixed two string index spaces. `ayunis-core-anonymize/app/presidio_service.py` returns Presidio's `result.start` / `result.end` verbatim — Python string indices, which count **code points**, so an emoji is 1. The backend fed them to `substring` / `slice`, which count **UTF-16 code units**, where an emoji is 2.

So every span after an astral character resolved one unit short per preceding emoji, in `toDetection`, `apply-replacements.ts` and `apply-mask-replacements.ts` alike.

## What that actually did — measured, not reasoned

Same input through `PresidioAnonymizationProvider` → `AnonymizeTextUseCase` → `deanonymizeText`, with the HTTP client stubbed. Text `Hi 😀 ich bin der Dani`, one `PERSON` detection at code points 17..21 (code units 18..22):

| | before | after |
| --- | --- | --- |
| anonymized | `Hi 😀 ich bin der{{pii:PERSON_NAME_1}}i` | `Hi 😀 ich bin der {{pii:PERSON_NAME_1}}` |
| mask value | `" Dan"` | `"Dani"` |
| whitelisting `Dani` | still masked | correctly exempt |

Two harms, and the first is the serious one:

1. **PII partially left in the clear.** The mask covered code units 17..21, so the trailing `i` of `Dani` survived into the output while the preceding space was consumed. A privacy control leaking characters of the very value it exists to hide, and it leaks one more character per preceding astral character.
2. **Whitelist entries stopped matching.** `whitelist-filter.ts` compares an entry's pattern against `detection.text`, which was the mis-sliced `" Dan"`. A configured exemption for `Dani` therefore did not match, and the value was masked anyway.

**Correcting the ticket:** it claimed the stored mask value "will not round-trip through de-anonymization". That is wrong — `deanonymizeText` reproduced the input exactly even before the fix, because the token and the stored value were both derived from the same wrong offsets, i.e. self-consistently corrupt. Verified, not assumed. The round-trip was never the defect; the leak and the whitelist bypass are.

## Change

Translation happens in the adapter, where engine-specific results already become domain `PiiDetection`s.

- Build the code-point → UTF-16 offset table once per `detect` call. Its length replaces `countCodePoints` for the input-size limit, so the single pass that already measured the text now also translates its spans — no extra traversal, one function instead of two.
- Clamp an out-of-range span to the end of the text rather than trusting an external service's indices.

**Why the backend and not the Python service:** it keeps one conversion point, and it cannot break under a rolling deploy. Changing the service's contract would mean a window where an old backend talks to a converting service (or the reverse), silently double-converting or not converting at all. Converting here needs no contract change at all.

Safe to confine to this module: the offsets never leave it — `grep` finds only `replacements.length`, read for a log count in `execute-run-and-set-title`. `dropOverlappingResults` still compares raw code-point values, which is fine because the translation is monotonic.

## Verification

- **Red before green** — the new spec asserted `text: 'Dani', start: 18, end: 22` and failed with `text: " Dan", start: 17, end: 21`. A second test covers a span *before* any astral character, so the ASCII path is pinned as identity.
- **Full backend suite**: 748 suites, 5035 tests passed. The existing ASCII offset assertions (`start: 12, end: 16` for `Ich bin der Dani`) still pass unchanged.
- `tsc --noEmit -p tsconfig.json` clean; `eslint --max-warnings=0` clean on both changed files; all pre-commit gates green.

No end-to-end test was added on top: the composed harms both reduce to "the offsets and `detection.text` agree with the original string", which the adapter tests assert directly, and `applyMaskReplacements` / `whitelist-filter` are pure functions already covered. The table above is evidence, not a coverage gap.

Note on deployment: production runs tag **v2.36.0** (revision `2e5d6a505`); merging this does not ship it.
