### PR TITLE
fix(admin-settings): remove credit usage column from credit limits table (AYC-916)

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/credit-limits-settings/ui/CreditLimitsTable.test.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/credit-limits-settings/ui/CreditLimitsTable.test.tsx
@@ -65,6 +65,25 @@ describe('CreditLimitsTable', () => {
     },
   );
 
+  it('keeps the row compact with only the target, its limit and the action', () => {
+    render(
+      <CreditLimitsTable
+        rows={rows}
+        filters={filters}
+        isPending={false}
+        isError={false}
+      />,
+    );
+    expect(
+      screen.getAllByRole('columnheader').map((h) => h.textContent),
+    ).toEqual(['tabs.users', 'table.limit', 'table.actions']);
+    expect(
+      screen.getAllByTestId('credit-limits-row-bob')[0].querySelectorAll('td'),
+    ).toHaveLength(3);
+    expect(screen.queryByText('table.used')).toBeNull();
+    expect(screen.queryByText('table.usageUnavailable')).toBeNull();
+  });
+
   it('shows no limit and zero distinctly and opens a zero limit for editing', () => {
     render(
       <CreditLimitsTable

--- a/ayunis-core-frontend/src/pages/admin-settings/credit-limits-settings/ui/CreditLimitsTable.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/credit-limits-settings/ui/CreditLimitsTable.tsx
@@ -44,7 +44,6 @@ export function CreditLimitsTable({
           <TableRow>
             <TableHead>{t(`tabs.${filters.tab}`)}</TableHead>
             <TableHead>{t('table.limit')}</TableHead>
-            <TableHead>{t('table.used')}</TableHead>
             <TableHead>
               <span className="sr-only">{t('table.actions')}</span>
             </TableHead>
@@ -61,7 +60,7 @@ export function CreditLimitsTable({
           ))}
           {rows.length === 0 && (
             <TableRow>
-              <TableCell colSpan={4}>{t('table.empty')}</TableCell>
+              <TableCell colSpan={3}>{t('table.empty')}</TableCell>
             </TableRow>
           )}
         </TableBody>
@@ -109,11 +108,6 @@ function CreditLimitTableRow({
             {t('table.blocked')}
           </span>
         )}
-      </TableCell>
-      <TableCell>
-        {limit
-          ? limit.creditsUsed.toLocaleString(i18n.language)
-          : t('table.usageUnavailable')}
       </TableCell>
       <TableCell className="text-right">
         <Button

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-credit-limits.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-credit-limits.json
@@ -19,13 +19,11 @@
     "teamsTitle": "Credit-Limits für Teams",
     "usersTitle": "Credit-Limits für Nutzer",
     "limit": "Monatliches Credit-Limit",
-    "used": "Diesen Monat verbraucht",
     "actions": "Aktionen",
     "configure": "Konfigurieren",
     "search": "Teams oder Nutzer suchen",
     "empty": "Keine passenden Teams oder Nutzer.",
-    "blocked": "Kostenpflichtige Modelle gesperrt",
-    "usageUnavailable": "Ohne konfiguriertes Limit nicht verfügbar"
+    "blocked": "Kostenpflichtige Modelle gesperrt"
   },
   "form": {
     "noLimit": "Kein zusätzliches Limit",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-credit-limits.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-credit-limits.json
@@ -19,13 +19,11 @@
     "teamsTitle": "Credit limits for teams",
     "usersTitle": "Credit limits for users",
     "limit": "Monthly credit limit",
-    "used": "Used this month",
     "actions": "Actions",
     "configure": "Configure",
     "search": "Search teams or users",
     "empty": "No matching teams or users.",
-    "blocked": "Paid-model usage blocked",
-    "usageUnavailable": "Not available without a configured limit"
+    "blocked": "Paid-model usage blocked"
   },
   "form": {
     "noLimit": "No additional limit",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the AYC-916 decision: compact the credit-limits table by removing the "Diesen Monat verbraucht" / "Used this month" column instead of widening the admin settings content area.

## Change

- `CreditLimitsTable` now renders three columns (target, monthly credit limit, action); the empty-state `colSpan` follows.
- Removed the now-unused `table.used` and `table.usageUnavailable` keys from the German and English locale files.
- `ContentAreaLayout`'s `max-w-[800px]` and its `fullWidth` prop are untouched, so no other admin settings page changes.

## Verification

Reproduced the overflow and the fix in a real browser (Chromium via Playwright, 1440px viewport) by rendering both table variants inside the same `max-w-[800px]` content container with the app's Tailwind styles. Measured on the table's scroll container:

| variant | scrollWidth | clientWidth | horizontal overflow |
| --- | --- | --- | --- |
| before (4 columns) | 844 | 734 | 110px |
| after (3 columns) | 734 | 734 | 0 |

![Credit limits table before and after removing the usage column](https://cursor.com/artifacts/c/art-4c5b52d7-3f3f-4555-9ada-e050e3940f48)

In the top card ("before") the `Konfigurieren` button is clipped at the card edge; in the bottom card ("after") it is fully visible with headroom.

Also ran:

- `pnpm vitest run src/pages/admin-settings/credit-limits-settings` — 8 passed, including a new test asserting the column set and that no usage text renders.
- `pnpm run build` and `pnpm exec eslint src/pages/admin-settings/credit-limits-settings --max-warnings=0` in `ayunis-core-frontend`.

## Note

Per-user/per-team consumption is no longer shown on this screen. Organization-level usage stays available through the budget card's "Budget und Nutzung ansehen" link, and the team detail page still shows a team's used/limit figure. The remaining admin settings tables are still constrained to 800px — that broader layout question was explicitly deferred by the ticket decision.

Closes AYC-916.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AYC-916](https://linear.app/ayunis/issue/AYC-916/admin-settings-content-width-forces-horizontal-scrolling-in-tables)

<div><a href="https://cursor.com/agents/bc-2c8bcaac-3f7c-44cd-95b7-2adef5627fb6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c8bcaac-3f7c-44cd-95b7-2adef5627fb6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

