### PR TITLE
fix(models): preserve the missing-default error page (AYC-881)

### DIFF
--- a/ayunis-core-frontend/src/app/routes/_authenticated/-chat.index.test.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/-chat.index.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient } from '@tanstack/react-query';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  extractErrorData: vi.fn(),
   getEffectiveDefaultModel: vi.fn(),
   getSystemPrompt: vi.fn(),
   hasActiveSubscription: vi.fn(),
@@ -29,7 +30,9 @@ vi.mock('@/shared/api', () => ({
     mocks.getEffectiveDefaultModel,
   subscriptionsControllerHasActiveSubscription: mocks.hasActiveSubscription,
 }));
-vi.mock('@/shared/api/extract-error-data', () => ({ default: vi.fn() }));
+vi.mock('@/shared/api/extract-error-data', () => ({
+  default: mocks.extractErrorData,
+}));
 
 const { Route } = await import('./chat.index');
 
@@ -55,6 +58,9 @@ async function runLoader(queryClient: QueryClient): Promise<LoaderResult> {
 describe('new chat route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.extractErrorData.mockImplementation((error: unknown) => {
+      throw error;
+    });
     mocks.getEffectiveDefaultModel.mockResolvedValue({
       permittedLanguageModel: { id: 'sol' },
     });
@@ -85,5 +91,13 @@ describe('new chat route', () => {
     const result = await runLoader(appQueryClient());
 
     expect(result.selectedModelId).toBeUndefined();
+  });
+
+  it('preserves the no-default-model error for the route error page', async () => {
+    const error = new Error('no default model');
+    mocks.getEffectiveDefaultModel.mockRejectedValue(error);
+    mocks.extractErrorData.mockReturnValue({ code: 'NO_DEFAULT_MODEL_FOUND' });
+
+    await expect(runLoader(appQueryClient())).rejects.toBe(error);
   });
 });

--- a/ayunis-core-frontend/src/app/routes/_authenticated/chat.index.tsx
+++ b/ayunis-core-frontend/src/app/routes/_authenticated/chat.index.tsx
@@ -12,6 +12,19 @@ import extractErrorData from '@/shared/api/extract-error-data';
 import { z } from 'zod';
 import { effectiveDefaultModelQueryOptions } from './-effective-default-model-query';
 
+function handleDefaultModelLoadError(error: unknown): null {
+  let code: string | undefined;
+  try {
+    code = extractErrorData(error).code;
+  } catch {
+    return null;
+  }
+  if (code === 'NO_DEFAULT_MODEL_FOUND') {
+    throw error;
+  }
+  return null;
+}
+
 const queryHasActiveSubscriptionOptions = () => ({
   queryKey: getSubscriptionsControllerHasActiveSubscriptionQueryKey(),
   queryFn: () => subscriptionsControllerHasActiveSubscription(),
@@ -39,7 +52,7 @@ export const Route = createFileRoute('/_authenticated/chat/')({
     } else {
       const defaultModelResponse = await queryClient
         .fetchQuery(effectiveDefaultModelQueryOptions())
-        .catch(() => null);
+        .catch(handleDefaultModelLoadError);
       selectedModelId = defaultModelResponse?.permittedLanguageModel?.id;
     }
     const { isEmbeddingModelEnabled } = await queryClient.fetchQuery(


### PR DESCRIPTION
## Summary
- preserve NO_DEFAULT_MODEL_FOUND so the existing route error page renders
- continue tolerating transient default-model load failures
- add a route-loader regression test for the distinction

## Verification
- pnpm exec vitest run src/app/routes/_authenticated/-chat.index.test.tsx
- pnpm exec eslint src/app/routes/_authenticated/chat.index.tsx src/app/routes/_authenticated/-chat.index.test.tsx --max-warnings=0
- pnpm run build
- pnpm run lint (passes with existing warning backlog)

The local Playwright run was blocked before the test because the managed command session tore down the isolated dev slot after startup; CI provides the authoritative built-app E2E verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to loader error handling on the chat index route, with a focused unit test and no auth or data-model changes.
> 
> **Overview**
> The new chat route loader no longer swallows **every** failure when loading the effective default model. It now uses `handleDefaultModelLoadError`, which still treats most failures as “no preselected model” (`null`), but **re-throws** when `extractErrorData` reports `NO_DEFAULT_MODEL_FOUND` so the route error UI can run.
> 
> Tests were updated to mock `extractErrorData` explicitly and assert that this specific error propagates from the loader instead of returning an undefined `selectedModelId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb063710b18c98f4ffbc829779106b9a6a35e94b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->