### PR TITLE
ci(deps): fail the build on a dedupable lockfile (AYC-000)

### DIFF
--- a/.github/workflows/lockfile-dedupe.yml
+++ b/.github/workflows/lockfile-dedupe.yml
@@ -1,0 +1,46 @@
+name: Lockfile Dedupe
+
+on:
+  pull_request:
+    paths:
+      # Any manifest change that could introduce a duplicate has to relock,
+      # or `pnpm install --frozen-lockfile` fails elsewhere first — so
+      # watching the lockfile covers every package.json in the workspace.
+      - 'pnpm-lock.yaml'
+      # The catalog decides which versions the workspace shares, so editing
+      # it changes resolutions without necessarily touching a package.json.
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/lockfile-dedupe.yml'
+      - '.github/actions/setup-node-pnpm/action.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  dedupe:
+    name: Lockfile Dedupe
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
+
+      # A package resolved at two versions gives its consumer a different
+      # module instance than the package itself uses, which breaks anything
+      # relying on shared state — a store, a React context, a class identity.
+      # That surfaced three times in one dependency batch: sonner (every
+      # toast stopped rendering), react-hook-form (Control<> mismatches) and
+      # @mistralai/mistralai (a defeated instanceof retry check).
+      - name: Check for dedupable packages
+        run: pnpm dedupe --check
+
+      - name: Explain the failure
+        if: failure()
+        run: |
+          echo "::error::Lockfile has dedupable packages. Run 'pnpm dedupe' and commit pnpm-lock.yaml. If a duplicate is intentional, pin the shared version in the pnpm-workspace.yaml catalog instead."


### PR DESCRIPTION
A package resolved at two versions hands its consumer a different module
instance than the package itself uses, which breaks anything relying on
shared state. That landed three times in a single dependency batch:
sonner (every toast in the app stopped rendering), react-hook-form
(Control<> from one copy unassignable to the other) and
@mistralai/mistralai (a defeated instanceof check that would have
silently dropped provider retries).

Each was found by hand, and only after something downstream broke. This
turns the class into a build failure.

Scope, so the guard is not over-trusted: pnpm dedupe --check flags
duplicates that could collapse under the ranges already declared — the
stale-lockfile-pin mechanism behind all three cases above, where the
ranges were compatible and pnpm simply kept an older pin. It does not
flag a duplicate created by declaring genuinely incompatible ranges,
because nothing is collapsible then. Verified: pinning ui to sonner
2.0.5 against the frontend's ^2.0.8 leaves both in the lockfile and the
check still exits 0. The pnpm-workspace.yaml catalog is what covers that
half, by removing the second place a shared version can be declared.

Watching the lockfile alone is sufficient: any manifest change that could
introduce a duplicate has to relock, or the existing --frozen-lockfile
steps fail first. pnpm-workspace.yaml is included because the catalog
changes resolutions without touching a package.json.

Verified against this repository's own history — exit 1 with 258 entries
on the pre-dedupe lockfile, exit 0 on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds read-only CI validation on lockfile changes; no runtime or application code is modified.
> 
> **Overview**
> Adds a **Lockfile Dedupe** GitHub Actions workflow that runs on pull requests when `pnpm-lock.yaml`, `pnpm-workspace.yaml`, or the lockfile-related workflow/setup paths change.
> 
> The job checks out the repo, uses the shared Node/pnpm setup action, and runs **`pnpm dedupe --check`** so collapsible duplicate resolutions in the lockfile fail CI instead of surfacing later as broken shared singletons (React context, stores, `instanceof`, etc.). On failure it emits a workflow error telling contributors to run `pnpm dedupe` and commit the lockfile, or align versions via the workspace catalog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d11aba7f6d521f94c87385a3fc4a013ff3101b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Verification

Tested against this repository's own history rather than a synthetic case:

| State | `pnpm dedupe --check` | |
| --- | --- | --- |
| main today (post-#1655) | **exit 0** | guard is green on arrival |
| the lockfile before #1655 | **exit 1**, 258 entries | guard correctly catches a real duplicate state |

Workflow YAML parsed and asserted: 4 trigger paths, one job, check name `Lockfile Dedupe`, four steps.

### What this guard does *not* catch

Worth stating so it isn't over-trusted. `pnpm dedupe --check` flags duplicates that **could collapse under the ranges already declared** — the stale-lockfile-pin mechanism behind all three incidents, where the ranges were compatible and pnpm just kept an older pin.

It does **not** flag a duplicate created by declaring genuinely incompatible ranges, because then nothing is collapsible. Verified directly:

```
packages/ui  devDependencies.sonner = "2.0.5"   (exact pin)
frontend     dependencies.sonner    = "^2.0.8"

lockfile:    sonner@2.0.5  sonner@2.0.8     <- a real, toast-breaking duplicate
dedupe --check: exit 0                      <- not caught
```

The `pnpm-workspace.yaml` catalog from #1654 is what covers that half, by removing the second place a shared version can be declared. The two are complementary:

- **catalog** — prevents declared divergence
- **this guard** — prevents lockfile drift

### Trigger scope

Watching `pnpm-lock.yaml` alone is sufficient for manifest changes: anything that could introduce a duplicate has to relock, or the existing `--frozen-lockfile` steps fail first. `pnpm-workspace.yaml` is included separately because the catalog changes resolutions without touching any `package.json`.

Note this also closes a real gap — a lockfile-only PR currently triggers the *fewest* checks in this repo (#1655 ran 11 where a frontend PR runs 22), because most workflows are path-filtered to source files. This one triggers precisely on the case that today has the least coverage.
