### PR TITLE
fix(workspace): confirm a saved workspace instruction (AYC-954)

### DIFF
--- a/ayunis-core-e2e/tests/workspaces/project-context.spec.ts
+++ b/ayunis-core-e2e/tests/workspaces/project-context.spec.ts
@@ -262,6 +262,9 @@ test("adds skills, knowledge bases, and instructions to a project", async ({
     .getByTestId("workspace-instruction-input")
     .fill(fixture.instruction);
   await page.getByTestId("workspace-instruction-save").click();
+  await expect(
+    page.locator('[data-sonner-toast][data-type="success"]'),
+  ).toBeVisible();
 
   await expect
     .poll(async () => {

--- a/ayunis-core-frontend/src/pages/workspace/api/useWorkspaceContextActions.ts
+++ b/ayunis-core-frontend/src/pages/workspace/api/useWorkspaceContextActions.ts
@@ -10,7 +10,7 @@ import {
   workspaceContextControllerUpdateInstruction,
 } from '@/shared/api/generated/ayunisCoreAPI';
 import type { CreateSkillDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
-import { showError } from '@/shared/lib/toast';
+import { showError, showSuccess } from '@/shared/lib/toast';
 import { useInvalidateWorkspaceResources } from './useInvalidateWorkspaceResources';
 
 type WorkspaceSkillInput = Omit<
@@ -72,6 +72,7 @@ export function useWorkspaceContextActions(workspaceId: string) {
         queryKey: getWorkspacesControllerFindOneQueryKey(workspaceId),
       });
       void invalidateContext();
+      showSuccess(t('context.instructions.saveSuccess', { ns: 'workspace' }));
     },
     onError: () =>
       showError(t('context.instructions.saveError', { ns: 'workspace' })),

--- a/ayunis-core-frontend/src/pages/workspace/api/workspace-resource-regressions.test.tsx
+++ b/ayunis-core-frontend/src/pages/workspace/api/workspace-resource-regressions.test.tsx
@@ -22,15 +22,16 @@ import {
   workspaceSkillListParams,
 } from '@/shared/api/skill-scopes';
 
-const { request, showError, invalidate } = vi.hoisted(() => ({
+const { request, showError, showSuccess, invalidate } = vi.hoisted(() => ({
   request: vi.fn(),
   showError: vi.fn(),
+  showSuccess: vi.fn(),
   invalidate: vi.fn(),
 }));
 vi.mock('@/shared/api/client', () => ({ customAxiosInstance: request }));
 vi.mock('@/shared/lib/toast', () => ({
   showError,
-  showSuccess: vi.fn(),
+  showSuccess,
   showInfo: vi.fn(),
 }));
 vi.mock('@tanstack/react-router', () => ({
@@ -284,6 +285,21 @@ describe('workspace resource regressions', () => {
       await waitFor(() => expect(showError).toHaveBeenCalledOnce());
     },
   );
+
+  it('confirms a saved workspace instruction', async () => {
+    request.mockResolvedValue({ instruction: 'Be concise.' });
+    const { wrapper } = setup();
+    const { result } = renderHook(() => useWorkspaceContextActions('project'), {
+      wrapper,
+    });
+
+    await act(() => result.current.updateInstruction('Be concise.'));
+
+    expect(showSuccess).toHaveBeenCalledWith(
+      'context.instructions.saveSuccess',
+    );
+    expect(showError).not.toHaveBeenCalled();
+  });
 
   it('invalidates canonical workspace caches without expiring other scopes', async () => {
     const { client, wrapper } = setup();


### PR DESCRIPTION
## What

Saving a workspace instruction showed nothing on success, so it was unclear whether the change applied ([AYC-954](https://linear.app/ayunis/issue/AYC-954)).

The mutation already had an `onError` toast and both locales already shipped an (unused) `context.instructions.saveSuccess` string — this just fires it on success.

```ts
showSuccess(t('context.instructions.saveSuccess', { ns: 'workspace' }));
```

## Verification

Driven against a live slot (backend 3050 / frontend 3051, `FEATURE_WORKSPACES_ENABLED=true`, minimal seed):

| Check | Result |
| --- | --- |
| Save shows a confirmation | ✅ "Anweisungen wurden gespeichert." |
| Instruction persists across reload | ✅ value intact after reload |
| Failed save (forced 500) | ✅ only the error toast — no false success |
| Horizontal overflow @ 375 / 768 / 1280 | ✅ 0px at every breakpoint |

Unit test and e2e assertion both verified red before the fix and green after. The e2e asserts `[data-sonner-toast][data-type="success"]`, which is locale-independent and distinguishes success from the error toast.

## Screenshots / demo

| Before save | After save |
| --- | --- |
| ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-954/docs/pr-media/ayc-954/01-before-save.png) | ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-954/docs/pr-media/ayc-954/02-after-save-confirmation.png) |

![demo](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-954/docs/pr-media/ayc-954/demo.gif)

<details><summary>Failure path + mobile</summary>

| Forced 500 | Mobile 375px |
| --- | --- |
| ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-954/docs/pr-media/ayc-954/03-save-failure.png) | ![](https://raw.githubusercontent.com/ayunis-core/ayunis-core/pr-media/ayc-954/docs/pr-media/ayc-954/resp-mobile.png) |

</details>

> Media hosted on the `pr-media/ayc-954` branch (not part of this PR's diff); safe to delete after merge.
