### PR TITLE
fix(letterheads): position letter content per DIN 5008 (AYC-711)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -217,6 +217,7 @@ jobs:
           MOCK_INFERENCE=true
           FEATURE_SKILLS_ENABLED=true
           FEATURE_WORKSPACES_ENABLED=true
+          FEATURE_LETTERHEADS_ENABLED=true
 
           # Database
           POSTGRES_HOST=localhost

--- a/ayunis-core-backend/src/domain/artifacts/SUMMARY.md
+++ b/ayunis-core-backend/src/domain/artifacts/SUMMARY.md
@@ -58,6 +58,8 @@ artifacts/
 │       ├── html-to-docx-converter.ts
 │       ├── paragraph-style-parser.ts
 │       ├── docx-document-config.ts
+│       ├── docx-table-styles.ts
+│       ├── letter-layout-tables.ts
 │       ├── pdf-letterhead-compositor.ts
 │       └── xlsx-spreadsheet-export.service.ts
 ├── presenters/http/
@@ -77,7 +79,7 @@ artifacts/
 ## Ports
 
 - **ArtifactsRepository** — CRUD for artifacts and versions
-- **DocumentExportPort** — Converts HTML content to DOCX/PDF buffers, optionally compositing PDF output onto stored letterhead backgrounds with configured margins
+- **DocumentExportPort** — Converts HTML content to DOCX/PDF buffers, optionally compositing PDF output onto stored letterhead backgrounds with configured margins. Letterhead exports also render a header-less table as the DIN 5008 head block (recipient address left, sender information block right), tagged at render time by `letter-layout-tables.ts` because the editor schema would drop a stored marker
 - **SpreadsheetExportPort** — Converts validated spreadsheet content to XLSX or CSV buffers
 
 ## Key Behaviors

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/docx-table-styles.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/docx-table-styles.ts
@@ -1,0 +1,53 @@
+import { BorderStyle } from 'docx';
+import type { HTMLElement } from 'node-html-parser';
+
+const TABLE_BORDER = {
+  style: BorderStyle.SINGLE,
+  size: 1,
+  color: 'CCCCCC',
+};
+
+const TABLE_BORDERS = {
+  top: TABLE_BORDER,
+  bottom: TABLE_BORDER,
+  left: TABLE_BORDER,
+  right: TABLE_BORDER,
+};
+
+const NO_BORDER = { style: BorderStyle.NONE, size: 0, color: 'auto' };
+
+/**
+ * A table without a header row carries the recipient address and sender
+ * information block of a letter, so it must not render as a visible grid.
+ * Mirrors `markLayoutTables` on the PDF path — see letter-layout-tables.ts.
+ */
+const LAYOUT_TABLE_BORDERS = {
+  top: NO_BORDER,
+  bottom: NO_BORDER,
+  left: NO_BORDER,
+  right: NO_BORDER,
+};
+
+const LAYOUT_CELL_MARGINS = { top: 0, bottom: 0, left: 0, right: 0 };
+
+/** Borders and padding for a cell — a layout cell carries neither. */
+export function cellFrame(isLayout: boolean) {
+  if (isLayout) {
+    return { borders: LAYOUT_TABLE_BORDERS, margins: LAYOUT_CELL_MARGINS };
+  }
+  return { borders: TABLE_BORDERS };
+}
+
+function parseSpan(attr: string | undefined): number | undefined {
+  return attr ? parseInt(attr, 10) : undefined;
+}
+
+export function cellSpans(cell: HTMLElement) {
+  const columnSpan = parseSpan(cell.getAttribute('colspan'));
+  const rowSpan = parseSpan(cell.getAttribute('rowspan'));
+
+  return {
+    ...(columnSpan && columnSpan > 1 && { columnSpan }),
+    ...(rowSpan && rowSpan > 1 && { rowSpan }),
+  };
+}

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
@@ -338,6 +338,89 @@ describe('HtmlDocumentExportService', () => {
         );
       });
 
+      describe('DIN 5008 letter layout', () => {
+        const headBlockHtml =
+          '<table><tbody><tr><td><p>Herr Müller</p></td>' +
+          '<td><p>Elisabetta Cavalet</p></td></tr></tbody></table>' +
+          '<p><strong>Beratungsgespräch</strong></p>';
+
+        it('should mark a header-less table as the letter head block', async () => {
+          await service.exportToPdf(headBlockHtml, letterheadConfig);
+
+          const htmlArg = mockPage.setContent.mock.calls[0][0] as string;
+          expect(htmlArg).toContain('<table class="letter-layout">');
+        });
+
+        it('should render the head block borderless', async () => {
+          await service.exportToPdf(headBlockHtml, letterheadConfig);
+
+          const htmlArg = mockPage.setContent.mock.calls[0][0] as string;
+          expect(htmlArg).toMatch(/table\.letter-layout td \{[^}]*border: 0/);
+        });
+
+        it('should reserve the DIN 5008 address field height so the body starts below it', async () => {
+          await service.exportToPdf(headBlockHtml, letterheadConfig);
+
+          const htmlArg = mockPage.setContent.mock.calls[0][0] as string;
+          expect(htmlArg).toContain('height: 53.5mm');
+          expect(htmlArg).toMatch(
+            /table\.letter-layout \{[^}]*margin-bottom: 0/,
+          );
+        });
+
+        it('should size the address column so the information block lands at 125mm', async () => {
+          await service.exportToPdf(headBlockHtml, letterheadConfig);
+
+          const htmlArg = mockPage.setContent.mock.calls[0][0] as string;
+          expect(htmlArg).toContain('width: 100mm');
+        });
+
+        it('should reserve the Vermerkzone so the recipient sits in the Anschriftzone', async () => {
+          await service.exportToPdf(headBlockHtml, letterheadConfig);
+
+          const htmlArg = mockPage.setContent.mock.calls[0][0] as string;
+          expect(htmlArg).toMatch(
+            /table\.letter-layout td:first-child \{[^}]*padding-top: 17\.7mm/,
+          );
+        });
+
+        it('should clear the top margin after the head block so the subject lands on the DIN line', async () => {
+          await service.exportToPdf(headBlockHtml, letterheadConfig);
+
+          const htmlArg = mockPage.setContent.mock.calls[0][0] as string;
+          expect(htmlArg).toMatch(
+            /table\.letter-layout \+ \* \{[^}]*margin-top: 0/,
+          );
+        });
+
+        it('should single-space the head block so a long address stays in its zone', async () => {
+          await service.exportToPdf(headBlockHtml, letterheadConfig);
+
+          const htmlArg = mockPage.setContent.mock.calls[0][0] as string;
+          expect(htmlArg).toMatch(
+            /table\.letter-layout p \{[^}]*margin: 0;[^}]*line-height: 1\.25/,
+          );
+        });
+
+        it('should leave a data table with a header row bordered', async () => {
+          await service.exportToPdf(
+            '<table><thead><tr><th>Posten</th></tr></thead>' +
+              '<tbody><tr><td>1</td></tr></tbody></table>',
+            letterheadConfig,
+          );
+
+          const htmlArg = mockPage.setContent.mock.calls[0][0] as string;
+          expect(htmlArg).not.toContain('<table class="letter-layout">');
+        });
+
+        it('should not apply letter layout rules without a letterhead', async () => {
+          await service.exportToPdf(headBlockHtml);
+
+          const htmlArg = mockPage.setContent.mock.calls[0][0] as string;
+          expect(htmlArg).not.toContain('letter-layout');
+        });
+      });
+
       it('should call compositor with content PDF and background PDFs', async () => {
         await service.exportToPdf('<p>Hello</p>', letterheadConfig);
 

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.ts
@@ -5,6 +5,7 @@ import {
 } from 'src/domain/artifacts/application/ports/document-export.port';
 import { convertHtmlToDocx } from './html-to-docx-converter';
 import { PdfLetterheadCompositor } from './pdf-letterhead-compositor';
+import { markLayoutTables } from './letter-layout-tables';
 import { LazyChromiumBrowser } from 'src/common/puppeteer/lazy-chromium-browser';
 import { sanitizeHtmlContent } from 'src/domain/artifacts/application/helpers/sanitize-html-content';
 import { TimeoutError } from 'puppeteer-core';
@@ -46,6 +47,60 @@ const PDF_CSS = `
   th { background-color: #f5f5f5; font-weight: bold; }
   a { color: #1a73e8; }
 `;
+
+/**
+ * DIN 5008 head block, applied only to letterhead exports.
+ *
+ * A header-less table (tagged by `markLayoutTables`) holds the recipient
+ * address on the left and the sender's information block on the right. The
+ * block reserves the norm's 45mm address field plus the 8.46mm gap to the
+ * subject line, so the body starts 53.5mm below the content top — 98.5mm on a
+ * Form B letterhead (45mm top margin), 80.5mm on Form A (27mm). The address
+ * field is 45mm tall in both forms, which is why one height serves both.
+ *
+ * The height acts as a minimum, so an information block taller than the
+ * address field grows the row instead of being clipped.
+ */
+const LETTER_LAYOUT_CSS = `
+  table.letter-layout {
+    width: 100%;
+    height: 53.5mm;
+    margin-bottom: 0;
+    border-collapse: collapse;
+  }
+  table.letter-layout td {
+    border: 0;
+    padding: 0;
+    vertical-align: top;
+  }
+  /* Both zones are single-spaced in the norm. The body's paragraph rhythm
+     would push a longer address past the 90mm Anschriftzone — out of a window
+     envelope and into the subject line. */
+  table.letter-layout p {
+    margin: 0;
+    line-height: 1.25;
+  }
+  /* The information block sits 125mm from the page edge and the content box
+     starts at the 25mm left margin, leaving 100mm for the address column.
+     The top padding is the 17.7mm Zusatz- und Vermerkzone, which reserves the
+     top of the address field for return-address and postal notations: the
+     recipient's name belongs in the Anschriftzone below it, so that it lines
+     up with a window envelope. */
+  table.letter-layout td:first-child {
+    width: 100mm;
+    padding-top: 17.7mm;
+  }
+  /* Form B drops the information block 5mm below the address field. */
+  table.letter-layout td + td {
+    padding-top: 5mm;
+  }
+  /* The reserved height only lands the subject on the DIN line if what
+     follows starts flush against the block. Paragraphs keep the user-agent
+     top margin (PDF_CSS sets margin-bottom only), which would push the
+     subject a line below 98.46mm. */
+  table.letter-layout + * {
+    margin-top: 0;
+  }`;
 
 @Injectable()
 export class HtmlDocumentExportService
@@ -143,20 +198,23 @@ export class HtmlDocumentExportService
     unsafeHtml: string,
     letterhead?: LetterheadConfig,
   ): string {
-    const html = sanitizeHtmlContent(unsafeHtml);
-    const marginCss = letterhead ? this.buildMarginCss(letterhead) : '';
+    const sanitized = sanitizeHtmlContent(unsafeHtml);
+    // Only letters carry a head block, and `markLayoutTables` must run after
+    // sanitization or the marker class is stripped again.
+    const html = letterhead ? markLayoutTables(sanitized) : sanitized;
+    const letterheadCss = letterhead ? this.buildLetterheadCss(letterhead) : '';
 
     return `<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
-  <style>${PDF_CSS}${marginCss}</style>
+  <style>${PDF_CSS}${letterheadCss}</style>
 </head>
 <body>${html}</body>
 </html>`;
   }
 
-  private buildMarginCss(letterhead: LetterheadConfig): string {
+  private buildLetterheadCss(letterhead: LetterheadConfig): string {
     const { continuationPageMargins: cont, firstPageMargins: first } =
       letterhead;
 
@@ -181,6 +239,6 @@ export class HtmlDocumentExportService
   @page :first {
     size: A4;
     margin: ${first.top}mm ${first.right}mm ${first.bottom}mm ${first.left}mm;
-  }`;
+  }${LETTER_LAYOUT_CSS}`;
   }
 }

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.spec.ts
@@ -119,6 +119,27 @@ describe('convertHtmlToDocx', () => {
     expect(xml).toContain('Alice');
   });
 
+  it('should render a header-less table without borders', async () => {
+    const buffer = await convertHtmlToDocx(
+      '<table><tr><td>Herr Müller</td><td>Elisabetta Cavalet</td></tr></table>',
+    );
+    const xml = await extractDocumentXml(buffer);
+
+    expect(xml).toContain('Herr Müller');
+    expect(xml).toContain('Elisabetta Cavalet');
+    expect(xml).not.toContain('CCCCCC');
+    expect(xml).toContain('w:val="none"');
+  });
+
+  it('should keep borders on a table that has a header row', async () => {
+    const buffer = await convertHtmlToDocx(
+      '<table><tr><th>Posten</th></tr><tr><td>1</td></tr></table>',
+    );
+    const xml = await extractDocumentXml(buffer);
+
+    expect(xml).toContain('CCCCCC');
+  });
+
   it('should render links as external hyperlinks', async () => {
     const buffer = await convertHtmlToDocx(
       '<p><a href="https://example.com">Click here</a></p>',

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.ts
@@ -19,6 +19,7 @@ import type { HTMLElement, TextNode } from 'node-html-parser';
 import { parse, NodeType } from 'node-html-parser';
 
 import { buildDocument } from './docx-document-config';
+import { cellFrame, cellSpans } from './docx-table-styles';
 import { parseAlignment, parseSpacing } from './paragraph-style-parser';
 
 /** Inline formatting context accumulated while walking the tree. */
@@ -57,19 +58,6 @@ const INLINE_FORMAT_BY_TAG: Record<string, Partial<InlineContext>> = {
   del: { strike: true },
   strike: { strike: true },
   code: { code: true },
-};
-
-const TABLE_BORDER = {
-  style: BorderStyle.SINGLE,
-  size: 1,
-  color: 'CCCCCC',
-};
-
-const TABLE_BORDERS = {
-  top: TABLE_BORDER,
-  bottom: TABLE_BORDER,
-  left: TABLE_BORDER,
-  right: TABLE_BORDER,
 };
 
 // A4 portrait usable width = 210mm page − 2×25mm margins (see docx-document-config.ts).
@@ -290,8 +278,9 @@ function convertTable(node: HTMLElement): Table {
   );
   const columnCount = Math.max(1, countTableColumns(rowElements));
   const columnWidths = buildEqualColumnWidths(columnCount);
+  const isLayout = !node.querySelector('th');
   const rows = rowElements
-    .map(convertTableRow)
+    .map((tr) => convertTableRow(tr, isLayout))
     .filter((r): r is TableRow => r !== null);
 
   if (rows.length === 0) {
@@ -337,21 +326,24 @@ function buildEqualColumnWidths(columnCount: number): number[] {
   return Array.from({ length: columnCount }, () => width);
 }
 
-function convertTableRow(tr: HTMLElement): TableRow | null {
+function convertTableRow(tr: HTMLElement, isLayout: boolean): TableRow | null {
   const cellElements = tr.querySelectorAll(':scope > td, :scope > th');
   if (cellElements.length === 0) return null;
 
   const isHeader = cellElements[0].tagName.toLowerCase() === 'th';
-  const cells = cellElements.map((cell) => convertTableCell(cell, isHeader));
+  const cells = cellElements.map((cell) =>
+    convertTableCell(cell, isHeader, isLayout),
+  );
 
   return new TableRow({ children: cells });
 }
 
-function convertTableCell(cell: HTMLElement, isHeader: boolean): TableCell {
+function convertTableCell(
+  cell: HTMLElement,
+  isHeader: boolean,
+  isLayout: boolean,
+): TableCell {
   const runs = collectInlineRuns(cell, { bold: isHeader || undefined });
-
-  const columnSpan = parseSpan(cell.getAttribute('colspan'));
-  const rowSpan = parseSpan(cell.getAttribute('rowspan'));
 
   // TipTap wraps cell content in a nested <p> that carries the paragraph
   // styles; fall back to the cell itself when there is no inner paragraph.
@@ -365,16 +357,11 @@ function convertTableCell(cell: HTMLElement, isHeader: boolean): TableCell {
         spacing: parseSpacing(styleNode) ?? parseSpacing(cell),
       }),
     ],
-    borders: TABLE_BORDERS,
+    ...cellFrame(isLayout),
     shading: isHeader ? { fill: 'F5F5F5' } : undefined,
     width: { size: 0, type: WidthType.AUTO },
-    ...(columnSpan && columnSpan > 1 && { columnSpan }),
-    ...(rowSpan && rowSpan > 1 && { rowSpan }),
+    ...cellSpans(cell),
   });
-}
-
-function parseSpan(attr: string | undefined): number | undefined {
-  return attr ? parseInt(attr, 10) : undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/letter-layout-tables.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/letter-layout-tables.spec.ts
@@ -1,0 +1,60 @@
+import { LAYOUT_TABLE_CLASS, markLayoutTables } from './letter-layout-tables';
+
+describe('markLayoutTables', () => {
+  it('should mark a header-less table as a layout table', () => {
+    const html =
+      '<table><tbody><tr><td>Herr Müller</td><td>Elisabetta Cavalet</td></tr></tbody></table>';
+
+    expect(markLayoutTables(html)).toContain(`class="${LAYOUT_TABLE_CLASS}"`);
+  });
+
+  it('should leave a table with a header row untouched', () => {
+    const html =
+      '<table><thead><tr><th>Posten</th></tr></thead><tbody><tr><td>1</td></tr></tbody></table>';
+
+    expect(markLayoutTables(html)).toBe(html);
+  });
+
+  it('should detect a header cell that is not wrapped in a thead', () => {
+    const html = '<table><tr><th>Posten</th></tr><tr><td>1</td></tr></table>';
+
+    expect(markLayoutTables(html)).toBe(html);
+  });
+
+  it('should return the input unchanged when there is no table', () => {
+    const html = '<p>Sehr geehrter Herr Müller,</p>';
+
+    expect(markLayoutTables(html)).toBe(html);
+  });
+
+  it('should preserve cell content while marking the table', () => {
+    const html =
+      '<table><tbody><tr><td><p>Hauptstraße 5</p></td><td><p>ZB 14</p></td></tr></tbody></table>';
+
+    const marked = markLayoutTables(html);
+
+    expect(marked).toContain('Hauptstraße 5');
+    expect(marked).toContain('ZB 14');
+  });
+
+  it('should mark each header-less table when several are present', () => {
+    const html =
+      '<table><tbody><tr><td>a</td></tr></tbody></table>' +
+      '<table><tbody><tr><td>b</td></tr></tbody></table>';
+
+    const occurrences = markLayoutTables(html).split(LAYOUT_TABLE_CLASS).length;
+
+    expect(occurrences - 1).toBe(2);
+  });
+
+  it('should mark only the header-less table in a mixed document', () => {
+    const html =
+      '<table><tbody><tr><td>address</td><td>contact</td></tr></tbody></table>' +
+      '<table><thead><tr><th>Posten</th></tr></thead><tbody><tr><td>1</td></tr></tbody></table>';
+
+    const marked = markLayoutTables(html);
+
+    expect(marked.split(LAYOUT_TABLE_CLASS)).toHaveLength(2);
+    expect(marked).toContain('<th>Posten</th>');
+  });
+});

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/letter-layout-tables.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/letter-layout-tables.ts
@@ -1,0 +1,35 @@
+import { parse } from 'node-html-parser';
+
+export const LAYOUT_TABLE_CLASS = 'letter-layout';
+
+/**
+ * Tags header-less tables so the letterhead stylesheet can render them as a
+ * DIN 5008 address/information block instead of a bordered data table.
+ *
+ * The marker is injected at render time instead of being stored in the
+ * artifact because the Tiptap editor schema drops classes and unknown
+ * attributes: a marker saved in the content would disappear the first time a
+ * user edited the letter. Tables, by contrast, survive that round trip.
+ *
+ * Must run *after* sanitization — `table` has no allowed attributes, so a
+ * class added earlier would be stripped again.
+ */
+export function markLayoutTables(html: string): string {
+  const root = parse(html);
+
+  // ponytail: a table without a header row is treated as layout. Tables reach
+  // a document only from the model today (the editor toolbar has no table
+  // controls), and the tool description tells it to keep data tables headed.
+  // If header-less data tables ever show up, replace this with an explicit
+  // marker plus a Tiptap attribute that survives saves.
+  const layoutTables = root
+    .querySelectorAll('table')
+    .filter((table) => !table.querySelector('th'));
+
+  if (layoutTables.length === 0) return html;
+
+  for (const table of layoutTables) {
+    table.setAttribute('class', LAYOUT_TABLE_CLASS);
+  }
+  return root.toString();
+}

--- a/ayunis-core-backend/src/domain/runs/application/services/letterhead-suffix.helper.spec.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/letterhead-suffix.helper.spec.ts
@@ -1,0 +1,89 @@
+import { Letterhead } from 'src/domain/letterheads/domain/letterhead.entity';
+import { buildLetterheadSuffix } from './letterhead-suffix.helper';
+
+const MARGINS = { top: 45, bottom: 20, left: 25, right: 20 };
+
+function makeLetterhead(
+  overrides: Partial<{ name: string; description: string | null }> = {},
+) {
+  return new Letterhead({
+    id: '11111111-1111-1111-1111-111111111111',
+    orgId: '22222222-2222-2222-2222-222222222222',
+    name: overrides.name ?? 'Offizielles Briefpapier',
+    description:
+      overrides.description === undefined
+        ? 'Kreisverwaltung'
+        : overrides.description,
+    firstPageStoragePath: 'letterheads/first.pdf',
+    firstPageMargins: MARGINS,
+    continuationPageMargins: MARGINS,
+  });
+}
+
+describe('buildLetterheadSuffix', () => {
+  it('should return an empty string when the org has no letterheads', () => {
+    expect(buildLetterheadSuffix([])).toBe('');
+  });
+
+  it('should list each letterhead id and name', () => {
+    const suffix = buildLetterheadSuffix([makeLetterhead()]);
+
+    expect(suffix).toContain('11111111-1111-1111-1111-111111111111');
+    expect(suffix).toContain('Offizielles Briefpapier');
+    expect(suffix).toContain('Kreisverwaltung');
+  });
+
+  it('should omit the separator when a letterhead has no description', () => {
+    const suffix = buildLetterheadSuffix([
+      makeLetterhead({ description: null }),
+    ]);
+
+    const listLine = suffix
+      .split('\n')
+      .find((line) => line.startsWith('- 11111111'));
+
+    expect(listLine).toBe(
+      '- 11111111-1111-1111-1111-111111111111: "Offizielles Briefpapier"',
+    );
+  });
+
+  describe('letter layout guidance', () => {
+    it('should ask for a header-less two-column block for the address and contact details', () => {
+      const suffix = buildLetterheadSuffix([makeLetterhead()]);
+
+      expect(suffix).toContain('two-column table');
+      expect(suffix).toMatch(/no header row/i);
+    });
+
+    it('should place the recipient left and the sender contact details right', () => {
+      const suffix = buildLetterheadSuffix([makeLetterhead()]);
+
+      expect(suffix).toMatch(/left cell.*recipient/i);
+      expect(suffix).toMatch(/right cell.*(sender|contact)/i);
+    });
+
+    it('should ask for a bold subject line before the body', () => {
+      const suffix = buildLetterheadSuffix([makeLetterhead()]);
+
+      expect(suffix).toMatch(/subject/i);
+      expect(suffix).toMatch(/bold/i);
+    });
+
+    it('should forbid repeating the letterhead header and footer in the content', () => {
+      const suffix = buildLetterheadSuffix([makeLetterhead()]);
+
+      expect(suffix).toMatch(/never repeat/i);
+      expect(suffix).toMatch(/logo|header|footer/i);
+    });
+
+    it('should require a header row on real data tables', () => {
+      const suffix = buildLetterheadSuffix([makeLetterhead()]);
+
+      expect(suffix).toContain('<th>');
+    });
+
+    it('should not emit guidance when there are no letterheads', () => {
+      expect(buildLetterheadSuffix([])).not.toMatch(/two-column/i);
+    });
+  });
+});

--- a/ayunis-core-backend/src/domain/runs/application/services/letterhead-suffix.helper.ts
+++ b/ayunis-core-backend/src/domain/runs/application/services/letterhead-suffix.helper.ts
@@ -1,5 +1,21 @@
 import type { Letterhead } from 'src/domain/letterheads/domain/letterhead.entity';
 
+/**
+ * Structure guidance for letters written onto a letterhead.
+ *
+ * The two-column table is the only layout primitive that survives the Tiptap
+ * editor round trip, so it carries the DIN 5008 address field and information
+ * block. PDF export detects it by the absence of a header row and renders it
+ * borderless at the norm's positions — hence the explicit instruction to head
+ * real data tables.
+ */
+const LETTER_LAYOUT_GUIDANCE = `
+When the document is a formal letter on a letterhead, structure the first page so it matches the letterhead's printed design:
+1. Open with a two-column table that has no header row: the left cell holds the recipient's address (name, street, postal code and city, one line each), the right cell holds the sender's contact details (case worker, department, phone, e-mail, postal address).
+2. Follow it with the subject line as a single bold paragraph, without a "Betreff:" prefix.
+3. Then the salutation, the body paragraphs, and the closing with the signer's name and role.
+Never repeat the letterhead's own logo, header or footer text — it is already printed on the page. Give real data tables a header row (<th>); a header-less table is reserved for the address and contact block.`;
+
 export function buildLetterheadSuffix(letterheads: Letterhead[]): string {
   if (letterheads.length === 0) return '';
   const lines = letterheads.map((l) => {
@@ -9,6 +25,7 @@ export function buildLetterheadSuffix(letterheads: Letterhead[]): string {
   return (
     '\n\nAvailable letterheads (Briefpapier) for this organization:\n' +
     `${lines.join('\n')}\n` +
-    'When the user asks for an official letter or document that should use a specific letterhead, include the letterhead_id parameter.'
+    'When the user asks for an official letter or document that should use a specific letterhead, include the letterhead_id parameter.\n' +
+    LETTER_LAYOUT_GUIDANCE
   );
 }

--- a/ayunis-core-frontend/src/pages/admin-settings/letterhead-detail/ui/LetterheadDetailPage.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/letterhead-detail/ui/LetterheadDetailPage.tsx
@@ -11,14 +11,17 @@ import {
   CardHeader,
   CardTitle,
 } from '@ayunis/ui/components/card';
-import SettingsLayout from '../../admin-settings-layout';
-import { MarginEditor } from '@/widgets/margin-editor';
+import SettingsLayout from '@/pages/admin-settings/admin-settings-layout';
+import { MarginEditor, useDinLetterPresets } from '@/widgets/margin-editor';
 import type { PdfSource } from '@/widgets/margin-editor';
-import { useUpdateLetterhead } from '../api/useUpdateLetterhead';
+import { useUpdateLetterhead } from '@/pages/admin-settings/letterhead-detail/api/useUpdateLetterhead';
 import type { PageMargins } from '@/shared/lib/letterhead-margins';
 import type { LetterheadResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
-import { buildPdfUrl, getContinuationPageSource } from '../lib/pdf-source';
-import type { LetterheadFormFields } from '../model/types';
+import {
+  buildPdfUrl,
+  getContinuationPageSource,
+} from '@/pages/admin-settings/letterhead-detail/lib/pdf-source';
+import type { LetterheadFormFields } from '@/pages/admin-settings/letterhead-detail/model/types';
 
 interface LetterheadDetailPageProps {
   letterhead: LetterheadResponseDto;
@@ -28,6 +31,7 @@ export function LetterheadDetailPage({
   letterhead,
 }: Readonly<LetterheadDetailPageProps>) {
   const { t } = useTranslation('admin-settings-letterheads');
+  const dinLetterPresets = useDinLetterPresets();
 
   const initialMargins = useMemo(
     () => ({
@@ -157,6 +161,7 @@ export function LetterheadDetailPage({
               margins={firstPageMargins}
               onMarginsChange={setFirstPageMargins}
               label={t('letterheads.createDialog.firstPageMarginsLabel')}
+              presets={dinLetterPresets}
             />
           </CardContent>
         </Card>

--- a/ayunis-core-frontend/src/pages/admin-settings/letterheads-settings/model/types.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/letterheads-settings/model/types.ts
@@ -1,2 +1,5 @@
 export type { PageMargins } from '@/shared/lib/letterhead-margins';
-export { DEFAULT_MARGINS } from '@/shared/lib/letterhead-margins';
+export {
+  DEFAULT_CONTINUATION_MARGINS,
+  DEFAULT_MARGINS,
+} from '@/shared/lib/letterhead-margins';

--- a/ayunis-core-frontend/src/pages/admin-settings/letterheads-settings/ui/LetterheadFormDialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/letterheads-settings/ui/LetterheadFormDialog.tsx
@@ -22,14 +22,17 @@ import { Button } from '@ayunis/ui/components/button';
 import { Input } from '@ayunis/ui/components/input';
 import { Label } from '@ayunis/ui/components/label';
 import { Switch } from '@ayunis/ui/components/switch';
-import { MarginEditor } from '@/widgets/margin-editor';
-import { useCreateLetterhead } from '../api/useCreateLetterhead';
-import type { PageMargins } from '../model/types';
-import { DEFAULT_MARGINS } from '../model/types';
+import { MarginEditor, useDinLetterPresets } from '@/widgets/margin-editor';
+import { useCreateLetterhead } from '@/pages/admin-settings/letterheads-settings/api/useCreateLetterhead';
+import type { PageMargins } from '@/pages/admin-settings/letterheads-settings/model/types';
+import {
+  DEFAULT_CONTINUATION_MARGINS,
+  DEFAULT_MARGINS,
+} from '@/pages/admin-settings/letterheads-settings/model/types';
 import {
   createLetterheadFormSchema,
   type LetterheadFormValues,
-} from '../model/letterheadFormSchema';
+} from '@/pages/admin-settings/letterheads-settings/model/letterheadFormSchema';
 
 interface LetterheadFormDialogProps {
   open: boolean;
@@ -70,10 +73,11 @@ function LetterheadFormContent({
   const [continuationPagePdf, setContinuationPagePdf] = useState<File | null>(
     null,
   );
+  const dinLetterPresets = useDinLetterPresets();
   const [firstPageMargins, setFirstPageMargins] =
     useState<PageMargins>(DEFAULT_MARGINS);
   const [continuationPageMargins, setContinuationPageMargins] =
-    useState<PageMargins>(DEFAULT_MARGINS);
+    useState<PageMargins>(DEFAULT_CONTINUATION_MARGINS);
 
   const form = useForm<LetterheadFormValues>({
     resolver: zodResolver(createLetterheadFormSchema(t)),
@@ -89,7 +93,7 @@ function LetterheadFormContent({
     setUseDifferentFollowingPages(false);
     setContinuationPagePdf(null);
     setFirstPageMargins(DEFAULT_MARGINS);
-    setContinuationPageMargins(DEFAULT_MARGINS);
+    setContinuationPageMargins(DEFAULT_CONTINUATION_MARGINS);
   };
 
   const handleClose = () => {
@@ -188,6 +192,7 @@ function LetterheadFormContent({
               margins={firstPageMargins}
               onMarginsChange={setFirstPageMargins}
               label={t('letterheads.createDialog.firstPageMarginsLabel')}
+              presets={dinLetterPresets}
             />
 
             {/* Toggle: different letterhead for following pages */}

--- a/ayunis-core-frontend/src/shared/lib/letterhead-margins.ts
+++ b/ayunis-core-frontend/src/shared/lib/letterhead-margins.ts
@@ -5,9 +5,42 @@ export interface PageMargins {
   right: number;
 }
 
-export const DEFAULT_MARGINS: PageMargins = {
-  top: 20,
+/**
+ * DIN 5008 letter margins in mm — the layout German official correspondence
+ * is written to.
+ *
+ * `left` is the norm's 25mm alignment line (Fluchtlinie) and `top` is where
+ * the address field starts: 45mm for Form B, whose taller letterhead leaves
+ * room for a logo, and 27mm for Form A. PDF export reserves a further 53.5mm
+ * for the address and contact block, so the body lands at the norm's 98.5mm
+ * (Form B) or 80.5mm (Form A).
+ *
+ * These are starting points, not fixed truths — a letterhead's own artwork
+ * decides where its zones really are, which is what the margin preview is for.
+ */
+export const DIN_5008_FORM_B_MARGINS: PageMargins = {
+  top: 45,
   bottom: 20,
-  left: 20,
+  left: 25,
   right: 20,
 };
+
+export const DIN_5008_FORM_A_MARGINS: PageMargins = {
+  top: 27,
+  bottom: 20,
+  left: 25,
+  right: 20,
+};
+
+/** Following pages carry no address field, so the text starts near the top. */
+export const DIN_5008_CONTINUATION_MARGINS: PageMargins = {
+  top: 25,
+  bottom: 20,
+  left: 25,
+  right: 20,
+};
+
+export const DEFAULT_MARGINS: PageMargins = DIN_5008_FORM_B_MARGINS;
+
+export const DEFAULT_CONTINUATION_MARGINS: PageMargins =
+  DIN_5008_CONTINUATION_MARGINS;

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-letterheads.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-letterheads.json
@@ -59,7 +59,9 @@
       "error": "Fehler beim Löschen des Briefpapiers."
     },
     "marginEditor": {
-      "contentArea": "Inhaltsbereich"
+      "contentArea": "Inhaltsbereich",
+      "presetFormA": "DIN 5008 Form A",
+      "presetFormB": "DIN 5008 Form B"
     }
   }
 }

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-letterheads.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-letterheads.json
@@ -59,7 +59,9 @@
       "error": "Failed to delete letterhead."
     },
     "marginEditor": {
-      "contentArea": "Content area"
+      "contentArea": "Content area",
+      "presetFormA": "DIN 5008 Form A",
+      "presetFormB": "DIN 5008 Form B"
     }
   }
 }

--- a/ayunis-core-frontend/src/widgets/artifact-editor/ui/ArtifactEditor.tsx
+++ b/ayunis-core-frontend/src/widgets/artifact-editor/ui/ArtifactEditor.tsx
@@ -72,8 +72,10 @@ export const ArtifactEditor = forwardRef<
     content: currentVersion?.content ?? '',
     editorProps: {
       attributes: {
+        // A table with no header row is a letter's address and contact block,
+        // not tabular data — render it borderless, as PDF export does.
         class:
-          'prose prose-sm dark:prose-invert max-w-none p-4 outline-none min-h-[200px]',
+          'prose prose-sm dark:prose-invert max-w-none p-4 outline-none min-h-[200px] [&_table:not(:has(th))_tr]:border-none [&_table:not(:has(th))_td]:border-none',
       },
     },
   });

--- a/ayunis-core-frontend/src/widgets/margin-editor/index.ts
+++ b/ayunis-core-frontend/src/widgets/margin-editor/index.ts
@@ -1,2 +1,3 @@
 export { MarginEditor } from './ui/MarginEditor';
-export type { PdfSource } from './ui/MarginEditor';
+export type { PdfSource, MarginPreset } from './ui/MarginEditor';
+export { useDinLetterPresets } from './model/useDinLetterPresets';

--- a/ayunis-core-frontend/src/widgets/margin-editor/model/useDinLetterPresets.ts
+++ b/ayunis-core-frontend/src/widgets/margin-editor/model/useDinLetterPresets.ts
@@ -1,0 +1,24 @@
+import { useTranslation } from 'react-i18next';
+import {
+  DIN_5008_FORM_A_MARGINS,
+  DIN_5008_FORM_B_MARGINS,
+} from '@/shared/lib/letterhead-margins';
+import type { MarginPreset } from '@/widgets/margin-editor/ui/MarginEditor';
+
+/**
+ * First-page presets for German official correspondence. Form B suits a
+ * letterhead with a tall header (room for a logo), Form A a shallow one.
+ */
+export function useDinLetterPresets(): readonly MarginPreset[] {
+  const { t } = useTranslation('admin-settings-letterheads');
+  return [
+    {
+      label: t('letterheads.marginEditor.presetFormB'),
+      margins: DIN_5008_FORM_B_MARGINS,
+    },
+    {
+      label: t('letterheads.marginEditor.presetFormA'),
+      margins: DIN_5008_FORM_A_MARGINS,
+    },
+  ];
+}

--- a/ayunis-core-frontend/src/widgets/margin-editor/ui/MarginEditor.tsx
+++ b/ayunis-core-frontend/src/widgets/margin-editor/ui/MarginEditor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { Input } from '@ayunis/ui/components/input';
 import { Label } from '@ayunis/ui/components/label';
+import { Button } from '@ayunis/ui/components/button';
 import { useTranslation } from 'react-i18next';
 import { AlertCircle } from 'lucide-react';
 import type { PageMargins } from '@/shared/lib/letterhead-margins';
@@ -13,12 +14,19 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorker;
 /** A PDF source — either a user-selected File or a remote URL. */
 export type PdfSource = File | string | null;
 
+/** A one-click set of margins, e.g. a DIN 5008 letter layout. */
+export interface MarginPreset {
+  label: string;
+  margins: PageMargins;
+}
+
 interface MarginEditorProps {
   /** File object (new upload) or URL string (existing PDF). */
   pdfSource: PdfSource;
   margins: PageMargins;
   onMarginsChange: (margins: PageMargins) => void;
   label: string;
+  presets?: readonly MarginPreset[];
 }
 
 const CANVAS_MAX_WIDTH = 280;
@@ -94,6 +102,7 @@ export function MarginEditor({
   margins,
   onMarginsChange,
   label,
+  presets,
 }: Readonly<MarginEditorProps>) {
   const { t } = useTranslation('admin-settings-letterheads');
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -224,21 +233,38 @@ export function MarginEditor({
             )}
           </div>
         )}
-        <div className="grid grid-cols-2 gap-2">
-          {(['top', 'bottom', 'left', 'right'] as const).map((field) => (
-            <div key={field} className="space-y-1">
-              <Label className="text-xs text-muted-foreground">
-                {t(`letterheads.createDialog.${field}`)}
-              </Label>
-              <Input
-                type="number"
-                min={0}
-                value={margins[field]}
-                onChange={(e) => handleChange(field, e.target.value)}
-                className="h-8"
-              />
+        <div className="space-y-2">
+          <div className="grid grid-cols-2 gap-2">
+            {(['top', 'bottom', 'left', 'right'] as const).map((field) => (
+              <div key={field} className="space-y-1">
+                <Label className="text-xs text-muted-foreground">
+                  {t(`letterheads.createDialog.${field}`)}
+                </Label>
+                <Input
+                  type="number"
+                  min={0}
+                  value={margins[field]}
+                  onChange={(e) => handleChange(field, e.target.value)}
+                  className="h-8"
+                />
+              </div>
+            ))}
+          </div>
+          {presets && presets.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {presets.map((preset) => (
+                <Button
+                  key={preset.label}
+                  type="button"
+                  variant="outline"
+                  size="xs"
+                  onClick={() => onMarginsChange(preset.margins)}
+                >
+                  {preset.label}
+                </Button>
+              ))}
             </div>
-          ))}
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Letters generated onto a stored letterhead started at the configured top
margin (20mm by default), landing the body inside the letterhead's printed
header, with the sender's contact details in the flat single column instead
of beside the address.

- PDF export renders a header-less table as the DIN 5008 head block:
  recipient in the Anschriftzone at 62.7mm, information block at 125mm,
  subject at 98.46mm, single-spaced so a long address stays in its zone
- The marker class is injected at render time, after sanitization: the
  Tiptap schema drops classes and data attributes, so a marker stored in
  the content would vanish on the first edit
- DOCX mirrors the rule so the head block is not a visible grid
- The document tools now describe the letter structure to the model
- Letterhead margins default to DIN 5008 Form B, with Form A/B presets in
  the margin editor for adjusting existing letterheads

Verified by measuring text positions in a rendered PDF for Form A, Form B,
a 6-line address, and a mixed letter with a real data table.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PDF/DOCX export layout heuristics (header-less tables) and default letterhead margins, which can affect existing exports and AI-generated letters; mitigated by tests and letterhead-only PDF layout CSS.
> 
> **Overview**
> **Letterhead PDF/DOCX export** now treats a **header-less two-column table** as the DIN 5008 address and sender block: PDF export runs `markLayoutTables` after sanitization (so TipTap cannot strip the marker), applies `letter-layout` CSS for zones, spacing, and subject alignment, and only when a letterhead is used. DOCX uses the same “no `<th>` ⇒ layout table” rule via `docx-table-styles` so the head block is borderless while real data tables stay gridded.
> 
> **AI document tooling** extends `buildLetterheadSuffix` with explicit letter structure guidance (two-column block, bold subject, headed data tables, no duplicated letterhead artwork).
> 
> **Admin UI** defaults new letterheads to DIN 5008 Form B margins, adds Form A/B one-click presets on the first-page margin editor, and continuation pages default to DIN continuation margins. The artifact editor previews header-less tables borderless to match export.
> 
> E2E CI turns on `FEATURE_LETTERHEADS_ENABLED`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7df9df748c577e0c13b76e1b36e34b3402769885. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->