### PR TITLE
fix(models): refresh default model for new chats (AYC-881)

### DIFF
--- a/ayunis-core-frontend/src/app/routes/_authenticated/-chat.index.test.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/-chat.index.test.tsx
@@ -1,0 +1,89 @@
+import { QueryClient } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getEffectiveDefaultModel: vi.fn(),
+  getSystemPrompt: vi.fn(),
+  hasActiveSubscription: vi.fn(),
+  isEmbeddingModelEnabled: vi.fn(),
+}));
+
+vi.mock('@/pages/new-chat', () => ({
+  NewChatPage: () => null,
+  NewChatPageNoModelError: () => null,
+}));
+vi.mock('@/shared/api', () => ({
+  chatSettingsControllerGetSystemPrompt: mocks.getSystemPrompt,
+  getChatSettingsControllerGetSystemPromptQueryKey: () => ['system-prompt'],
+  getModelsControllerIsEmbeddingModelEnabledQueryKey: () => [
+    'embedding-model-enabled',
+  ],
+  getModelsDefaultsControllerGetEffectiveDefaultModelQueryKey: () => [
+    'effective-default-model',
+  ],
+  getSubscriptionsControllerHasActiveSubscriptionQueryKey: () => [
+    'active-subscription',
+  ],
+  modelsControllerIsEmbeddingModelEnabled: mocks.isEmbeddingModelEnabled,
+  modelsDefaultsControllerGetEffectiveDefaultModel:
+    mocks.getEffectiveDefaultModel,
+  subscriptionsControllerHasActiveSubscription: mocks.hasActiveSubscription,
+}));
+vi.mock('@/shared/api/extract-error-data', () => ({ default: vi.fn() }));
+
+const { Route } = await import('./chat.index');
+
+interface LoaderResult {
+  selectedModelId?: string;
+}
+
+function appQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 5 * 60 * 1000 } },
+  });
+}
+
+async function runLoader(queryClient: QueryClient): Promise<LoaderResult> {
+  const loader = Route.options.loader as (args: {
+    deps: { modelId?: string };
+    context: { queryClient: QueryClient };
+  }) => Promise<LoaderResult>;
+
+  return loader({ deps: {}, context: { queryClient } });
+}
+
+describe('new chat route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getEffectiveDefaultModel.mockResolvedValue({
+      permittedLanguageModel: { id: 'sol' },
+    });
+    mocks.getSystemPrompt.mockResolvedValue({});
+    mocks.hasActiveSubscription.mockResolvedValue({
+      hasActiveSubscription: true,
+    });
+    mocks.isEmbeddingModelEnabled.mockResolvedValue({
+      isEmbeddingModelEnabled: true,
+    });
+  });
+
+  it('loads the current default instead of trusting a fresh cached value', async () => {
+    const queryClient = appQueryClient();
+    queryClient.setQueryData(['effective-default-model'], {
+      permittedLanguageModel: { id: 'terra' },
+    });
+
+    const result = await runLoader(queryClient);
+
+    expect(result.selectedModelId).toBe('sol');
+    expect(mocks.getEffectiveDefaultModel).toHaveBeenCalledOnce();
+  });
+
+  it('renders without a preselected model when the default cannot be loaded', async () => {
+    mocks.getEffectiveDefaultModel.mockRejectedValue(new Error('offline'));
+
+    const result = await runLoader(appQueryClient());
+
+    expect(result.selectedModelId).toBeUndefined();
+  });
+});

--- a/ayunis-core-frontend/src/app/routes/_authenticated/-effective-default-model-query.ts
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/-effective-default-model-query.ts
@@ -1,0 +1,12 @@
+import {
+  getModelsDefaultsControllerGetEffectiveDefaultModelQueryKey,
+  modelsDefaultsControllerGetEffectiveDefaultModel,
+} from '@/shared/api';
+
+export function effectiveDefaultModelQueryOptions() {
+  return {
+    queryKey: getModelsDefaultsControllerGetEffectiveDefaultModelQueryKey(),
+    queryFn: () => modelsDefaultsControllerGetEffectiveDefaultModel(),
+    staleTime: 0,
+  };
+}

--- a/ayunis-core-frontend/src/app/routes/_authenticated/chat.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/chat.index.tsx
@@ -1,10 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { NewChatPage, NewChatPageNoModelError } from '@/pages/new-chat';
 import {
-  modelsDefaultsControllerGetEffectiveDefaultModel,
   getSubscriptionsControllerHasActiveSubscriptionQueryKey,
   subscriptionsControllerHasActiveSubscription,
-  getModelsDefaultsControllerGetEffectiveDefaultModelQueryKey,
   getModelsControllerIsEmbeddingModelEnabledQueryKey,
   modelsControllerIsEmbeddingModelEnabled,
   chatSettingsControllerGetSystemPrompt,
@@ -12,11 +10,7 @@ import {
 } from '@/shared/api';
 import extractErrorData from '@/shared/api/extract-error-data';
 import { z } from 'zod';
-
-const queryDefaultModelOptions = () => ({
-  queryKey: getModelsDefaultsControllerGetEffectiveDefaultModelQueryKey(),
-  queryFn: () => modelsDefaultsControllerGetEffectiveDefaultModel(),
-});
+import { effectiveDefaultModelQueryOptions } from './-effective-default-model-query';
 
 const queryHasActiveSubscriptionOptions = () => ({
   queryKey: getSubscriptionsControllerHasActiveSubscriptionQueryKey(),
@@ -43,11 +37,10 @@ export const Route = createFileRoute('/_authenticated/chat/')({
     if (modelId) {
       selectedModelId = modelId;
     } else {
-      const defaultModelResponse = await queryClient.fetchQuery(
-        queryDefaultModelOptions(),
-      );
-      const defaultModel = defaultModelResponse.permittedLanguageModel;
-      selectedModelId = defaultModel?.id;
+      const defaultModelResponse = await queryClient
+        .fetchQuery(effectiveDefaultModelQueryOptions())
+        .catch(() => null);
+      selectedModelId = defaultModelResponse?.permittedLanguageModel?.id;
     }
     const { isEmbeddingModelEnabled } = await queryClient.fetchQuery(
       queryIsEmbeddingModelEnabledOptions(),

--- a/ayunis-core-frontend/src/app/routes/_authenticated/workspaces.$workspaceId.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/workspaces.$workspaceId.tsx
@@ -8,22 +8,16 @@ import {
   getThreadsControllerFindAllQueryKey,
   appControllerFeatureToggles,
   getAppControllerFeatureTogglesQueryKey,
-  modelsDefaultsControllerGetEffectiveDefaultModel,
-  getModelsDefaultsControllerGetEffectiveDefaultModelQueryKey,
   modelsControllerIsEmbeddingModelEnabled,
   getModelsControllerIsEmbeddingModelEnabledQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
+import { effectiveDefaultModelQueryOptions } from './-effective-default-model-query';
 
 const WORKSPACE_CHATS_LIMIT = 20;
 
 const searchSchema = z.object({
   search: z.string().optional(),
   page: z.number().min(1).optional().catch(1),
-});
-
-const queryDefaultModelOptions = () => ({
-  queryKey: getModelsDefaultsControllerGetEffectiveDefaultModelQueryKey(),
-  queryFn: () => modelsDefaultsControllerGetEffectiveDefaultModel(),
 });
 
 const queryIsEmbeddingModelEnabledOptions = () => ({
@@ -71,7 +65,9 @@ export const Route = createFileRoute('/_authenticated/workspaces/$workspaceId')(
       });
 
       const [defaultModelResponse, embeddingModelResponse] = await Promise.all([
-        queryClient.fetchQuery(queryDefaultModelOptions()).catch(() => null),
+        queryClient
+          .fetchQuery(effectiveDefaultModelQueryOptions())
+          .catch(() => null),
         queryClient
           .fetchQuery(queryIsEmbeddingModelEnabledOptions())
           .catch(() => null),

--- a/ayunis-core-frontend/src/pages/admin-settings/model-settings/api/useCreatePermittedModel.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/model-settings/api/useCreatePermittedModel.ts
@@ -7,7 +7,7 @@ import {
   getModelsControllerGetPermittedLanguageModelsQueryKey,
   type ModelWithConfigResponseDto,
 } from '@/shared/api';
-import type { Model } from '../model/openapi';
+import type { Model } from '@/pages/admin-settings/model-settings/model/openapi';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized route-loader and query-cache behavior for default model selection, with tests; no auth or API contract changes.
> 
> **Overview**
> Fixes new chat and workspace flows showing a **stale effective default model** when React Query already had cached data (e.g. after an admin changes the default).
> 
> Introduces shared `effectiveDefaultModelQueryOptions()` with **`staleTime: 0`** so route loaders always refetch the current default instead of reusing a fresh-looking cache entry. The **new chat** loader now **tolerates fetch failures** (no preselected model) instead of failing the route. **Workspace** loader uses the same options. **Vitest** covers refetch-over-cache and the offline default case. Unrelated: corrects a `Model` type import path in admin permitted-model creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf97e7e4402c680462500a1c2a6c6d4107b7e7a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->