### PR TITLE
fix(ui): close the mobile sidebar on link clicks (AYC-937)

### DIFF
--- a/ayunis-core-e2e/tests/navigation/mobile-sidebar.spec.ts
+++ b/ayunis-core-e2e/tests/navigation/mobile-sidebar.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '../../src/fixtures/test';
+
+test('closes and reopens the mobile sidebar after current-route navigation', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/chat');
+
+  await page.getByRole('button', { name: 'Toggle Sidebar' }).click();
+  const sidebar = page.getByRole('dialog');
+  await expect(sidebar).toBeVisible();
+
+  await page.getByTestId('sidebar-navigation-new-chat').click();
+  await expect(sidebar).toBeHidden();
+
+  await page.getByRole('button', { name: 'Toggle Sidebar' }).click();
+  await expect(sidebar).toBeVisible();
+});

--- a/ayunis-core-frontend/src/widgets/app-sidebar/hooks/useMobileSidebarNavigationHandler.ts
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/hooks/useMobileSidebarNavigationHandler.ts
@@ -1,0 +1,17 @@
+import { useCallback, type MouseEventHandler } from 'react';
+import { useSidebar } from '@ayunis/ui/components/sidebar';
+
+export function useMobileSidebarNavigationHandler(): MouseEventHandler<HTMLDivElement> {
+  const { closeMobileWithCleanup } = useSidebar();
+
+  return useCallback(
+    (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+
+      const control = target.closest('a, button, input, [role="button"]');
+      if (control?.tagName === 'A') closeMobileWithCleanup();
+    },
+    [closeMobileWithCleanup],
+  );
+}

--- a/ayunis-core-frontend/src/widgets/app-sidebar/ui/AppSidebar.tsx
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/ui/AppSidebar.tsx
@@ -39,7 +39,6 @@ import { useNavigate } from '@tanstack/react-router';
 import brandFullLight from '@/shared/assets/brand/brand-full-light.svg';
 import brandFullDark from '@/shared/assets/brand/brand-full-dark.svg';
 import { useTheme } from '@/features/theme';
-import { useSidebar } from '@ayunis/ui/components/sidebar';
 import { MeResponseDtoSystemRole } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import config from '@/shared/config';
 import { ReleaseNotesButton } from './ReleaseNotesButton';
@@ -56,6 +55,7 @@ import {
   ACADEMY_LANDING_PAGE_URL,
 } from '@/features/academy';
 import { OnboardingCard } from './OnboardingCard';
+import { useMobileSidebarNavigationHandler } from '@/widgets/app-sidebar/hooks/useMobileSidebarNavigationHandler';
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { theme } = useTheme();
@@ -68,7 +68,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { logout } = useLogout();
   const { t } = useTranslation('common');
   const navigate = useNavigate();
-  const { closeMobileWithCleanup } = useSidebar();
+  const handleMobileNavigation = useMobileSidebarNavigationHandler();
   const featureToggles = useFeatureToggles();
   const marketplace = useMarketplaceConfig();
   const academyAddonActive = useIsAcademyAddonActive();
@@ -121,7 +121,12 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   ];
 
   return (
-    <Sidebar {...props} variant="inset" data-testid="sidebar">
+    <Sidebar
+      {...props}
+      variant="inset"
+      data-testid="sidebar"
+      onClickCapture={handleMobileNavigation}
+    >
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>
@@ -154,6 +159,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 >
                   <Link
                     to={item.url}
+                    data-testid={
+                      item.url === '/chat'
+                        ? 'sidebar-navigation-new-chat'
+                        : undefined
+                    }
                     // `disabled` is inert on an anchor; the sidebar variants
                     // style aria-disabled and block pointer events for us.
                     aria-disabled={item.disabled}
@@ -235,14 +245,14 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 sideOffset={4}
               >
                 <DropdownMenuItem asChild>
-                  <Link to="/settings/general" onClick={closeMobileWithCleanup}>
+                  <Link to="/settings/general">
                     <User2 />
                     {t('sidebar.accountSettings')}
                   </Link>
                 </DropdownMenuItem>
                 {canOpenSettings && (
                   <DropdownMenuItem asChild>
-                    <Link to="/admin-settings" onClick={closeMobileWithCleanup}>
+                    <Link to="/admin-settings">
                       <Settings2 />
                       {t('sidebar.adminSettings')}
                     </Link>
@@ -250,10 +260,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 )}
                 {user?.systemRole === MeResponseDtoSystemRole.super_admin && (
                   <DropdownMenuItem asChild>
-                    <Link
-                      to="/super-admin-settings"
-                      onClick={closeMobileWithCleanup}
-                    >
+                    <Link to="/super-admin-settings">
                       <Settings2 />
                       {t('sidebar.superAdminSettings')}
                     </Link>

--- a/ayunis-core-frontend/src/widgets/app-sidebar/ui/ChatsSidebarGroup.tsx
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/ui/ChatsSidebarGroup.tsx
@@ -10,7 +10,7 @@ import {
   SidebarMenuItem,
   SidebarGroupContent,
 } from '@ayunis/ui/components/sidebar';
-import { useThreads } from '../api';
+import { useThreads } from '@/widgets/app-sidebar/api';
 import { useDeleteThread } from '@/features/thread-run';
 import { useChatsSidebarOpen } from '@/features/useChatsSidebarOpen';
 import { useFavorites } from '@/features/favorites';
@@ -144,11 +144,8 @@ export function ChatsSidebarGroup() {
                   <div className="text-xs text-muted-foreground">
                     {t('sidebar.emptyChatsDescription')}
                   </div>
-                  <Button
-                    className="mt-2"
-                    onClick={() => void navigate({ to: '/chat' })}
-                  >
-                    {t('sidebar.newChat')}
+                  <Button asChild className="mt-2">
+                    <Link to="/chat">{t('sidebar.newChat')}</Link>
                   </Button>
                 </div>
               </div>

--- a/ayunis-core-frontend/src/widgets/app-sidebar/ui/mobile-sidebar-close.test.tsx
+++ b/ayunis-core-frontend/src/widgets/app-sidebar/ui/mobile-sidebar-close.test.tsx
@@ -1,0 +1,118 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPortal } from 'react-dom';
+import {
+  Sidebar,
+  SidebarProvider,
+  useSidebar,
+} from '@ayunis/ui/components/sidebar';
+import { useMobileSidebarNavigationHandler } from '@/widgets/app-sidebar/hooks/useMobileSidebarNavigationHandler';
+
+function OpenSidebarButton() {
+  const { setOpenMobile } = useSidebar();
+  return <button onClick={() => setOpenMobile(true)}>open sidebar</button>;
+}
+
+function MobileSidebar({ children }: Readonly<{ children: React.ReactNode }>) {
+  const handleMobileNavigation = useMobileSidebarNavigationHandler();
+  return <Sidebar onClickCapture={handleMobileNavigation}>{children}</Sidebar>;
+}
+
+function renderMobileSidebar(link: React.ReactNode) {
+  render(
+    <SidebarProvider pathname="/chat">
+      <OpenSidebarButton />
+      <MobileSidebar>{link}</MobileSidebar>
+    </SidebarProvider>,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'open sidebar' }));
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  window.innerWidth = 375;
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: true,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+});
+afterEach(() => {
+  cleanup();
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+});
+
+describe('mobile sidebar', () => {
+  it('closes when a link is clicked, even if it points at the current route', () => {
+    renderMobileSidebar(<a href="/chat">New chat</a>);
+
+    fireEvent.click(screen.getByRole('link', { name: 'New chat' }));
+
+    expect(screen.queryByRole('link', { name: 'New chat' })).toBeNull();
+  });
+
+  it('closes even when the link stops propagation, without swallowing its handler', () => {
+    const onClick = vi.fn((event: React.MouseEvent) => event.stopPropagation());
+    renderMobileSidebar(
+      <a href="/chats" onClick={onClick}>
+        Search chats
+      </a>,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Search chats' }));
+
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('link', { name: 'Search chats' })).toBeNull();
+  });
+
+  it('closes for links rendered through a menu portal', () => {
+    renderMobileSidebar(
+      createPortal(
+        <a href="/settings/general">Account settings</a>,
+        document.body,
+      ),
+    );
+
+    const portalLink = document.querySelector<HTMLAnchorElement>(
+      'a[href="/settings/general"]',
+    );
+    expect(portalLink).not.toBeNull();
+    fireEvent.click(portalLink!);
+
+    expect(screen.queryByRole('link', { name: 'Account settings' })).toBeNull();
+  });
+
+  it('stays open when a control nested inside a link is clicked', () => {
+    renderMobileSidebar(
+      <a href="/getting-started">
+        Getting started
+        <button onClick={(event) => event.preventDefault()}>dismiss</button>
+      </a>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'dismiss' }));
+
+    expect(
+      screen.queryByRole('link', { name: /Getting started/ }),
+    ).not.toBeNull();
+  });
+
+  it('does not remove the overlay when the sidebar is reopened', () => {
+    renderMobileSidebar(<a href="/chat">New chat</a>);
+
+    fireEvent.click(screen.getByRole('link', { name: 'New chat' }));
+    fireEvent.click(screen.getByRole('button', { name: 'open sidebar' }));
+    act(() => vi.advanceTimersByTime(400));
+
+    expect(
+      document.querySelector('[data-slot="sheet-overlay"]'),
+    ).not.toBeNull();
+  });
+});

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -83,17 +83,43 @@ function SidebarProvider({
 }): React.ReactElement {
   const isMobile = useIsMobile();
   const [openMobile, setOpenMobile] = React.useState(false);
+  const cleanupTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  const cancelPendingCleanup = React.useCallback((): void => {
+    if (cleanupTimeoutRef.current !== null) {
+      clearTimeout(cleanupTimeoutRef.current);
+      cleanupTimeoutRef.current = null;
+    }
+  }, []);
+
+  React.useEffect(() => cancelPendingCleanup, [cancelPendingCleanup]);
+
+  React.useEffect(() => {
+    if (openMobile) cancelPendingCleanup();
+  }, [cancelPendingCleanup, openMobile]);
 
   // Defensive cleanup function for Radix/Chrome quirks when the mobile sidebar
   // closes. Several browser bugs leave artifacts behind (stuck inert,
   // aria-hidden, stale overlays, pointer-events on body, scroll-lock styles)
-  // that can make the page unresponsive. We run cleanup three times to catch
-  // Chrome's delayed paint passes.
+  // that can make the page unresponsive. The pass runs after Radix's exit
+  // animation so React-owned portal nodes have already unmounted.
   const cleanupMobileSidebar = React.useCallback((): void => {
     if (isMobile && openMobile) {
       setOpenMobile(false);
+      cancelPendingCleanup();
 
       const performCleanup = (): void => {
+        cleanupTimeoutRef.current = null;
+        if (
+          document.querySelector(
+            '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]',
+          )
+        ) {
+          return;
+        }
+
         // Remove any lingering inert attributes
         document.querySelectorAll('[inert]').forEach((el) => {
           el.removeAttribute('inert');
@@ -104,26 +130,6 @@ function SidebarProvider({
           .querySelectorAll('body > *[aria-hidden="true"]')
           .forEach((el) => {
             el.removeAttribute('aria-hidden');
-          });
-
-        // Remove any sheet overlays that might still exist
-        document
-          .querySelectorAll('[data-slot="sheet-overlay"]')
-          .forEach((el) => {
-            el.remove();
-          });
-
-        // Chrome-specific: remove any radix overlays still pointing at a
-        // closed state (or outside the sidebar tree)
-        document
-          .querySelectorAll('[data-radix-dismissable-layer]')
-          .forEach((el) => {
-            if (
-              el.getAttribute('data-state') === 'closed' ||
-              !el.closest('[data-slot="sidebar"]')
-            ) {
-              el.remove();
-            }
           });
 
         // Ensure body doesn't have pointer-events / overflow / transform stuck
@@ -139,23 +145,9 @@ function SidebarProvider({
             (el as HTMLElement).style.pointerEvents = '';
           });
 
-        // Remove lingering radix focus guards from closed overlays
-        document.querySelectorAll('[data-radix-focus-guard]').forEach((el) => {
-          if (!el.closest('[data-state="open"]')) {
-            el.remove();
-          }
-        });
-
         // Reset scroll-lock styles on html element
         document.documentElement.style.overflow = '';
         document.documentElement.style.paddingRight = '';
-
-        // Remove style tags injected by radix for scroll lock
-        document
-          .querySelectorAll('style[data-radix-scroll-area-viewport]')
-          .forEach((el) => {
-            el.remove();
-          });
 
         // If focus is trapped inside the closed sheet, release it
         if (document.activeElement?.closest('[data-slot="sheet-content"]')) {
@@ -168,11 +160,9 @@ function SidebarProvider({
         document.body.offsetHeight;
       };
 
-      performCleanup();
-      setTimeout(performCleanup, 50);
-      setTimeout(performCleanup, 150);
+      cleanupTimeoutRef.current = setTimeout(performCleanup, 350);
     }
-  }, [isMobile, openMobile]);
+  }, [cancelPendingCleanup, isMobile, openMobile]);
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
@@ -290,6 +280,7 @@ function Sidebar({
   collapsible = 'offcanvas',
   className,
   children,
+  onClickCapture,
   ...props
 }: React.ComponentProps<'div'> & {
   side?: 'left' | 'right';
@@ -302,6 +293,7 @@ function Sidebar({
     return (
       <div
         data-slot="sidebar"
+        onClickCapture={onClickCapture}
         className={cn(
           'bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col',
           className,
@@ -332,7 +324,12 @@ function Sidebar({
             <SheetTitle>Sidebar</SheetTitle>
             <SheetDescription>Displays the mobile sidebar.</SheetDescription>
           </SheetHeader>
-          <div className="flex h-full w-full flex-col">{children}</div>
+          <div
+            className="flex h-full w-full flex-col"
+            onClickCapture={onClickCapture}
+          >
+            {children}
+          </div>
         </SheetContent>
       </Sheet>
     );
@@ -361,6 +358,7 @@ function Sidebar({
       />
       <div
         data-slot="sidebar-container"
+        onClickCapture={onClickCapture}
         className={cn(
           'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex',
           side === 'left'


### PR DESCRIPTION
- The drawer only closed from the pathname effect, which never fires when
  a link points at the route already open (New chat on /chat, Workspaces
  on /workspaces, the open chat in the chat list)
- Defer the Chrome overlay cleanup by a tick: it detaches Radix nodes
  React still owns, so running it synchronously with setOpenMobile makes
  React's unmount throw NotFoundError

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared sidebar DOM cleanup and global click capture; incorrect timing or event handling could leave the page non-interactive or close the drawer unexpectedly on mobile.
> 
> **Overview**
> Fixes the mobile drawer staying open when users tap sidebar links that don’t change the URL (e.g. **New chat** on `/chat` or the active chat), which previously only closed on pathname changes.
> 
> **App sidebar** now closes the sheet on any anchor click via a shared capture handler (`useMobileSidebarNavigationHandler` + `Sidebar` `onClickCapture`), replacing per-link `closeMobileWithCleanup` handlers. Empty-state **New chat** uses a `Link` so it participates in that behavior; **New chat** gets a `data-testid` for e2e.
> 
> **`@ayunis/ui` sidebar** plumbs `onClickCapture` through mobile/desktop shells and reworks mobile cleanup: one deferred pass (~350ms) after Radix’s exit animation, with pending cleanup cancelled when the drawer reopens and no DOM tearing of sheet overlays (avoids React `NotFoundError` and missing overlay on reopen).
> 
> Adds Vitest coverage for link clicks, propagation, portals, nested controls, and reopen; Playwright covers close/reopen on mobile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c48f3328c7296a3508dce6caa62f066964d6a49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->