### PR TITLE
fix(integrations): refetch the list after disabling an integration (AYC-941)

### DIFF
--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/api/useToggleIntegration.test.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/api/useToggleIntegration.test.tsx
@@ -1,0 +1,71 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useToggleIntegration } from './useToggleIntegration';
+import type { McpIntegration } from '@/pages/admin-settings/integrations-settings/model/types';
+
+const LIST_QUERY_KEY = ['/mcp-integrations'] as const;
+
+type MutationOptions = {
+  onSuccess: () => void;
+  onSettled: (data: unknown, error: unknown, variables: { id: string }) => void;
+};
+
+const mocks = vi.hoisted(() => ({
+  invalidateQueries: vi.fn(),
+  enableOptions: undefined as MutationOptions | undefined,
+  disableOptions: undefined as MutationOptions | undefined,
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: mocks.invalidateQueries }),
+}));
+vi.mock('@/shared/api/generated/ayunisCoreAPI', () => ({
+  useMcpIntegrationsControllerEnable: (options: {
+    mutation: MutationOptions;
+  }) => {
+    mocks.enableOptions = options.mutation;
+    return { mutate: vi.fn() };
+  },
+  useMcpIntegrationsControllerDisable: (options: {
+    mutation: MutationOptions;
+  }) => {
+    mocks.disableOptions = options.mutation;
+    return { mutate: vi.fn() };
+  },
+  getMcpIntegrationsControllerListQueryKey: () => LIST_QUERY_KEY,
+}));
+vi.mock('@/shared/lib/toast', () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe(useToggleIntegration.name, () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each([
+    ['enable', () => mocks.enableOptions],
+    ['disable', () => mocks.disableOptions],
+  ])('refetches the integrations list after %s succeeds', (_, getOptions) => {
+    renderHook(() => useToggleIntegration());
+
+    act(() => getOptions()?.onSuccess());
+
+    expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: LIST_QUERY_KEY,
+    });
+  });
+
+  it('leaves the integration out of togglingIds once the request settles', () => {
+    const integration = { id: 'integration-1' } as McpIntegration;
+    const { result } = renderHook(() => useToggleIntegration());
+
+    act(() => result.current.toggleIntegration(integration, false));
+    expect(result.current.togglingIds.has(integration.id)).toBe(true);
+
+    act(() => mocks.disableOptions?.onSettled(undefined, null, integration));
+    expect(result.current.togglingIds.has(integration.id)).toBe(false);
+  });
+});

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/api/useToggleIntegration.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/api/useToggleIntegration.ts
@@ -7,7 +7,7 @@ import {
   useMcpIntegrationsControllerDisable,
   getMcpIntegrationsControllerListQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
-import type { McpIntegration } from '../model/types';
+import type { McpIntegration } from '@/pages/admin-settings/integrations-settings/model/types';
 import extractErrorData from '@/shared/api/extract-error-data';
 
 export function useToggleIntegration() {
@@ -56,7 +56,7 @@ export function useToggleIntegration() {
     mutation: {
       onSuccess: () => {
         void queryClient.invalidateQueries({
-          queryKey: ['useMcpIntegrationsControllerList'],
+          queryKey: getMcpIntegrationsControllerListQueryKey(),
         });
         showSuccess(t('integrations.toggleIntegration.disableSuccess'));
       },


### PR DESCRIPTION
Fixes AYC-941.

## Problem

Deactivating an integration on **Admin Settings → Integrations** showed a success toast but left the toggle visually enabled until a page refresh.

## Root cause

`useToggleIntegration` invalidated a hand-written query key on the disable path:

```ts
queryKey: ['useMcpIntegrationsControllerList']   // never matches
```

The generated list key is `['/mcp-integrations']`, so the invalidation matched nothing and the list never refetched. The enable path already used `getMcpIntegrationsControllerListQueryKey()` — only disable was wrong.

## Fix

Use the generated key on the disable path too. This was the only hand-written controller query key in the frontend.

## Acceptance criteria

- **Toggle updates immediately after activation or deactivation** — the card renders `checked={integration.enabled}` straight from the list query, so the now-matching invalidation refetches and flips it.
- **Rendered state stays consistent after refresh** — the refetch reads the same persisted state a reload would.
- **A failed request preserves the previous state and reports the failure** — there is no optimistic update, so a failure leaves server state untouched and the existing `onError` handlers show the error toast.

## Tests

`useToggleIntegration.test.tsx` asserts both enable and disable invalidate the generated list key, plus the toggling-state cleanup. The disable case fails on `main` and passes here.