### PR TITLE
feat(dev): add slot management dashboard (AYC-000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,12 @@ port, it exits with an actionable error instead of terminating that process.
 ./dev logs --slot 2 frontend
 ./dev logs --slot 2 infra
 
+# Inspect every worktree that has selected a slot.
+./dev slots
+
+# Open the local slot control panel URL printed by this command.
+./dev ui
+
 # Recover an unhealthy managed backend or frontend session.
 ./dev up --slot 2
 ```
@@ -268,6 +274,25 @@ lockfile, preserves an already-healthy stack, and replaces stale slot-owned
 backend or frontend sessions before waiting for both services to become ready.
 Do not kill a process reported as an unmanaged port owner; stop it from its
 own checkout or choose another slot.
+
+The control panel binds to `127.0.0.1` and exposes safe, checkout-owned stop
+operations. It blocks stopping duplicate slot claims because Docker
+infrastructure is shared by slot number. Stopped checkouts can release their
+slot selection without deleting the worktree or database data. A stopped,
+uncontested slot can separately delete its Compose containers, network, and
+Postgres/MinIO volumes after typing `DELETE SLOT N`; the worktree and slot claim
+remain. Once slot data is gone, a clean stopped linked worktree whose branch is
+published and has no unpushed commits can be removed after typing
+`REMOVE WORKTREE N`; its branch is preserved. The primary checkout and the
+checkout serving the dashboard cannot be removed there. Unmanaged process
+termination is intentionally not available from the UI. **Stop all safely**
+stops every eligible managed slot while
+skipping stopped, conflicting, or unmanaged entries. Unmanaged listeners include
+read-only ownership details:
+PID, command, working directory, and a conservative active-worktree, orphan,
+or unknown classification. Stopped checkouts can be started on their current
+slot or reassigned to a verified free slot; managed running checkouts can be
+restarted in standard, E2E-mock, or anonymisation mode.
 
 ### Git Hooks (Husky)
 

--- a/dev
+++ b/dev
@@ -62,8 +62,9 @@ if [ -n "$SLOT" ]; then
 elif [ -f "$SLOT_FILE" ]; then
   SLOT="$(cat "$SLOT_FILE")"
 else
-  # No slot given and none saved — only help works without a slot
-  if [[ "$COMMAND" != "help" && "$COMMAND" != "--help" && "$COMMAND" != "-h" ]]; then
+  # Inventory and UI commands discover slots across worktrees.
+  if [[ "$COMMAND" != "help" && "$COMMAND" != "--help" && "$COMMAND" != "-h" \
+    && "$COMMAND" != "slots" && "$COMMAND" != "ui" ]]; then
     die "No slot specified and none previously saved. Run: ./dev up --slot N"
   fi
   SLOT=0  # dummy for help
@@ -760,8 +761,10 @@ case "$COMMAND" in
   down)   cmd_down ;;
   status) cmd_status ;;
   logs)   cmd_logs "$@" ;;
+  slots)  node "$REPO_DIR/scripts/dev-slots-ui.mjs" list ;;
+  ui)     node "$REPO_DIR/scripts/dev-slots-ui.mjs" serve "$@" ;;
   help|--help|-h)
-    echo "Usage: ./dev <up|down|status|logs> [--slot N] [logs options]"
+    echo "Usage: ./dev <up|down|status|logs|slots|ui> [options]"
     echo ""
     echo "Commands:"
     echo "  up     --slot N [--with-anonymisation] [--e2e]"
@@ -771,6 +774,8 @@ case "$COMMAND" in
     echo "  status [--slot N]                          Show what's running"
     echo "  logs   [--slot N] [--tail N] [backend|frontend|infra|all]"
     echo "                                             Print recent logs (default: all, 80 lines)"
+    echo "  slots                                     List slots across all worktrees as JSON"
+    echo "  ui     [--port N]                         Start the local slot control panel"
     echo ""
     echo "The --slot flag is required on first use (./dev up --slot N)."
     echo "After that, the slot is saved to .dev/slot and all commands work without --slot."

--- a/scripts/dev-slots-api.mjs
+++ b/scripts/dev-slots-api.mjs
@@ -1,0 +1,151 @@
+import { deleteSlotData } from "./dev-slots-cleanup.mjs";
+import { restartSlot, startSlot } from "./dev-slots-lifecycle.mjs";
+import {
+  findAvailableSlots,
+  readSlotLogs,
+  releaseSlotClaim,
+  stopAllSlots,
+  stopSlot,
+} from "./dev-slots-lib.mjs";
+import {
+  discoverSlotsWithRemoval,
+  removeWorktree,
+} from "./dev-slots-worktree.mjs";
+
+function json(response, status, body) {
+  response.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "no-store",
+  });
+  response.end(JSON.stringify(body));
+}
+
+function routeId(pathname, action) {
+  return pathname.match(new RegExp(`^/api/slots/([^/]+)/${action}$`))?.[1];
+}
+
+function isLoopbackHost(host) {
+  try {
+    const hostname = new URL(`http://${host}`).hostname;
+    return hostname === "127.0.0.1" || hostname === "localhost";
+  } catch {
+    return false;
+  }
+}
+
+export function createSlotsHandler({
+  repoDir,
+  token,
+  renderPage,
+  discover = discoverSlotsWithRemoval,
+  stop = stopSlot,
+  stopAll = stopAllSlots,
+  release = releaseSlotClaim,
+  deleteData = deleteSlotData,
+  remove = removeWorktree,
+  start = startSlot,
+  restart = restartSlot,
+  available = findAvailableSlots,
+  logs = readSlotLogs,
+}) {
+  return async (request, response) => {
+    try {
+      if (!isLoopbackHost(request.headers.host)) {
+        json(response, 403, {
+          error: "Dashboard requests must use a loopback host.",
+        });
+        return;
+      }
+      const url = new URL(request.url, "http://127.0.0.1");
+      if (
+        url.pathname.startsWith("/api/") &&
+        request.headers["x-dev-slots-token"] !== token
+      ) {
+        json(response, 403, { error: "Invalid dashboard session token." });
+        return;
+      }
+      if (request.method === "GET" && url.pathname === "/") {
+        response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+        response.end(renderPage(token));
+        return;
+      }
+      const records = await discover(repoDir);
+      if (request.method === "GET" && url.pathname === "/api/slots") {
+        json(response, 200, {
+          slots: records,
+          availableSlots: await available(records),
+        });
+        return;
+      }
+      if (request.method === "POST" && url.pathname === "/api/slots/stop-all") {
+        json(response, 200, await stopAll({ records }));
+        return;
+      }
+      const logId = routeId(url.pathname, "logs");
+      if (request.method === "GET" && logId) {
+        const record = records.find(({ id }) => id === logId);
+        if (!record)
+          throw new Error(
+            "Slot owner no longer exists. Refresh and try again.",
+          );
+        json(response, 200, { logs: await logs(record) });
+        return;
+      }
+      const stopId = routeId(url.pathname, "stop");
+      if (request.method === "POST" && stopId) {
+        json(response, 200, { output: await stop({ id: stopId, records }) });
+        return;
+      }
+      const releaseId = routeId(url.pathname, "release");
+      if (request.method === "POST" && releaseId) {
+        json(response, 200, {
+          output: await release({ id: releaseId, records }),
+        });
+        return;
+      }
+      const deleteDataId = routeId(url.pathname, "delete-data");
+      if (request.method === "POST" && deleteDataId) {
+        json(response, 200, {
+          output: await deleteData({
+            id: deleteDataId,
+            confirmation: url.searchParams.get("confirmation"),
+            records,
+          }),
+        });
+        return;
+      }
+      const removeWorktreeId = routeId(url.pathname, "remove-worktree");
+      if (request.method === "POST" && removeWorktreeId) {
+        json(response, 200, {
+          output: await remove({
+            id: removeWorktreeId,
+            confirmation: url.searchParams.get("confirmation"),
+            records,
+            repoDir,
+          }),
+        });
+        return;
+      }
+      const startId = routeId(url.pathname, "start");
+      if (request.method === "POST" && startId) {
+        const targetSlot = Number(url.searchParams.get("slot"));
+        const mode = url.searchParams.get("mode") ?? "standard";
+        json(response, 200, {
+          output: await start({ id: startId, targetSlot, mode, records }),
+        });
+        return;
+      }
+      const restartId = routeId(url.pathname, "restart");
+      if (request.method === "POST" && restartId) {
+        const mode = url.searchParams.get("mode") ?? "standard";
+        json(response, 200, {
+          output: await restart({ id: restartId, mode, records }),
+        });
+        return;
+      }
+      json(response, 404, { error: "Not found." });
+    } catch (error) {
+      json(response, 409, { error: error.message });
+    }
+  };
+}

--- a/scripts/dev-slots-cleanup.mjs
+++ b/scripts/dev-slots-cleanup.mjs
@@ -1,0 +1,18 @@
+import { runCommand } from "./dev-slots-lib.mjs";
+import { composeDown } from "./dev-slots-compose.mjs";
+
+export async function deleteSlotData({
+  id,
+  confirmation,
+  records,
+  run = runCommand,
+}) {
+  const record = records.find((candidate) => candidate.id === id);
+  if (!record) throw new Error("Slot owner no longer exists. Refresh and try again.");
+  if (!record.deleteDataAllowed) {
+    throw new Error("Stop the slot and resolve conflicts or unmanaged listeners first.");
+  }
+  const expected = `DELETE SLOT ${record.slot}`;
+  if (confirmation !== expected) throw new Error(`Type ${expected} to delete this slot's data.`);
+  return composeDown({ record, run, deleteVolumes: true });
+}

--- a/scripts/dev-slots-compose.mjs
+++ b/scripts/dev-slots-compose.mjs
@@ -1,0 +1,41 @@
+import path from "node:path";
+
+const portBases = {
+  POSTGRES_HOST_PORT: 5432,
+  MINIO_HOST_PORT: 9000,
+  MINIO_CONSOLE_HOST_PORT: 9001,
+  MAILCATCHER_SMTP_HOST_PORT: 1025,
+  MAILCATCHER_WEB_HOST_PORT: 1080,
+  CODE_EXEC_HOST_PORT: 8080,
+  ANONYMIZE_HOST_PORT: 8002,
+  REDIS_HOST_PORT: 6379,
+  GOTENBERG_HOST_PORT: 3100,
+};
+
+function slotEnvironment(slot) {
+  const offset = slot * 10;
+  return {
+    ...Object.fromEntries(
+    Object.entries(portBases).map(([name, base]) => [name, String(base + offset)]),
+    ),
+    MINIO_ROOT_USER: "placeholder",
+    MINIO_ROOT_PASSWORD: "placeholder",
+    REDIS_PASSWORD: "placeholder",
+  };
+}
+
+export function composeDown({ record, run, deleteVolumes = false }) {
+  const args = [
+    "compose",
+    "-f",
+    path.join(record.worktree, "compose.dev.yml"),
+    "-p",
+    `ayunis-dev-${record.slot}`,
+    "down",
+  ];
+  if (deleteVolumes) args.push("--volumes");
+  return run("docker", args, {
+    cwd: record.worktree,
+    env: slotEnvironment(record.slot),
+  });
+}

--- a/scripts/dev-slots-lib.mjs
+++ b/scripts/dev-slots-lib.mjs
@@ -1,0 +1,454 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFile, unlink } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+
+export function parseWorktrees(output) {
+  return output
+    .trim()
+    .split(/\n\s*\n/)
+    .filter(Boolean)
+    .map((block) => {
+      const fields = new Map();
+      for (const line of block.split("\n")) {
+        const separator = line.indexOf(" ");
+        const key = separator === -1 ? line : line.slice(0, separator);
+        const value = separator === -1 ? true : line.slice(separator + 1);
+        fields.set(key, value);
+      }
+      const branchRef = fields.get("branch");
+      return {
+        path: String(fields.get("worktree")),
+        head: String(fields.get("HEAD")),
+        branch:
+          typeof branchRef === "string"
+            ? branchRef.replace(/^refs\/heads\//, "")
+            : "detached",
+        detached: fields.has("detached"),
+        prunable: fields.has("prunable"),
+      };
+    });
+}
+
+function slotId(worktree, slot) {
+  return createHash("sha256")
+    .update(`${worktree}:${slot}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+async function readSelectedSlot(worktree) {
+  try {
+    const value = (
+      await readFile(path.join(worktree, ".dev", "slot"), "utf8")
+    ).trim();
+    return /^\d+$/.test(value) ? Number(value) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function classifyStatus(detail) {
+  if (/unhealthy|occupied by unmanaged/i.test(detail)) return "attention";
+  if (/Backend:\s+running|Frontend:\s+running/i.test(detail)) return "running";
+  if (!/Docker infra:\s+not running/i.test(detail)) return "running";
+  return "stopped";
+}
+
+export function parseUnmanagedListeners(detail) {
+  const listeners = [];
+  for (const line of detail.split("\n")) {
+    const match = line.match(
+      /^\s*(Backend|Frontend):.*port\s+(\d+).*unmanaged PID\s+([\d\s,]+)/i,
+    );
+    if (!match) continue;
+    for (const pid of match[3].match(/\d+/g) ?? []) {
+      listeners.push({
+        service: match[1][0].toUpperCase() + match[1].slice(1).toLowerCase(),
+        port: Number(match[2]),
+        pid: Number(pid),
+      });
+    }
+  }
+  return listeners;
+}
+
+export function classifyProcessOwner(cwd, worktrees) {
+  if (cwd.includes("/.git/wt/trash/")) {
+    return {
+      kind: "orphan",
+      label: "Trashed orphan",
+      worktree: null,
+      branch: null,
+    };
+  }
+  if (cwd.includes(" (deleted)")) {
+    return {
+      kind: "orphan",
+      label: "Deleted-directory orphan",
+      worktree: null,
+      branch: null,
+    };
+  }
+  const owner = [...worktrees]
+    .sort((left, right) => right.path.length - left.path.length)
+    .find(
+      (worktree) =>
+        cwd === worktree.path || cwd.startsWith(`${worktree.path}${path.sep}`),
+    );
+  if (owner) {
+    return {
+      kind: "active-worktree",
+      label: "Active worktree",
+      worktree: owner.path,
+      branch: owner.branch,
+    };
+  }
+  return {
+    kind: "unknown",
+    label: "Unknown owner",
+    worktree: null,
+    branch: null,
+  };
+}
+
+function ownerRecommendation(owner, claimWorktree) {
+  if (owner.worktree === claimWorktree) {
+    return "This process is inside the checkout but is not tracked; inspect it manually.";
+  }
+  if (owner.kind === "active-worktree")
+    return "Stop this slot from the owning worktree.";
+  if (owner.kind === "orphan")
+    return "This process is eligible for guarded orphan cleanup.";
+  return "Inspect this process manually before taking action.";
+}
+
+async function inspectProcess(listener, worktrees, claimWorktree, run) {
+  const read = async (command, args) => {
+    try {
+      return await run(command, args);
+    } catch {
+      return "";
+    }
+  };
+  const [command, lsofOutput] = await Promise.all([
+    read("ps", ["-o", "command=", "-p", String(listener.pid)]),
+    read("lsof", ["-a", "-p", String(listener.pid), "-d", "cwd", "-Fn"]),
+  ]);
+  const cwd =
+    lsofOutput
+      .split("\n")
+      .find((line) => line.startsWith("n"))
+      ?.slice(1) ?? "";
+  const owner = classifyProcessOwner(cwd, worktrees);
+  return {
+    ...listener,
+    command: command || "Process exited or command unavailable",
+    cwd: cwd || "Working directory unavailable",
+    owner,
+    recommendation: ownerRecommendation(owner, claimWorktree),
+  };
+}
+
+export async function inspectUnmanagedListeners({
+  detail,
+  worktrees,
+  claimWorktree = null,
+  run = runCommand,
+}) {
+  return Promise.all(
+    parseUnmanagedListeners(detail).map((listener) =>
+      inspectProcess(listener, worktrees, claimWorktree, run),
+    ),
+  );
+}
+
+function unmanagedListener(detail) {
+  return /occupied by unmanaged PID/i.test(detail ?? "");
+}
+
+function servicesStopped(detail) {
+  return (
+    /Backend:\s+stopped/i.test(detail ?? "") &&
+    /Frontend:\s+stopped/i.test(detail ?? "")
+  );
+}
+
+function claimCanBeReleased(record) {
+  return (
+    servicesStopped(record.detail) &&
+    (record.summary === "stopped" || record.conflict)
+  );
+}
+
+function hasManagedService(detail) {
+  return /(Backend|Frontend):\s+(running|unhealthy)/i.test(detail ?? "");
+}
+
+function hasUnhealthyInfrastructure(detail) {
+  return (detail ?? "")
+    .split("\n")
+    .some(
+      (line) =>
+        /unhealthy/i.test(line) && !/^\s*(Backend|Frontend):/i.test(line),
+    );
+}
+
+export function slotPorts(slot) {
+  const offset = slot * 10;
+  return [3000, 3001, 5432, 9000, 9001, 1025, 1080, 8080, 8002, 6379, 3100].map(
+    (base) => base + offset,
+  );
+}
+
+export function suggestAvailableSlots({
+  records,
+  listeningPorts,
+  first = 2,
+  last = 20,
+}) {
+  const claimedPorts = new Set(records.flatMap(({ slot }) => slotPorts(slot)));
+  const available = [];
+  for (let slot = first; slot <= last; slot += 1) {
+    if (
+      slotPorts(slot).some(
+        (port) => claimedPorts.has(port) || listeningPorts.has(port),
+      )
+    ) {
+      continue;
+    }
+    available.push(slot);
+  }
+  return available;
+}
+
+export async function listListeningPorts(run = runCommand) {
+  let output;
+  try {
+    output = await run("lsof", ["-nP", "-iTCP", "-sTCP:LISTEN", "-Fn"]);
+  } catch (error) {
+    if (error.code === 1) output = String(error.stdout ?? "");
+    else throw error;
+  }
+  return new Set(
+    output
+      .split("\n")
+      .map((line) => line.match(/:(\d+)$/)?.[1])
+      .filter(Boolean)
+      .map(Number),
+  );
+}
+
+export async function findAvailableSlots(records) {
+  return suggestAvailableSlots({
+    records,
+    listeningPorts: await listListeningPorts(),
+  });
+}
+
+export async function runCommand(command, args, options = {}) {
+  const result = await execFile(command, args, {
+    maxBuffer: 16 * 1024 * 1024,
+    ...options,
+    encoding: "utf8",
+    env: { ...process.env, ...options.env },
+  });
+  return result.stdout.trim();
+}
+
+export async function inspectWorktree({ worktree, slot }) {
+  try {
+    const detail = await runCommand(path.join(worktree, "dev"), ["status"], {
+      cwd: worktree,
+    });
+    return { summary: classifyStatus(detail), detail };
+  } catch (error) {
+    const detail = [error.stdout, error.stderr, error.message]
+      .filter(Boolean)
+      .join("\n");
+    return { summary: "attention", detail };
+  }
+}
+
+export async function isWorktreeDirty({ worktree }) {
+  try {
+    return Boolean(
+      await runCommand("git", ["status", "--short"], { cwd: worktree }),
+    );
+  } catch {
+    return false;
+  }
+}
+
+export async function buildSlotRecords({
+  worktrees,
+  inspect = inspectWorktree,
+  isDirty = isWorktreeDirty,
+  diagnose = inspectUnmanagedListeners,
+  inspectRemoval = async () => ({}),
+}) {
+  const candidates = (
+    await Promise.all(
+      worktrees.map(async (worktree) => ({
+        ...worktree,
+        slot: await readSelectedSlot(worktree.path),
+      })),
+    )
+  ).filter(({ slot }) => slot !== null);
+
+  const counts = new Map();
+  for (const { slot } of candidates)
+    counts.set(slot, (counts.get(slot) ?? 0) + 1);
+
+  return Promise.all(
+    candidates.map(async (worktree) => {
+      const [{ summary, detail }, dirty] = await Promise.all([
+        inspect({ worktree: worktree.path, slot: worktree.slot }),
+        isDirty({ worktree: worktree.path }),
+      ]);
+      const diagnostics = await diagnose({
+        detail,
+        worktrees,
+        claimWorktree: worktree.path,
+      });
+      const conflict = counts.get(worktree.slot) > 1;
+      const record = {
+        id: slotId(worktree.path, worktree.slot),
+        slot: worktree.slot,
+        worktree: worktree.path,
+        branch: worktree.branch,
+        head: worktree.head,
+        detached: worktree.detached,
+        prunable: worktree.prunable,
+        dirty,
+        summary,
+        detail,
+        diagnostics,
+        conflict,
+        stopBlockedReason: conflict
+          ? "Resolve the duplicate slot claim first."
+          : unmanagedListener(detail)
+            ? "An unmanaged process owns a slot port. Inspect its owner before stopping anything."
+            : null,
+        ports: {
+          backend: 3000 + worktree.slot * 10,
+          frontend: 3001 + worktree.slot * 10,
+          postgres: 5432 + worktree.slot * 10,
+        },
+      };
+      const localUntrackedProcess = diagnostics.some(
+        ({ owner }) => owner.worktree === worktree.path,
+      );
+      const removal = await inspectRemoval(record);
+      return {
+        ...record,
+        ...removal,
+        frontendRunning: /Frontend:\s+running/i.test(detail),
+        stopAllowed:
+          !conflict &&
+          !unmanagedListener(detail) &&
+          (summary === "running" ||
+            hasManagedService(detail) ||
+            hasUnhealthyInfrastructure(detail)),
+        releaseAllowed: claimCanBeReleased(record),
+        deleteDataAllowed:
+          servicesStopped(detail) && !conflict && !unmanagedListener(detail),
+        startAllowed:
+          servicesStopped(detail) && !conflict && !unmanagedListener(detail),
+        reassignAllowed:
+          servicesStopped(detail) &&
+          (conflict || unmanagedListener(detail)) &&
+          !localUntrackedProcess,
+        restartAllowed:
+          hasManagedService(detail) && !conflict && !unmanagedListener(detail),
+      };
+    }),
+  );
+}
+
+export async function discoverSlots(repoDir) {
+  const output = await runCommand("git", ["worktree", "list", "--porcelain"], {
+    cwd: repoDir,
+  });
+  return buildSlotRecords({ worktrees: parseWorktrees(output) });
+}
+
+export async function stopSlot({ id, records, run = runCommand }) {
+  const record = records.find((candidate) => candidate.id === id);
+  if (!record)
+    throw new Error("Slot owner no longer exists. Refresh and try again.");
+  if (record.conflict) {
+    throw new Error(`Slot ${record.slot} is claimed by multiple worktrees.`);
+  }
+  if (unmanagedListener(record.detail)) {
+    throw new Error(
+      "An unmanaged process owns a slot port; safe stop is blocked.",
+    );
+  }
+  return run(
+    path.join(record.worktree, "dev"),
+    ["down", "--slot", String(record.slot)],
+    { cwd: record.worktree },
+  );
+}
+
+function canStopRecord(record) {
+  if (record.stopAllowed !== undefined) return record.stopAllowed;
+  return (
+    !record.conflict &&
+    !unmanagedListener(record.detail) &&
+    (record.summary === "running" ||
+      hasManagedService(record.detail) ||
+      hasUnhealthyInfrastructure(record.detail))
+  );
+}
+
+function batchRecord(record, extra = {}) {
+  return { id: record.id, slot: record.slot, branch: record.branch, ...extra };
+}
+
+export async function stopAllSlots({ records, stop = stopSlot }) {
+  const result = { stopped: [], skipped: [], failed: [] };
+  for (const record of records) {
+    if (!canStopRecord(record)) {
+      result.skipped.push(batchRecord(record));
+      continue;
+    }
+    try {
+      await stop({ id: record.id, records });
+      result.stopped.push(batchRecord(record));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      result.failed.push(batchRecord(record, { error: message }));
+    }
+  }
+  return result;
+}
+
+export async function releaseSlotClaim({ id, records }) {
+  const record = records.find((candidate) => candidate.id === id);
+  if (!record)
+    throw new Error("Slot owner no longer exists. Refresh and try again.");
+  if (!(record.releaseAllowed ?? claimCanBeReleased(record))) {
+    throw new Error("This checkout still has a managed service running.");
+  }
+  const selectedSlot = await readSelectedSlot(record.worktree);
+  if (selectedSlot !== record.slot) {
+    throw new Error(
+      "The checkout's selected slot changed. Refresh and try again.",
+    );
+  }
+  await unlink(path.join(record.worktree, ".dev", "slot"));
+  return `Slot ${record.slot} claim released for ${record.worktree}.`;
+}
+
+export async function readSlotLogs(record) {
+  return runCommand(
+    path.join(record.worktree, "dev"),
+    ["logs", "--tail", "120", "all"],
+    { cwd: record.worktree },
+  );
+}

--- a/scripts/dev-slots-lifecycle.mjs
+++ b/scripts/dev-slots-lifecycle.mjs
@@ -1,0 +1,124 @@
+import path from "node:path";
+
+import { composeDown } from "./dev-slots-compose.mjs";
+import { listListeningPorts, runCommand, slotPorts } from "./dev-slots-lib.mjs";
+
+const modeFlags = {
+  standard: [],
+  e2e: ["--e2e"],
+  anonymisation: ["--with-anonymisation"],
+};
+
+const servicesStopped = (detail) =>
+  /Backend:\s+stopped/i.test(detail ?? "") &&
+  /Frontend:\s+stopped/i.test(detail ?? "");
+
+const unmanagedListener = (detail) =>
+  /occupied by unmanaged PID/i.test(detail ?? "");
+
+const hasManagedService = (detail) =>
+  /(Backend|Frontend):\s+(running|unhealthy)/i.test(detail ?? "");
+
+const hasLocalUnmanagedProcess = (record) =>
+  record.diagnostics?.some(
+    ({ owner }) => owner.worktree === record.worktree,
+  ) ?? false;
+
+function requestedMode(mode) {
+  const flags = modeFlags[mode];
+  if (!flags) throw new Error("Unknown start mode.");
+  return flags;
+}
+
+function requestedSlot(targetSlot) {
+  if (!Number.isInteger(targetSlot) || targetSlot < 2 || targetSlot > 99) {
+    throw new Error("Slot must be an integer between 2 and 99.");
+  }
+  return targetSlot;
+}
+
+async function ensureSlotAvailable(targetSlot, records, run) {
+  const targetPorts = new Set(slotPorts(targetSlot));
+  const overlappingClaim = records.find(({ slot }) =>
+    slotPorts(slot).some((port) => targetPorts.has(port)),
+  );
+  if (overlappingClaim) {
+    if (overlappingClaim.slot === targetSlot) {
+      throw new Error(`Slot ${targetSlot} is already claimed.`);
+    }
+    throw new Error(
+      `Slot ${targetSlot} shares ports with claimed slot ${overlappingClaim.slot}.`,
+    );
+  }
+  const listeningPorts = await listListeningPorts(run);
+  const occupied = slotPorts(targetSlot).filter((port) =>
+    listeningPorts.has(port),
+  );
+  if (occupied.length) {
+    throw new Error(
+      `Slot ${targetSlot} has occupied ports: ${occupied.join(", ")}.`,
+    );
+  }
+}
+
+export async function startSlot({
+  id,
+  targetSlot,
+  mode,
+  records,
+  run = runCommand,
+  ensureAvailable = (slot) =>
+    ensureSlotAvailable(
+      slot,
+      records.filter((candidate) => candidate.id !== id),
+      run,
+    ),
+}) {
+  const record = records.find((candidate) => candidate.id === id);
+  if (!record)
+    throw new Error("Slot owner no longer exists. Refresh and try again.");
+  const slot =
+    targetSlot === record.slot ? record.slot : requestedSlot(targetSlot);
+  const flags = requestedMode(mode);
+  if (!servicesStopped(record.detail))
+    throw new Error("The checkout is not stopped.");
+  if (slot !== record.slot && hasLocalUnmanagedProcess(record)) {
+    throw new Error("Stop the unmanaged process inside this worktree first.");
+  }
+  if (slot === record.slot) {
+    if (record.conflict)
+      throw new Error("Resolve or reassign the duplicate slot first.");
+    if (unmanagedListener(record.detail))
+      throw new Error("A slot port has an unmanaged owner.");
+  } else {
+    await ensureAvailable(slot);
+  }
+  const command = path.join(record.worktree, "dev");
+  if (slot !== record.slot && !record.conflict) {
+    await composeDown({ record, run });
+  }
+  return run(command, ["up", "--slot", String(slot), ...flags], {
+    cwd: record.worktree,
+  });
+}
+
+export async function restartSlot({ id, mode, records, run = runCommand }) {
+  const record = records.find((candidate) => candidate.id === id);
+  if (!record)
+    throw new Error("Slot owner no longer exists. Refresh and try again.");
+  if (
+    record.conflict ||
+    unmanagedListener(record.detail) ||
+    !hasManagedService(record.detail)
+  ) {
+    throw new Error("This slot is not safely restartable.");
+  }
+  const flags = requestedMode(mode);
+  const command = path.join(record.worktree, "dev");
+  await run(command, ["down", "--slot", String(record.slot)], {
+    cwd: record.worktree,
+  });
+  return run(command, ["up", "--slot", String(record.slot), ...flags], {
+    cwd: record.worktree,
+  });
+}

--- a/scripts/dev-slots-ui.mjs
+++ b/scripts/dev-slots-ui.mjs
@@ -1,0 +1,450 @@
+#!/usr/bin/env node
+import { randomBytes } from "node:crypto";
+import http from "node:http";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { createSlotsHandler as createApiHandler } from "./dev-slots-api.mjs";
+import { discoverSlotsWithRemoval } from "./dev-slots-worktree.mjs";
+
+export async function disableDuring(button, action) {
+  button.disabled = true;
+  try {
+    return await action();
+  } catch (error) {
+    button.disabled = false;
+    throw error;
+  }
+}
+
+export function updateNotice(notice, message, isError = false) {
+  notice.textContent = message;
+  notice.style.color = isError ? "#ff9aa8" : "";
+}
+
+export function selectableSlots(slot, availableSlots) {
+  const alternatives = availableSlots.filter((choice) => choice !== slot.slot);
+  return slot.startAllowed ? [slot.slot, ...alternatives] : alternatives;
+}
+
+export function startActionLabel(currentSlot, targetSlot) {
+  return currentSlot === targetSlot ? "Start" : "Reassign & start";
+}
+
+function page(token) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ayunis Dev Slots</title>
+  <script>
+    try {
+      const savedTheme = localStorage.getItem('dev-slots-theme');
+      const preferredTheme = matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+      document.documentElement.dataset.theme = savedTheme ?? preferredTheme;
+    } catch { document.documentElement.dataset.theme = 'dark'; }
+  </script>
+  <style>
+    :root {
+      color-scheme: dark;
+      font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+      --background: #0b0d10;
+      --glow: #1b2634;
+      --text: #f3f5f7;
+      --muted: #9ca6b3;
+      --branch: #b9c3cf;
+      --surface: rgba(19, 23, 29, .88);
+      --surface-solid: #101419;
+      --subtle-surface: #0c0f13;
+      --border: #2a3039;
+      --divider: #353b44;
+      --secondary: #252b33;
+      --secondary-hover: #303842;
+      --secondary-text: #d9e0e7;
+      --primary: #edf2f7;
+      --primary-hover: #fff;
+      --primary-text: #11151a;
+      --path-text: #9faab6;
+      --pre-text: #c7d2df;
+      --success: #91d9b3;
+      --warning-surface: #2e2115;
+      --warning-text: #ffc279;
+      background: var(--background);
+      color: var(--text);
+    }
+    :root[data-theme="light"] {
+      color-scheme: light;
+      --background: #f4f6f8;
+      --glow: #dbe9f5;
+      --text: #17202a;
+      --muted: #66717e;
+      --branch: #4f5c69;
+      --surface: rgba(255, 255, 255, .9);
+      --surface-solid: #fff;
+      --subtle-surface: #f6f8fa;
+      --border: #d8dee5;
+      --divider: #d5dbe2;
+      --secondary: #e8edf2;
+      --secondary-hover: #dce3e9;
+      --secondary-text: #26323e;
+      --primary: #17202a;
+      --primary-hover: #293746;
+      --primary-text: #fff;
+      --path-text: #566370;
+      --pre-text: #33404d;
+      --success: #24734a;
+      --warning-surface: #fff1da;
+      --warning-text: #8b4a08;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-height: 100vh; background: radial-gradient(circle at 15% 0%, var(--glow) 0, transparent 40%), var(--background); color: var(--text); }
+    main { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 56px 0 80px; }
+    header { display: flex; justify-content: space-between; gap: 24px; align-items: end; margin-bottom: 32px; }
+    h1 { margin: 0; font-size: clamp(2rem, 5vw, 3.5rem); letter-spacing: -.055em; line-height: .95; }
+    header p { margin: 12px 0 0; color: var(--muted); }
+    button, .link { border: 0; border-radius: 10px; padding: 10px 14px; font: inherit; font-weight: 650; cursor: pointer; text-decoration: none; }
+    button { background: var(--primary); color: var(--primary-text); }
+    button:hover { background: var(--primary-hover); }
+    button:disabled { cursor: not-allowed; opacity: .45; }
+    select { border: 1px solid var(--border); border-radius: 9px; padding: 9px 10px; background: var(--subtle-surface); color: var(--text); font: inherit; }
+    .mode { display: grid; gap: 4px; color: var(--muted); font-size: .75rem; font-weight: 700; }
+    .grid { display: grid; gap: 16px; }
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: 16px; padding: 20px; box-shadow: 0 14px 40px rgba(0,0,0,.1); }
+    .card-head, .actions, .meta { display: flex; align-items: center; gap: 10px; }
+    .card-head { justify-content: space-between; align-items: start; }
+    h2 { margin: 0; font-size: 1.25rem; letter-spacing: -.02em; }
+    .branch { margin-top: 5px; color: var(--branch); overflow-wrap: anywhere; }
+    .badge { border-radius: 999px; padding: 5px 9px; font-size: .76rem; font-weight: 750; text-transform: uppercase; letter-spacing: .06em; background: #26303b; color: #cbd5df; }
+    .running { background: #143b2b; color: #7ce2ad; }
+    .attention { background: #482c13; color: #ffc279; }
+    .stopped { background: #292e35; color: #adb6c0; }
+    .conflict { background: #4d1f27; color: #ff9aa8; }
+    .meta { margin: 18px 0; flex-wrap: wrap; color: var(--muted); font-size: .9rem; }
+    .meta span { border-right: 1px solid var(--divider); padding-right: 10px; }
+    .meta span:last-child { border: 0; }
+    .path { padding: 11px 12px; background: var(--subtle-surface); border: 1px solid var(--border); border-radius: 9px; color: var(--path-text); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .79rem; overflow-wrap: anywhere; }
+    .warning { margin-bottom: 12px; padding: 10px 12px; border-radius: 9px; background: var(--warning-surface); color: var(--warning-text); font-size: .86rem; }
+    .diagnostics { margin-bottom: 12px; overflow: hidden; border: 1px solid var(--border); border-radius: 10px; background: var(--subtle-surface); }
+    .diagnostics summary { padding: 11px 12px; cursor: pointer; font-weight: 700; }
+    .process { display: grid; gap: 9px; padding: 14px 12px; border-top: 1px solid var(--border); }
+    .process-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+    .process-command { color: var(--pre-text); font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; overflow-wrap: anywhere; }
+    .process-owner, .recommendation { color: var(--muted); font-size: .84rem; overflow-wrap: anywhere; }
+    .recommendation { color: var(--text); }
+    .owner-active-worktree { background: #143b2b; color: #7ce2ad; }
+    .owner-orphan { background: #4d1f27; color: #ff9aa8; }
+    .actions { margin-top: 16px; justify-content: flex-end; flex-wrap: wrap; }
+    .secondary { background: var(--secondary); color: var(--secondary-text); }
+    .secondary:hover { background: var(--secondary-hover); }
+    .danger { background: #56232b; color: #ffc7cf; }
+    .danger:hover { background: #6c2934; }
+    .empty, .error { padding: 56px 24px; text-align: center; color: var(--muted); }
+    dialog { width: min(850px, calc(100% - 32px)); border: 1px solid var(--border); border-radius: 16px; background: var(--surface-solid); color: var(--text); padding: 0; }
+    dialog::backdrop { background: rgba(0,0,0,.7); backdrop-filter: blur(4px); }
+    .dialog-head { display: flex; justify-content: space-between; align-items: center; padding: 16px 18px; border-bottom: 1px solid var(--border); }
+    pre { margin: 0; padding: 18px; max-height: 65vh; overflow: auto; color: var(--pre-text); font: 12px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; }
+    #notice { min-height: 24px; margin: 0 0 14px; color: var(--success); }
+    @media (max-width: 760px) { header { align-items: start; flex-direction: column; } .card-head { gap: 14px; } }
+  </style>
+</head>
+<body>
+  <main>
+    <header><div><h1>Dev slots</h1><p>Every checkout, one calm control surface.</p></div><div class="actions"><label class="mode">Run mode<select id="mode"><option value="standard">Standard</option><option value="e2e">E2E mocks</option><option value="anonymisation">With anonymisation</option></select></label><button class="danger" id="stop-all">Stop all safely</button><button class="secondary" id="theme">Light mode</button><button id="refresh">Refresh</button></div></header>
+    <p id="notice" role="status"></p>
+    <section id="slots" class="grid" aria-live="polite"><div class="card empty">Inspecting worktrees…</div></section>
+  </main>
+  <dialog id="logs"><div class="dialog-head"><strong>Slot logs</strong><button class="secondary" id="close-logs">Close</button></div><pre></pre></dialog>
+  <script>
+    const token = ${JSON.stringify(token)};
+    const slotsElement = document.querySelector('#slots');
+    const notice = document.querySelector('#notice');
+    const logsDialog = document.querySelector('#logs');
+    const stopAllButton = document.querySelector('#stop-all');
+    const themeButton = document.querySelector('#theme');
+    const disableDuring = ${disableDuring.toString()};
+    const updateNotice = ${updateNotice.toString()};
+    const selectableSlots = ${selectableSlots.toString()};
+    const startActionLabel = ${startActionLabel.toString()};
+    let availableSlots = [];
+    let slots = [];
+    const setText = (element, value) => { element.textContent = value; return element; };
+    const make = (tag, className, text) => {
+      const element = document.createElement(tag);
+      if (className) element.className = className;
+      if (text !== undefined) element.textContent = text;
+      return element;
+    };
+    function diagnosticPanel(diagnostics) {
+      const details = make('details', 'diagnostics');
+      const noun = diagnostics.length === 1 ? 'listener' : 'listeners';
+      details.append(make('summary', '', diagnostics.length + ' unmanaged ' + noun));
+      for (const diagnostic of diagnostics) {
+        const process = make('div', 'process');
+        const head = make('div', 'process-head');
+        head.append(
+          make('strong', '', diagnostic.service + ' · port ' + diagnostic.port),
+          make('span', 'badge owner-' + diagnostic.owner.kind, diagnostic.owner.label),
+        );
+        const owner = diagnostic.owner.branch
+          ? 'Owner: ' + diagnostic.owner.branch + ' · ' + diagnostic.owner.worktree
+          : 'Working directory: ' + diagnostic.cwd;
+        process.append(
+          head,
+          make('div', 'process-owner', 'PID ' + diagnostic.pid + ' · ' + owner),
+          make('div', 'process-command', diagnostic.command),
+          make('div', 'recommendation', diagnostic.recommendation),
+        );
+        details.append(process);
+      }
+      return details;
+    }
+    function card(slot) {
+      const article = make('article', 'card');
+      const head = make('div', 'card-head');
+      const title = make('div');
+      title.append(make('h2', '', 'Slot ' + slot.slot), make('div', 'branch', slot.branch));
+      const badges = make('div', 'actions');
+      badges.append(make('span', 'badge ' + slot.summary, slot.summary));
+      if (slot.conflict) badges.append(make('span', 'badge conflict', 'conflict'));
+      head.append(title, badges);
+      const meta = make('div', 'meta');
+      meta.append(
+        make('span', '', 'Frontend :' + slot.ports.frontend),
+        make('span', '', 'Backend :' + slot.ports.backend),
+        make('span', '', slot.dirty ? 'Dirty worktree' : 'Clean worktree'),
+      );
+      const actions = make('div', 'actions');
+      if (slot.frontendRunning) {
+        const open = make('a', 'link secondary', 'Open app');
+        open.href = 'http://localhost:' + slot.ports.frontend;
+        open.target = '_blank';
+        actions.append(open);
+      }
+      const logButton = make('button', 'secondary', 'Logs');
+      logButton.onclick = () => showLogs(slot).catch(showError);
+      if (slot.startAllowed || slot.reassignAllowed) {
+        const slotSelect = make('select', 'slot-select');
+        slotSelect.setAttribute('aria-label', 'Slot for ' + slot.branch);
+        const choices = selectableSlots(slot, availableSlots);
+        for (const choice of choices) {
+          const option = make('option', '', 'Slot ' + choice);
+          option.value = choice;
+          slotSelect.append(option);
+        }
+        if (!choices.length) {
+          const option = make('option', '', 'No free slots');
+          option.value = '';
+          slotSelect.append(option);
+          slotSelect.disabled = true;
+        }
+        const startButton = make('button', '', startActionLabel(slot.slot, Number(slotSelect.value)));
+        startButton.disabled = !choices.length;
+        slotSelect.onchange = () => { startButton.textContent = startActionLabel(slot.slot, Number(slotSelect.value)); };
+        startButton.onclick = () => start(slot, slotSelect, startButton).catch(showError);
+        actions.append(slotSelect, startButton);
+      }
+      if (slot.restartAllowed) {
+        const restartButton = make('button', '', 'Restart');
+        restartButton.onclick = () => restart(slot, restartButton).catch(showError);
+        actions.append(restartButton);
+      }
+      if (slot.releaseAllowed) {
+        const releaseButton = make('button', 'secondary', 'Release claim');
+        releaseButton.onclick = () => releaseClaim(slot, releaseButton).catch(showError);
+        actions.append(releaseButton);
+      }
+      if (slot.deleteDataAllowed) {
+        const deleteButton = make('button', 'danger', 'Delete slot data');
+        deleteButton.onclick = () => deleteData(slot, deleteButton).catch(showError);
+        actions.append(deleteButton);
+      }
+      if (!slot.removalProtection) {
+        const removeButton = make('button', 'danger', 'Remove worktree');
+        removeButton.disabled = !slot.removeWorktreeAllowed;
+        removeButton.title = slot.removeWorktreeBlockedReason ?? '';
+        removeButton.onclick = () => removeWorktree(slot, removeButton).catch(showError);
+        actions.append(removeButton);
+      }
+      const stopButton = make('button', 'danger', 'Stop safely');
+      stopButton.disabled = !slot.stopAllowed;
+      stopButton.title = slot.stopBlockedReason ?? (!slot.stopAllowed ? 'No safely stoppable managed services were detected.' : '');
+      stopButton.onclick = () => stop(slot, stopButton).catch(showError);
+      actions.append(logButton, stopButton);
+      article.append(head, meta);
+      if (slot.stopBlockedReason) article.append(make('div', 'warning', slot.stopBlockedReason));
+      if (slot.diagnostics?.length) article.append(diagnosticPanel(slot.diagnostics));
+      article.append(make('div', 'path', slot.worktree), actions);
+      return article;
+    }
+    async function load({ clearNotice = true } = {}) {
+      if (clearNotice) updateNotice(notice, '');
+      const response = await fetch('/api/slots', { cache: 'no-store', headers: { 'x-dev-slots-token': token } });
+      if (!response.ok) throw new Error(await response.text());
+      const result = await response.json();
+      slots = result.slots;
+      availableSlots = result.availableSlots;
+      stopAllButton.disabled = !slots.some((slot) => slot.stopAllowed);
+      slotsElement.replaceChildren(...(slots.length ? slots.map(card) : [make('div', 'card empty', 'No worktree has selected a slot yet.') ]));
+    }
+    async function stop(slot, button) {
+      if (!confirm('Stop slot ' + slot.slot + ' owned by ' + slot.branch + '? Database data will be preserved.')) return;
+      return disableDuring(button, async () => {
+        updateNotice(notice, 'Stopping slot ' + slot.slot + '…');
+        const response = await fetch('/api/slots/' + slot.id + '/stop', { method: 'POST', headers: { 'x-dev-slots-token': token } });
+        const result = await response.json();
+        if (!response.ok) throw new Error(result.error);
+        updateNotice(notice, 'Slot ' + slot.slot + ' stopped. Data was preserved.');
+        await load({ clearNotice: false });
+      });
+    }
+    async function stopAll(button) {
+      const count = slots.filter((slot) => slot.stopAllowed).length;
+      if (!count || !confirm('Stop ' + count + ' safely stoppable slot' + (count === 1 ? '' : 's') + '? Database data will be preserved; blocked slots will be skipped.')) return;
+      return disableDuring(button, async () => {
+        updateNotice(notice, 'Stopping ' + count + ' slot' + (count === 1 ? '' : 's') + '…');
+        const response = await fetch('/api/slots/stop-all', { method: 'POST', headers: { 'x-dev-slots-token': token } });
+        const result = await response.json();
+        if (!response.ok) throw new Error(result.error);
+        const message = 'Stopped ' + result.stopped.length + '; skipped ' + result.skipped.length + '; failed ' + result.failed.length + '.';
+        updateNotice(notice, message, result.failed.length > 0);
+        await load({ clearNotice: false });
+      });
+    }
+    async function releaseClaim(slot, button) {
+      const message = 'Release slot ' + slot.slot + ' from ' + slot.branch + '? This only clears the slot selection; worktree and database data stay untouched.';
+      if (!confirm(message)) return;
+      return disableDuring(button, async () => {
+        updateNotice(notice, 'Releasing slot ' + slot.slot + ' claim…');
+        const response = await fetch('/api/slots/' + slot.id + '/release', { method: 'POST', headers: { 'x-dev-slots-token': token } });
+        const result = await response.json();
+        if (!response.ok) throw new Error(result.error);
+        updateNotice(notice, 'Slot ' + slot.slot + ' claim released. Worktree and database data were preserved.');
+        await load({ clearNotice: false });
+      });
+    }
+    async function deleteData(slot, button) {
+      const expected = 'DELETE SLOT ' + slot.slot;
+      const confirmation = prompt('Permanently delete Postgres and MinIO data for slot ' + slot.slot + ' (' + slot.branch + ')? The worktree and slot claim will remain. Type ' + expected + ' to continue.');
+      if (confirmation === null) return;
+      return disableDuring(button, async () => {
+        updateNotice(notice, 'Deleting data for slot ' + slot.slot + '…');
+        const query = new URLSearchParams({ confirmation });
+        const response = await fetch('/api/slots/' + slot.id + '/delete-data?' + query, { method: 'POST', headers: { 'x-dev-slots-token': token } });
+        const result = await response.json();
+        if (!response.ok) throw new Error(result.error);
+        updateNotice(notice, 'Slot ' + slot.slot + ' data deleted. Worktree and slot claim were preserved.');
+        await load({ clearNotice: false });
+      });
+    }
+    async function removeWorktree(slot, button) {
+      const expected = 'REMOVE WORKTREE ' + slot.slot;
+      const confirmation = prompt('Permanently remove worktree ' + slot.worktree + '? Its slot claim will be removed with it, but branch ' + slot.branch + ' will remain. Type ' + expected + ' to continue.');
+      if (confirmation === null) return;
+      return disableDuring(button, async () => {
+        updateNotice(notice, 'Removing worktree for slot ' + slot.slot + '…');
+        const query = new URLSearchParams({ confirmation });
+        const response = await fetch('/api/slots/' + slot.id + '/remove-worktree?' + query, { method: 'POST', headers: { 'x-dev-slots-token': token } });
+        const result = await response.json();
+        if (!response.ok) throw new Error(result.error);
+        updateNotice(notice, 'Worktree removed. Branch ' + slot.branch + ' was preserved.');
+        await load({ clearNotice: false });
+      });
+    }
+    function selectedMode() { return document.querySelector('#mode').value; }
+    async function start(slot, slotSelect, button) {
+      const targetSlot = Number(slotSelect.value);
+      const mode = selectedMode();
+      const movement = targetSlot === slot.slot ? '' : ' and move its claim to slot ' + targetSlot;
+      if (!confirm('Start ' + slot.branch + movement + ' in ' + mode + ' mode?')) return;
+      return disableDuring(button, async () => {
+        updateNotice(notice, 'Starting ' + slot.branch + ' on slot ' + targetSlot + '…');
+        const query = new URLSearchParams({ slot: String(targetSlot), mode });
+        const response = await fetch('/api/slots/' + slot.id + '/start?' + query, { method: 'POST', headers: { 'x-dev-slots-token': token } });
+        const result = await response.json();
+        if (!response.ok) throw new Error(result.error);
+        updateNotice(notice, 'Slot ' + targetSlot + ' is ready in ' + mode + ' mode.');
+        await load({ clearNotice: false });
+      });
+    }
+    async function restart(slot, button) {
+      const mode = selectedMode();
+      if (!confirm('Restart slot ' + slot.slot + ' in ' + mode + ' mode? Database data will be preserved.')) return;
+      return disableDuring(button, async () => {
+        updateNotice(notice, 'Restarting slot ' + slot.slot + '…');
+        const query = new URLSearchParams({ mode });
+        const response = await fetch('/api/slots/' + slot.id + '/restart?' + query, { method: 'POST', headers: { 'x-dev-slots-token': token } });
+        const result = await response.json();
+        if (!response.ok) throw new Error(result.error);
+        updateNotice(notice, 'Slot ' + slot.slot + ' restarted in ' + mode + ' mode.');
+        await load({ clearNotice: false });
+      });
+    }
+    async function showLogs(slot) {
+      setText(logsDialog.querySelector('strong'), 'Slot ' + slot.slot + ' logs');
+      setText(logsDialog.querySelector('pre'), 'Loading…');
+      logsDialog.showModal();
+      const response = await fetch('/api/slots/' + slot.id + '/logs', { headers: { 'x-dev-slots-token': token } });
+      const result = await response.json();
+      setText(logsDialog.querySelector('pre'), response.ok ? result.logs : result.error);
+    }
+    document.querySelector('#refresh').onclick = () => load().catch(showError);
+    stopAllButton.onclick = () => stopAll(stopAllButton).catch(showError);
+    document.querySelector('#close-logs').onclick = () => logsDialog.close();
+    function updateThemeButton() {
+      const isLight = document.documentElement.dataset.theme === 'light';
+      themeButton.textContent = isLight ? 'Dark mode' : 'Light mode';
+    }
+    themeButton.onclick = () => {
+      const theme = document.documentElement.dataset.theme === 'light' ? 'dark' : 'light';
+      document.documentElement.dataset.theme = theme;
+      try { localStorage.setItem('dev-slots-theme', theme); } catch {}
+      updateThemeButton();
+    };
+    function showError(error) { updateNotice(notice, error.message, true); }
+    updateThemeButton();
+    load().catch(showError);
+  </script>
+</body>
+</html>`;
+}
+
+export function createSlotsHandler(options) {
+  return createApiHandler({ ...options, renderPage: page });
+}
+
+export function createSlotsServer(options) {
+  return http.createServer(createSlotsHandler(options));
+}
+
+export async function main(args = process.argv.slice(2)) {
+  const repoDir = path.resolve(import.meta.dirname, "..");
+  const command = args[0] ?? "serve";
+  if (command === "list") {
+    process.stdout.write(
+      `${JSON.stringify(await discoverSlotsWithRemoval(repoDir), null, 2)}\n`,
+    );
+    return;
+  }
+  if (command !== "serve")
+    throw new Error(`Unknown dev slots command: ${command}`);
+  const portIndex = args.indexOf("--port");
+  const port = portIndex === -1 ? 4317 : Number(args[portIndex + 1]);
+  if (!Number.isInteger(port) || port < 1 || port > 65535)
+    throw new Error("--port must be a valid port number.");
+  const token = randomBytes(24).toString("base64url");
+  const server = createSlotsServer({ repoDir, token });
+  server.listen(port, "127.0.0.1", () => {
+    process.stdout.write(`Ayunis dev slots: http://127.0.0.1:${port}\n`);
+  });
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    process.stderr.write(`ERROR: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/dev-slots-worktree.mjs
+++ b/scripts/dev-slots-worktree.mjs
@@ -1,0 +1,179 @@
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+
+import {
+  buildSlotRecords,
+  parseWorktrees,
+  runCommand,
+} from "./dev-slots-lib.mjs";
+
+const stoppedServices = (detail) =>
+  /Backend:\s+stopped/i.test(detail ?? "") &&
+  /Frontend:\s+stopped/i.test(detail ?? "");
+
+function staticBlockReason(record, repoDir, primaryWorktree) {
+  if (record.worktree === repoDir || record.removalProtection === "dashboard") {
+    return "This worktree is serving the dashboard.";
+  }
+  if (
+    record.worktree === primaryWorktree ||
+    record.removalProtection === "primary"
+  ) {
+    return "The primary checkout cannot be removed as a linked worktree.";
+  }
+  if (!stoppedServices(record.detail))
+    return "Stop the worktree's services first.";
+  if (record.conflict) return "Resolve the duplicate slot claim first.";
+  if (/occupied by unmanaged PID/i.test(record.detail ?? "")) {
+    return "Resolve the unmanaged slot listener first.";
+  }
+  if (record.dirty)
+    return "The worktree is dirty; commit, stash, or discard its changes first.";
+  if (record.detached)
+    return "A detached worktree cannot be removed from the dashboard.";
+  if (record.prunable)
+    return "Prune this stale worktree manually before removing it.";
+  return null;
+}
+
+async function slotResources(record, run) {
+  const label = `label=com.docker.compose.project=ayunis-dev-${record.slot}`;
+  const resources = [];
+  for (const kind of ["container", "volume", "network"]) {
+    const quietFlag = kind === "container" ? "-aq" : "-q";
+    const output = await run("docker", [
+      kind,
+      "ls",
+      quietFlag,
+      "--filter",
+      label,
+    ]);
+    if (output) resources.push(kind);
+  }
+  return resources;
+}
+
+const blockedRemoval = (reason, upstream = null) => ({
+  removeWorktreeAllowed: false,
+  removeWorktreeBlockedReason: reason,
+  upstream,
+});
+
+async function inspectPublishedBranch(record, run) {
+  let upstream;
+  try {
+    upstream = await run(
+      "git",
+      ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+      { cwd: record.worktree },
+    );
+  } catch {
+    return blockedRemoval("The branch has no published upstream.");
+  }
+  const ahead = Number(
+    await run("git", ["rev-list", "--count", "@{upstream}..HEAD"], {
+      cwd: record.worktree,
+    }),
+  );
+  return ahead > 0
+    ? blockedRemoval(
+        `${ahead} unpushed commit${ahead === 1 ? "" : "s"} remain.`,
+        upstream,
+      )
+    : { upstream };
+}
+
+async function inspectSlotResources(record, upstream, run) {
+  try {
+    return (await slotResources(record, run)).length
+      ? blockedRemoval("Delete slot data first.", upstream)
+      : null;
+  } catch {
+    return blockedRemoval("Docker resources could not be verified.", upstream);
+  }
+}
+
+export async function inspectWorktreeRemoval({
+  record,
+  repoDir,
+  primaryWorktree,
+  run,
+}) {
+  const blocked = staticBlockReason(record, repoDir, primaryWorktree);
+  if (blocked) return blockedRemoval(blocked);
+  const publication = await inspectPublishedBranch(record, run);
+  if (publication.removeWorktreeBlockedReason) return publication;
+  const { upstream } = publication;
+  const resourceBlock = await inspectSlotResources(record, upstream, run);
+  if (resourceBlock) return resourceBlock;
+  return {
+    removeWorktreeAllowed: true,
+    removeWorktreeBlockedReason: null,
+    upstream,
+  };
+}
+
+export async function removeWorktree({
+  id,
+  confirmation,
+  records,
+  repoDir,
+  run = runCommand,
+  inspect = inspectWorktreeRemoval,
+  readSlot = async (worktree) =>
+    Number(
+      (await readFile(path.join(worktree, ".dev", "slot"), "utf8")).trim(),
+    ),
+}) {
+  const record = records.find((candidate) => candidate.id === id);
+  if (!record)
+    throw new Error("Slot owner no longer exists. Refresh and try again.");
+  const expected = `REMOVE WORKTREE ${record.slot}`;
+  if (confirmation !== expected)
+    throw new Error(`Type ${expected} to remove this worktree.`);
+  if ((await readSlot(record.worktree)) !== record.slot) {
+    throw new Error(
+      "The worktree's selected slot changed. Refresh and try again.",
+    );
+  }
+  const dirty = Boolean(
+    await run("git", ["status", "--short"], { cwd: record.worktree }),
+  );
+  const safety = await inspect({ record: { ...record, dirty }, repoDir, run });
+  if (!safety.removeWorktreeAllowed)
+    throw new Error(safety.removeWorktreeBlockedReason);
+  await run("git", ["worktree", "remove", record.worktree], { cwd: repoDir });
+  return `Removed worktree ${record.worktree}. The branch was preserved.`;
+}
+
+function removalProtection(worktree, repoDir, primaryWorktree) {
+  if (path.resolve(worktree) === path.resolve(repoDir)) return "dashboard";
+  if (path.resolve(worktree) === path.resolve(primaryWorktree))
+    return "primary";
+  return null;
+}
+
+export async function discoverSlotsWithRemoval(repoDir, run = runCommand) {
+  const output = await run("git", ["worktree", "list", "--porcelain"], {
+    cwd: repoDir,
+  });
+  const worktrees = parseWorktrees(output);
+  const primaryWorktree = worktrees[0]?.path ?? repoDir;
+  return buildSlotRecords({
+    worktrees,
+    inspectRemoval: async (record) => {
+      const protection = removalProtection(
+        record.worktree,
+        repoDir,
+        primaryWorktree,
+      );
+      const safety = await inspectWorktreeRemoval({
+        record: { ...record, removalProtection: protection },
+        repoDir,
+        primaryWorktree,
+        run,
+      });
+      return { ...safety, removalProtection: protection };
+    },
+  });
+}

--- a/scripts/dev-slots.test.mjs
+++ b/scripts/dev-slots.test.mjs
@@ -1,0 +1,1264 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  buildSlotRecords,
+  classifyProcessOwner,
+  inspectUnmanagedListeners,
+  listListeningPorts,
+  parseWorktrees,
+  parseUnmanagedListeners,
+  releaseSlotClaim,
+  runCommand,
+  stopAllSlots,
+  stopSlot,
+  suggestAvailableSlots,
+} from "./dev-slots-lib.mjs";
+import { restartSlot, startSlot } from "./dev-slots-lifecycle.mjs";
+import { deleteSlotData } from "./dev-slots-cleanup.mjs";
+import {
+  inspectWorktreeRemoval,
+  removeWorktree,
+} from "./dev-slots-worktree.mjs";
+import {
+  createSlotsHandler,
+  disableDuring,
+  selectableSlots,
+  startActionLabel,
+  updateNotice,
+} from "./dev-slots-ui.mjs";
+
+test("parseWorktrees keeps branch and detached checkout information", () => {
+  const worktrees = parseWorktrees(`worktree /repo/main
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo/review
+HEAD def456
+detached
+prunable gitdir file points to non-existent location
+`);
+
+  assert.deepEqual(worktrees, [
+    {
+      path: "/repo/main",
+      head: "abc123",
+      branch: "main",
+      detached: false,
+      prunable: false,
+    },
+    {
+      path: "/repo/review",
+      head: "def456",
+      branch: "detached",
+      detached: true,
+      prunable: true,
+    },
+  ]);
+});
+
+test("parseUnmanagedListeners extracts every service, port, and PID", () => {
+  const listeners =
+    parseUnmanagedListeners(`Backend:   stopped  port 3080 occupied by unmanaged PID 4175 4176
+Frontend:  stopped  port 3081 occupied by unmanaged PID 5000`);
+
+  assert.deepEqual(listeners, [
+    { service: "Backend", port: 3080, pid: 4175 },
+    { service: "Backend", port: 3080, pid: 4176 },
+    { service: "Frontend", port: 3081, pid: 5000 },
+  ]);
+});
+
+test("classifyProcessOwner distinguishes active worktrees and verified orphans", () => {
+  const worktrees = [
+    { path: "/repo/main", branch: "main" },
+    { path: "/repo/review", branch: "review" },
+  ];
+
+  assert.deepEqual(
+    classifyProcessOwner("/repo/review/ayunis-core-backend", worktrees),
+    {
+      kind: "active-worktree",
+      label: "Active worktree",
+      worktree: "/repo/review",
+      branch: "review",
+    },
+  );
+  assert.deepEqual(
+    classifyProcessOwner("/repo/main/.git/wt/trash/old", worktrees),
+    {
+      kind: "orphan",
+      label: "Trashed orphan",
+      worktree: null,
+      branch: null,
+    },
+  );
+  assert.deepEqual(classifyProcessOwner("/repo/review (deleted)", worktrees), {
+    kind: "orphan",
+    label: "Deleted-directory orphan",
+    worktree: null,
+    branch: null,
+  });
+  assert.deepEqual(classifyProcessOwner("/tmp/unrelated", worktrees), {
+    kind: "unknown",
+    label: "Unknown owner",
+    worktree: null,
+    branch: null,
+  });
+});
+
+test("classifyProcessOwner chooses a nested worktree over its parent checkout", () => {
+  const owner = classifyProcessOwner(
+    "/repo/.claude/worktrees/review/ayunis-core-frontend",
+    [
+      { path: "/repo", branch: "main" },
+      { path: "/repo/.claude/worktrees/review", branch: "review" },
+    ],
+  );
+
+  assert.equal(owner.worktree, "/repo/.claude/worktrees/review");
+  assert.equal(owner.branch, "review");
+});
+
+test("inspectUnmanagedListeners reports command and owning worktree", async () => {
+  const diagnostics = await inspectUnmanagedListeners({
+    detail: "Backend: stopped port 3080 occupied by unmanaged PID 4175",
+    worktrees: [
+      { path: "/repo/main", branch: "main" },
+      { path: "/repo/review", branch: "review" },
+    ],
+    run: async (command) =>
+      command === "ps"
+        ? "node nest start --watch"
+        : "p4175\nfcwd\nn/repo/review/ayunis-core-backend",
+  });
+
+  assert.deepEqual(diagnostics, [
+    {
+      service: "Backend",
+      port: 3080,
+      pid: 4175,
+      command: "node nest start --watch",
+      cwd: "/repo/review/ayunis-core-backend",
+      owner: {
+        kind: "active-worktree",
+        label: "Active worktree",
+        worktree: "/repo/review",
+        branch: "review",
+      },
+      recommendation: "Stop this slot from the owning worktree.",
+    },
+  ]);
+});
+
+test("inspectUnmanagedListeners does not recommend dev down for an untracked local process", async () => {
+  const diagnostics = await inspectUnmanagedListeners({
+    detail: "Backend: stopped port 3080 occupied by unmanaged PID 4175",
+    claimWorktree: "/repo/review",
+    worktrees: [{ path: "/repo/review", branch: "review" }],
+    run: async (command) =>
+      command === "ps"
+        ? "node nest start --watch"
+        : "n/repo/review/ayunis-core-backend",
+  });
+
+  assert.equal(
+    diagnostics[0].recommendation,
+    "This process is inside the checkout but is not tracked; inspect it manually.",
+  );
+});
+
+test("buildSlotRecords lists only worktrees that have selected a valid slot", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "dev-slots-"));
+  const main = path.join(root, "main");
+  const review = path.join(root, "review");
+  const unused = path.join(root, "unused");
+  await Promise.all([
+    mkdir(path.join(main, ".dev"), { recursive: true }),
+    mkdir(path.join(review, ".dev"), { recursive: true }),
+    mkdir(path.join(unused, ".dev"), { recursive: true }),
+  ]);
+  await Promise.all([
+    writeFile(path.join(main, ".dev", "slot"), "2\n"),
+    writeFile(path.join(review, ".dev", "slot"), "2\n"),
+    writeFile(path.join(unused, ".dev", "slot"), "not-a-slot\n"),
+  ]);
+
+  const records = await buildSlotRecords({
+    worktrees: [
+      {
+        path: main,
+        head: "aaa",
+        branch: "main",
+        detached: false,
+        prunable: false,
+      },
+      {
+        path: review,
+        head: "bbb",
+        branch: "review",
+        detached: false,
+        prunable: false,
+      },
+      {
+        path: unused,
+        head: "ccc",
+        branch: "unused",
+        detached: false,
+        prunable: false,
+      },
+    ],
+    inspect: async ({ worktree }) => ({
+      summary: worktree === main ? "running" : "stopped",
+      detail: "status output",
+    }),
+    isDirty: async ({ worktree }) => worktree === review,
+  });
+
+  assert.equal(records.length, 2);
+  assert.deepEqual(
+    records.map(({ slot, branch, summary, conflict, dirty }) => ({
+      slot,
+      branch,
+      summary,
+      conflict,
+      dirty,
+    })),
+    [
+      {
+        slot: 2,
+        branch: "main",
+        summary: "running",
+        conflict: true,
+        dirty: false,
+      },
+      {
+        slot: 2,
+        branch: "review",
+        summary: "stopped",
+        conflict: true,
+        dirty: true,
+      },
+    ],
+  );
+});
+
+test("buildSlotRecords only marks the frontend open when it is running", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "dev-slots-frontend-"));
+  await mkdir(path.join(root, ".dev"), { recursive: true });
+  await writeFile(path.join(root, ".dev", "slot"), "4\n");
+
+  const [record] = await buildSlotRecords({
+    worktrees: [
+      {
+        path: root,
+        head: "aaa",
+        branch: "main",
+        detached: false,
+        prunable: false,
+      },
+    ],
+    inspect: async () => ({
+      summary: "running",
+      detail: "Backend: running\nFrontend: stopped\nDocker infra: running",
+    }),
+    isDirty: async () => false,
+    diagnose: async () => [],
+  });
+
+  assert.equal(record.frontendRunning, false);
+});
+
+test("buildSlotRecords allows a stopped checkout to move away from an orphan listener", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "dev-slots-orphan-"));
+  await mkdir(path.join(root, ".dev"), { recursive: true });
+  await writeFile(path.join(root, ".dev", "slot"), "8\n");
+
+  const [record] = await buildSlotRecords({
+    worktrees: [
+      {
+        path: root,
+        head: "aaa",
+        branch: "main",
+        detached: false,
+        prunable: false,
+      },
+    ],
+    inspect: async () => ({
+      summary: "attention",
+      detail:
+        "Backend: stopped port 3080 occupied by unmanaged PID 42\nFrontend: stopped",
+    }),
+    isDirty: async () => false,
+    diagnose: async () => [{ owner: { kind: "orphan", worktree: null } }],
+  });
+
+  assert.equal(record.startAllowed, false);
+  assert.equal(record.reassignAllowed, true);
+  assert.equal(record.deleteDataAllowed, false);
+});
+
+test("buildSlotRecords allows managed unhealthy infrastructure to be stopped", async () => {
+  const root = await mkdtemp(
+    path.join(os.tmpdir(), "dev-slots-unhealthy-infra-"),
+  );
+  await mkdir(path.join(root, ".dev"), { recursive: true });
+  await writeFile(path.join(root, ".dev", "slot"), "6\n");
+
+  const [record] = await buildSlotRecords({
+    worktrees: [
+      {
+        path: root,
+        head: "aaa",
+        branch: "main",
+        detached: false,
+        prunable: false,
+      },
+    ],
+    inspect: async () => ({
+      summary: "attention",
+      detail:
+        "postgres  Up 2 minutes (unhealthy)\nBackend: stopped\nFrontend: stopped",
+    }),
+    isDirty: async () => false,
+    diagnose: async () => [],
+  });
+
+  assert.equal(record.stopAllowed, true);
+  assert.equal(record.releaseAllowed, false);
+  assert.equal(record.deleteDataAllowed, true);
+});
+
+test("runCommand does not force the local Infisical fallback", async () => {
+  const previous = process.env.AYUNIS_NO_INFISICAL;
+  delete process.env.AYUNIS_NO_INFISICAL;
+  try {
+    const value = await runCommand(process.execPath, [
+      "-e",
+      "process.stdout.write(process.env.AYUNIS_NO_INFISICAL ?? 'unset')",
+    ]);
+    assert.equal(value, "unset");
+  } finally {
+    if (previous === undefined) delete process.env.AYUNIS_NO_INFISICAL;
+    else process.env.AYUNIS_NO_INFISICAL = previous;
+  }
+});
+
+test("runCommand captures output larger than Node's default child-process buffer", async () => {
+  const value = await runCommand(process.execPath, [
+    "-e",
+    "process.stdout.write('x'.repeat(1100000))",
+  ]);
+
+  assert.equal(value.length, 1_100_000);
+});
+
+test("disableDuring restores a failed action button", async () => {
+  const button = { disabled: false };
+
+  await assert.rejects(
+    disableDuring(button, async () => {
+      assert.equal(button.disabled, true);
+      throw new Error("request failed");
+    }),
+    /request failed/,
+  );
+
+  assert.equal(button.disabled, false);
+});
+
+test("updateNotice clears stale error styling on success", () => {
+  const notice = { textContent: "", style: { color: "" } };
+
+  updateNotice(notice, "Request failed", true);
+  assert.equal(notice.style.color, "#ff9aa8");
+
+  updateNotice(notice, "Slot started");
+  assert.equal(notice.textContent, "Slot started");
+  assert.equal(notice.style.color, "");
+});
+
+test("a safely stopped slot offers its current slot and verified-free alternatives", () => {
+  assert.deepEqual(
+    selectableSlots(
+      { slot: 4, startAllowed: true, reassignAllowed: false },
+      [6, 7],
+    ),
+    [4, 6, 7],
+  );
+  assert.deepEqual(
+    selectableSlots(
+      { slot: 4, startAllowed: false, reassignAllowed: true },
+      [6, 7],
+    ),
+    [6, 7],
+  );
+});
+
+test("the start action label follows the selected target slot", () => {
+  assert.equal(startActionLabel(4, 4), "Start");
+  assert.equal(startActionLabel(4, 6), "Reassign & start");
+});
+
+test("stopSlot refuses a slot claimed by more than one worktree", async () => {
+  const records = [
+    { id: "one", slot: 2, conflict: true, worktree: "/repo/one" },
+    { id: "two", slot: 2, conflict: true, worktree: "/repo/two" },
+  ];
+  let called = false;
+
+  await assert.rejects(
+    stopSlot({
+      id: "one",
+      records,
+      run: async () => {
+        called = true;
+      },
+    }),
+    /claimed by multiple worktrees/,
+  );
+  assert.equal(called, false);
+});
+
+test("stopSlot refuses to partially stop a slot with unmanaged listeners", async () => {
+  let called = false;
+  await assert.rejects(
+    stopSlot({
+      id: "owner",
+      records: [
+        {
+          id: "owner",
+          slot: 8,
+          conflict: false,
+          worktree: "/repo/owner",
+          detail: "Backend: stopped port 3080 occupied by unmanaged PID 42",
+        },
+      ],
+      run: async () => {
+        called = true;
+      },
+    }),
+    /unmanaged process owns a slot port/,
+  );
+  assert.equal(called, false);
+});
+
+test("stopSlot runs the owning checkout's dev command", async () => {
+  const calls = [];
+  const record = {
+    id: "owner",
+    slot: 4,
+    conflict: false,
+    worktree: "/repo/owner",
+  };
+
+  await stopSlot({
+    id: "owner",
+    records: [record],
+    run: async (command, args, options) =>
+      calls.push({ command, args, options }),
+  });
+
+  assert.deepEqual(calls, [
+    {
+      command: "/repo/owner/dev",
+      args: ["down", "--slot", "4"],
+      options: { cwd: "/repo/owner" },
+    },
+  ]);
+});
+
+test("stopAllSlots stops only safe records and continues after failures", async () => {
+  const records = [
+    { id: "safe", slot: 2, branch: "safe", summary: "running", detail: "" },
+    {
+      id: "stopped",
+      slot: 3,
+      branch: "stopped",
+      summary: "stopped",
+      detail: "",
+    },
+    {
+      id: "blocked",
+      slot: 4,
+      branch: "blocked",
+      summary: "attention",
+      conflict: true,
+      detail: "Backend: unhealthy",
+    },
+    { id: "fails", slot: 5, branch: "fails", summary: "running", detail: "" },
+  ];
+  const attempted = [];
+
+  const result = await stopAllSlots({
+    records,
+    stop: async ({ id }) => {
+      attempted.push(id);
+      if (id === "fails") throw new Error("changed while stopping");
+    },
+  });
+
+  assert.deepEqual(attempted, ["safe", "fails"]);
+  assert.deepEqual(
+    result.stopped.map(({ id }) => id),
+    ["safe"],
+  );
+  assert.deepEqual(
+    result.skipped.map(({ id }) => id),
+    ["stopped", "blocked"],
+  );
+  assert.deepEqual(result.failed, [
+    {
+      id: "fails",
+      slot: 5,
+      branch: "fails",
+      error: "changed while stopping",
+    },
+  ]);
+});
+
+test("deleteSlotData requires exact confirmation and removes only the slot compose data", async () => {
+  const calls = [];
+  const records = [
+    {
+      id: "owner",
+      slot: 6,
+      branch: "cleanup",
+      worktree: "/repo/owner",
+      deleteDataAllowed: true,
+    },
+  ];
+
+  await assert.rejects(
+    deleteSlotData({ id: "owner", confirmation: "DELETE", records }),
+    /Type DELETE SLOT 6/,
+  );
+  await assert.rejects(
+    deleteSlotData({
+      id: "blocked",
+      confirmation: "DELETE SLOT 6",
+      records: [{ ...records[0], id: "blocked", deleteDataAllowed: false }],
+      run: async () => calls.push("unexpected"),
+    }),
+    /Stop the slot/,
+  );
+  await deleteSlotData({
+    id: "owner",
+    confirmation: "DELETE SLOT 6",
+    records,
+    run: async (command, args, options) =>
+      calls.push({ command, args, options }),
+  });
+
+  assert.equal(calls[0].command, "docker");
+  assert.deepEqual(calls[0].args, [
+    "compose",
+    "-f",
+    "/repo/owner/compose.dev.yml",
+    "-p",
+    "ayunis-dev-6",
+    "down",
+    "--volumes",
+  ]);
+  assert.equal(calls[0].options.cwd, "/repo/owner");
+  assert.equal(calls[0].options.env.POSTGRES_HOST_PORT, "5492");
+  assert.equal(calls[0].options.env.MINIO_HOST_PORT, "9060");
+  assert.equal(calls[0].options.env.MINIO_ROOT_USER, "placeholder");
+  assert.equal(calls[0].options.env.MINIO_ROOT_PASSWORD, "placeholder");
+  assert.equal(calls[0].options.env.REDIS_PASSWORD, "placeholder");
+});
+
+test("inspectWorktreeRemoval allows only a stopped clean published checkout with no slot resources", async () => {
+  const calls = [];
+  const result = await inspectWorktreeRemoval({
+    record: {
+      slot: 6,
+      branch: "feat/review",
+      worktree: "/repo/review",
+      dirty: false,
+      detached: false,
+      prunable: false,
+      conflict: false,
+      detail: "Backend: stopped\nFrontend: stopped",
+    },
+    repoDir: "/repo/dashboard",
+    primaryWorktree: "/repo/main",
+    run: async (command, args, options) => {
+      calls.push({ command, args, options });
+      if (command === "git" && args[0] === "rev-parse")
+        return "origin/feat/review";
+      if (command === "git") return "0";
+      return "";
+    },
+  });
+
+  assert.deepEqual(result, {
+    removeWorktreeAllowed: true,
+    removeWorktreeBlockedReason: null,
+    upstream: "origin/feat/review",
+  });
+  assert.deepEqual(calls.at(-1).args, [
+    "network",
+    "ls",
+    "-q",
+    "--filter",
+    "label=com.docker.compose.project=ayunis-dev-6",
+  ]);
+});
+
+test("inspectWorktreeRemoval blocks protected, dirty, detached, and uncleaned worktrees", async () => {
+  const base = {
+    slot: 6,
+    branch: "feat/review",
+    worktree: "/repo/review",
+    dirty: false,
+    detached: false,
+    prunable: false,
+    conflict: false,
+    detail: "Backend: stopped\nFrontend: stopped",
+  };
+  const inspect = (record, run = async () => "") =>
+    inspectWorktreeRemoval({
+      record,
+      repoDir: "/repo/dashboard",
+      primaryWorktree: "/repo/main",
+      run,
+    });
+
+  assert.match(
+    (await inspect({ ...base, worktree: "/repo/dashboard" }))
+      .removeWorktreeBlockedReason,
+    /serving the dashboard/,
+  );
+  assert.match(
+    (await inspect({ ...base, worktree: "/repo/main" }))
+      .removeWorktreeBlockedReason,
+    /primary checkout/,
+  );
+  assert.match(
+    (await inspect({ ...base, dirty: true })).removeWorktreeBlockedReason,
+    /dirty/,
+  );
+  assert.match(
+    (await inspect({ ...base, detached: true })).removeWorktreeBlockedReason,
+    /detached/,
+  );
+  assert.match(
+    (
+      await inspect(base, async (command, args) => {
+        if (command === "git" && args[0] === "rev-parse")
+          return "origin/feat/review";
+        if (command === "git") return "0";
+        return args[0] === "volume" ? "ayunis-dev-6_postgres-data" : "";
+      })
+    ).removeWorktreeBlockedReason,
+    /Delete slot data first/,
+  );
+});
+
+test("inspectWorktreeRemoval blocks unpublished and ahead branches", async () => {
+  const record = {
+    slot: 6,
+    branch: "feat/review",
+    worktree: "/repo/review",
+    dirty: false,
+    detached: false,
+    prunable: false,
+    conflict: false,
+    detail: "Backend: stopped\nFrontend: stopped",
+  };
+  const inspect = (run) =>
+    inspectWorktreeRemoval({
+      record,
+      repoDir: "/repo/dashboard",
+      primaryWorktree: "/repo/main",
+      run,
+    });
+
+  assert.match(
+    (
+      await inspect(async () => {
+        throw new Error("no upstream");
+      })
+    ).removeWorktreeBlockedReason,
+    /published upstream/,
+  );
+  assert.match(
+    (
+      await inspect(async (command, args) => {
+        if (args[0] === "rev-parse") return "origin/feat/review";
+        if (command === "git") return "2";
+        return "";
+      })
+    ).removeWorktreeBlockedReason,
+    /2 unpushed commits/,
+  );
+});
+
+test("removeWorktree rechecks safety, requires exact confirmation, and never forces removal", async () => {
+  const calls = [];
+  const records = [
+    { id: "owner", slot: 6, branch: "feat/review", worktree: "/repo/review" },
+  ];
+  const inspect = async () => ({ removeWorktreeAllowed: true });
+
+  await assert.rejects(
+    removeWorktree({
+      id: "owner",
+      confirmation: "REMOVE",
+      records,
+      repoDir: "/repo",
+      inspect,
+    }),
+    /Type REMOVE WORKTREE 6/,
+  );
+  await removeWorktree({
+    id: "owner",
+    confirmation: "REMOVE WORKTREE 6",
+    records,
+    repoDir: "/repo",
+    inspect,
+    readSlot: async () => 6,
+    run: async (command, args, options) =>
+      calls.push({ command, args, options }),
+  });
+
+  assert.deepEqual(calls, [
+    {
+      command: "git",
+      args: ["status", "--short"],
+      options: { cwd: "/repo/review" },
+    },
+    {
+      command: "git",
+      args: ["worktree", "remove", "/repo/review"],
+      options: { cwd: "/repo" },
+    },
+  ]);
+});
+
+test("removeWorktree refuses a checkout that became dirty after inventory", async () => {
+  let removed = false;
+  await assert.rejects(
+    removeWorktree({
+      id: "owner",
+      confirmation: "REMOVE WORKTREE 6",
+      records: [
+        { id: "owner", slot: 6, worktree: "/repo/review", dirty: false },
+      ],
+      repoDir: "/repo",
+      readSlot: async () => 6,
+      inspect: async ({ record }) => ({
+        removeWorktreeAllowed: !record.dirty,
+        removeWorktreeBlockedReason: "The worktree became dirty.",
+      }),
+      run: async (command, args) => {
+        if (args[0] === "status") return "?? untracked-file";
+        if (command === "git") removed = true;
+        return "";
+      },
+    }),
+    /became dirty/,
+  );
+  assert.equal(removed, false);
+});
+
+test("removeWorktree refuses a changed slot claim before running git", async () => {
+  let ran = false;
+  await assert.rejects(
+    removeWorktree({
+      id: "owner",
+      confirmation: "REMOVE WORKTREE 6",
+      records: [{ id: "owner", slot: 6, worktree: "/repo/review" }],
+      repoDir: "/repo",
+      readSlot: async () => 7,
+      run: async () => {
+        ran = true;
+      },
+    }),
+    /selected slot changed/,
+  );
+  assert.equal(ran, false);
+});
+
+test("releaseSlotClaim removes only a stopped checkout's slot selection", async () => {
+  const worktree = await mkdtemp(path.join(os.tmpdir(), "dev-slot-release-"));
+  const slotFile = path.join(worktree, ".dev", "slot");
+  await mkdir(path.dirname(slotFile), { recursive: true });
+  await writeFile(slotFile, "4\n");
+
+  await releaseSlotClaim({
+    id: "owner",
+    records: [
+      {
+        id: "owner",
+        slot: 4,
+        worktree,
+        summary: "stopped",
+        detail: "Backend:   stopped\nFrontend:  stopped",
+      },
+    ],
+  });
+
+  await assert.rejects(access(slotFile), { code: "ENOENT" });
+});
+
+test("releaseSlotClaim preserves a running checkout's slot selection", async () => {
+  const worktree = await mkdtemp(path.join(os.tmpdir(), "dev-slot-running-"));
+  const slotFile = path.join(worktree, ".dev", "slot");
+  await mkdir(path.dirname(slotFile), { recursive: true });
+  await writeFile(slotFile, "4\n");
+
+  await assert.rejects(
+    releaseSlotClaim({
+      id: "owner",
+      records: [
+        {
+          id: "owner",
+          slot: 4,
+          worktree,
+          summary: "running",
+          detail: "Backend:   running\nFrontend:  stopped",
+        },
+      ],
+    }),
+    /still has a managed service running/,
+  );
+  assert.equal(await readFile(slotFile, "utf8"), "4\n");
+});
+
+test("suggestAvailableSlots excludes claims and occupied service ports", () => {
+  assert.deepEqual(
+    suggestAvailableSlots({
+      records: [{ slot: 2 }, { slot: 5 }],
+      listeningPorts: new Set([3031]),
+      first: 2,
+      last: 5,
+    }),
+    [4],
+  );
+});
+
+test("suggestAvailableSlots excludes ports reserved by another claimed slot", () => {
+  assert.deepEqual(
+    suggestAvailableSlots({
+      records: [{ slot: 2 }],
+      listeningPorts: new Set(),
+      first: 12,
+      last: 12,
+    }),
+    [],
+  );
+});
+
+test("listListeningPorts keeps partial lsof output from exit code 1", async () => {
+  const ports = await listListeningPorts(async () => {
+    throw Object.assign(new Error("some processes were unreadable"), {
+      code: 1,
+      stdout: "p123\nn127.0.0.1:3040\np456\nn*:3041\n",
+    });
+  });
+
+  assert.deepEqual(ports, new Set([3040, 3041]));
+});
+
+test("startSlot starts a stopped checkout in the selected mode", async () => {
+  const calls = [];
+  await startSlot({
+    id: "owner",
+    targetSlot: 4,
+    mode: "e2e",
+    records: [
+      {
+        id: "owner",
+        slot: 4,
+        conflict: false,
+        worktree: "/repo/owner",
+        detail: "Backend: stopped\nFrontend: stopped",
+      },
+    ],
+    run: async (command, args, options) =>
+      calls.push({ command, args, options }),
+  });
+
+  assert.deepEqual(calls, [
+    {
+      command: "/repo/owner/dev",
+      args: ["up", "--slot", "4", "--e2e"],
+      options: { cwd: "/repo/owner" },
+    },
+  ]);
+});
+
+test("startSlot accepts an existing slot 1 claim", async () => {
+  const calls = [];
+  await startSlot({
+    id: "owner",
+    targetSlot: 1,
+    mode: "standard",
+    records: [
+      {
+        id: "owner",
+        slot: 1,
+        conflict: false,
+        worktree: "/repo/owner",
+        detail: "Backend: stopped\nFrontend: stopped",
+      },
+    ],
+    run: async (command, args) => calls.push({ command, args }),
+  });
+
+  assert.deepEqual(calls[0].args, ["up", "--slot", "1"]);
+});
+
+test("startSlot can move a stopped conflicting checkout to a verified free slot", async () => {
+  const calls = [];
+  await startSlot({
+    id: "owner",
+    targetSlot: 6,
+    mode: "standard",
+    records: [
+      {
+        id: "owner",
+        slot: 5,
+        conflict: true,
+        worktree: "/repo/owner",
+        detail: "Backend: stopped\nFrontend: stopped",
+      },
+      { id: "other", slot: 5, worktree: "/repo/other" },
+    ],
+    ensureAvailable: async (slot) => assert.equal(slot, 6),
+    run: async (command, args) => calls.push({ command, args }),
+  });
+
+  assert.deepEqual(calls[0].args, ["up", "--slot", "6"]);
+});
+
+test("startSlot rejects reassignment while an unmanaged local process remains", async () => {
+  let started = false;
+  await assert.rejects(
+    startSlot({
+      id: "owner",
+      targetSlot: 6,
+      mode: "standard",
+      records: [
+        {
+          id: "owner",
+          slot: 5,
+          conflict: false,
+          worktree: "/repo/owner",
+          detail:
+            "Backend: stopped port 3050 occupied by unmanaged PID 42\nFrontend: stopped",
+          diagnostics: [
+            { owner: { kind: "active-worktree", worktree: "/repo/owner" } },
+          ],
+        },
+      ],
+      ensureAvailable: async () => {},
+      run: async () => {
+        started = true;
+      },
+    }),
+    /unmanaged process inside this worktree/,
+  );
+  assert.equal(started, false);
+});
+
+test("startSlot tears down old managed infrastructure before an ordinary reassignment", async () => {
+  const calls = [];
+  await startSlot({
+    id: "owner",
+    targetSlot: 6,
+    mode: "standard",
+    records: [
+      {
+        id: "owner",
+        slot: 5,
+        conflict: false,
+        worktree: "/repo/owner",
+        detail: "Docker infra: running\nBackend: stopped\nFrontend: stopped",
+      },
+    ],
+    ensureAvailable: async (slot) => assert.equal(slot, 6),
+    run: async (command, args, options) =>
+      calls.push({ command, args, options }),
+  });
+
+  assert.equal(calls[0].command, "docker");
+  assert.deepEqual(calls[0].args.slice(-1), ["down"]);
+  assert.deepEqual(calls[1].args, ["up", "--slot", "6"]);
+});
+
+test("startSlot stops old managed infrastructure before moving away from an unmanaged listener", async () => {
+  const calls = [];
+  await startSlot({
+    id: "owner",
+    targetSlot: 6,
+    mode: "standard",
+    records: [
+      {
+        id: "owner",
+        slot: 5,
+        conflict: false,
+        worktree: "/repo/owner",
+        detail:
+          "Backend: stopped port 3050 occupied by unmanaged PID 42\nFrontend: stopped",
+      },
+    ],
+    ensureAvailable: async (slot) => assert.equal(slot, 6),
+    run: async (command, args, options) =>
+      calls.push({ command, args, options }),
+  });
+
+  assert.equal(calls[0].command, "docker");
+  assert.deepEqual(calls[0].args, [
+    "compose",
+    "-f",
+    "/repo/owner/compose.dev.yml",
+    "-p",
+    "ayunis-dev-5",
+    "down",
+  ]);
+  assert.equal(calls[0].options.env.POSTGRES_HOST_PORT, "5482");
+  assert.deepEqual(calls[1].args, ["up", "--slot", "6"]);
+});
+
+test("startSlot rejects a target whose ports overlap another claim", async () => {
+  let started = false;
+
+  await assert.rejects(
+    startSlot({
+      id: "owner",
+      targetSlot: 12,
+      mode: "standard",
+      records: [
+        {
+          id: "owner",
+          slot: 5,
+          conflict: false,
+          worktree: "/repo/owner",
+          detail: "Backend: stopped\nFrontend: stopped",
+        },
+        { id: "other", slot: 2, worktree: "/repo/other" },
+      ],
+      run: async (command) => {
+        if (command === "lsof") return "";
+        started = true;
+      },
+    }),
+    /shares ports with claimed slot 2/,
+  );
+
+  assert.equal(started, false);
+});
+
+test("restartSlot stops before starting with the selected mode", async () => {
+  const calls = [];
+  await restartSlot({
+    id: "owner",
+    mode: "anonymisation",
+    records: [
+      {
+        id: "owner",
+        slot: 4,
+        conflict: false,
+        worktree: "/repo/owner",
+        detail: "Backend: running\nFrontend: running",
+      },
+    ],
+    run: async (command, args) => calls.push({ command, args }),
+  });
+
+  assert.deepEqual(
+    calls.map(({ args }) => args),
+    [
+      ["down", "--slot", "4"],
+      ["up", "--slot", "4", "--with-anonymisation"],
+    ],
+  );
+});
+
+test("slot UI API protects lifecycle mutations with its session token", async () => {
+  const record = {
+    id: "owner",
+    slot: 4,
+    conflict: false,
+    summary: "running",
+    worktree: "/repo/owner",
+  };
+  let stops = 0;
+  let releases = 0;
+  const dataDeletions = [];
+  const worktreeRemovals = [];
+  let batchStops = 0;
+  const starts = [];
+  const restarts = [];
+  const handler = createSlotsHandler({
+    repoDir: "/repo",
+    token: "test-token",
+    discover: async () => [record],
+    stop: async () => {
+      stops += 1;
+      return "Slot 4 stopped.";
+    },
+    release: async () => {
+      releases += 1;
+      return "Slot 4 claim released.";
+    },
+    deleteData: async (request) => {
+      dataDeletions.push(request);
+      return "Slot 4 data deleted.";
+    },
+    remove: async (request) => {
+      worktreeRemovals.push(request);
+      return "Worktree removed.";
+    },
+    stopAll: async () => {
+      batchStops += 1;
+      return { stopped: [], skipped: [], failed: [] };
+    },
+    start: async (request) => starts.push(request),
+    restart: async (request) => restarts.push(request),
+    available: async () => [6, 7],
+    logs: async () => "backend log",
+  });
+  const request = (method, url, headers = {}) =>
+    new Promise((resolve) => {
+      const response = {
+        writeHead(status) {
+          this.status = status;
+        },
+        end(body) {
+          resolve({ status: this.status, body: JSON.parse(body) });
+        },
+      };
+      handler(
+        { method, url, headers: { host: "127.0.0.1:4317", ...headers } },
+        response,
+      );
+    });
+
+  const rejectedList = await request("GET", "/api/slots");
+  assert.equal(rejectedList.status, 403);
+
+  const listResponse = await request("GET", "/api/slots", {
+    "x-dev-slots-token": "test-token",
+  });
+  assert.equal(listResponse.status, 200);
+  assert.deepEqual(listResponse.body, {
+    slots: [record],
+    availableSlots: [6, 7],
+  });
+
+  const rejected = await request("POST", "/api/slots/owner/stop");
+  assert.equal(rejected.status, 403);
+  assert.equal(stops, 0);
+
+  const accepted = await request("POST", "/api/slots/owner/stop", {
+    "x-dev-slots-token": "test-token",
+  });
+  assert.equal(accepted.status, 200);
+  assert.equal(stops, 1);
+
+  const acceptedStopAll = await request("POST", "/api/slots/stop-all", {
+    "x-dev-slots-token": "test-token",
+  });
+  assert.equal(acceptedStopAll.status, 200);
+  assert.deepEqual(acceptedStopAll.body, {
+    stopped: [],
+    skipped: [],
+    failed: [],
+  });
+  assert.equal(batchStops, 1);
+
+  const rejectedRelease = await request("POST", "/api/slots/owner/release");
+  assert.equal(rejectedRelease.status, 403);
+  assert.equal(releases, 0);
+
+  const acceptedRelease = await request("POST", "/api/slots/owner/release", {
+    "x-dev-slots-token": "test-token",
+  });
+  assert.equal(acceptedRelease.status, 200);
+  assert.equal(releases, 1);
+
+  const acceptedDelete = await request(
+    "POST",
+    "/api/slots/owner/delete-data?confirmation=DELETE%20SLOT%204",
+    { "x-dev-slots-token": "test-token" },
+  );
+  assert.equal(acceptedDelete.status, 200);
+  assert.deepEqual(dataDeletions, [
+    { id: "owner", confirmation: "DELETE SLOT 4", records: [record] },
+  ]);
+
+  const acceptedRemove = await request(
+    "POST",
+    "/api/slots/owner/remove-worktree?confirmation=REMOVE%20WORKTREE%204",
+    { "x-dev-slots-token": "test-token" },
+  );
+  assert.equal(acceptedRemove.status, 200);
+  assert.deepEqual(worktreeRemovals, [
+    {
+      id: "owner",
+      confirmation: "REMOVE WORKTREE 4",
+      records: [record],
+      repoDir: "/repo",
+    },
+  ]);
+
+  const rejectedStart = await request(
+    "POST",
+    "/api/slots/owner/start?slot=6&mode=e2e",
+  );
+  assert.equal(rejectedStart.status, 403);
+  assert.equal(starts.length, 0);
+
+  const acceptedStart = await request(
+    "POST",
+    "/api/slots/owner/start?slot=6&mode=e2e",
+    { "x-dev-slots-token": "test-token" },
+  );
+  assert.equal(acceptedStart.status, 200);
+  assert.deepEqual(starts[0], {
+    id: "owner",
+    targetSlot: 6,
+    mode: "e2e",
+    records: [record],
+  });
+
+  const acceptedRestart = await request(
+    "POST",
+    "/api/slots/owner/restart?mode=anonymisation",
+    { "x-dev-slots-token": "test-token" },
+  );
+  assert.equal(acceptedRestart.status, 200);
+  assert.equal(restarts[0].mode, "anonymisation");
+});
+
+test("slot UI rejects non-loopback hosts before serving its session token", async () => {
+  const handler = createSlotsHandler({
+    repoDir: "/repo",
+    token: "test-token",
+    discover: async () => [],
+  });
+  const response = await new Promise((resolve) => {
+    const target = {
+      writeHead(status) {
+        this.status = status;
+      },
+      end(body) {
+        resolve({ status: this.status, body });
+      },
+    };
+    handler(
+      { method: "GET", url: "/", headers: { host: "attacker.example" } },
+      target,
+    );
+  });
+
+  assert.equal(response.status, 403);
+  assert.doesNotMatch(response.body, /test-token/);
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Destructive dev-only actions (volume delete, worktree remove, batch stop) shell out to git/docker/`./dev`; guards and confirmations reduce accidents but mistakes can still drop local Postgres/MinIO data or remove checkouts.
> 
> **Overview**
> Adds a **local dev slot control panel** for managing multiple git worktrees: `./dev slots` lists slot claims as JSON and `./dev ui` serves a loopback-only dashboard (default port 4317).
> 
> The dashboard discovers worktrees with a `.dev/slot` file, shows status/conflicts/unmanaged port listeners (with PID/CWD hints), and drives guarded actions via existing `./dev` and Docker Compose: safe stop, stop-all, release claim, typed **DELETE SLOT N** volume wipe, typed **REMOVE WORKTREE N** (with publish/clean guards), start/reassign to free slots, and restart in standard/E2E/anonymisation modes. API mutations require a per-session token and loopback host checks.
> 
> Implementation is new Node modules under `scripts/dev-slots-*.mjs` plus a large `dev-slots.test.mjs` suite; README documents the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abfe150bbc3d5e37cd870f2a13cd40757ff37f19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->