### PR TITLE
chore(deps): upgrade the OpenAI SDK to v7 (AYC-000)

### DIFF
--- a/ayunis-core-backend/package.json
+++ b/ayunis-core-backend/package.json
@@ -105,7 +105,7 @@
     "node-html-parser": "^7.1.0",
     "nodemailer": "^7.0.5",
     "ollama": "^0.6.3",
-    "openai": "^4.104.0",
+    "openai": "^7.12.1",
     "openid-client": "^6.8.7",
     "otplib": "^12.0.1",
     "p-limit": "^7.3.1",

--- a/ayunis-core-backend/src/domain/models/infrastructure/image-generation/azure.image-generation.spec.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/image-generation/azure.image-generation.spec.ts
@@ -112,7 +112,7 @@ describe('AzureImageGenerationHandler', () => {
           },
         },
         'content policy violation',
-        {},
+        new Headers(),
       );
 
       mockImagesGenerate.mockRejectedValue(apiError);
@@ -130,7 +130,7 @@ describe('AzureImageGenerationHandler', () => {
         500,
         { error: { message: 'server error', code: 'server_error' } },
         'server error',
-        {},
+        new Headers(),
       );
 
       mockImagesGenerate.mockRejectedValue(apiError);

--- a/ayunis-core-backend/src/domain/models/infrastructure/image-generation/azure.image-generation.ts
+++ b/ayunis-core-backend/src/domain/models/infrastructure/image-generation/azure.image-generation.ts
@@ -1,7 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { APIError, AzureOpenAI, toFile } from 'openai';
-import type { ImageEditParams, ImagesResponse } from 'openai/resources/images';
+import type {
+  ImageEditParamsNonStreaming,
+  ImagesResponse,
+} from 'openai/resources/images';
 import { contentTypeToExtension } from 'src/common/util/content-type.util';
 import {
   ImageGenerationHandler,
@@ -143,7 +146,7 @@ export class AzureImageGenerationHandler extends ImageGenerationHandler {
         ),
       ),
     );
-    const params: ImageEditParams = {
+    const params: ImageEditParamsNonStreaming = {
       model: input.model.name,
       prompt: input.prompt,
       image,
@@ -152,13 +155,9 @@ export class AzureImageGenerationHandler extends ImageGenerationHandler {
       n: 1,
     };
     // Without this, INPUT_FIDELITY_MODELS drop the fine detail (logos,
-    // scans) the references exist to preserve. The SDK's v4 typings predate
-    // the param but serialize every body key, so it reaches the API.
+    // scans) the references exist to preserve.
     if (INPUT_FIDELITY_MODELS.has(input.model.name)) {
-      return client.images.edit({
-        ...params,
-        input_fidelity: 'high',
-      } as ImageEditParams);
+      return client.images.edit({ ...params, input_fidelity: 'high' });
     }
     return client.images.edit(params);
   }

--- a/packages/provider-openai/package.json
+++ b/packages/provider-openai/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@ayunis/inference": "workspace:*",
-    "openai": "^4.104.0"
+    "openai": "^7.12.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",

--- a/packages/provider-openai/src/convert-request.ts
+++ b/packages/provider-openai/src/convert-request.ts
@@ -3,7 +3,7 @@ import type {
   ChatCompletionContentPart,
   ChatCompletionMessageParam,
   ChatCompletionMessageToolCall,
-  ChatCompletionTool,
+  ChatCompletionFunctionTool,
   ChatCompletionToolChoiceOption,
   ChatCompletionUserMessageParam,
 } from 'openai/resources/chat/completions';
@@ -21,7 +21,7 @@ import { normalizeSchemaForOpenAI } from './normalize-schema';
 export const convertTool = (
   tool: ToolSchema,
   codec: ToolNameCodec,
-): ChatCompletionTool => ({
+): ChatCompletionFunctionTool => ({
   type: 'function',
   function: {
     name: codec.encode(tool.name),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,8 +197,8 @@ importers:
         specifier: ^0.6.3
         version: 0.6.3
       openai:
-        specifier: ^4.104.0
-        version: 4.104.0(encoding@0.1.13)(ws@8.21.3)(zod@3.25.76)
+        specifier: ^7.12.1
+        version: 7.12.1(@aws-sdk/credential-provider-node@3.972.46)(@smithy/signature-v4@5.4.5)(undici@7.29.0)(ws@8.21.3)(zod@3.25.76)
       openid-client:
         specifier: ^6.8.7
         version: 6.8.7
@@ -1072,8 +1072,8 @@ importers:
         specifier: workspace:*
         version: link:../inference
       openai:
-        specifier: ^4.104.0
-        version: 4.104.0(encoding@0.1.13)(ws@8.21.3)(zod@3.25.76)
+        specifier: ^7.12.1
+        version: 7.12.1(@aws-sdk/credential-provider-node@3.972.46)(@smithy/signature-v4@5.4.5)(undici@7.29.0)(ws@8.21.3)(zod@4.5.4)
     devDependencies:
       '@eslint/js':
         specifier: ^9.18.0
@@ -6806,14 +6806,8 @@ packages:
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
 
-  '@types/node-fetch@2.6.13':
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
-
   '@types/node@14.18.63':
     resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
-
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
@@ -7371,10 +7365,6 @@ packages:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  abort-controller@3.0.0:
-    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
-    engines: {node: '>=6.5'}
-
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -7422,10 +7412,6 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
-
-  agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
 
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -9096,10 +9082,6 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  event-target-shim@5.0.1:
-    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
-    engines: {node: '>=6'}
-
   eventemitter2@6.4.9:
     resolution: {integrity: sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==}
 
@@ -9367,9 +9349,6 @@ packages:
       typescript: '>3.6.0'
       webpack: ^5.11.0
 
-  form-data-encoder@1.7.2:
-    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
-
   form-data-encoder@4.1.0:
     resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
     engines: {node: '>= 18'}
@@ -9391,10 +9370,6 @@ packages:
     resolution: {integrity: sha512-7CXJtIIA0zy/u12StsYk25qVKxvdLA2ep2sTNxK3ov0mGNIIDqIvAXDSgTnAfDJFsPfWjuz0WjfYSdpvnLA5Tg==}
     engines: {node: '>=18.3.0'}
     hasBin: true
-
-  formdata-node@4.4.1:
-    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
-    engines: {node: '>= 12.20'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -9773,9 +9748,6 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
-
-  humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -11508,13 +11480,25 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
-  openai@4.104.0:
-    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
-    hasBin: true
+  openai@7.12.1:
+    resolution: {integrity: sha512-D0d8NevCWPe+cxE5kw/ZaBRh1Od4FfhRmD6FlNeLN1j96Xll5MYEJTbaFF9/F3eQHJANjrSuq2nWBCpVT+TmnQ==}
+    engines: {node: '>=22.0.0'}
     peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.23.8
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
+      undici: '>=5 <9'
+      ws: ^8.21.0
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
+      undici:
+        optional: true
       ws:
         optional: true
       zod:
@@ -13610,9 +13594,6 @@ packages:
   unbzip2-stream@1.4.3:
     resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -13963,10 +13944,6 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
-
-  web-streams-polyfill@4.0.0-beta.3:
-    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
-    engines: {node: '>= 14'}
 
   web-vitals@4.2.4:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
@@ -19915,16 +19892,7 @@ snapshots:
     dependencies:
       '@types/node': 24.13.3
 
-  '@types/node-fetch@2.6.13':
-    dependencies:
-      '@types/node': 24.13.3
-      form-data: 4.0.6
-
   '@types/node@14.18.63': {}
-
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
 
   '@types/node@22.20.1':
     dependencies:
@@ -20810,10 +20778,6 @@ snapshots:
 
   abbrev@3.0.1: {}
 
-  abort-controller@3.0.0:
-    dependencies:
-      event-target-shim: 5.0.1
-
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -20852,10 +20816,6 @@ snapshots:
       - supports-color
 
   agent-base@7.1.4: {}
-
-  agentkeepalive@4.6.0:
-    dependencies:
-      humanize-ms: 1.2.1
 
   ajv-draft-04@1.0.0(ajv@8.20.0):
     optionalDependencies:
@@ -22861,8 +22821,6 @@ snapshots:
 
   etag@1.8.1: {}
 
-  event-target-shim@5.0.1: {}
-
   eventemitter2@6.4.9: {}
 
   eventemitter3@4.0.7: {}
@@ -23233,8 +23191,6 @@ snapshots:
       typescript: 5.9.3
       webpack: 5.106.2(@swc/core@1.16.1)(postcss@8.5.15)
 
-  form-data-encoder@1.7.2: {}
-
   form-data-encoder@4.1.0: {}
 
   form-data@4.0.6:
@@ -23255,11 +23211,6 @@ snapshots:
     dependencies:
       fd-package-json: 2.0.0
       package-manager-detector: 1.8.0
-
-  formdata-node@4.4.1:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 4.0.0-beta.3
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -23712,10 +23663,6 @@ snapshots:
   human-signals@5.0.0: {}
 
   human-signals@8.0.1: {}
-
-  humanize-ms@1.2.1:
-    dependencies:
-      ms: 2.1.3
 
   husky@9.1.7: {}
 
@@ -26165,20 +26112,21 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@4.104.0(encoding@0.1.13)(ws@8.21.3)(zod@3.25.76):
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0(encoding@0.1.13)
+  openai@7.12.1(@aws-sdk/credential-provider-node@3.972.46)(@smithy/signature-v4@5.4.5)(undici@7.29.0)(ws@8.21.3)(zod@3.25.76):
     optionalDependencies:
+      '@aws-sdk/credential-provider-node': 3.972.46
+      '@smithy/signature-v4': 5.4.5
+      undici: 7.29.0
       ws: 8.21.3
       zod: 3.25.76
-    transitivePeerDependencies:
-      - encoding
+
+  openai@7.12.1(@aws-sdk/credential-provider-node@3.972.46)(@smithy/signature-v4@5.4.5)(undici@7.29.0)(ws@8.21.3)(zod@4.5.4):
+    optionalDependencies:
+      '@aws-sdk/credential-provider-node': 3.972.46
+      '@smithy/signature-v4': 5.4.5
+      undici: 7.29.0
+      ws: 8.21.3
+      zod: 4.5.4
 
   openid-client@6.8.7:
     dependencies:
@@ -28821,8 +28769,6 @@ snapshots:
       buffer: 5.7.1
       through: 2.3.8
 
-  undici-types@5.26.5: {}
-
   undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
@@ -29278,8 +29224,6 @@ snapshots:
       - encoding
 
   web-streams-polyfill@3.3.3: {}
-
-  web-streams-polyfill@4.0.0-beta.3: {}
 
   web-vitals@4.2.4: {}
 


### PR DESCRIPTION
openai 4.104.0 was three majors behind and declared a zod 3-only
optional peer (^3.23.8); v7 declares ^3.25 || ^4.0.

Our call surface is narrow — client construction, chat completions
streaming, embeddings and images — so the migration is four changes:

- images.edit() gained a streaming overload, so its return type is now
  a union. Declaring the params as ImageEditParamsNonStreaming selects
  the ImagesResponse overload we already return.
- input_fidelity is a first-class ImageEditParams field in v7, so the
  cast that forced it through the v4 typings is gone, along with the
  comment explaining the workaround.
- APIError.generate() takes a Headers instance rather than a plain
  object, so the image-generation spec passes new Headers().
- ChatCompletionTool is now a union of the function and custom tool
  shapes. convertTool only ever builds a function tool, so it returns
  ChatCompletionFunctionTool.

This does not remove the second zod major from the workspace:
@mistralai/mistralai declares zod as a hard dependency, so the
@hookform/resolvers packageExtensions entry is still required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major SDK bump on shared chat, embedding, and image paths; changes are small but affect production LLM and Azure image generation behavior.
> 
> **Overview**
> **Upgrades the `openai` package from v4 to v7** in `core-backend` and `@ayunis/provider-openai`, with lockfile refresh (v7 now targets Node ≥22 and broadens optional peers such as zod 3/4).
> 
> Call sites are adjusted for v7 typings and APIs: Azure reference-image edits use `ImageEditParamsNonStreaming` so `images.edit` resolves to the non-streaming `ImagesResponse` overload, and `input_fidelity: 'high'` is passed without the old type cast. Image-generation tests construct `APIError` with `new Headers()` instead of `{}`. The OpenAI provider’s `convertTool` return type is narrowed to `ChatCompletionFunctionTool` because `ChatCompletionTool` is now a union.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4c2f1416c89c578d7ee8b232d0d8bcb638a40d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Live QA

Verified against a real Azure/OpenAI environment (isolated dev slot, since torn down) — every changed line was exercised, not just typechecked.

| Chat via `openai()` — GPT-4o | Chat via `azure()` — GPT-5.4 |
| --- | --- |
| ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/pr-1645/docs/pr-media/pr-1645/01-chat-openai-gpt4o.png) | ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/pr-1645/docs/pr-media/pr-1645/02-chat-azure-gpt5.png) |

Both constructors stream a real reply through `chat.completions`, exercising `convertTool`'s new `ChatCompletionFunctionTool` return type. The Azure thread also auto-titled, which is a second model round-trip.

| `images.generate` — gpt-image-1 | `images.edit` + `input_fidelity: 'high'` |
| --- | --- |
| ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/pr-1645/docs/pr-media/pr-1645/03-image-generate.png) | ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/pr-1645/docs/pr-media/pr-1645/04-image-edit-input-fidelity.png) |

The right-hand shot is the one that matters for this diff: the follow-up edit ran with `referenceImageCount: 1` on `gpt-image-1`, so it took the `INPUT_FIDELITY_MODELS` branch — the exact line where the `as ImageEditParams` cast was removed. Composition, wall and shadow are preserved across the recolour, which is what `input_fidelity: 'high'` is for.

Not shown: a GIF. These are provider round-trips with no motion worth animating; the static frames carry the evidence.

> Media hosted on the `pr-media/pr-1645` branch, outside this PR's diff. It carries no `.pr-media/scenes.ts`, so the scene-capture job reports pr-media disabled rather than failing.
