### PR TITLE
feat(sources): accept .odt and .odp uploads (AYC-159)

### DIFF
--- a/ayunis-core-backend/src/common/util/file-type.spec.ts
+++ b/ayunis-core-backend/src/common/util/file-type.spec.ts
@@ -2,7 +2,9 @@ import {
   detectFileType,
   getCanonicalMimeType,
   isAudioFile,
+  isDocumentFile,
   isEmailFile,
+  isOfficeDocumentFile,
   MIME_TYPES,
 } from './file-type';
 
@@ -217,6 +219,68 @@ describe('detectFileType', () => {
     it('is case-insensitive for the .eml extension', () => {
       expect(detectFileType('application/octet-stream', 'MESSAGE.EML')).toBe(
         'eml',
+      );
+    });
+  });
+
+  describe('ODF detection', () => {
+    it('returns "odt" when MIME type is correct', () => {
+      expect(detectFileType(MIME_TYPES.ODT, 'letter.odt')).toBe('odt');
+    });
+
+    it('returns "odt" from the .odt extension when MIME type is generic', () => {
+      expect(detectFileType('application/octet-stream', 'letter.odt')).toBe(
+        'odt',
+      );
+    });
+
+    it('is case-insensitive for the .odt extension', () => {
+      expect(detectFileType('application/octet-stream', 'LETTER.ODT')).toBe(
+        'odt',
+      );
+    });
+
+    it('returns "odp" when MIME type is correct', () => {
+      expect(detectFileType(MIME_TYPES.ODP, 'deck.odp')).toBe('odp');
+    });
+
+    it('returns "odp" from the .odp extension when MIME type is generic', () => {
+      expect(detectFileType('application/octet-stream', 'deck.odp')).toBe(
+        'odp',
+      );
+    });
+  });
+
+  describe('isOfficeDocumentFile', () => {
+    it('returns true for the LibreOffice-convertible types', () => {
+      expect(isOfficeDocumentFile('docx')).toBe(true);
+      expect(isOfficeDocumentFile('pptx')).toBe(true);
+      expect(isOfficeDocumentFile('odt')).toBe(true);
+      expect(isOfficeDocumentFile('odp')).toBe(true);
+    });
+
+    it('returns false for pdf and non-document types', () => {
+      expect(isOfficeDocumentFile('pdf')).toBe(false);
+      expect(isOfficeDocumentFile('txt')).toBe(false);
+      expect(isOfficeDocumentFile('xlsx')).toBe(false);
+      expect(isOfficeDocumentFile('unknown')).toBe(false);
+    });
+  });
+
+  describe('isDocumentFile for ODF', () => {
+    it('accepts odt and odp alongside docx and pptx', () => {
+      expect(isDocumentFile('odt')).toBe(true);
+      expect(isDocumentFile('odp')).toBe(true);
+    });
+  });
+
+  describe('getCanonicalMimeType for ODF', () => {
+    it('maps odt and odp to their OASIS MIME types', () => {
+      expect(getCanonicalMimeType('odt')).toBe(
+        'application/vnd.oasis.opendocument.text',
+      );
+      expect(getCanonicalMimeType('odp')).toBe(
+        'application/vnd.oasis.opendocument.presentation',
       );
     });
   });

--- a/ayunis-core-backend/src/common/util/file-type.ts
+++ b/ayunis-core-backend/src/common/util/file-type.ts
@@ -13,6 +13,10 @@ export const MIME_TYPES = {
   // PowerPoint
   PPTX: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
 
+  // OpenDocument (LibreOffice) — text and presentation
+  ODT: 'application/vnd.oasis.opendocument.text',
+  ODP: 'application/vnd.oasis.opendocument.presentation',
+
   // Excel
   XLSX: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   XLS: 'application/vnd.ms-excel',
@@ -45,6 +49,8 @@ export const FILE_EXTENSIONS = {
   PDF: '.pdf',
   DOCX: '.docx',
   PPTX: '.pptx',
+  ODT: '.odt',
+  ODP: '.odp',
   XLSX: '.xlsx',
   XLS: '.xls',
   CSV: '.csv',
@@ -62,6 +68,8 @@ export const SUPPORTED_FILE_TYPES: string[] = [
   'PDF',
   'DOCX',
   'PPTX',
+  'ODT',
+  'ODP',
   'TXT',
   'EML',
   'CSV',
@@ -77,6 +85,8 @@ export type DetectedFileType =
   | 'pdf'
   | 'docx'
   | 'pptx'
+  | 'odt'
+  | 'odp'
   | 'xlsx'
   | 'xls'
   | 'csv'
@@ -93,6 +103,8 @@ const MIME_TO_FILE_TYPE: Record<string, DetectedFileType> = {
   [MIME_TYPES.PDF]: 'pdf',
   [MIME_TYPES.DOCX]: 'docx',
   [MIME_TYPES.PPTX]: 'pptx',
+  [MIME_TYPES.ODT]: 'odt',
+  [MIME_TYPES.ODP]: 'odp',
   [MIME_TYPES.XLSX]: 'xlsx',
   [MIME_TYPES.CSV]: 'csv',
   // Note: MIME_TYPES.XLS is intentionally excluded — XLS MIME can also indicate CSV files
@@ -111,6 +123,8 @@ const EXT_TO_FILE_TYPE: Record<string, DetectedFileType> = {
   [FILE_EXTENSIONS.PDF]: 'pdf',
   [FILE_EXTENSIONS.DOCX]: 'docx',
   [FILE_EXTENSIONS.PPTX]: 'pptx',
+  [FILE_EXTENSIONS.ODT]: 'odt',
+  [FILE_EXTENSIONS.ODP]: 'odp',
   [FILE_EXTENSIONS.XLSX]: 'xlsx',
   [FILE_EXTENSIONS.XLS]: 'xls',
   [FILE_EXTENSIONS.CSV]: 'csv',
@@ -153,10 +167,25 @@ export function isPlainTextFile(fileType: DetectedFileType): boolean {
 }
 
 /**
- * Check if the file type is a document (PDF, Word, PowerPoint)
+ * Office formats that reach the text pipeline by way of a LibreOffice
+ * conversion to PDF. Callers of the converter must gate on this rather than on
+ * their own literal list, so an added format cannot be accepted on upload and
+ * then rejected during retrieval.
+ */
+export function isOfficeDocumentFile(fileType: DetectedFileType): boolean {
+  return (
+    fileType === 'docx' ||
+    fileType === 'pptx' ||
+    fileType === 'odt' ||
+    fileType === 'odp'
+  );
+}
+
+/**
+ * Check if the file type is a document (PDF, Word, PowerPoint, OpenDocument)
  */
 export function isDocumentFile(fileType: DetectedFileType): boolean {
-  return fileType === 'pdf' || fileType === 'docx' || fileType === 'pptx';
+  return fileType === 'pdf' || isOfficeDocumentFile(fileType);
 }
 
 /**
@@ -214,6 +243,8 @@ const CANONICAL_MIME_BY_FILE_TYPE: Record<
   pdf: MIME_TYPES.PDF,
   docx: MIME_TYPES.DOCX,
   pptx: MIME_TYPES.PPTX,
+  odt: MIME_TYPES.ODT,
+  odp: MIME_TYPES.ODP,
   xlsx: MIME_TYPES.XLSX,
   xls: MIME_TYPES.XLS,
   csv: MIME_TYPES.CSV,

--- a/ayunis-core-backend/src/db/migrations/1788877033485-AddOdfToFileTypeEnum.ts
+++ b/ayunis-core-backend/src/db/migrations/1788877033485-AddOdfToFileTypeEnum.ts
@@ -1,0 +1,31 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOdfToFileTypeEnum1788877033485 implements MigrationInterface {
+  name = 'AddOdfToFileTypeEnum1788877033485';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."sources_filetype_enum" RENAME TO "sources_filetype_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."sources_filetype_enum" AS ENUM('pdf', 'docx', 'pptx', 'odt', 'odp', 'txt', 'eml', 'audio')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sources" ALTER COLUMN "fileType" TYPE "public"."sources_filetype_enum" USING "fileType"::"text"::"public"."sources_filetype_enum"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."sources_filetype_enum_old"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."sources_filetype_enum_old" AS ENUM('audio', 'docx', 'eml', 'pdf', 'pptx', 'txt')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sources" ALTER COLUMN "fileType" TYPE "public"."sources_filetype_enum_old" USING "fileType"::"text"::"public"."sources_filetype_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."sources_filetype_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."sources_filetype_enum_old" RENAME TO "sources_filetype_enum"`,
+    );
+  }
+}

--- a/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
+++ b/ayunis-core-backend/src/domain/knowledge-bases/presenters/http/knowledge-bases.controller.ts
@@ -85,7 +85,8 @@ const DOCUMENT_UPLOAD_API_BODY: ApiBodyOptions = {
       file: {
         type: 'string',
         format: 'binary',
-        description: 'The file to upload (PDF, DOCX, PPTX, TXT, max 25 MB)',
+        description:
+          'The file to upload (PDF, DOCX, PPTX, ODT, ODP, TXT, max 25 MB)',
       },
     },
     required: ['file'],
@@ -350,7 +351,7 @@ export class KnowledgeBasesController {
       errorMessage: (reason, detectedType) =>
         reason === 'missing-mime'
           ? `Unable to determine MIME type for detected file type: ${detectedType}`
-          : `Unsupported file type: ${file.originalname}. Knowledge bases only support PDF, DOCX, PPTX, TXT, EML, and audio files (MP3, M4A, WAV, WebM).`,
+          : `Unsupported file type: ${file.originalname}. Knowledge bases only support PDF, DOCX, PPTX, ODT, ODP, TXT, EML, and audio files (MP3, M4A, WAV, WebM).`,
     });
   }
 

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.spec.ts
@@ -352,4 +352,45 @@ describe('RetrieveFileContentUseCase', () => {
     );
     expect(result).toBe(expectedResult);
   });
+
+  it.each([
+    ['letter.odt', 'application/vnd.oasis.opendocument.text'],
+    ['deck.odp', 'application/vnd.oasis.opendocument.presentation'],
+  ])(
+    'should convert %s to PDF via Gotenberg then process with Mistral',
+    async (fileName, mimeType) => {
+      const odfBuffer = Buffer.from('fake odf content');
+      const pdfBuffer = Buffer.from('converted pdf content');
+      const expectedResult = new FileRetrieverResult([
+        new FileRetrieverPage('extracted text from converted odf', 1),
+      ]);
+
+      jest
+        .spyOn(mockDocumentConverter, 'convertToPdf')
+        .mockResolvedValue(pdfBuffer);
+      jest
+        .spyOn(mockMistralHandler, 'processFile')
+        .mockResolvedValue(expectedResult);
+
+      const result = await useCase.execute(
+        new RetrieveFileContentCommand({
+          fileData: odfBuffer,
+          fileName,
+          fileType: mimeType,
+        }),
+      );
+
+      expect(mockDocumentConverter.convertToPdf).toHaveBeenCalledWith(
+        odfBuffer,
+        fileName,
+      );
+      expect(mockMistralHandler.processFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filename: fileName.replace(/\.od[tp]$/, '.pdf'),
+          fileType: 'application/pdf',
+        }),
+      );
+      expect(result).toBe(expectedResult);
+    },
+  );
 });

--- a/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.ts
+++ b/ayunis-core-backend/src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case.ts
@@ -18,6 +18,7 @@ import {
 import {
   detectFileType,
   isAudioFile,
+  isOfficeDocumentFile,
   MIME_TYPES,
 } from 'src/common/util/file-type';
 import { extractTextFromEml } from 'src/common/util/eml';
@@ -75,7 +76,7 @@ export class RetrieveFileContentUseCase {
       );
     }
 
-    if (fileType === 'docx' || fileType === 'pptx') {
+    if (isOfficeDocumentFile(fileType)) {
       return await this.processOfficeDocument(
         command.fileData,
         command.fileName,
@@ -158,7 +159,7 @@ export class RetrieveFileContentUseCase {
   }
 
   /**
-   * DOCX/PPTX: Convert to PDF via Gotenberg, then process as PDF.
+   * DOCX/PPTX/ODT/ODP: Convert to PDF via Gotenberg, then process as PDF.
    */
   private async processOfficeDocument(
     fileData: Buffer,

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-processing-source/create-processing-source.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-processing-source/create-processing-source.use-case.spec.ts
@@ -55,6 +55,29 @@ describe('CreateProcessingSourceUseCase', () => {
   });
 
   it.each([
+    ['application/vnd.oasis.opendocument.text', 'Brief.odt', FileType.ODT],
+    [
+      'application/vnd.oasis.opendocument.presentation',
+      'Praesentation.odp',
+      FileType.ODP,
+    ],
+  ])(
+    'should create a FileSource with PROCESSING status for %s',
+    async (mimeType, fileName, expectedFileType) => {
+      const command = new CreateProcessingSourceCommand({
+        fileType: mimeType,
+        fileName,
+      });
+
+      const result = await useCase.execute(command);
+
+      expect(result.fileType).toBe(expectedFileType);
+      expect(result.textType).toBe(TextType.FILE);
+      expect(result.status).toBe(SourceStatus.PROCESSING);
+    },
+  );
+
+  it.each([
     ['audio/mpeg', 'meeting.mp3'],
     ['audio/x-m4a', 'voice-memo.m4a'],
     ['audio/wav', 'interview.wav'],

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-processing-source/create-processing-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-processing-source/create-processing-source.use-case.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { FileSource } from 'src/domain/sources/domain/sources/text-source.entity';
 import { FileType, TextType } from 'src/domain/sources/domain/source-type.enum';
 import { SourceStatus } from 'src/domain/sources/domain/source-status.enum';
-import { MIME_TYPES } from 'src/common/util/file-type';
+import { fileTypeFromMimeType } from 'src/domain/sources/application/util/source-file-type.helpers';
 import { SourceRepository } from 'src/domain/sources/application/ports/source.repository';
 import {
   UnsupportedSourceFileTypeError,
@@ -50,24 +50,8 @@ export class CreateProcessingSourceUseCase {
   }
 
   private getFileType(mimeType: string): FileType {
-    switch (mimeType) {
-      case MIME_TYPES.PDF:
-        return FileType.PDF;
-      case MIME_TYPES.DOCX:
-        return FileType.DOCX;
-      case MIME_TYPES.PPTX:
-        return FileType.PPTX;
-      case MIME_TYPES.TXT:
-        return FileType.TXT;
-      case MIME_TYPES.EML:
-        return FileType.EML;
-      case MIME_TYPES.MP3:
-      case MIME_TYPES.M4A:
-      case MIME_TYPES.WAV:
-      case MIME_TYPES.WEBM:
-        return FileType.AUDIO;
-      default:
-        throw new UnsupportedSourceFileTypeError(mimeType);
-    }
+    const fileType = fileTypeFromMimeType(mimeType);
+    if (!fileType) throw new UnsupportedSourceFileTypeError(mimeType);
+    return fileType;
   }
 }

--- a/ayunis-core-backend/src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case.ts
+++ b/ayunis-core-backend/src/domain/sources/application/use-cases/create-text-source/create-text-source.use-case.ts
@@ -32,7 +32,7 @@ import { SplitterType } from 'src/domain/rag/splitters/domain/splitter-type.enum
 import { SourceRepository } from 'src/domain/sources/application/ports/source.repository';
 import { RetrieveFileContentCommand } from 'src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.command';
 import { RetrieveFileContentUseCase } from 'src/domain/retrievers/file-retrievers/application/use-cases/retrieve-file-content/retrieve-file-content.use-case';
-import { MIME_TYPES } from 'src/common/util/file-type';
+import { fileTypeFromMimeType } from 'src/domain/sources/application/util/source-file-type.helpers';
 
 interface TextSourceWithContent {
   source: TextSource;
@@ -143,29 +143,15 @@ export class CreateTextSourceUseCase {
   }
 
   private getFileType(mimeType: string): FileType {
-    switch (mimeType) {
-      case MIME_TYPES.PDF:
-        return FileType.PDF;
-      case MIME_TYPES.DOCX:
-        return FileType.DOCX;
-      case MIME_TYPES.PPTX:
-        return FileType.PPTX;
-      case MIME_TYPES.TXT:
-        return FileType.TXT;
-      case MIME_TYPES.EML:
-        return FileType.EML;
-      case MIME_TYPES.MP3:
-      case MIME_TYPES.M4A:
-      case MIME_TYPES.WAV:
-      case MIME_TYPES.WEBM:
-        return FileType.AUDIO;
-      default:
-        // This is a programming error - caller should validate/route file types before calling this use case
-        throw new Error(
-          `CreateTextSourceUseCase received unsupported file type: ${mimeType}. ` +
-            `This use case only handles PDF, DOCX, PPTX, TXT, EML, and audio. Spreadsheets should be routed to CreateDataSourceUseCase.`,
-        );
+    const fileType = fileTypeFromMimeType(mimeType);
+    if (!fileType) {
+      // This is a programming error - caller should validate/route file types before calling this use case
+      throw new Error(
+        `CreateTextSourceUseCase received unsupported file type: ${mimeType}. ` +
+          `This use case only handles PDF, DOCX, PPTX, ODT, ODP, TXT, EML, and audio. Spreadsheets should be routed to CreateDataSourceUseCase.`,
+      );
     }
+    return fileType;
   }
 
   /**

--- a/ayunis-core-backend/src/domain/sources/application/util/source-file-type.helpers.ts
+++ b/ayunis-core-backend/src/domain/sources/application/util/source-file-type.helpers.ts
@@ -1,0 +1,27 @@
+import { MIME_TYPES } from 'src/common/util/file-type';
+import { FileType } from 'src/domain/sources/domain/source-type.enum';
+
+/**
+ * Canonical upload MIME type → the {@link FileType} persisted on a file
+ * source. Every source-creation path resolves through this one map, so a newly
+ * accepted format cannot be recorded by one entry point and rejected by
+ * another. Keys are the canonical MIMEs produced by `getCanonicalMimeType`.
+ */
+const FILE_TYPE_BY_MIME_TYPE: Record<string, FileType> = {
+  [MIME_TYPES.PDF]: FileType.PDF,
+  [MIME_TYPES.DOCX]: FileType.DOCX,
+  [MIME_TYPES.PPTX]: FileType.PPTX,
+  [MIME_TYPES.ODT]: FileType.ODT,
+  [MIME_TYPES.ODP]: FileType.ODP,
+  [MIME_TYPES.TXT]: FileType.TXT,
+  [MIME_TYPES.EML]: FileType.EML,
+  [MIME_TYPES.MP3]: FileType.AUDIO,
+  [MIME_TYPES.M4A]: FileType.AUDIO,
+  [MIME_TYPES.WAV]: FileType.AUDIO,
+  [MIME_TYPES.WEBM]: FileType.AUDIO,
+};
+
+/** Returns undefined for MIME types that are not a text/file source. */
+export function fileTypeFromMimeType(mimeType: string): FileType | undefined {
+  return FILE_TYPE_BY_MIME_TYPE[mimeType];
+}

--- a/ayunis-core-backend/src/domain/sources/domain/source-type.enum.ts
+++ b/ayunis-core-backend/src/domain/sources/domain/source-type.enum.ts
@@ -12,6 +12,8 @@ export enum FileType {
   PDF = 'pdf',
   DOCX = 'docx',
   PPTX = 'pptx',
+  ODT = 'odt',
+  ODP = 'odp',
   TXT = 'txt',
   EML = 'eml',
   AUDIO = 'audio',

--- a/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-base/ui/KnowledgeBaseDocumentsCard.tsx
@@ -48,14 +48,16 @@ import {
   useUploadDocument,
   useAddUrl,
   useRemoveDocument,
-} from '../api';
-import { isValidUrl } from '../lib/isValidUrl';
+} from '@/pages/knowledge-base/api';
+import { isValidUrl } from '@/pages/knowledge-base/lib/isValidUrl';
 import { AddUrlDialog } from './AddUrlDialog';
 
 const ACCEPTED_EXTENSIONS = [
   '.pdf',
   '.docx',
   '.pptx',
+  '.odt',
+  '.odp',
   '.txt',
   '.md',
   '.eml',

--- a/ayunis-core-frontend/src/pages/workspace/ui/WorkspaceKnowledgeTab.tsx
+++ b/ayunis-core-frontend/src/pages/workspace/ui/WorkspaceKnowledgeTab.tsx
@@ -26,7 +26,7 @@ import { CONTEXT_PAGE_SIZE, pageTotal } from './WorkspaceContextList.model';
 import { useWorkspaceContextActions } from '@/pages/workspace/api/useWorkspaceContextActions';
 
 const ACCEPTED_DOCUMENT_FILE_TYPES =
-  '.pdf,.docx,.pptx,.txt,.md,.eml,.mp3,.m4a,.wav,.webm';
+  '.pdf,.docx,.pptx,.odt,.odp,.txt,.md,.eml,.mp3,.m4a,.wav,.webm';
 
 export function WorkspaceKnowledgeTab({
   workspaceId,

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -2299,6 +2299,8 @@ export const FileSourceResponseDtoFileType = {
   pdf: 'pdf',
   docx: 'docx',
   pptx: 'pptx',
+  odt: 'odt',
+  odp: 'odp',
   txt: 'txt',
   eml: 'eml',
   audio: 'audio',
@@ -5610,7 +5612,7 @@ export type ThreadSourcesControllerAddFileSourceBody = {
 export type ThreadSourcesControllerAddFileSource201Item = FileSourceResponseDto | UrlSourceResponseDto | CSVDataSourceResponseDto;
 
 export type KnowledgeBasesControllerAddDocumentBody = {
-  /** The file to upload (PDF, DOCX, PPTX, TXT, max 25 MB) */
+  /** The file to upload (PDF, DOCX, PPTX, ODT, ODP, TXT, max 25 MB) */
   file: Blob;
 };
 

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -5038,7 +5038,7 @@
                   "file": {
                     "type": "string",
                     "format": "binary",
-                    "description": "The file to upload (PDF, DOCX, PPTX, TXT, max 25 MB)"
+                    "description": "The file to upload (PDF, DOCX, PPTX, ODT, ODP, TXT, max 25 MB)"
                   }
                 },
                 "required": ["file"]
@@ -15222,7 +15222,7 @@
           "fileType": {
             "type": "string",
             "description": "Type of file",
-            "enum": ["pdf", "docx", "pptx", "txt", "eml", "audio"]
+            "enum": ["pdf", "docx", "pptx", "odt", "odp", "txt", "eml", "audio"]
           }
         },
         "required": [

--- a/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/de/knowledge-bases.json
@@ -139,9 +139,9 @@
     },
     "documents": {
       "title": "Dokumente",
-      "description": "Verwalten Sie die Dokumente in dieser Wissenssammlung. Unterstützte Formate: PDF, DOCX.",
+      "description": "Verwalten Sie die Dokumente in dieser Wissenssammlung. Unterstützte Formate: PDF, DOCX, PPTX, ODT, ODP, TXT, EML und Audio.",
       "upload": "Hochladen",
-      "empty": "Noch keine Dokumente hochgeladen. Laden Sie eine PDF- oder DOCX-Datei hoch, um zu beginnen.",
+      "empty": "Noch keine Dokumente hochgeladen. Laden Sie eine PDF-, DOCX- oder ODT-Datei hoch, um zu beginnen.",
       "uploadSuccess": "Dokument erfolgreich hochgeladen!",
       "uploadAccepted": "Dokument hochgeladen — wird im Hintergrund verarbeitet...",
       "uploadError": "Dokument konnte nicht hochgeladen werden. Bitte versuchen Sie es erneut.",

--- a/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
+++ b/ayunis-core-frontend/src/shared/locales/en/knowledge-bases.json
@@ -139,9 +139,9 @@
     },
     "documents": {
       "title": "Documents",
-      "description": "Manage the documents in this knowledge base. Supported formats: PDF, DOCX.",
+      "description": "Manage the documents in this knowledge base. Supported formats: PDF, DOCX, PPTX, ODT, ODP, TXT, EML and audio.",
       "upload": "Upload",
-      "empty": "No documents uploaded yet. Upload a PDF or DOCX file to get started.",
+      "empty": "No documents uploaded yet. Upload a PDF, DOCX or ODT file to get started.",
       "uploadSuccess": "Document uploaded successfully!",
       "uploadAccepted": "Document uploaded — processing in the background...",
       "uploadError": "Failed to upload document. Please try again.",

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/PlusButton.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/PlusButton.tsx
@@ -18,14 +18,14 @@ import { Badge } from '@ayunis/ui/components/badge';
 import { Brain, Loader2, Paperclip, Plus } from 'lucide-react';
 import { Input } from '@ayunis/ui/components/input';
 import { useRef } from 'react';
-import { useKnowledgeBases } from '../api/useKnowledgeBases';
+import { useKnowledgeBases } from '@/widgets/chat-input/api/useKnowledgeBases';
 import { useTranslation } from 'react-i18next';
 import { showError } from '@/shared/lib/toast';
 import { useNavigate } from '@tanstack/react-router';
 import {
   separateFilesByType,
   createFileListFromFiles,
-} from '../utils/fileHandlers';
+} from '@/widgets/chat-input/utils/fileHandlers';
 import type {
   IntegrationSummary,
   KnowledgeBaseSummary,
@@ -198,7 +198,7 @@ export default function PlusButton({
         type="file"
         hidden
         multiple
-        accept="image/*,.pdf,.csv,.xlsx,.xls,.docx,.pptx,.txt,.md,.eml,.mp3,.m4a,.wav,.webm"
+        accept="image/*,.pdf,.csv,.xlsx,.xls,.docx,.pptx,.odt,.odp,.txt,.md,.eml,.mp3,.m4a,.wav,.webm"
         onChange={(e) => handleFileChange(e.target.files)}
         ref={fileInputRef}
       />

--- a/ayunis-core-frontend/src/widgets/chat-input/utils/fileHandlers.ts
+++ b/ayunis-core-frontend/src/widgets/chat-input/utils/fileHandlers.ts
@@ -7,6 +7,8 @@ export const ACCEPTED_DOCUMENT_EXTENSIONS = [
   '.xls',
   '.docx',
   '.pptx',
+  '.odt',
+  '.odp',
   '.txt',
   '.eml',
 ];

--- a/ayunis-core-frontend/src/widgets/knowledge-base-card/ui/KnowledgeBaseCard.tsx
+++ b/ayunis-core-frontend/src/widgets/knowledge-base-card/ui/KnowledgeBaseCard.tsx
@@ -60,6 +60,8 @@ const ACCEPTED_EXTENSIONS = [
   '.pdf',
   '.docx',
   '.pptx',
+  '.odt',
+  '.odp',
   '.txt',
   '.md',
   '.eml',


### PR DESCRIPTION
OpenDocument text and presentation files were rejected on upload, so public-sector users had to convert them by hand before using them as a source. Both formats ride the existing document path: Gotenberg's LibreOffice endpoint reads ODF natively, so no new conversion infrastructure is needed.

Closes AYC-159.

## What changed

- `.odt` and `.odp` are accepted at all four upload entry points — chat, skills, knowledge bases and projects. Three of them share the `isDocumentSourceFile` gate, so extending `isDocumentFile` carries them; the frontend accept lists are updated per surface.
- `isOfficeDocumentFile` is now the single gate for the LibreOffice-to-PDF route. Previously `isDocumentFile` (upload) and a literal `docx || pptx` check (retrieval) could drift, letting a format be accepted on upload and then rejected during retrieval.
- The two duplicated mime-to-`FileType` switches collapse into one shared map (`source-file-type.helpers.ts`), so a new format cannot be recorded by one entry point and rejected by another. This also brings both `getFileType` methods back under the cyclomatic-complexity gate.
- `FileType` gains `ODT`/`ODP` plus an enum migration following the `AddEmlToFileTypeEnum` rename/add-value/cast pattern.
- `.odp` yields one text source per file, like PPTX — nothing slide-aware.
- Knowledge-base copy claimed "Supported formats: PDF, DOCX" (already stale before this change); it now names the formats the picker actually accepts.

Same 25 MB limit as every other source file — the cap is uniform in `SOURCE_FILE_UPLOAD_OPTIONS`, so no per-type change was needed.

## Verification

Unit: 750 suites / 5073 tests pass; lint, prettier, typecheck, complexity gate and file-size gate pass on the changed files.

Behaviour, on a dedicated dev slot (slot 5, real Bedrock/Azure models and real Mistral OCR — no mocked inference), seeded with `seed:minimal:ts`:

| Entry point | Endpoint | Result |
| --- | --- | --- |
| Chat | `POST /threads/{id}/sources/file` | 201, `fileType` `odt`/`odp`, both `ready` |
| Skill | `POST /skills/{id}/sources/file` | assigned in `skill_sources`, both `ready` |
| Knowledge base | `POST /knowledge-bases/{id}/documents` | 202, both listed `ready` |
| Project | `POST /workspaces/{id}/context/documents` (`FEATURE_WORKSPACES_ENABLED=true`) | 201, both `ready` |

Extracted text is structurally intact — the ODT yields markdown headings, a bullet list and a markdown table; the ODP yields per-slide text as a single source. The model answers from both files (screenshot below).

Migration: generated against a clean slot-12 database (zero unrelated drift), applied to a database holding existing source rows, and `migration:generate` afterwards reports "No changes in database schema were found".

Existing types re-checked on the same slot: TXT, DOCX and PPTX uploads all processed to `ready`.

One pre-existing bug surfaced during QA. It is **not** caused by this change and reproduces for DOCX just as much as for ODF, so it is filed separately rather than fixed here: a knowledge-base document intermittently loses its `knowledgeBaseId`. `assignSourceToKnowledgeBase` runs after `startDocumentProcessing` has already enqueued the job, and the consumer's full-record save (`source.mapper.createTextSourceRecord` writes `knowledgeBaseId`) can write back the value it loaded before the assign. Observed on `race-docx-1.docx` while all four ODT uploads in the same batch survived.

One ODT upload also failed once with `Mistral OCR processing failed` on the converted PDF. That is the OCR stage PDF/DOCX/PPTX share, the same file then succeeded 5/5 on retry, and `classifyJobFailure` settles a deterministic provider rejection on the first attempt by design (AYC-655). The error body is redacted in logs, so the upstream status is unknown — recording it as an observation, not a finding.

## Screenshots / demo

| ODF attached in chat | Model answering from the ODT table and ODP slides |
| --- | --- |
| ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-159/docs/pr-media/ayc-159/02-chat-odf-attached.png) | ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-159/docs/pr-media/ayc-159/03-chat-answer-from-odf.png) |

`.odt` documents in a knowledge base:

![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-159/docs/pr-media/ayc-159/04-knowledge-base-odf.png)

![demo](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-159/docs/pr-media/ayc-159/demo.gif)

> Media hosted on the `pr-media/ayc-159` branch (not part of this PR's diff); safe to delete after merge.
