### PR TITLE
fix(i18n): localize zod's default validation messages (AYC-000)

### DIFF
--- a/ayunis-core-frontend/src/i18n.test.ts
+++ b/ayunis-core-frontend/src/i18n.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import * as z from 'zod';
+import i18n from './i18n';
+
+// Validators without an explicit message fall back to zod's built-in copy.
+// i18n.ts configures zod's locale so those defaults follow the active
+// language; without that wiring they surface in English in a German UI.
+const maxMessage = () =>
+  z.string().max(2).safeParse('abc').error?.issues[0]?.message ?? '';
+
+describe('zod locale follows the active language', () => {
+  afterAll(async () => {
+    await i18n.changeLanguage('de');
+  });
+
+  // Deliberately does not switch the language first: this asserts the locale
+  // is already configured once i18n.ts has loaded.
+  it('is configured for the fallback language on load', () => {
+    expect(maxMessage()).toBe('Zu groß: erwartet, dass string <=2 Zeichen hat');
+  });
+
+  it('switches the defaults when the language changes', async () => {
+    await i18n.changeLanguage('en');
+    expect(maxMessage()).toBe(
+      'Too big: expected string to have <=2 characters',
+    );
+  });
+});

--- a/ayunis-core-frontend/src/i18n.ts
+++ b/ayunis-core-frontend/src/i18n.ts
@@ -1,5 +1,6 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import * as z from 'zod';
 
 // Import translation files directly
 import enAuth from './shared/locales/en/auth.json';
@@ -193,11 +194,20 @@ const resources = {
 //   checkWhitelist: true,
 // };
 
+// Validators that carry no explicit message fall back to zod's built-in
+// copy, which is English unless a locale is configured. i18next emits
+// languageChanged during init, so the handler below covers the initial
+// language too.
+function applyZodLocale(lng: string): void {
+  z.config(lng.startsWith('en') ? z.locales.en() : z.locales.de());
+}
+
 // Keep <html lang> in sync with the active locale. A mismatched lang
 // (e.g. lang="en" on German content) triggers Chrome auto-translate,
 // which rewrites DOM text nodes and corrupts streamed assistant messages.
 i18n.on('languageChanged', (lng) => {
   document.documentElement.lang = lng;
+  applyZodLocale(lng);
 });
 
 void i18n

--- a/ayunis-core-frontend/src/pages/auth/invite-accept/api/useInviteAccept.ts
+++ b/ayunis-core-frontend/src/pages/auth/invite-accept/api/useInviteAccept.ts
@@ -21,7 +21,7 @@ export function useInviteAccept(invite: Invite, inviteToken: string) {
 
   const inviteAcceptFormSchema = z
     .object({
-      email: z.email(),
+      email: z.email({ message: t('inviteAccept.emailInvalid') }),
       name: z.string().min(1, {
         message: t('inviteAccept.nameRequired'),
       }),

--- a/ayunis-core-frontend/src/shared/locales/de/auth.json
+++ b/ayunis-core-frontend/src/shared/locales/de/auth.json
@@ -123,6 +123,7 @@
     "description": "Sie wurden eingeladen, der Organisation als {{role}} beizutreten.",
     "email": "E-Mail",
     "emailPlaceholder": "Ihre E-Mail-Adresse",
+    "emailInvalid": "Ungültige E-Mail-Adresse",
     "name": "Name",
     "namePlaceholder": "Ihr Name",
     "password": "Passwort",

--- a/ayunis-core-frontend/src/shared/locales/en/auth.json
+++ b/ayunis-core-frontend/src/shared/locales/en/auth.json
@@ -122,6 +122,7 @@
     "description": "You've been invited to join the organization as a {{role}}.",
     "email": "Email",
     "emailPlaceholder": "Your email address",
+    "emailInvalid": "Invalid email address",
     "name": "Name",
     "namePlaceholder": "Your name",
     "password": "Password",


### PR DESCRIPTION
zod 4 rewrote its built-in messages, and validators that carry no
explicit message render them verbatim — so a German form could answer
an over-long name with 'Too big: expected string to have <=100
characters'. The wording changed with the zod 4 upgrade, but the gap
predates it: those defaults were always English.

zod 4 ships 62 locales. Configuring the one matching the active
language covers every message-less validator at once, including any
added later, instead of annotating each call site and relying on the
next person to remember. i18next emits languageChanged during init, so
the existing handler is the only hook needed.

The invite-accept email field also gets a real message, matching what
the register form already does for the same validator.

Reachable today via, among others, skill and knowledge-base name and
description limits, none of which cap length at the input.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side i18n and form validation messaging only; no auth, API, or data-handling changes.
> 
> **Overview**
> **Zod’s built-in validation copy now tracks the active i18next language**, so message-less validators (e.g. `max` on skill/knowledge-base fields) show German or English instead of always English.
> 
> `i18n.ts` calls `z.config` with `z.locales.en()` or `z.locales.de()` inside the existing `languageChanged` handler (including initial init). **`i18n.test.ts`** asserts fallback German on load and English after `changeLanguage('en')`.
> 
> The invite-accept form’s email field uses **`inviteAccept.emailInvalid`** from auth locales, aligned with register/login-style explicit email messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaec544e79dc0fceb8eba8a78ad91571f8000ff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Verification

Driven in a running app (isolated dev slot, since torn down) through the **skill-name `max(100)`** validator — one of the message-less ones, and reachable by typing since the input sets no `maxLength`.

| German (active language) | English (after switching) |
| --- | --- |
| ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/pr-1649/docs/pr-media/pr-1649/01-german-default-message.png) | ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/pr-1649/docs/pr-media/pr-1649/02-english-default-message.png) |

```
before:  Too big: expected string to have <=100 characters      (English, in a German UI)
de:      Zu groß: erwartet, dass string <=100 Zeichen hat
en:      Too big: expected string to have <=100 characters      (correct for the language)
```

App-provided messages in the same form are untouched — "Auslöser ist erforderlich" / "Trigger is required" still come from our own keys.

**Message-less validators this covers** (all previously English): skill name `max(100)` in create and update, knowledge-base name `max(255)` and description `max(2000)` in create and update, `departmentOther` `max(94)` in register and invite-accept, the academy `correctOptionIndex`, and the subscription-type enum. Plus anything added later.

**Checks:** frontend tsc 0 errors · lint 0 errors / 368 warnings (identical to main) · 135 files, 686 tests pass · build ✓

The new `src/i18n.test.ts` guards both halves of the contract — that the locale is configured on load, and that it follows a language change. I confirmed it fails if either the `applyZodLocale` call or the `languageChanged` wiring is removed.

**Dropped one line during review:** an eager `applyZodLocale('de')` before the handler. i18next emits `languageChanged` during `init()`, so it never did anything — verified by tightening the first test to assert the load-time state, then removing the call and watching it still pass.

> Media hosted on `pr-media/pr-1649`, outside this PR's diff.
