### PR TITLE
fix(ui): keep primary surfaces usable on mobile (AYC-230)

### DIFF
--- a/ayunis-core-frontend/src/features/patchAnnouncableMobileLayout.spec.ts
+++ b/ayunis-core-frontend/src/features/patchAnnouncableMobileLayout.spec.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { patchAnnouncableMobileLayout } from './patchAnnouncableMobileLayout';
+
+class FakeWidgetSidebar extends HTMLElement {
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: 'open' });
+    shadow.innerHTML = '<div class="sidebar"></div>';
+  }
+}
+
+if (!customElements.get('widget-sidebar')) {
+  customElements.define('widget-sidebar', FakeWidgetSidebar);
+}
+
+describe(patchAnnouncableMobileLayout.name, () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('injects a full-viewport mobile override into the widget shadow root', () => {
+    const host = document.createElement('widget-sidebar');
+    document.body.append(host);
+
+    const observer = patchAnnouncableMobileLayout();
+    const style = host.shadowRoot?.getElementById('ayunis-mobile-patch');
+
+    expect(style).toBeTruthy();
+    expect(style?.textContent).toContain('width: 100vw !important');
+
+    observer.disconnect();
+  });
+});

--- a/ayunis-core-frontend/src/features/patchAnnouncableMobileLayout.ts
+++ b/ayunis-core-frontend/src/features/patchAnnouncableMobileLayout.ts
@@ -1,0 +1,55 @@
+const WIDGET_HOST_SELECTOR =
+  'widget-sidebar, widget-modal, widget-popover, ui-dialog';
+
+const MOBILE_PATCH_STYLE_ID = 'ayunis-mobile-patch';
+
+const ANNOUNCABLE_MOBILE_CSS = `
+@media (max-width: 40rem) {
+  .sidebar {
+    width: 100vw !important;
+    max-width: 100vw !important;
+  }
+  .popover {
+    width: calc(100vw - 2rem) !important;
+    max-width: calc(100vw - 2rem) !important;
+    left: 1rem !important;
+    right: 1rem !important;
+  }
+  dialog {
+    max-width: 100% !important;
+    padding: 0.5rem !important;
+  }
+}
+`;
+
+function injectIntoShadowRoot(shadow: ShadowRoot): void {
+  if (shadow.getElementById(MOBILE_PATCH_STYLE_ID)) {
+    return;
+  }
+  const style = document.createElement('style');
+  style.id = MOBILE_PATCH_STYLE_ID;
+  style.textContent = ANNOUNCABLE_MOBILE_CSS;
+  shadow.appendChild(style);
+  patchTree(shadow);
+}
+
+function patchTree(root: ParentNode): void {
+  root.querySelectorAll(WIDGET_HOST_SELECTOR).forEach((element) => {
+    const shadow = (element as HTMLElement).shadowRoot;
+    if (shadow) {
+      injectIntoShadowRoot(shadow);
+    }
+  });
+}
+
+export function patchAnnouncableMobileLayout(
+  root: ParentNode = document,
+): MutationObserver {
+  patchTree(root);
+  const observer = new MutationObserver(() => {
+    patchTree(root);
+  });
+  const target = root instanceof Document ? root.body : root;
+  observer.observe(target, { childList: true, subtree: true });
+  return observer;
+}

--- a/ayunis-core-frontend/src/features/useReleaseNotes.ts
+++ b/ayunis-core-frontend/src/features/useReleaseNotes.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import config from '@/shared/config';
+import { patchAnnouncableMobileLayout } from '@/features/patchAnnouncableMobileLayout';
 
 interface AnnouncableInit {
   org_id: string;
@@ -21,6 +22,11 @@ let announcableLoaded = false;
  * Must be called in a component that renders AFTER the #updates-button element exists.
  */
 export function useReleaseNotes(): void {
+  useEffect(() => {
+    const observer = patchAnnouncableMobileLayout();
+    return () => observer.disconnect();
+  }, []);
+
   useEffect(() => {
     const orgId = config.features.announcableOrgId;
 

--- a/ayunis-core-frontend/src/layouts/app-layout/ui/AppLayout.tsx
+++ b/ayunis-core-frontend/src/layouts/app-layout/ui/AppLayout.tsx
@@ -26,7 +26,7 @@ export default function AppLayout({
         <div className="flex flex-1 flex-col min-h-0">
           <AppAlertBanner />
           <CertificateExpiryBanner />
-          <div className="flex flex-1 flex-col min-h-0 p-4 pt-0 relative md:rounded-xl md:overflow-hidden">
+          <div className="relative flex min-h-0 flex-1 flex-col overflow-x-hidden p-2 pt-0 sm:p-4 sm:pt-0 md:rounded-xl md:overflow-hidden">
             {children}
           </div>
           <CertificateExpiryDialog />

--- a/ayunis-core-frontend/src/layouts/chat-interface-layout/ui/ChatInterfaceLayout.tsx
+++ b/ayunis-core-frontend/src/layouts/chat-interface-layout/ui/ChatInterfaceLayout.tsx
@@ -52,7 +52,7 @@ export const ChatInterfaceLayout: React.FC<ChatInterfaceLayoutProps> = ({
 
   const chatPane = (
     <div
-      className={`flex h-full min-h-0 flex-col overflow-hidden rounded-t-xl pb-4 ${className}`}
+      className={`flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-t-xl pb-2 sm:pb-4 ${className}`}
     >
       <div className="content-scroll-region relative flex min-h-0 flex-1 flex-col">
         <div
@@ -71,7 +71,7 @@ export const ChatInterfaceLayout: React.FC<ChatInterfaceLayoutProps> = ({
         </div>
       </div>
 
-      <div className="mx-auto w-full max-w-[800px] flex-shrink-0 sticky bottom-0 z-10 bg-background">
+      <div className="sticky bottom-0 z-10 mx-auto w-full min-w-0 max-w-[800px] flex-shrink-0 bg-background">
         {chatInput}
       </div>
     </div>

--- a/ayunis-core-frontend/src/layouts/content-area-layout/ui/ContentAreaLayout.tsx
+++ b/ayunis-core-frontend/src/layouts/content-area-layout/ui/ContentAreaLayout.tsx
@@ -35,7 +35,7 @@ export const ContentAreaLayout: React.FC<ContentAreaLayoutProps> = ({
             <div className="content-scroll-header-offset" aria-hidden />
           )}
           <div
-            className={`mx-auto w-full px-2 pb-3 ${fullWidth ? '' : 'max-w-[800px]'}`}
+            className={`mx-auto w-full min-w-0 px-1 pb-3 sm:px-2 ${fullWidth ? '' : 'max-w-[800px]'}`}
           >
             {contentArea}
           </div>

--- a/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBasesPage.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/ui/KnowledgeBasesPage.tsx
@@ -38,10 +38,10 @@ export default function KnowledgeBasesPage({
     .sort((a, b) => a.name.localeCompare(b.name));
 
   const headerAction = (
-    <div className="flex gap-2">
+    <div className="flex min-w-0 w-full flex-wrap items-center justify-end gap-2">
       <HelpLink path="knowledge-collections/" />
       <OnboardingTourTarget name={TOUR_TARGET.createKnowledgeBase}>
-        <CreateKnowledgeBaseDialog />
+        <CreateKnowledgeBaseDialog buttonClassName="max-sm:max-w-full" />
       </OnboardingTourTarget>
     </div>
   );

--- a/ayunis-core-frontend/src/pages/knowledge-bases/ui/tabs-list-overflow.test.tsx
+++ b/ayunis-core-frontend/src/pages/knowledge-bases/ui/tabs-list-overflow.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Tabs, TabsList, TabsTrigger } from '@ayunis/ui/components/tabs';
+
+describe('TabsList overflow', () => {
+  it('keeps tab triggers at content width so long labels can scroll', () => {
+    render(
+      <Tabs defaultValue="personal">
+        <TabsList>
+          <TabsTrigger value="personal">Eigene Wissenssammlungen</TabsTrigger>
+          <TabsTrigger value="shared">Geteilte Wissenssammlungen</TabsTrigger>
+        </TabsList>
+      </Tabs>,
+    );
+
+    const list = screen.getByRole('tablist');
+    expect(list.className).toContain('max-w-full');
+    expect(list.className).toContain('overflow-x-auto');
+
+    for (const trigger of screen.getAllByRole('tab')) {
+      expect(trigger.className).toMatch(/(?:^|\s)shrink-0(?:\s|$)/);
+      expect(trigger.className).not.toMatch(/(?:^|\s)flex-1(?:\s|$)/);
+    }
+  });
+});

--- a/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPageLayout.tsx
+++ b/ayunis-core-frontend/src/pages/new-chat/ui/NewChatPageLayout.tsx
@@ -1,7 +1,7 @@
 import AppLayout from '@/layouts/app-layout';
 import { cn } from '@ayunis/ui/lib/cn';
 import NewChatBackdrop, { type NewChatBackdropPhase } from './NewChatBackdrop';
-import { useComposeLift } from '../model/useComposeLift';
+import { useComposeLift } from '@/pages/new-chat/model/useComposeLift';
 
 export type NewChatMistPhase = NewChatBackdropPhase | 'hidden';
 
@@ -45,7 +45,7 @@ export default function NewChatPageLayout({
           {useComposeLayout ? (
             <div
               ref={stageRef}
-              className="flex min-h-0 flex-1 flex-col justify-end px-4 pb-4"
+              className="flex min-h-0 flex-1 flex-col justify-end px-2 pb-2 sm:px-4 sm:pb-4"
             >
               <div
                 ref={composeRef}
@@ -72,7 +72,7 @@ export default function NewChatPageLayout({
               </div>
             </div>
           ) : (
-            <div className="flex min-h-0 flex-1 flex-col items-center justify-center overflow-y-auto px-4 pb-4">
+            <div className="flex min-h-0 flex-1 flex-col items-center justify-center overflow-y-auto px-2 pb-2 sm:px-4 sm:pb-4">
               <div className="w-full max-w-[800px]">{children}</div>
             </div>
           )}

--- a/ayunis-core-frontend/src/pages/settings/account-settings/ui/AcademyCertificateCard.tsx
+++ b/ayunis-core-frontend/src/pages/settings/account-settings/ui/AcademyCertificateCard.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/features/academy';
 import { AcademyAccessMode } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { formatDate } from '@/shared/lib/format-date';
+import { SettingsFieldRow } from '@/pages/settings/settings-layout';
 
 /**
  * When the user last completed the KI-Schulung nach EU AI Act and — for orgs
@@ -79,13 +80,13 @@ export function AcademyCertificateCard() {
       <CardContent className="space-y-4">
         {isLoading && <Skeleton className="h-5 w-2/3" />}
         {!isLoading && (
-          <div className="flex items-center justify-between gap-4">
+          <SettingsFieldRow>
             {lastPassedAt === null ? (
-              <div className="text-sm text-muted-foreground">
+              <div className="min-w-0 text-sm text-muted-foreground">
                 {t('account.notPassedDescription')}
               </div>
             ) : (
-              <dl className="space-y-1 text-sm">
+              <dl className="min-w-0 space-y-1 text-sm">
                 <div className="flex gap-2">
                   <dt className="text-muted-foreground">
                     {t('account.lastPassed')}
@@ -104,10 +105,14 @@ export function AcademyCertificateCard() {
                 )}
               </dl>
             )}
-            <Button variant="outline" asChild>
+            <Button
+              variant="outline"
+              className="w-full shrink-0 sm:w-auto"
+              asChild
+            >
               <Link to="/academy">{t('account.action')}</Link>
             </Button>
-          </div>
+          </SettingsFieldRow>
         )}
       </CardContent>
     </Card>

--- a/ayunis-core-frontend/src/pages/settings/account-settings/ui/AccountSettingsPage.test.tsx
+++ b/ayunis-core-frontend/src/pages/settings/account-settings/ui/AccountSettingsPage.test.tsx
@@ -3,9 +3,13 @@ import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import AccountSettingsPage from '@/pages/settings/account-settings/ui/AccountSettingsPage';
 
-vi.mock('@/pages/settings/settings-layout', () => ({
-  SettingsLayout: ({ children }: { children: ReactNode }) => children,
-}));
+vi.mock('@/pages/settings/settings-layout', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    SettingsLayout: ({ children }: { children: ReactNode }) => children,
+  };
+});
 vi.mock('@/pages/settings/account-settings/ui/ProfileInformationCard', () => ({
   ProfileInformationCard: () => null,
 }));

--- a/ayunis-core-frontend/src/pages/settings/account-settings/ui/AccountSettingsPage.test.tsx
+++ b/ayunis-core-frontend/src/pages/settings/account-settings/ui/AccountSettingsPage.test.tsx
@@ -3,13 +3,9 @@ import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import AccountSettingsPage from '@/pages/settings/account-settings/ui/AccountSettingsPage';
 
-vi.mock('@/pages/settings/settings-layout', async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...actual,
-    SettingsLayout: ({ children }: { children: ReactNode }) => children,
-  };
-});
+vi.mock('@/pages/settings/settings-layout', () => ({
+  SettingsLayout: ({ children }: { children: ReactNode }) => children,
+}));
 vi.mock('@/pages/settings/account-settings/ui/ProfileInformationCard', () => ({
   ProfileInformationCard: () => null,
 }));

--- a/ayunis-core-frontend/src/pages/settings/account-settings/ui/AccountSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/settings/account-settings/ui/AccountSettingsPage.tsx
@@ -12,7 +12,7 @@ import { HelpLink } from '@/shared/ui/help-link/HelpLink';
 import PasswordSettingsPage from '@/pages/settings/account-settings/ui/PasswordSettingsPage';
 import { TwoFactorCard } from '@/pages/settings/account-settings/ui/TwoFactorCard';
 import { AcademyCertificateCard } from '@/pages/settings/account-settings/ui/AcademyCertificateCard';
-import { SettingsFieldRow } from '@/pages/settings/settings-layout';
+import { SettingsFieldRow } from '@/pages/settings/settings-layout/ui/SettingsFieldRow';
 
 export default function AccountSettingsPage({
   user,

--- a/ayunis-core-frontend/src/pages/settings/account-settings/ui/AccountSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/settings/account-settings/ui/AccountSettingsPage.tsx
@@ -12,6 +12,7 @@ import { HelpLink } from '@/shared/ui/help-link/HelpLink';
 import PasswordSettingsPage from '@/pages/settings/account-settings/ui/PasswordSettingsPage';
 import { TwoFactorCard } from '@/pages/settings/account-settings/ui/TwoFactorCard';
 import { AcademyCertificateCard } from '@/pages/settings/account-settings/ui/AcademyCertificateCard';
+import { SettingsFieldRow } from '@/pages/settings/settings-layout';
 
 export default function AccountSettingsPage({
   user,
@@ -46,17 +47,17 @@ export default function AccountSettingsPage({
             <CardTitle>{t('account.accountActions')}</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="flex items-center justify-between p-4 border border-destructive/20 rounded-lg">
-              <div>
+            <SettingsFieldRow className="rounded-lg border border-destructive/20 p-4">
+              <div className="min-w-0">
                 <div className="font-medium">{t('account.deleteAccount')}</div>
                 <div className="text-sm text-muted-foreground">
                   {t('account.deleteAccountDescription')}
                 </div>
               </div>
-              <Button variant="destructive">
+              <Button variant="destructive" className="w-full sm:w-auto">
                 {t('account.deleteAccount')}
               </Button>
-            </div>
+            </SettingsFieldRow>
           </CardContent>
         </Card>
       </div>

--- a/ayunis-core-frontend/src/pages/settings/account-settings/ui/TwoFactorCard.tsx
+++ b/ayunis-core-frontend/src/pages/settings/account-settings/ui/TwoFactorCard.tsx
@@ -21,7 +21,8 @@ import {
   MfaEnrollmentPanel,
   RecoveryCodesPanel,
 } from '@/widgets/mfa-enrollment';
-import { useMfa } from '../api/useMfa';
+import { useMfa } from '@/pages/settings/account-settings/api/useMfa';
+import { SettingsFieldRow } from '@/pages/settings/settings-layout';
 
 export function TwoFactorCard() {
   const { t } = useTranslation('settings');
@@ -54,10 +55,10 @@ export function TwoFactorCard() {
       </CardHeader>
       <CardContent className="space-y-4">
         {mfa.isLoadingStatus && (
-          <div className="flex items-center justify-between gap-4">
+          <SettingsFieldRow>
             <Skeleton className="h-5 w-2/3" />
-            <Skeleton className="h-9 w-24" />
-          </div>
+            <Skeleton className="h-9 w-24 shrink-0" />
+          </SettingsFieldRow>
         )}
         {mfa.isStatusError && (
           <p className="text-sm text-destructive">
@@ -65,8 +66,8 @@ export function TwoFactorCard() {
           </p>
         )}
         {!mfa.isLoadingStatus && !mfa.isStatusError && (
-          <div className="flex items-center justify-between gap-4">
-            <div className="text-sm text-muted-foreground">
+          <SettingsFieldRow>
+            <div className="min-w-0 text-sm text-muted-foreground">
               {enabled
                 ? t('account.mfa.enabledDescription', {
                     count: mfa.status?.recoveryCodesRemaining ?? 0,
@@ -74,15 +75,22 @@ export function TwoFactorCard() {
                 : t('account.mfa.disabledDescription')}
             </div>
             {enabled ? (
-              <Button variant="outline" onClick={() => setDisableOpen(true)}>
+              <Button
+                variant="outline"
+                className="w-full shrink-0 sm:w-auto"
+                onClick={() => setDisableOpen(true)}
+              >
                 {t('account.mfa.disableButton')}
               </Button>
             ) : (
-              <Button onClick={openEnable}>
+              <Button
+                className="w-full shrink-0 sm:w-auto"
+                onClick={openEnable}
+              >
                 {t('account.mfa.enableButton')}
               </Button>
             )}
-          </div>
+          </SettingsFieldRow>
         )}
       </CardContent>
 

--- a/ayunis-core-frontend/src/pages/settings/chat-settings/ui/ChatSettingsCard.tsx
+++ b/ayunis-core-frontend/src/pages/settings/chat-settings/ui/ChatSettingsCard.tsx
@@ -14,8 +14,9 @@ import {
 } from '@ayunis/ui/components/select';
 import { useTranslation } from 'react-i18next';
 import { usePermittedModels } from '@/features/usePermittedModels';
-import { useUserDefaultModel } from '../api/useUserDefaultModel';
+import { useUserDefaultModel } from '@/pages/settings/chat-settings/api/useUserDefaultModel';
 import { ModelSelectOptions } from '@/widgets/model-select-options';
+import { SettingsFieldRow } from '@/pages/settings/settings-layout';
 
 export function ChatSettingsCard() {
   const { t } = useTranslation('settings');
@@ -44,8 +45,8 @@ export function ChatSettingsCard() {
         <CardTitle>{t('chat.defaultModel')}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex items-center justify-between">
-          <div className="space-y-0.5">
+        <SettingsFieldRow>
+          <div className="min-w-0 space-y-0.5">
             <Label htmlFor="default-settings-select">
               {t('chat.defaultModelSelection')}
             </Label>
@@ -58,7 +59,10 @@ export function ChatSettingsCard() {
             onValueChange={handleDefaultSettingChange}
             disabled={modelsLoading}
           >
-            <SelectTrigger id="default-settings-select" className="w-[180px]">
+            <SelectTrigger
+              id="default-settings-select"
+              className="w-full min-w-0 sm:w-[180px]"
+            >
               <SelectValue
                 placeholder={
                   modelsLoading ? 'Loading...' : t('chat.selectDefaultModel')
@@ -74,7 +78,7 @@ export function ChatSettingsCard() {
               />
             </SelectContent>
           </Select>
-        </div>
+        </SettingsFieldRow>
       </CardContent>
     </Card>
   );

--- a/ayunis-core-frontend/src/pages/settings/chat-settings/ui/ChatSettingsPage.tsx
+++ b/ayunis-core-frontend/src/pages/settings/chat-settings/ui/ChatSettingsPage.tsx
@@ -1,9 +1,9 @@
-import { SettingsLayout } from '../../settings-layout';
 import { useTranslation } from 'react-i18next';
 import { HelpLink } from '@/shared/ui/help-link/HelpLink';
 import { OnboardingTourTarget, TOUR_TARGET } from '@/widgets/onboarding';
 import { ChatSettingsCard } from './ChatSettingsCard';
 import { SystemPromptCard } from './SystemPromptCard';
+import { SettingsLayout } from '@/pages/settings/settings-layout';
 
 export default function ChatSettingsPage() {
   const { t } = useTranslation('settings');

--- a/ayunis-core-frontend/src/pages/settings/general-settings/ui/LanguageSettingsCard.tsx
+++ b/ayunis-core-frontend/src/pages/settings/general-settings/ui/LanguageSettingsCard.tsx
@@ -14,6 +14,7 @@ import {
 } from '@ayunis/ui/components/select';
 import { useLanguage, type Language } from '@/features/language';
 import { useTranslation } from 'react-i18next';
+import { SettingsFieldRow } from '@/pages/settings/settings-layout';
 
 export function LanguageSettingsCard() {
   const { t } = useTranslation('settings');
@@ -25,8 +26,8 @@ export function LanguageSettingsCard() {
         <CardTitle>{t('general.languageRegion')}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex items-center justify-between">
-          <div className="space-y-0.5">
+        <SettingsFieldRow>
+          <div className="min-w-0 space-y-0.5">
             <Label htmlFor="language-select">
               {t('general.displayLanguage')}
             </Label>
@@ -40,7 +41,10 @@ export function LanguageSettingsCard() {
               void setLanguage(value);
             }}
           >
-            <SelectTrigger id="language-select" className="w-[180px]">
+            <SelectTrigger
+              id="language-select"
+              className="w-full min-w-0 sm:w-[180px]"
+            >
               <SelectValue placeholder={t('general.selectLanguage')} />
             </SelectTrigger>
             <SelectContent>
@@ -51,7 +55,7 @@ export function LanguageSettingsCard() {
               ))}
             </SelectContent>
           </Select>
-        </div>
+        </SettingsFieldRow>
       </CardContent>
     </Card>
   );

--- a/ayunis-core-frontend/src/pages/settings/general-settings/ui/ThemeSettingsCard.tsx
+++ b/ayunis-core-frontend/src/pages/settings/general-settings/ui/ThemeSettingsCard.tsx
@@ -8,6 +8,7 @@ import { Label } from '@ayunis/ui/components/label';
 import { Switch } from '@ayunis/ui/components/switch';
 import { useTheme } from '@/features/theme';
 import { useTranslation } from 'react-i18next';
+import { SettingsFieldRow } from '@/pages/settings/settings-layout';
 
 export function ThemeSettingsCard() {
   const { t } = useTranslation('settings');
@@ -23,8 +24,8 @@ export function ThemeSettingsCard() {
         <CardTitle>{t('general.appearance')}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex items-center justify-between">
-          <div className="space-y-0.5">
+        <SettingsFieldRow>
+          <div className="min-w-0 space-y-0.5">
             <Label htmlFor="dark-mode">{t('general.darkMode')}</Label>
             <div className="text-sm text-muted-foreground">
               {t('general.darkModeDescription')}
@@ -32,10 +33,11 @@ export function ThemeSettingsCard() {
           </div>
           <Switch
             id="dark-mode"
+            className="shrink-0"
             checked={theme === 'dark'}
             onCheckedChange={handleThemeChange}
           />
-        </div>
+        </SettingsFieldRow>
       </CardContent>
     </Card>
   );

--- a/ayunis-core-frontend/src/pages/settings/settings-layout/index.ts
+++ b/ayunis-core-frontend/src/pages/settings/settings-layout/index.ts
@@ -1,1 +1,2 @@
 export { default as SettingsLayout } from './ui/SettingsLayout';
+export { SettingsFieldRow } from './ui/SettingsFieldRow';

--- a/ayunis-core-frontend/src/pages/settings/settings-layout/ui/SettingsFieldRow.test.tsx
+++ b/ayunis-core-frontend/src/pages/settings/settings-layout/ui/SettingsFieldRow.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SettingsFieldRow } from './SettingsFieldRow';
+
+describe(SettingsFieldRow.name, () => {
+  it('stacks label and control on narrow viewports', () => {
+    render(
+      <SettingsFieldRow>
+        <p>Label</p>
+        <button type="button">Action</button>
+      </SettingsFieldRow>,
+    );
+
+    const row = screen.getByTestId('settings-field-row');
+    expect(row.className).toContain('flex-col');
+    expect(row.className).toContain('sm:flex-row');
+  });
+});

--- a/ayunis-core-frontend/src/pages/settings/settings-layout/ui/SettingsFieldRow.tsx
+++ b/ayunis-core-frontend/src/pages/settings/settings-layout/ui/SettingsFieldRow.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+import { cn } from '@ayunis/ui/lib/cn';
+
+interface SettingsFieldRowProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function SettingsFieldRow({
+  children,
+  className,
+}: Readonly<SettingsFieldRowProps>) {
+  return (
+    <div
+      data-testid="settings-field-row"
+      className={cn(
+        'flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/pages/skills/ui/SkillsPage.tsx
+++ b/ayunis-core-frontend/src/pages/skills/ui/SkillsPage.tsx
@@ -5,7 +5,7 @@ import { OnboardingTourTarget, TOUR_TARGET } from '@/widgets/onboarding';
 import CreateSkillDialog from './CreateSkillDialog';
 import MarketplacePromoCard from './MarketplacePromoCard';
 import SkillCard from './SkillCard';
-import type { Skill } from '../model/openapi';
+import type { Skill } from '@/pages/skills/model/openapi';
 import SkillsEmptyState from './SkillsEmptyState';
 import FullScreenMessageLayout from '@/layouts/full-screen-message-layout/ui/FullScreenMessageLayout';
 import { useTranslation } from 'react-i18next';
@@ -49,7 +49,7 @@ export default function SkillsPage({ skills }: Readonly<SkillsPageProps>) {
   );
 
   const headerAction = (
-    <div className="flex gap-2">
+    <div className="flex min-w-0 w-full flex-wrap items-center justify-end gap-2">
       <HelpLink path="skills/" />
       {hasPinnableSkill ? (
         createSkillAction

--- a/ayunis-core-frontend/src/shared/ui/help-link/HelpLink.test.tsx
+++ b/ayunis-core-frontend/src/shared/ui/help-link/HelpLink.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { HelpLink } from './HelpLink';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/shared/lib/help-center', () => ({
+  getHelpCenterUrl: (path: string) => `https://help.example/${path}`,
+}));
+
+describe(HelpLink.name, () => {
+  it('keeps the help label accessible while hiding it on narrow viewports', () => {
+    render(<HelpLink path="knowledge-collections/" />);
+
+    const label = screen.getByText('common.helpLink');
+    expect(label.tagName).toBe('SPAN');
+    expect(label.className).toContain('max-sm:sr-only');
+  });
+});

--- a/ayunis-core-frontend/src/shared/ui/help-link/HelpLink.tsx
+++ b/ayunis-core-frontend/src/shared/ui/help-link/HelpLink.tsx
@@ -44,7 +44,7 @@ export function HelpLink({
     <Button variant="outline" size="sm" asChild>
       <a href={url} target="_blank" rel="noopener noreferrer">
         <CircleHelp className="h-4 w-4" />
-        {label}
+        <span className="max-sm:sr-only">{label}</span>
       </a>
     </Button>
   );

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInput.tsx
@@ -7,7 +7,6 @@ import {
 } from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 import { Card, CardContent } from '@ayunis/ui/components/card';
-import { OnboardingTourTarget, TOUR_TARGET } from '@/widgets/onboarding';
 import useKeyboardShortcut from '@/features/useKeyboardShortcut';
 import { useTranslation } from 'react-i18next';
 import type {
@@ -16,12 +15,6 @@ import type {
   SourceResponseDtoStatus,
   SourceResponseDtoType,
 } from '@/shared/api';
-import PlusButton from './PlusButton';
-import ModelSelector from './ModelSelector';
-import TooltipIf from '@/widgets/tooltip-if/ui/TooltipIf';
-import { SendButton } from './SendButton';
-import { AnonymousButton } from './AnonymousButton';
-import { SkillBadge } from './SkillBadge';
 import {
   usePendingImages,
   type PendingImage,
@@ -36,9 +29,9 @@ import { PendingImageThumbnail } from './PendingImageThumbnail';
 import { cn } from '@ayunis/ui/lib/cn';
 import { SourcesList } from './SourcesList';
 import { ChatInputExpandable } from './ChatInputExpandable';
+import { ChatInputActionBar } from './ChatInputActionBar';
 import { showError } from '@/shared/lib/toast';
 import './chat-input-glow.css';
-import { MicrophoneButton } from './MicrophoneButton';
 import type {
   IntegrationSummary,
   KnowledgeBaseSummary,
@@ -344,13 +337,13 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
           )}
           <Card
             className={cn(
-              'chat-input-shell__card py-4',
+              'chat-input-shell__card py-3 sm:py-4',
               isDragging &&
                 'border-2 border-dashed border-primary bg-primary/5',
               showProcessingGlow && !isDragging && 'bg-card',
             )}
           >
-            <CardContent className="px-4">
+            <CardContent className="px-3 sm:px-4">
               <div className="chat-input-body flex flex-col gap-4">
                 {hasAttachmentChips && (
                   <ChatInputExpandable show>
@@ -403,84 +396,33 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
                   data-testid="input"
                 />
 
-                <div className="flex items-center justify-between">
-                  {/* Left side */}
-                  <div className="flex-shrink-0 flex items-center space-x-2">
-                    <OnboardingTourTarget
-                      name={TOUR_TARGET.chatUpload}
-                      settleMs={900}
-                    >
-                      <PlusButton
-                        onFileUpload={onFileUpload}
-                        onImageSelect={handleImageSelect}
-                        isFileSourceDisabled={
-                          !isEmbeddingModelEnabled || isSubmitting
-                        }
-                        isImageUploadDisabled={!isVisionEnabled || isSubmitting}
-                        onKnowledgeBaseSelect={onAddKnowledgeBase}
-                        attachedKnowledgeBaseIds={knowledgeBases?.map(
-                          (kb) => kb.id,
-                        )}
-                        onIntegrationSelect={onAddIntegration}
-                        attachedIntegrationIds={mcpIntegrations?.map(
-                          (integration) => integration.id,
-                        )}
-                      />
-                    </OnboardingTourTarget>
-                    <OnboardingTourTarget
-                      name={TOUR_TARGET.anonymousMode}
-                      settleMs={900}
-                    >
-                      <AnonymousButton
-                        isAnonymous={isAnonymous}
-                        onAnonymousChange={onAnonymousChange}
-                        isDisabled={isAnonymousChangeDisabled}
-                        isEnforced={isAnonymousEnforced}
-                      />
-                    </OnboardingTourTarget>
-                    {selectedSkillId && selectedSkillName && onSkillRemove && (
-                      <SkillBadge
-                        skillName={selectedSkillName}
-                        onRemove={() => onSkillRemove()}
-                      />
-                    )}
-                  </div>
-
-                  <div className="flex-shrink-0 flex space-x-2">
-                    <TooltipIf
-                      condition={isModelChangeDisabled ?? false}
-                      tooltip={t('chatInput.modelChangeDisabledTooltip')}
-                    >
-                      <OnboardingTourTarget name={TOUR_TARGET.modelSelector}>
-                        <ModelSelector
-                          isDisabled={isModelChangeDisabled ?? false}
-                          selectedModelId={modelId}
-                          onModelChange={onModelChange}
-                        />
-                      </OnboardingTourTarget>
-                    </TooltipIf>
-                    <MicrophoneButton
-                      onTranscriptionComplete={(text) => {
-                        setMessage((prev) => (prev ? `${prev} ${text}` : text));
-                        // Focus textarea and place cursor at end after transcription
-                        setTimeout(() => {
-                          const textarea = textareaRef.current;
-                          if (textarea) {
-                            textarea.focus();
-                            const length = textarea.value.length;
-                            textarea.setSelectionRange(length, length);
-                          }
-                        }, 0);
-                      }}
-                    />
-                    <SendButton
-                      inFlight={inFlight}
-                      canSend={!!canSend}
-                      onSend={handleSend}
-                      onCancel={onCancel}
-                    />
-                  </div>
-                </div>
+                <ChatInputActionBar
+                  isSubmitting={isSubmitting}
+                  isEmbeddingModelEnabled={isEmbeddingModelEnabled}
+                  isVisionEnabled={isVisionEnabled}
+                  knowledgeBases={knowledgeBases}
+                  mcpIntegrations={mcpIntegrations}
+                  onFileUpload={onFileUpload}
+                  onImageSelect={handleImageSelect}
+                  onAddKnowledgeBase={onAddKnowledgeBase}
+                  onAddIntegration={onAddIntegration}
+                  isAnonymous={isAnonymous}
+                  onAnonymousChange={onAnonymousChange}
+                  isAnonymousChangeDisabled={isAnonymousChangeDisabled}
+                  isAnonymousEnforced={isAnonymousEnforced}
+                  selectedSkillId={selectedSkillId}
+                  selectedSkillName={selectedSkillName}
+                  onSkillRemove={onSkillRemove}
+                  isModelChangeDisabled={isModelChangeDisabled}
+                  modelId={modelId}
+                  onModelChange={onModelChange}
+                  inFlight={inFlight}
+                  canSend={!!canSend}
+                  onSend={handleSend}
+                  onCancel={onCancel}
+                  setMessage={setMessage}
+                  textareaRef={textareaRef}
+                />
               </div>
             </CardContent>
           </Card>

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInputActionBar.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInputActionBar.tsx
@@ -1,0 +1,155 @@
+import type { Dispatch, RefObject, SetStateAction } from 'react';
+import { useTranslation } from 'react-i18next';
+import { OnboardingTourTarget, TOUR_TARGET } from '@/widgets/onboarding';
+import PlusButton from './PlusButton';
+import ModelSelector from './ModelSelector';
+import TooltipIf from '@/widgets/tooltip-if/ui/TooltipIf';
+import { SendButton } from './SendButton';
+import { AnonymousButton } from './AnonymousButton';
+import { SkillBadge } from './SkillBadge';
+import { MicrophoneButton } from './MicrophoneButton';
+import { ChatInputToolbar } from './ChatInputToolbar';
+import type {
+  IntegrationSummary,
+  KnowledgeBaseSummary,
+} from '@/shared/contexts/chat/chatContext';
+
+interface ChatInputActionBarProps {
+  isSubmitting: boolean;
+  isEmbeddingModelEnabled: boolean;
+  isVisionEnabled: boolean;
+  knowledgeBases?: KnowledgeBaseSummary[];
+  mcpIntegrations?: IntegrationSummary[];
+  onFileUpload: (files: File[]) => void;
+  onImageSelect: (files: FileList | null) => void;
+  onAddKnowledgeBase?: (knowledgeBase: KnowledgeBaseSummary) => void;
+  onAddIntegration?: (integration: IntegrationSummary) => void;
+  isAnonymous: boolean;
+  onAnonymousChange?: (isAnonymous: boolean) => void;
+  isAnonymousChangeDisabled?: boolean;
+  isAnonymousEnforced?: boolean;
+  selectedSkillId?: string;
+  selectedSkillName?: string;
+  onSkillRemove?: () => void;
+  isModelChangeDisabled?: boolean;
+  modelId: string | undefined;
+  onModelChange: (modelId: string) => void;
+  inFlight: boolean;
+  canSend: boolean;
+  onSend: () => void;
+  onCancel: () => void;
+  setMessage: Dispatch<SetStateAction<string>>;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+}
+
+function appendTranscription(
+  setMessage: Dispatch<SetStateAction<string>>,
+  textareaRef: RefObject<HTMLTextAreaElement | null>,
+  text: string,
+): void {
+  setMessage((prev) => (prev ? `${prev} ${text}` : text));
+  setTimeout(() => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.focus();
+      const length = textarea.value.length;
+      textarea.setSelectionRange(length, length);
+    }
+  }, 0);
+}
+
+export function ChatInputActionBar({
+  isSubmitting,
+  isEmbeddingModelEnabled,
+  isVisionEnabled,
+  knowledgeBases,
+  mcpIntegrations,
+  onFileUpload,
+  onImageSelect,
+  onAddKnowledgeBase,
+  onAddIntegration,
+  isAnonymous,
+  onAnonymousChange,
+  isAnonymousChangeDisabled,
+  isAnonymousEnforced,
+  selectedSkillId,
+  selectedSkillName,
+  onSkillRemove,
+  isModelChangeDisabled,
+  modelId,
+  onModelChange,
+  inFlight,
+  canSend,
+  onSend,
+  onCancel,
+  setMessage,
+  textareaRef,
+}: Readonly<ChatInputActionBarProps>) {
+  const { t } = useTranslation('common');
+
+  return (
+    <ChatInputToolbar
+      leading={
+        <>
+          <OnboardingTourTarget name={TOUR_TARGET.chatUpload} settleMs={900}>
+            <PlusButton
+              onFileUpload={onFileUpload}
+              onImageSelect={onImageSelect}
+              isFileSourceDisabled={!isEmbeddingModelEnabled || isSubmitting}
+              isImageUploadDisabled={!isVisionEnabled || isSubmitting}
+              onKnowledgeBaseSelect={onAddKnowledgeBase}
+              attachedKnowledgeBaseIds={knowledgeBases?.map((kb) => kb.id)}
+              onIntegrationSelect={onAddIntegration}
+              attachedIntegrationIds={mcpIntegrations?.map(
+                (integration) => integration.id,
+              )}
+            />
+          </OnboardingTourTarget>
+          <OnboardingTourTarget name={TOUR_TARGET.anonymousMode} settleMs={900}>
+            <AnonymousButton
+              isAnonymous={isAnonymous}
+              onAnonymousChange={onAnonymousChange}
+              isDisabled={isAnonymousChangeDisabled}
+              isEnforced={isAnonymousEnforced}
+            />
+          </OnboardingTourTarget>
+          {selectedSkillId && selectedSkillName && onSkillRemove && (
+            <SkillBadge
+              skillName={selectedSkillName}
+              onRemove={() => onSkillRemove()}
+            />
+          )}
+        </>
+      }
+      modelSelector={
+        <TooltipIf
+          condition={isModelChangeDisabled ?? false}
+          tooltip={t('chatInput.modelChangeDisabledTooltip')}
+        >
+          <OnboardingTourTarget name={TOUR_TARGET.modelSelector}>
+            <ModelSelector
+              isDisabled={isModelChangeDisabled ?? false}
+              selectedModelId={modelId}
+              onModelChange={onModelChange}
+            />
+          </OnboardingTourTarget>
+        </TooltipIf>
+      }
+      trailing={
+        <>
+          <MicrophoneButton
+            onTranscriptionComplete={(text) => {
+              appendTranscription(setMessage, textareaRef, text);
+            }}
+          />
+          <SendButton
+            inFlight={inFlight}
+            canSend={canSend}
+            onSend={onSend}
+            onCancel={onCancel}
+          />
+        </>
+      }
+    />
+  );
+}

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInputToolbar.test.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInputToolbar.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ChatInputToolbar } from './ChatInputToolbar';
+
+describe(ChatInputToolbar.name, () => {
+  it('lets the model selector shrink so send stays visible on narrow viewports', () => {
+    render(
+      <ChatInputToolbar
+        leading={<button type="button">plus</button>}
+        modelSelector={<button type="button">model</button>}
+        trailing={<button type="button">send</button>}
+      />,
+    );
+
+    const toolbar = screen.getByTestId('chat-input-toolbar');
+    const modelSlot = screen.getByRole('button', {
+      name: 'model',
+    }).parentElement;
+
+    expect(toolbar.className).toContain('min-w-0');
+    expect(modelSlot?.className).toContain('min-w-0');
+    expect(modelSlot?.className).toContain('flex-1');
+  });
+});

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInputToolbar.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ChatInputToolbar.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+
+interface ChatInputToolbarProps {
+  leading: ReactNode;
+  modelSelector: ReactNode;
+  trailing: ReactNode;
+}
+
+export function ChatInputToolbar({
+  leading,
+  modelSelector,
+  trailing,
+}: Readonly<ChatInputToolbarProps>) {
+  return (
+    <div
+      data-testid="chat-input-toolbar"
+      className="flex min-w-0 items-center gap-1 sm:gap-2"
+    >
+      <div className="flex shrink-0 items-center gap-1 sm:gap-2">{leading}</div>
+      <div className="flex min-w-0 flex-1 items-center justify-end gap-1 sm:gap-2">
+        <div className="min-w-0 flex-1 sm:flex-initial">{modelSelector}</div>
+        <div className="flex shrink-0 items-center gap-1 sm:gap-2">
+          {trailing}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/ModelSelector.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/ModelSelector.tsx
@@ -32,7 +32,7 @@ export default function ModelSelector({
       disabled={isDisabled || isDisabledModels || !selectedModelId}
     >
       <SelectTrigger
-        className="border-none shadow-none"
+        className="min-w-0 w-full max-w-full border-none shadow-none sm:w-fit"
         disabled={isDisabled || isDisabledModels}
         aria-label={t('chatInput.modelSelectorAriaLabel')}
         data-testid="chat-model-selector"

--- a/ayunis-core-frontend/src/widgets/chat-input/ui/SkillBadge.tsx
+++ b/ayunis-core-frontend/src/widgets/chat-input/ui/SkillBadge.tsx
@@ -19,12 +19,12 @@ export function SkillBadge({ skillName, onRemove }: Readonly<SkillBadgeProps>) {
       <TooltipTrigger asChild>
         <Badge
           variant="secondary"
-          className="cursor-pointer"
+          className="max-w-[9rem] min-w-0 cursor-pointer"
           onClick={() => onRemove()}
         >
-          <Sparkles className="h-3 w-3" />
-          {skillName}
-          <XIcon className="h-3 w-3" />
+          <Sparkles className="h-3 w-3 shrink-0" />
+          <span className="truncate">{skillName}</span>
+          <XIcon className="h-3 w-3 shrink-0" />
         </Badge>
       </TooltipTrigger>
       <TooltipContent>{t('chatInput.deactivateSkillTooltip')}</TooltipContent>

--- a/ayunis-core-frontend/src/widgets/content-area-header/ui/ContentAreaHeader.test.tsx
+++ b/ayunis-core-frontend/src/widgets/content-area-header/ui/ContentAreaHeader.test.tsx
@@ -22,6 +22,8 @@ describe('ContentAreaHeader', () => {
 
     expect(header.className).toContain('max-sm:flex-col');
     expect(actionRegion?.className).toContain('content-area-header-actions');
+    expect(actionRegion?.className).toContain('flex-wrap');
+    expect(actionRegion?.className).toContain('max-sm:w-full');
     expect(actionRegion?.className).toContain('max-sm:justify-end');
   });
 

--- a/ayunis-core-frontend/src/widgets/content-area-header/ui/ContentAreaHeader.tsx
+++ b/ayunis-core-frontend/src/widgets/content-area-header/ui/ContentAreaHeader.tsx
@@ -63,7 +63,7 @@ export default function ContentAreaHeader({
         </Breadcrumb>
       </div>
       {action && (
-        <div className="content-area-header-actions flex shrink-0 items-center gap-2 empty:hidden max-sm:justify-end">
+        <div className="content-area-header-actions flex min-w-0 shrink-0 flex-wrap items-center gap-2 empty:hidden max-sm:w-full max-sm:justify-end">
           {action}
         </div>
       )}

--- a/ayunis-core-frontend/src/widgets/create-entity-dialog/ui/CreateEntityDialog.tsx
+++ b/ayunis-core-frontend/src/widgets/create-entity-dialog/ui/CreateEntityDialog.tsx
@@ -50,7 +50,7 @@ export default function CreateEntityDialog({
       <DialogTrigger asChild>
         <Button
           size="sm"
-          className={`${showIcon ? 'inline-flex items-center gap-2' : ''} ${buttonClassName}`}
+          className={`${showIcon ? 'inline-flex items-center gap-2' : ''} max-sm:max-w-full ${buttonClassName}`}
         >
           {showIcon && <Plus className="h-4 w-4" />}
           {buttonText ?? translations.buttonText}

--- a/packages/ui/src/components/tabs.stories.tsx
+++ b/packages/ui/src/components/tabs.stories.tsx
@@ -20,3 +20,16 @@ export const Default: Story = {
     </Tabs>
   ),
 };
+
+export const Overflow: Story = {
+  render: () => (
+    <Tabs defaultValue="personal" className="w-72">
+      <TabsList>
+        <TabsTrigger value="personal">Eigene Wissenssammlungen</TabsTrigger>
+        <TabsTrigger value="shared">Geteilte Wissenssammlungen</TabsTrigger>
+      </TabsList>
+      <TabsContent value="personal">Personal collections.</TabsContent>
+      <TabsContent value="shared">Shared collections.</TabsContent>
+    </Tabs>
+  ),
+};

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -24,7 +24,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
+        'bg-muted text-muted-foreground inline-flex h-9 w-fit max-w-full items-center justify-start overflow-x-auto rounded-lg p-[3px]',
         className,
       )}
       {...props}

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -40,7 +40,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] shrink-0 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes chat, knowledge, settings, and shared layouts overflowing on narrow phones (AYC-230).

## Problem

On ~390–590px viewports the app clipped or crowded several primary surfaces:

- Chat composer: plus / anonymous / model / mic / send sat in two `flex-shrink-0` rows, so the send button was cut off
- Knowledge bases (and skills): long tab labels overflowed; header actions (Hilfe + create) cramped
- Settings: label + control rows (`w-[180px]` selects, delete-account) overflowed horizontally
- Product updates: Announcable sidebar widget is a fixed `32rem` panel, leaving a dark strip on the left

## Approach

Shared layout first, then the screenshot-specific surfaces.

- Chat toolbar shrinks the model selector (`min-w-0`) and keeps mic/send visible
- `TabsList` scrolls horizontally instead of overflowing
- Page headers wrap actions; help links stay icon-only on small screens (label remains in the accessibility tree)
- Settings fields stack on mobile via `SettingsFieldRow`
- Tighter shell padding on small viewports
- Inject a mobile CSS patch into the Announcable widget shadow roots so the panel is `100vw`

## Validation

- Focused unit tests for the toolbar, help-link label, settings row, header wrap, and Announcable patch
- Pre-commit: ESLint, Prettier, staged TypeScript, file-size, duplication, circular deps

## Follow-ups (not in this PR)

- Admin/super-admin tables and the chat artifact side-panel still deserve a dedicated mobile pass
- A first-class responsive API from Announcable would replace the shadow-DOM CSS patch

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85639799-c691-4646-ad1c-7e42ca0175b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85639799-c691-4646-ad1c-7e42ca0175b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

