### PR TITLE
fix(integrations): allow editing connection settings (AYC-942)

### DIFF
--- a/ayunis-core-backend/src/domain/mcp/application/ports/mcp-integration-user-config.repository.port.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/ports/mcp-integration-user-config.repository.port.ts
@@ -1,5 +1,5 @@
 import type { UUID } from 'crypto';
-import type { McpIntegrationUserConfig } from '../../domain/mcp-integration-user-config.entity';
+import type { McpIntegrationUserConfig } from 'src/domain/mcp/domain/mcp-integration-user-config.entity';
 
 /**
  * Repository port for MCP integration user-level configuration.
@@ -35,4 +35,9 @@ export abstract class McpIntegrationUserConfigRepositoryPort {
    * Used when an integration is deleted.
    */
   abstract deleteByIntegrationId(integrationId: UUID): Promise<void>;
+
+  abstract removeKeysByIntegrationId(
+    integrationId: UUID,
+    keys: string[],
+  ): Promise<void>;
 }

--- a/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/services/mcp-client.service.spec.ts
@@ -42,6 +42,7 @@ class MockUserConfigRepository extends McpIntegrationUserConfigRepositoryPort {
   findByIntegrationAndUser = jest.fn();
   findByIntegrationIdsAndUser = jest.fn();
   deleteByIntegrationId = jest.fn();
+  removeKeysByIntegrationId = jest.fn();
 }
 
 describe('McpClientService', () => {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/delete-mcp-integration/delete-mcp-integration.use-case.spec.ts
@@ -79,6 +79,7 @@ describe('DeleteMcpIntegrationUseCase', () => {
           provide: McpIntegrationUserConfigRepositoryPort,
           useValue: {
             deleteByIntegrationId: jest.fn(),
+            removeKeysByIntegrationId: jest.fn(),
           },
         },
         {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/get-user-mcp-config/get-user-mcp-config.use-case.spec.ts
@@ -75,6 +75,7 @@ describe('GetUserMcpConfigUseCase', () => {
       findByIntegrationAndUser: jest.fn(),
       findByIntegrationIdsAndUser: jest.fn(),
       deleteByIntegrationId: jest.fn(),
+      removeKeysByIntegrationId: jest.fn(),
     };
 
     contextService = {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/set-user-mcp-config/set-user-mcp-config.use-case.spec.ts
@@ -83,6 +83,7 @@ describe('SetUserMcpConfigUseCase', () => {
       findByIntegrationAndUser: jest.fn(),
       findByIntegrationIdsAndUser: jest.fn(),
       deleteByIntegrationId: jest.fn(),
+      removeKeysByIntegrationId: jest.fn(),
     };
 
     credentialEncryption = {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.command.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.command.ts
@@ -1,6 +1,17 @@
+import type { IntegrationConfigSchema } from 'src/domain/mcp/domain/value-objects/integration-config-schema';
+
+type UpdateIntegrationConfigSchema = Omit<
+  IntegrationConfigSchema,
+  'authType'
+> & {
+  authType?: IntegrationConfigSchema['authType'];
+};
+
 interface UpdateMcpIntegrationParams {
   integrationId: string;
   name?: string;
+  serverUrl?: string;
+  configSchema?: UpdateIntegrationConfigSchema;
   credentials?: string;
   authHeaderName?: string;
   returnsPii?: boolean;
@@ -11,6 +22,8 @@ interface UpdateMcpIntegrationParams {
 export class UpdateMcpIntegrationCommand {
   public readonly integrationId: string;
   public readonly name?: string;
+  public readonly serverUrl?: string;
+  public readonly configSchema?: UpdateIntegrationConfigSchema;
   public readonly credentials?: string;
   public readonly authHeaderName?: string;
   public readonly returnsPii?: boolean;
@@ -20,6 +33,8 @@ export class UpdateMcpIntegrationCommand {
   constructor(params: UpdateMcpIntegrationParams) {
     this.integrationId = params.integrationId;
     this.name = params.name;
+    this.serverUrl = params.serverUrl;
+    this.configSchema = params.configSchema;
     this.credentials = params.credentials;
     this.authHeaderName = params.authHeaderName;
     this.returnsPii = params.returnsPii;

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.spec.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import { UpdateMcpIntegrationUseCase } from './update-mcp-integration.use-case';
 import { UpdateMcpIntegrationCommand } from './update-mcp-integration.command';
 import type { McpIntegrationsRepositoryPort } from 'src/domain/mcp/application/ports/mcp-integrations.repository.port';
+import type { McpIntegrationUserConfigRepositoryPort } from 'src/domain/mcp/application/ports/mcp-integration-user-config.repository.port';
 import type { ContextService } from 'src/common/context/services/context.service';
 import type { McpCredentialEncryptionPort } from 'src/domain/mcp/application/ports/mcp-credential-encryption.port';
 import { McpConfigService } from 'src/domain/mcp/application/services/mcp-config.service';
@@ -20,14 +21,17 @@ import { NoAuthMcpIntegrationAuth } from 'src/domain/mcp/domain/auth/no-auth-mcp
 import {
   McpIntegrationNotConfigurableError,
   McpMissingRequiredConfigError,
+  McpValidationFailedError,
 } from 'src/domain/mcp/application/mcp.errors';
 import type { IntegrationConfigSchema } from 'src/domain/mcp/domain/value-objects/integration-config-schema';
+import type { SchemaConfiguredMcpIntegration } from 'src/domain/mcp/domain/integrations/schema-configured-mcp-integration.entity';
 
 describe('UpdateMcpIntegrationUseCase', () => {
   const orgId = randomUUID();
   const integrationId = randomUUID();
 
   let repository: jest.Mocked<McpIntegrationsRepositoryPort>;
+  let userConfigRepository: jest.Mocked<McpIntegrationUserConfigRepositoryPort>;
   let context: jest.Mocked<ContextService>;
   let encryption: jest.Mocked<McpCredentialEncryptionPort>;
   let configService: McpConfigService;
@@ -48,6 +52,10 @@ describe('UpdateMcpIntegrationUseCase', () => {
       findByOrgIdAndMarketplaceIdentifier: jest.fn(),
       delete: jest.fn(),
     } as unknown as jest.Mocked<McpIntegrationsRepositoryPort>;
+
+    userConfigRepository = {
+      removeKeysByIntegrationId: jest.fn(),
+    } as unknown as jest.Mocked<McpIntegrationUserConfigRepositoryPort>;
 
     context = {
       get: jest.fn(),
@@ -73,6 +81,7 @@ describe('UpdateMcpIntegrationUseCase', () => {
 
     useCase = new UpdateMcpIntegrationUseCase(
       repository,
+      userConfigRepository,
       context,
       encryption,
       configService,
@@ -203,6 +212,296 @@ describe('UpdateMcpIntegrationUseCase', () => {
       (result.auth as CustomHeaderMcpIntegrationAuth).getAuthHeaderName(),
     ).toBe('X-NEW-KEY');
     expect(repository.save).toHaveBeenCalledWith(integration);
+  });
+
+  it('updates a custom integration server URL and revalidates the connection', async () => {
+    const integration = aCustomMcpIntegration({
+      id: integrationId,
+      orgId,
+      name: 'Document archive',
+      serverUrl: 'https://old.example.com/mcp',
+      auth: new NoAuthMcpIntegrationAuth(),
+    });
+    repository.findById.mockResolvedValue(integration);
+
+    const result = await useCase.execute(
+      new UpdateMcpIntegrationCommand({
+        integrationId,
+        serverUrl: 'https://new.example.com/mcp',
+      }),
+    );
+
+    expect(result.serverUrl).toBe('https://new.example.com/mcp');
+    expect(validateUseCase.execute).toHaveBeenCalledWith({ integrationId });
+    expect(repository.save).toHaveBeenCalledTimes(2);
+  });
+
+  it('updates custom header definitions while preserving an omitted secret', async () => {
+    const integration = aCustomMcpIntegration({
+      id: integrationId,
+      orgId,
+      name: 'Document archive',
+      serverUrl: 'https://documents.example.com/mcp',
+      auth: new NoAuthMcpIntegrationAuth(),
+      configSchema: {
+        authType: 'CUSTOM',
+        orgFields: [
+          {
+            key: 'apiToken',
+            label: 'API token',
+            type: 'secret',
+            headerName: 'X-Old-Token',
+            required: true,
+          },
+        ],
+        userFields: [],
+      },
+      orgConfigValues: { apiToken: 'encrypted:existing-token' },
+    });
+    repository.findById.mockResolvedValue(integration);
+
+    const result = await useCase.execute(
+      new UpdateMcpIntegrationCommand({
+        integrationId,
+        configSchema: {
+          authType: 'CUSTOM',
+          orgFields: [
+            {
+              key: 'apiToken',
+              label: 'API token',
+              type: 'secret',
+              headerName: 'Authorization',
+              prefix: 'Bearer ',
+              required: true,
+            },
+          ],
+          userFields: [],
+        },
+        orgConfigValues: {},
+      }),
+    );
+
+    expect(
+      (result as SchemaConfiguredMcpIntegration).configSchema.orgFields[0],
+    ).toEqual(
+      expect.objectContaining({
+        headerName: 'Authorization',
+        prefix: 'Bearer ',
+      }),
+    );
+    expect(
+      (result as SchemaConfiguredMcpIntegration).orgConfigValues.apiToken,
+    ).toBe('encrypted:existing-token');
+    expect(encryption.encrypt).not.toHaveBeenCalled();
+    expect(validateUseCase.execute).toHaveBeenCalledWith({ integrationId });
+  });
+
+  it('rejects changing the type of an existing configuration field', async () => {
+    const integration = aCustomMcpIntegration({
+      id: integrationId,
+      orgId,
+      name: 'Document archive',
+      serverUrl: 'https://documents.example.com/mcp',
+      auth: new NoAuthMcpIntegrationAuth(),
+      configSchema: {
+        authType: 'CUSTOM',
+        orgFields: [
+          {
+            key: 'apiToken',
+            label: 'API token',
+            type: 'secret',
+            headerName: 'Authorization',
+            required: true,
+          },
+        ],
+        userFields: [],
+      },
+      orgConfigValues: { apiToken: 'encrypted:existing-token' },
+    });
+    repository.findById.mockResolvedValue(integration);
+
+    await expect(
+      useCase.execute(
+        new UpdateMcpIntegrationCommand({
+          integrationId,
+          name: 'Partially changed name',
+          configSchema: {
+            authType: 'CUSTOM',
+            orgFields: [
+              {
+                key: 'apiToken',
+                label: 'API token',
+                type: 'text',
+                headerName: 'Authorization',
+                required: true,
+              },
+            ],
+            userFields: [],
+          },
+        }),
+      ),
+    ).rejects.toThrow(McpValidationFailedError);
+    expect(integration.name).toBe('Document archive');
+    expect(repository.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects moving an existing configuration field to another scope', async () => {
+    const integration = aCustomMcpIntegration({
+      id: integrationId,
+      orgId,
+      name: 'Document archive',
+      serverUrl: 'https://documents.example.com/mcp',
+      auth: new NoAuthMcpIntegrationAuth(),
+      configSchema: {
+        authType: 'CUSTOM',
+        orgFields: [
+          {
+            key: 'tenant',
+            label: 'Tenant',
+            type: 'text',
+            headerName: 'X-Tenant',
+            required: true,
+          },
+        ],
+        userFields: [],
+      },
+      orgConfigValues: { tenant: 'council-42' },
+    });
+    repository.findById.mockResolvedValue(integration);
+
+    await expect(
+      useCase.execute(
+        new UpdateMcpIntegrationCommand({
+          integrationId,
+          configSchema: {
+            authType: 'CUSTOM',
+            orgFields: [],
+            userFields: [
+              {
+                key: 'tenant',
+                label: 'Tenant',
+                type: 'text',
+                headerName: 'X-Tenant',
+                required: true,
+              },
+            ],
+          },
+        }),
+      ),
+    ).rejects.toThrow(McpValidationFailedError);
+    expect(repository.save).not.toHaveBeenCalled();
+  });
+
+  it('does not centrally validate integrations requiring user configuration', async () => {
+    const integration = aCustomMcpIntegration({
+      id: integrationId,
+      orgId,
+      name: 'User-scoped archive',
+      serverUrl: 'https://documents.example.com/mcp',
+      auth: new NoAuthMcpIntegrationAuth(),
+      configSchema: {
+        authType: 'CUSTOM',
+        orgFields: [],
+        userFields: [
+          {
+            key: 'apiToken',
+            label: 'API token',
+            type: 'secret',
+            headerName: 'Authorization',
+            required: true,
+          },
+        ],
+      },
+    });
+    repository.findById.mockResolvedValue(integration);
+
+    await useCase.execute(
+      new UpdateMcpIntegrationCommand({
+        integrationId,
+        serverUrl: 'https://new-documents.example.com/mcp',
+      }),
+    );
+
+    expect(validateUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('removes deleted user field values from every user config', async () => {
+    const integration = aCustomMcpIntegration({
+      id: integrationId,
+      orgId,
+      configSchema: {
+        authType: 'CUSTOM',
+        orgFields: [],
+        userFields: [
+          {
+            key: 'personalToken',
+            label: 'Personal token',
+            type: 'secret',
+            headerName: 'Authorization',
+            required: true,
+          },
+          {
+            key: 'region',
+            label: 'Region',
+            type: 'text',
+            headerName: 'X-Region',
+            required: false,
+          },
+        ],
+      },
+    });
+    repository.findById.mockResolvedValue(integration);
+
+    await useCase.execute(
+      new UpdateMcpIntegrationCommand({
+        integrationId,
+        configSchema: {
+          authType: 'CUSTOM',
+          orgFields: [],
+          userFields: [
+            {
+              key: 'region',
+              label: 'Region',
+              type: 'text',
+              headerName: 'X-Region',
+              required: false,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(userConfigRepository.removeKeysByIntegrationId).toHaveBeenCalledWith(
+      integrationId,
+      ['personalToken'],
+    );
+  });
+
+  it('preserves OAuth authType when an update schema omits it', async () => {
+    const integration = aCustomMcpIntegration({
+      id: integrationId,
+      orgId,
+      configSchema: {
+        authType: 'OAUTH',
+        orgFields: [],
+        userFields: [],
+        oauth: { clientRegistration: 'automatic', scopes: [] },
+      },
+    });
+    repository.findById.mockResolvedValue(integration);
+
+    await useCase.execute(
+      new UpdateMcpIntegrationCommand({
+        integrationId,
+        configSchema: {
+          orgFields: [],
+          userFields: [],
+          oauth: { clientRegistration: 'automatic', scopes: [] },
+        },
+      }),
+    );
+
+    expect(integration.configSchema.authType).toBe('OAUTH');
   });
 
   it('throws when user is not authenticated', async () => {

--- a/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.ts
+++ b/ayunis-core-backend/src/domain/mcp/application/use-cases/update-mcp-integration/update-mcp-integration.use-case.ts
@@ -2,11 +2,13 @@ import { Injectable, UnauthorizedException, Logger } from '@nestjs/common';
 import { UUID } from 'crypto';
 import { UpdateMcpIntegrationCommand } from './update-mcp-integration.command';
 import { McpIntegrationsRepositoryPort } from 'src/domain/mcp/application/ports/mcp-integrations.repository.port';
+import { McpIntegrationUserConfigRepositoryPort } from 'src/domain/mcp/application/ports/mcp-integration-user-config.repository.port';
 import { ContextService } from 'src/common/context/services/context.service';
 import {
   McpIntegrationNotFoundError,
   McpIntegrationAccessDeniedError,
   McpIntegrationNotConfigurableError,
+  InvalidServerUrlError,
   UnexpectedMcpError,
 } from 'src/domain/mcp/application/mcp.errors';
 import { HandleUnexpectedErrors } from 'src/common/decorators/handle-unexpected-errors.decorator';
@@ -22,6 +24,12 @@ import { ConnectionValidationService } from 'src/domain/mcp/application/services
 import { McpCapabilityCacheService } from 'src/domain/mcp/application/services/mcp-capability-cache.service';
 import { McpOAuthClientConfigurationService } from 'src/domain/mcp/application/services/mcp-oauth-client-configuration.service';
 import { McpClientService } from 'src/domain/mcp/application/services/mcp-client.service';
+import { CustomMcpIntegration } from 'src/domain/mcp/domain/integrations/custom-mcp-integration.entity';
+import {
+  type ConfigField,
+  normalizeScopes,
+  type IntegrationConfigSchema,
+} from 'src/domain/mcp/domain/value-objects/integration-config-schema';
 
 @Injectable()
 export class UpdateMcpIntegrationUseCase {
@@ -29,6 +37,7 @@ export class UpdateMcpIntegrationUseCase {
 
   constructor(
     private readonly repository: McpIntegrationsRepositoryPort,
+    private readonly userConfigRepository: McpIntegrationUserConfigRepositoryPort,
     private readonly contextService: ContextService,
     private readonly credentialEncryption: McpCredentialEncryptionPort,
     private readonly configService: McpConfigService,
@@ -50,9 +59,15 @@ export class UpdateMcpIntegrationUseCase {
       integration,
       command.oauthClient,
     );
+    this.validateConfigurationUpdate(integration, command);
+    const removedUserFieldKeys = this.removedUserFieldKeys(
+      integration,
+      command.configSchema,
+    );
 
     await this.applyUpdates(integration, command);
     const saved = await this.repository.save(integration);
+    await this.removeDeletedUserConfigValues(saved, removedUserFieldKeys);
 
     if (oauthIntegration && command.oauthClient) {
       await this.oauthClientConfiguration.initialize(
@@ -115,6 +130,8 @@ export class UpdateMcpIntegrationUseCase {
       integration.updateReturnsPii(command.returnsPii);
     }
 
+    this.updateServerUrl(integration, command.serverUrl);
+
     if (
       command.credentials !== undefined ||
       command.authHeaderName !== undefined
@@ -126,8 +143,11 @@ export class UpdateMcpIntegrationUseCase {
       );
     }
 
-    if (command.orgConfigValues !== undefined) {
-      await this.updateOrgConfigValues(integration, command.orgConfigValues);
+    if (
+      command.configSchema !== undefined ||
+      command.orgConfigValues !== undefined
+    ) {
+      await this.updateConfiguration(integration, command);
     }
   }
 
@@ -136,10 +156,10 @@ export class UpdateMcpIntegrationUseCase {
     command: UpdateMcpIntegrationCommand,
   ): Promise<McpIntegration> {
     if (
-      command.orgConfigValues !== undefined &&
+      this.hasConnectionChanges(command) &&
       !(
         integration instanceof SchemaConfiguredMcpIntegration &&
-        integration.configSchema.oauth
+        integration.requiresUserAuthorization
       )
     ) {
       return this.connectionValidationService.validateAndUpdateStatus(
@@ -150,21 +170,196 @@ export class UpdateMcpIntegrationUseCase {
     return integration;
   }
 
-  private async updateOrgConfigValues(
+  private hasConnectionChanges(command: UpdateMcpIntegrationCommand): boolean {
+    return [
+      command.serverUrl,
+      command.configSchema,
+      command.orgConfigValues,
+      command.credentials,
+      command.authHeaderName,
+    ].some((value) => value !== undefined);
+  }
+
+  private async updateConfiguration(
     integration: McpIntegration,
-    orgConfigValues: Record<string, string>,
+    command: UpdateMcpIntegrationCommand,
   ): Promise<void> {
     if (!(integration instanceof SchemaConfiguredMcpIntegration)) {
       throw new McpIntegrationNotConfigurableError(integration.id);
     }
 
+    const targetSchema = command.configSchema
+      ? this.completeConfigSchema(
+          integration.configSchema,
+          command.configSchema,
+        )
+      : integration.configSchema;
     const mergedValues = await this.configService.mergeForUpdate(
       integration.orgConfigValues,
-      orgConfigValues,
-      integration.configSchema.orgFields,
+      command.orgConfigValues ?? {},
+      targetSchema.orgFields,
     );
 
+    if (command.configSchema !== undefined) {
+      integration.updateConfigSchema(targetSchema);
+    }
     integration.updateOrgConfigValues(mergedValues);
+  }
+
+  private validateConfigurationUpdate(
+    integration: McpIntegration,
+    command: UpdateMcpIntegrationCommand,
+  ): void {
+    if (command.configSchema === undefined) return;
+    if (!(integration instanceof CustomMcpIntegration)) {
+      throw new McpIntegrationNotConfigurableError(integration.id);
+    }
+
+    this.ensureAuthenticationConfigurationUnchanged(
+      integration.configSchema,
+      this.completeConfigSchema(integration.configSchema, command.configSchema),
+      integration,
+    );
+    const targetSchema = this.completeConfigSchema(
+      integration.configSchema,
+      command.configSchema,
+    );
+    this.ensureExistingFieldsStable(
+      integration.configSchema,
+      targetSchema,
+      integration,
+    );
+    this.configService.validateCustomSchema(
+      targetSchema,
+      command.orgConfigValues ?? {},
+      command.name ?? integration.name,
+    );
+  }
+
+  private completeConfigSchema(
+    current: IntegrationConfigSchema,
+    update: NonNullable<UpdateMcpIntegrationCommand['configSchema']>,
+  ): IntegrationConfigSchema {
+    return {
+      ...update,
+      authType: update.authType ?? current.authType,
+    };
+  }
+
+  private removedUserFieldKeys(
+    integration: McpIntegration,
+    update: UpdateMcpIntegrationCommand['configSchema'],
+  ): string[] {
+    if (!(integration instanceof SchemaConfiguredMcpIntegration) || !update) {
+      return [];
+    }
+    const nextKeys = new Set(update.userFields.map((field) => field.key));
+    return integration.configSchema.userFields
+      .map((field) => field.key)
+      .filter((key) => !nextKeys.has(key));
+  }
+
+  private async removeDeletedUserConfigValues(
+    integration: McpIntegration,
+    keys: string[],
+  ): Promise<void> {
+    if (keys.length === 0) return;
+    await this.userConfigRepository.removeKeysByIntegrationId(
+      integration.id,
+      keys,
+    );
+  }
+
+  private ensureExistingFieldsStable(
+    current: IntegrationConfigSchema,
+    next: IntegrationConfigSchema,
+    integration: CustomMcpIntegration,
+  ): void {
+    const nextFields = this.indexFieldsByKey(next);
+    for (const field of this.fieldsWithScope(current)) {
+      const nextField = nextFields.get(field.key);
+      if (!nextField) continue;
+      if (nextField.type !== field.type || nextField.scope !== field.scope) {
+        throw new McpValidationFailedError(
+          integration.id,
+          integration.name,
+          'Changing the scope or value type of an existing configuration field is not supported.',
+        );
+      }
+    }
+  }
+
+  private indexFieldsByKey(
+    schema: IntegrationConfigSchema,
+  ): Map<string, ConfigField & { scope: 'organization' | 'user' }> {
+    return new Map(
+      this.fieldsWithScope(schema).map((field) => [field.key, field]),
+    );
+  }
+
+  private fieldsWithScope(
+    schema: IntegrationConfigSchema,
+  ): (ConfigField & { scope: 'organization' | 'user' })[] {
+    return [
+      ...schema.orgFields.map((field) => ({
+        ...field,
+        scope: 'organization' as const,
+      })),
+      ...schema.userFields.map((field) => ({
+        ...field,
+        scope: 'user' as const,
+      })),
+    ];
+  }
+
+  private ensureAuthenticationConfigurationUnchanged(
+    current: IntegrationConfigSchema,
+    next: IntegrationConfigSchema,
+    integration: CustomMcpIntegration,
+  ): void {
+    const currentAuth = JSON.stringify(this.authenticationConfig(current));
+    const nextAuth = JSON.stringify(this.authenticationConfig(next));
+    if (currentAuth !== nextAuth) {
+      throw new McpValidationFailedError(
+        integration.id,
+        integration.name,
+        'Changing the authentication method is not supported.',
+      );
+    }
+  }
+
+  private authenticationConfig(schema: IntegrationConfigSchema): object {
+    return {
+      authType: schema.authType,
+      oauth: schema.oauth
+        ? {
+            clientRegistration: schema.oauth.clientRegistration,
+            scopes: normalizeScopes(schema.oauth.scopes),
+          }
+        : undefined,
+    };
+  }
+
+  private updateServerUrl(
+    integration: McpIntegration,
+    serverUrl?: string,
+  ): void {
+    if (serverUrl === undefined) return;
+    if (!(integration instanceof CustomMcpIntegration)) {
+      throw new McpIntegrationNotConfigurableError(integration.id);
+    }
+    if (!this.isValidServerUrl(serverUrl)) {
+      throw new InvalidServerUrlError(serverUrl);
+    }
+    integration.updateServerUrl(serverUrl);
+  }
+
+  private isValidServerUrl(serverUrl: string): boolean {
+    try {
+      return ['http:', 'https:'].includes(new URL(serverUrl).protocol);
+    } catch {
+      return false;
+    }
   }
 
   private async rotateCredentials(

--- a/ayunis-core-backend/src/domain/mcp/domain/integrations/custom-mcp-integration.entity.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/integrations/custom-mcp-integration.entity.ts
@@ -1,11 +1,11 @@
 import type { UUID } from 'crypto';
 import { SchemaConfiguredMcpIntegration } from './schema-configured-mcp-integration.entity';
-import type { McpIntegrationAuth } from '../auth/mcp-integration-auth.entity';
-import { McpIntegrationKind } from '../value-objects/mcp-integration-kind.enum';
-import type { IntegrationConfigSchema } from '../value-objects/integration-config-schema';
+import type { McpIntegrationAuth } from 'src/domain/mcp/domain/auth/mcp-integration-auth.entity';
+import { McpIntegrationKind } from 'src/domain/mcp/domain/value-objects/mcp-integration-kind.enum';
+import type { IntegrationConfigSchema } from 'src/domain/mcp/domain/value-objects/integration-config-schema';
 
 export class CustomMcpIntegration extends SchemaConfiguredMcpIntegration {
-  private readonly _serverUrl: string;
+  private _serverUrl: string;
 
   constructor(params: {
     id?: UUID;
@@ -50,5 +50,10 @@ export class CustomMcpIntegration extends SchemaConfiguredMcpIntegration {
 
   get serverUrl(): string {
     return this._serverUrl;
+  }
+
+  updateServerUrl(serverUrl: string): void {
+    this._serverUrl = serverUrl;
+    this.touch();
   }
 }

--- a/ayunis-core-backend/src/domain/mcp/domain/integrations/schema-configured-mcp-integration.entity.ts
+++ b/ayunis-core-backend/src/domain/mcp/domain/integrations/schema-configured-mcp-integration.entity.ts
@@ -1,18 +1,18 @@
 import type { UUID } from 'crypto';
-import type { McpIntegrationAuth } from '../auth/mcp-integration-auth.entity';
-import { McpIntegration } from '../mcp-integration.entity';
+import type { McpIntegrationAuth } from 'src/domain/mcp/domain/auth/mcp-integration-auth.entity';
+import { McpIntegration } from 'src/domain/mcp/domain/mcp-integration.entity';
 import type {
   ConfigField,
   IntegrationConfigSchema,
-} from '../value-objects/integration-config-schema';
+} from 'src/domain/mcp/domain/value-objects/integration-config-schema';
 import {
   fieldRequiresInput,
   isConfigValuePresent,
   normalizeIntegrationConfigSchema,
-} from '../value-objects/integration-config-schema';
+} from 'src/domain/mcp/domain/value-objects/integration-config-schema';
 
 export abstract class SchemaConfiguredMcpIntegration extends McpIntegration {
-  public readonly configSchema: IntegrationConfigSchema;
+  private _configSchema: IntegrationConfigSchema;
   private _orgConfigValues: Record<string, string>;
 
   protected constructor(params: {
@@ -32,12 +32,21 @@ export abstract class SchemaConfiguredMcpIntegration extends McpIntegration {
     description?: string;
   }) {
     super(params);
-    this.configSchema = normalizeIntegrationConfigSchema(params.configSchema);
+    this._configSchema = normalizeIntegrationConfigSchema(params.configSchema);
     this._orgConfigValues = { ...params.orgConfigValues };
   }
 
   get orgConfigValues(): Record<string, string> {
     return { ...this._orgConfigValues };
+  }
+
+  get configSchema(): IntegrationConfigSchema {
+    return this._configSchema;
+  }
+
+  updateConfigSchema(schema: IntegrationConfigSchema): void {
+    this._configSchema = normalizeIntegrationConfigSchema(schema);
+    this.touch();
   }
 
   updateOrgConfigValues(values: Record<string, string>): void {

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-user-config.repository.spec.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-user-config.repository.spec.ts
@@ -111,4 +111,45 @@ describe('McpIntegrationUserConfigRepository', () => {
       expect(mockTypeOrmRepo.delete).toHaveBeenCalledWith({ integrationId });
     });
   });
+
+  describe('removeKeysByIntegrationId', () => {
+    it('removes the keys from every config in one set-based update', async () => {
+      const execute = jest.fn().mockResolvedValue({ affected: 2 });
+      const setParameter = jest.fn().mockReturnValue({ execute });
+      const where = jest.fn().mockReturnValue({ setParameter });
+      const set = jest.fn().mockReturnValue({ where });
+      const update = jest.fn().mockReturnValue({ set });
+      mockTypeOrmRepo.createQueryBuilder = jest
+        .fn()
+        .mockReturnValue({ update });
+
+      await repository.removeKeysByIntegrationId(integrationId, [
+        'personalToken',
+      ]);
+
+      expect(set).toHaveBeenCalledWith({
+        configValues: expect.any(Function),
+        updatedAt: expect.any(Function),
+      });
+      const values = set.mock.calls[0][0] as {
+        configValues: () => string;
+        updatedAt: () => string;
+      };
+      expect(values.configValues()).toBe('"config_values" - :keys::text[]');
+      expect(values.updatedAt()).toBe('CURRENT_TIMESTAMP');
+      expect(where).toHaveBeenCalledWith('"integration_id" = :integrationId', {
+        integrationId,
+      });
+      expect(setParameter).toHaveBeenCalledWith('keys', ['personalToken']);
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not issue an update when there are no keys', async () => {
+      mockTypeOrmRepo.createQueryBuilder = jest.fn();
+
+      await repository.removeKeysByIntegrationId(integrationId, []);
+
+      expect(mockTypeOrmRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-user-config.repository.ts
+++ b/ayunis-core-backend/src/domain/mcp/infrastructure/persistence/postgres/mcp-integration-user-config.repository.ts
@@ -84,6 +84,25 @@ export class McpIntegrationUserConfigRepository extends McpIntegrationUserConfig
     await this.repository.delete({ integrationId });
   }
 
+  async removeKeysByIntegrationId(
+    integrationId: UUID,
+    keys: string[],
+  ): Promise<void> {
+    if (keys.length === 0) return;
+
+    this.logger.log({ integrationId, keys }, 'removeKeysByIntegrationId');
+    await this.repository
+      .createQueryBuilder()
+      .update()
+      .set({
+        configValues: () => '"config_values" - :keys::text[]',
+        updatedAt: () => 'CURRENT_TIMESTAMP',
+      })
+      .where('"integration_id" = :integrationId', { integrationId })
+      .setParameter('keys', keys)
+      .execute();
+  }
+
   private toRecord(
     entity: McpIntegrationUserConfig,
   ): McpIntegrationUserConfigRecord {

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/dto/update-mcp-integration.dto.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/dto/update-mcp-integration.dto.ts
@@ -6,11 +6,15 @@ import {
   IsObject,
   Length,
   MinLength,
+  IsUrl,
 } from 'class-validator';
 import { IsStringRecord } from 'src/common/validators/is-string-record.validator';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { McpOAuthClientDto } from './create-custom-integration.dto';
+import {
+  CustomMcpConfigSchemaDto,
+  McpOAuthClientDto,
+} from './create-custom-integration.dto';
 
 /**
  * DTO for updating an existing MCP integration.
@@ -36,6 +40,27 @@ export class UpdateMcpIntegrationDto {
   @IsString()
   @Length(1, 255)
   name?: string;
+
+  @ApiPropertyOptional({
+    description: 'Custom MCP server URL',
+    example: 'https://my-mcp-server.example.com/mcp',
+  })
+  @IsOptional()
+  @IsUrl({
+    protocols: ['http', 'https'],
+    require_protocol: true,
+    require_tld: false,
+  })
+  serverUrl?: string;
+
+  @ApiPropertyOptional({
+    description: 'Header configuration for a custom MCP integration',
+    type: CustomMcpConfigSchemaDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CustomMcpConfigSchemaDto)
+  configSchema?: CustomMcpConfigSchemaDto;
 
   @ApiProperty({
     description:

--- a/ayunis-core-backend/src/domain/mcp/presenters/http/mcp-integrations.controller.ts
+++ b/ayunis-core-backend/src/domain/mcp/presenters/http/mcp-integrations.controller.ts
@@ -302,6 +302,8 @@ export class McpIntegrationsController {
     const command = new UpdateMcpIntegrationCommand({
       integrationId: id,
       name: dto.name,
+      serverUrl: dto.serverUrl,
+      configSchema: dto.configSchema,
       credentials: dto.credentials,
       authHeaderName: dto.authHeaderName,
       returnsPii: dto.returnsPii,

--- a/ayunis-core-e2e/src/clients/api/integrations.client.ts
+++ b/ayunis-core-e2e/src/clients/api/integrations.client.ts
@@ -1,0 +1,56 @@
+import type { APIRequestContext } from "@playwright/test";
+import type {
+  CreateCustomIntegrationDto,
+  McpIntegrationResponseDto,
+  SetUserConfigDto,
+  UpdateMcpIntegrationDto,
+  UserConfigResponseDto,
+} from "../generated/ayunisCoreAPI.schemas";
+import { generatedApi } from "./generated-api";
+
+export function createCustomIntegration(
+  api: APIRequestContext,
+  data: CreateCustomIntegrationDto,
+): Promise<McpIntegrationResponseDto> {
+  return generatedApi.mcpIntegrationsControllerCreateCustom(data, { api });
+}
+
+export function getIntegration(
+  api: APIRequestContext,
+  integrationId: string,
+): Promise<McpIntegrationResponseDto> {
+  return generatedApi.mcpIntegrationsControllerGetById(integrationId, {
+    api,
+  });
+}
+
+export function updateIntegration(
+  api: APIRequestContext,
+  integrationId: string,
+  data: UpdateMcpIntegrationDto,
+): Promise<McpIntegrationResponseDto> {
+  return generatedApi.mcpIntegrationsControllerUpdate(integrationId, data, {
+    api,
+  });
+}
+
+export function setUserIntegrationConfig(
+  api: APIRequestContext,
+  integrationId: string,
+  data: SetUserConfigDto,
+): Promise<UserConfigResponseDto> {
+  return generatedApi.mcpIntegrationsControllerSetUserConfig(
+    integrationId,
+    data,
+    { api },
+  );
+}
+
+export function getUserIntegrationConfig(
+  api: APIRequestContext,
+  integrationId: string,
+): Promise<UserConfigResponseDto> {
+  return generatedApi.mcpIntegrationsControllerGetUserConfig(integrationId, {
+    api,
+  });
+}

--- a/ayunis-core-e2e/src/clients/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-e2e/src/clients/generated/ayunisCoreAPI.schemas.ts
@@ -3170,6 +3170,10 @@ export interface UpdateMcpIntegrationDto {
      * @maxLength 255
      */
   name?: string;
+  /** Custom MCP server URL */
+  serverUrl?: string;
+  /** Header configuration for a custom MCP integration */
+  configSchema?: CustomMcpConfigSchemaDto;
   /** Authentication credentials (will be encrypted). Provide to rotate the stored secret/token. */
   credentials?: string;
   /** Custom auth header name. Only used in combination with CUSTOM_HEADER integrations. */

--- a/ayunis-core-e2e/tests/admin/integrations.spec.ts
+++ b/ayunis-core-e2e/tests/admin/integrations.spec.ts
@@ -1,0 +1,158 @@
+import {
+  createCustomIntegration,
+  getIntegration,
+  getUserIntegrationConfig,
+  setUserIntegrationConfig,
+  updateIntegration,
+} from "../../src/clients/api/integrations.client";
+import { config } from "../../src/config";
+import { test, expect } from "../../src/fixtures/test";
+
+test("edits a custom integration connection without replacing its secret", async ({
+  page,
+  api,
+}) => {
+  const suffix = Date.now();
+  const integration = await createCustomIntegration(api, {
+    name: `Document archive ${suffix}`,
+    serverUrl: `${config.apiURL}/health`,
+    configSchema: {
+      authType: "CUSTOM",
+      orgFields: [
+        {
+          key: "apiToken",
+          label: "API token",
+          type: "secret",
+          headerName: "X-Archive-Token",
+          required: true,
+        },
+      ],
+      userFields: [],
+    },
+    orgConfigValues: { apiToken: `secret-${suffix}` },
+  });
+
+  await page.goto("/admin-settings/integrations");
+  const card = page.getByTestId(`integration-card-${integration.id}`);
+  await card.getByTestId("integration-actions").click();
+  await page.getByTestId("integration-edit-action").click();
+
+  const updatedUrl = `${config.apiURL}/health?updated=${suffix}`;
+  await page.getByTestId("integration-edit-server-url").fill(updatedUrl);
+  await page
+    .getByTestId("integration-edit-field-0-header-name")
+    .fill("Authorization");
+  await page.getByTestId("integration-edit-submit").click();
+
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await expect(page.getByTestId("integration-edit-submit")).toBeEnabled();
+  await expect
+    .poll(async () => {
+      const updated = await getIntegration(api, integration.id);
+      const schema = updated.configSchema as {
+        orgFields: Array<{ headerName?: string }>;
+      };
+      return {
+        serverUrl: updated.serverUrl,
+        headerName: schema.orgFields[0]?.headerName,
+        secret: updated.orgConfigValues?.apiToken,
+      };
+    })
+    .toEqual({
+      serverUrl: updatedUrl,
+      headerName: "Authorization",
+      secret: "••••••",
+    });
+});
+
+test("closes cleanly after editing an integration that requires user config", async ({
+  page,
+  api,
+}) => {
+  const suffix = Date.now();
+  const integration = await createCustomIntegration(api, {
+    name: `Personal archive ${suffix}`,
+    serverUrl: `${config.apiURL}/health`,
+    configSchema: {
+      authType: "CUSTOM",
+      orgFields: [],
+      userFields: [
+        {
+          key: "apiToken",
+          label: "API token",
+          type: "secret",
+          headerName: "X-Archive-Token",
+          required: true,
+        },
+      ],
+    },
+    orgConfigValues: {},
+  });
+
+  await page.goto("/admin-settings/integrations");
+  const card = page.getByTestId(`integration-card-${integration.id}`);
+  await card.getByTestId("integration-actions").click();
+  await page.getByTestId("integration-edit-action").click();
+  await page
+    .getByTestId("integration-edit-field-0-header-name")
+    .fill("Authorization");
+  await page.getByTestId("integration-edit-submit").click();
+
+  await expect(page.getByRole("dialog")).toBeHidden();
+  await expect
+    .poll(() => page.evaluate(() => document.body.style.pointerEvents))
+    .toBe("");
+  await expect
+    .poll(async () => {
+      const updated = await getIntegration(api, integration.id);
+      const schema = updated.configSchema as {
+        userFields: Array<{ headerName?: string }>;
+      };
+      return schema.userFields[0]?.headerName;
+    })
+    .toBe("Authorization");
+});
+
+test("removes stored user secrets when their configuration field is deleted", async ({
+  api,
+}) => {
+  const suffix = Date.now();
+  const userField = {
+    key: "personalToken",
+    label: "Personal token",
+    type: "secret" as const,
+    headerName: "Authorization",
+    required: true,
+  };
+  const integration = await createCustomIntegration(api, {
+    name: `Disposable user config ${suffix}`,
+    serverUrl: `${config.apiURL}/health`,
+    configSchema: {
+      authType: "CUSTOM",
+      orgFields: [],
+      userFields: [userField],
+    },
+    orgConfigValues: {},
+  });
+  await setUserIntegrationConfig(api, integration.id, {
+    configValues: { personalToken: `secret-${suffix}` },
+  });
+
+  await updateIntegration(api, integration.id, {
+    configSchema: {
+      authType: "CUSTOM",
+      orgFields: [],
+      userFields: [],
+    },
+  });
+  await updateIntegration(api, integration.id, {
+    configSchema: {
+      authType: "CUSTOM",
+      orgFields: [],
+      userFields: [userField],
+    },
+  });
+
+  const userConfig = await getUserIntegrationConfig(api, integration.id);
+  expect(userConfig.configValues).toEqual({});
+});

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/api/useUpdateIntegration.test.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/api/useUpdateIntegration.test.tsx
@@ -1,0 +1,193 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUpdateIntegration } from './useUpdateIntegration';
+
+const mocks = vi.hoisted(() => ({
+  invalidateQueries: vi.fn(),
+  mutate: vi.fn(),
+  mutationOptions: undefined as
+    | {
+        onSuccess: (
+          data: {
+            connectionStatus?: string;
+            lastConnectionError?: string;
+            configSchema?: {
+              authType?: string;
+              oauth?: { clientRegistration: 'automatic' | 'static' };
+            };
+            userAuthorizationRequired?: boolean;
+          },
+          variables?: { data: Record<string, unknown> },
+        ) => void;
+        onError: (error: unknown) => void;
+      }
+    | undefined,
+  errorCode: 'UNKNOWN',
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: mocks.invalidateQueries }),
+}));
+vi.mock('@/shared/api/generated/ayunisCoreAPI', () => ({
+  getMcpIntegrationsControllerListQueryKey: () => ['integrations'],
+  useMcpIntegrationsControllerUpdate: (options: {
+    mutation: {
+      onSuccess: (
+        data: {
+          connectionStatus?: string;
+          lastConnectionError?: string;
+          configSchema?: {
+            authType?: string;
+            oauth?: { clientRegistration: 'automatic' | 'static' };
+          };
+          userAuthorizationRequired?: boolean;
+        },
+        variables?: { data: Record<string, unknown> },
+      ) => void;
+      onError: (error: unknown) => void;
+    };
+  }) => {
+    mocks.mutationOptions = options.mutation;
+    return { mutate: mocks.mutate, isPending: false };
+  },
+}));
+vi.mock('@/shared/lib/toast', () => ({
+  showError: mocks.showError,
+  showSuccess: mocks.showSuccess,
+}));
+vi.mock('@/shared/api/extract-error-data', () => ({
+  default: () => ({ code: mocks.errorCode }),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { message?: string }) =>
+      options?.message ? `${key}:${options.message}` : key,
+  }),
+}));
+
+describe(useUpdateIntegration.name, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.errorCode = 'UNKNOWN';
+  });
+
+  it('reports a failed connection and keeps the edit dialog open', () => {
+    const onSuccess = vi.fn();
+    renderHook(() => useUpdateIntegration(onSuccess));
+
+    act(() => {
+      mocks.mutationOptions?.onSuccess(
+        {
+          connectionStatus: 'error',
+          lastConnectionError: 'Authentication failed',
+        },
+        { data: { serverUrl: 'https://broken.example.com/mcp' } },
+      );
+    });
+
+    expect(mocks.showError).toHaveBeenCalledWith(
+      'integrations.updateIntegration.connectionFailed:Authentication failed',
+    );
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('does not describe an existing error as a new connection test failure', () => {
+    const onSuccess = vi.fn();
+    renderHook(() => useUpdateIntegration(onSuccess));
+
+    act(() => {
+      mocks.mutationOptions?.onSuccess(
+        {
+          connectionStatus: 'error',
+          lastConnectionError: 'Existing connection error',
+        },
+        { data: { name: 'Renamed integration' } },
+      );
+    });
+
+    expect(mocks.showSuccess).toHaveBeenCalledWith(
+      'integrations.updateIntegration.success',
+    );
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  it('does not report an OAuth save as a failed connection test', () => {
+    const onSuccess = vi.fn();
+    renderHook(() => useUpdateIntegration(onSuccess));
+
+    act(() => {
+      mocks.mutationOptions?.onSuccess(
+        {
+          connectionStatus: 'error',
+          lastConnectionError: 'Existing OAuth connection error',
+          configSchema: {
+            authType: 'OAUTH',
+            oauth: { clientRegistration: 'automatic' },
+          },
+        },
+        { data: { orgConfigValues: { tenant: 'council-42' } } },
+      );
+    });
+
+    expect(mocks.showSuccess).toHaveBeenCalledWith(
+      'integrations.updateIntegration.success',
+    );
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  it('does not report a user-config save as a failed connection test', () => {
+    const onSuccess = vi.fn();
+    renderHook(() => useUpdateIntegration(onSuccess));
+
+    act(() => {
+      mocks.mutationOptions?.onSuccess(
+        {
+          connectionStatus: 'error',
+          lastConnectionError: 'Existing user connection error',
+          userAuthorizationRequired: true,
+        },
+        { data: { serverUrl: 'https://new.example.com/mcp' } },
+      );
+    });
+
+    expect(mocks.showSuccess).toHaveBeenCalledWith(
+      'integrations.updateIntegration.success',
+    );
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  it('reports a successful connection and closes the edit dialog', () => {
+    const onSuccess = vi.fn();
+    renderHook(() => useUpdateIntegration(onSuccess));
+
+    act(() => {
+      mocks.mutationOptions?.onSuccess(
+        { connectionStatus: 'connected' },
+        { data: { serverUrl: 'https://working.example.com/mcp' } },
+      );
+    });
+
+    expect(mocks.showSuccess).toHaveBeenCalledWith(
+      'integrations.updateIntegration.success',
+    );
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ['MCP_VALIDATION_FAILED', 'invalidConfiguration'],
+    ['MCP_MISSING_REQUIRED_CONFIG', 'missingRequiredConfiguration'],
+  ])('reports %s with a specific configuration error', (code, messageKey) => {
+    mocks.errorCode = code;
+    renderHook(() => useUpdateIntegration());
+
+    act(() => {
+      mocks.mutationOptions?.onError(new Error('request failed'));
+    });
+
+    expect(mocks.showError).toHaveBeenCalledWith(
+      `integrations.updateIntegration.${messageKey}`,
+    );
+  });
+});

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/api/useUpdateIntegration.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/api/useUpdateIntegration.ts
@@ -5,8 +5,9 @@ import {
   useMcpIntegrationsControllerUpdate,
   getMcpIntegrationsControllerListQueryKey,
 } from '@/shared/api/generated/ayunisCoreAPI';
-import type { UpdateIntegrationFormData } from '../model/types';
+import type { UpdateIntegrationFormData } from '@/pages/admin-settings/integrations-settings/model/types';
 import extractErrorData from '@/shared/api/extract-error-data';
+import { hasOAuthConfiguration } from '@/shared/lib/mcp-oauth';
 
 export function useUpdateIntegration(onSuccess?: () => void) {
   const queryClient = useQueryClient();
@@ -14,15 +15,32 @@ export function useUpdateIntegration(onSuccess?: () => void) {
 
   const mutation = useMcpIntegrationsControllerUpdate({
     mutation: {
-      onSuccess: () => {
+      onSuccess: (integration, variables) => {
         void queryClient.invalidateQueries({
           queryKey: getMcpIntegrationsControllerListQueryKey(),
         });
+        const configSchema = integration.configSchema as Parameters<
+          typeof hasOAuthConfiguration
+        >[0];
+        if (
+          hasConnectionChanges(variables.data) &&
+          !hasOAuthConfiguration(configSchema) &&
+          integration.userAuthorizationRequired !== true &&
+          integration.connectionStatus === 'error'
+        ) {
+          showError(
+            integration.lastConnectionError
+              ? t('integrations.updateIntegration.connectionFailed', {
+                  message: integration.lastConnectionError,
+                })
+              : t('integrations.updateIntegration.connectionFailedGeneric'),
+          );
+          return;
+        }
         showSuccess(t('integrations.updateIntegration.success'));
         onSuccess?.();
       },
       onError: (error: unknown) => {
-        console.error('Update integration failed:', error);
         try {
           const { code } = extractErrorData(error);
           switch (code) {
@@ -31,6 +49,18 @@ export function useUpdateIntegration(onSuccess?: () => void) {
               break;
             case 'INVALID_SERVER_URL':
               showError(t('integrations.updateIntegration.invalidServerUrl'));
+              break;
+            case 'MCP_VALIDATION_FAILED':
+              showError(
+                t('integrations.updateIntegration.invalidConfiguration'),
+              );
+              break;
+            case 'MCP_MISSING_REQUIRED_CONFIG':
+              showError(
+                t(
+                  'integrations.updateIntegration.missingRequiredConfiguration',
+                ),
+              );
               break;
             default:
               showError(t('integrations.updateIntegration.error'));
@@ -51,4 +81,14 @@ export function useUpdateIntegration(onSuccess?: () => void) {
     updateIntegration,
     isUpdating: mutation.isPending,
   };
+}
+
+function hasConnectionChanges(data: UpdateIntegrationFormData): boolean {
+  return [
+    data.serverUrl,
+    data.configSchema,
+    data.orgConfigValues,
+    data.credentials,
+    data.authHeaderName,
+  ].some((value) => value !== undefined);
 }

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/lib/edit-custom-integration.spec.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/lib/edit-custom-integration.spec.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import type { McpIntegration } from '@/pages/admin-settings/integrations-settings/model/types';
+import {
+  buildCustomIntegrationUpdatePayload,
+  toEditCustomIntegrationFormData,
+} from './edit-custom-integration';
+
+const integration = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: 'Document archive',
+  type: 'custom',
+  serverUrl: 'https://old.example.com/mcp',
+  enabled: true,
+  organizationId: '22222222-2222-2222-2222-222222222222',
+  hasCredentials: false,
+  createdAt: '2026-09-01T10:00:00.000Z',
+  updatedAt: '2026-09-01T10:00:00.000Z',
+  returnsPii: true,
+  configSchema: {
+    authType: 'CUSTOM',
+    orgFields: [
+      {
+        key: 'apiToken',
+        label: 'API token',
+        type: 'secret',
+        headerName: 'X-Old-Token',
+        required: true,
+      },
+      {
+        key: 'tenantUrl',
+        label: 'Tenant URL',
+        type: 'url',
+        headerName: 'X-Tenant-Url',
+        required: true,
+      },
+    ],
+    userFields: [],
+  },
+  orgConfigValues: {
+    apiToken: '••••••',
+    tenantUrl: 'https://tenant.example.com',
+  },
+} as McpIntegration;
+
+describe('custom integration edit mapping', () => {
+  it('prefills the server URL and non-secret values while masking secrets', () => {
+    const formData = toEditCustomIntegrationFormData(integration);
+
+    expect(formData.serverUrl).toBe('https://old.example.com/mcp');
+    expect(formData.fields).toEqual([
+      expect.objectContaining({
+        key: 'apiToken',
+        headerName: 'X-Old-Token',
+        value: '',
+      }),
+      expect.objectContaining({
+        key: 'tenantUrl',
+        value: 'https://tenant.example.com',
+      }),
+    ]);
+  });
+
+  it('sends changed URL and header definitions without the unchanged secret', () => {
+    const formData = toEditCustomIntegrationFormData(integration);
+    formData.serverUrl = ' https://new.example.com/mcp ';
+    formData.fields[0].headerName = 'Authorization';
+    formData.fields[0].prefix = 'Bearer ';
+
+    expect(buildCustomIntegrationUpdatePayload(formData, integration)).toEqual(
+      expect.objectContaining({
+        serverUrl: 'https://new.example.com/mcp',
+        configSchema: expect.objectContaining({
+          orgFields: [
+            expect.objectContaining({
+              key: 'apiToken',
+              headerName: 'Authorization',
+              prefix: 'Bearer ',
+            }),
+            expect.objectContaining({ key: 'tenantUrl' }),
+          ],
+        }),
+      }),
+    );
+    expect(
+      buildCustomIntegrationUpdatePayload(formData, integration),
+    ).not.toHaveProperty('orgConfigValues');
+  });
+
+  it('sends only the name for a rename-only edit', () => {
+    const formData = toEditCustomIntegrationFormData(integration);
+    formData.name = 'Renamed document archive';
+
+    expect(buildCustomIntegrationUpdatePayload(formData, integration)).toEqual({
+      name: 'Renamed document archive',
+    });
+  });
+
+  it('builds an empty payload when the form is unchanged', () => {
+    const formData = toEditCustomIntegrationFormData(integration);
+
+    expect(buildCustomIntegrationUpdatePayload(formData, integration)).toEqual(
+      {},
+    );
+  });
+
+  it('builds an empty payload for an unchanged OAuth schema with no scopes', () => {
+    const oauthIntegration = {
+      ...integration,
+      configSchema: {
+        authType: 'OAUTH',
+        orgFields: [],
+        userFields: [],
+        oauth: {
+          clientRegistration: 'automatic',
+          scopes: [],
+        },
+      },
+      orgConfigValues: {},
+    } as McpIntegration;
+    const formData = toEditCustomIntegrationFormData(oauthIntegration);
+
+    expect(
+      buildCustomIntegrationUpdatePayload(formData, oauthIntegration),
+    ).toEqual({});
+  });
+});

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/lib/edit-custom-integration.ts
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/lib/edit-custom-integration.ts
@@ -1,0 +1,153 @@
+import type {
+  CustomMcpConfigFieldDto,
+  CustomMcpConfigSchemaDto,
+} from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import type {
+  CreateCustomIntegrationFormData,
+  CustomConfigFieldFormData,
+  McpIntegration,
+  UpdateIntegrationFormData,
+} from '@/pages/admin-settings/integrations-settings/model/types';
+import { parseOAuthScopes } from '@/shared/lib/mcp-oauth';
+
+type CustomIntegrationUpdatePayload = UpdateIntegrationFormData;
+
+export function toEditCustomIntegrationFormData(
+  integration: McpIntegration,
+): CreateCustomIntegrationFormData {
+  const schema =
+    integration.configSchema as unknown as CustomMcpConfigSchemaDto;
+  const orgValues = integration.orgConfigValues ?? {};
+
+  return {
+    name: integration.name,
+    serverUrl: integration.serverUrl ?? '',
+    authType: schema.authType,
+    oauthClientRegistration: schema.oauth?.clientRegistration ?? 'automatic',
+    oauthScopes: schema.oauth?.scopes?.join(' ') ?? '',
+    oauthClientId: '',
+    oauthClientSecret: '',
+    fields: [
+      ...schema.orgFields.map((field) =>
+        toFormField(field, 'organization', orgValues[field.key]),
+      ),
+      ...schema.userFields.map((field) => toFormField(field, 'user')),
+    ],
+  };
+}
+
+export function buildCustomIntegrationUpdatePayload(
+  data: CreateCustomIntegrationFormData,
+  integration: McpIntegration,
+): CustomIntegrationUpdatePayload {
+  const schema =
+    integration.configSchema as unknown as CustomMcpConfigSchemaDto;
+  const targetSchema = buildTargetSchema(data, schema);
+  const changedOrgConfigValues = collectChangedOrgConfigValues(
+    data.fields,
+    integration.orgConfigValues ?? {},
+  );
+  const payload: CustomIntegrationUpdatePayload = {
+    ...buildOAuthClientUpdate(data),
+  };
+
+  const name = data.name.trim();
+  if (name !== integration.name) payload.name = name;
+  const serverUrl = data.serverUrl.trim();
+  if (serverUrl !== integration.serverUrl) payload.serverUrl = serverUrl;
+  if (JSON.stringify(targetSchema) !== JSON.stringify(schema)) {
+    payload.configSchema = targetSchema;
+  }
+  if (Object.keys(changedOrgConfigValues).length > 0) {
+    payload.orgConfigValues = changedOrgConfigValues;
+  }
+  return payload;
+}
+
+function buildTargetSchema(
+  data: CreateCustomIntegrationFormData,
+  current: CustomMcpConfigSchemaDto,
+): CustomMcpConfigSchemaDto {
+  const scopes = parseOAuthScopes(data.oauthScopes);
+  return {
+    authType: current.authType,
+    orgFields: data.fields
+      .filter((field) => field.scope === 'organization')
+      .map(toConfigField),
+    userFields: data.fields
+      .filter((field) => field.scope === 'user')
+      .map(toConfigField),
+    ...(current.oauth
+      ? {
+          oauth: {
+            clientRegistration: current.oauth.clientRegistration,
+            scopes: scopes ?? [],
+          },
+        }
+      : {}),
+  };
+}
+
+function collectChangedOrgConfigValues(
+  fields: CustomConfigFieldFormData[],
+  currentValues: Record<string, unknown>,
+): Record<string, string> {
+  return Object.fromEntries(
+    fields
+      .filter((field) => {
+        if (field.scope !== 'organization') return false;
+        if (field.type === 'secret') return field.value.trim().length > 0;
+        return field.value !== (currentValues[field.key] ?? '');
+      })
+      .map((field) => [field.key, field.value]),
+  );
+}
+
+function toFormField(
+  field: CustomMcpConfigFieldDto,
+  scope: CustomConfigFieldFormData['scope'],
+  currentValue?: unknown,
+): CustomConfigFieldFormData {
+  return {
+    key: field.key,
+    scope,
+    label: field.label,
+    type: field.type,
+    headerName: field.headerName,
+    prefix: field.prefix ?? '',
+    required: field.required,
+    help: field.help ?? '',
+    value:
+      scope === 'organization' &&
+      field.type !== 'secret' &&
+      typeof currentValue === 'string'
+        ? currentValue
+        : '',
+  };
+}
+
+function toConfigField(field: CustomConfigFieldFormData) {
+  return {
+    key: field.key,
+    label: field.label.trim(),
+    type: field.type,
+    headerName: field.headerName.trim(),
+    required: field.required,
+    ...(field.prefix.trim() ? { prefix: field.prefix } : {}),
+    ...(field.help.trim() ? { help: field.help.trim() } : {}),
+  };
+}
+
+function buildOAuthClientUpdate(
+  data: CreateCustomIntegrationFormData,
+): Pick<UpdateIntegrationFormData, 'oauthClient'> | Record<string, never> {
+  const clientId = data.oauthClientId.trim();
+  if (!clientId) return {};
+  const clientSecret = data.oauthClientSecret.trim();
+  return {
+    oauthClient: {
+      clientId,
+      ...(clientSecret ? { clientSecret } : {}),
+    },
+  };
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/create-custom-dialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/create-custom-dialog.tsx
@@ -9,26 +9,18 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@ayunis/ui/components/dialog';
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@ayunis/ui/components/form';
-import { Input } from '@ayunis/ui/components/input';
+import { Form } from '@ayunis/ui/components/form';
 import { Button } from '@ayunis/ui/components/button';
-import type { CreateCustomIntegrationFormData } from '../model/types';
-import { useCreateCustomIntegration } from '../api/useCreateCustomIntegration';
-import { buildCustomIntegrationPayload } from '../lib/build-custom-integration-payload';
+import type { CreateCustomIntegrationFormData } from '@/pages/admin-settings/integrations-settings/model/types';
+import { useCreateCustomIntegration } from '@/pages/admin-settings/integrations-settings/api/useCreateCustomIntegration';
+import { buildCustomIntegrationPayload } from '@/pages/admin-settings/integrations-settings/lib/build-custom-integration-payload';
 import {
   findDuplicateHeaderIndexes,
   findOAuthAuthorizationHeaderIndexes,
-} from '../lib/custom-config-field-validation';
+} from '@/pages/admin-settings/integrations-settings/lib/custom-config-field-validation';
 import { CustomConfigFieldEditor } from './custom-config-field-editor';
 import { CustomOAuthFields } from './custom-oauth-fields';
+import { CustomIntegrationIdentityFields } from './custom-integration-identity-fields';
 
 interface CreateCustomDialogProps {
   open: boolean;
@@ -121,57 +113,9 @@ export function CreateCustomDialog({
             onSubmit={(event) => void form.handleSubmit(submit)(event)}
             className="space-y-4"
           >
-            <FormField
-              control={form.control}
-              name="name"
-              rules={{ required: true }}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>
-                    {t('integrations.createCustomDialog.name')}
-                  </FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder={t(
-                        'integrations.createCustomDialog.namePlaceholder',
-                      )}
-                      {...field}
-                      disabled={isCreating}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    {t('integrations.createCustomDialog.nameDescription')}
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="serverUrl"
-              rules={{ required: true }}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>
-                    {t('integrations.createCustomDialog.serverUrl')}
-                  </FormLabel>
-                  <FormControl>
-                    <Input
-                      type="url"
-                      placeholder={t(
-                        'integrations.createCustomDialog.serverUrlPlaceholder',
-                      )}
-                      {...field}
-                      disabled={isCreating}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    {t('integrations.createCustomDialog.serverUrlDescription')}
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
+            <CustomIntegrationIdentityFields
+              form={form}
+              disabled={isCreating}
             />
 
             <CustomOAuthFields form={form} disabled={isCreating} />

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/custom-config-field-editor.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/custom-config-field-editor.tsx
@@ -5,8 +5,8 @@ import type {
 } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { Trash2 } from 'lucide-react';
-import type { CreateCustomIntegrationFormData } from '../model/types';
-import { HTTP_HEADER_NAME_PATTERN } from '../lib/custom-config-field-validation';
+import type { CreateCustomIntegrationFormData } from '@/pages/admin-settings/integrations-settings/model/types';
+import { HTTP_HEADER_NAME_PATTERN } from '@/pages/admin-settings/integrations-settings/lib/custom-config-field-validation';
 import { Button } from '@ayunis/ui/components/button';
 import { Checkbox } from '@ayunis/ui/components/checkbox';
 import {
@@ -31,6 +31,9 @@ interface CustomConfigFieldEditorProps {
   fields: FieldArrayWithId<CreateCustomIntegrationFormData, 'fields', 'id'>[];
   remove: UseFieldArrayRemove;
   disabled: boolean;
+  storedSecretKeys?: ReadonlySet<string>;
+  lockedFieldKeys?: ReadonlySet<string>;
+  testIdPrefix?: string;
 }
 
 export function CustomConfigFieldEditor({
@@ -38,6 +41,9 @@ export function CustomConfigFieldEditor({
   fields,
   remove,
   disabled,
+  storedSecretKeys = new Set(),
+  lockedFieldKeys = new Set(),
+  testIdPrefix,
 }: Readonly<CustomConfigFieldEditorProps>) {
   const { t } = useTranslation('admin-settings-integrations');
 
@@ -85,7 +91,7 @@ export function CustomConfigFieldEditor({
                   <Select
                     value={input.value}
                     onValueChange={input.onChange}
-                    disabled={disabled}
+                    disabled={disabled || lockedFieldKeys.has(field.key)}
                   >
                     <FormControl>
                       <SelectTrigger>
@@ -117,7 +123,7 @@ export function CustomConfigFieldEditor({
                   <Select
                     value={input.value}
                     onValueChange={input.onChange}
-                    disabled={disabled}
+                    disabled={disabled || lockedFieldKeys.has(field.key)}
                   >
                     <FormControl>
                       <SelectTrigger>
@@ -150,6 +156,9 @@ export function CustomConfigFieldEditor({
               label={t('integrations.createCustomDialog.fieldLabel')}
               required
               disabled={disabled}
+              testId={
+                testIdPrefix ? `${testIdPrefix}-${index}-label` : undefined
+              }
             />
             <TextField
               form={form}
@@ -159,6 +168,11 @@ export function CustomConfigFieldEditor({
               placeholder="Authorization"
               required
               disabled={disabled}
+              testId={
+                testIdPrefix
+                  ? `${testIdPrefix}-${index}-header-name`
+                  : undefined
+              }
             />
           </div>
 
@@ -170,6 +184,9 @@ export function CustomConfigFieldEditor({
               label={t('integrations.createCustomDialog.prefix')}
               placeholder="Bearer "
               disabled={disabled}
+              testId={
+                testIdPrefix ? `${testIdPrefix}-${index}-prefix` : undefined
+              }
             />
             <TextField
               form={form}
@@ -177,6 +194,9 @@ export function CustomConfigFieldEditor({
               name="help"
               label={t('integrations.createCustomDialog.help')}
               disabled={disabled}
+              testId={
+                testIdPrefix ? `${testIdPrefix}-${index}-help` : undefined
+              }
             />
           </div>
 
@@ -203,6 +223,8 @@ export function CustomConfigFieldEditor({
             form={form}
             index={index}
             disabled={disabled}
+            hasStoredSecret={storedSecretKeys.has(field.key)}
+            testId={testIdPrefix ? `${testIdPrefix}-${index}-value` : undefined}
           />
         </div>
       ))}
@@ -218,6 +240,7 @@ function TextField({
   placeholder,
   required = false,
   disabled,
+  testId,
 }: Readonly<{
   form: UseFormReturn<CreateCustomIntegrationFormData>;
   index: number;
@@ -226,6 +249,7 @@ function TextField({
   placeholder?: string;
   required?: boolean;
   disabled: boolean;
+  testId?: string;
 }>) {
   const { t } = useTranslation('admin-settings-integrations');
   const rules =
@@ -248,7 +272,12 @@ function TextField({
         <FormItem>
           <FormLabel>{label}</FormLabel>
           <FormControl>
-            <Input {...field} placeholder={placeholder} disabled={disabled} />
+            <Input
+              {...field}
+              placeholder={placeholder}
+              disabled={disabled}
+              data-testid={testId}
+            />
           </FormControl>
           <FormMessage />
         </FormItem>
@@ -261,15 +290,21 @@ function OrganizationValueField({
   form,
   index,
   disabled,
+  hasStoredSecret,
+  testId,
 }: Readonly<{
   form: UseFormReturn<CreateCustomIntegrationFormData>;
   index: number;
   disabled: boolean;
+  hasStoredSecret: boolean;
+  testId?: string;
 }>) {
   const { t } = useTranslation('admin-settings-integrations');
   const scope = form.watch(`fields.${index}.scope`);
   const type = form.watch(`fields.${index}.type`);
-  const required = form.watch(`fields.${index}.required`);
+  const configuredAsRequired = form.watch(`fields.${index}.required`);
+  const required =
+    configuredAsRequired && !(type === 'secret' && hasStoredSecret);
   if (scope !== 'organization') return null;
 
   return (
@@ -284,12 +319,22 @@ function OrganizationValueField({
           </FormLabel>
           <FormControl>
             {type === 'secret' ? (
-              <PasswordInput {...field} disabled={disabled} />
+              <PasswordInput
+                {...field}
+                disabled={disabled}
+                data-testid={testId}
+                placeholder={
+                  hasStoredSecret
+                    ? t('integrations.editDialog.secretPlaceholder')
+                    : undefined
+                }
+              />
             ) : (
               <Input
                 {...field}
                 type={type === 'url' ? 'url' : 'text'}
                 disabled={disabled}
+                data-testid={testId}
               />
             )}
           </FormControl>

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/custom-integration-identity-fields.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/custom-integration-identity-fields.tsx
@@ -1,0 +1,79 @@
+import type { UseFormReturn } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@ayunis/ui/components/form';
+import { Input } from '@ayunis/ui/components/input';
+import type { CreateCustomIntegrationFormData } from '@/pages/admin-settings/integrations-settings/model/types';
+
+export function CustomIntegrationIdentityFields({
+  form,
+  disabled,
+  serverUrlTestId,
+}: Readonly<{
+  form: UseFormReturn<CreateCustomIntegrationFormData>;
+  disabled: boolean;
+  serverUrlTestId?: string;
+}>) {
+  const { t } = useTranslation('admin-settings-integrations');
+
+  return (
+    <>
+      <FormField
+        control={form.control}
+        name="name"
+        rules={{ required: true }}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>{t('integrations.createCustomDialog.name')}</FormLabel>
+            <FormControl>
+              <Input
+                placeholder={t(
+                  'integrations.createCustomDialog.namePlaceholder',
+                )}
+                {...field}
+                disabled={disabled}
+              />
+            </FormControl>
+            <FormDescription>
+              {t('integrations.createCustomDialog.nameDescription')}
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="serverUrl"
+        rules={{ required: true }}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>
+              {t('integrations.createCustomDialog.serverUrl')}
+            </FormLabel>
+            <FormControl>
+              <Input
+                type="url"
+                placeholder={t(
+                  'integrations.createCustomDialog.serverUrlPlaceholder',
+                )}
+                {...field}
+                disabled={disabled}
+                data-testid={serverUrlTestId}
+              />
+            </FormControl>
+            <FormDescription>
+              {t('integrations.createCustomDialog.serverUrlDescription')}
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </>
+  );
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-custom-integration-dialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-custom-integration-dialog.tsx
@@ -1,0 +1,203 @@
+import { useEffect } from 'react';
+import { useFieldArray, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { Plus } from 'lucide-react';
+import { Button } from '@ayunis/ui/components/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@ayunis/ui/components/dialog';
+import { Form, FormDescription } from '@ayunis/ui/components/form';
+import type {
+  CreateCustomIntegrationFormData,
+  McpIntegration,
+} from '@/pages/admin-settings/integrations-settings/model/types';
+import type { CustomMcpConfigSchemaDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
+import { useUpdateIntegration } from '@/pages/admin-settings/integrations-settings/api/useUpdateIntegration';
+import {
+  buildCustomIntegrationUpdatePayload,
+  toEditCustomIntegrationFormData,
+} from '@/pages/admin-settings/integrations-settings/lib/edit-custom-integration';
+import {
+  findDuplicateHeaderIndexes,
+  findOAuthAuthorizationHeaderIndexes,
+} from '@/pages/admin-settings/integrations-settings/lib/custom-config-field-validation';
+import { CustomConfigFieldEditor } from './custom-config-field-editor';
+import { CustomIntegrationIdentityFields } from './custom-integration-identity-fields';
+import { EditOAuthClientFields } from './edit-oauth-client-fields';
+
+interface EditCustomIntegrationDialogProps {
+  integration: McpIntegration;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function EditCustomIntegrationDialog({
+  integration,
+  open,
+  onOpenChange,
+}: Readonly<EditCustomIntegrationDialogProps>) {
+  const { t } = useTranslation('admin-settings-integrations');
+  const form = useForm<CreateCustomIntegrationFormData>({
+    defaultValues: toEditCustomIntegrationFormData(integration),
+  });
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: 'fields',
+  });
+  const { updateIntegration, isUpdating } = useUpdateIntegration(() => {
+    onOpenChange(false);
+  });
+
+  useEffect(() => {
+    if (open) form.reset(toEditCustomIntegrationFormData(integration));
+  }, [form, integration, open]);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && !isUpdating) {
+      form.reset(toEditCustomIntegrationFormData(integration));
+    }
+    onOpenChange(nextOpen);
+  };
+
+  const addField = () => {
+    append({
+      key: `field_${crypto.randomUUID().replaceAll('-', '')}`,
+      scope: 'organization',
+      label: '',
+      type: 'secret',
+      headerName: '',
+      prefix: '',
+      required: true,
+      help: '',
+      value: '',
+    });
+  };
+
+  const submit = (data: CreateCustomIntegrationFormData) => {
+    const duplicateIndexes = findDuplicateHeaderIndexes(data.fields);
+    const oauthHeaderIndexes =
+      data.authType === 'OAUTH'
+        ? findOAuthAuthorizationHeaderIndexes(data.fields)
+        : [];
+    setHeaderErrors(form, duplicateIndexes, oauthHeaderIndexes, t);
+    if (duplicateIndexes.length > 0 || oauthHeaderIndexes.length > 0) return;
+
+    const payload = buildCustomIntegrationUpdatePayload(data, integration);
+    if (Object.keys(payload).length === 0) {
+      onOpenChange(false);
+      return;
+    }
+    updateIntegration(integration.id, payload);
+  };
+
+  const isOAuth = form.getValues('authType') === 'OAUTH';
+  const hasStaticOAuthClient =
+    isOAuth && form.getValues('oauthClientRegistration') === 'static';
+  const storedSecretKeys = new Set(
+    Object.keys(integration.orgConfigValues ?? {}).filter((key) =>
+      fields.some((field) => field.key === key && field.type === 'secret'),
+    ),
+  );
+  const configSchema =
+    integration.configSchema as unknown as CustomMcpConfigSchemaDto;
+  const lockedFieldKeys = new Set(
+    [...configSchema.orgFields, ...configSchema.userFields].map(
+      (field) => field.key,
+    ),
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{t('integrations.editDialog.title')}</DialogTitle>
+          <DialogDescription>
+            {t('integrations.editDialog.customDescription')}
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form
+            onSubmit={(event) => void form.handleSubmit(submit)(event)}
+            className="space-y-4"
+          >
+            <CustomIntegrationIdentityFields
+              form={form}
+              disabled={isUpdating}
+              serverUrlTestId="integration-edit-server-url"
+            />
+            <FormDescription>
+              {t('integrations.editDialog.authMethodDescription', {
+                method: isOAuth
+                  ? t('integrations.oauth.oauth')
+                  : t('integrations.oauth.customHeaders'),
+              })}
+            </FormDescription>
+            <CustomConfigFieldEditor
+              form={form}
+              fields={fields}
+              remove={remove}
+              disabled={isUpdating}
+              storedSecretKeys={storedSecretKeys}
+              lockedFieldKeys={lockedFieldKeys}
+              testIdPrefix="integration-edit-field"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={addField}
+              disabled={isUpdating}
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              {t('integrations.createCustomDialog.addField')}
+            </Button>
+            {hasStaticOAuthClient && (
+              <EditOAuthClientFields disabled={isUpdating} />
+            )}
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={isUpdating}
+              >
+                {t('integrations.editDialog.cancel')}
+              </Button>
+              <Button
+                type="submit"
+                disabled={isUpdating}
+                data-testid="integration-edit-submit"
+              >
+                {isUpdating
+                  ? t('integrations.editDialog.updating')
+                  : t('integrations.editDialog.update')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function setHeaderErrors(
+  form: ReturnType<typeof useForm<CreateCustomIntegrationFormData>>,
+  duplicateIndexes: number[],
+  oauthHeaderIndexes: number[],
+  t: (key: string) => string,
+): void {
+  for (const index of duplicateIndexes) {
+    form.setError(`fields.${index}.headerName`, {
+      message: t('integrations.createCustomDialog.headerDuplicate'),
+    });
+  }
+  for (const index of oauthHeaderIndexes) {
+    form.setError(`fields.${index}.headerName`, {
+      message: t('integrations.createCustomDialog.oauthHeaderConflict'),
+    });
+  }
+}

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-integration-dialog.test.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-integration-dialog.test.tsx
@@ -1,0 +1,137 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { McpIntegration } from '@/pages/admin-settings/integrations-settings/model/types';
+import { EditIntegrationDialog } from './edit-integration-dialog';
+
+const mocks = vi.hoisted(() => ({ updateIntegration: vi.fn() }));
+
+vi.mock(
+  '@/pages/admin-settings/integrations-settings/api/useUpdateIntegration',
+  () => ({
+    useUpdateIntegration: () => ({
+      updateIntegration: mocks.updateIntegration,
+      isUpdating: false,
+    }),
+  }),
+);
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@/features/mcp-oauth', () => ({
+  useMcpOAuthClientMetadata: () => ({ callbackUri: 'https://callback.test' }),
+}));
+
+beforeAll(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+const integration = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: 'Document archive',
+  type: 'custom',
+  serverUrl: 'https://documents.example.com/mcp',
+  enabled: true,
+  organizationId: '22222222-2222-2222-2222-222222222222',
+  hasCredentials: false,
+  createdAt: '2026-09-01T10:00:00.000Z',
+  updatedAt: '2026-09-01T10:00:00.000Z',
+  returnsPii: true,
+  configSchema: {
+    authType: 'CUSTOM',
+    orgFields: [
+      {
+        key: 'apiToken',
+        label: 'API token',
+        type: 'secret',
+        headerName: 'X-Archive-Token',
+        required: true,
+      },
+    ],
+    userFields: [],
+  },
+  orgConfigValues: { apiToken: '••••••' },
+} as McpIntegration;
+
+describe(EditIntegrationDialog.name, () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('exposes the custom server URL and header definitions', () => {
+    render(
+      <EditIntegrationDialog
+        integration={integration}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByDisplayValue('https://documents.example.com/mcp'),
+    ).toBeTruthy();
+    expect(screen.getByDisplayValue('X-Archive-Token')).toBeTruthy();
+  });
+
+  it('preserves a required stored secret when its input stays blank', async () => {
+    render(
+      <EditIntegrationDialog
+        integration={integration}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByDisplayValue('X-Archive-Token'), {
+      target: { value: 'Authorization' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'integrations.editDialog.update',
+      }),
+    );
+
+    await waitFor(() => expect(mocks.updateIntegration).toHaveBeenCalledOnce());
+    expect(mocks.updateIntegration.mock.calls[0][1]).not.toHaveProperty(
+      'orgConfigValues',
+    );
+  });
+
+  it('closes without sending an update when nothing changed', async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <EditIntegrationDialog
+        integration={integration}
+        open
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'integrations.editDialog.update',
+      }),
+    );
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    expect(mocks.updateIntegration).not.toHaveBeenCalled();
+  });
+
+  it('locks the scope and type of existing fields', () => {
+    render(
+      <EditIntegrationDialog
+        integration={integration}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    const [scope, type] = screen.getAllByRole('combobox');
+    expect((scope as HTMLButtonElement).disabled).toBe(true);
+    expect((type as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-integration-dialog.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-integration-dialog.tsx
@@ -21,11 +21,15 @@ import { Input } from '@ayunis/ui/components/input';
 import { PasswordInput } from '@ayunis/ui/components/password-input';
 import { ConfigFieldInput } from '@/shared/ui/config-field-input';
 import { Button } from '@ayunis/ui/components/button';
-import type { McpIntegration, UpdateIntegrationFormData } from '../model/types';
-import { useUpdateIntegration } from '../api/useUpdateIntegration';
+import type {
+  McpIntegration,
+  UpdateIntegrationFormData,
+} from '@/pages/admin-settings/integrations-settings/model/types';
+import { useUpdateIntegration } from '@/pages/admin-settings/integrations-settings/api/useUpdateIntegration';
 import type { MarketplaceIntegrationConfigFieldDto } from '@/shared/api/generated/ayunisCoreAPI.schemas';
 import { hasOAuthConfiguration } from '@/shared/lib/mcp-oauth';
 import { EditOAuthClientFields } from './edit-oauth-client-fields';
+import { EditCustomIntegrationDialog } from './edit-custom-integration-dialog';
 
 interface EditIntegrationDialogProps {
   integration: McpIntegration | null;
@@ -148,15 +152,13 @@ function buildUpdatePayload({
 
 function OptionalOAuthClientFields({
   enabled,
-  form,
   disabled,
 }: Readonly<{
   enabled: boolean;
-  form: UseFormReturn<UpdateIntegrationFormData>;
   disabled: boolean;
 }>) {
   if (!enabled) return null;
-  return <EditOAuthClientFields form={form} disabled={disabled} />;
+  return <EditOAuthClientFields disabled={disabled} />;
 }
 
 function useResetEditForm(
@@ -180,6 +182,30 @@ function useResetEditForm(
 }
 
 export function EditIntegrationDialog({
+  integration,
+  open,
+  onOpenChange,
+}: Readonly<EditIntegrationDialogProps>) {
+  if (integration?.type === 'custom') {
+    return (
+      <EditCustomIntegrationDialog
+        integration={integration}
+        open={open}
+        onOpenChange={onOpenChange}
+      />
+    );
+  }
+
+  return (
+    <LegacyEditIntegrationDialog
+      integration={integration}
+      open={open}
+      onOpenChange={onOpenChange}
+    />
+  );
+}
+
+function LegacyEditIntegrationDialog({
   integration,
   open,
   onOpenChange,
@@ -333,7 +359,6 @@ export function EditIntegrationDialog({
 
               <OptionalOAuthClientFields
                 enabled={hasStaticOAuthClient}
-                form={form}
                 disabled={isUpdating}
               />
 

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-oauth-client-fields.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/edit-oauth-client-fields.tsx
@@ -1,4 +1,4 @@
-import type { UseFormReturn } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import {
   FormControl,
@@ -11,17 +11,20 @@ import {
 import { Input } from '@ayunis/ui/components/input';
 import { PasswordInput } from '@ayunis/ui/components/password-input';
 import { useMcpOAuthClientMetadata } from '@/features/mcp-oauth';
-import type { UpdateIntegrationFormData } from '../model/types';
+
+interface OAuthClientFormValues {
+  oauthClientId?: string;
+  oauthClientSecret?: string;
+}
 
 export function EditOAuthClientFields({
-  form,
   disabled,
 }: Readonly<{
-  form: UseFormReturn<UpdateIntegrationFormData>;
   disabled: boolean;
 }>) {
   const { t } = useTranslation('admin-settings-integrations');
   const { callbackUri } = useMcpOAuthClientMetadata();
+  const form = useFormContext<OAuthClientFormValues>();
   return (
     <div className="space-y-4">
       <FormItem>

--- a/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/integration-card.tsx
+++ b/ayunis-core-frontend/src/pages/admin-settings/integrations-settings/ui/integration-card.tsx
@@ -14,8 +14,8 @@ import {
   TooltipTrigger,
 } from '@ayunis/ui/components/tooltip';
 import { MoreVertical, Loader2 } from 'lucide-react';
-import type { McpIntegration } from '../model/types';
-import { getIntegrationTypeLabel } from '../lib/helpers';
+import type { McpIntegration } from '@/pages/admin-settings/integrations-settings/model/types';
+import { getIntegrationTypeLabel } from '@/pages/admin-settings/integrations-settings/lib/helpers';
 import {
   Item,
   ItemActions,
@@ -50,7 +50,7 @@ export function IntegrationCard({
   const requiresUserConfig = integration.userAuthorizationRequired === true;
 
   return (
-    <Item variant="outline">
+    <Item variant="outline" data-testid={`integration-card-${integration.id}`}>
       <ItemContent>
         <ItemTitle>
           {integration.name}
@@ -84,13 +84,20 @@ export function IntegrationCard({
         />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm">
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="integration-actions"
+            >
               <MoreVertical className="h-4 w-4" />
               <span className="sr-only">{t('integrations.card.openMenu')}</span>
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={() => onEdit(integration)}>
+            <DropdownMenuItem
+              onClick={() => onEdit(integration)}
+              data-testid="integration-edit-action"
+            >
               {t('integrations.card.edit')}
             </DropdownMenuItem>
             <DropdownMenuItem

--- a/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
+++ b/ayunis-core-frontend/src/shared/api/generated/ayunisCoreAPI.schemas.ts
@@ -3170,6 +3170,10 @@ export interface UpdateMcpIntegrationDto {
      * @maxLength 255
      */
   name?: string;
+  /** Custom MCP server URL */
+  serverUrl?: string;
+  /** Header configuration for a custom MCP integration */
+  configSchema?: CustomMcpConfigSchemaDto;
   /** Authentication credentials (will be encrypted). Provide to rotate the stored secret/token. */
   credentials?: string;
   /** Custom auth header name. Only used in combination with CUSTOM_HEADER integrations. */

--- a/ayunis-core-frontend/src/shared/api/openapi-schema.json
+++ b/ayunis-core-frontend/src/shared/api/openapi-schema.json
@@ -16366,6 +16366,19 @@
             "minLength": 1,
             "maxLength": 255
           },
+          "serverUrl": {
+            "type": "string",
+            "description": "Custom MCP server URL",
+            "example": "https://my-mcp-server.example.com/mcp"
+          },
+          "configSchema": {
+            "description": "Header configuration for a custom MCP integration",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CustomMcpConfigSchemaDto"
+              }
+            ]
+          },
           "credentials": {
             "type": "string",
             "description": "Authentication credentials (will be encrypted). Provide to rotate the stored secret/token.",

--- a/ayunis-core-frontend/src/shared/locales/de/admin-settings-integrations.json
+++ b/ayunis-core-frontend/src/shared/locales/de/admin-settings-integrations.json
@@ -14,9 +14,13 @@
     },
     "updateIntegration": {
       "success": "Integration erfolgreich aktualisiert",
+      "connectionFailed": "Integration gespeichert, aber der Verbindungstest ist fehlgeschlagen: {{message}}",
+      "connectionFailedGeneric": "Integration gespeichert, aber der Verbindungstest ist fehlgeschlagen.",
       "error": "Integration konnte nicht aktualisiert werden. Bitte versuchen Sie es erneut.",
       "notFound": "Integration nicht gefunden. Sie wurde möglicherweise gelöscht.",
-      "invalidServerUrl": "Ungültige Server-URL. Bitte überprüfen Sie das URL-Format."
+      "invalidServerUrl": "Ungültige Server-URL. Bitte überprüfen Sie das URL-Format.",
+      "invalidConfiguration": "Die Integrationskonfiguration ist ungültig. Überprüfen Sie die Felddefinitionen und versuchen Sie es erneut.",
+      "missingRequiredConfiguration": "Ein erforderlicher Integrationswert fehlt. Füllen Sie alle erforderlichen Organisationsfelder aus und versuchen Sie es erneut."
     },
     "deleteIntegration": {
       "success": "Integration erfolgreich gelöscht",
@@ -155,6 +159,8 @@
     },
     "editDialog": {
       "title": "Integration bearbeiten",
+      "customDescription": "Aktualisieren Sie die Server-URL und die HTTP-Header-Konfiguration. Beim Speichern wird die aktualisierte Verbindung getestet.",
+      "authMethodDescription": "Authentifizierung: {{method}}. Um die Authentifizierungsmethode zu ändern, erstellen Sie die Integration neu.",
       "name": "Name",
       "namePlaceholder": "Meine Integration",
       "headerName": "Header-Name",

--- a/ayunis-core-frontend/src/shared/locales/en/admin-settings-integrations.json
+++ b/ayunis-core-frontend/src/shared/locales/en/admin-settings-integrations.json
@@ -14,9 +14,13 @@
     },
     "updateIntegration": {
       "success": "Integration updated successfully",
+      "connectionFailed": "Integration saved, but the connection test failed: {{message}}",
+      "connectionFailedGeneric": "Integration saved, but the connection test failed.",
       "error": "Failed to update integration. Please try again.",
       "notFound": "Integration not found. It may have been deleted.",
-      "invalidServerUrl": "Invalid server URL. Please check the URL format."
+      "invalidServerUrl": "Invalid server URL. Please check the URL format.",
+      "invalidConfiguration": "The integration configuration is invalid. Check the field definitions and try again.",
+      "missingRequiredConfiguration": "A required integration value is missing. Complete all required organization fields and try again."
     },
     "deleteIntegration": {
       "success": "Integration deleted successfully",
@@ -154,6 +158,8 @@
     },
     "editDialog": {
       "title": "Edit Integration",
+      "customDescription": "Update the server URL and HTTP header configuration. Saving tests the updated connection.",
+      "authMethodDescription": "Authentication: {{method}}. To change the authentication method, recreate the integration.",
       "name": "Name",
       "namePlaceholder": "My Integration",
       "headerName": "Header Name",


### PR DESCRIPTION
## Summary

Administrators can now edit supported connection settings for custom MCP integrations instead of deleting and recreating a misconfigured integration.

## What changed

- Expose the server URL and custom header configuration in the Edit dialog.
- Preserve existing masked secrets when their fields are left unchanged.
- Revalidate connection-affecting updates and keep the dialog open when validation fails.
- Surface clear success and failure feedback after saving.
- Keep authentication-method changes locked and explain that changing authentication requires recreating the integration.
- Regenerate the API clients and add backend, frontend, and Playwright regression coverage.

## Validation

- Backend MCP suite: 485 tests passed.
- Frontend integration suite: 20 tests passed.
- Controller suite: 14 tests passed.
- Browser E2E passed in CI.
- Desktop and mobile QA screenshots were captured and published by CI.
- Backend/frontend builds, type checks, and lint passed.
- Dependency, duplication, complexity, and file-size checks passed.

## QA evidence

[View the CI-generated desktop and mobile screenshots](https://github.com/ayunis-core/ayunis-core/pull/1664#issuecomment-5635661795)

Linear: AYC-942

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes integration update semantics, encrypted org/user config, and connection validation paths; mistakes could break live MCP connections or leave stale user secrets if cleanup regresses.
> 
> **Overview**
> Administrators can **edit custom MCP integrations** in place—server URL, header/schema definitions, and org values—without recreating the integration.
> 
> The **update API and use case** now accept optional `serverUrl` and `configSchema`, validate custom updates (HTTP(S) URL, schema rules, unchanged auth method), merge org secrets when fields are omitted, and **reject** changing an existing field’s type or org/user scope. Removing user-scoped fields triggers **`removeKeysByIntegrationId`** so stored per-user secrets are cleared. **Connection tests** run after connection-affecting saves for org-level integrations, but are skipped when OAuth or per-user authorization is required.
> 
> The **admin UI** routes custom integrations to a dedicated edit dialog that sends **diff-only** payloads, keeps masked secrets when unchanged, locks scope/type on existing fields, and **stays open** with a connection-failure toast when a save changes connectivity and validation fails. OpenAPI clients, locales, and **Playwright** coverage were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb0a42702af72f8e3048fc80dfd6b16e9bf5979c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

