### PR TITLE
fix(admin-settings): render credit budget usage link as outline button (AYC-915)

### DIFF
--- a/ayunis-core-frontend/src/widgets/credit-limit-context/ui/CreditLimitBudget.tsx
+++ b/ayunis-core-frontend/src/widgets/credit-limit-context/ui/CreditLimitBudget.tsx
@@ -2,10 +2,12 @@ import { Link } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import {
   Card,
+  CardAction,
   CardContent,
   CardHeader,
   CardTitle,
 } from '@ayunis/ui/components/card';
+import { Button } from '@ayunis/ui/components/button';
 import { CreditBudgetDisplay } from '@/widgets/credit-budget-display';
 import { useCreditLimitBudget } from '@/features/credit-limits/api/useCreditLimitQueries';
 
@@ -18,6 +20,11 @@ export function CreditLimitBudget() {
     <Card>
       <CardHeader>
         <CardTitle>{t('budget.title')}</CardTitle>
+        <CardAction>
+          <Button variant="outline" size="sm" asChild>
+            <Link to="/admin-settings/usage">{t('budget.manage')}</Link>
+          </Button>
+        </CardAction>
       </CardHeader>
       <CardContent className="space-y-4">
         <CreditBudgetDisplay
@@ -40,9 +47,6 @@ export function CreditLimitBudget() {
             usageProgress: t('budget.progress'),
           }}
         />
-        <Link to="/admin-settings/usage" className="text-sm underline">
-          {t('budget.manage')}
-        </Link>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes [AYC-915](https://linear.app/ayunis/issue/AYC-915).

## What

On the credit-limit settings page, "Budget und Nutzung ansehen" was the only clickable control rendered as a plain underlined link. It now renders as a `Button variant="outline" size="sm" asChild` inside a `CardAction` in the budget card's `CardHeader`, matching the pattern in `TeamDetailPage.tsx` and `LicenseSeatsSection.tsx`.

Single file changed: `ayunis-core-frontend/src/widgets/credit-limit-context/ui/CreditLimitBudget.tsx`.

`CardContent`'s `space-y-4` is kept — `CreditBudgetDisplay` returns a fragment with two children, so it still does spacing work.

## Result

![Credit budget card with outline button in the header](https://cursor.com/artifacts/c/art-f879d9a4-ece5-4451-a35c-590b1b8b90a6)

## Verification

Docker is unavailable in this environment, so the full stack could not be started. Instead the real `CreditLimitBudget` component was rendered in a throwaway Vite scene (outside the product diff, since deleted) with a memory-history TanStack router and a stubbed `useCreditLimitBudget`, then driven with Playwright/Chrome:

- The control is an `<a href="/admin-settings/usage">` carrying the outline + `size="sm"` button classes (`border bg-background shadow-xs hover:bg-accent … h-8 gap-1.5 rounded-md px-3`).
- It sits inside `[data-slot="card-action"]` within `[data-slot="card-header"]`.
- Clicking it navigates to the `/admin-settings/usage` route; no console/page errors.

Also run: `pnpm exec tsc --noEmit` (frontend, clean) and the full pre-commit suite (Prettier, ESLint, typecheck, dependency-cruiser, jscpd, file-size) — all passed.

## Out of scope

Table width on the same page is tracked separately in [AYC-916](https://linear.app/ayunis/issue/AYC-916/admin-settings-content-width-forces-horizontal-scrolling-in-tables).

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-915](https://linear.app/ayunis/issue/AYC-915/make-credit-limit-budget-link-a-button-for-consistency)

<div><a href="https://cursor.com/agents/bc-143187b2-c4c8-4d37-90c5-b89a347f57ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-143187b2-c4c8-4d37-90c5-b89a347f57ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

