### PR TITLE
fix(letterheads): say why a letterhead PDF was rejected (AYC-921)

### DIFF
--- a/ayunis-core-backend/src/domain/letterheads/application/letterheads.errors.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/letterheads.errors.ts
@@ -1,11 +1,12 @@
 import type { ErrorMetadata } from 'src/common/errors/base.error';
 import { ApplicationError } from 'src/common/errors/base.error';
 
-export { InvalidPageMarginsError } from '../domain/letterhead.errors';
+export { InvalidPageMarginsError } from 'src/domain/letterheads/domain/letterhead.errors';
 
 export enum LetterheadErrorCode {
   LETTERHEAD_NOT_FOUND = 'LETTERHEAD_NOT_FOUND',
   LETTERHEAD_INVALID_PDF = 'LETTERHEAD_INVALID_PDF',
+  LETTERHEAD_PDF_NOT_SINGLE_PAGE = 'LETTERHEAD_PDF_NOT_SINGLE_PAGE',
   LETTERHEAD_ORG_MISMATCH = 'LETTERHEAD_ORG_MISMATCH',
   UNEXPECTED_LETTERHEAD_ERROR = 'UNEXPECTED_LETTERHEAD_ERROR',
 }
@@ -37,6 +38,23 @@ export class LetterheadInvalidPdfError extends LetterheadError {
     super(
       `Invalid letterhead PDF: ${reason}`,
       LetterheadErrorCode.LETTERHEAD_INVALID_PDF,
+      400,
+      metadata,
+    );
+  }
+}
+
+/**
+ * Distinct from {@link LetterheadInvalidPdfError}: the file parsed fine, it
+ * just has the wrong number of pages. Letterheads are commonly distributed as
+ * one file holding both the first and the continuation page, so the UI needs
+ * to tell the user to split it rather than claim the PDF is broken.
+ */
+export class LetterheadPdfNotSinglePageError extends LetterheadError {
+  constructor(label: string, pageCount: number, metadata?: ErrorMetadata) {
+    super(
+      `Invalid letterhead PDF: ${label} PDF must be exactly 1 page, got ${pageCount}`,
+      LetterheadErrorCode.LETTERHEAD_PDF_NOT_SINGLE_PAGE,
       400,
       metadata,
     );

--- a/ayunis-core-backend/src/domain/letterheads/application/services/letterhead-pdf.service.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/services/letterhead-pdf.service.spec.ts
@@ -1,7 +1,25 @@
 import type { UUID } from 'crypto';
 import { PDFDocument } from 'pdf-lib';
 import { LetterheadPdfService } from './letterhead-pdf.service';
-import { LetterheadInvalidPdfError } from '../letterheads.errors';
+import {
+  LetterheadErrorCode,
+  LetterheadInvalidPdfError,
+  LetterheadPdfNotSinglePageError,
+} from 'src/domain/letterheads/application/letterheads.errors';
+
+/**
+ * pdf-lib cannot encrypt, so this flags encryption the way pdf-lib detects it
+ * — an `/Encrypt` entry in the trailer (see PDFDocument's `isEncrypted`). The
+ * streams are not really RC4-encrypted, but `load` takes the same branch it
+ * takes for a genuinely protected letterhead.
+ */
+async function createEncryptedPdf(): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  doc.addPage();
+  const encryptDict = doc.context.obj({ Filter: 'Standard', V: 1, R: 2 });
+  doc.context.trailerInfo.Encrypt = doc.context.register(encryptDict);
+  return Buffer.from(await doc.save());
+}
 
 async function createSinglePagePdf(): Promise<Buffer> {
   const doc = await PDFDocument.create();
@@ -34,17 +52,44 @@ describe('LetterheadPdfService', () => {
       ).resolves.toBeUndefined();
     });
 
-    it('should reject a multi-page PDF', async () => {
+    it('should reject a multi-page PDF as not single-page, not as unreadable', async () => {
       const pdf = await createMultiPagePdf(3);
       await expect(
         service.validateSinglePagePdf(pdf, 'first page'),
-      ).rejects.toThrow(LetterheadInvalidPdfError);
+      ).rejects.toThrow(LetterheadPdfNotSinglePageError);
+    });
+
+    it('should carry a distinct code and the actual page count for support', async () => {
+      const pdf = await createMultiPagePdf(2);
+
+      await expect(
+        service.validateSinglePagePdf(pdf, 'first page'),
+      ).rejects.toMatchObject({
+        code: LetterheadErrorCode.LETTERHEAD_PDF_NOT_SINGLE_PAGE,
+        message: expect.stringContaining('got 2'),
+      });
     });
 
     it('should reject an invalid buffer', async () => {
       const buffer = Buffer.from('not a pdf');
       await expect(
         service.validateSinglePagePdf(buffer, 'first page'),
+      ).rejects.toThrow(LetterheadInvalidPdfError);
+    });
+
+    it('should reject an empty buffer as unreadable', async () => {
+      await expect(
+        service.validateSinglePagePdf(Buffer.alloc(0), 'first page'),
+      ).rejects.toThrow(LetterheadInvalidPdfError);
+    });
+
+    it('should reject an encrypted PDF as unreadable rather than swallowing it', async () => {
+      // pdf-lib throws EncryptedPDFError because `load` runs with the default
+      // `ignoreEncryption: false`. Permission-restricted letterheads (no open
+      // password, but printing/editing locked) land here.
+      const encrypted = await createEncryptedPdf();
+      await expect(
+        service.validateSinglePagePdf(encrypted, 'first page'),
       ).rejects.toThrow(LetterheadInvalidPdfError);
     });
   });

--- a/ayunis-core-backend/src/domain/letterheads/application/services/letterhead-pdf.service.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/services/letterhead-pdf.service.ts
@@ -1,23 +1,34 @@
 import { Injectable } from '@nestjs/common';
 import type { UUID } from 'crypto';
 import { PDFDocument } from 'pdf-lib';
-import { LetterheadInvalidPdfError } from '../letterheads.errors';
+import {
+  LetterheadInvalidPdfError,
+  LetterheadPdfNotSinglePageError,
+} from 'src/domain/letterheads/application/letterheads.errors';
 
 @Injectable()
 export class LetterheadPdfService {
   async validateSinglePagePdf(buffer: Buffer, label: string): Promise<void> {
+    const pdfDoc = await this.loadPdf(buffer, label);
+
+    const pageCount = pdfDoc.getPageCount();
+    if (pageCount !== 1) {
+      throw new LetterheadPdfNotSinglePageError(label, pageCount);
+    }
+  }
+
+  /**
+   * Kept separate so the page-count check below runs outside this catch —
+   * a catch-all around both would report a wrong-page-count PDF as unreadable.
+   *
+   * `load` runs with pdf-lib's default `ignoreEncryption: false`, so
+   * password- or permission-protected PDFs throw here and are reported as
+   * unreadable, which is what the user has to act on.
+   */
+  private async loadPdf(buffer: Buffer, label: string): Promise<PDFDocument> {
     try {
-      const pdfDoc = await PDFDocument.load(buffer);
-      const pageCount = pdfDoc.getPageCount();
-      if (pageCount !== 1) {
-        throw new LetterheadInvalidPdfError(
-          `${label} PDF must be exactly 1 page, got ${pageCount}`,
-        );
-      }
-    } catch (error) {
-      if (error instanceof LetterheadInvalidPdfError) {
-        throw error;
-      }
+      return await PDFDocument.load(buffer);
+    } catch {
       throw new LetterheadInvalidPdfError(`${label} is not a valid PDF file`);
     }
   }

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/create-letterhead/create-letterhead.use-case.spec.ts
@@ -9,7 +9,10 @@ import { LetterheadPdfService } from 'src/domain/letterheads/application/service
 import { ContextService } from 'src/common/context/services/context.service';
 import { UploadObjectUseCase } from 'src/domain/storage/application/use-cases/upload-object/upload-object.use-case';
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
-import { LetterheadInvalidPdfError } from 'src/domain/letterheads/application/letterheads.errors';
+import {
+  LetterheadInvalidPdfError,
+  LetterheadPdfNotSinglePageError,
+} from 'src/domain/letterheads/application/letterheads.errors';
 
 async function createSinglePagePdf(): Promise<Buffer> {
   const doc = await PDFDocument.create();
@@ -129,7 +132,7 @@ describe('CreateLetterheadUseCase', () => {
     });
 
     await expect(useCase.execute(command)).rejects.toThrow(
-      LetterheadInvalidPdfError,
+      LetterheadPdfNotSinglePageError,
     );
     expect(letterheadsRepository.save).not.toHaveBeenCalled();
   });
@@ -147,7 +150,7 @@ describe('CreateLetterheadUseCase', () => {
     });
 
     await expect(useCase.execute(command)).rejects.toThrow(
-      LetterheadInvalidPdfError,
+      LetterheadPdfNotSinglePageError,
     );
     expect(letterheadsRepository.save).not.toHaveBeenCalled();
   });

--- a/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/letterheads/application/use-cases/update-letterhead/update-letterhead.use-case.spec.ts
@@ -12,7 +12,7 @@ import { DeleteObjectUseCase } from 'src/domain/storage/application/use-cases/de
 import { UnauthorizedAccessError } from 'src/common/errors/unauthorized-access.error';
 import {
   LetterheadNotFoundError,
-  LetterheadInvalidPdfError,
+  LetterheadPdfNotSinglePageError,
 } from 'src/domain/letterheads/application/letterheads.errors';
 import { Letterhead } from 'src/domain/letterheads/domain/letterhead.entity';
 
@@ -208,7 +208,7 @@ describe('UpdateLetterheadUseCase', () => {
     });
 
     await expect(useCase.execute(command)).rejects.toThrow(
-      LetterheadInvalidPdfError,
+      LetterheadPdfNotSinglePageError,
     );
   });
 

--- a/ayunis-core-frontend/src/pages/admin-settings/letterhead-detail/api/useUpdateLetterhead.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/letterhead-detail/api/useUpdateLetterhead.ts
@@ -79,6 +79,9 @@ export function useUpdateLetterhead() {
       try {
         const { code } = extractErrorData(error);
         switch (code) {
+          case 'LETTERHEAD_PDF_NOT_SINGLE_PAGE':
+            showError(t('letterheads.editDialog.pdfNotSinglePage'));
+            break;
           case 'LETTERHEAD_INVALID_PDF':
             showError(t('letterheads.editDialog.invalidPdf'));
             break;

--- a/ayunis-core-frontend/src/pages/admin-settings/letterheads-settings/api/useCreateLetterhead.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/letterheads-settings/api/useCreateLetterhead.ts
@@ -5,7 +5,7 @@ import { getLetterheadsControllerFindAllQueryKey } from '@/shared/api/generated/
 import { customAxiosInstance } from '@/shared/api';
 import extractErrorData from '@/shared/api/extract-error-data';
 import type { LetterheadResponseDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
-import type { PageMargins } from '../model/types';
+import type { PageMargins } from '@/pages/admin-settings/letterheads-settings/model/types';
 
 interface CreateLetterheadParams {
   name: string;
@@ -58,6 +58,9 @@ export function useCreateLetterhead(onSuccess?: () => void) {
       try {
         const { code } = extractErrorData(error);
         switch (code) {
+          case 'LETTERHEAD_PDF_NOT_SINGLE_PAGE':
+            showError(t('letterheads.createDialog.pdfNotSinglePage'));
+            break;
           case 'LETTERHEAD_INVALID_PDF':
             showError(t('letterheads.createDialog.invalidPdf'));
             break;

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-letterheads.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-letterheads.json
@@ -32,7 +32,8 @@
       "success": "Briefpapier erfolgreich erstellt.",
       "error": "Fehler beim Erstellen des Briefpapiers.",
       "firstPageRequired": "Eine PDF-Datei für die erste Seite ist erforderlich.",
-      "invalidPdf": "Bitte laden Sie eine gültige PDF-Datei hoch.",
+      "invalidPdf": "Diese PDF-Datei konnte nicht gelesen werden. Bitte laden Sie eine ungeschützte PDF-Datei hoch – Kennwort- oder Berechtigungsschutz verhindert die Verarbeitung.",
+      "pdfNotSinglePage": "Diese Datei hat mehr als eine Seite. Bitte laden Sie eine einseitige PDF-Datei hoch und verwenden Sie für die Folgeseiten eine separate Datei.",
       "invalidPageMargins": "Bitte geben Sie gültige nicht-negative Seitenränder ein.",
       "pdfPreviewError": "PDF-Vorschau konnte nicht gerendert werden."
     },
@@ -43,7 +44,8 @@
       "saving": "Wird gespeichert…",
       "success": "Briefpapier erfolgreich aktualisiert.",
       "error": "Fehler beim Aktualisieren des Briefpapiers.",
-      "invalidPdf": "Bitte laden Sie eine gültige PDF-Datei hoch.",
+      "invalidPdf": "Diese PDF-Datei konnte nicht gelesen werden. Bitte laden Sie eine ungeschützte PDF-Datei hoch – Kennwort- oder Berechtigungsschutz verhindert die Verarbeitung.",
+      "pdfNotSinglePage": "Diese Datei hat mehr als eine Seite. Bitte laden Sie eine einseitige PDF-Datei hoch und verwenden Sie für die Folgeseiten eine separate Datei.",
       "invalidPageMargins": "Bitte geben Sie gültige nicht-negative Seitenränder ein.",
       "removeContinuationPage": "Folgeseiten-Briefpapier entfernen",
       "useDifferentFollowingPages": "Anderes Briefpapier für Folgeseiten verwenden"

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-letterheads.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-letterheads.json
@@ -32,7 +32,8 @@
       "success": "Letterhead created successfully.",
       "error": "Failed to create letterhead.",
       "firstPageRequired": "A PDF file for the first page is required.",
-      "invalidPdf": "Please upload a valid PDF file.",
+      "invalidPdf": "This PDF could not be read. Please upload an unprotected PDF — password or permission protection prevents processing.",
+      "pdfNotSinglePage": "This file has more than one page. Please upload a single-page PDF, and use a separate file for the following pages.",
       "invalidPageMargins": "Please enter valid non-negative page margins.",
       "pdfPreviewError": "Could not render PDF preview."
     },
@@ -43,7 +44,8 @@
       "saving": "Saving…",
       "success": "Letterhead updated successfully.",
       "error": "Failed to update letterhead.",
-      "invalidPdf": "Please upload a valid PDF file.",
+      "invalidPdf": "This PDF could not be read. Please upload an unprotected PDF — password or permission protection prevents processing.",
+      "pdfNotSinglePage": "This file has more than one page. Please upload a single-page PDF, and use a separate file for the following pages.",
       "invalidPageMargins": "Please enter valid non-negative page margins.",
       "removeContinuationPage": "Remove following pages letterhead",
       "useDifferentFollowingPages": "Use different letterhead for following pages"


### PR DESCRIPTION
The upload rejected every bad PDF with "Please upload a valid PDF file",
which is wrong for the most common case: letterheads are often shipped as
one file holding the first and the continuation page, and a 2-page PDF is
a perfectly valid PDF. The reason was already computed server-side but
collapsed into a single error code.

- Split the page-count case into LETTERHEAD_PDF_NOT_SINGLE_PAGE so the
  create and edit dialogs can name the fix (split the file, use a separate
  continuation page) in the user's own language
- Scope the PDF load to its own try/catch, so a wrong-page-count PDF can
  no longer be reported as unreadable
- Say that protection blocks processing in the unreadable case: pdf-lib
  loads with ignoreEncryption: false, so permission-restricted letterheads
  land there

Refs: AYC-711

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to letterhead PDF validation and admin UI error handling; no auth, persistence, or document-export behavior changes beyond clearer API error codes.
> 
> **Overview**
> Letterhead uploads no longer lump every PDF failure into a generic “invalid PDF” message. **Multi-page files** (a common case when first and continuation pages are bundled) now return `LETTERHEAD_PDF_NOT_SINGLE_PAGE` with a message that includes the actual page count, while **unreadable** files (corrupt, empty, or encryption/permission-protected per pdf-lib’s default load) still use `LETTERHEAD_INVALID_PDF`.
> 
> `LetterheadPdfService` splits PDF loading from the single-page check so a valid multi-page PDF is never misreported as unreadable. Create/edit hooks map the new code to dedicated copy in EN/DE; the invalid-PDF strings now explain that password or permission protection blocks processing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26643e5ae8c32848d6ed2e3d32d90a9295e45942. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->