### PR TITLE
fix(artifacts): preserve list item spacing in Word export (AYC-689)

### DIFF
--- a/ayunis-core-backend/src/domain/artifacts/application/helpers/sanitize-html-content.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/helpers/sanitize-html-content.spec.ts
@@ -149,6 +149,13 @@ describe('sanitizeHtmlContent', () => {
       expect(result).toContain('margin-bottom:0pt');
     });
 
+    it('should preserve paragraph spacing styles on list items', () => {
+      const html =
+        '<ul><li style="line-height:1;margin-top:0pt;margin-bottom:0pt">Item</li></ul>';
+
+      expect(sanitizeHtmlContent(html)).toBe(html);
+    });
+
     it('should strip spacing styles with unsupported units', () => {
       const html = '<p style="line-height:1.5em;margin-bottom:2rem">Text</p>';
       const result = sanitizeHtmlContent(html);

--- a/ayunis-core-backend/src/domain/artifacts/application/helpers/sanitize-html-content.ts
+++ b/ayunis-core-backend/src/domain/artifacts/application/helpers/sanitize-html-content.ts
@@ -68,6 +68,7 @@ const SANITIZE_OPTIONS: IOptions = {
     h6: ['style', 'class'],
     span: ['style', 'class'],
     p: ['style', 'class'],
+    li: ['style', 'class'],
     div: ['style', 'class'],
     blockquote: ['style', 'class'],
     pre: ['class'],

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-document-export.service.spec.ts
@@ -180,6 +180,18 @@ describe('HtmlDocumentExportService', () => {
       expect(xml).toMatch(/<w:spacing[^>]*w:before="0"/);
       expect(xml).toContain('both'); // JUSTIFIED alignment
     });
+
+    it('should preserve spacing styled directly on list items', async () => {
+      const html =
+        '<ul><li style="line-height: 1; margin-top: 0pt; margin-bottom: 0pt; text-align: justify;">Item</li></ul>';
+      const result = await service.exportToDocx(html);
+      const xml = await extractDocumentXml(result);
+
+      expect(xml).toMatch(
+        /<w:spacing[^>]*w:after="0"[^>]*w:before="0"[^>]*w:line="240"[^>]*w:lineRule="auto"/,
+      );
+      expect(xml).toContain('w:val="both"');
+    });
   });
 
   describe('exportToPdf', () => {

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.spec.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.spec.ts
@@ -267,6 +267,19 @@ describe('convertHtmlToDocx', () => {
     expect(xml).toMatch(/<w:spacing[^>]*w:line="240"/);
   });
 
+  it('should preserve spacing styled directly on list items', async () => {
+    const buffer = await convertHtmlToDocx(
+      '<ul><li style="line-height: 1; margin-top: 0pt; margin-bottom: 0pt; text-align: justify">Direct item</li></ul>',
+    );
+    const xml = await extractDocumentXml(buffer);
+
+    expect(xml).toContain('Direct item');
+    expect(xml).toMatch(
+      /<w:spacing[^>]*w:after="0"[^>]*w:before="0"[^>]*w:line="240"[^>]*w:lineRule="auto"/,
+    );
+    expect(xml).toContain('w:val="both"');
+  });
+
   it('should convert px margins to twips', async () => {
     const buffer = await convertHtmlToDocx(
       '<p style="margin-bottom: 16px">Pixels</p>',

--- a/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.ts
+++ b/ayunis-core-backend/src/domain/artifacts/infrastructure/export/html-to-docx-converter.ts
@@ -249,8 +249,8 @@ function convertListItem(
       out.push(
         new Paragraph({
           children: collectInlineRuns(child, {}),
-          alignment: parseAlignment(child),
-          spacing: parseSpacing(child),
+          alignment: parseAlignment(child) ?? parseAlignment(li),
+          spacing: parseSpacing(child) ?? parseSpacing(li),
           ...listProps(ordered, level),
         }),
       );
@@ -260,6 +260,8 @@ function convertListItem(
         out.push(
           new Paragraph({
             children: [new TextRun(text)],
+            alignment: parseAlignment(li),
+            spacing: parseSpacing(li),
             ...listProps(ordered, level),
           }),
         );


### PR DESCRIPTION
## Summary

- Preserve inline `line-height`, paragraph margins, and alignment when they are set directly on list items.
- Keep `li` paragraph styles through HTML sanitization.
- Apply list-item styles to direct text and as fallback styles for nested paragraphs during DOCX conversion.
- Add sanitizer, converter, and export-service regression coverage.

## QA

Tested the submitted commit `3a27a4ef11dc0adeb4230941766e53ad8974dd7a` in an isolated local QA worktree on slot 6 (backend `http://localhost:3060`).

- [x] Seeded the standard local fixture and authenticated through `POST /api/auth/login`.
- [x] Created a thread and document through the public API using the ticket's inline styles on `h1`, `p`, direct `li`, and `td`.
- [x] Confirmed the persisted/sanitized artifact retained `line-height:1`, `margin-top:0pt`, `margin-bottom:0pt`, and `text-align:justify` on all four elements, including `li`.
- [x] Downloaded the Word file through `GET /api/artifacts/{id}/export?format=docx`; the response was a valid Microsoft Word DOCX archive.
- [x] Inspected `word/document.xml`: heading, paragraph, direct list item, and table-cell paragraphs each contain `<w:spacing w:after="0" w:before="0" w:line="240" w:lineRule="auto"/>` and `<w:jc w:val="both"/>`.
- [x] Focused regression suites: 91 tests passed.
- [x] Full artifacts suite: 23 suites / 285 tests passed.
- [x] Backend ESLint and TypeScript checks passed.

### Visual evidence

The DOCX downloaded from the running API was rendered with LibreOffice. The heading, paragraph, direct list item, and table-cell text appear consecutively with single line spacing and no default 8 pt gaps after paragraphs.

![Rendered Word export showing single line spacing and zero paragraph gaps](https://raw.githubusercontent.com/ayunis-core/ayunis-core/6aba0a058936e67b9a19aa4414eb5506d342846c/.pr-media/generated/ayc689-word-export-page-1.png)

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped to HTML sanitization allowlist and list-item DOCX mapping; no auth or data-path changes, with regression tests added.
> 
> **Overview**
> Fixes **Word export** dropping paragraph spacing and alignment when those styles are set on **`li`** instead of an inner **`p`**.
> 
> **Sanitization** now allows `style` and `class` on **`li`**, so line-height and margin styles on list items survive the export pipeline like they already do for paragraphs.
> 
> **DOCX conversion** applies list-item alignment and spacing when building list paragraphs: nested **`p`** elements fall back to the parent **`li`** styles, and plain text directly inside **`li`** gets spacing and justification from the **`li`** element. New tests cover sanitization and end-to-end DOCX XML for this case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a27a4ef11dc0adeb4230941766e53ad8974dd7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
