### PR TITLE
feat(editor): add justified text alignment (AYC-664)

### DIFF
--- a/ayunis-core-frontend/src/shared/locales/de/artifacts.json
+++ b/ayunis-core-frontend/src/shared/locales/de/artifacts.json
@@ -26,6 +26,7 @@
       "alignLeft": "Linksbündig",
       "alignCenter": "Zentriert",
       "alignRight": "Rechtsbündig",
+      "alignJustify": "Blocksatz",
       "link": "Link",
       "undo": "Rückgängig",
       "redo": "Wiederholen"

--- a/ayunis-core-frontend/src/shared/locales/en/artifacts.json
+++ b/ayunis-core-frontend/src/shared/locales/en/artifacts.json
@@ -26,6 +26,7 @@
       "alignLeft": "Align Left",
       "alignCenter": "Align Center",
       "alignRight": "Align Right",
+      "alignJustify": "Align Justify",
       "link": "Link",
       "undo": "Undo",
       "redo": "Redo"

--- a/ayunis-core-frontend/src/widgets/artifact-editor/ui/EditorToolbar.test.tsx
+++ b/ayunis-core-frontend/src/widgets/artifact-editor/ui/EditorToolbar.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { Editor } from '@tiptap/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EditorToolbar } from './EditorToolbar';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+type ToolbarEditor = {
+  chain: ReturnType<typeof vi.fn>;
+  isActive: ReturnType<typeof vi.fn>;
+  getAttributes: ReturnType<typeof vi.fn>;
+  run: ReturnType<typeof vi.fn>;
+  setTextAlign: ReturnType<typeof vi.fn>;
+};
+
+function createEditor(): ToolbarEditor {
+  const run = vi.fn();
+  const setTextAlign = vi.fn();
+  const chainApi = {
+    focus: vi.fn(),
+    toggleBold: vi.fn(),
+    toggleItalic: vi.fn(),
+    toggleUnderline: vi.fn(),
+    toggleHeading: vi.fn(),
+    toggleBulletList: vi.fn(),
+    toggleOrderedList: vi.fn(),
+    setTextAlign,
+    extendMarkRange: vi.fn(),
+    unsetLink: vi.fn(),
+    setLink: vi.fn(),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    run,
+  };
+
+  chainApi.focus.mockReturnValue(chainApi);
+  chainApi.toggleBold.mockReturnValue(chainApi);
+  chainApi.toggleItalic.mockReturnValue(chainApi);
+  chainApi.toggleUnderline.mockReturnValue(chainApi);
+  chainApi.toggleHeading.mockReturnValue(chainApi);
+  chainApi.toggleBulletList.mockReturnValue(chainApi);
+  chainApi.toggleOrderedList.mockReturnValue(chainApi);
+  chainApi.setTextAlign.mockReturnValue(chainApi);
+  chainApi.extendMarkRange.mockReturnValue(chainApi);
+  chainApi.unsetLink.mockReturnValue(chainApi);
+  chainApi.setLink.mockReturnValue(chainApi);
+  chainApi.undo.mockReturnValue(chainApi);
+  chainApi.redo.mockReturnValue(chainApi);
+
+  return {
+    chain: vi.fn(() => chainApi),
+    isActive: vi.fn(() => false),
+    getAttributes: vi.fn(() => ({})),
+    run,
+    setTextAlign,
+  };
+}
+
+describe('EditorToolbar', () => {
+  let editor: ToolbarEditor;
+
+  beforeEach(() => {
+    editor = createEditor();
+  });
+
+  it('applies justified alignment to the current block', () => {
+    render(<EditorToolbar editor={editor as unknown as Editor} />);
+
+    fireEvent.click(screen.getByTitle('editor.toolbar.alignJustify'));
+
+    expect(editor.setTextAlign).toHaveBeenCalledWith('justify');
+    expect(editor.run).toHaveBeenCalled();
+  });
+
+  it('marks the justify control active when the block is justified', () => {
+    editor.isActive.mockImplementation(
+      (attrs: { textAlign?: string } | string) =>
+        typeof attrs === 'object' && attrs.textAlign === 'justify',
+    );
+
+    render(<EditorToolbar editor={editor as unknown as Editor} />);
+
+    expect(
+      screen.getByTitle('editor.toolbar.alignJustify').className,
+    ).toContain('bg-secondary');
+  });
+});

--- a/ayunis-core-frontend/src/widgets/artifact-editor/ui/EditorToolbar.tsx
+++ b/ayunis-core-frontend/src/widgets/artifact-editor/ui/EditorToolbar.tsx
@@ -12,6 +12,7 @@ import {
   AlignLeft,
   AlignCenter,
   AlignRight,
+  AlignJustify,
   Link,
   Undo,
   Redo,
@@ -163,6 +164,12 @@ export function EditorToolbar({ editor }: EditorToolbarProps) {
           isActive: editor.isActive({ textAlign: 'right' }),
           icon: AlignRight,
           title: t('editor.toolbar.alignRight'),
+        },
+        {
+          onClick: () => chain().setTextAlign('justify').run(),
+          isActive: editor.isActive({ textAlign: 'justify' }),
+          icon: AlignJustify,
+          title: t('editor.toolbar.alignJustify'),
         },
       ],
       [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a justified alignment control to the integrated document editor so letterhead-based official correspondence can use Blocksatz.

Export, HTML sanitization, and DOCX conversion already preserve `text-align: justify`. This change exposes that alignment in the editor toolbar (next to left/center/right) with English and German labels.

Fixes AYC-664

## Test plan
- [x] Unit tests: clicking justify calls `setTextAlign('justify')` and the control is marked active when the block is justified
- [ ] Manual: open a document artifact, apply justify, save, export PDF/DOCX, confirm alignment is preserved

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73445ff6-87f0-426a-81f5-347d3c0cfa73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73445ff6-87f0-426a-81f5-347d3c0cfa73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

